### PR TITLE
Validate args for includes in handlers too

### DIFF
--- a/changelogs/fragments/validate-include-args-in-handlers.yml
+++ b/changelogs/fragments/validate-include-args-in-handlers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Validate include args in handlers.

--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -31,7 +31,9 @@ class HandlerTaskInclude(Handler, TaskInclude):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = HandlerTaskInclude(block=block, role=role, task_include=task_include)
-        handler = t.load_data(data, variable_manager=variable_manager, loader=loader)
-        handler = t.check_options(handler, data)
+        handler = t.check_options(
+            t.load_data(data, variable_manager=variable_manager, loader=loader),
+            data
+        )
 
         return handler

--- a/lib/ansible/playbook/handler_task_include.py
+++ b/lib/ansible/playbook/handler_task_include.py
@@ -31,4 +31,7 @@ class HandlerTaskInclude(Handler, TaskInclude):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = HandlerTaskInclude(block=block, role=role, task_include=task_include)
-        return t.load_data(data, variable_manager=variable_manager, loader=loader)
+        handler = t.load_data(data, variable_manager=variable_manager, loader=loader)
+        handler = t.check_options(handler, data)
+
+        return handler

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -58,8 +58,10 @@ class TaskInclude(Task):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         ti = TaskInclude(block=block, role=role, task_include=task_include)
-        task = ti.load_data(data, variable_manager=variable_manager, loader=loader)
-        task = ti.check_options(task, data)
+        task = ti.check_options(
+            ti.load_data(data, variable_manager=variable_manager, loader=loader),
+            data
+        )
 
         return task
 

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -59,12 +59,21 @@ class TaskInclude(Task):
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         ti = TaskInclude(block=block, role=role, task_include=task_include)
         task = ti.load_data(data, variable_manager=variable_manager, loader=loader)
+        task = ti.check_options(task, data)
 
-        # Validate options
+        return task
+
+    def check_options(self, task, data):
+        '''
+        Method for options validation to use in 'load_data' for TaskInclude and HandlerTaskInclude
+        since they share the same validations. It is not named 'validate_options' on purpose
+        to prevent confusion with '_validate_*" methods. Note that the task passed might be changed
+        as a side-effect of this method.
+        '''
         my_arg_names = frozenset(task.args.keys())
 
         # validate bad args, otherwise we silently ignore
-        bad_opts = my_arg_names.difference(TaskInclude.VALID_ARGS)
+        bad_opts = my_arg_names.difference(self.VALID_ARGS)
         if bad_opts and task.action in ('include_tasks', 'import_tasks'):
             raise AnsibleParserError('Invalid options for %s: %s' % (task.action, ','.join(list(bad_opts))), obj=data)
 

--- a/test/integration/targets/include_import/valid_include_keywords/playbook.yml
+++ b/test/integration/targets/include_import/valid_include_keywords/playbook.yml
@@ -1,7 +1,8 @@
 - hosts: localhost
   gather_facts: false
   handlers:
-    - include_tasks: include_me_listen.yml
+    - include_tasks:
+        file: include_me_listen.yml
       listen:
         - include_me_listen
 


### PR DESCRIPTION
##### SUMMARY
Fixes issue when the following would fail with `No include file was specified to the include`:

```yaml
  handlers:
    - name: handler
      include_tasks:                                                                                                                                                                                              
        file: include_tasks_file_include.yml
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/playbook/task_include.py