### PR TITLE
Add TTL as a parameter to the digital_ocean_domain module

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -38,6 +38,7 @@ options:
     description:
      - An 'A' record for '@' ($ORIGIN) will be created with the value 'ip'.  'ip' is an IP version 4 address.
   ttl:
+    version_added: "2.9"
     description:
      - TTL of the DNS record. Defaults to 1800 (30 minutes).
 extends_documentation_fragment: digital_ocean.documentation


### PR DESCRIPTION
##### SUMMARY
Adds `ttl` as a parameter to this module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
digital_ocean_domain module

##### ADDITIONAL INFORMATION
This module uses DigitalOcean's default TTL of 1800 seconds, which is too high for my needs.

This pull request adds support for lowering that TTL.

As my Python sucks I'd appreciate someone double-checking this implementation :slightly_smiling_face:
