### PR TITLE
[2.8] acme_*: new test container, tests for IP certificates

### DIFF
--- a/test/integration/targets/acme_certificate/tasks/impl.yml
+++ b/test/integration/targets/acme_certificate/tasks/impl.yml
@@ -193,6 +193,46 @@
     remaining_days: 10
     terms_agreed: yes
     account_email: "example@example.org"
+- name: Obtain cert 7
+  include_tasks: obtain-cert.yml
+  vars:
+    certgen_title: Certificate 7
+    certificate_name: cert-7
+    key_type: rsa
+    rsa_bits: 2048
+    subject_alt_name:
+    - "IP:127.0.0.1"
+    # - "IP:::1"
+    subject_alt_name_critical: no
+    account_key: account-ec256
+    challenge: http-01
+    modify_account: yes
+    deactivate_authzs: no
+    force: no
+    remaining_days: 10
+    terms_agreed: yes
+    account_email: "example@example.org"
+- name: Obtain cert 8
+  include_tasks: obtain-cert.yml
+  vars:
+    certgen_title: Certificate 8
+    certificate_name: cert-8
+    key_type: rsa
+    rsa_bits: 2048
+    subject_alt_name:
+    - "IP:127.0.0.1"
+    # IPv4 only since our test validation server doesn't work
+    # with IPv6 (thanks to Python's socketserver).
+    subject_alt_name_critical: no
+    account_key: account-ec256
+    challenge: tls-alpn-01
+    challenge_alpn_tls: acme_challenge_cert_helper
+    modify_account: yes
+    deactivate_authzs: no
+    force: no
+    remaining_days: 10
+    terms_agreed: yes
+    account_email: "example@example.org"
 ## DISSECT CERTIFICATES #######################################################################
 # Make sure certificates are valid. Root certificate for Pebble equals the chain certificate.
 - name: Verifying cert 1
@@ -219,6 +259,14 @@
   command: openssl verify -CAfile "{{ output_dir }}/cert-6-root.pem" -untrusted "{{ output_dir }}/cert-6-chain.pem" "{{ output_dir }}/cert-6.pem"
   ignore_errors: yes
   register: cert_6_valid
+- name: Verifying cert 7
+  command: openssl verify -CAfile "{{ output_dir }}/cert-7-root.pem" -untrusted "{{ output_dir }}/cert-7-chain.pem" "{{ output_dir }}/cert-7.pem"
+  ignore_errors: yes
+  register: cert_7_valid
+- name: Verifying cert 8
+  command: openssl verify -CAfile "{{ output_dir }}/cert-8-root.pem" -untrusted "{{ output_dir }}/cert-8-chain.pem" "{{ output_dir }}/cert-8.pem"
+  ignore_errors: yes
+  register: cert_8_valid
 # Dump certificate info
 - name: Dumping cert 1
   command: openssl x509 -in "{{ output_dir }}/cert-1.pem" -noout -text
@@ -238,3 +286,9 @@
 - name: Dumping cert 6
   command: openssl x509 -in "{{ output_dir }}/cert-6.pem" -noout -text
   register: cert_6_text
+- name: Dumping cert 7
+  command: openssl x509 -in "{{ output_dir }}/cert-7.pem" -noout -text
+  register: cert_7_text
+- name: Dumping cert 8
+  command: openssl x509 -in "{{ output_dir }}/cert-8.pem" -noout -text
+  register: cert_8_text

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -95,7 +95,7 @@
   when: "challenge_data is changed and challenge == 'tls-alpn-01' and (challenge_alpn_tls is defined and challenge_alpn_tls == 'acme_challenge_cert_helper')"
 - name: ({{ certgen_title }}) Set TLS ALPN challenges (acm_challenge_cert_helper)
   uri:
-    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.domain }}/certificate-and-key"
+    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.domain }}/{{ item.identifier }}/certificate-and-key"
     method: PUT
     body_format: raw
     body: "{{ item.challenge_certificate }}\n{{ lookup('file', output_dir ~ '/' ~ certificate_name ~ '.key') }}"
@@ -105,7 +105,7 @@
   when: "challenge_data is changed and challenge == 'tls-alpn-01' and (challenge_alpn_tls is defined and challenge_alpn_tls == 'acme_challenge_cert_helper')"
 - name: ({{ certgen_title }}) Create TLS ALPN challenges (der-value-b64)
   uri:
-    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.value['tls-alpn-01'].resource }}/der-value-b64"
+    url: "http://{{ acme_host }}:5000/tls-alpn/{{ item.value['tls-alpn-01'].resource }}/{{ item.value['tls-alpn-01'].resource_original }}/der-value-b64"
     method: PUT
     body_format: raw
     body: "{{ item.value['tls-alpn-01'].resource_value }}"

--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -44,7 +44,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.4.2'
+            self.image = 'quay.io/ansible/acme-test-container:1.5.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Uses the latest ACME test container, and adds tests for IP certificates (supported in 2.8.0, but had no tests so far due to lack of appropriate test container).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
test/runner/lib/cloud/acme.py
