### PR TITLE
Implement netbox groups option

### DIFF
--- a/changelogs/fragments/57688-netbox-groups.yaml
+++ b/changelogs/fragments/57688-netbox-groups.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - netbox - Fix missing implementation of `groups` option (https://github.com/ansible/ansible/issues/57688)

--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -434,8 +434,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             # Composed variables
             self._set_composite_vars(self.get_option('compose'), host, hostname, strict=strict)
+
             # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-            self._set_composite_vars(self.get_option('compose'), host, hostname, strict=strict)
+            self._add_host_to_composed_groups(self.get_option('groups'), host, hostname, strict=strict)
 
             # Create groups based on variable values and add the corresponding hosts to it
             self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)


### PR DESCRIPTION
##### SUMMARY
Implement the `groups` option in the Netbox inventory plugin. It was documented but not implemented.

Fixes #57688

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
netbox

##### ADDITIONAL INFORMATION
