### PR TITLE
postgresql_idx: self.__exec_sql -> module_utils.postgres.exec_sql

### DIFF
--- a/changelogs/fragments/57684-postgresql_idx_use_exec_sql_instead_of_methods.yml
+++ b/changelogs/fragments/57684-postgresql_idx_use_exec_sql_instead_of_methods.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - postgresql_idx - remove __exec_sql method and use module_utils.postgres.exec_sql instead (https://github.com/ansible/ansible/pull/57684)
+  - postgresql_idx - remove ``__exec_sql`` method and use ``module_utils.postgres.exec_sql`` instead (https://github.com/ansible/ansible/pull/57684)

--- a/changelogs/fragments/57684-postgresql_idx_use_exec_sql_instead_of_methods.yml
+++ b/changelogs/fragments/57684-postgresql_idx_use_exec_sql_instead_of_methods.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_idx - remove __exec_sql method and use module_utils.postgres.exec_sql instead (https://github.com/ansible/ansible/pull/57684)


### PR DESCRIPTION
##### SUMMARY
postgresql_idx: remove self.__exec_sql method and use module_utils.postgres.exec_sql instead

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request