### PR TITLE
openssh_keypair: make fingerprint result a string

### DIFF
--- a/changelogs/fragments/57295-openssh_keypair-fingerprint.yaml
+++ b/changelogs/fragments/57295-openssh_keypair-fingerprint.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+   - openssh_keypair - The fingerprint return value was incorrectly returning a list of ssh-keygen output; it now returns just the fingerprint value as a string

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -107,7 +107,7 @@ fingerprint:
     description: The fingerprint of the key.
     returned: changed or success
     type: str
-    sample: 4096 SHA256:r4YCZxihVjedH2OlfjVGI6Y5xAYtdCwk8VxKyzVyYfM example@example.com (RSA)
+    sample: SHA256:r4YCZxihVjedH2OlfjVGI6Y5xAYtdCwk8VxKyzVyYfM
 public_key:
     description: The public key of the generated SSH private key
     returned: changed or success
@@ -232,13 +232,13 @@ class Keypair(object):
         # return result as a dict
 
         """Serialize the object into a dictionary."""
-
         result = {
             'changed': self.changed,
             'size': self.size,
             'type': self.type,
             'filename': self.path,
-            'fingerprint': self.fingerprint,
+            # On removal this has no value
+            'fingerprint': self.fingerprint[1] if self.fingerprint else '',
             'public_key': self.public_key,
         }
 

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -1,6 +1,7 @@
 - name: Generate privatekey1 - standard
   openssh_keypair:
     path: '{{ output_dir }}/privatekey1'
+  register: privatekey1_result
 
 - name: Generate privatekey2 - size 2048
   openssh_keypair:

--- a/test/integration/targets/openssh_keypair/tests/validate.yml
+++ b/test/integration/targets/openssh_keypair/tests/validate.yml
@@ -1,3 +1,33 @@
+- name: Log privatekey1 return values
+  debug:
+    var: privatekey1_result
+
+- name: Validate privatekey1 return fingerprint
+  assert:
+    that:
+      - privatekey1_result["fingerprint"] is string
+      - privatekey1_result["fingerprint"].startswith("SHA256:")
+  # only distro old enough that it still gives md5 with no prefix
+  when: ansible_distribution != 'CentOS' and ansible_distribution_major_version != '6'
+
+- name: Validate privatekey1 return public_key
+  assert:
+    that:
+      - privatekey1_result["public_key"] is string
+      - privatekey1_result["public_key"].startswith("ssh-rsa ")
+
+- name: Validate privatekey1 return size value
+  assert:
+    that:
+      - privatekey1_result["size"]|type_debug == 'int'
+      - privatekey1_result["size"] == 4096
+
+- name: Validate privatekey1 return key type
+  assert:
+    that:
+      - privatekey1_result["type"] is string
+      - privatekey1_result["type"] == "rsa"
+
 - name: Validate privatekey1 (test - RSA key with size 4096 bits)
   shell: "ssh-keygen -lf {{ output_dir }}/privatekey1 | grep -o -E '^[0-9]+'"
   register: privatekey1


### PR DESCRIPTION
##### SUMMARY

The extant documentation says that the fingerprint return value is a
single string, but it is currently being returned as a split list.
Convert the returned value to a string as documented, and add some
basic test-case coverage for the return values.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_keypair

##### ADDITIONAL INFORMATION

As seen below, the result currently returns the split fingerprint value directly

```yaml
- hosts: all
  connection: local
  tasks:

    - openssh_keypair:
        path: /tmp/tmp_key
      register: res

    - debug:
        var: res
```

```
TASK [debug] ****************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "res": {
        "changed": true,
        "failed": false,
        "filename": "/tmp/tmp_key",
        "fingerprint": [
            "4096",
            "SHA256:YVuaDeU1+h0HlP7BKXzME/ufU3wWlVPbxRZgLYJdxQc",
            "/tmp/tmp_key.pub",
            "(RSA)"
        ],
        "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBGNTNm6eDprcX/DXrAszIsNdwkj+D93voV/GBqcZ7La/oJOpchvMzeIDTY2G3fB3HMGsWZCjxcHXbwHIM9XS1N2yaF0gu6Bth/PyCnbFzeh7y7CxH8gOaS3qFFZo8l/i9mnvhn/gScyDxlwSCAPqJ2E5hIUtOH4zwrZrn/31yBOunFycw1ii/qrZe3UEofh/OlX2+cuElTt13ERlGaS6YrwepDscQaLWUzFthkFW3E0xzbTO3aBkuoC/7KTi4XbQRdQCLJA1Tweo4BZqi35pj3szsHdnXljfLHguyewe2jctJggiBnexrzCs1nMT7b05spssSC0r7f2xsjldM7R3L/B15sYdNd/O0mIxeQrMc9TR2VTEeQ+btGGhvIME8mBnIe+RjJ6K9aKAvtkjXtPak6X3WzyofgJBXxGE10Zp4/4AYWdwv3+YV6JqMlK5x28cixq7fteeA4G16Q/UrTtSgFjpuIeOwvZvSEwams3SMkKy9a2cdMqwGSPFqf5gavLDB7LMcehZHjyrhiM2fElUZ+iq1C0C3tRFjDSINcqyj41LRlxbYovyBGWC5JCkzC7+QGwy1GLmA6gEj/WR7fzyydepp2O+poEPKCCeLut82e/GJYcEpCsbFc5FwxlfbTTDE7Wk2rVcqUBZlgid6rsp0bkVYdLLnm0pDxdENNsZi1w==",
        "size": 4096,
        "type": "rsa"
    }
}
```
