### PR TITLE
Remove trailing new line while including vars

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -50,7 +50,7 @@ class ActionModule(ActionBase):
         self.source_dir = self._task.args.get('dir', None)
         self.source_file = self._task.args.get('file', None)
         if not self.source_dir and not self.source_file:
-            self.source_file = self._task.args.get('_raw_params')
+            self.source_file = self._task.args.get('_raw_params').rstrip('\n')
 
         self.depth = self._task.args.get('depth', None)
         self.files_matching = self._task.args.get('files_matching', None)

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -65,12 +65,12 @@
       - "testing == 456"
       - "base_dir == 'services'"
       - "webapp_containers == 10"
-      - "{{ include_every_dir.ansible_included_var_files | length }} == 5"
+      - "{{ include_every_dir.ansible_included_var_files | length }} == 6"
       - "'vars/all/all.yml' in include_every_dir.ansible_included_var_files[0]"
       - "'vars/environments/development/all.yml' in include_every_dir.ansible_included_var_files[1]"
       - "'vars/environments/development/services/webapp.yml' in include_every_dir.ansible_included_var_files[2]"
-      - "'vars/services/webapp.yml' in include_every_dir.ansible_included_var_files[3]"
-      - "'vars/webapp/file_without_extension' in include_every_dir.ansible_included_var_files[4]"
+      - "'vars/services/webapp.yml' in include_every_dir.ansible_included_var_files[4]"
+      - "'vars/webapp/file_without_extension' in include_every_dir.ansible_included_var_files[5]"
 
 - name: include every directory in vars except files matching webapp.yml
   include_vars:
@@ -85,7 +85,7 @@
     that:
       - "testing == 789"
       - "base_dir == 'environments/development'"
-      - "{{ include_without_webapp.ansible_included_var_files | length }} == 2"
+      - "{{ include_without_webapp.ansible_included_var_files | length }} == 3"
       - "'webapp.yml' not in '{{ include_without_webapp.ansible_included_var_files | join(' ') }}'"
       - "'file_without_extension' not in '{{ include_without_webapp.ansible_included_var_files | join(' ') }}'"
 
@@ -129,3 +129,12 @@
   assert:
     that:
       - "'a valid extension' in include_with_unknown_file_extension.message"
+
+- name: include var with raw params
+  include_vars: >
+    services/service_vars.yml
+
+- name: Verify that files with raw params is include without new line character
+  assert:
+    that:
+      - "service_name ==  'my_custom_service'"

--- a/test/integration/targets/include_vars/vars/services/service_vars.yml
+++ b/test/integration/targets/include_vars/vars/services/service_vars.yml
@@ -1,0 +1,2 @@
+---
+service_name: 'my_custom_service'


### PR DESCRIPTION
##### SUMMARY
While including var files using _raw_params adds additional new line
character, which makes Ansible to fail to include that file in.
This fix removes extraneous new line character while parsing the var file.

Fixes: #57593

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/include_vars.py
test/integration/targets/include_vars/tasks/main.yml
test/integration/targets/include_vars/vars/services/service_vars.yml