### PR TITLE
Fix podman_image_info parsing of podman output.

### DIFF
--- a/lib/ansible/modules/cloud/podman/podman_image_info.py
+++ b/lib/ansible/modules/cloud/podman/podman_image_info.py
@@ -173,7 +173,7 @@ def get_image_info(module, executable, name):
 def get_all_image_info(module, executable):
     command = [executable, 'image', 'ls', '-q']
     rc, out, err = module.run_command(command)
-    name = out.split('\n')
+    name = out.strip().split('\n')
     out = get_image_info(module, executable, name)
 
     return out


### PR DESCRIPTION
##### SUMMARY

Fix podman_image_info parsing of podman output.

Stripping the output from `podman image ls -q` prevents passing a blank image ID to `podman image inspect`, which would fail.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

podman_image_info
