### PR TITLE
Various ansible-test fixes and improvements.

### DIFF
--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -182,6 +182,10 @@ def parse_args():
                         action='store_true',
                         help='redact sensitive values in output')
 
+    common.add_argument('--check-python',
+                        choices=SUPPORTED_PYTHON_VERSIONS,
+                        help=argparse.SUPPRESS)
+
     test = argparse.ArgumentParser(add_help=False, parents=[common])
 
     test.add_argument('include',

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -165,6 +165,14 @@ def delegate_tox(args, exclude, require, integration_targets):
         if not args.python:
             cmd += ['--python', version]
 
+        # newer versions of tox do not support older python versions and will silently fall back to a different version
+        # passing this option will allow the delegated ansible-test to verify it is running under the expected python version
+        # tox 3.0.0 dropped official python 2.6 support: https://tox.readthedocs.io/en/latest/changelog.html#v3-0-0-2018-04-02
+        # tox 3.1.3 is the first version to support python 3.8 and later: https://tox.readthedocs.io/en/latest/changelog.html#v3-1-3-2018-08-03
+        # tox 3.1.3 appears to still work with python 2.6, making it a good version to use when supporting all python versions we use
+        # virtualenv 16.0.0 dropped python 2.6 support: https://virtualenv.pypa.io/en/latest/changes/#v16-0-0-2018-05-16
+        cmd += ['--check-python', version]
+
         if isinstance(args, TestConfig):
             if args.coverage and not args.coverage_label:
                 cmd += ['--coverage-label', 'tox-%s' % version]

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -74,6 +74,7 @@ from lib.docker_util import (
 
 from lib.ansible_util import (
     ansible_environment,
+    check_pyyaml,
 )
 
 from lib.target import (
@@ -804,6 +805,8 @@ def command_integration_filtered(args, targets, all_targets, inventory_path, pre
     if setup_errors:
         raise ApplicationError('Found %d invalid setup aliases:\n%s' % (len(setup_errors), '\n'.join(setup_errors)))
 
+    check_pyyaml(args, args.python_version)
+
     test_dir = os.path.expanduser('~/ansible_testing')
 
     if not args.explain and any('needs/ssh/' in target.aliases for target in targets):
@@ -1347,6 +1350,8 @@ def command_units(args):
         sys.exit()
 
     for version, command, env in version_commands:
+        check_pyyaml(args, version)
+
         display.info('Unit test with Python %s' % version)
 
         try:

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -23,6 +23,7 @@ from lib.util import (
 
 from lib.ansible_util import (
     ansible_environment,
+    check_pyyaml,
 )
 
 from lib.target import (
@@ -99,6 +100,8 @@ def command_sanity(args):
         for version in versions:
             if args.python and version and version != args.python_version:
                 continue
+
+            check_pyyaml(args, version or args.python_version)
 
             display.info('Sanity check using %s%s' % (test.name, ' with Python %s' % version if version else ''))
 

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -215,6 +215,10 @@ class SanityTest(ABC):
 
 class SanityCodeSmellTest(SanityTest):
     """Sanity test script."""
+    UNSUPPORTED_PYTHON_VERSIONS = (
+        '2.6',  # some tests use voluptuous, but the version we require does not support python 2.6
+    )
+
     def __init__(self, path):
         name = os.path.splitext(os.path.basename(path))[0]
         config_path = os.path.splitext(path)[0] + '.json'
@@ -238,6 +242,10 @@ class SanityCodeSmellTest(SanityTest):
         :type targets: SanityTargets
         :rtype: TestResult
         """
+        if args.python_version in self.UNSUPPORTED_PYTHON_VERSIONS:
+            display.warning('Skipping %s on unsupported Python version %s.' % (self.name, args.python_version))
+            return SanitySkipped(self.name)
+
         if self.path.endswith('.py'):
             cmd = [args.python_executable, self.path]
         else:

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -489,6 +489,17 @@ def common_environment():
         # export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
         'OBJC_DISABLE_INITIALIZE_FORK_SAFETY',
         'ANSIBLE_KEEP_REMOTE_FILES',
+        # MacOS Homebrew Compatibility
+        # https://cryptography.io/en/latest/installation/#building-cryptography-on-macos
+        # This may also be required to install pyyaml with libyaml support when installed in non-standard locations.
+        # Example configuration for brew on macOS:
+        # export LDFLAGS="-L$(brew --prefix openssl)/lib/     -L$(brew --prefix libyaml)/lib/"
+        # export  CFLAGS="-I$(brew --prefix openssl)/include/ -I$(brew --prefix libyaml)/include/"
+        # However, this is not adequate for PyYAML 3.13, which is the latest version supported on Python 2.6.
+        # For that version the standard location must be used, or `pip install` must be invoked with additional options:
+        # --global-option=build_ext --global-option=-L{path_to_lib_dir}
+        'LDFLAGS',
+        'CFLAGS',
     )
 
     env.update(pass_vars(required=required, optional=optional))

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -485,6 +485,8 @@ def common_environment():
         'SSH_AUTH_SOCK',
         # MacOS High Sierra Compatibility
         # http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html
+        # Example configuration for macOS:
+        # export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
         'OBJC_DISABLE_INITIALIZE_FORK_SAFETY',
         'ANSIBLE_KEEP_REMOTE_FILES',
     )

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -40,5 +40,5 @@ isort == 4.3.15
 lazy-object-proxy == 1.3.1
 mccabe == 0.6.1
 pylint == 2.3.1
-typed-ast == 1.3.1
+typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1

--- a/test/runner/requirements/integration.cloud.hcloud.txt
+++ b/test/runner/requirements/integration.cloud.hcloud.txt
@@ -1,1 +1,1 @@
-hcloud
+hcloud ; python_version >= '2.7' and python_version <= '3.7'  # Python 2.6 and 3.8 are not supported

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -9,5 +9,5 @@ rstcheck ; python_version >= '2.7' # rstcheck requires python 2.7+
 sphinx
 straight.plugin  # needed for hacking/build-ansible which will host changelog generation
 virtualenv
-voluptuous
+voluptuous ; python_version >= '2.7' # voluptuous 0.11.0 and later require python 2.7+
 yamllint

--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -5,7 +5,7 @@ minversion = 2.5.0
 [testenv]
 changedir = {toxinidir}/../../
 commands = {posargs}
-passenv = HOME LC_ALL SHIPPABLE* ANSIBLE_KEEP_REMOTE_FILES
+passenv = HOME LC_ALL SHIPPABLE* ANSIBLE_KEEP_REMOTE_FILES LDFLAGS CFLAGS
 args_are_paths = False
 deps = setuptools == 35.0.2
     wheel < 0.30.0 ; python_version < '2.7'

--- a/test/runner/yamlcheck.py
+++ b/test/runner/yamlcheck.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Show python and pip versions."""
+
+import json
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+try:
+    from yaml import CLoader
+except ImportError:
+    CLoader = None
+
+print(json.dumps(dict(
+    yaml=bool(yaml),
+    cloader=bool(CLoader),
+)))


### PR DESCRIPTION
##### SUMMARY

Various ansible-test fixes and improvements:

- Add missing constraints for hcloud requirement.
- Add missing Python 2.6 constraint for voluptuous.
- Update typed-ast version to support Python 3.8.
- Comment on OBJC_DISABLE_INITIALIZE_FORK_SAFETY.
- Support passing CFLAGS and LDFLAGS.
- Add python version checking when using --tox.
- Disable code-smell tests on Python 2.6.
- Add PyYAML check for libyaml support. 

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
