### PR TITLE
Add inventory cache to the netbox plugin

### DIFF
--- a/changelogs/fragments/netbox-add-cache.yaml
+++ b/changelogs/fragments/netbox-add-cache.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - netbox - use inventory cache if configured


### PR DESCRIPTION
##### SUMMARY
The netbox inventory plugin can be quite slow, especially when config_context is enabled. This
patch adds caching support to the plugin so that delays can be minimised.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
netbox

##### ADDITIONAL INFORMATION
