### PR TITLE
Fix purefa_user module. Incorrect parameter used causing crashes.

### DIFF
--- a/changelogs/fragments/57588-purefa_user_change_api_token_to_api.yaml
+++ b/changelogs/fragments/57588-purefa_user_change_api_token_to_api.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - purefa_user - change module parameter I(api_token) to I(api) and to stop clash with known variable.
+  - purefa_user - change resulting facts from I(api_token) to I(user_api) for clarity (https://github.com/ansible/ansible/pull/57588)

--- a/lib/ansible/modules/storage/purestorage/purefa_user.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_user.py
@@ -44,7 +44,7 @@ options:
     description:
     - If changing an existing password, you must provide the old password for security
     type: str
-  api_token:
+  api:
     description:
     - Define whether to create an API token for this user
     - Token can be exposed using the I(debug) module
@@ -92,7 +92,7 @@ EXAMPLES = r'''
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
   debug:
-    msg: "API Token: {{ ansible_facts['api_token'] }}"
+    msg: "API Token: {{ ansible_facts['user_api'] }}"
 '''
 
 RETURN = r'''
@@ -128,9 +128,9 @@ def create_user(module, array):
                 role = 'readonly'
             array.create_admin(module.params['name'], role=role,
                                password=module.params['password'])
-            if module.params['api_token']:
+            if module.params['api']:
                 try:
-                    user_token['api_token'] = array.create_api_token(module.params['name'])['api_token']
+                    user_token['user_api'] = array.create_api_token(module.params['name'])['api_token']
                 except Exception:
                     array.delete_user(module.params['name'])
                     module.fail_json(msg='Local User {0}: Creation failed'.format(module.params['name']))
@@ -153,11 +153,11 @@ def create_user(module, array):
             else:
                 module.fail_json(msg='Local User Account {0}: Password change failed - '
                                  'Check both old and new passwords'.format(module.params['name']))
-        if module.params['api_token']:
+        if module.params['api']:
             try:
                 if not array.get_api_token(module.params['name'])['api_token'] is None:
                     array.delete_api_token(module.params['name'])
-                user_token['api_token'] = array.create_api_token(module.params['name'])['api_token']
+                user_token['user_api'] = array.create_api_token(module.params['name'])['api_token']
                 api_changed = True
             except Exception:
                 module.fail_json(msg='Local User {0}: API token change failed'.format(module.params['name']))
@@ -192,7 +192,7 @@ def main():
         state=dict(type='str', default='present', choices=['absent', 'present']),
         password=dict(type='str', no_log=True),
         old_password=dict(type='str', no_log=True),
-        api_token=dict(type='bool', default=False),
+        api=dict(type='bool', default=False),
     ))
 
     module = AnsibleModule(argument_spec,


### PR DESCRIPTION
##### SUMMARY
Internal CI bug causes this to slip through. 
Incorrect parameter api_token used which clashes with the default required parameter used to give access to the array. 
Change references to be more appropriate. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_user.py