### PR TITLE
Correct grammar

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -280,7 +280,7 @@ class InventoryManager(object):
                         tb = ''.join(traceback.format_tb(sys.exc_info()[2]))
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': AnsibleError(e), 'tb': tb})
                 else:
-                    display.vvv("%s declined parsing %s as it did not pass it's verify_file() method" % (plugin_name, source))
+                    display.vvv("%s declined parsing %s as it did not pass its verify_file() method" % (plugin_name, source))
             else:
                 if not parsed and failures:
                     # only if no plugin processed files should we show errors.


### PR DESCRIPTION
"it's" == "it is"
"its" == "belonging to it"

##### SUMMARY

Trivial grammar fix

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ADDITIONAL INFORMATION

Drive-by fix; should have minimal/zero impact, unless there's something else in the codebase looking for the tool to produce this particular string.  (I searched the repo and couldn't find any such code.)