### PR TITLE
Limit Python 2.6 units to modules & module_utils.

### DIFF
--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -15,5 +15,14 @@ fi
 
 ansible-test env --timeout "${timeout}" --color -v
 
+if [[ "${version}" = "2.6" ]]; then
+    # Python 2.6 is only supported for modules and module_utils.
+    # Eventually this logic will move into ansible-test itself.
+    targets=("test/units/(modules|module_utils)/")
+else
+    targets=()
+fi
+
 # shellcheck disable=SC2086
 ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    "${targets[@]}" \

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -20,7 +20,7 @@ if [[ "${version}" = "2.6" ]]; then
     # Eventually this logic will move into ansible-test itself.
     targets=("test/units/(modules|module_utils)/")
 else
-    targets=()
+    targets=("test/units/")
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY

Limit Python 2.6 units to modules & module_utils.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unit tests
