### PR TITLE
[stable-2.6] Limit tests to paramiko < 2.5.0.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -15,6 +15,7 @@ pycrypto >= 2.6 # Need features found in 2.6 and greater
 ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
 idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
+paramiko < 2.5.0 ; python_version >= '2.7' # paramiko 2.5.0 requires cryptography 2.5.0+
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 ntlm-auth >= 1.0.6 # message encryption support
 requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6


### PR DESCRIPTION
##### SUMMARY

[stable-2.6] Limit tests to paramiko < 2.5.0.

Backport of https://github.com/ansible/ansible/pull/57640

(cherry picked from commit 1e6edf2ccc970e790692df819f22ead4e28ec0b4)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
