### PR TITLE
tower_workflow_template: unify implementation and add missing parameter

### DIFF
--- a/changelogs/fragments/57350-tower_workflow_template-unify_implementation.yml
+++ b/changelogs/fragments/57350-tower_workflow_template-unify_implementation.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+- use same code structure as in ``tower_job_template``
+- use same parameters as in ``tower_job_template`` module
+- rename survey to survey_spec
+- rename allow_simultaneous to concurrent_jobs_enabled
+- add deprecation warnings for renamed parameters
+- add missing parameter ask_extra_vars

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -57,6 +57,8 @@ No notable changes
 Noteworthy module changes
 -------------------------
 
+* :ref:`tower_workflow_template <tower_workflow_template_module>` `survey` parameter will be deprecated in version `2.14`, use `survey_spec` parameter instead.
+* :ref:`tower_workflow_template <tower_workflow_template_module>` `allow_simultaneous` parameter will be deprecated in version `2.14`, use `concurrent_jobs_enabled` parameter instead.
 * :ref:`vmware_datastore_maintenancemode <vmware_datastore_maintenancemode_module>` now returns ``datastore_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_kernel_manager <vmware_host_kernel_manager_module>` now returns ``host_kernel_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_ntp <vmware_host_ntp_module>` now returns ``host_ntp_status`` instead of Ansible internal key ``results``.

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -40,6 +40,14 @@ except ImportError:
     TOWER_CLI_IMP_ERR = traceback.format_exc()
     HAS_TOWER_CLI = False
 
+YAML_IMP_ERR = None
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    YAML_IMP_ERR = traceback.format_exc()
+    HAS_YAML = False
+
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
@@ -87,6 +95,11 @@ def tower_check_mode(module):
             module.fail_json(changed=False, msg='Failed check mode: {0}'.format(excinfo))
 
 
+def tower_dump_yaml(v):
+    '''Convert variable to yaml'''
+    return yaml.dump(v)
+
+
 class TowerModule(AnsibleModule):
     def __init__(self, argument_spec, **kwargs):
         args = dict(
@@ -111,3 +124,7 @@ class TowerModule(AnsibleModule):
         if not HAS_TOWER_CLI:
             self.fail_json(msg=missing_required_lib('ansible-tower-cli'),
                            exception=TOWER_CLI_IMP_ERR)
+
+        if not HAS_YAML:
+            self.fail_json(msg=missing_required_lib("PyYAML"),
+                           exception=YAML_IMP_ERR)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_template.py
@@ -8,9 +8,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'metadata_version': '1.1'}
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = '''
@@ -18,182 +18,242 @@ DOCUMENTATION = '''
 module: tower_workflow_template
 author: "Adrien Fleury (@fleu42)"
 version_added: "2.7"
-short_description: create, update, or destroy Ansible Tower workflow template.
+short_description: create, update, or destroy Ansible Tower workflow job template.
 description:
