### PR TITLE
Fix #56640: Map k8s ansible keys to api keys

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -169,7 +169,6 @@ class K8sAnsibleMixin(object):
                         env_value = env_value.lower() not in ['0', 'false', 'no']
                     auth[true_name] = env_value
             else:
-                print( "Setting", true_name, "from", arg_name, "to value", auth_params[arg_name] )
                 auth[true_name] = auth_params[arg_name]
 
         def auth_set(*names):
@@ -190,7 +189,7 @@ class K8sAnsibleMixin(object):
         # Override any values in the default configuration with Ansible parameters
         configuration = kubernetes.client.Configuration()
         for key, value in iteritems(auth):
-            if key in AUTH_ARG_MAP and value is not None:
+            if key in AUTH_ARG_MAP.keys() and value is not None:
                 if key == 'api_key':
                     setattr(configuration, key, {'authorization': "Bearer {0}".format(value)})
                 else:

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -125,7 +125,7 @@ AUTH_ARG_SPEC = {
     'proxy': {},
 }
 
-# Map ansible parameters to kubernetes-client parameters
+# Map kubernetes-client parameters to ansible parameters
 AUTH_ARG_MAP = {
     'kubeconfig': 'kubeconfig',
     'context': 'context',

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -140,6 +140,7 @@ AUTH_ARG_MAP = {
     'proxy': 'proxy',
 }
 
+
 class K8sAnsibleMixin(object):
     _argspec_cache = None
 

--- a/test/integration/targets/k8s/tasks/full_test.yml
+++ b/test/integration/targets/k8s/tasks/full_test.yml
@@ -18,6 +18,19 @@
       debug:
         var: output
 
+    - name: Setting validate_certs to true causes a failure
+      k8s:
+        name: testing
+        kind: namespace
+        validate_certs: yes
+      ignore_errors: yes
+      register: output
+
+    - name: assert that validate_certs caused a failure (and therefore was correctly translated to verify_ssl)
+      assert:
+        that:
+          - output is failed
+
     - name: k8s_info works with empty resources
       k8s_info:
         kind: Deployment


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #56640

This creates a map of api -> ansible keys to feed to the upstream API. I used the [suggestion](https://github.com/ansible/ansible/pull/56643#issuecomment-497824736) from @fabianvf as a base. 

There's another pull request that took a stab as fixing this (#56643) but that one hasn't been updated to reflect suggested changes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s/common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
