### PR TITLE
win_domain_group_membership: Fix missing @extra_vars on Get-ADObject to support different domain and credentials for retrieval

### DIFF
--- a/changelogs/fragments/win_domain_group_membership-Fix-missing-vars-for-Get-command.yml
+++ b/changelogs/fragments/win_domain_group_membership-Fix-missing-vars-for-Get-command.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_domain_group_membership - Fix missing @extra_vars on Get-ADObject to support dirrent domain and credentials for retrival (https://github.com/ansible/ansible/issues/57404)"

--- a/lib/ansible/modules/windows/win_domain_group_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_group_membership.ps1
@@ -52,7 +52,7 @@ $members_before = Get-AdGroupMember -Identity $name @extra_args
 $pure_members = [System.Collections.Generic.List`1[String]]@()
 
 foreach ($member in $members) {
-    $group_member = Get-ADObject -Filter "SamAccountName -eq '$member' -and $ad_object_class_filter" -Properties objectSid, sAMAccountName
+    $group_member = Get-ADObject -Filter "SamAccountName -eq '$member' -and $ad_object_class_filter" -Properties objectSid, sAMAccountName @extra_vars
     if (!$group_member) {
         Fail-Json -obj $result "Could not find domain user, group, service account or computer named $member"
     }


### PR DESCRIPTION
##### SUMMARY
Fixes #57404 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_group_membership.ps1

##### ADDITIONAL INFORMATION
Seems it was accidentally missed since all other operations do have @extra_vars
