### PR TITLE
Remove the unnecessary warning about aptitude not being installed (#56832)

### DIFF
--- a/changelogs/fragments/57487-aptitude-not-installed-warning.yml
+++ b/changelogs/fragments/57487-aptitude-not-installed-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Remove the unnecessary warning about aptitude not being installed (https://github.com/ansible/ansible/issues/56832).

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1057,7 +1057,6 @@ def main():
     use_apt_get = p['force_apt_get']
 
     if not use_apt_get and not APTITUDE_CMD:
-        module.warn("Could not find aptitude. Using apt-get instead")
         use_apt_get = True
 
     updated_cache = False


### PR DESCRIPTION
Signed-off-by: Marco Dickert <marco@misterunknown.de>

##### SUMMARY
Remove the unnecessary warning about aptitude not being installed. Fixes #56832

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
Steps to reproduce can be found here: #56832 

This is my first pull request. As I don't know [how to predict the PR number](https://docs.ansible.com/ansible/latest/community/development_process.html#creating-a-changelog-fragment), I commit the changelog fragment after creating the PR.