### PR TITLE
Add module read_mail

### DIFF
--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -3,8 +3,8 @@
 # Copyright: (c) 2018, Caio Ramos <caioramos97@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-__metaclass__ = type
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: read_mail
 
@@ -23,7 +23,7 @@ version_added: "2.9"
 description:
     - Get emails from a IMAP server using basic filtering rules and returns
       the email count and a list of dictionaries where each represents an email
-      that satisfied the filters. This module is intended to be used by other 
+      that satisfied the filters. This module is intended to be used by other
       tasks that take actions depending on the result of the emails.
 
 options:
@@ -66,7 +66,7 @@ author:
     - Gabriely Rangel (@gprangel)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Read mails from "imap.myhost.com" with default user (localhost) and password "mypass"
   read_mail:
     host: imap.myhost.com
@@ -100,7 +100,7 @@ EXAMPLES = '''
       unseen:
 '''
 
-RETURN = '''
+RETURN = r'''
 host:
     description: The host used to perform the request
     type: str

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -110,7 +110,7 @@ username:
     type: str
     returned: always
 mails:
-    description: A list of dictionaries with the keys 'to', 'from' and 'subject',
+    description: A list of dictionaries with the keys 'to', 'from', 'subject' and 'body',
         where each one represents an email that satisfied the filter
     type: list
     returned: always
@@ -200,7 +200,8 @@ def run_module():
         result['mails'].append({
             'to': decode_header(msg['to'])[0][0],
             'from': decode_header(msg['from'])[0][0],
-            'subject': decode_header(msg['subject'])[0][0]
+            'subject': decode_header(msg['subject'])[0][0],
+            'body': msg.get_payload(0).get_payload(None, True)
         })
     result['mails_count'] = len(result['mails'])
 

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -3,6 +3,9 @@
 # Copyright: (c) 2018, Caio Ramos <caioramos97@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+__metaclass__ = type
+from __future__ import (absolute_import, division, print_function)
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
@@ -15,7 +18,7 @@ module: read_mail
 
 short_description: Module for reading emails from a IMAP server
 
-version_added: "2.8"
+version_added: "2.9"
 
 description:
     - "Get emails from a IMAP server using basic filtering rules an returns an email count and list"
@@ -28,9 +31,9 @@ options:
         default: localhost
     port:
         description:
-            - IMAP server port
+            - IMAP server port (defaults to 993 or 143)
         required: false
-        default: 993 or 143
+        default: None
     username:
         description:
             - Username to get the emails
@@ -53,11 +56,11 @@ options:
         description:
             - Default IMAP filters. Checkout the options at blablabla.
         required: false
-        default: ALL
+        default: {'ALL': ''}
 
 author:
     - Caio Ramos (@caiohsramos)
-    - Gabriely Rangel (@)
+    - Gabriely Rangel (@gprangel)
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -111,7 +111,7 @@ username:
     returned: always
 mails:
     description: A list of dictionaries with the keys 'to', 'from' and 'subject',
-    where each one represents an email that satisfied the filter
+        where each one represents an email that satisfied the filter
     type: list
     returned: always
 mails_count:

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -33,7 +33,7 @@ options:
         description:
             - IMAP server port (defaults to 993 or 143)
         required: false
-        default: None
+        default: 993
     username:
         description:
             - Username to get the emails
@@ -54,7 +54,7 @@ options:
         default: INBOX
     filter:
         description:
-            - Default IMAP filters. Checkout the options at blablabla.
+            - Default IMAP filters. Checkout the options at RFC 3501 section 6.4.4.
         required: false
         default: {'ALL': ''}
 
@@ -80,7 +80,7 @@ EXAMPLES = '''
     ssl: no
 
 # using filters
-- name: Read mails with filters
+- name: Read mails with 'subject' and 'to' filters
   read_mail:
     host: imap.myhost.com
     port: 42
@@ -89,6 +89,15 @@ EXAMPLES = '''
     filter:
       subject: mysubject
       to: example@example.com
+
+- name: Read unseen mails with 'subject' filter
+  read_mail:
+    host: imap.myhost.com
+    username: myuser
+    password: mypass
+    filter:
+      subject: mysubject
+      unseen: 
 '''
 
 RETURN = '''
@@ -173,7 +182,8 @@ def run_module():
     search_array = []
     for k, v in module.params['filter'].items():
         search_array.append(k)
-        search_array.append(v)
+        if v:
+            search_array.append(v)
     status, search = M.search(None, *search_array)
     if status != 'OK':
         module.fail_json(msg='Error filtering', **result)

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -31,9 +31,9 @@ options:
         default: localhost
     port:
         description:
-            - IMAP server port (defaults to 993 or 143)
+            - IMAP server port (defaults to 993 or 143 when less then 0)
         required: false
