### PR TITLE
VMware: Restrict vcenter_folder for vCenter

### DIFF
--- a/changelogs/fragments/49938-vcenter_folder-restrict_folder.yml
+++ b/changelogs/fragments/49938-vcenter_folder-restrict_folder.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Restrict vcenter_folder to vCenter only, since folder creation api is not supported on ESXi hostsystem (https://github.com/ansible/ansible/issues/49938).

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -19,6 +19,7 @@ module: vcenter_folder
 short_description: Manage folders on given datacenter
 description:
 - This module can be used to create, delete, move and rename folder on then given datacenter.
+- This module is only supported for vCenter.
 version_added: '2.5'
 author:
 - Abhijeet Kasurde (@Akasurde)
@@ -330,6 +331,9 @@ def main():
         module.fail_json(msg="Failed to manage folder as folder_name can only contain 80 characters.")
 
     vcenter_folder_mgr = VmwareFolderManager(module)
+    if not vcenter_folder_mgr.is_vcenter():
+        module.fail_json(msg="Module vcenter_folder is meant for vCenter, hostname %s "
+                             "is not vCenter server." % module.params.get('hostname'))
     vcenter_folder_mgr.ensure()
 
 


### PR DESCRIPTION
##### SUMMARY
Folder creation API is only supported by vCenter, specifying
Standalone ESXi system will raise error.
This fix adds an user warning for suggesting this restriction.

Fixes: #49938

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/49938-vcenter_folder-restrict_folder.yml
lib/ansible/modules/cloud/vmware/vcenter_folder.py
