### PR TITLE
Fix deprecation warning message from grafana_annotations

### DIFF
--- a/lib/ansible/plugins/callback/grafana_annotations.py
+++ b/lib/ansible/plugins/callback/grafana_annotations.py
@@ -190,7 +190,7 @@ class CallbackModule(CallbackBase):
             self._display.warning('Grafana URL was not provided. The '
                                   'Grafana URL can be provided using '
                                   'the `GRAFANA_URL` environment variable.')
-        self._display.info('Grafana URL: %s' % self.grafana_url)
+        self._display.debug('Grafana URL: %s' % self.grafana_url)
 
     def v2_playbook_on_start(self, playbook):
         self.playbook = playbook._file_name


### PR DESCRIPTION
The Display class has no `info` attribute/method. The use of the method
was raising an Exception in task_queue_manager.py and displayed an
unappropriate deprecation warning.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
When running the `grafana_annotations` callback plugin the following message is displayed:
```
[DEPRECATION WARNING]: grafana_annotations callback, does not support setting 'options', it will work for now, but this will be required in the future and should be updated, see the 2.4 porting guide for details.. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

The issue comes from an attempt to use an `info` method on the Display class. This method does not exists.
This patch simply fix this usage and replace the use of `info` by `debug`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_annotations