### PR TITLE
ovirt vmpool fix

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpool.py
@@ -267,7 +267,7 @@ class VmPoolsModule(BaseModule):
             type=otypes.VmPoolType(
                 self._module.params['type']
             ) if self._module.params['type'] else None,
-            vm=self.build_vm(vm)
+            vm=self.build_vm(vm) if self._module.params['vm'] else None,
         )
 
     def build_vm(self, vm):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ovirt vmpool fix
bug: when user wanted to create vmpool without defining 'vm' it throw 
The error was: AttributeError: 'NoneType' object has no attribute 'get' 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
