### PR TITLE
Allow terraform to have null workspace

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -310,12 +310,13 @@ def main():
     if force_init:
         init_plugins(command[0], project_path, backend_config)
 
-    workspace_ctx = get_workspace_context(command[0], project_path)
-    if workspace_ctx["current"] != workspace:
-        if workspace not in workspace_ctx["all"]:
-            create_workspace(command[0], project_path, workspace)
-        else:
-            select_workspace(command[0], project_path, workspace)
+    if workspace is not None:
+        workspace_ctx = get_workspace_context(command[0], project_path)
+        if workspace_ctx["current"] != workspace:
+            if workspace not in workspace_ctx["all"]:
+                create_workspace(command[0], project_path, workspace)
+            else:
+                select_workspace(command[0], project_path, workspace)
 
     if state == 'present':
         command.extend(APPLY_ARGS)
@@ -384,10 +385,11 @@ def main():
         outputs = json.loads(outputs_text)
 
     # Restore the Terraform workspace found when running the module
-    if workspace_ctx["current"] != workspace:
-        select_workspace(command[0], project_path, workspace_ctx["current"])
-    if state == 'absent' and workspace != 'default' and purge_workspace is True:
-        remove_workspace(command[0], project_path, workspace)
+    if workspace is not None:
+        if workspace_ctx["current"] != workspace:
+            select_workspace(command[0], project_path, workspace_ctx["current"])
+        if state == 'absent' and workspace != 'default' and purge_workspace is True:
+            remove_workspace(command[0], project_path, workspace)
 
     module.exit_json(changed=changed, state=state, workspace=workspace, outputs=outputs, stdout=out, stderr=err, command=' '.join(command))
 


### PR DESCRIPTION
##### SUMMARY
The new remote backend (https://www.terraform.io/docs/backends/types/remote.html) does not support workspace commands, as it handles workspaces through configuration. Workspace commands fail with an error message `workspaces not supported`. Ansible currently always tries to list the workspaces to check whether it is in the active workspace. 

This allows for a null workspace flag to be passed which bypasses the workspaces checks. This would allow for remote backends to be supported without changing default workspace behaviour.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
terraform

##### ADDITIONAL INFORMATION
Example of workspace configuration for remote workspaces (truncated)
```
{

    "backend": {
        "type": "remote",
        "config": {
            "workspaces": {
                "name": "example",
                "prefix": null
            }
        },
    }
    ]
}
```