### PR TITLE
aws: Update description for iam_role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -338,7 +338,7 @@ def create_or_update_role(connection, module):
                 connection.add_role_to_instance_profile(InstanceProfileName=params['RoleName'], RoleName=params['RoleName'])
 
     # Check Description update
-    if not role.get('MadeInCheckMode') and params.get('Description') and role['Description'] != params['Description']:
+    if not role.get('MadeInCheckMode') and params.get('Description') and role.get('Description') != params['Description']:
         try:
             if not module.check_mode:
                 connection.update_role_description(RoleName=params['RoleName'], Description=params['Description'])


### PR DESCRIPTION
##### SUMMARY
If IAM Role is created without description using aws cli or UI,
then Ansible failed to update description for such IAM role.
This fixes such condition.

Fixes: #52942

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/iam_role.py
