### PR TITLE
FTD configuration module: fix a bug with response parsing

### DIFF
--- a/lib/ansible/module_utils/network/ftd/common.py
+++ b/lib/ansible/module_utils/network/ftd/common.py
@@ -65,7 +65,7 @@ def construct_ansible_facts(response, params):
         response_body = response['items'] if 'items' in response else response
         if params.get('register_as'):
             facts[params['register_as']] = response_body
-        elif response_body.get('name') and response_body.get('type'):
+        elif type(response_body) is dict and response_body.get('name') and response_body.get('type'):
             object_name = re.sub(INVALID_IDENTIFIER_SYMBOLS, '_', response_body['name'].lower())
             fact_name = '%s_%s' % (response_body['type'], object_name)
             facts[fact_name] = response_body

--- a/lib/ansible/module_utils/network/ftd/device.py
+++ b/lib/ansible/module_utils/network/ftd/device.py
@@ -30,7 +30,7 @@ except ImportError:
 def assert_kick_is_installed(module):
     if not HAS_KICK:
         module.fail_json(msg='Firepower-kickstart library is required to run this module. '
-                             'Please, install it with `pip install firepower-kickstart` '
+                             'Please, install the library with `pip install firepower-kickstart` '
                              'command and run the playbook again.')
 
 

--- a/lib/ansible/module_utils/network/ftd/device.py
+++ b/lib/ansible/module_utils/network/ftd/device.py
@@ -29,8 +29,9 @@ except ImportError:
 
 def assert_kick_is_installed(module):
     if not HAS_KICK:
-        module.fail_json(msg='Firepower-kick library is required to run this module. '
-                             'Please, install it with `pip install firepower-kick` command and run the playbook again.')
+        module.fail_json(msg='Firepower-kickstart library is required to run this module. '
+                             'Please, install it with `pip install firepower-kickstart` '
+                             'command and run the playbook again.')
 
 
 class FtdModel:

--- a/lib/ansible/modules/network/ftd/ftd_install.py
+++ b/lib/ansible/modules/network/ftd/ftd_install.py
@@ -37,9 +37,9 @@ description:
     the `local` connection should be used only when the device cannot be accessed via
     REST API.
 version_added: "2.8"
-requirements: [ "python >= 3.5", "firepower-kick" ]
+requirements: [ "python >= 3.5", "firepower-kickstart" ]
 notes:
-  - Requires `firepower-kick` library that should be installed separately and requires Python >= 3.5.
+  - Requires `firepower-kickstart` library that should be installed separately and requires Python >= 3.5.
   - On localhost, Ansible can be still run with Python >= 2.7, but the interpreter for this particular module must be
     Python >= 3.5.
   - Python interpreter for the module can overwritten in `ansible_python_interpreter` variable.

--- a/test/units/module_utils/network/ftd/test_common.py
+++ b/test/units/module_utils/network/ftd/test_common.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from ansible.module_utils.network.ftd.common import equal_objects, delete_ref_duplicates
+from ansible.module_utils.network.ftd.common import equal_objects, delete_ref_duplicates, construct_ansible_facts
 
 
 # simple objects
@@ -372,3 +372,75 @@ def test_delete_ref_duplicates_with_object_containing_duplicate_refs_in_nested_o
             ]
         }
     } == delete_ref_duplicates(data)
+
+
+def test_construct_ansible_facts_should_make_default_fact_with_name_and_type():
+    response = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar'
+    }
+
+    assert {'bar_foo': response} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_not_make_default_fact_with_no_name():
+    response = {
+        'id': '123',
+        'name': 'foo'
+    }
+
+    assert {} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_not_make_default_fact_with_no_type():
+    response = {
+        'id': '123',
+        'type': 'bar'
+    }
+
+    assert {} == construct_ansible_facts(response, {})
+
+
+def test_construct_ansible_facts_should_use_register_as_when_given():
+    response = {
+        'id': '123',
+        'name': 'foo',
+        'type': 'bar'
+    }
+    params = {'register_as': 'fact_name'}
+
+    assert {'fact_name': response} == construct_ansible_facts(response, params)
+
+
+def test_construct_ansible_facts_should_extract_items():
+    response = {'items': [
+        {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }, {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }
+    ]}
+    params = {'register_as': 'fact_name'}
+
+    assert {'fact_name': response['items']} == construct_ansible_facts(response, params)
+
+
+def test_construct_ansible_facts_should_ignore_items_with_no_register_as():
+    response = {'items': [
+        {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }, {
+            'id': '123',
+            'name': 'foo',
+            'type': 'bar'
+        }
+    ]}
+
+    assert {} == construct_ansible_facts(response, {})

--- a/test/units/modules/network/ftd/test_ftd_install.py
+++ b/test/units/modules/network/ftd/test_ftd_install.py
@@ -85,7 +85,7 @@ class TestFtdInstall(object):
 
         result = ex.value.args[0]
         assert result['failed']
-        assert "Firepower-kick library is required to run this module" in result['msg']
+        assert "Firepower-kickstart library is required to run this module" in result['msg']
 
     def test_module_should_fail_when_platform_is_not_supported(self, config_resource_mock):
         config_resource_mock.execute_operation.return_value = {'platformModel': 'nonSupportedModel'}


### PR DESCRIPTION
##### SUMMARY
* Fixes a bug with parsing server response: the `construct_ansible_facts` util function made a wrong assumption that the response is always a `dict` and called `get` method on it (that resulted in raising `AttributeError: 'list' object has no attribute 'get'` error). It turned out that there are cases when the server returns a `list` and we should not call `get` method in this case;
* Updates a wrong dependency name for the `ftd_install` module. The module used to use `firepower-kick` naming while the package is published as `firepower-kickstart` on [PyPI](https://pypi.org/project/firepower-kickstart/).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* `ftd_configuration` module;
* `ftd_install` module.
