### PR TITLE
Only update essential tower role parameters

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -87,7 +87,7 @@ def update_resources(module, p):
     '''update_resources attempts to fetch any of the resources given
     by name using their unique field (identity)
     '''
-    params = p.copy()
+    params = dict()
     identity_map = {
         'user': 'username',
         'team': 'name',
@@ -100,9 +100,9 @@ def update_resources(module, p):
     }
     for k, v in identity_map.items():
         try:
-            if params[k]:
+            if p[k]:
                 key = 'team' if k == 'target_team' else k
-                result = tower_cli.get_resource(key).get(**{v: params[k]})
+                result = tower_cli.get_resource(key).get(**{v: p[k]})
                 params[k] = result['id']
         except (exc.NotFound) as excinfo:
             module.fail_json(msg='Failed to update role, {0} not found: {1}'.format(k, excinfo), changed=False)


### PR DESCRIPTION
##### SUMMARY

Copying all tower_role parameters means that flags such as
`tower_verify_ssl` gets passed to role.grant, which errors with:

```
    Response: {"detail":"Role has no field named 'tower_verify_ssl'"}
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower_role

##### ADDITIONAL INFORMATION
Backport candidate for 2.8