### PR TITLE
Update consul_kv.py add token to lookup get kv

### DIFF
--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -143,8 +143,9 @@ class LookupModule(LookupBase):
                     scheme = kwargs.get('scheme', 'http')
                     validate_certs = kwargs.get('validate_certs', True)
                     client_cert = kwargs.get('client_cert', None)
+                    tokenapi =  kwargs.get('token', None)
                     consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs,
-                                               cert=client_cert)
+                                               cert=client_cert, token=tokenapi)
 
                 results = consul_api.kv.get(params['key'],
                                             token=params['token'],

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -143,7 +143,7 @@ class LookupModule(LookupBase):
                     scheme = kwargs.get('scheme', 'http')
                     validate_certs = kwargs.get('validate_certs', True)
                     client_cert = kwargs.get('client_cert', None)
-                    tokenapi =  kwargs.get('token', None)
+                    tokenapi = kwargs.get('token', None)
                     consul_api = consul.Consul(host=host, port=port, scheme=scheme, verify=validate_certs,
                                                cert=client_cert, token=tokenapi)
 


### PR DESCRIPTION
add token for lookup get kv

##### SUMMARY

Token is not apply with lookup to get kv and needed to target host

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

consul_kv.py

##### ADDITIONAL INFORMATION
Error was rpc error making call: Permission denied"

{{ lookup('consul_kv', '{{item}}',token='xxxx-zzzz-xxxx-zzzz', host='xx.xx.xx.xx', port='8500') }}
