### PR TITLE
Support stack policy on update

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -73,6 +73,10 @@ options:
       - the path of the cloudformation stack policy. A policy cannot be removed once placed, but it can be modified.
         for instance, allow all updates U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html#d0e9051)
     version_added: "1.9"
+  stack_policy_on_update:
+    description:
+      - the body of the cloudformation stack policy only applied during this update.
+    version_added: "2.x"
   tags:
     description:
       - Dictionary of tags to associate with stack and its resources during stack creation. Can be updated later, updating tags removes previous entries.
@@ -629,6 +633,7 @@ def main():
         template=dict(default=None, required=False, type='path'),
         notification_arns=dict(default=None, required=False),
         stack_policy=dict(default=None, required=False),
+        stack_policy_on_update=dict(default=None, required=False),
         disable_rollback=dict(default=False, type='bool'),
         on_create_failure=dict(default=None, required=False, choices=['DO_NOTHING', 'ROLLBACK', 'DELETE']),
         create_timeout=dict(default=None, type='int'),
@@ -765,6 +770,10 @@ def main():
             if module.params.get('termination_protection') is not None:
                 update_termination_protection(module, cfn, stack_params['StackName'],
                                               bool(module.params.get('termination_protection')))
+            # only use the policy on update
+            if module.params['stack_policy_on_update'] is not None:
+                stack_params['StackPolicyDuringUpdateBody'] = module.params['stack_policy_on_update']
+                
             result = update_stack(module, stack_params, cfn, module.params.get('events_limit'))
 
         # format the stack output

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -76,7 +76,6 @@ options:
   stack_policy_on_update:
     description:
       - the body of the cloudformation stack policy only applied during this update.
-    version_added: "2.x"
   tags:
     description:
       - Dictionary of tags to associate with stack and its resources during stack creation. Can be updated later, updating tags removes previous entries.
@@ -773,7 +772,7 @@ def main():
             # only use the policy on update
             if module.params['stack_policy_on_update'] is not None:
                 stack_params['StackPolicyDuringUpdateBody'] = module.params['stack_policy_on_update']
-                
+
             result = update_stack(module, stack_params, cfn, module.params.get('events_limit'))
 
         # format the stack output


### PR DESCRIPTION
##### SUMMARY
Cloudformation supports a policy that applies to a particular update only.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/amazon/cloudformation.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Use the aws cloudformation update-stack command with the --stack-policy-during-update-body option to type in a modified policy..

AWS CloudFormation applies the override policy only during this update. The override policy doesn't permanently change the stack policy. To modify a stack policy, see Modifying a Stack Policy .
Boto3 documentation of the parameter used: 
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.update_stack

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
