### PR TITLE
Temp disable podman_image_info tests.

### DIFF
--- a/test/integration/targets/podman_image_info/aliases
+++ b/test/integration/targets/podman_image_info/aliases
@@ -2,3 +2,4 @@ shippable/posix/group2
 skip/osx
 skip/freebsd
 destructive
+disabled  # temporarily disabled until https://github.com/ansible/ansible/pull/57433 is merged


### PR DESCRIPTION
##### SUMMARY

Temp disable podman_image_info tests.

The fix in https://github.com/ansible/ansible/pull/57433 is required for tests to pass.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

podman_image_info integration tests
