### PR TITLE
New module postgresql_vacuum - Garbage-collect and optionally analyze a PostgreSQL database

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -1,0 +1,399 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = r'''
+---
+module: postgresql_vacuum
+short_description: Garbage-collect and optionally analyze a PostgreSQL database
+description:
+- Garbage-collect and optionally analyze a PostgreSQL database
+  U(https://www.postgresql.org/docs/current/sql-vacuum.html).
+version_added: '2.9'
+
+options:
+  table:
+    description:
+    - Name of a table that needs to be vacuumed.
+    type: str
+  columns:
+    description:
+    - List of column names of I(table) that need to be vacuumed.
+      Used only with I(table).
+    type: list
+  analyze:
+    description:
+    - Updates statistics used by the planner to determine the most efficient way to execute a query.
+    - Mutually exclusive with I(analyze_only).
+    type: bool
+  analyze_only:
+    description:
+    - Only update optimizer statistics, no vacuum. Mutually exclusive with I(analyze).
+    type: bool
+  full:
+    description:
+    - Selects full vacuum, which can reclaim more space,
+      but takes much longer and exclusively locks the table.
+    - This method also requires extra disk space, since it writes a new copy
+      of the table and doesn't release the old copy until the operation is complete.
+    - Usually this should only be used when a significant amount of space needs
+      to be reclaimed from within the table.
+    - Mutually exclusive with I(analyze_only).
+    type: bool
+  disable_page_skipping:
+    description:
+    - Normally, VACUUM will skip pages based on the visibility map.
+    - Pages where all tuples are known to be frozen can always be skipped,
+      and those where all tuples are known to be visible to all transactions
+      may be skipped except when performing an aggressive vacuum.
+    - Furthermore, except when performing an aggressive vacuum,
+      some pages may be skipped in order to avoid waiting for other sessions to finish using them.
+    - This option disables all page-skipping behavior, and is intended to be used only when
+      the contents of the visibility map are suspect, which should happen only if there is
+      a hardware or software issue causing database corruption.
+    - Available from PostgreSQL 9.6.
+    - Mutually exclusive with I(analyze_only).
+    type: bool
+  freeze:
+    description:
+    - Selects aggressive freezing of tuples.
+    - Specifying FREEZE is equivalent to performing VACUUM with
+      the vacuum_freeze_min_age and vacuum_freeze_table_age parameters set to zero.
+      Aggressive freezing is always performed when the table is rewritten,
+      so this option is redundant when FULL is specified.
+    - Mutually exclusive with I(analyze_only).
+  db:
+    description:
+    - Name of a database for vacuum (used as a database to connect to).
+    type: str
+    aliases: [ login_db ]
+  session_role:
+    description:
+    - Switch to session_role after connecting.
+      The specified session_role must be a role that the current login_user is a member of.
+    - Permissions checking for SQL commands is carried out as though
+      the session_role were the one that had logged in originally.
+    type: str
+
+notes:
+- Supports PostgreSQL version 9.4+.
+
+author:
+- Andrew Klychkov (@Andersson007)
+
+extends_documentation_fragment: postgres
+'''
+
+EXAMPLES = r'''
+- name: Vacuum database acme
+  postgresql_vacuum:
+    db: acme
+
+- name: Vacuum and analyze database acme
+  postgresql_vacuum:
+    db: acme
+    analyze: yes
+
+- name: Vacuum full and analyze database foo. Pay attention that the database will be locked
+  postgresql_vacuum:
+    db: foo
+    full: yes
+    analyze: yes
+
+- name: Analyze table mytable in database bar
+  postgresql_vacuum:
+    db: bar
+    table: mytable
+    analyze_only: yes
+
+- name: Vacuum and analyze columns col1, col2, and col3 of mytable in database acme
+  postgresql_vacuum:
+    db: acme
+    table: mytable
+    columns:
+    - col1
+    - col2
+    - col3
+    analyze: yes
+
+- name: Vacuum of mytable with freeze
+  postgresql_vacuum:
+    db: acme
+    table: mytable
+    freeze: yes
+
+- name: Vacuum of mytable with disabled page skipping
+  postgresql_vacuum:
+    db: acme
+    table: mytable
+    disable_page_skipping: yes
+'''
+
+RETURN = r'''
+queries:
+  description: List of executed queries.
+  returned: always
+  type: str
+  sample: [ "VACUUM (ANALYZE) mytable (col1, col2, col3)" ]
+'''
+
+try:
+    from psycopg2.extras import DictCursor
+except ImportError:
+    # psycopg2 is checked by connect_to_db()
+    # from ansible.module_utils.postgres
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.database import pg_quote_identifier
+from ansible.module_utils.postgres import connect_to_db, postgres_common_argument_spec
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
+
+
+DISABLE_PAGE_SKIPPING_VER = 96000
+
+
+def exec_sql(obj, query, ddl=False, add_to_executed=True):
+    """Execute SQL.
+
+    Auxiliary function for PostgreSQL user classes.
+
+    Returns a query result if possible or True/False if ddl=True arg was passed.
+    It necessary for statements that don't return any result (like DDL queries).
+
+    Arguments:
+        obj (obj) -- must be an object of a user class.
+            The object must have module (AnsibleModule class object) and
+            cursor (psycopg cursor object) attributes
+        query (str) -- SQL query to execute
+        ddl (bool) -- must return True or False instead of rows (typical for DDL queries)
+            (default False)
+        add_to_executed (bool) -- append the query to obj.executed_queries attribute
+    """
+    try:
+        obj.cursor.execute(query)
+
+        if add_to_executed:
+            obj.executed_queries.append(query)
+
+        if not ddl:
+            res = obj.cursor.fetchall()
+            return res
+        return True
+    except Exception as e:
+        obj.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
+    return False
+
+
+class Vacuum(object):
+
+    """Implements VACUUM [FULL] and/or ANALYZE PostgreSQL command behavior.
+
+    args:
+        module (AnsibleModule) -- object of AnsibleModule class
+        cursor (cursor) -- cursor objec of psycopg2 library
+
+    attrs:
+        module (AnsibleModule) -- object of AnsibleModule class
+        cursor (cursor) -- cursor objec of psycopg2 library
+        changed (bool) --  something was changed after execution or not
+        executed_queries (list) -- executed queries
+        query_frag (list) -- list for making SQL query
+    """
+
+    def __init__(self, module, cursor):
+        self.module = module
+        self.cursor = cursor
+        self.executed_queries = []
+        self.changed = False
+        self.query_frag = []
+
+    def __check_obj(self):
+        """
+        Check the table or columns that need to be vacuumed/analyzed exist.
+        """
+
+        query_frag = ['SELECT']
+        if self.module.params.get('columns'):
+            query_frag.append(','.join(self.module.params['columns']))
+        else:
+            query_frag.append('*')
+
+        query_frag.append['FROM %s LIMIT 1' % pg_quote_identifier(self.module.param['table'], 'table')]
+
+        if exec_sql(obj, ' '.join(query_frag), ddl=True, add_to_executed=False):
+            return True
+
+        return None
+
+    def do_vacuum(self):
+        """Do VACUUM."""
+
+        self.query_frag.append('VACUUM')
+
+        if (self.module.params.get('freeze') or
+                self.module.params.get('disable_page_skipping') or
+                self.module.params.get('analyze')):
+
+            opt_list = []
+            if self.module.params.get('freeze'):
+                opt_list.append('FREEZE')
+
+            if self.module.params.get('disable_page_skipping'):
+                opt_list.append('DISABLE_PAGE_SKIPPING')
+
+            if self.module.params.get('analyze'):
+                opt_list.append('ANALYZE')
+
+            self.query_frag.append('(%s)' % ', '.join(opt_list))
+
+        self.__do_rest_of_task()
+
+    def do_analyze(self):
+        """Do ANALYZE."""
+
+        self.query_frag.append('ANALYZE')
+
+        self.__do_rest_of_task()
+
+    def do_full_vacuum(self):
+        """Do VACUUM FULL."""
+
+        self.query_frag.append('VACUUM FULL')
+
+        if self.module.params.get('analyze'):
+            self.query_frag.append('ANALYZE')
+
+        self.__do_rest_of_task()
+
+    def __do_rest_of_task(self):
+        """Do the rest of the task for all public methods.
+
+        Complete query fragments list self.query_frag if needed and make SQL query.
+        If check_mode, change self.changed and return None, otherwise, execute SQL.
+        """
+
+        if self.module.params.get('table'):
+            self.query_frag.append('%s' % pg_quote_identifier(self.module.params['table'], 'table'))
+
+        if self.module.params.get('columns'):
+            self.query_frag.append('(%s)' % ', '.join(self.module.params['columns']))
+
+        query = ' '.join(self.query_frag)
+
+        if self.module.check_mode:
+            if self.module.params.get('table'):
+                if self.__check_obj:
+                    # if the table or column doesn't exist,
+                    # self.__check_obj will fail
+                    self.changed = True
+            else:
+                # If a table hasn't been passed, it means that
+                # the database will be vacuumed/analyzed.
+                # The database exists if the module is able to connect to it,
+                # so we don't need to check it:
+                self.changed = True
+
+            self.executed_queries.append(query)
+            return None
+
+        if exec_sql(self, query, ddl=True):
+            self.changed = True
+
+# ===========================================
+# Module execution.
+#
+
+
+def main():
+    argument_spec = postgres_common_argument_spec()
+    argument_spec.update(
+        table=dict(type='str'),
+        columns=dict(type='list'),
+        analyze=dict(type='bool'),
+        analyze_only=dict(type='bool'),
+        full=dict(type='bool'),
+        freeze=dict(type='bool'),
+        disable_page_skipping=dict(type='bool'),
+        db=dict(type='str', aliases=['login_db']),
+        session_role=dict(type='str'),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ['analyze', 'analyze_only'],
+            ['full', 'analyze_only'],
+            ['freeze', 'analyze_only'],
+            ['disable_page_skipping', 'analyze_only'],
+        ]
+    )
+
+    # CHECK PARAMETERS:
+    #
+    # Note: we don't need to check mutually exclusive params here, because they are
+    # checked automatically by AnsibleModule (mutually_exclusive=[] list above).
+    if module.params.get('columns') and not module.params.get('table'):
+        module.fail_json(msg='table param is necessary with columns')
+
+    if module.params.get('columns') and (not module.params.get('analyze') and
+                                         not module.params.get('analyze_only')):
+        module.fail_json(msg='analyze option must be specified when a column list is provided')
+
+    # Connect to DB and make cursor object:
+    # (autocommit=True because VACUUM/ANALYZE cannot run inside a transaction block)
+    db_connection = connect_to_db(module, autocommit=True)
+
+    if module.params.get('disable_page_skipping'):
+        # Check server version:
+        if db_connection.server_version < DISABLE_PAGE_SKIPPING_VER:
+            module.warn('DISABLE_PAGE_SKIPPING is supported from PostgreSQL 9.6, skipped')
+            module.params['disable_page_skipping'] = ''
+
+    cursor = db_connection.cursor(cursor_factory=DictCursor)
+
+    ##############
+    # Create the object and do main job:
+    vacuum = Vacuum(module, cursor)
+
+    # Note: parameters are got
+    # from module object into data object of Vacuum class.
+    # Therefore not need to pass args to the methods below.
+    # Note: check mode is implemented inside the methods below
+    # by checking passed module.check_mode arg.
+
+    if module.params.get('full'):
+        vacuum.do_full_vacuum()
+
+    elif module.params.get('analyze_only'):
+        vacuum.do_analyze()
+
+    else:
+        # Do common vacuum by default:
+        vacuum.do_vacuum()
+
+    # Clean up:
+    cursor.close()
+    db_connection.close()
+
+    # Return some values:
+    module.exit_json(
+        changed=vacuum.changed,
+        queries=vacuum.executed_queries,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -173,7 +173,7 @@ def exec_sql(obj, query, ddl=False, add_to_executed=True):
     Returns a query result if possible or True/False if ddl=True arg was passed.
     It necessary for statements that don't return any result (like DDL queries).
 
-    Arguments:
+    args:
         obj (obj) -- must be an object of a user class.
             The object must have module (AnsibleModule class object) and
             cursor (psycopg cursor object) attributes
@@ -233,7 +233,7 @@ class Vacuum(object):
 
         query_frag.append['FROM %s LIMIT 1' % pg_quote_identifier(self.module.param['table'], 'table')]
 
-        if exec_sql(obj, ' '.join(query_frag), ddl=True, add_to_executed=False):
+        if exec_sql(self, ' '.join(query_frag), ddl=True, add_to_executed=False):
             return True
 
         return None
@@ -388,7 +388,7 @@ def main():
     cursor.close()
     db_connection.close()
 
-    # Return some values:
+    # Return values:
     module.exit_json(
         changed=vacuum.changed,
         queries=vacuum.executed_queries,

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -157,44 +157,16 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier
-from ansible.module_utils.postgres import connect_to_db, postgres_common_argument_spec
+from ansible.module_utils.postgres import (
+    connect_to_db,
+    exec_sql,
+    postgres_common_argument_spec,
+)
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 
 
 DISABLE_PAGE_SKIPPING_VER = 96000
-
-
-def exec_sql(obj, query, ddl=False, add_to_executed=True):
-    """Execute SQL.
-
-    Auxiliary function for PostgreSQL user classes.
-
-    Returns a query result if possible or True/False if ddl=True arg was passed.
-    It necessary for statements that don't return any result (like DDL queries).
-
-    args:
-        obj (obj) -- must be an object of a user class.
-            The object must have module (AnsibleModule class object) and
-            cursor (psycopg cursor object) attributes
-        query (str) -- SQL query to execute
-        ddl (bool) -- must return True or False instead of rows (typical for DDL queries)
-            (default False)
-        add_to_executed (bool) -- append the query to obj.executed_queries attribute
-    """
-    try:
-        obj.cursor.execute(query)
-
-        if add_to_executed:
-            obj.executed_queries.append(query)
-
-        if not ddl:
-            res = obj.cursor.fetchall()
-            return res
-        return True
-    except Exception as e:
-        obj.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
-    return False
 
 
 class Vacuum(object):

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -162,14 +162,12 @@ from ansible.module_utils.postgres import (
     exec_sql,
     postgres_common_argument_spec,
 )
-from ansible.module_utils._text import to_native
-from ansible.module_utils.six import iteritems
 
 
 DISABLE_PAGE_SKIPPING_VER = 96000
 
 
-class Vacuum(object):
+class Vacuum():
 
     """Implements VACUUM [FULL] and/or ANALYZE PostgreSQL command behavior.
 
@@ -198,9 +196,9 @@ class Vacuum(object):
         """
 
         if '.' in self.module.params['table']:
-            t = self.module.params['table'].split('.')
-            table_schema = t[-2]
-            table_name = t[-1]
+            tmp = self.module.params['table'].split('.')
+            table_schema = tmp[-2]
+            table_name = tmp[-1]
         else:
             table_schema = 'public'
             table_name = self.module.params['table']
@@ -267,6 +265,7 @@ class Vacuum(object):
             self.query_frag.append('ANALYZE')
 
         self.__do_rest_of_task()
+        return None
 
     def __do_rest_of_task(self):
         """Do the rest of the task for all public methods.

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -175,11 +175,11 @@ class Vacuum(object):
 
     args:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor objec of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg2 library
 
     attrs:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor objec of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg2 library
         changed (bool) --  something was changed after execution or not
         executed_queries (list) -- executed queries
         query_frag (list) -- list for making SQL query

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -231,7 +231,7 @@ class Vacuum(object):
         else:
             query_frag.append('*')
 
-        query_frag.append['FROM %s LIMIT 1' % pg_quote_identifier(self.module.param['table'], 'table')]
+        query_frag.append('FROM %s LIMIT 1' % pg_quote_identifier(self.module.params['table'], 'table'))
 
         if exec_sql(self, ' '.join(query_frag), ddl=True, add_to_executed=False):
             return True
@@ -295,7 +295,7 @@ class Vacuum(object):
 
         if self.module.check_mode:
             if self.module.params.get('table'):
-                if self.__check_obj:
+                if self.__check_obj():
                     # if the table or column doesn't exist,
                     # self.__check_obj will fail
                     self.changed = True

--- a/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_vacuum.py
@@ -194,7 +194,6 @@ class Vacuum():
         """
         Check the table or columns that need to be vacuumed/analyzed exist.
         """
-
         if '.' in self.module.params['table']:
             tmp = self.module.params['table'].split('.')
             table_schema = tmp[-2]
@@ -228,7 +227,6 @@ class Vacuum():
 
     def do_vacuum(self):
         """Do VACUUM."""
-
         self.query_frag.append('VACUUM')
 
         if (self.module.params.get('freeze') or
@@ -251,14 +249,12 @@ class Vacuum():
 
     def do_analyze(self):
         """Do ANALYZE."""
-
         self.query_frag.append('ANALYZE')
 
         self.__do_rest_of_task()
 
     def do_full_vacuum(self):
         """Do VACUUM FULL."""
-
         self.query_frag.append('VACUUM FULL')
 
         if self.module.params.get('analyze'):
@@ -273,7 +269,6 @@ class Vacuum():
         Complete query fragments list self.query_frag if needed and make SQL query.
         If check_mode, change self.changed and return None, otherwise, execute SQL.
         """
-
         if self.module.params.get('table'):
             self.query_frag.append('%s' % pg_quote_identifier(self.module.params['table'], 'table'))
 

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -801,6 +801,10 @@
 - include: ssl.yml
   when: ansible_os_family == 'Debian' and postgres_version_resp.stdout is version('9.4', '>=')
 
+# Test postgresql_vacuum module
+- include: postgresql_vacuum.yml
+  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD'
+
 # Test postgresql_set
 - include: postgresql_set.yml
   when: postgres_version_resp.stdout is version('9.4', '>=')

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -802,9 +802,8 @@
   when: ansible_os_family == 'Debian' and postgres_version_resp.stdout is version('9.4', '>=')
 
 # Test postgresql_vacuum module.
-# Local integration tests on excluded OS pass well.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16)
+  when: postgres_version_resp.stdout is version('9.6', '>=')
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -801,9 +801,10 @@
 - include: ssl.yml
   when: ansible_os_family == 'Debian' and postgres_version_resp.stdout is version('9.4', '>=')
 
-# Test postgresql_vacuum module
+# Test postgresql_vacuum module.
+# Local integration tests on excluded OS pass well.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD'
+  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16)
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -803,7 +803,7 @@
 
 # Test postgresql_vacuum module.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.6', '>=')
+  when: postgres_version_resp.stdout is version('10', '>=')
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -804,7 +804,7 @@
 # Test postgresql_vacuum module.
 # Local integration tests on excluded OS pass well.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16) and (ansible_distribution != 'Fedora' and ansible_distribution_major_version != 28)
+  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16)
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -803,7 +803,8 @@
 
 # Test postgresql_vacuum module.
 - include: postgresql_vacuum.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04'
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04') or
+        (ansible_distribution == 'Fedora' and ansible_distribution_version == '29')
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -804,7 +804,7 @@
 # Test postgresql_vacuum module.
 # Local integration tests on excluded OS pass well.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16)
