### PR TITLE
group_chars: default change warning only when needed (#57312)

### DIFF
--- a/changelogs/fragments/group-chars-ignore.yaml
+++ b/changelogs/fragments/group-chars-ignore.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- suppress "default will change" warnings for ``TRANSFORM_INVALID_GROUP_CHARS``
+  setting when non-default option value is chosen

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -48,8 +48,10 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
                     warn = 'Invalid characters were found in group names but not replaced, use -vvvv to see details'
 
                 # remove this message after 2.10 AND changing the default to 'always'
-                display.deprecated('The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default,'
-                                   ' this will change, but still be user configurable on deprecation', version='2.10')
+                group_chars_setting, group_chars_origin = C.config.get_config_value_and_origin('TRANSFORM_INVALID_GROUP_CHARS')
+                if group_chars_origin == 'default':
+                    display.deprecated('The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default,'
+                                       ' this will change, but still be user configurable on deprecation', version='2.10')
 
     if warn:
         display.warning(warn)


### PR DESCRIPTION
(cherry picked from commit 1fb0335243b4d0cdeda4462a8f0fdf01a8a89cf5)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/ansible/ansible/pull/57312

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
