### PR TITLE
Add full IPv6 support to win_dns_client - Fixes #55962

### DIFF
--- a/changelogs/fragments/win_dns_client_ipv6.yaml
+++ b/changelogs/fragments/win_dns_client_ipv6.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_dns_client - Added support for setting IPv6 DNS servers - https://github.com/ansible/ansible/issues/55962

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -159,7 +159,7 @@ Function Test-DnsClientMatch {
             return $false
         }
     }
-    Write-DebugLog ("Current DNS settings match ({0})." -f ($dns_servers.IPAddressToString -join ", "))
+    Write-DebugLog ("Current DNS settings match ({0})." -f ([string[]]$dns_servers -join ", "))
     return $true
 }
 
@@ -178,7 +178,7 @@ Function Set-DnsClientAddresses
         [System.Net.IPAddress[]] $dns_servers
     )
 
-    Write-DebugLog ("Setting DNS addresses for adapter {0} to ({1})" -f $adapter_name, ($dns_servers.IPAddressToString -join ", "))
+    Write-DebugLog ("Setting DNS addresses for adapter {0} to ({1})" -f $adapter_name, ([string[]]$dns_servers -join ", "))
 
     If ($dns_servers) {
         Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ServerAddresses $dns_servers
@@ -194,12 +194,12 @@ if($dns_servers -is [string]) {
         $dns_servers = @()
     }
 }
