### PR TITLE
Solve SHA256 keytool of java11 version issue(#57301)

### DIFF
--- a/changelogs/fragments/57302-java_keystore_sha256.yaml
+++ b/changelogs/fragments/57302-java_keystore_sha256.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- java_keystore - Use SHA256 to check the fingerprints' certs. The module is compatible with java<=8 (SHA1 by default) and Java>=9 (SHA256 by default) now.

--- a/lib/ansible/modules/system/java_keystore.py
+++ b/lib/ansible/modules/system/java_keystore.py
@@ -106,7 +106,7 @@ cmd:
   description: Executed command to get action done
   returned: changed and failure
   type: str
-  sample: "openssl x509 -noout -in /tmp/cert.crt -fingerprint -sha1"
+  sample: "openssl x509 -noout -in /tmp/cert.crt -fingerprint -sha256"
 '''
 
 
@@ -116,7 +116,7 @@ import re
 
 
 def read_certificate_fingerprint(module, openssl_bin, certificate_path):
-    current_certificate_fingerprint_cmd = "%s x509 -noout -in %s -fingerprint -sha1" % (openssl_bin, certificate_path)
+    current_certificate_fingerprint_cmd = "%s x509 -noout -in %s -fingerprint -sha256" % (openssl_bin, certificate_path)
     (rc, current_certificate_fingerprint_out, current_certificate_fingerprint_err) = run_commands(module, current_certificate_fingerprint_cmd)
     if rc != 0:
         return module.fail_json(msg=current_certificate_fingerprint_out,
@@ -136,7 +136,7 @@ def read_certificate_fingerprint(module, openssl_bin, certificate_path):
 
 
 def read_stored_certificate_fingerprint(module, keytool_bin, alias, keystore_path, keystore_password):
-    stored_certificate_fingerprint_cmd = "%s -list -alias '%s' -keystore '%s' -storepass '%s'" % (keytool_bin, alias, keystore_path, keystore_password)
+    stored_certificate_fingerprint_cmd = "%s -list -alias '%s' -keystore '%s' -storepass '%s' -v" % (keytool_bin, alias, keystore_path, keystore_password)
     (rc, stored_certificate_fingerprint_out, stored_certificate_fingerprint_err) = run_commands(module, stored_certificate_fingerprint_cmd)
     if rc != 0:
         if "keytool error: java.lang.Exception: Alias <%s> does not exist" % alias not in stored_certificate_fingerprint_out:
@@ -147,7 +147,7 @@ def read_stored_certificate_fingerprint(module, keytool_bin, alias, keystore_pat
         else:
             return None
     else:
-        stored_certificate_match = re.search(r": ([\w:]+)", stored_certificate_fingerprint_out)
+        stored_certificate_match = re.search(r"SHA256: ([\w:]+)", stored_certificate_fingerprint_out)
         if not stored_certificate_match:
             return module.fail_json(
                 msg="Unable to find the stored certificate fingerprint in %s" % stored_certificate_fingerprint_out,

--- a/test/units/modules/system/test_java_keystore.py
+++ b/test/units/modules/system/test_java_keystore.py
@@ -168,7 +168,7 @@ class TestCertChanged(ModuleTestCase):
         )
 
         with patch('os.remove', return_value=True):
-            self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'foo: abcd:1234:efgh', '')]
+            self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: abcd:1234:efgh', '')]
             result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertFalse(result, 'Fingerprint is identical')
 
@@ -187,7 +187,7 @@ class TestCertChanged(ModuleTestCase):
         )
 
         with patch('os.remove', return_value=True):
-            self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'foo: wxyz:9876:stuv', '')]
+            self.run_commands.side_effect = [(0, 'foo=abcd:1234:efgh', ''), (0, 'SHA256: wxyz:9876:stuv', '')]
             result = cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             self.assertTrue(result, 'Fingerprint mismatch')
 
@@ -228,10 +228,10 @@ class TestCertChanged(ModuleTestCase):
         module.fail_json = Mock()
 
         with patch('os.remove', return_value=True):
-            self.run_commands.side_effect = [(1, '', 'Oops'), (0, 'foo: wxyz:9876:stuv', '')]
+            self.run_commands.side_effect = [(1, '', 'Oops'), (0, 'SHA256: wxyz:9876:stuv', '')]
             cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             module.fail_json.assert_called_once_with(
-                cmd="openssl x509 -noout -in /tmp/foo.crt -fingerprint -sha1",
+                cmd="openssl x509 -noout -in /tmp/foo.crt -fingerprint -sha256",
                 msg='',
                 err='Oops',
                 rc=1
@@ -257,7 +257,7 @@ class TestCertChanged(ModuleTestCase):
             self.run_commands.side_effect = [(0, 'foo: wxyz:9876:stuv', ''), (1, '', 'Oops')]
             cert_changed(module, "openssl", "keytool", "/path/to/keystore.jks", "changeit", 'foo')
             module.fail_json.assert_called_with(
-                cmd="keytool -list -alias 'foo' -keystore '/path/to/keystore.jks' -storepass 'changeit'",
+                cmd="keytool -list -alias 'foo' -keystore '/path/to/keystore.jks' -storepass 'changeit' -v",
                 msg='',
                 err='Oops',
                 rc=1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
keytool shows SHA1 or SHA256 (depends java version). To solve this list all hashes with verbose option and re.match by "SHA1:" string.
Fixes #57301
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
java_keystore module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
>>> stored_certificate_fingerprint_out=os.popen('/usr/lib/jvm/java-1.11.0-openjdk-amd64/bin/keytool -list -alias test-ssl -keystore keystore.p12 -storepass changeit -v').read()
>>> print(stored_certificate_fingerprint_out)
Nombre de Alias: test-ssl
Fecha de Creación: 3 jun. 2019
Tipo de Entrada: PrivateKeyEntry
Longitud de la Cadena de Certificado: 1
Certificado[1]:
Propietario: CN=localhost, O=Default Company Ltd, L=Default City, C=ES
Emisor: CN=localhost, O=Default Company Ltd, L=Default City, C=ES
Número de serie: 92e27965545459c6
Válido desde: Sun Jun 02 13:12:07 CEST 2019 hasta: Wed May 30 13:12:07 CEST 2029
Huellas digitales del certificado:
	 SHA1: 88:5E:0C:8E:00:D1:81:B4:12:2F:FF:28:DC:BD:77:39:8D:A5:F3:91
	 SHA256: CC:2F:2A:B6:EA:CE:86:66:22:91:84:68:9C:52:DF:6B:AF:B5:48:51:2A:0F:EC:F3:F5:E9:F7:48:3A:CF:F7:36
Nombre del algoritmo de firma: SHA256withRSA
Algoritmo de clave pública de asunto: Clave RSA de 1024 bits
Versión: 1

>>> stored_certificate_match = re.search(r"SHA1: ([\w:]+)", stored_certificate_fingerprint_out)
>>> print(stored_certificate_match.group(1))
88:5E:0C:8E:00:D1:81:B4:12:2F:FF:28:DC:BD:77:39:8D:A5:F3:91

```
The actual version show a wrong fingerprint to compare with a openssl sha1:
```
>>> stored_certificate_fingerprint_out_old=os.popen('/usr/lib/jvm/java-1.11.0-openjdk-amd64/bin/keytool -list -alias test-ssl -keystore keystore.p12 -storepass changeit').read()
>>> print(stored_certificate_fingerprint_out_old)
test-ssl, 3 jun. 2019, PrivateKeyEntry, 
Huella de certificado (SHA-256): CC:2F:2A:B6:EA:CE:86:66:22:91:84:68:9C:52:DF:6B:AF:B5:48:51:2A:0F:EC:F3:F5:E9:F7:48:3A:CF:F7:36
>>> stored_certificate_match = re.search(r": ([\w:]+)", stored_certificate_fingerprint_out_old)
>>> print(stored_certificate_match.group(1))
CC:2F:2A:B6:EA:CE:86:66:22:91:84:68:9C:52:DF:6B:AF:B5:48:51:2A:0F:EC:F3:F5:E9:F7:48:3A:CF:F7:36
```
