### PR TITLE
Bug Fix: Portset did not allow you to add port when creating a portset

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_portset.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_portset.py
@@ -211,7 +211,7 @@ class NetAppONTAPPortset(object):
         :return: None
         """
         for port in ports:
-            self.modify_port(port, 'portset-remove')
+            self.modify_port(port, 'portset-remove', 'removing')
 
     def add_ports(self):
         """
@@ -222,9 +222,9 @@ class NetAppONTAPPortset(object):
         if self.parameters.get('ports') == [''] or self.parameters.get('ports') is None:
             return
         for port in self.parameters['ports']:
-            self.modify_port(port, 'portset-add')
+            self.modify_port(port, 'portset-add', 'adding')
 
-    def modify_port(self, port, zapi):
+    def modify_port(self, port, zapi, action):
         """
         Add or remove an port to/from a portset
         """
@@ -237,8 +237,8 @@ class NetAppONTAPPortset(object):
         try:
             self.server.invoke_successfully(portset_modify, enable_tunneling=True)
         except netapp_utils.zapi.NaApiError as error:
-            self.module.fail_json(msg='Error modifying port in portset %s: %s' % (self.parameters['name'],
-                                                                                  to_native(error)),
+            self.module.fail_json(msg='Error %s port in portset %s: %s' % (action, self.parameters['name'],
+                                                                           to_native(error)),
                                   exception=traceback.format_exc())
 
     def apply(self):
@@ -257,6 +257,7 @@ class NetAppONTAPPortset(object):
             else:
                 if cd_action == 'create':
                     self.create_portset()
+                    self.add_ports()
                 elif cd_action == 'delete':
                     self.delete_portset()
                 elif modify:

--- a/test/units/modules/storage/netapp/test_na_ontap_portset.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_portset.py
@@ -102,6 +102,7 @@ class TestMyModule(unittest.TestCase):
             name = 'test'
             type = 'mixed'
             vserver = 'ansible_test'
+            ports = ['a1', 'a2']
         else:
             hostname = 'hostname'
             username = 'username'
@@ -109,13 +110,15 @@ class TestMyModule(unittest.TestCase):
             name = 'name'
             type = 'mixed'
             vserver = 'vserver'
+            ports = ['a1', 'a2']
         return dict({
             'hostname': hostname,
             'username': username,
             'password': password,
             'name': name,
             'type': type,
-            'vserver': vserver
+            'vserver': vserver,
+            'ports': ports
         })
 
     def test_module_fail_when_required_args_missing(self):


### PR DESCRIPTION
##### SUMMARY
Portset did not allow you to add port when creating a portset

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_portset.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