+  when: postgres_version_resp.stdout is version('9.4', '>=') and ansible_distribution != 'FreeBSD' and (ansible_distribution != 'Ubuntu' and ansible_distribution_major_version != 16) and (ansible_distribution != 'Fedora' and ansible_distribution_major_version != 28)
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -803,7 +803,10 @@
 
 # Test postgresql_vacuum module.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('10', '>=')
+  when: postgres_version_resp.stdout is version('9.4', '>=') and
+        ansible_distribution == 'RedHat' or
+        ansible_distribution == 'CentOS' or
+        ansible_distribution == 'Ubuntu'
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -803,9 +803,7 @@
 
 # Test postgresql_vacuum module.
 - include: postgresql_vacuum.yml
-  when: postgres_version_resp.stdout is version('9.4', '>=') and
-        ansible_distribution == 'RedHat' or
-        (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == 18)
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04'
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -805,8 +805,7 @@
 - include: postgresql_vacuum.yml
   when: postgres_version_resp.stdout is version('9.4', '>=') and
         ansible_distribution == 'RedHat' or
-        ansible_distribution == 'CentOS' or
-        ansible_distribution == 'Ubuntu'
+        (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version == 18)
 
 # Test postgresql_set
 - include: postgresql_set.yml

--- a/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
@@ -4,6 +4,7 @@
 
 - vars:
     test_table: acme
