### PR TITLE
Option for setting PowerShell -ExecutionPolicy by environment variable

### DIFF
--- a/changelogs/fragments/powershel_executionpolicy_setting.yml
+++ b/changelogs/fragments/powershel_executionpolicy_setting.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - powershell - setting -ExecutionPolicy by env variable POWERSHELL_EXECUTIONPOLICY
+  - powershell - support raw module in version 1.0 by setting POWERSHELL_EXECUTIONPOLICY=None

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -28,7 +28,12 @@ from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.shell import ShellBase
 
 
-_common_args = ['PowerShell', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Unrestricted']
+_common_args = ['PowerShell', '-NoProfile', '-NonInteractive']
+
+# Setting to None allows limited support for PowerShell 1.0 (raw module only)
+_powershell_executionpolicy = os.environ.get('POWERSHELL_EXECUTIONPOLICY', 'Unrestricted')
+if _powershell_executionpolicy != "None":
+    _common_args.extend(['-ExecutionPolicy', _powershell_executionpolicy])
 
 # Primarily for testing, allow explicitly specifying PowerShell version via
 # an environment variable.


### PR DESCRIPTION
##### SUMMARY
Allow setting -ExecutionPolicy common argument in PowerShell.

Setting POWESHELL_EXECUTIONPOLICY=None allows running raw winrm commands even on PowerShell 1.0 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
powershell

##### ADDITIONAL INFORMATION
This is a handy hack for all those who must support legacy environments, where PowerShell upgrade or unrestricted PowerShell scripts are not allowed.

Before:
```paste below
# ansible -c winrm win2008host -m raw -a "Get-Host" -v

win2008host | CHANGED | rc=0 >>
Missing expression after unary operator '-'.
At line:1 char:2
+ -E <<<< xecutionPolicy Unrestricted -EncodedCommand RwBlAHQALQBIAG8AcwB0AA==
```

After:
```paste below
# POWERSHELL_EXECUTIONPOLICY=None ansible -c winrm win2008host -m raw -a "Get-Host" -v

win2008host | CHANGED | rc=0 >>

Name             : ConsoleHost
Version          : 1.0.0.0
InstanceId       : [...]
UI               : System.Management.Automation.Internal.Host.InternalHostUserI
                   nterface
CurrentCulture   : en-US
CurrentUICulture : en-US
PrivateData      : Microsoft.PowerShell.ConsoleHost+ConsoleColorProxy
```
