### PR TITLE
VMware: vmware_dvs_host: Add vendor_specific_config

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
@@ -54,7 +54,7 @@ options:
     vendor_specific_config:
         description:
             - List of key,value dictionaries for the Vendor Specific Configuration.
-            -'Element attributes are:'
+            - 'Element attributes are:'
             - '- C(key) (str): Key of setting. (default: None)'
             - '- C(value) (str): Value of setting. (default: None)'
         required: False

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
@@ -4,6 +4,7 @@
 # Copyright: (c) 2015, Joseph Callen <jcallen () csc.com>
 # Copyright: (c) 2018, Ansible Project
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2019, VMware Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -25,6 +26,7 @@ version_added: 2.0
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
+- Joseph Andreatta (@vmwjoseph)
 notes:
     - Tested on vSphere 5.5
 requirements:
@@ -49,6 +51,14 @@ options:
         choices: [ present, absent ]
         required: True
         default: 'present'
+    vendor_specific_config:
+        description:
+            - List of key,value dictionaries for the Vendor Specific Configuration.
+            -'Element attributes are:'
+            - '- C(key) (str): Key of setting. (default: None)'
+            - '- C(value) (str): Value of setting. (default: None)'
+        required: False
+        version_added: '2.9'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -96,6 +106,7 @@ class VMwareDvsHost(PyVmomi):
         self.switch_name = self.module.params['switch_name']
         self.esxi_hostname = self.module.params['esxi_hostname']
         self.vmnics = self.module.params['vmnics']
+        self.vendor_specific_config = self.module.params['vendor_specific_config']
 
     def process_state(self):
         dvs_host_states = {
@@ -133,6 +144,11 @@ class VMwareDvsHost(PyVmomi):
         spec.host = [vim.dvs.HostMember.ConfigSpec()]
         spec.host[0].operation = operation
         spec.host[0].host = self.host
+        if self.vendor_specific_config:
+            config = list()
+            for item in self.vendor_specific_config:
+                config.append(vim.dvs.KeyedOpaqueBlob(key=item['key'], opaqueData=item['value']))
+            spec.host[0].vendorSpecificConfig = config
 
         if operation in ("edit", "add"):
             spec.host[0].backing = vim.dvs.HostMember.PnicBacking()
@@ -226,14 +242,23 @@ class VMwareDvsHost(PyVmomi):
 
 def main():
     argument_spec = vmware_argument_spec()
-    argument_spec.update(dict(esxi_hostname=dict(required=True, type='str'),
-                              switch_name=dict(required=True, type='str'),
-                              vmnics=dict(required=True, type='list'),
-                              state=dict(default='present',
-                                         choices=['present', 'absent'],
-                                         type='str')
-                              )
-                         )
+    argument_spec.update(
+        dict(
+            esxi_hostname=dict(required=True, type='str'),
+            switch_name=dict(required=True, type='str'),
+            vmnics=dict(required=True, type='list'),
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            vendor_specific_config=dict(
+                type='list',
+                elements='dict',
+                required=False,
+                options=dict(
+                    key=dict(type='str', required=True),
+                    value=dict(type='str', required=True),
+                ),
+            ),
+        )
+    )
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
@@ -75,6 +75,22 @@ EXAMPLES = '''
         - vmnic1
     state: present
   delegate_to: localhost
+
+- name: Add Host to dVS/enable learnswitch (https://labs.vmware.com/flings/learnswitch)
+  vmware_dvs_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: '{{ esxi_hostname }}'
+    switch_name: dvSwitch
+    vendor_specific_config:
+        - key: com.vmware.netoverlay.layer1
+          value: learnswitch
+    vmnics:
+        - vmnic0
+        - vmnic1
+    state: present
+  delegate_to: localhost
 '''
 
 try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add vendor specific config option. This is required to implement learnswitch functionality. https://labs.vmware.com/flings/learnswitch

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_host

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ok: [10.193.24.57 -> localhost] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "esxi_hostname": "10.193.24.57", 
            "hostname": "10.193.30.210", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "state": "present", 
            "switch_name": "nova_dvs", 
            "username": "administrator@vsphere.local", 
            "validate_certs": false, 
            "vendor_specific_config": [
                {
                    "key": "com.vmware.netoverlay.layer1", 
                    "value": "learnswitch"
                }
            ], 
            "vmnics": [
                "vmnic0"
            ]
        }
    }
}
```

