### PR TITLE
Fix missing labels propagation hcloud inventory.

### DIFF
--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -179,6 +179,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.inventory.set_variable(server.name, "image_name", to_native(server.image.name))
         self.inventory.set_variable(server.name, "image_os_flavor", to_native(server.image.os_flavor))
 
+        # Labels
+        self.inventory.set_variable(server.name, "labels", dict(server.labels))
+
     def verify_file(self, path):
         """Return the possibly of a file being consumable by this plugin."""
         return (


### PR DESCRIPTION
##### SUMMARY
Labels those are supported by hcloud_server component weren't propagated by hcloud dynamic inventory.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/hcloud
