### PR TITLE
Backport 57507

### DIFF
--- a/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
+++ b/changelogs/fragments/57507-postgresql_pg_hba_multiple_options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_pg_hba - After splitting fields, merge authentication options back into a single field to prevent losing options beyond the first (https://github.com/ansible/ansible/issues/57505)

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -482,20 +482,19 @@ class PgHbaRule(dict):
             msg = "Rule {0} has unknown type: {1}."
             raise PgHbaValueError(msg.format(line, cols[0]))
         if cols[0] == 'local':
-            if cols[3] not in PG_HBA_METHODS:
-                raise PgHbaValueError("Rule {0} of 'local' type has invalid auth-method {1}"
-                                      "on 4th column ".format(line, cols[3]))
-            cols.insert(3, None)
-            cols.insert(3, None)
+            cols.insert(3, None)  # No address
+            cols.insert(3, None)  # No IP-mask
+        if len(cols) < 6:
+            cols.insert(4, None)  # No IP-mask
+        elif cols[5] not in PG_HBA_METHODS:
+            cols.insert(4, None)  # No IP-mask
+        if cols[5] not in PG_HBA_METHODS:
+            raise PgHbaValueError("Rule {0} of '{1}' type has invalid auth-method '{2}'".format(line, cols[0], cols[5]))
+
+        if len(cols) < 7:
+            cols.insert(6, None)  # No auth-options
         else:
-            if len(cols) < 6:
-                cols.insert(4, None)
-            elif cols[5] not in PG_HBA_METHODS:
-                cols.insert(4, None)
-            if len(cols) < 7:
-                cols.insert(7, None)
-            if cols[5] not in PG_HBA_METHODS:
-                raise PgHbaValueError("Rule {0} has no valid method.".format(line))
+            cols[6] = " ".join(cols[6:])  # combine all auth-options
         rule = dict(zip(PG_HBA_HDR, cols[:7]))
         for key, value in rule.items():
             if value:

--- a/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
@@ -58,6 +58,22 @@
   register: pg_hba_change
   with_items: "{{pg_hba_test_ips}}"
 
+- name: Retain options even if they contain spaces
+  postgresql_pg_hba:
+    dest: "/tmp/pg_hba.conf"
+    users: "+some"
+    order: "sud"
+    state: "present"
+    contype: "{{ item.contype }}"
+    method: "{{ item.method }}"
+    options: "{{ item.options }}"
+    address: "{{ item.address }}"
+  with_items:
+  - { address: "", contype: "local", method: "ldap", options: "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" }
+  - { address: "red", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
+  - { address: "blue", contype: "hostssl", method: "cert", options: "clientcert=1 map=mymap" }
+  register: pg_hba_options
+
 - name: read pg_hba rules
   postgresql_pg_hba:
     dest: /tmp/pg_hba.conf
@@ -127,6 +143,9 @@
     - 'pg_hba.pg_hba == [
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
            { "db": "all", "method": "md5", "type": "local", "usr": "postgres" },
+           { "db": "all", "method": "ldap", "type": "local", "usr": "+some", "options": "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" },
+           { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
+           { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "md5", "src": "0:ff00::/120", "type": "host", "usr": "all" },
            { "db": "all", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
            { "db": "replication", "method": "md5", "src": "192.168.0.0/24", "type": "host", "usr": "all" },
@@ -141,3 +160,4 @@
     - 'prebackupstat.stat.checksum == postbackupstat.stat.checksum'
     - 'pg_hba_fail_src_all_with_netmask is failed'
     - 'not netmask_sameas_prefix_check is changed'
+    - 'pg_hba_options is changed'


### PR DESCRIPTION
##### SUMMARY
Fixes #57505

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_pg_hba_module


##### ADDITIONAL INFORMATION
The fields are split on whitespace, but the final options field should be able to contain spaces. This joins the options back together.

