### PR TITLE
kubevirt: enable/update tests + fix merge_dicts()

### DIFF
--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -134,6 +134,14 @@ class KubeVirtRawModule(KubernetesRawModule):
         merging_dicts can be a dict or a list or tuple of dicts.  In the latter case, the
         dictionaries at the front of the list have higher precedence over the ones at the end.
         """
+        def _deepupdate(D, E):
+            for k in E:
+                if isinstance(E[k], dict) and isinstance(D.get(k), dict):
+                    D[k] = _deepupdate(D[k], E[k])
+                else:
+                    D[k] = E[k]
+            return D
+
         if not merging_dicts:
             merging_dicts = ({},)
 
@@ -142,9 +150,9 @@ class KubeVirtRawModule(KubernetesRawModule):
 
         new_dict = {}
         for d in reversed(merging_dicts):
-            new_dict.update(d)
+            _deepupdate(new_dict, d)
 
-        new_dict.update(base_dict)
+        _deepupdate(new_dict, base_dict)
 
         return new_dict
 

--- a/test/units/module_utils/test_kubevirt.py
+++ b/test/units/module_utils/test_kubevirt.py
@@ -1,0 +1,25 @@
+import json
+import pytest
+
+from ansible.module_utils import kubevirt as mymodule
+
+
+def test_simple_merge_dicts():
+    dict1 = {'labels': {'label1': 'value'}}
+    dict2 = {'labels': {'label2': 'value'}}
+    dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value'}}, sort_keys=True)
+    assert dict3 == json.dumps(dict(mymodule.KubeVirtRawModule.merge_dicts(dict1, dict2)), sort_keys=True)
+
+
+def test_simple_multi_merge_dicts():
+    dict1 = {'labels': {'label1': 'value', 'label3': 'value'}}
+    dict2 = {'labels': {'label2': 'value'}}
+    dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}, sort_keys=True)
+    assert dict3 == json.dumps(dict(mymodule.KubeVirtRawModule.merge_dicts(dict1, dict2)), sort_keys=True)
+
+
+def test_double_nested_merge_dicts():
+    dict1 = {'metadata': {'labels': {'label1': 'value', 'label3': 'value'}}}
+    dict2 = {'metadata': {'labels': {'label2': 'value'}}}
+    dict3 = json.dumps({'metadata': {'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}}, sort_keys=True)
+    assert dict3 == json.dumps(dict(mymodule.KubeVirtRawModule.merge_dicts(dict1, dict2)), sort_keys=True)

--- a/test/units/modules/cloud/kubevirt/test_kubevirt_vm.py
+++ b/test/units/modules/cloud/kubevirt/test_kubevirt_vm.py
@@ -10,8 +10,8 @@ from ansible.module_utils.k8s.raw import KubernetesRawModule
 
 from ansible.modules.cloud.kubevirt import kubevirt_vm as mymodule
 
-openshiftdynamic = pytest.importorskip("openshift.dynamic", minversion="0.6.2")
-helpexceptions = pytest.importorskip("openshift.helper.exceptions", minversion="0.6.2")
+openshiftdynamic = pytest.importorskip("openshift.dynamic")
+helpexceptions = pytest.importorskip("openshift.helper.exceptions")
 
 KIND = 'VirtulMachine'
 RESOURCE_DEFAULT_ARGS = {'api_version': 'v1', 'group': 'kubevirt.io',
@@ -56,7 +56,7 @@ def fail_json(*args, **kwargs):
 
 
 @pytest.fixture(autouse=True)
-def setup_mixtures(self, monkeypatch):
+def setup_mixtures(monkeypatch):
     monkeypatch.setattr(
         KubernetesRawModule, "exit_json", exit_json)
     monkeypatch.setattr(
@@ -74,7 +74,7 @@ def setup_mixtures(self, monkeypatch):
     K8sAnsibleMixin.find_resource = MagicMock()
 
 
-def test_vm_multus_creation(self):
+def test_vm_multus_creation():
     args = dict(
         state='present', name='testvm',
         namespace='vms', api_version='v1',
@@ -98,7 +98,7 @@ def test_vm_multus_creation(self):
 
 
 @pytest.mark.parametrize("_wait", (False, True))
-def test_resource_absent(self, _wait):
+def test_resource_absent(_wait):
     # Desired state:
     args = dict(
         state='absent', name='testvmi',
@@ -118,7 +118,7 @@ def test_resource_absent(self, _wait):
 
 
 @patch('openshift.watch.Watch')
-def test_stream_creation(self, mock_watch):
+def test_stream_creation(mock_watch):
     # Desired state:
     args = dict(
         state='running', name='testvmi', namespace='vms',
@@ -130,24 +130,3 @@ def test_stream_creation(self, mock_watch):
     mock_watch.side_effect = helpexceptions.KubernetesException("Test", value=42)
     with pytest.raises(AnsibleFailJson):
         mymodule.KubeVirtVM().execute_module()
-
-
-def test_simple_merge_dicts(self):
-    dict1 = {'labels': {'label1': 'value'}}
-    dict2 = {'labels': {'label2': 'value'}}
-    dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value'}}, sort_keys=True)
-    assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)), sort_keys=True)
-
-
-def test_simple_multi_merge_dicts(self):
-    dict1 = {'labels': {'label1': 'value', 'label3': 'value'}}
-    dict2 = {'labels': {'label2': 'value'}}
-    dict3 = json.dumps({'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}, sort_keys=True)
-    assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)), sort_keys=True)
-
-
-def test_double_nested_merge_dicts(self):
-    dict1 = {'metadata': {'labels': {'label1': 'value', 'label3': 'value'}}}
-    dict2 = {'metadata': {'labels': {'label2': 'value'}}}
-    dict3 = json.dumps({'metadata': {'labels': {'label1': 'value', 'label2': 'value', 'label3': 'value'}}}, sort_keys=True)
-    assert dict3 == json.dumps(dict(mymodule.KubeVirtVM.merge_dicts(dict1, dict2)), sort_keys=True)

--- a/test/units/modules/cloud/kubevirt/test_kubevirt_vm.py
+++ b/test/units/modules/cloud/kubevirt/test_kubevirt_vm.py
@@ -7,6 +7,7 @@ from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.k8s.common import K8sAnsibleMixin
 from ansible.module_utils.k8s.raw import KubernetesRawModule
+from ansible.module_utils.kubevirt import KubeVirtRawModule
 
 from ansible.modules.cloud.kubevirt import kubevirt_vm as mymodule
 
@@ -14,7 +15,7 @@ openshiftdynamic = pytest.importorskip("openshift.dynamic")
 helpexceptions = pytest.importorskip("openshift.helper.exceptions")
 
 KIND = 'VirtulMachine'
-RESOURCE_DEFAULT_ARGS = {'api_version': 'v1', 'group': 'kubevirt.io',
+RESOURCE_DEFAULT_ARGS = {'api_version': 'v1alpha3', 'group': 'kubevirt.io',
                          'prefix': 'apis', 'namespaced': True}
 
 
@@ -72,12 +73,14 @@ def setup_mixtures(monkeypatch):
     K8sAnsibleMixin.get_api_client = MagicMock()
     K8sAnsibleMixin.get_api_client.return_value = None
     K8sAnsibleMixin.find_resource = MagicMock()
+    KubeVirtRawModule.find_supported_resource = MagicMock()
 
 
 def test_vm_multus_creation():
+    # Desired state:
     args = dict(
         state='present', name='testvm',
-        namespace='vms', api_version='v1',
+        namespace='vms',
         interfaces=[
             {'bridge': {}, 'name': 'default', 'network': {'pod': {}}},
             {'bridge': {}, 'name': 'mynet', 'network': {'multus': {'networkName': 'mynet'}}},
@@ -86,15 +89,16 @@ def test_vm_multus_creation():
     )
     set_module_args(args)
 
+    # State as "returned" by the "k8s cluster":
     openshiftdynamic.Resource.get.return_value = None
     resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
-    K8sAnsibleMixin.find_resource.return_value = openshiftdynamic.Resource(**resource_args)
+    KubeVirtRawModule.find_supported_resource.return_value = openshiftdynamic.Resource(**resource_args)
 
     # Actual test:
     with pytest.raises(AnsibleExitJson) as result:
         mymodule.KubeVirtVM().execute_module()
     assert result.value['changed']
-    assert result.value['result']['method'] == 'create'
+    assert result.value['method'] == 'create'
 
 
 @pytest.mark.parametrize("_wait", (False, True))
@@ -102,31 +106,18 @@ def test_resource_absent(_wait):
     # Desired state:
     args = dict(
         state='absent', name='testvmi',
-        namespace='vms', api_version='v1',
+        namespace='vms',
         wait=_wait,
     )
     set_module_args(args)
 
+    # State as "returned" by the "k8s cluster":
     openshiftdynamic.Resource.get.return_value = None
     resource_args = dict(kind=KIND, **RESOURCE_DEFAULT_ARGS)
-    K8sAnsibleMixin.find_resource.return_value = openshiftdynamic.Resource(**resource_args)
+    KubeVirtRawModule.find_supported_resource.return_value = openshiftdynamic.Resource(**resource_args)
 
     # Actual test:
     with pytest.raises(AnsibleExitJson) as result:
         mymodule.KubeVirtVM().execute_module()
-    assert result.value['result']['method'] == 'delete'
-
-
-@patch('openshift.watch.Watch')
-def test_stream_creation(mock_watch):
-    # Desired state:
-    args = dict(
-        state='running', name='testvmi', namespace='vms',
-        api_version='v1', wait=True,
-    )
-    set_module_args(args)
-
-    # Actual test:
-    mock_watch.side_effect = helpexceptions.KubernetesException("Test", value=42)
-    with pytest.raises(AnsibleFailJson):
-        mymodule.KubeVirtVM().execute_module()
+    assert result.value['method'] == 'delete'
+    assert not result.value['kubevirt_vm']


### PR DESCRIPTION
##### SUMMARY
None of the unit tests for kubevirt actually did anything. Fix that. 

Also fix the regression in `merge_dicts()` introduced by [this change](https://github.com/ansible/ansible/pull/56833#discussion_r287500476).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
kubevirt
