### PR TITLE
Update links to AWS module guidelines to target the devel docsite since it's been removed from devel

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -160,7 +160,7 @@ Ansible conventions offer a predictable user interface across all modules, playb
 * Implement declarative operations (not CRUD) so the user can ignore existing state and focus on final state. For example, use ``started/stopped``, ``present/absent``.
 * Strive for a consistent final state (aka idempotency). If running your module twice in a row against the same system would result in two different states, see if you can redesign or rewrite to achieve consistent final state. If you can't, document the behavior and the reasons for it.
 * Provide consistent return values within the standard Ansible return structure, even if NA/None are used for keys normally returned under other options.
-* Follow additional guidelines that apply to families of modules if applicable. For example, AWS modules should follow `the Amazon guidelines <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_
+* Follow additional guidelines that apply to families of modules if applicable. For example, AWS modules should follow `the Amazon guidelines <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_
 
 Module Security
 ===============

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -40,5 +40,5 @@ Other checklists
 ================
 
 * :ref:`Tips for module development <developing_modules_best_practices>`.
-* `Amazon development checklist <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_.
+* `Amazon development checklist <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_.
 * :ref:`Windows development checklist <developing_modules_general_windows>`.

--- a/docs/docsite/rst/dev_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/index.rst
@@ -24,7 +24,7 @@ Find the task that best describes what you want to do:
    * I want to :ref:`get started writing a module <developing_modules_general>`.
    * I want to :ref:`write a network module <developing_modules_network>`.
    * I want to :ref:`write a Windows module <developing_modules_general_windows>`.
-   * I want to `write an Amazon module <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_.
+   * I want to `write an Amazon module <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_.
    * I want to :ref:`write a series of related modules <developing_modules_in_groups>` that integrate Ansible with a new product (for example, a database, cloud provider, network platform, etc.).
 
 * I want to refine my code:


### PR DESCRIPTION
##### SUMMARY

Guidelines for AWS modules have been moved into the docsite. However the currently published docsite for 2.8 (and previous versions) still link to the old GUIDELINES.md file.

As a result we have a broken link in the published doc and it's difficult to find the contributing guidelines if you don't already know they exist.

This updates the links to this file in the 2.8 docs to refer to the devel docsite. While this is inconsistent with the rest of the dev guides that link to the same version, discussion on #ansible-docs came to the conclusion that this was the best option since we want developers building modules to use the latest guidelines.

Related PRs:

* #57466 - Backport to 2.7
* #57467 - Backport to 2.6

cc: @acozine 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws docs