### PR TITLE
[WIP] meraki - is_update_required type comparison fix

### DIFF
--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -33,6 +33,7 @@ import os
 from ansible.module_utils.basic import AnsibleModule, json, env_fallback
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native, to_bytes, to_text
 
 
@@ -147,8 +148,8 @@ class MerakiModule(object):
         if optional_ignore is not None:
             self.ignored_keys = self.ignored_keys + optional_ignore
 
-        if type(original) != type(proposed):
-            # self.fail_json(msg="Types don't match")
+        if not isinstance(original, string_types) and not isinstance(proposed, string_types) and type(original) != type(proposed):
+            # self.fail_json(msg="Types don't match", original=str(type(original)), proposed=str(type(proposed)))
             return True
         if isinstance(original, list):
             if len(original) != len(proposed):

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -238,6 +238,8 @@ def main():
             net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
         else:
             nets = meraki.get_nets(org_id=org_id)
+    else:
+        nets = meraki.get_nets(org_id=org_id)
 
     if meraki.params['state'] == 'query':
         meraki.result['data'] = get_config_templates(meraki, org_id)

--- a/test/integration/targets/meraki_config_template/tasks/main.yml
+++ b/test/integration/targets/meraki_config_template/tasks/main.yml
@@ -8,22 +8,6 @@
     fail:
       msg: Please define an API key
     when: auth_key is not defined
-    
-  - name: Use an invalid domain
-    meraki_config_template:
-      auth_key: '{{ auth_key }}'
-      host: marrrraki.com
-      state: query
-      org_name: '{{test_org_name}}'
-      output_level: debug
-    delegate_to: localhost
-    register: invalid_domain
-    ignore_errors: yes
-
-  - name: Connection assertions
-    assert:
-      that:
-        - '"Failed to connect to" in invalid_domain.msg'
 
   - name: Query all configuration templates
     meraki_config_template:
@@ -180,27 +164,27 @@
         unbind_id.changed == True
 
   # This is disabled by default since they can't be created via API
-  - name: Delete sacrificial template with check mode
-    meraki_config_template:
-      auth_key: '{{auth_key}}'
-      state: absent
-      org_name: '{{test_org_name}}'
-      config_template: sacrificial_template
-    check_mode: yes
-    register: delete_template_check
+  # - name: Delete sacrificial template with check mode
+  #   meraki_config_template:
+  #     auth_key: '{{auth_key}}'
+  #     state: absent
+  #     org_name: '{{test_org_name}}'
+  #     config_template: sacrificial_template
+  #   check_mode: yes
+  #   register: delete_template_check
 
-  # This is disabled by default since they can't be created via API
-  - name: Delete sacrificial template
-    meraki_config_template:
-      auth_key: '{{auth_key}}'
-      state: absent
-      org_name: '{{test_org_name}}'
-      config_template: sacrificial_template
-      output_level: debug
-    register: delete_template
+  # # This is disabled by default since they can't be created via API
+  # - name: Delete sacrificial template
+  #   meraki_config_template:
+  #     auth_key: '{{auth_key}}'
+  #     state: absent
+  #     org_name: '{{test_org_name}}'
+  #     config_template: sacrificial_template
+  #     output_level: debug
+  #   register: delete_template
 
-  - debug:
-      var: delete_template
+  # - debug:
+  #     var: delete_template
 
   always:
   - name: Delete network

--- a/test/integration/targets/meraki_vlan/tasks/main.yml
+++ b/test/integration/targets/meraki_vlan/tasks/main.yml
@@ -8,33 +8,6 @@
     fail:
       msg: Please define an API key
     when: auth_key is not defined
-    
-  - name: Use an invalid domain
-    meraki_vlan:
-      auth_key: '{{ auth_key }}'
-      host: marrrraki.com
-      state: present
-      org_name: IntTestOrg
-      output_level: debug
-    delegate_to: localhost
-    register: invalid_domain
-    ignore_errors: yes
-    
-  - name: Disable HTTP
-    meraki_vlan:
-      auth_key: '{{ auth_key }}'
-      use_https: false
-      state: query
-      output_level: debug
-    delegate_to: localhost
-    register: http
-    ignore_errors: yes
-
-  - name: Connection assertions
-    assert:
-      that:
-        - '"Failed to connect to" in invalid_domain.msg'
-        - '"http" in http.url'
 
   - name: Test play without auth_key
     meraki_network:


### PR DESCRIPTION
##### SUMMARY
The new `is_update_required()` pull request introduced a bug which wasn't always reproducible. The type comparison would fail when comparing unicast and strings. sivel recommended using the `string_types` and make sure they aren't `string_types`. I've run many integration test and this seems to fix the problem.

This pull request also includes a few other fixes I've uncovered while testing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
