### PR TITLE
Fix azure_rm_virtualnetwork integration test.

### DIFF
--- a/test/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
@@ -71,7 +71,7 @@
       - testing
 
 - assert:
-    that: "azure_virtualnetworks | length == 1"
+    that: "azure_virtualnetworks | length >= 1"
 
 - name: Gather facts by tags
   azure_rm_virtualnetwork_facts:


### PR DESCRIPTION
##### SUMMARY

Fix azure_rm_virtualnetwork integration test.

Previously the test would fail when run after another test which also created a virtual network tagged with the 'testing' tag.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_virtualnetwork integration test