+# Using object equals here, to check for exact match (without implicit type conversion)
+if([System.Object]::Equals($adapter_names, "*")) {
+    $adapter_names = Get-NetAdapter | Select-Object -ExpandProperty Name
+}
 if($adapter_names -is [string]) {
-    if($adapter_names -eq "*") {
-        $adapter_names = Get-NetAdapter | Select-Object -ExpandProperty Name
-    } else {
-        $adapter_names = @($adapter_names)
-    }
+    $adapter_names = @($adapter_names)
 }
 
 

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -130,19 +130,12 @@ If(-not $(Get-Command Set-DnsClientServerAddress -ErrorAction SilentlyContinue))
 Function Test-DnsClientMatch {
     Param(
         [string] $adapter_name,
-        [string[]] $dns_servers
+        [System.Net.IPAddress[]] $dns_servers
     )
-    $dns_servers = $dns_servers | Where-Object {
-        (Assert-IPAddress $_) -and (([System.Net.IPAddress]$_).AddressFamily -in $AddressFamilies)
-    } | ForEach-Object {
-        [System.Net.IPAddress]$_
-    }
     Write-DebugLog ("Getting DNS config for adapter {0}" -f $adapter_name)
 
-    $current_dns = [System.Net.IPAddress[]](
-        Get-DnsClientServerAddress -InterfaceAlias $adapter_name | ForEach-Object {
-            [System.Net.IPAddress]($_.ServerAddresses)
-        } | Where-Object {
+    $current_dns = ([System.Net.IPAddress[]](
+        (Get-DnsClientServerAddress -InterfaceAlias $adapter_name).ServerAddresses) | Where-Object {
             (Assert-IPAddress $_) -and ($_.AddressFamily -in $AddressFamilies)
         }
     )
@@ -186,9 +179,8 @@ Function Set-DnsClientAddresses
 {
     Param(
         [string] $adapter_name,
-        [string[]] $dns_servers
+        [System.Net.IPAddress[]] $dns_servers
     )
-    $dns_servers = [System.Net.IPAddress[]]$dns_servers
 
     Write-DebugLog ("Setting DNS addresses for adapter {0} to ({1})" -f $adapter_name, ($dns_servers.IPAddressToString -join ", "))
 

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -110,7 +110,7 @@ Function Set-DnsClientServerAddressLegacy {
         $arguments = @{}
     }
     Else {
-        $arguments = @{ DNSServerSearchOrder = $ServerAddresses }
+        $arguments = @{ DNSServerSearchOrder = [string[]]$ServerAddresses }
     }
     $res = Invoke-CimMethod -InputObject $adapter_config -MethodName SetDNSServerSearchOrder -Arguments $arguments
 

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -135,7 +135,7 @@ Function Test-DnsClientMatch {
 
     $current_dns = [System.Net.IPAddress[]](
         Get-DnsClientServerAddress -InterfaceAlias $adapter_name | ForEach-Object {
-            $_.ServerAddresses
+            [System.Net.IPAddress]($_.ServerAddresses)
         } | Where-Object {
             (Assert-IPAddress $_) -and ($_.AddressFamily -in $AddressFamilies)
         }

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -38,10 +38,6 @@ Function Write-DebugLog {
     $msg = "$date_str $msg"
 
     Write-Debug $msg
-
-    $log_path = $null
-    $log_path = Get-AnsibleParam -obj $params -name "log_path"
-
     if($log_path) {
         Add-Content $log_path $msg
     }

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -185,9 +185,9 @@ Function Set-DnsClientAddresses
     Write-DebugLog ("Setting DNS addresses for adapter {0} to ({1})" -f $adapter_name, ($dns_servers.IPAddressToString -join ", "))
 
     If ($dns_servers) {
-        Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ResetServerAddress
-    } Else {
         Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ServerAddresses $dns_servers
+    } Else {
+        Set-DnsClientServerAddress -InterfaceAlias $adapter_name -ResetServerAddress
     }
 }
 

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -16,10 +16,16 @@ Set-Variable -Visibility Public -Option ReadOnly,AllScope,Constant -Name "Addres
     [System.Net.Sockets.AddressFamily]::InterNetworkV6,
     [System.Net.Sockets.AddressFamily]::InterNetwork
 )
+$result = @{changed=$false}
 
+$params = Parse-Args -arguments $args -supports_check_mode $true
 Set-Variable -Visibility Public -Option ReadOnly,AllScope,Constant -Name "log_path" -Value (
     Get-AnsibleParam $params "log_path"
 )
+$adapter_names = Get-AnsibleParam $params "adapter_names" -Default "*"
+$dns_servers = Get-AnsibleParam $params "dns_servers" -aliases "ipv4_addresses","ip_addresses","addresses" -FailIfEmpty $result
+$check_mode = Get-AnsibleParam $params "_ansible_check_mode" -Default $false
+
 
 Function Write-DebugLog {
     Param(
@@ -193,13 +199,6 @@ Function Set-DnsClientAddresses
     }
 }
 
-$result = @{changed=$false}
-
-$params = Parse-Args -arguments $args -supports_check_mode $true
-
-$adapter_names = Get-AnsibleParam $params "adapter_names" -Default "*"
-$dns_servers = Get-AnsibleParam $params "dns_servers" -aliases "ipv4_addresses","ip_addresses","addresses" -FailIfEmpty $result
-
 if($dns_servers -is [string]) {
     if($dns_servers.Length -gt 0) {
         $dns_servers = @($dns_servers)
@@ -211,7 +210,6 @@ if($adapter_names -is [string]) {
     $adapter_names = @($adapter_names)
 }
 
-$check_mode = Get-AnsibleParam $params "_ansible_check_mode" -Default $false
 
 Try {
 

--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -135,7 +135,7 @@ Function Test-DnsClientMatch {
             (Assert-IPAddress $_) -and ($_.AddressFamily -in $AddressFamilies)
         }
     )
-    Write-DebugLog ("Current DNS settings: " + ($current_dns.IPAddressToString | Out-String))
+    Write-DebugLog ("Current DNS settings: {0}" -f ([string[]]$dns_servers -join ", "))
 
     if(($null -eq $current_dns) -and ($null -eq $dns_servers)) {
         Write-DebugLog "Neither are dns servers configured nor specified within the playbook."

--- a/lib/ansible/modules/windows/win_dns_client.py
+++ b/lib/ansible/modules/windows/win_dns_client.py
@@ -30,7 +30,6 @@ options:
     type: list
     required: yes
     aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
-    version_added: "2.9"
 notes:
   - When setting an empty list of DNS server addresses on an adapter with DHCP enabled, a change will always be registered, since it is not possible to
     detect the difference between a DHCP-sourced server value and one that is statically set.

--- a/lib/ansible/modules/windows/win_dns_client.py
+++ b/lib/ansible/modules/windows/win_dns_client.py
@@ -20,12 +20,14 @@ options:
     description:
       - Adapter name or list of adapter names for which to manage DNS settings ('*' is supported as a wildcard value).
       - The adapter name used is the connection caption in the Network Control Panel or the InterfaceAlias of C(Get-DnsClientServerAddress).
+    type: list
     required: yes
   dns_servers:
     description:
       - Single or ordered list of DNS servers (IPv4 and IPv6 addresses) to configure for lookup. An empty list will configure the adapter to use the
         DHCP-assigned values on connections where DHCP is enabled, or disable DNS lookup on statically-configured connections.
       - Before 2.9 use ipv4_addresses instead.
+    type: list
     required: yes
     aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
     version_added: "2.9"

--- a/lib/ansible/modules/windows/win_dns_client.py
+++ b/lib/ansible/modules/windows/win_dns_client.py
@@ -19,15 +19,16 @@ options:
   adapter_names:
     description:
       - Adapter name or list of adapter names for which to manage DNS settings ('*' is supported as a wildcard value).
-      - The adapter name used is the connection caption in the Network Control Panel or via C(Get-NetAdapter), eg C(Local Area Connection).
-    type: str
+      - The adapter name used is the connection caption in the Network Control Panel or the InterfaceAlias of C(Get-DnsClientServerAddress).
     required: yes
-  ipv4_addresses:
+  dns_servers:
     description:
-      - Single or ordered list of DNS server IPv4 addresses to configure for lookup. An empty list will configure the adapter to use the
+      - Single or ordered list of DNS servers (IPv4 and IPv6 addresses) to configure for lookup. An empty list will configure the adapter to use the
         DHCP-assigned values on connections where DHCP is enabled, or disable DNS lookup on statically-configured connections.
-    type: str
+      - Before 2.9 use ipv4_addresses instead.
     required: yes
+    aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
+    version_added: "2.9"
 notes:
   - When setting an empty list of DNS server addresses on an adapter with DHCP enabled, a change will always be registered, since it is not possible to
     detect the difference between a DHCP-sourced server value and one that is statically set.
@@ -39,12 +40,12 @@ EXAMPLES = r'''
 - name: Set a single address on the adapter named Ethernet
   win_dns_client:
     adapter_names: Ethernet
-    ipv4_addresses: 192.168.34.5
+    dns_servers: 192.168.34.5
 
 - name: Set multiple lookup addresses on all visible adapters (usually physical adapters that are in the Up state), with debug logging to a file
   win_dns_client:
     adapter_names: '*'
-    ipv4_addresses:
+    dns_servers:
     - 192.168.34.5
     - 192.168.34.6
     log_path: C:\dns_log.txt
@@ -52,7 +53,7 @@ EXAMPLES = r'''
 - name: Configure all adapters whose names begin with Ethernet to use DHCP-assigned DNS values
   win_dns_client:
     adapter_names: 'Ethernet*'
-    ipv4_addresses: []
+    dns_servers: []
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_dns_client.py
+++ b/lib/ansible/modules/windows/win_dns_client.py
@@ -26,7 +26,8 @@ options:
     description:
       - Single or ordered list of DNS servers (IPv4 and IPv6 addresses) to configure for lookup. An empty list will configure the adapter to use the
         DHCP-assigned values on connections where DHCP is enabled, or disable DNS lookup on statically-configured connections.
-      - Before 2.9 use ipv4_addresses instead.
+      - IPv6 DNS servers can only be set on Windows Server 2012 or newer, older hosts can only set IPv4 addresses.
+      - Before 2.10 use ipv4_addresses instead.
     type: list
     required: yes
     aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
@@ -50,6 +51,13 @@ EXAMPLES = r'''
     - 192.168.34.5
     - 192.168.34.6
     log_path: C:\dns_log.txt
+
+- name: Set IPv6 DNS servers on the adapter named Ethernet
+  win_dns_client:
+    adapter_names: Ethernet
+    dns_servers:
+    - '2001:db8::2'
+    - '2001:db8::3'
 
 - name: Configure all adapters whose names begin with Ethernet to use DHCP-assigned DNS values
   win_dns_client:

--- a/test/integration/targets/win_dns_client/tasks/main.yml
+++ b/test/integration/targets/win_dns_client/tasks/main.yml
@@ -176,3 +176,31 @@
     that:
     - set_dhcp is changed
     - set_dhcp_actual.stdout_lines == []
+
+# Legacy WMI does not support setting IPv6 addresses so we can only test this on newer hosts that have the new cmdlets
+- name: check if server supports IPv6
+  win_shell: if (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue) { $true } else { $false }
+  changed_when: no
+  register: new_os
+
+- name: run IPv6 tests
+  when: new_os.stdout | trim | bool
+  block:
+  - name: set IPv6 DNS address
+    win_dns_client:
+      adapter_names: '{{ network_adapter_name }}'
+      dns_servers:
+      - 2001:db8::1
+      - 2001:db8::2
+    register: set_ipv6
+
+  - name: get result of set IPv6 DNS address
+    win_shell: (Get-DnsClientServerAddress -InterfaceAlias '{{ network_adapter_name }}' -AddressFAmily IPv6).ServerAddresses
+    changed_when: no
+    register: set_ipv6_actual
+
+  - name: assert set IPv6 DNS address
+    assert:
+      that:
+      - set_ipv6 is changed
+      - set_ipv6_actual.stdout_lines == ['2001:db8::1', '2001:db8::2']

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5621,7 +5621,6 @@ lib/ansible/modules/windows/win_copy.ps1 pslint:PSUseApprovedVerbs
 lib/ansible/modules/windows/win_credential.ps1 pslint:PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_credential.ps1 validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/windows/win_dns_client.ps1 pslint:PSCustomUseLiteralPath
-lib/ansible/modules/windows/win_dns_client.ps1 pslint:PSUseApprovedVerbs
 lib/ansible/modules/windows/win_domain.ps1 pslint:PSAvoidUsingEmptyCatchBlock # Keep
 lib/ansible/modules/windows/win_domain.ps1 pslint:PSUseApprovedVerbs
 lib/ansible/modules/windows/win_domain_controller.ps1 pslint:PSAvoidGlobalVars # New PR


### PR DESCRIPTION
##### SUMMARY

Add full IPv6 support to win_dns_client.

Fixes #55962

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

win_dns_client

##### ADDITIONAL INFORMATION

Fully implement ipv6 support within win_dns_client, former it was in a weird/undefined state and unintentionally kinda working.