### PR TITLE
Don't warn when trying to read missing cache file

### DIFF
--- a/changelogs/fragments/cache-file-missing-warning.yaml
+++ b/changelogs/fragments/cache-file-missing-warning.yaml
@@ -1,2 +1,2 @@
 minor_changes:
- - cache: do not show warning when cache file does not (yet) exist
+ - cache - do not show warning when cache file does not (yet) exist

--- a/changelogs/fragments/cache-file-missing-warning.yaml
+++ b/changelogs/fragments/cache-file-missing-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+ - cache: do not show warning when cache file does not (yet) exist

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -153,7 +153,7 @@ class BaseFileCacheModule(BaseCacheModule):
                 raise AnsibleError("The cache file %s was corrupt, or did not otherwise contain valid data. "
                                    "It has been removed, so you can re-run your command now." % cachefile)
             except (OSError, IOError) as e:
-                display.warning("error in '%s' cache plugin while trying to read %s : %s" % (self.plugin_name, cachefile, to_bytes(e)))
+                display.v("error in '%s' cache plugin while trying to read %s : %s" % (self.plugin_name, cachefile, to_bytes(e)))
                 raise KeyError
             except Exception as e:
                 raise AnsibleError("Error while decoding the cache file %s: %s" % (cachefile, to_bytes(e)))

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -153,7 +153,10 @@ class BaseFileCacheModule(BaseCacheModule):
                 raise AnsibleError("The cache file %s was corrupt, or did not otherwise contain valid data. "
                                    "It has been removed, so you can re-run your command now." % cachefile)
             except (OSError, IOError) as e:
-                display.v("error in '%s' cache plugin while trying to read %s : %s" % (self.plugin_name, cachefile, to_bytes(e)))
+                if e.errno == errno.ENOENT:
+                    display.v("'%s' cache plugin tried to read non-existent %s" % (self.plugin_name, cachefile))
+                else:
+                    display.warning("error in '%s' cache plugin while trying to read %s : %s" % (self.plugin_name, cachefile, to_bytes(e)))
                 raise KeyError
             except Exception as e:
                 raise AnsibleError("Error while decoding the cache file %s: %s" % (cachefile, to_bytes(e)))


### PR DESCRIPTION
##### SUMMARY
A missing cache entry should fail silently. Showing warning messages when failing to open a cache
file, and then working as expected, is confusing to the user. This patch changes the warning to
a debug message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cache

##### ADDITIONAL INFORMATION
Currently warning message such as this are shown:

```
[WARNING]: error in 'jsonfile' cache plugin while trying to read .cache/inventory/netbox_b42bfs_ef540 : b"[Errno 2] No such file or directory: '.cache/inventory/netbox_b42bfs_ef540'"
```
