### PR TITLE
Mark win_chocolatey as unstable in 2.8 until next release

### DIFF
--- a/test/integration/targets/win_chocolatey/aliases
+++ b/test/integration/targets/win_chocolatey/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group5
+disabled


### PR DESCRIPTION
##### SUMMARY
Disables the test so we can do the 2.8.1 release, once that is over the tests can be re-enabled with https://github.com/ansible/ansible/pull/57380.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_chocolatey