-    - Create, update, or destroy Ansible Tower workflows. See
+    - Create, update, or destroy Ansible Tower workflow job templates. See
       U(https://www.ansible.com/tower) for an overview.
 options:
-    allow_simultaneous:
-      description:
-        - If enabled, simultaneous runs of this job template will be allowed.
-      type: bool
-    ask_extra_vars:
-      description:
-        - Prompt user for (extra_vars) on launch.
-      type: bool
-      version_added: "2.9"
-    ask_inventory:
-      description:
-        - Prompt user for inventory on launch.
-      type: bool
-      version_added: "2.9"
-    description:
-      description:
-        - The description to use for the workflow.
-    extra_vars:
-      description:
-        - Extra variables used by Ansible in YAML or key=value format.
-    inventory:
-      description:
-        - Name of the inventory to use for the job template.
-      version_added: "2.9"
     name:
       description:
-        - The name to use for the workflow.
+        - Name to use for the workflow job template.
       required: True
+    description:
+      description:
+        - Description to use for the workflow job template.
     organization:
       description:
         - The organization the workflow is linked to.
-    schema:
+    inventory:
       description:
-        - >
-          The schema is a JSON- or YAML-formatted string defining the
-          hierarchy structure that connects the nodes. Refer to Tower
-          documentation for more information.
+        - Name of the inventory to use for the workflow job template.
+      version_added: 2.9
+    extra_vars:
+      description:
+        - Specify C(extra_vars) for the template.
+      type: dict
+    ask_extra_vars:
+      description:
+        - Prompt user for (extra_vars) on launch.
+      version_added: 2.9
+      type: bool
+      default: 'no'
+    ask_inventory:
+      description:
+        - Prompt user for inventory on launch.
+      version_added: 2.9
+      type: bool
+      default: 'no'
     survey_enabled:
       description:
-        - Setting that variable will prompt the user for job type on the
-          workflow launch.
+        - Enable a survey on the workflow job template.
       type: bool
+      default: 'no'
+    survey_spec:
+      description:
+        - Survey definition
+      version_added: 2.9
+      type: dict
+      required: False
     survey:
       description:
         - The definition of the survey associated to the workflow.
+        - Deprecated in 2.9, will be removed in 2.13. Use parameter C(survey_spec) instead.
+      type: dict
+    schema:
+      description:
+        - >
+          The schema is YAML-formatted list defining the
+          hierarchy structure that connects the nodes. Refer to Tower
+          documentation for more information.
+      type: list
+      required: False
+    concurrent_jobs_enabled:
+      description:
+        - Allow simultaneous runs of the workflow job template.
+      version_added: 2.9
+      type: bool
+      default: 'no'
+    allow_simultaneous:
+      description:
+        - If enabled, simultaneous runs of this job template will be allowed.
+        - Deprecated in 2.9, will be removed in 2.13. Use parameter C(concurrent_jobs_enabled) instead.
+      type: bool
     state:
       description:
         - Desired state of the resource.
       default: "present"
       choices: ["present", "absent"]
 extends_documentation_fragment: tower
+notes:
+  - JSON for survey_spec can be found in Tower API documentation. See
+    U(https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html)
+    for POST operation payload example.
+  - Documentation of schema format can be found in tower-cli documentation API reference. See
+    U(https://tower-cli.readthedocs.io/en/latest/api_ref/resources/workflow.html) for details.
 '''
 
 
 EXAMPLES = '''
-- tower_workflow_template:
+- name: Create workflow template
+  tower_workflow_template:
     name: Workflow Template
     description: My very first Workflow Template
     organization: My optional Organization
-    schema: "{{ lookup('file', 'my_workflow.json') }}"
+    schema:
+      - job_template: "my-job-1"
+        success:
+          - job_template: "my-job-2"
+
+- name: Create workflow template with survey
+  tower_workflow_template:
+    name: workflow-1
+    survey_spec:
+      name: test survey
+      description: test description
+      spec:
+        - index: 0
+          question_name: "my question"
+          default: "mydef"
+          variable: "myvar"
+          type: "text"
+          required: false
+    schema:
+      - job_template: "my-job-1"
+        success:
+          - job_template: "my-job-2"
 
 - tower_worflow_template:
-    name: Workflow Template
+    name: workflow template
     state: absent
 '''
 
-
-RETURN = ''' # '''
-
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ansible_tower import (
-    TowerModule,
-    tower_auth_config,
-    tower_check_mode
-)
+from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode, tower_dump_yaml
 
 try:
     import tower_cli
     import tower_cli.exceptions as exc
+
     from tower_cli.conf import settings
 except ImportError:
     pass
+
+from ansible.module_utils._text import to_text
+
+
+def update_fields(module, p):
+    '''This updates the module field names
+    to match the field names tower-cli expects to make
+    calling of the modify/delete methods easier.
+    '''
+    params = p.copy()
+    field_map = {
+        'ask_extra_vars': 'ask_variables_on_launch',
+        'ask_inventory': 'ask_inventory_on_launch',
+        'concurrent_jobs_enabled': 'allow_simultaneous',
+    }
+
+    params_update = {}
+    for old_k, new_k in field_map.items():
+        v = params.pop(old_k)
+        params_update[new_k] = v
+
+    extra_vars = params.get('extra_vars')
+    schema = params.get('schema')
+
+    if extra_vars is not None:
+        params_update['extra_vars'] = [tower_dump_yaml(extra_vars)]
+
+    if schema is not None:
+        params_update['schema'] = to_text(schema)
+
+    params.update(params_update)
+    return params
+
+
+def update_resources(module, p):
+    params = p.copy()
+    identity_map = {
+        'inventory': 'name',
+        'organization': 'name',
+    }
+
+    for k, v in identity_map.items():
+        try:
+            if params[k]:
+                result = tower_cli.get_resource(k).get(**{v: params[k]})
+                params[k] = result['id']
+            elif k in params:
+                # unset empty parameters to avoid ValueError: invalid literal for int() with base 10: ''
+                del(params[k])
+        except (exc.NotFound) as excinfo:
+            module.fail_json(msg='Failed to update workflow job template: {0}'.format(excinfo), changed=False)
+    return params
 
 
 def main():
     argument_spec = dict(
         name=dict(required=True),
-        description=dict(required=False),
-        extra_vars=dict(required=False),
+        description=dict(default=''),
         organization=dict(required=False),
-        allow_simultaneous=dict(type='bool', required=False),
-        schema=dict(required=False),
-        survey=dict(required=False),
-        survey_enabled=dict(type='bool', required=False),
-        inventory=dict(required=False),
-        ask_inventory=dict(type='bool', required=False),
-        ask_extra_vars=dict(type='bool', required=False),
+        inventory=dict(default=''),
+        extra_vars=dict(type='dict', required=False),
+        ask_extra_vars=dict(type='bool', default=False),
+        ask_inventory=dict(type='bool', default=False),
+        schema=dict(type='list', required=False),
+        survey_enabled=dict(type='bool', default=False),
+        survey_spec=dict(type='dict', required=False),
+        survey=dict(type='dict', required=False),
+        concurrent_jobs_enabled=dict(type='bool', default=False),
+        allow_simultaneous=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
-    module = TowerModule(
-        argument_spec=argument_spec,
-        supports_check_mode=False
-    )
+    module = TowerModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    if module.params.get('allow_simultaneous'):
+        module.params['concurrent_jobs_enabled'] = module.params['allow_simultaneous']
+        module.deprecate("The 'allow_simultaneous' option is being replaced by 'concurrent_jobs_enabled'", version="2.14")
+
+    if module.params.get('survey'):
+        module.params['survey_spec'] = module.params['survey']
+        module.deprecate("The 'survey' option is being replaced by 'survey_spec'", version="2.14")
+
+    module.params.pop('survey')
+    module.params.pop('allow_simultaneous')
 
     name = module.params.get('name')
-    state = module.params.get('state')
-
-    schema = None
-    if module.params.get('schema'):
-        schema = module.params.get('schema')
-
-    if schema and state == 'absent':
-        module.fail_json(
-            msg='Setting schema when state is absent is not allowed',
-            changed=False
-        )
-
+    state = module.params.pop('state')
     json_output = {'workflow_template': name, 'state': state}
 
     tower_auth = tower_auth_config(module)
     with settings.runtime_values(**tower_auth):
         tower_check_mode(module)
-        wfjt_res = tower_cli.get_resource('workflow')
-        params = {}
-        params['name'] = name
+        wfjt = tower_cli.get_resource('workflow')
 
-        if module.params.get('description'):
-            params['description'] = module.params.get('description')
-
-        if module.params.get('organization'):
-            organization_res = tower_cli.get_resource('organization')
-            try:
-                organization = organization_res.get(
-                    name=module.params.get('organization'))
-                params['organization'] = organization['id']
-            except exc.NotFound as excinfo:
-                module.fail_json(
-                    msg='Failed to update organization source,'
-                    'organization not found: {0}'.format(excinfo),
-                    changed=False
-                )
-
-        if module.params.get('survey'):
-            params['survey_spec'] = module.params.get('survey')
-
-        if module.params.get('ask_extra_vars'):
-            params['ask_variables_on_launch'] = module.params.get('ask_extra_vars')
-
-        if module.params.get('ask_inventory'):
-            params['ask_inventory_on_launch'] = module.params.get('ask_inventory')
-
-        for key in ('allow_simultaneous', 'extra_vars', 'inventory',
-                    'survey_enabled', 'description'):
-            if module.params.get(key):
-                params[key] = module.params.get(key)
+        params = update_resources(module, module.params)
+        params = update_fields(module, params)
+        params['create_on_missing'] = True
 
         try:
             if state == 'present':
-                params['create_on_missing'] = True
-                result = wfjt_res.modify(**params)
+                result = wfjt.modify(**params)
                 json_output['id'] = result['id']
-                if schema:
-                    wfjt_res.schema(result['id'], schema)
+                if params['schema']:
+                    wfjt.schema(result['id'], params['schema'])
             elif state == 'absent':
-                params['fail_on_missing'] = False
-                result = wfjt_res.delete(**params)
-        except (exc.ConnectionError, exc.BadRequest, exc.AuthError) as excinfo:
-            module.fail_json(msg='Failed to update workflow template: \
-                    {0}'.format(excinfo), changed=False)
+                result = wfjt.delete(**params)
+        except (exc.ConnectionError, exc.BadRequest, exc.NotFound, exc.AuthError) as excinfo:
+            module.fail_json(msg='Failed to update workflow job template: {0}'.format(excinfo), changed=False)
 
     json_output['changed'] = result['changed']
     module.exit_json(**json_output)

--- a/test/integration/targets/tower_workflow_template/tasks/main.yml
+++ b/test/integration/targets/tower_workflow_template/tasks/main.yml
@@ -59,47 +59,135 @@
     job_type: run
     state: present
 
-- name: Add a Survey to second Job Template
-  tower_job_template:
-    name: my-job-2
-    project: Job Template Test Project
-    inventory: Demo Inventory
-    playbook: hello_world.yml
-    credential: Demo Credential
-    job_type: run
-    state: present
-    survey_enabled: yes
-    survey_spec: '{"spec": [{"index": 0, "question_name": "my question?", "default": "mydef", "variable": "myvar", "type": "text", "required": "false"}], "description": "test", "name": "test"}'
+
+- name: Create empty workflow job template
+  tower_workflow_template:
+    name: my-workflow
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- tower_receive:
+    workflow: my-workflow
+  register: result
+
+- assert:
+    that:
+      - "result.assets[0].name == 'my-workflow'"
+      - "result.assets[0].asset_relation.workflow_nodes | length == 0 "
+      - "result.assets[0].asset_relation.survey_spec.name is undefined"
+      - "result.assets[0].allow_simultaneous is undefined"
+      - "result.assets[0].ask_inventory_on_launch is undefined"
+      - "result.assets[0].ask_variables_on_launch is undefined"
 
 
 - name: Create a workflow job template
   tower_workflow_template:
     name: my-workflow
-    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+    inventory: Demo Inventory
+    schema: 
+      - job_template: "my-job-1"
+        success:
+          - job_template: "my-job-2"
+    survey_spec:
+      name: test survey
+      description: test description
+      spec:
+        - index: 0
+          question_name: "my question?"
+          default: "mydef"
+          variable: "myvar"
+          type: "text"
+          required: false
+    extra_vars:
+      var1: value1
+      var2: value2
+    concurrent_jobs_enabled: yes
+    ask_inventory: yes
+    ask_extra_vars: yes
   register: result
 
 - assert:
     that:
       - "result is changed"
+
+- tower_receive:
+    workflow: my-workflow
+  register: result
+
+- assert:
+    that:
+      - "result.assets[0].name == 'my-workflow'"
+      - "result.assets[0].inventory is defined"
+      - "(result.assets[0].extra_vars | from_json).var1 is defined"
+      - "(result.assets[0].extra_vars | from_json).var2 is defined"
+      - "result.assets[0].asset_relation.workflow_nodes[0].unified_job_name == 'my-job-1'"
+      - "result.assets[0].asset_relation.workflow_nodes[1].unified_job_name == 'my-job-2'"
+      - "result.assets[0].asset_relation.survey_spec.name == 'test survey'"
+      - "result.assets[0].allow_simultaneous is defined"
+      - "result.assets[0].ask_inventory_on_launch is defined"
+      - "result.assets[0].ask_variables_on_launch is defined"
+
+
+- name: Create a workflow job template with deprecated parameters
+  tower_workflow_template:
+    name: my-deprecated-workflow
+    inventory: Demo Inventory
+    survey: '{"spec": [{"index": 0, "question_name": "my second question?", "default": "mydef", "variable": "myvar", "type": "text", "required": false}], "description": "test", "name": "test"}'
+    allow_simultaneous: yes
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.deprecations[0].msg is defined"
+      - "result.deprecations[1].msg is defined"
+
+- tower_receive:
+    workflow: my-deprecated-workflow
+  register: result
+
+- assert:
+    that:
+      - "result.assets[0].name == 'my-deprecated-workflow'"
+      - "result.assets[0].allow_simultaneous is defined"
+      - "result.assets[0].asset_relation.survey_spec.name == 'test'"
+
 
 - name: Delete a workflow job template
   tower_workflow_template:
-    name: my-workflow
+    name: "{{ item }}"
     state: absent
   register: result
+  with_items:
+    - my-workflow
+    - my-deprecated-workflow
 
 - assert:
     that:
       - "result is changed"
 
-- name: Check module fails with correct msg
+- name: Check module fails with correct msg (organization)
   tower_workflow_template:
     name: my-workflow
     organization: Non Existing Organization
-    schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'
+    state: present
   register: result
   ignore_errors: true
 
 - assert:
     that:
-      - "result.msg =='Failed to update organization source,organization not found: The requested object could not be found.'"
+      - "result.msg =='Failed to update workflow job template: The requested object could not be found.'"
+
+- name: Check module fails with correct msg (inventory)
+  tower_workflow_template:
+    name: my-workflow
+    inventory: Non Existing Inventory
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result.msg =='Failed to update workflow job template: The requested object could not be found.'"


### PR DESCRIPTION
##### SUMMARY

The implementation of the modules `tower_workflow_template` and `tower_job_template` diverge in terms of parameter naming and code structure.

Parameters:

| tower_job_template      | tower_workflow_template |
|-------------------------|-------------------------|
| ask_extra_vars     | _missing_   |
| concurrent_jobs_enabled | allow_simultaneous      |
| survey_spec             | survey                  |


This PR tries to unify those two modules, to improve usability and maintainability.

Fixes #57350

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tower_workflow_template

##### ADDITIONAL INFORMATION

I took into account latest PR (#57225) which affects the tower_job_template module.

PR "tower_workflow_template: Add missing options" #56891 would be obsolete.

```