### PR TITLE
Fixes lack of support for Cumulus Linux with Hostname module

### DIFF
--- a/changelogs/fragments/hostname_cumulus_linux_support.yaml
+++ b/changelogs/fragments/hostname_cumulus_linux_support.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - Readded support for Cumulus Linux which broke in v2.8.0 (https://github.com/ansible/ansible/pull/57493)

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -637,6 +637,12 @@ class DebianHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class CumulusHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Cumulus-linux'
+    strategy_class = DebianStrategy
+
+
 class KaliHostname(Hostname):
     platform = 'Linux'
     distribution = 'Kali'


### PR DESCRIPTION
…le v2.8.0. Broken in Pull Request #52199.

##### SUMMARY
Fixing support for Cumulus Linux in the Hostname module. This no longer worked in 2.8.0 as a result of Pull Request #52199.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
hostname

##### ADDITIONAL INFORMATION
Before
```
cumulus@oob-mgmt-server:~$ ansible -m hostname -a "name=test01" spine01
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow 
bad characters in group names by default, this will change, but still be user 
configurable on deprecation. This feature will be removed in version 2.10. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
 [WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details

 [WARNING]: Platform linux on host spine01 is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_a
ppendices/interpreter_discovery.html for more information.

spine01 | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "msg": "hostname module cannot be used on platform Linux (Cumulus-linux)"
}

```
After
```
cumulus@oob-mgmt-server:~$ ansible -m hostname -a "name=test01" spine01 -b 
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow 
bad characters in group names by default, this will change, but still be user 
configurable on deprecation. This feature will be removed in version 2.10. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
 [WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details

 [WARNING]: Platform linux on host spine01 is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_a
ppendices/interpreter_discovery.html for more information.

spine01 | CHANGED => {
    "ansible_facts": {
        "ansible_domain": "", 
        "ansible_fqdn": "test01", 
        "ansible_hostname": "test01", 
        "ansible_nodename": "test01", 
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": true, 
    "name": "test01"
}

```
