### PR TITLE
Update setup-iam playbook to use aws_caller_info rather than deprecated aws_caller___facts

### DIFF
--- a/hacking/aws_config/setup-iam.yml
+++ b/hacking/aws_config/setup-iam.yml
@@ -25,13 +25,13 @@
       when: iam_group is not defined
 
     - name: Get aws account ID
-      aws_caller_facts:
+      aws_caller_info:
         profile: "{{ profile|default(omit) }}"
-      register: aws_caller_facts
+      register: aws_caller_info
 
     - name: Set aws_account_fact
       set_fact:
-        aws_account: "{{ aws_caller_facts.account }}"
+        aws_account: "{{ aws_caller_info.account }}"
 
 
     - name: Ensure Managed IAM policies exist


### PR DESCRIPTION
##### SUMMARY
All the *_facts cloud modules are being  deprecated in favour of *_info variants.

This updates theaws test setup playbook setup-iam.yml to use the new  aws_caller_info module rather than  the deprecated _facts version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup-iam.yml

cc: @felixfontein 