### PR TITLE
Fix nxos_vtp_version test

### DIFF
--- a/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vtp_version/tests/common/sanity.yaml
@@ -21,6 +21,11 @@
       provider: "{{ connection }}"
       state: enabled
 
+  - name: configure supporting vtp domain
+    nxos_vtp_domain:
+      domain: foo
+      provider: "{{ connection }}"
+
   - name: configure vtp version
     nxos_vtp_version: &configure
       version: 2
@@ -30,7 +35,7 @@
   - assert: &true
       that:
         - "result.changed == true"
-  
+
   - name: "Conf Idempotence"
     nxos_vtp_version: *configure
     register: result
@@ -39,7 +44,7 @@
       that:
         - "result.changed == false"
 
-  when: vtp_run
+  when: vtp_run | bool
 
   always:
   - name: disable feature vtp


### PR DESCRIPTION
##### SUMMARY
Some nxos versions require a vtp domain name to be configured before the version can be set.

This PR adds a step to configure a supporting domain name and fixes an ansible warning when evaluating bare boolean expression.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vtp_version

##### ADDITIONAL INFORMATION
Tested against n3k, n6k, n7k, n9k platforms