### PR TITLE
postgresql: moved function exec_sql from the modules to module_utils

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_copy.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_copy.py
@@ -175,41 +175,13 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier
-from ansible.module_utils.postgres import connect_to_db, postgres_common_argument_spec
+from ansible.module_utils.postgres import (
+    connect_to_db,
+    exec_sql,
+    postgres_common_argument_spec,
+)
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
-
-
-def exec_sql(obj, query, ddl=False, add_to_executed=True):
-    """Execute SQL.
-
-    Auxiliary function for PostgreSQL user classes.
-
-    Returns a query result if possible or True/False if ddl=True arg was passed.
-    It necessary for statements that don't return any result (like DDL queries).
-
-    Arguments:
-        obj (obj) -- must be an object of a user class.
-            The object must have module (AnsibleModule class object) and
-            cursor (psycopg cursor object) attributes
-        query (str) -- SQL query to execute
-        ddl (bool) -- must return True or False instead of rows (typical for DDL queries)
-            (default False)
-        add_to_executed (bool) -- append the query to obj.executed_queries attribute
-    """
-    try:
-        obj.cursor.execute(query)
-
-        if add_to_executed:
-            obj.executed_queries.append(query)
-
-        if not ddl:
-            res = obj.cursor.fetchall()
-            return res
-        return True
-    except Exception as e:
-        obj.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
-    return False
 
 
 class PgCopyData(object):

--- a/lib/ansible/modules/database/postgresql/postgresql_sequence.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_sequence.py
@@ -284,40 +284,12 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier
-from ansible.module_utils.postgres import connect_to_db, postgres_common_argument_spec
+from ansible.module_utils.postgres import (
+    connect_to_db,
+    exec_sql,
+    postgres_common_argument_spec,
+)
 from ansible.module_utils._text import to_native
-
-
-def exec_sql(obj, query, ddl=False, add_to_executed=True):
-    """Execute SQL.
-
-    Auxiliary function for PostgreSQL user classes.
-
-    Returns a query result if possible or True/False if ddl=True arg was passed.
-    It necessary for statements that don't return any result (like DDL queries).
-
-    Arguments:
-        obj (obj) -- must be an object of a user class.
-            The object must have module (AnsibleModule class object) and
-            cursor (psycopg cursor object) attributes
-        query (str) -- SQL query to execute
-        ddl (bool) -- must return True or False instead of rows (typical for DDL queries)
-            (default False)
-        add_to_executed (bool) -- append the query to obj.executed_queries attribute
-    """
-    try:
-        obj.cursor.execute(query)
-
-        if add_to_executed:
-            obj.executed_queries.append(query)
-
-        if not ddl:
-            res = obj.cursor.fetchall()
-            return res
-        return True
-    except Exception as e:
-        obj.module.fail_json(msg="Cannot execute SQL '%s': %s" % (query, to_native(e)))
-    return False
 
 
 class Sequence(object):


### PR DESCRIPTION
##### SUMMARY
postgresql: moved function exec_sql from the modules to module_utils to avoid code duplication

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

note: I haven't added a changelog fragment because these are new modules in 2.9 
note: after this code is merged I'm going to remove this function also from new module postgresql_vacuum that was not merged yet.