### PR TITLE
PR to fix the IOS_NTP integration TC failure

### DIFF
--- a/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
+++ b/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
@@ -92,7 +92,6 @@
   always:
   - name: Remove ntp config
     ios_ntp: *remove
-    ignore_errors: yes
 
   - name: remove NTP_ACL from device
     ios_config:

--- a/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
+++ b/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
@@ -11,6 +11,7 @@
     auth_key: 15435A030726242723273C21181319000A
     auth: true
     state: absent
+    provider: "{{ cli }}"
   ignore_errors: true
 
 - block:
@@ -20,6 +21,7 @@
       server: 10.75.32.5
       source_int: "{{ test_interface }}"
       state: present
+      provider: "{{ cli }}"
     register: result
 
   - assert: &true
@@ -39,6 +41,7 @@
       lines:
         - 10 permit ip host 192.0.2.1 any log
       parents: ip access-list extended NTP_ACL
+      provider: "{{ cli }}"
     register: result
 
   - assert: *true
@@ -48,6 +51,7 @@
       acl: NTP_ACL
       logging: true
       state: present
+      provider: "{{ cli }}"
     register: result
 
   - assert: *true
@@ -64,6 +68,7 @@
       auth_key: 15435A030726242723273C21181319000A
       auth: true
       state: present
+      provider: "{{ cli }}"
     register: result
 
   - assert: *true
@@ -79,6 +84,7 @@
       acl: NTP_ACL
       logging: true
       state: absent
+      provider: "{{ cli }}"
     register: result
 
   - assert: *true
@@ -97,3 +103,5 @@
     ios_config:
       lines:
         - no ip access-list extended NTP_ACL
+      provider: "{{ cli }}"
+

--- a/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
+++ b/test/integration/targets/ios_ntp/tests/cli/ntp_configuration.yaml
@@ -1,4 +1,6 @@
 ---
+- debug: msg="START connection={{ ansible_connection }} ios_ntp sanity test"
+
 - name: remove NTP (if set)
   ios_ntp: &remove
     server: 10.75.32.5
@@ -31,6 +33,15 @@
   - assert: &false
       that:
         - "result.changed == false"
+
+  - name: load acl NTP_ACL into device
+    ios_config:
+      lines:
+        - 10 permit ip host 192.0.2.1 any log
+      parents: ip access-list extended NTP_ACL
+    register: result
+
+  - assert: *true
 
   - name: configure NTP
     ios_ntp: &config1
@@ -81,3 +92,9 @@
   always:
   - name: Remove ntp config
     ios_ntp: *remove
+    ignore_errors: yes
+
+  - name: remove NTP_ACL from device
+    ios_config:
+      lines:
+        - no ip access-list extended NTP_ACL


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to fix the IOS_NTP integration TC failure, where TC was failing coz of missing configuration which needed to be set before firing the TC.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_ntp
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