+    non_existent_table: non_existent_table
     task_parameters: &task_parameters
       become_user: '{{ pg_user }}'
       become: True
@@ -43,6 +44,19 @@
   #
   # ANALYZE
   #
+  # check_mode analyze only of non-existent table, must fail:
+  - name: postgresql_vacuum - check mode of table analyze, the table doesn't exist
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ non_existent_table }}'
+      analyze_only: yes
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result.failed == true
 
   # check_mode analyze only - if it's OK, must always return changed=True:
   - name: postgresql_vacuum - check mode of table analyze
@@ -142,6 +156,18 @@
   #
   # VACUUM
   #
+  # check_mode vacuum of non-existent table:
+  - name: postgresql_vacuum - check mode of table vacuum, non-existent table, must fail
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ non_existent_table }}'
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result.failed == true
 
   # check_mode vacuum - if it's OK, must always return changed=True:
   - name: postgresql_vacuum - check mode of table vacuum
@@ -272,8 +298,23 @@
       <<: *pg_parameters
       query: "SELECT pg_stat_reset()"
 
+  # check_mode vacuum full analyze for non-existent table, must fail:
+  - name: postgresql_vacuum - check mode of table vacuum full, non-existent table
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ non_existent_table }}'
+      full: yes
+      analyze: yes
+    ignore_errors: yes
+
+  - assert:
+      that:
+      - result.failed == true
+
   # check_mode vacuum full analyze - if it's OK, must always return changed=True:
