### PR TITLE
Don't throw error when cache entry doesn't exist

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -54,9 +54,12 @@ class CacheModule(BaseFileCacheModule):
     """
 
     def _load(self, filepath):
-        # Valid JSON is always UTF-8 encoded.
-        with codecs.open(filepath, 'r', encoding='utf-8') as f:
-            return json.load(f, cls=AnsibleJSONDecoder)
+        try:
+            # Valid JSON is always UTF-8 encoded.
+            with codecs.open(filepath, 'r', encoding='utf-8') as f:
+                return json.load(f, cls=AnsibleJSONDecoder)
+        except IOError:
+            return None
 
     def _dump(self, value, filepath):
         with codecs.open(filepath, 'w', encoding='utf-8') as f:

--- a/lib/ansible/plugins/cache/pickle.py
+++ b/lib/ansible/plugins/cache/pickle.py
@@ -55,12 +55,15 @@ class CacheModule(BaseFileCacheModule):
     """
 
     def _load(self, filepath):
-        # Pickle is a binary format
-        with open(filepath, 'rb') as f:
-            if PY3:
-                return pickle.load(f, encoding='bytes')
-            else:
-                return pickle.load(f)
+        try:
+            # Pickle is a binary format
+            with open(filepath, 'rb') as f:
+                if PY3:
+                    return pickle.load(f, encoding='bytes')
+                else:
+                    return pickle.load(f)
+        except IOError:
+            return None
 
     def _dump(self, value, filepath):
         with open(filepath, 'wb') as f:

--- a/lib/ansible/plugins/cache/yaml.py
+++ b/lib/ansible/plugins/cache/yaml.py
@@ -57,8 +57,11 @@ class CacheModule(BaseFileCacheModule):
     """
 
     def _load(self, filepath):
-        with codecs.open(filepath, 'r', encoding='utf-8') as f:
-            return AnsibleLoader(f).get_single_data()
+        try:
+            with codecs.open(filepath, 'r', encoding='utf-8') as f:
+                return AnsibleLoader(f).get_single_data()
+        except IOError:
+            return None
 
     def _dump(self, value, filepath):
         with codecs.open(filepath, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
##### SUMMARY
A missing cache entry should fail silently. Showing warning messages  when failing to open a cache
file, and then working as expected, is confusing to the user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
jsonfile, pickle, yaml

##### ADDITIONAL INFORMATION
Currently error message such as this are shown:

```paste below
 [WARNING]: error in 'jsonfile' cache plugin while trying to read .cache/inventory/netbox_b42bfs_ef540 : b"[Errno 2] No such file or directory: '.cache/inventory/netbox_b42bfs_ef540'"
```