### PR TITLE
fixed reference to a non-existing hcloud_server parameter

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_server.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server.py
@@ -126,7 +126,7 @@ EXAMPLES = """
   hcloud_server:
     name: my-server
     server_type: cx21
-    keep_disk: yes
+    upgrade_disk: yes
     state: present
 
 - name: Ensure the server is absent (remove if needed)


### PR DESCRIPTION
##### SUMMARY
param `keep_disk` does not seem to exist.. it looks like the `upgrade_disk` bool so I've updated the docs.

Couldn't find any other references to `keep_disk` in the codebase


##### COMPONENT NAME
- `hcloud_server`

##### ADDITIONAL INFORMATION
Doesn't effect the tests as they use `upgrade_disk` already... just a documentation fix
