### PR TITLE
Fix ios_smoke failure

### DIFF
--- a/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
@@ -27,6 +27,7 @@
     - show running-config all
   vars:
     ansible_command_timeout: 1
+    ansible_buffer_read_timeout: 2
   ignore_errors: True
   register: result
   when: ansible_connection == 'network_cli'
@@ -34,7 +35,7 @@
 - assert:
     that:
       - 'result.failed == true'
-      - "'command timeout triggered' in result.msg"
+      - "'timeout value 1 seconds reached' in result.msg"
   when: ansible_connection == 'network_cli'
 
 - debug: msg="END ios_smoke cli/misc_tests.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
Fix ios_smoke failure

Set ansible_buffer_read_timeout to be larger then
ansible_command_timeout, as both appliance / controller are on the same
physical network and we are not triggering ansible_command_timeout.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_smoke tests