### PR TITLE
postgresql modules: use postgres.exec_sql instead of __exec_sql methods

### DIFF
--- a/changelogs/fragments/57674-postgres_modules_use_exec_sql_instead_of_methods.yml
+++ b/changelogs/fragments/57674-postgres_modules_use_exec_sql_instead_of_methods.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql modules - use module_utils.postgres.exec_sql function instead of __exec_sql method (https://github.com/ansible/ansible/pull/57674)
+  - postgresql modules - use ``module_utils.postgres.exec_sql`` function instead of ``__exec_sql`` method (https://github.com/ansible/ansible/pull/57674)

--- a/changelogs/fragments/57674-postgres_modules_use_exec_sql_instead_of_methods.yml
+++ b/changelogs/fragments/57674-postgres_modules_use_exec_sql_instead_of_methods.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql modules - use module_utils.postgres.exec_sql function instead of __exec_sql method (https://github.com/ansible/ansible/pull/57674)

--- a/lib/ansible/modules/database/postgresql/postgresql_ping.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ping.py
@@ -80,7 +80,11 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.database import SQLParseError
-from ansible.module_utils.postgres import connect_to_db, postgres_common_argument_spec
+from ansible.module_utils.postgres import (
+    connect_to_db,
+    exec_sql,
+    postgres_common_argument_spec,
+)
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 
@@ -103,7 +107,7 @@ class PgPing(object):
 
     def get_pg_version(self):
         query = "SELECT version()"
-        raw = self.__exec_sql(query)[0][0]
+        raw = exec_sql(self, query, add_to_executed=False)[0][0]
         if raw:
             self.is_available = True
             raw = raw.split()[1].split('.')
@@ -112,16 +116,6 @@ class PgPing(object):
                 minor=int(raw[1]),
             )
 
-    def __exec_sql(self, query):
-        try:
-            self.cursor.execute(query)
-            res = self.cursor.fetchall()
-            if res:
-                return res
-        except Exception as e:
-            self.module.fail_json("Unable to execute '%s': %s" % (query, to_native(e)))
-
-        return False
 
 # ===========================================
 # Module execution.


### PR DESCRIPTION
##### SUMMARY
postgresql modules: use postgres.exec_sql instead of __exec_sql methods

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request