### PR TITLE
Fix an RST link to the changelog config in docs

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -165,7 +165,7 @@ To create a changelog entry, create a new file with a unique name in the ``chang
 
 A single changelog fragment may contain multiple sections but most will only contain one section.
 The toplevel keys (bugfixes, major_changes, etc) are defined in the
-`config file <https://github.com/ansible/ansible/blob/devel/changelogs/config.yaml>` for our release note tool. Here are the valid sections and a description of each:
+`config file <https://github.com/ansible/ansible/blob/devel/changelogs/config.yaml>`_ for our release note tool. Here are the valid sections and a description of each:
 
 **major_changes**
     Major changes to Ansible itself. Generally does not include module or plugin changes.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a backport of #57407 which fixes a silly typo in RST link syntax in the dev flow guide.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A