### PR TITLE
[2.8] VMware: Handle VMs with no configurations

### DIFF
--- a/changelogs/fragments/55929-vmware_vm_inventory-skip_orphan_vm.yml
+++ b/changelogs/fragments/55929-vmware_vm_inventory-skip_orphan_vm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Skip orphan VMs from inventory while running vmware_vm_inventory as VMs does not return any facts (https://github.com/ansible/ansible/pull/55929).

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -411,6 +411,10 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
                 # VMware does not provide a way to uniquely identify VM by its name
                 # i.e. there can be two virtual machines with same name
                 # Appending "_" and VMware UUID to make it unique
+                if not vm_obj.obj.config:
+                    # Sometime orphaned VMs return no configurations
+                    continue
+
                 current_host = vm_obj_property.val + "_" + vm_obj.obj.config.uuid
 
                 if current_host not in hostvars:


### PR DESCRIPTION
##### SUMMARY
Sometime VMs does not return any configurations which leads
to failing the inventory plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 7505550500b6cf6eb89c973985d8141480c533ff)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/55929-vmware_vm_inventory-skip_orphan_vm.yml
lib/ansible/plugins/inventory/vmware_vm_inventory.py