### PR TITLE
Revert "Disable the rabbitmq tests for now"

### DIFF
--- a/test/integration/targets/rabbitmq_binding/aliases
+++ b/test/integration/targets/rabbitmq_binding/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_lookup/aliases
+++ b/test/integration/targets/rabbitmq_lookup/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_publish/aliases
+++ b/test/integration/targets/rabbitmq_publish/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed


### PR DESCRIPTION
This reverts commit 5f47ab958f8ff9c964dc22cf3008292f7ff3a181.

Disabling the rabbitmq tests was only temporary, until the
erlang-solutions repository gets its repository for Ubuntu18 fixed.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
rabbitmq tests