-  - name: postgresql_vacuum - check mode of table vacuum
+  - name: postgresql_vacuum - check mode of table vacuum full
     check_mode: yes
     <<: *task_parameters
     postgresql_vacuum:

--- a/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
@@ -95,9 +95,6 @@
       - result.changed == true
       - result.queries == ['ANALYZE "{{ test_table }}"']
 
-  - pause:
-      seconds: 2
-
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
     postgresql_query:
@@ -124,9 +121,6 @@
       - result.changed == true
       - result.queries == ['ANALYZE "{{ test_table }}" (id, name)']
 
-  - pause:
-      seconds: 2
-
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
     postgresql_query:
@@ -148,9 +142,6 @@
       that:
       - result.changed == true
       - result.queries == ['ANALYZE']
-
-  - pause:
-      seconds: 2
 
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
@@ -213,9 +204,6 @@
       - result.changed == true
       - result.queries == ['VACUUM "{{ test_table }}"']
 
-  - pause:
-      seconds: 2
-
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
     postgresql_query:
@@ -241,9 +229,6 @@
       - result.changed == true
       - result.queries == ['VACUUM (FREEZE, ANALYZE) "{{ test_table }}" (id)']
 
-  - pause:
-      seconds: 2
-
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
     postgresql_query:
@@ -264,9 +249,6 @@
       that:
       - result.changed == true
       - result.queries == ['VACUUM']
