### PR TITLE
Disable the rabbitmq tests for now

### DIFF
--- a/test/integration/targets/rabbitmq_binding/aliases
+++ b/test/integration/targets/rabbitmq_binding/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_lookup/aliases
+++ b/test/integration/targets/rabbitmq_lookup/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_publish/aliases
+++ b/test/integration/targets/rabbitmq_publish/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed


### PR DESCRIPTION
The erlang-solutions repository is broken for Ubuntu18 (They did not
sign their repository metadata).  For now, disable the rabbitmq tests
which depend upon that.  I'll open a PR with a revert of this commit.
We can watch it to see when it passes in Ci to know that the
erlang-soutions repository has been fixed

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rabbit_mq tests