### PR TITLE
[stable-2.8] Disable the rabbitmq tests for now

### DIFF
--- a/test/integration/targets/rabbitmq_binding/aliases
+++ b/test/integration/targets/rabbitmq_binding/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_lookup/aliases
+++ b/test/integration/targets/rabbitmq_lookup/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_publish/aliases
+++ b/test/integration/targets/rabbitmq_publish/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled  # temporarily disabled until the erlang-solution repositories are fixed


### PR DESCRIPTION
The erlang-solutions repository is broken for Ubuntu18 (They did not
sign their repository metadata).  For now, disable the rabbitmq tests
which depend upon that.  I'll open a PR with a revert of this commit.
We can watch it to see when it passes in Ci to know that the
erlang-soutions repository has been fixed
(cherry picked from commit 5f47ab9)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