-
-  - pause:
-      seconds: 2
 
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
@@ -346,9 +328,6 @@
       - result.changed == true
       - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
 
-  - pause:
-      seconds: 2
-
   - name: postgresql_vacuum - check vacuum counter
     <<: *task_parameters
     postgresql_query:
@@ -372,9 +351,6 @@
       that:
       - result.changed == true
       - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
-
-  - pause:
-      seconds: 2
 
   - name: postgresql_vacuum - check vacuum counter
     <<: *task_parameters

--- a/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
@@ -95,6 +95,9 @@
       - result.changed == true
       - result.queries == ['ANALYZE "{{ test_table }}"']
 
+  - pause:
+      seconds: 2
+
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
     postgresql_query:
@@ -121,6 +124,9 @@
       - result.changed == true
       - result.queries == ['ANALYZE "{{ test_table }}" (id, name)']
 
+  - pause:
+      seconds: 2
+
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
     postgresql_query:
@@ -142,6 +148,9 @@
       that:
       - result.changed == true
       - result.queries == ['ANALYZE']
+
+  - pause:
+      seconds: 2
 
   - name: postgresql_vacuum - check analyze counter
     <<: *task_parameters
@@ -204,6 +213,9 @@
       - result.changed == true
       - result.queries == ['VACUUM "{{ test_table }}"']
 
