### PR TITLE
Improve speed of the gcp_compute dynamic inventory, fixes #56752

### DIFF
--- a/changelogs/fragments/57591-speed-up-gcp-compute-dynamic-inventory.yaml
+++ b/changelogs/fragments/57591-speed-up-gcp-compute-dynamic-inventory.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "gcp_compute - Speed up dynamic invetory up to 30x."

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -76,7 +76,12 @@ class GcpSession(object):
     def get(self, url, body=None, **kwargs):
         kwargs.update({'json': body, 'headers': self._headers()})
         try:
-            return self.session().get(url, **kwargs)
+            # Ignore the google-auth library warning for user credentials. More
+            # details: https://github.com/googleapis/google-auth-library-python/issues/271
+            import warnings
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
+                return self.session().get(url, **kwargs)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 


### PR DESCRIPTION
##### SUMMARY
To get all instances gcp_compute made a call to the Google API for each zone separately. Because of this if all zones needed to be queried fetching hosts lasted 30+ seconds. Now the module will use a single
query that will return all the instances, so the execution should last just a few seconds. This PR should resolve https://github.com/ansible/ansible/issues/56752.

This commit also suppresses the following warning from the google-auth library about using user credentials:
```
/usr/lib/python3.7/site-packages/google/auth/_default.py:66: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/
  warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
```
 If an Ansible user wants to use user credentials, there is no need to warn him about it and they are a totally valid option with `application` auth kind.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/gcp_compute.py
