### PR TITLE
Fix tower_credential example: lookup are run on controller

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -165,10 +165,14 @@ EXAMPLES = '''
     ssh_key_data: "{{ lookup('file', '/tmp/id_rsa') }}"
     ssh_key_unlock: "passphrase"
 
+- name: Fetch private key
+  slurp:
+    src: '$HOME/.ssh/aws-private.pem'
+  register: aws_ssh_key
 - name: Add Credential Into Tower
   tower_credential:
     name: Workshop Credential
-    ssh_key_data: "{{ lookup('file', '/home/' ~ {{ansible_user}} ~ '/.ssh/aws-private.pem') }}"
+    ssh_key_data: "{{ aws_ssh_key['content'] | b64decode }}"
     kind: ssh
     organization: Default
     tower_username: admin
@@ -311,7 +315,7 @@ def main():
                 data = module.params.get('ssh_key_data')
                 if os.path.exists(data):
                     module.deprecate(
-                        msg='ssh_key_data should be a string, not a path to a file. Use lookup(\'file\', \'/path/to/file\') instead',
+                        msg='ssh_key_data should be a string, not a path to a file.',
                         version="2.12"
                     )
                     if os.path.isdir(data):


### PR DESCRIPTION
##### SUMMARY

Whooops, fixup  #57113:
- don't advise to use lookup in order to fetch path on managed nodes: update deprecation warning
- fix example:
    - use `slurp` module instead of `file` lookup
    - remove extraneous brackets

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tower_credential

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
