### PR TITLE
enabled check mode on nxos bgp modules

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp.py
@@ -650,7 +650,8 @@ def main():
 
     if candidate:
         candidate = candidate.items_text()
-        load_config(module, candidate)
+        if not module.check_mode:
+            load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -763,7 +763,8 @@ def main():
 
     if candidate:
         candidate = candidate.items_text()
-        load_config(module, candidate)
+        if not module.check_mode:
+          load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -764,7 +764,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-          load_config(module, candidate)
+        	load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -764,7 +764,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-        	load_config(module, candidate)
+            load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -473,7 +473,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-        	load_config(module, candidate)
+            load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -472,7 +472,8 @@ def main():
 
     if candidate:
         candidate = candidate.items_text()
-        load_config(module, candidate)
+        if not module.check_mode:
+          load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -473,7 +473,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-          load_config(module, candidate)
+        	load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -679,7 +679,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-        	load_config(module, candidate)
+            load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -678,7 +678,8 @@ def main():
 
     if candidate:
         candidate = candidate.items_text()
-        load_config(module, candidate)
+        if not module.check_mode:
+          load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -679,7 +679,7 @@ def main():
     if candidate:
         candidate = candidate.items_text()
         if not module.check_mode:
-          load_config(module, candidate)
+        	load_config(module, candidate)
         result['changed'] = True
         result['commands'] = candidate
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implemented "Check Mode" for the following NXOS BGP modules:
- nxos_bgp
- nxos_bgp_af
- nxos_bgp_neighbor
- nxos_bgp_neighbor_af

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- nxos_bgp
- nxos_bgp_af
- nxos_bgp_neighbor
- nxos_bgp_neighbor_af

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I unfortunately found out that these modules did not have "check mode" implemented when testing against network infrastructure and thought I would contribute back to the community.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
