### PR TITLE
Add a placeholder AWS guidelines that links to the development docsite so that links in existing published documentation are not broken.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -1,0 +1,8 @@
+This document has moved
+=======================
+
+The Guidelines for Ansible Amazon AWS module development is being moved into the Ansible
+documentation.
+
+The updated documentation will be published with Ansible 2.9, for now it's accessible
+as [Guidelines for Ansible Amazon AWS module development on the development branch of the docsite](https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html).


### PR DESCRIPTION

##### SUMMARY
Guidelines for AWS modules have been moved into the docsite. However the currently published docsite for 2.8 (and previous versions) still link to the old GUIDELINES.md file.

As a result we have a broken link in the published doc and it's difficult to find the contributing guidelines if you don't already know they exist.

This re-introduces a stub GUIDELINES.md file that links to the new page in the devel docsite so that any existing links still give the user a path to find the information.

I think this is probably the easier short term option till 2.9 is released rather than re-publishing old versions of the docsite. Hoever the approach to resolve this issue is still being discussed on #ansible-docs. So up to @acozine about whether this is a good way to solve or whether rebuilidng the published docsite is preferrable.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws docs
