### PR TITLE
docs: correct default for assemble module remote_src param

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -48,10 +48,10 @@ options:
     version_added: "1.4"
   remote_src:
     description:
-      - If False, it will search for src at originating/master machine, if True it will
-        go to the remote/target machine for the src. Default is True.
+      - If False, it will search for src at originating/master machine.
+      - If True it will go to the remote/target machine for the src.
     type: bool
-    default: 'yes'
+    default: 'no'
     version_added: "1.4"
   regexp:
     description:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -553,7 +553,6 @@ lib/ansible/modules/database/vertica/vertica_schema.py E322
 lib/ansible/modules/database/vertica/vertica_user.py E322
 lib/ansible/modules/database/vertica/vertica_user.py E325
 lib/ansible/modules/files/assemble.py E323
-lib/ansible/modules/files/assemble.py E324
 lib/ansible/modules/files/blockinfile.py E324
 lib/ansible/modules/files/blockinfile.py E326
 lib/ansible/modules/files/copy.py E322


### PR DESCRIPTION
##### SUMMARY
See #57348.

In Ansible 2.7, the documentation for the assemble module states that the default setting for `remote_src` is True. The argspec clearly states `remote_src=dict(default=False, type='bool'),`. 

This PR corrects the documentation to match the argspec.

This was fixed in Ansible 2.8 by #50111, but that PR is rather large to backport wholesale.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
