### PR TITLE
Provide a better error when python-dnf install fails

### DIFF
--- a/changelogs/fragments/dnf-better-error.yml
+++ b/changelogs/fragments/dnf-better-error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- dnf - Provide a better error message including python version info when installing python-dnf fails

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -285,6 +285,7 @@ EXAMPLES = '''
 
 import os
 import re
+import sys
 import tempfile
 
 try:
@@ -488,7 +489,7 @@ class DnfModule(YumDnf):
                     results=[],
                 )
 
-            self.module.run_command(['dnf', 'install', '-y', package], check_rc=True)
+            rc, stdout, stderr = self.module.run_command(['dnf', 'install', '-y', package])
             global dnf
             try:
                 import dnf
@@ -499,9 +500,15 @@ class DnfModule(YumDnf):
                 import dnf.util
             except ImportError:
                 self.module.fail_json(
-                    msg="Could not import the dnf python module. "
-                    "Please install `{0}` package.".format(package),
+                    msg="Could not import the dnf python module using {0} ({1}). "
+                        "Please install `{2}` package or ensure you have specified the "
+                        "correct ansible_python_interpreter.".format(sys.executable, sys.version.replace('\n', ''),
+                                                                     package),
                     results=[],
+                    cmd='dnf install -y {0}'.format(package),
+                    rc=rc,
+                    stdout=stdout,
+                    stderr=stderr,
                 )
 
     def _configure_base(self, base, conf_file, disable_gpg_check, installroot='/'):


### PR DESCRIPTION
##### SUMMARY
Provide a better error when python-dnf install fails
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/dnf.py

##### ADDITIONAL INFORMATION
The improved part is `msg`, which now includes the path of the interpreter used, the version info from that interpreter, and a short message about `ansible_python_interpreter`.

Before:
```
localhost | FAILED! => {
    "changed": false,
    "cmd": "dnf install -y python2-dnf",
    "msg": "Error: Unable to find a match",
    "rc": 1,
    "stderr": "Error: Unable to find a match\n",
    "stderr_lines": [
        "Error: Unable to find a match"
    ],
    "stdout": "Last metadata expiration check: 0:07:31 ago on Mon 10 Jun 2019 01:19:13 PM UTC.\nNo match for argument: python2-dnf\n",
    "stdout_lines": [
        "Last metadata expiration check: 0:07:31 ago on Mon 10 Jun 2019 01:19:13 PM UTC.",
        "No match for argument: python2-dnf"
    ]
}
```

After:
```
localhost | FAILED! => {
    "changed": false,
    "cmd": "dnf install -y python2-dnf",
    "msg": "Could not import the dnf python module using /usr/bin/python (2.7.16 (default, Apr 30 2019, 15:54:43) [GCC 9.0.1 20190312 (Red Hat 9.0.1-0.10)]). Please install `python2-dnf` package or ensure you have specified the correct ansible_python_interpreter.",
    "rc": 1,
    "results": [],
    "stderr": "Error: Unable to find a match\n",
    "stderr_lines": [
        "Error: Unable to find a match"
    ],
    "stdout": "Last metadata expiration check: 0:09:26 ago on Mon 10 Jun 2019 01:19:13 PM UTC.\nNo match for argument: python2-dnf\n",
    "stdout_lines": [
        "Last metadata expiration check: 0:09:26 ago on Mon 10 Jun 2019 01:19:13 PM UTC.",
        "No match for argument: python2-dnf"
    ]
}
```