### PR TITLE
[Backport 2.8] Make purefa_pgsnap module handle its own exit correctly (#56954)

### DIFF
--- a/changelogs/fragments/56954-purefa_pgsnap_handle_exit_correctly.yaml
+++ b/changelogs/fragments/56954-purefa_pgsnap_handle_exit_correctly.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - "purefa_pgsnap - handle exit correctly if selected remote volume or snapshot does not exist."

--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -235,8 +235,12 @@ def main():
         module.fail_json(msg="Selected volume {0} does not exist in the Protection Group".format(module.params['name']))
     if ":" in module.params['name']:
         rvolume = get_rpgsnapshot(module, array)
+        if rvolume is None:
+            module.fail_json(msg="Selected restore snapshot {0} does not exist in the Protection Group".format(module.params['restore']))
     else:
         rvolume = get_pgroupvolume(module, array)
+        if rvolume is None:
+            module.fail_json(msg="Selected restore volume {0} does not exist in the Protection Group".format(module.params['restore']))
 
     if state == 'copy' and rvolume:
         restore_pgsnapvolume(module, array)
@@ -250,6 +254,8 @@ def main():
         delete_pgsnapshot(module, array)
     elif state == 'absent' and not pgsnap:
         module.exit_json(changed=False)
+
+    module.exit_json(changed=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(cherry picked from commit d4c0269fbbb177165d9eeb2dbec450f8552face8)

##### SUMMARY
Backport of #56954 to stable/2.8
Handle module exit correctly if an unknown remote volume or snapshot is referenced. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_pgsnap.py