### PR TITLE
modules/gem: work around "default:" in version list

### DIFF
--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -171,7 +171,7 @@ def get_installed_versions(module, remote=False):
     (rc, out, err) = module.run_command(cmd, environ_update=environ, check_rc=True)
     installed_versions = []
     for line in out.splitlines():
-        match = re.match(r"\S+\s+\((.+)\)", line)
+        match = re.match(r"\S+\s+\((?:default: )?(.+)\)", line)
         if match:
             versions = match.group(1)
             for version in versions.split(', '):


### PR DESCRIPTION
##### SUMMARY

Fix parsing of installed version in get_installed_versions:

gem query output of

    bundler (default: 1.17.2, 1.17.1)

Gets parsed as:

    ['default:', '1.17.1']

Fix this by skipping "default: " if present in the list of versions - by adding
it as an optional part of the regex, grouped as a non-capturing group to keep
the index of existing group.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gem

##### ADDITIONAL INFORMATION
Included in summary.