-        default: 993
+        default: -1
     username:
         description:
             - Username to get the emails
@@ -97,7 +97,7 @@ EXAMPLES = '''
     password: mypass
     filter:
       subject: mysubject
-      unseen: 
+      unseen:
 '''
 
 RETURN = '''
@@ -137,7 +137,7 @@ def run_module():
         username=dict(type='str', required=True),
         password=dict(type='str', required=True, no_log=True),
         ssl=dict(type='bool', required=False, default=True),
-        port=dict(type='int', required=False, default=None),
+        port=dict(type='int', required=False, default=-1),
         mailbox=dict(type='str', required=False, default='INBOX'),
         filter=dict(type='dict', required=False, default={'ALL': ''})
     )
@@ -161,10 +161,10 @@ def run_module():
     # create connection
     try:
         if module.params['ssl']:
-            port = 993 if module.params['port'] is None else module.params['port']
+            port = 993 if module.params['port'] < 0 else module.params['port']
             M = imaplib.IMAP4_SSL(module.params['host'], port=port)
         else:
-            port = 143 if module.params['port'] is None else module.params['port']
+            port = 143 if module.params['port'] < 0 else module.params['port']
             M = imaplib.IMAP4(module.params['host'], port=port)
     except Exception as e:
         module.fail_json(msg=str(e), **result)

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -62,13 +62,13 @@ author:
 
 EXAMPLES = '''
 # simplest use
-- name: Test with a message
+- name: Read mails
   read_mail:
     host: imap.myhost.com
     password: mypass
 
 # no ssl and custom username and port
-- name: Test with a message and changed output
+- name: Read mails
   read_mail:
     host: imap.myhost.com
     port: 42
@@ -77,7 +77,7 @@ EXAMPLES = '''
     ssl: no
 
 # using filters
-- name: Test failure of the module
+- name: Read mails with filters
   read_mail:
     host: imap.myhost.com
     port: 42
@@ -120,7 +120,6 @@ else:
 
 
 def run_module():
-    # define available arguments/parameters a user can pass to the module
     module_args = dict(
         host=dict(type='str', required=False, default='localhost'),
         username=dict(type='str', required=True),
@@ -131,20 +130,11 @@ def run_module():
         filter=dict(type='dict', required=False, default={'ALL': ''})
     )
 
-    # the AnsibleModule object will be our abstraction working with Ansible
-    # this includes instantiation, a couple of common attr would be the
-    # args/params passed to the execution, as well as if the module
-    # supports check mode
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=True
     )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
     result = dict(
         changed=True,
         username=module.params['username'],
@@ -153,17 +143,8 @@ def run_module():
         mails_count=0
     )
 
-    # if the user is working with this module in only check mode we do not
-    # want to make any changes to the environment, just return the current
-    # state with no modifications
     if module.check_mode:
         module.exit_json(**result)
-
-    # during the execution of the module, if there is an exception or a
-    # conditional state that effectively causes a failure, run
-    # AnsibleModule.fail_json() to pass in the message and the result
-    # if module.params['name'] == 'fail me':
-    #     module.fail_json(msg='You requested this to fail', **result)
 
     # create connection
     try:
@@ -208,8 +189,7 @@ def run_module():
             'subject': decode_header(msg['subject'])[0][0]
         })
     result['mails_count'] = len(result['mails'])
-    # in the event of a successful module execution, you will want to
-    # simple AnsibleModule.exit_json(), passing the key/value results
+
     module.exit_json(**result)
 
 

--- a/lib/ansible/modules/net_tools/basics/read_mail.py
+++ b/lib/ansible/modules/net_tools/basics/read_mail.py
@@ -110,7 +110,7 @@ username:
     type: str
     returned: always
 mails:
-    description: A list of dictionaries with the keys: 'to', 'from' and 'subject',
+    description: A list of dictionaries with the keys 'to', 'from' and 'subject',
     where each one represents an email that satisfied the filter
     type: list
     returned: always

--- a/lib/ansible/modules/notification/read_mail.py
+++ b/lib/ansible/modules/notification/read_mail.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: my_sample_module
+
+short_description: This is my sample module
+
+version_added: "2.4"
+
+description:
+    - "This is my longer description explaining my sample module"
+
+options:
+    name:
+        description:
+            - This is the message to send to the sample module
+        required: true
+    new:
+        description:
+            - Control to demo if the result of this module is changed or not
+        required: false
+
+extends_documentation_fragment:
+    - azure
+
+author:
+    - Your Name (@yourhandle)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Test with a message
+  my_new_test_module:
+    name: hello world
+
+# pass in a message and have changed true
+- name: Test with a message and changed output
+  my_new_test_module:
+    name: hello world
+    new: true
+
+# fail the module
+- name: Test failure of the module
+  my_new_test_module:
+    name: fail me
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+    returned: always
+message:
+    description: The output message that the sample module generates
+    type: str
+    returned: always
+'''
+import imaplib
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        host=dict(type='str', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True),
+        ssl=dict(type='bool', required=False, default=True),
+        port=dict(type='int', required=False, default=None)
+    )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # change is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+        username='',
+        host='',
+        password='',
+        ssl='',
+        list=''
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        module.exit_json(**result)
+
+    # during the execution of the module, if there is an exception or a
+    # conditional state that effectively causes a failure, run
+    # AnsibleModule.fail_json() to pass in the message and the result
+    # if module.params['name'] == 'fail me':
+    #     module.fail_json(msg='You requested this to fail', **result)
+    try:
+        if module.params['ssl']:
+            port = 993 if module.params['port'] is None else module.params['port']
+            M = imaplib.IMAP4_SSL(module.params['host'], port=port)
+        else:
+            port = 143 if module.params['port'] is None else module.params['port']
+            M = imaplib.IMAP4(module.params['host'], port=port)
+    except Exception as e:
+        module.fail_json(msg=str(e), **result)
+
+    try:
+        M.login(module.params['username'], module.params['password'])
+    except Exception as e:
+        module.fail_json(msg=str(e), **result)
+
+    M.list()
+    M.select('inbox')
+    _, search = M.search(None, 'SUBJECT', '"Subject"')
+    last_email_id = search[0].split()[-1]
+    _, body = M.fetch(last_email_id, '(RFC822)')
+    print(body[0][1])
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/notification/read_mail.py
+++ b/lib/ansible/modules/notification/read_mail.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# Copyright: (c) 2018, Caio Ramos <caioramos97@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {
@@ -11,58 +11,99 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: my_sample_module
+module: read_mail
 
