### PR TITLE
IOS cliconf: remove garbage from top configuration

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -65,7 +65,11 @@ class Cliconf(CliconfBase):
         cmd += ' '.join(to_list(flags))
         cmd = cmd.strip()
 
-        return self.send_command(cmd)
+        data = self.send_command(cmd)
+        data = re.sub(r'^Building configuration...\s+Current configuration : \d+ bytes\n', '', data, re.MULTILINE)
+        data = re.sub(r'^Using \d+ out of \d+ bytes\n', '', data, re.MULTILINE)
+
+        return data
 
     def get_diff(self, candidate=None, running=None, diff_match='line', diff_ignore_lines=None, path=None, diff_replace='line'):
         """


### PR DESCRIPTION
##### SUMMARY
* fixes #57522

The "get_config" method should return the device configuration without any additional non-configuration strings, because otherwise this method would be redundant and you could use the "run_commands" method, passing it the "show running-config" command. The change was made to the plugin, and not to the "ios_config" module, because this problem is common and not directly related to the module and it may be useful in other modules and functions. Making a change to the plugin will allow you to stop cleaning these lines in other parts of the code. Comments on the date of the change are not removed from the configuration, since they are valid configuration lines (they are ignored) and their need for each specific situation must be solved by the calling code. These comments may lead to a false comparison of some saved configuration and received from the device (if you compare them directly as strings), but the developer should use the "get_diff" method for comparison or the possibilities of comparing the class "ansible.module_utils.network.common.config.NetworkConfig"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cliconf/ios.py
