### PR TITLE
Upgrade tests to use default-test-container 1.8.0.

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:1.8.0 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora28 name=quay.io/ansible/fedora28-test-container:1.8.0 python=2.7


### PR DESCRIPTION
##### SUMMARY

Upgrade tests to use default-test-container 1.8.0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
