### PR TITLE
WIP: Fix win_domain_controller on windows server core

### DIFF
--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -29,7 +29,7 @@ Function Write-DebugLog {
     }
 }
 
-$required_features = @("AD-Domain-Services","RSAT-ADDS")
+$required_features = @("AD-Domain-Services","RSAT-AD-PowerShell", "RSAT-ADDS-Tools")
 
 Function Get-MissingFeatures {
     Write-DebugLog "Checking for missing Windows features..."


### PR DESCRIPTION
##### SUMMARY

I tried to use this module against a windows server 2019 core using the vmware_tools transporter and it fails with a exception, no real error message is shown.

Fixes: #57607

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

win_domain_controller

##### ADDITIONAL INFORMATION

Installing RSAT-ADDS also includes the Administration Center a component that is only present on the GUI version of windows. I replaced it with the two modules responsible for the powershell commandlets and the legacy cmd commandlets.