+  - pause:
+      seconds: 2
+
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
     postgresql_query:
@@ -229,6 +241,9 @@
       - result.changed == true
       - result.queries == ['VACUUM (FREEZE, ANALYZE) "{{ test_table }}" (id)']
 
+  - pause:
+      seconds: 2
+
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
     postgresql_query:
@@ -249,6 +264,9 @@
       that:
       - result.changed == true
       - result.queries == ['VACUUM']
+
+  - pause:
+      seconds: 2
 
   - name: postgresql_vacuum - check vacuum count
     <<: *task_parameters
@@ -328,6 +346,9 @@
       - result.changed == true
       - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
 
+  - pause:
+      seconds: 2
+
   - name: postgresql_vacuum - check vacuum counter
     <<: *task_parameters
     postgresql_query:
@@ -351,6 +372,9 @@
       that:
       - result.changed == true
       - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
+
+  - pause:
+      seconds: 2
 
   - name: postgresql_vacuum - check vacuum counter
     <<: *task_parameters

--- a/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_vacuum.yml
@@ -1,0 +1,332 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# The file for testing postgresql_vacuum module.
+
+- vars:
+    test_table: acme
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: True
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: postgres
+
+  block:
+  # Test preparation:
+  - name: postgresql_vacuum - create test table
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: '{{ test_table }}'
+      columns:
+      - id int
+      - name text
+
+  # Insert the data:
+  - name: postgresql_vacuum - insert rows into test table
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "INSERT INTO {{ test_table }} (id, name) VALUES (1, 'first')"
+
+  # Reset statistics:
+  - name: postgresql_vacuum - reset statistics
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT pg_stat_reset()"
+
+  # ##############
+  # Do main tests:
+
+  #
+  # ANALYZE
+  #
+
+  # check_mode analyze only - if it's OK, must always return changed=True:
+  - name: postgresql_vacuum - check mode of table analyze
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      analyze_only: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['ANALYZE "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check analyze counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 0
+
+  # true mode:
+  - name: postgresql_vacuum - analyze a table
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      analyze_only: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['ANALYZE "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check analyze counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 1
+
+  # true mode analyze with specific columns:
+  - name: postgresql_vacuum - analyze table columns
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      analyze_only: yes
+      table: '{{ test_table }}'
+      columns:
+      - id
+      - name
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['ANALYZE "{{ test_table }}" (id, name)']
+
+  - name: postgresql_vacuum - check analyze counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 2
+
+  # true mode:
+  - name: postgresql_vacuum - analyze a database
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      analyze_only: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['ANALYZE']
+
+  - name: postgresql_vacuum - check analyze counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 3
+
+  #
+  # VACUUM
+  #
+
+  # check_mode vacuum - if it's OK, must always return changed=True:
+  - name: postgresql_vacuum - check mode of table vacuum
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check vacuum counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT vacuum_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].vacuum_count == 0
+
+  # true mode:
+  - name: postgresql_vacuum - vacuum a table
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check vacuum count
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT vacuum_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].vacuum_count == 1
+
+  # true mode:
+  - name: postgresql_vacuum - vacuum analyze freeze a table
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      columns: id
+      analyze: yes
+      freeze: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM (FREEZE, ANALYZE) "{{ test_table }}" (id)']
+
+  - name: postgresql_vacuum - check vacuum count
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT vacuum_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].vacuum_count == 2
+
+  # true mode:
+  - name: postgresql_vacuum - vacuum a database
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM']
+
+  - name: postgresql_vacuum - check vacuum count
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT vacuum_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].vacuum_count == 3
+
+  # true mode:
+  - name: postgresql_vacuum - vacuum with disable page skipping
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      disable_page_skipping: yes
+    when: postgres_version_resp.stdout is version('9.6', '>=')
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM (DISABLE_PAGE_SKIPPING) "{{ test_table }}"']
+    when: postgres_version_resp.stdout is version('9.6', '>=')
+
+  - name: postgresql_vacuum - check vacuum count
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT vacuum_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+    when: postgres_version_resp.stdout is version('9.6', '>=')
+
+  - assert:
+      that:
+      - result.query_result[0].vacuum_count == 4
+    when: postgres_version_resp.stdout is version('9.6', '>=')
+
+  #
+  # VACUUM FULL
+  #
+
+  # Reset statistics:
+  - name: postgresql_vacuum - reset statistics
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT pg_stat_reset()"
+
+  # check_mode vacuum full analyze - if it's OK, must always return changed=True:
+  - name: postgresql_vacuum - check mode of table vacuum
+    check_mode: yes
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      full: yes
+      analyze: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check vacuum counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 0
+
+  # true mode vacuum full analyze
+  - name: postgresql_vacuum - vacuum full
+    <<: *task_parameters
+    postgresql_vacuum:
+      <<: *pg_parameters
+      table: '{{ test_table }}'
+      full: yes
+      analyze: yes
+
+  - assert:
+      that:
+      - result.changed == true
+      - result.queries == ['VACUUM FULL ANALYZE "{{ test_table }}"']
+
+  - name: postgresql_vacuum - check vacuum counter
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: "SELECT analyze_count FROM pg_stat_user_tables WHERE relname = '{{ test_table }}'"
+
+  - assert:
+      that:
+      - result.query_result[0].analyze_count == 1
+
+  #
+  # Clean up
+  #
+  - name: postgresql_vacuum - drop the test table
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: '{{ test_table }}'
+      state: absent

