### PR TITLE
[stable-2.8] Use bintray to install erlang for rabbitmq tests. 

### DIFF
--- a/test/integration/targets/rabbitmq_binding/aliases
+++ b/test/integration/targets/rabbitmq_binding/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_lookup/aliases
+++ b/test/integration/targets/rabbitmq_lookup/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_publish/aliases
+++ b/test/integration/targets/rabbitmq_publish/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled  # temporarily disabled until the erlang-solution repositories are fixed

--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -18,15 +18,15 @@
     state: latest
     force: yes
 
-- name: Add Erlang Solutions public GPG key
+- name: Add RabbitMQ release signing key
   apt_key:
-    url: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_rabbitmq/erlang_solutions.asc
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rabbitmq/rabbitmq-release-signing-key.asc
     state: present
 
-- name: Add Erlang Solutions repository
+- name: Add RabbitMQ Erlang repository
   apt_repository:
-    repo: "deb https://packages.erlang-solutions.com/ubuntu {{ ansible_distribution_release }} contrib"
-    filename: 'erlang-solutions'
+    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang-20.x"
+    filename: 'rabbitmq-erlang'
     state: present
     update_cache: yes
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Use bintray to install erlang for rabbitmq tests.

Backport of https://github.com/ansible/ansible/pull/57514

Cherry picked from commits:

- b2791718e5743a7f39a9db791307ad8790485e63
- 047fd3cfbcd6e3251cf2d91f90b64a619f89b4f9

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

rabbitmq integration tests
