### PR TITLE
Merge authentication options back into a single field to prevent losing options beyond the first

### DIFF
--- a/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
+++ b/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql_pg_hba - Merge authentication options back into a single field to prevent losing options beyond the first (https://github.com/ansible/ansible/issues/57505)
+  - postgresql_pg_hba - After splitting fields, merge authentication options back into a single field to prevent losing options beyond the first (https://github.com/ansible/ansible/issues/57505)

--- a/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
+++ b/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - postgresql_pg_hba - Merge authentication options back into a single field to prevent losing options beyond the first (https://github.com/ansible/ansible/issues/57505)
+

--- a/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
+++ b/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - postgresql_pg_hba - Merge authentication options back into a single field to prevent losing options beyond the first (https://github.com/ansible/ansible/issues/57505)
-

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -493,6 +493,8 @@ class PgHbaRule(dict):
                 cols.insert(4, None)
             if len(cols) < 7:
                 cols.insert(7, None)
+            else:
+                cols[6] = " ".join(cols[6:])
             if cols[5] not in PG_HBA_METHODS:
                 raise PgHbaValueError("Rule {0} has no valid method.".format(line))
         rule = dict(zip(PG_HBA_HDR, cols[:7]))

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -481,22 +481,19 @@ class PgHbaRule(dict):
             msg = "Rule {0} has unknown type: {1}."
             raise PgHbaValueError(msg.format(line, cols[0]))
         if cols[0] == 'local':
-            if cols[3] not in PG_HBA_METHODS:
-                raise PgHbaValueError("Rule {0} of 'local' type has invalid auth-method {1}"
-                                      "on 4th column ".format(line, cols[3]))
-            cols.insert(3, None)
-            cols.insert(3, None)
+            cols.insert(3, None) # No address
+            cols.insert(3, None) # No IP-mask
+        if len(cols) < 6:
+            cols.insert(4, None) # No IP-mask
+        elif cols[5] not in PG_HBA_METHODS:
+            cols.insert(4, None) # No IP-mask
+        if cols[5] not in PG_HBA_METHODS:
+            raise PgHbaValueError("Rule {0} of '{1}' type has invalid auth-method '{2}'".format(line, cols[0], cols[5]))
+
+        if len(cols) < 7:
+            cols.insert(6, None) # No auth-options
         else:
-            if len(cols) < 6:
-                cols.insert(4, None)
-            elif cols[5] not in PG_HBA_METHODS:
-                cols.insert(4, None)
-            if len(cols) < 7:
-                cols.insert(7, None)
-            else:
-                cols[6] = " ".join(cols[6:])
-            if cols[5] not in PG_HBA_METHODS:
-                raise PgHbaValueError("Rule {0} has no valid method.".format(line))
+            cols[6] = " ".join(cols[6:]) # combine all auth-options
         rule = dict(zip(PG_HBA_HDR, cols[:7]))
         for key, value in rule.items():
             if value:
@@ -576,7 +573,7 @@ class PgHbaRule(dict):
             return myweight < hisweight
         try:
             return self['src'] < other['src']
-        except TypeError:
+        except (TypeError, KeyError):
             return self.source_type_weight() < other.source_type_weight()
         errormessage = 'We have two rules ({1}, {2})'.format(self, other)
         errormessage += ' with exact same weight. Please file a bug.'
@@ -626,6 +623,9 @@ class PgHbaRule(dict):
         Basically make sure that IPv6Networks are sorted higher than IPv4Networks.
         This is a 'when all else fails' solution in __lt__.
         """
+        if self['type'] == 'local':
+            return 3
+
         sourceobj = self.source()
         if isinstance(sourceobj, ipaddress.IPv4Network):
             return 2

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -481,19 +481,19 @@ class PgHbaRule(dict):
             msg = "Rule {0} has unknown type: {1}."
             raise PgHbaValueError(msg.format(line, cols[0]))
         if cols[0] == 'local':
-            cols.insert(3, None) # No address
-            cols.insert(3, None) # No IP-mask
+            cols.insert(3, None)  # No address
+            cols.insert(3, None)  # No IP-mask
         if len(cols) < 6:
-            cols.insert(4, None) # No IP-mask
+            cols.insert(4, None)  # No IP-mask
         elif cols[5] not in PG_HBA_METHODS:
-            cols.insert(4, None) # No IP-mask
+            cols.insert(4, None)  # No IP-mask
         if cols[5] not in PG_HBA_METHODS:
             raise PgHbaValueError("Rule {0} of '{1}' type has invalid auth-method '{2}'".format(line, cols[0], cols[5]))
 
         if len(cols) < 7:
-            cols.insert(6, None) # No auth-options
+            cols.insert(6, None)  # No auth-options
         else:
-            cols[6] = " ".join(cols[6:]) # combine all auth-options
+            cols[6] = " ".join(cols[6:])  # combine all auth-options
         rule = dict(zip(PG_HBA_HDR, cols[:7]))
         for key, value in rule.items():
             if value:

--- a/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
@@ -58,6 +58,18 @@
   register: pg_hba_change
   with_items: "{{pg_hba_test_ips}}"
 
+- name: Retain options even if they contain spaces
+  postgresql_pg_hba:
+    contype: hostssl
+    dest: /tmp/pg_hba.conf
+    method: cert
+    options: "clientcert=1 map=mymap"
+    address: "{{ item }}"
+  with_items:
+  - red
+  - blue
+  register: pg_hba_options
+
 - name: read pg_hba rules
   postgresql_pg_hba:
     dest: /tmp/pg_hba.conf
@@ -131,6 +143,8 @@
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
            { "db": "all", "method": "md5", "src": "127.0.0.1/32", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "::1/128", "type": "host", "usr": "all" },
+           { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "all", "options": "clientcert=1 map=mymap" },
+           { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "all", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "scram-sha-256", "src": "0:ff00::/120", "type": "host", "usr": "all" },
            { "db": "replication", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
@@ -146,3 +160,4 @@
     - 'prebackupstat.stat.checksum == postbackupstat.stat.checksum'
     - 'pg_hba_fail_src_all_with_netmask is failed'
     - 'not netmask_sameas_prefix_check is changed'
+    - 'pg_hba_options is changed'

--- a/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
@@ -60,14 +60,18 @@
 
 - name: Retain options even if they contain spaces
   postgresql_pg_hba:
-    contype: hostssl
-    dest: /tmp/pg_hba.conf
-    method: cert
-    options: "clientcert=1 map=mymap"
-    address: "{{ item }}"
+    dest: "/tmp/pg_hba.conf"
+    users: "+some"
+    order: "sud"
+    state: "present"
+    contype: "{{ item.contype }}"
+    method: "{{ item.method }}"
+    options: "{{ item.options }}"
+    address: "{{ item.address }}"
   with_items:
-  - red
-  - blue
+  - { address: "", contype: "local", method: "ldap", options: "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" }
+  - { address: "red", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
+  - { address: "blue", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
   register: pg_hba_options
 
 - name: read pg_hba rules
@@ -140,11 +144,12 @@
     that:
     - 'pg_hba.pg_hba == [
            { "db": "all", "method": "md5", "type": "local", "usr": "postgres" },
+           { "db": "all", "method": "ldap", "type": "local", "usr": "+some", "options": "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" },
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
+           { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
+           { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "md5", "src": "127.0.0.1/32", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "::1/128", "type": "host", "usr": "all" },
-           { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "all", "options": "clientcert=1 map=mymap" },
-           { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "all", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "scram-sha-256", "src": "0:ff00::/120", "type": "host", "usr": "all" },
            { "db": "replication", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },


### PR DESCRIPTION
##### SUMMARY
Fixes #57505

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_pg_hba_module


##### ADDITIONAL INFORMATION
The fields are split on whitespace, but the final options field should be able to contain spaces. This joins the options back together.