-short_description: This is my sample module
+short_description: Module for reading emails from a IMAP server
 
-version_added: "2.4"
+version_added: "2.8"
 
 description:
-    - "This is my longer description explaining my sample module"
+    - "Get emails from a IMAP server using basic filtering rules an returns an email count and list"
 
 options:
-    name:
+    host:
         description:
-            - This is the message to send to the sample module
-        required: true
-    new:
-        description:
-            - Control to demo if the result of this module is changed or not
+            - IMAP server host
         required: false
-
-extends_documentation_fragment:
-    - azure
+        default: localhost
+    port:
+        description:
+            - IMAP server port
+        required: false
+        default: 993 or 143
+    username:
+        description:
+            - Username to get the emails
+        required: true
+    password:
+        description:
+            - Password to get the emails
+        required: true
+    ssl:
+        description:
+            - Whether to use SSL or not
+        required: false
+        default: true
+    mailbox:
+        description:
+            - Select the mailbox to use
+        required: false
+        default: INBOX
+    filter:
+        description:
+            - Default IMAP filters. Checkout the options at blablabla.
+        required: false
+        default: ALL
 
 author:
-    - Your Name (@yourhandle)
+    - Caio Ramos (@caiohsramos)
+    - Gabriely Rangel (@)
 '''
 
 EXAMPLES = '''
-# Pass in a message
+# simplest use
 - name: Test with a message
-  my_new_test_module:
-    name: hello world
+  read_mail:
+    host: imap.myhost.com
+    password: mypass
 
-# pass in a message and have changed true
+# no ssl and custom username and port
 - name: Test with a message and changed output
-  my_new_test_module:
-    name: hello world
-    new: true
+  read_mail:
+    host: imap.myhost.com
+    port: 42
+    username: myuser
+    password: mypass
+    ssl: no
 
-# fail the module
+# using filters
 - name: Test failure of the module
-  my_new_test_module:
-    name: fail me
+  read_mail:
+    host: imap.myhost.com
+    port: 42
+    username: myuser
+    password: mypass
+    filter:
+      subject: mysubject
+      to: example@example.com
 '''
 
 RETURN = '''
-original_message:
-    description: The original name param that was passed in
+host:
+    description: The original host param that was passed in
     type: str
     returned: always
-message:
-    description: The output message that the sample module generates
+username:
+    description: The username used in the request
     type: str
+    returned: always
+mails:
+    description: A list of the email's headers that satisfied the filter
+    type: list
+    returned: always
+mails_count:
+    description: The email count that satisfied the filter
+    type: int
     returned: always
 '''
 import imaplib


### PR DESCRIPTION
##### SUMMARY
Developing new module `read_mail` with IMAP standart lib

Fixes #51151

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
read_mail.py

##### ADDITIONAL INFORMATION
Usage example:
```yml
- read_mail:
    host: "{{ imap_host }}"
    username: "{{ imap_user }}"
    password: "{{ imap_password }}"
    ssl: True
    filter:
      subject: "subject_should_contain_this"
      from: "email@example.com"
```