### PR TITLE
Set vscan_fileop_profile for na_ontap_cifs

### DIFF
--- a/test/units/modules/storage/netapp/test_na_ontap_cifs.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_cifs.py
@@ -75,8 +75,11 @@ class MockONTAPConnection(object):
         data = {'num-records': 1, 'attributes-list': {'cifs-share': {
             'share-name': 'test',
             'path': '/test',
-            'share-properties': {'cifs-share-properties': 'browsable'},
-            'symlink-properties': {'cifs-share-symlink-properties': 'enable'},
+            'vscan-fileop-profile': 'standard',
+            'share-properties': {'cifs-share-properties': 'browsable',
+                                 'cifs-share-properties': 'oplocks'},
+            'symlink-properties': {'cifs-share-symlink-properties': 'enable',
+                                   'cifs-share-symlink-properties': 'read_only'},
         }}}
         xml.translate_struct(data)
         print(xml.to_string())
@@ -104,6 +107,7 @@ class TestMyModule(unittest.TestCase):
             path = '/test'
             share_properties = 'browsable,oplocks'
             symlink_properties = 'disable'
+            vscan_fileop_profile = 'standard'
             vserver = 'abc'
         else:
             hostname = '10.193.77.37'
@@ -113,6 +117,7 @@ class TestMyModule(unittest.TestCase):
             path = '/test'
             share_properties = 'show_previous_versions'
             symlink_properties = 'disable'
+            vscan_fileop_profile = 'no_scan'
             vserver = 'abc'
         return dict({
             'hostname': hostname,
@@ -122,6 +127,7 @@ class TestMyModule(unittest.TestCase):
             'path': path,
             'share_properties': share_properties,
             'symlink_properties': symlink_properties,
+            'vscan_fileop_profile': vscan_fileop_profile,
             'vserver': vserver
         })
 

--- a/test/units/modules/storage/netapp/test_na_ontap_cifs.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_cifs.py
@@ -76,10 +76,10 @@ class MockONTAPConnection(object):
             'share-name': 'test',
             'path': '/test',
             'vscan-fileop-profile': 'standard',
-            'share-properties': {'cifs-share-properties': 'browsable',
-                                 'cifs-share-properties': 'oplocks'},
-            'symlink-properties': {'cifs-share-symlink-properties': 'enable',
-                                   'cifs-share-symlink-properties': 'read_only'},
+            'share-properties': [{'cifs-share-properties': 'browsable'},
+                                 {'cifs-share-properties': 'oplocks'}],
+            'symlink-properties': [{'cifs-share-symlink-properties': 'enable'},
+                                   {'cifs-share-symlink-properties': 'read_only'}],
         }}}
         xml.translate_struct(data)
         print(xml.to_string())


### PR DESCRIPTION
##### SUMMARY
Set vscan_fileop_profile for na_ontap_cifs

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
- na_ontap_cifs.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
