### PR TITLE
meraki_mr_l3_firewall - Fix integration test cleanup

### DIFF
--- a/changelogs/fragments/53600-meraki_mr_l3_firewall_int_test_fix.yml
+++ b/changelogs/fragments/53600-meraki_mr_l3_firewall_int_test_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - meraki_mr_l3_firewall - Integration test now uses net_id in some tests for improved code coverage.

--- a/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/test/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -82,11 +82,19 @@
 # Tear down starts here
 ############################################################################
   always:
-  - name: Delete wireless network
+  - name: Delete wireless SSID
     meraki_ssid:
       auth_key: '{{ auth_key }}'
       state: absent
       org_name: '{{test_org_name}}'
       net_id: '{{net}}'
       number: 1
+    delegate_to: localhost
+
+  - name: Delete wireless network
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_id: '{{net}}'
     delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
Integration tests now delete both a SSID and the network. It also uses `net_id` for better coverage.

Fixes #53600

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_mr_l3_firewall
