### PR TITLE
[stable-2.8] Fix podman_image_info parsing of podman output.

### DIFF
--- a/lib/ansible/modules/cloud/podman/podman_image_info.py
+++ b/lib/ansible/modules/cloud/podman/podman_image_info.py
@@ -173,7 +173,7 @@ def get_image_info(module, executable, name):
 def get_all_image_info(module, executable):
     command = [executable, 'image', 'ls', '-q']
     rc, out, err = module.run_command(command)
-    name = out.split('\n')
+    name = out.strip().split('\n')
     out = get_image_info(module, executable, name)
 
     return out

--- a/test/integration/targets/podman_image_info/aliases
+++ b/test/integration/targets/podman_image_info/aliases
@@ -2,4 +2,3 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
-disabled  # temporarily disabled until https://github.com/ansible/ansible/pull/57433 is merged


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Fix podman_image_info parsing of podman output.

Backport of https://github.com/ansible/ansible/pull/57431

Stripping the output from `podman image ls -q` prevents passing a blank image ID to `podman image inspect`, which would fail.

(cherry picked from commit a05be890adc28a1a985cdc2891a819e535728a68)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

podman_image_info