### PR TITLE
Remove hardcoded ansible user for junos_user integration tests (#56452)

### DIFF
--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -172,7 +172,8 @@
 - name: Create list of users
   junos_user:
     aggregate:
-      - name: ansible
+      # NOTE(pabelanger): We noop our ansible-test user, as not to lose SSH access
+      - name: "{{ ansible_user|default('ansible') }}"
       - {name: test_user1, full_name: test_user2, role: operator}
       - {name: test_user2, full_name: test_user2, role: read-only}
     provider: "{{ netconf }}"
@@ -181,7 +182,8 @@
 - name: Purge users except the users in aggregate
   junos_user:
     aggregate:
-      - name: ansible
+      # NOTE(pabelanger): We noop our ansible-test user, as not to lose SSH access
+      - name: "{{ ansible_user|default('ansible') }}"
     purge: True
     provider: "{{ netconf }}"
   register: result


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/56452

We don't use ansible user for testing in zuul.ansible.com. We can find this info using ansible variables.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_user tests

Depends-On: https://github.com/ansible/ansible/pull/57639
Depends-On: https://github.com/ansible/ansible/pull/57638