### PR TITLE
Added description of 'hostname'

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -151,6 +151,9 @@ options:
       - "From version 2.5 onwards, this parameter is required."
       required: True
       version_added: 2.5
+    hostname:
+      descriptiom:
+      - Address or fqdn of the vCenter if present, required if using distributed virtual switch
 extends_documentation_fragment: vmware.documentation
 '''
 


### PR DESCRIPTION
##### SUMMARY
The documentation refers to esxi hostname for both 'hostname' and 'esxi_hostname'. I found that hostname is intended for vCenter host definition and is required when working with vds. I did not update examples, only the description section.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Added description for 'hostname' to readme. 

##### ADDITIONAL INFORMATION
