### PR TITLE
file: Raise error on permission denied

### DIFF
--- a/changelogs/fragments/57574-warn-if-absent-file-inaccessible.yaml
+++ b/changelogs/fragments/57574-warn-if-absent-file-inaccessible.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - file - warn, if path being removed is inaccessible

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -296,7 +296,7 @@ def get_state(path):
 
     b_path = to_bytes(path, errors='surrogate_or_strict')
     try:
-        if os.path.lexists(b_path):
+        if os.lstat(b_path):
             if os.path.islink(b_path):
                 return 'link'
             elif os.path.isdir(b_path):

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -683,3 +683,46 @@
         - hard_link_file.txt
 
 # END #55971
+
+# https://github.com/ansible/ansible/issues/57573
+- name: Create directory
+  file:
+    path: "{{ output_dir }}/foobar2"
+    state: directory
+    mode: 0700
+
+- name: Touch file in directory
+  file:
+    path: "{{ output_dir }}/foobar2/test.txt"
+    state: touch
+
+- name: Change permissions on directory
+  file:
+    path: "{{ output_dir }}/foobar2"
+    state: directory
+    mode: 0000
+
+- name: Try to remove file from inaccessible directory
+  become: yes
+  become_user: nobody
+  file:
+    path: "{{ output_dir }}/foobar2/test.txt"
+    state: absent
+  register: removal_result
+
+- block:
+    - name: Verify that warning about inaccessible path has been displayed
+      assert:
+        that:
+          - >
+            removal_result.warnings
+            | select('match', '^Cannot access .+ Treating path as absent')
+            | list
+            | length >= 1
+  always:
+    - name: Clean up
+      file:
+        path: "{{ output_dir }}/foobar2"
+        state: absent
+
+# END #57573


### PR DESCRIPTION
##### SUMMARY
Fixes #57573.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`file` module

##### ADDITIONAL INFORMATION
`os.path.lexists` won't report error when process has no permission to access path. See: https://github.com/python/cpython/blob/e119b3d136bd94d880bce4b382096f6de3f38062/Lib/posixpath.py#L174. It means that inaccessible paths will be treated as absent.