### PR TITLE
Correct virtualenv usage in integration tests.

### DIFF
--- a/test/integration/targets/aws_eks/runme.sh
+++ b/test/integration/targets/aws_eks/runme.sh
@@ -1,25 +1,13 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
-
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+set -eux
 
 # Test graceful failure for older versions of botocore
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
-source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
-$PYTHON -m pip install 'botocore<1.10.0' boto3
+source virtualenv.sh
+pip install 'botocore<1.10.0' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/old_version.yml "$@"
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.10.1' boto3
+source virtualenv.sh
+pip install 'botocore>=1.10.1' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/cloudformation_stack_set/runme.sh
+++ b/test/integration/targets/cloudformation_stack_set/runme.sh
@@ -1,19 +1,8 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
-
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+set -eux
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>1.10.26' boto3
+source virtualenv.sh
+pip install 'botocore>1.10.26' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/ec2_instance/runme.sh
+++ b/test/integration/targets/ec2_instance/runme.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
+set -eux
 
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+export ANSIBLE_ROLES_PATH=../
 
 # Test graceful failure for older versions of botocore
-export ANSIBLE_ROLES_PATH=../
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-less-than-1.10.16"
-source "${MYTMPDIR}/botocore-less-than-1.10.16/bin/activate"
-"${PYTHON}" -m pip install 'botocore<1.10.16' 'boto3<1.7.16'
+source virtualenv.sh
+pip install 'botocore<1.10.16' 'boto3<1.7.16'
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.10.16' boto3
+source virtualenv.sh
+pip install 'botocore>=1.10.16' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/ec2_launch_template/runme.sh
+++ b/test/integration/targets/ec2_launch_template/runme.sh
@@ -1,26 +1,15 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
+set -eux
 
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+export ANSIBLE_ROLES_PATH=../
 
 # Test graceful failure for older versions of botocore
-export ANSIBLE_ROLES_PATH=../
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/boto3-less-than-1.6.0"
-source "${MYTMPDIR}/boto3-less-than-1.6.0/bin/activate"
-"${PYTHON}" -m pip install 'boto3<1.6.0'
+source virtualenv.sh
+pip install 'boto3<1.6.0'
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/boto3-recent"
-source "${MYTMPDIR}/boto3-recent/bin/activate"
-$PYTHON -m pip install 'boto3>1.6.0'
+source virtualenv.sh
+pip install 'boto3>1.6.0'
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/ecs_cluster/runme.sh
+++ b/test/integration/targets/ecs_cluster/runme.sh
@@ -1,48 +1,31 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
-
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
-
-
+set -eux
 
 # Test graceful failure for older versions of botocore
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.40"
-source "${MYTMPDIR}/botocore-1.7.40/bin/activate"
-$PYTHON -m pip install 'botocore<=1.7.40' boto3
+source virtualenv.sh
+pip install 'botocore<=1.7.40' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/network_fail.yml "$@"
 
 # Test graceful failure for assign public ip
 # applies for botocore >= 1.7.44 and < 1.8.4
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.44"
-source "${MYTMPDIR}/botocore-1.7.44/bin/activate"
-$PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
+source virtualenv.sh
+pip install 'botocore>=1.7.44,<1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/network_assign_public_ip_fail.yml "$@"
 
 # Test graceful failure for force new deployment #42518
 # applies for botocore < 1.8.4
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.4"
-source "${MYTMPDIR}/botocore-1.8.4/bin/activate"
-$PYTHON -m pip install 'botocore>=1.7.44,<1.8.4' boto3
+source virtualenv.sh
+pip install 'botocore>=1.7.44,<1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/network_force_new_deployment_fail.yml "$@"
 
 # Test force new deployment #42518
 # applies for botocore < 1.8.4
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.8.5"
-source "${MYTMPDIR}/botocore-1.8.5/bin/activate"
-$PYTHON -m pip install 'botocore>1.8.4' boto3
+source virtualenv.sh
+pip install 'botocore>1.8.4' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/network_force_new_deployment.yml "$@"
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.10.37' boto3 # version 1.10.37 for scheduling strategy
+source virtualenv.sh
+pip install 'botocore>=1.10.37' boto3 # version 1.10.37 for scheduling strategy
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/efs/runme.sh
+++ b/test/integration/targets/efs/runme.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
-# Test graceful failure for older versions of botocore
+
+set -eux
+
 export ANSIBLE_ROLES_PATH=../
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-less-than-1.10.57"
-source "${MYTMPDIR}/botocore-less-than-1.10.57/bin/activate"
-"${PYTHON}" -m pip install 'botocore<1.10.57' boto3
+
+# Test graceful failure for older versions of botocore
+source virtualenv.sh
+pip install 'botocore<1.10.57' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
+
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.10.57' boto3
+source virtualenv.sh
+pip install 'botocore>=1.10.57' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/elb_target/runme.sh
+++ b/test/integration/targets/elb_target/runme.sh
@@ -1,26 +1,13 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
-
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
+set -eux
 
 # Test graceful failure for older versions of botocore
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-1.7.1"
-source "${MYTMPDIR}/botocore-1.7.1/bin/activate"
-$PYTHON -m pip install 'botocore<=1.7.1' boto3
+source virtualenv.sh
+pip install 'botocore<=1.7.1' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/botocore-recent"
-source "${MYTMPDIR}/botocore-recent/bin/activate"
-$PYTHON -m pip install 'botocore>=1.8.0' boto3
+source virtualenv.sh
+pip install 'botocore>=1.8.0' boto3
 ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
-

--- a/test/integration/targets/old_style_cache_plugins/runme.sh
+++ b/test/integration/targets/old_style_cache_plugins/runme.sh
@@ -1,19 +1,8 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
+set -eux
 
-MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
-
-trap 'rm -rf "${MYTMPDIR}"' EXIT
-
-# This is needed for the ubuntu1604py3 tests
-# Ubuntu patches virtualenv to make the default python2
-# but for the python3 tests we need virtualenv to use python3
-PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
-
-virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/redis-cache"
-source "${MYTMPDIR}/redis-cache/bin/activate"
+source virtualenv.sh
 
 # Run test if dependencies are installed
 failed_dep_1=$(ansible localhost -m pip -a "name=redis>=2.4.5 state=present" "$@" | tee out.txt | grep -c 'FAILED!' || true)


### PR DESCRIPTION
##### SUMMARY

Correct virtualenv usage in integration tests.

Tests that invoke `virtualenv` directly don't work properly under ansible-test any more. This PR simply replaces those direct invocations with usage of our `virtualenv.sh` helper script.

Since these tests are all marked unsupported they may still have other issues preventing them from passing.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
