### PR TITLE
tower_role: ensure alias of "validate_certs" parameter is handled

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -70,6 +70,7 @@ def tower_auth_config(module):
         password = module.params.pop('tower_password', None)
         if password:
             auth_config['password'] = password
+        module.params.pop('tower_verify_ssl', None)  # pop alias if used
         verify_ssl = module.params.pop('validate_certs', None)
         if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl

--- a/test/integration/targets/tower_role/tasks/main.yml
+++ b/test/integration/targets/tower_role/tasks/main.yml
@@ -27,6 +27,14 @@
     that:
       - "result is changed"
 
+- name: Test tower_verify_ssl alias
+  tower_role:
+    user: joe
+    role: update
+    project: Demo Project
+    tower_verify_ssl: true
+    state: absent
+
 - name: Delete a User
   tower_user:
     username: joe


### PR DESCRIPTION
##### SUMMARY
`tower_role`: fix exception when `tower_verify_ssl` parameter is used

integration test provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tower modules

##### ADDITIONAL INFORMATION
Caused by #54315.
Once merged, i will create propose a backport.