### PR TITLE
Replace links to AWS module guidelines with links to devel docsite (Backport to 2.7)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -150,7 +150,7 @@ Ansible conventions offer a predictable user interface across all modules, playb
 * Implement declarative operations (not CRUD) so the user can ignore existing state and focus on final state. For example, use ``started/stopped``, ``present/absent``.
 * Strive for a consistent final state (aka idempotency). If running your module twice in a row against the same system would result in two different states, see if you can redesign or rewrite to achieve consistent final state. If you can't, document the behavior and the reasons for it.
 * Provide consistent return values within the standard Ansible return structure, even if NA/None are used for keys normally returned under other options.
-* Follow additional guidelines that apply to families of modules if applicable. For example, AWS modules should follow `the Amazon guidelines <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_
+* Follow additional guidelines that apply to families of modules if applicable. For example, AWS modules should follow `the Amazon guidelines <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_
 
 Module Security
 ===============

--- a/docs/docsite/rst/dev_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/index.rst
@@ -20,7 +20,7 @@ Find the task that best describes what you want to do:
    * I want to :ref:`set up my Python development environment <environment_setup>`.
    * I want to :ref:`get started writing a module <developing_modules_general>`.
    * I want to :ref:`write a Windows module <developing_modules_general_windows>`.
-   * I want to `write an Amazon (AWS) module <https://github.com/ansible/ansible/blob/stable-2.7/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_.
+   * I want to `write an Amazon (AWS) module <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_.
    * I want to :ref:`write a series of related modules <developing_modules_in_groups>` that integrate Ansible with a new product (for example, a database, cloud provider, network platform, etc.).
 
 * I want to refine my code:


### PR DESCRIPTION
##### SUMMARY
This is the 2.7 version of #57465 see that PR for more details and context.

cc @acozine 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws docs