### PR TITLE
TRANSFORM_INVALID_GROUP_CHARS: document "ignore" option

### DIFF
--- a/changelogs/fragments/group-chars-ignore-doc.yaml
+++ b/changelogs/fragments/group-chars-ignore-doc.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- documented ``ignore`` option for ``TRANSFORM_INVALID_GROUP_CHARS``

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1492,13 +1492,14 @@ TRANSFORM_INVALID_GROUP_CHARS:
   description:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
     - If 'never' it will allow for the group name but warn about the issue.
+    - When 'ignore', it does the same as 'never' sans the warning.
     - When 'always' it will replace any invalid charachters with '_' (underscore) and warn the user
     - When 'silently', it does the same as 'always' sans the warnings.
   env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}
   type: string
-  choices: ['always', 'never', 'silently']
+  choices: ['always', 'never', 'ignore', 'silently']
   version_added: '2.8'
 INVALID_TASK_ATTRIBUTE_FAILED:
   name: Controls whether invalid attributes for a task result in errors instead of warnings

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1492,9 +1492,9 @@ TRANSFORM_INVALID_GROUP_CHARS:
   description:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
     - If 'never' it will allow for the group name but warn about the issue.
-    - When 'ignore', it does the same as 'never' sans the warning.
+    - When 'ignore', it does the same as 'never', without issuing a warning.
     - When 'always' it will replace any invalid charachters with '_' (underscore) and warn the user
-    - When 'silently', it does the same as 'always' sans the warnings.
+    - When 'silently', it does the same as 'always', without issuing a warning.
   env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There were no docs for the `ignore` option to `TRANSFORM_INVALID_GROUP_CHARS`.  This remediates that lack of documentation.

This should be backported to 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