--- a/test/integration/targets/postgresql/tasks/ssl.yml
+++ b/test/integration/targets/postgresql/tasks/ssl.yml
@@ -28,42 +28,42 @@
   package: name=openssl state=present
 
 - name: postgresql SSL - create certs 1
-  become_user: "{{ pg_user }}"
+  become_user: root
   become: yes
   shell: 'openssl req -new -nodes -text -out ~{{ pg_user }}/root.csr \
          -keyout ~{{ pg_user }}/root.key -subj "/CN=localhost.local"'
 
-- name: postgresql SSL - set right permissions to root.key
-  become_user: "{{ pg_user }}"
-  become: yes
-  file:
-    path: '~{{ pg_user }}/root.key'
-    mode: 0770
-
-- name: postgresql SSL - create certs 3
-  become_user: "{{ pg_user }}"
+- name: postgresql SSL - create certs 2
+  become_user: root
   become: yes
   shell: 'openssl x509 -req -in ~{{ pg_user }}/root.csr -text -days 3650 \
          -extensions v3_ca -signkey ~{{ pg_user }}/root.key -out ~{{ pg_user }}/root.crt'
 
-- name: postgresql SSL - create certs 4
-  become_user: "{{ pg_user }}"
+- name: postgresql SSL - create certs 3
+  become_user: root
   become: yes
   shell: 'openssl req -new -nodes -text -out ~{{ pg_user }}/server.csr \
          -keyout ~{{ pg_user }}/server.key -subj "/CN=localhost.local"'
 
