### PR TITLE
aws: Narrow down ami filter for elb_application_lb integration tests

### DIFF
--- a/test/integration/targets/elb_application_lb/tasks/test_alb_with_asg.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_alb_with_asg.yml
@@ -16,6 +16,7 @@
           virtualization-type: hvm
           root-device-type: ebs
           name: "amzn-ami-hvm*"
+          owner-alias: "amazon"
       register: amis
 
     - set_fact:


### PR DESCRIPTION
##### SUMMARY
The filter used to select the ami used in the elb_application_lb integration tests is not narrow enough. Sometimes the AMI selected was from the marketplace and not from amazon. This caused the autoscaling group that uses the ami to fail to come up. By narrowing the filter it insures the proper ami is selected.

Fixes: #43375

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
elb_application_lb
