### PR TITLE
Actually run valid_include_keywords test

### DIFF
--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -101,3 +101,6 @@ test "$(egrep -c 'Templating the path of the parent include_tasks failed.' test_
 
 # https://github.com/ansible/ansible/issues/54618
 ansible-playbook test_loop_var_bleed.yaml "$@"
+
+# https://github.com/ansible/ansible/issues/56580
+ansible-playbook valid_include_keywords/playbook.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The test added in https://github.com/ansible/ansible/pull/56586 hasn't been actually running.

This should be backported to `2.8` once merged.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/include_import/runme.sh`