### PR TITLE
[stable-2.8] Fix file descriptor leak in lineinfile module. (#57328)

### DIFF
--- a/changelogs/fragments/57327-fix-file-descriptor-leak.yaml
+++ b/changelogs/fragments/57327-fix-file-descriptor-leak.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- lineinfile - fix a race / file descriptor leak when writing the file (https://github.com/ansible/ansible/issues/57327)

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -215,7 +215,7 @@ from ansible.module_utils._text import to_bytes, to_native
 def write_changes(module, b_lines, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
-    with open(tmpfile, 'wb') as f:
+    with os.fdopen(tmpfd, 'wb') as f:
         f.writelines(b_lines)
 
     validate = module.params.get('validate', None)


### PR DESCRIPTION
##### SUMMARY
Backport of #57328 for Ansible 2.8

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/files/lineinfile.py`