### PR TITLE
acme_certificate: fix docs

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -269,7 +269,7 @@ EXAMPLES = r'''
 #     wait: yes
 #     # Note: route53 requires TXT entries to be enclosed in quotes
 #     value: "{{ sample_com_challenge.challenge_data['sample.com']['dns-01'].resource_value | regex_replace('^(.*)$', '\"\\1\"') }}"
-#     when: sample_com_challenge is changed
+#   when: sample_com_challenge is changed
 #
 # Alternative way:
 #
@@ -283,8 +283,8 @@ EXAMPLES = r'''
 #     # Note: item.value is a list of TXT entries, and route53
 #     # requires every entry to be enclosed in quotes
 #     value: "{{ item.value | map('regex_replace', '^(.*)$', '\"\\1\"' ) | list }}"
-#     loop: "{{ sample_com_challenge.challenge_data_dns | dictsort }}"
-#     when: sample_com_challenge is changed
+#   loop: "{{ sample_com_challenge.challenge_data_dns | dictsort }}"
+#   when: sample_com_challenge is changed
 
 - name: Let the challenge be validated and retrieve the cert and intermediate certificate
   acme_certificate:

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -298,6 +298,7 @@ EXAMPLES = r'''
     acme_directory: https://acme-v01.api.letsencrypt.org/directory
     remaining_days: 60
     data: "{{ sample_com_challenge }}"
+  when: sample_com_challenge is changed
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
The acme_certificate documentation contains two errors:
 1. the last `acme_certificate` has no `when` condition (reported in #57554);
 2. some YAML indentations are wrong.

Fixes #57554.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
acme_certificate
