### PR TITLE
VMware: Fix vmware_guest_move undefined VM name error

### DIFF
--- a/changelogs/fragments/57580-vmware_guest_move-fix_undefined_name.yml
+++ b/changelogs/fragments/57580-vmware_guest_move-fix_undefined_name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Make VM name and VM UUID as mutual exclusive and required one of (https://github.com/ansible/ansible/issues/57580).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -180,7 +180,15 @@ def main():
         datacenter=dict(type='str', required=True),
     )
     module = AnsibleModule(
-        argument_spec=argument_spec, required_one_of=[['name', 'uuid']])
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['name', 'uuid']
+        ],
+        mutually_exclusive=[
+            ['name', 'uuid']
+        ],
+        supports_check_mode=True
+    )
 
     # FindByInventoryPath() does not require an absolute path
     # so we should leave the input folder path unmodified
@@ -195,12 +203,18 @@ def main():
     if vm:
         try:
             vm_path = pyv.get_vm_path(pyv.content, vm).lstrip('/')
-            vm_full = vm_path + '/' + module.params['name']
-            folder = search_index.FindByInventoryPath(
-                module.params['dest_folder'])
+            if module.params['name']:
+                vm_name = module.params['name']
+            else:
+                vm_name = vm.name
+
+            vm_full = vm_path + '/' + vm_name
+            folder = search_index.FindByInventoryPath(module.params['dest_folder'])
             if folder is None:
                 module.fail_json(msg="Folder name and/or path does not exist")
             vm_to_move = search_index.FindByInventoryPath(vm_full)
+            if module.check_mode:
+                module.exit_json(changed=True, instance=pyv.gather_facts(vm))
             if vm_path != module.params['dest_folder'].lstrip('/'):
                 move_task = folder.MoveInto([vm_to_move])
                 changed, err = wait_for_task(move_task)
@@ -213,6 +227,8 @@ def main():
             module.fail_json(msg="Failed to move VM with exception %s" %
                              to_native(exc))
     else:
+        if module.check_mode:
+            module.exit_json(changed=False)
         module.fail_json(msg="Unable to find VM %s to move to %s" % (
             (module.params.get('uuid') or module.params.get('name')),
             module.params.get('dest_folder')))

--- a/test/integration/targets/vmware_guest_move/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_move/tasks/main.yml
@@ -24,26 +24,27 @@
 - name: Move VM (Changed)
   vmware_guest_move:
     validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    name: "{{ virtual_machines[0].name }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
+    name: '{{ virtual_machines[0].name }}'
     # Depends-On: https://github.com/ansible/ansible/pull/55237
-    dest_folder: "{{ dest_folder.result.path }}"
+    dest_folder: '{{ dest_folder.result.path }}'
   register: vm_facts_0001
 
 
 # Testcase 0002: Move vm and get OK status (Already Moved)
-- name: Move VM (OK)
+- &vm_move
+  name: Move VM (OK)
   vmware_guest_move:
     validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    name: "{{ virtual_machines[0].name }}"
-    dest_folder: "{{ dest_folder.result.path }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
+    name: '{{ virtual_machines[0].name }}'
+    dest_folder: '{{ dest_folder.result.path }}'
   register: vm_facts_0002
 
 - debug:
@@ -52,7 +53,18 @@
 - debug:
     msg: "{{ vm_facts_0002 }}"
 
-- assert:
+- name: Make sure changes are done
+  assert:
     that:
       - vm_facts_0001.changed
       - not vm_facts_0002.changed
+
+- <<: *vm_move
+  name: Move VM in check mode
+  check_mode: yes
+  register: vm_move_0003
+
+- name: Make sure changes are not made in check mode
+  assert:
+    that:
+    - vm_move_0003.changed


### PR DESCRIPTION
##### SUMMARY
* Updated testcase
* Added check mode support
* Added check for mutual exclusive for Name and UUID

Fixes: #57580

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/57580-vmware_guest_move-fix_undefined_name.yml
lib/ansible/modules/cloud/vmware/vmware_guest_move.py
test/integration/targets/vmware_guest_move/tasks/main.yml
