### PR TITLE
combine filter: allow merging dict and list

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -864,17 +864,28 @@ The resulting hash would be::
 
     {'a':1, 'b':3}
 
-The filter also accepts an optional `recursive=True` parameter to not
-only override keys in the first hash, but also recurse into nested
-hashes and merge their keys too
+The filter also accepts an optional `recursive` parameter.
+`recursive='merge_hash'` (or `recursive=True`) not only override keys in the
+first hash, but also recurse into nested hashes and merge their keys too.
 
 .. code-block:: jinja
 
-    {{ {'a':{'foo':1, 'bar':2}, 'b':2} | combine({'a':{'bar':3, 'baz':4}}, recursive=True) }}
+    {{ {'a':{'foo':1, 'bar':2}, 'b':2} | combine({'a':{'bar':3, 'baz':4}}, recursive='merge_hash') }}
 
 This would result in::
 
     {'a':{'foo':1, 'bar':3, 'baz':4}, 'b':2}
+
+`recursive='merge_hash_and_array'` has the same effect as
+`recursive='merge_hash'` but also append lists.
+
+.. code-block:: jinja
+
+    {{ {'a': ['b', 'c']} | combine({'a': ['c']}, recursive='merge_hash_and_array') }}
+
+This would result in::
+
+    {'a': ['b', 'c', 'c']}
 
 The filter can also take multiple arguments to merge::
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -53,7 +53,7 @@ from ansible.utils.display import Display
 from ansible.utils.encrypt import passlib_or_crypt
 from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
-from ansible.utils.vars import merge_hash
+from ansible.utils.vars import merge_hash, merge_hash_and_array
 
 display = Display()
 
@@ -310,7 +310,12 @@ def combine(*terms, **kwargs):
             raise AnsibleFilterError("|combine expects dictionaries, got " + repr(t))
 
     if recursive:
-        return reduce(merge_hash, dicts)
+        if recursive is True or recursive == 'merge_hash':
+            return reduce(merge_hash, dicts)
+        elif recursive == 'merge_hash_and_array':
+            return reduce(merge_hash_and_array, dicts)
+        else:
+            raise AnsibleFilterError("'recursive' unknown value '%s'" % recursive)
     else:
         return dict(itertools.chain(*map(iteritems, dicts)))
 


### PR DESCRIPTION
##### SUMMARY

new feature.

allow the combine filter to merge (append) lists.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

component =lib/ansible/plugins/filter/core.py

##### ADDITIONAL INFORMATION

```max@mde-oxalide % cat toto.yml
- hosts: localhost
  gather_facts: false
  vars:
    toto_default:
      titi:
        titi: truc
      test:
        - a
        - b
    toto:
      titi:
        tata: truc
      test:
        - c
  tasks:
    - debug:
        msg: "{{toto_default|combine(toto, recursive=True)}}"
    - debug:
        msg: "{{toto_default|combine(toto, recursive='merge_hash_and_array')}}"
    - debug:
        msg: "{{toto_default|combine(toto, recursive=False)}}"
```

```
max@mde-oxalide % ansible-playbook toto.yml

PLAY [localhost] *************

TASK [debug] *************************
ok: [localhost] => {
    "msg": {
        "test": [
            "c"
        ],
        "titi": {
            "tata": "truc",
            "titi": "truc"
        }
    }
}

TASK [debug] ***********************
ok: [localhost] => {
    "msg": {
        "test": [
            "a",
            "b",
            "c"
        ],
        "titi": {
            "tata": "truc",
            "titi": "truc"
        }
    }
}

TASK [debug] *************************************
ok: [localhost] => {
    "msg": {
        "test": [
            "c"
        ],
        "titi": {
            "tata": "truc"
        }
    }
}

PLAY RECAP *********************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```