### PR TITLE
Replace links to AWS module guidelines with links to devel docsite (Backport to 2.6)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -76,7 +76,7 @@ Read the complete :ref:`module metadata specification <ansible_metadata_block>` 
     * Avoid catchall exceptions, they are not very useful unless the underlying API gives very good error messages pertaining the attempted action.
 * Module-dependent guidelines: Additional module guidelines may exist for certain families of modules.
     * Be sure to check out the modules themselves for additional information.
-        * `Amazon <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md>`_
+        * `Amazon <https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html>`_
     * Modules should make use of the "extends_documentation_fragment" to ensure documentation available. For example, the AWS module should include::
 
         extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY
This is the 2.6 version of #57465 see that PR for more details and context.

cc @acozine 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws docs