-- name: postgresql SSL - set right permissions to server.key
-  become_user: "{{ pg_user }}"
-  become: yes
-  file:
-    path: '~{{ pg_user }}/server.key'
-    mode: 0770
-
-- name: postgresql SSL - create certs 5
-  become_user: "{{ pg_user }}"
+- name: postgresql SSL - create certs 4
+  become_user: root
   become: yes
   shell: 'openssl x509 -req -in ~{{ pg_user }}/server.csr -text -days 365 \
          -CA ~{{ pg_user }}/root.crt -CAkey ~{{ pg_user }}/root.key -CAcreateserial -out server.crt'
+
+- name: postgresql SSL - set right permissions to files
+  become_user: root
+  become: yes
+  file:
+    path: '{{ item }}'
+    mode: 0600
+    owner: '{{ pg_user }}'
+    group: '{{ pg_user }}'
+  with_items:
+  - '~{{ pg_user }}/root.key'
+  - '~{{ pg_user }}/server.key'
+  - '~{{ pg_user }}/root.crt'
+  - '~{{ pg_user }}/server.csr'
 
 - name: postgresql SSL - enable SSL
   become_user: "{{ pg_user }}"


### PR DESCRIPTION
##### SUMMARY
New module postgresql_vacuum - Garbage-collect and optionally analyze a PostgreSQL database.

Specific options:
- db - Name of a database for vacuum (used as a database to connect to)
- table - Name of a table that needs to be vacuumed
- columns - List of column names of I(table) that need to be vacuumed
- analyze - Updates statistics used by the planner to determine the most efficient way to execute a query.
- analyze_only - Only update optimizer statistics, no vacuum
- full - [documentation](https://www.postgresql.org/docs/current/sql-vacuum.html)
- disable_page_skipping - [documentation](https://www.postgresql.org/docs/current/sql-vacuum.html)

Note:
I came across with strange behavior on Ubuntu 1604 when it doesn't allow to create ssl certs by user postgres into his home directory but there is no code changes in this PR that's related with ssl.
To avoid excluding Ubuntu 1604 from SSL tests, I fixed ssl.yml too.

##### ISSUE TYPE
- New Module Pull Request

##### EXAMPLES
```
- name: Vacuum database acme
  postgresql_vacuum:
    db: acme

- name: Vacuum and analyze database acme
  postgresql_vacuum:
    db: acme
    analyze: yes

- name: Vacuum full and analyze database foo. Pay attention that the database will be locked
  postgresql_vacuum:
    db: foo
    full: yes
    analyze: yes

- name: Analyze table mytable in database bar
  postgresql_vacuum:
    db: bar
    table: mytable
    analyze_only: yes

- name: Vacuum and analyze columns col1, col2, and col3 of mytable in database acme
  postgresql_vacuum:
    db: acme
    table: mytable
    columns:
    - col1
    - col2
    - col3
    analyze: yes

- name: Vacuum of mytable with freeze
  postgresql_vacuum:
    db: acme
    table: mytable
    freeze: yes

- name: Vacuum of mytable with disabled page skipping
  postgresql_vacuum:
    db: acme
    table: mytable
    disable_page_skipping: yes
```
##### RETURN
```
queries:
  description: List of executed queries.
  returned: always
  type: str
  sample: [ "VACUUM (ANALYZE) mytable (col1, col2, col3)" ]
```