### PR TITLE
Fix file descriptor leak in lineinfile module.

### DIFF
--- a/changelogs/fragments/57327-fix-file-descriptor-leak.yaml
+++ b/changelogs/fragments/57327-fix-file-descriptor-leak.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- lineinfile - fix a race / file descriptor leak when writing the file (https://github.com/ansible/ansible/issues/57327)

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -215,7 +215,7 @@ from ansible.module_utils._text import to_bytes, to_native
 def write_changes(module, b_lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
-    with open(tmpfile, 'wb') as f:
+    with os.fdopen(tmpfd, 'wb') as f:
         f.writelines(b_lines)
 
     validate = module.params.get('validate', None)


### PR DESCRIPTION
##### SUMMARY

Fix a minor file descriptor leak in the lineinfile module.

Fixes #57327

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- lineinfile

##### ADDITIONAL INFORMATION

This simply restores the prior `os.fdopen()` call so that the unmanaged file descriptor is consumed by a Python file object.