### PR TITLE
Add note regarding remote_src default change

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -57,6 +57,7 @@ options:
     description:
     - If C(no), it will search for src at originating/master machine.
     - If C(yes), it will go to the remote/target machine for the src.
+    - Note: Default was changed from C(yes) to C(no) in version 2.8
     type: bool
     default: no
     version_added: '1.4'

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -57,7 +57,7 @@ options:
     description:
     - If C(no), it will search for src at originating/master machine.
     - If C(yes), it will go to the remote/target machine for the src.
-    - Note: Default was changed from C(yes) to C(no) in version 2.8
+    - Note the default was changed from C(yes) to C(no) in version 2.8
     type: bool
     default: no
     version_added: '1.4'


### PR DESCRIPTION
##### SUMMARY
The default value for Assemble "remote_src" parameter has been changed from "yes" to "no" in version 2.8.
Added a note to that effect.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
assemble module

##### ADDITIONAL INFORMATION
As evidenced by the documentation:
https://docs.ansible.com/ansible/2.7/modules/assemble_module.html
https://docs.ansible.com/ansible/2.8/modules/assemble_module.html