### PR TITLE
filter bare variable with |bool (deprecation warn)

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -84,7 +84,7 @@ Tip: Sometimes you'll get back a variable that's a string and you'll want to do 
 
 .. note:: the above example requires the lsb_release package on the target host in order to return the 'lsb major_release' fact.
 
-Variables defined in the playbooks or inventory can also be used.  An example may be the execution of a task based on a variable's boolean value::
+Variables defined in the playbooks or inventory can also be used, just make sure to apply the `|bool` filter to the expression.  An example may be the execution of a task based on a variable's boolean value::
 
     vars:
       epic: true
@@ -93,13 +93,13 @@ Then a conditional execution might look like::
 
     tasks:
         - shell: echo "This certainly is epic!"
-          when: epic
+          when: epic|bool
 
 or::
 
     tasks:
         - shell: echo "This certainly isn't epic!"
-          when: not epic
+          when: not epic|bool
 
 If a required variable has not been set, you can skip or fail using Jinja2's `defined` test. For example::
 

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -84,22 +84,23 @@ Tip: Sometimes you'll get back a variable that's a string and you'll want to do 
 
 .. note:: the above example requires the lsb_release package on the target host in order to return the 'lsb major_release' fact.
 
-Variables defined in the playbooks or inventory can also be used, just make sure to apply the `|bool` filter to the expression.  An example may be the execution of a task based on a variable's boolean value::
+Variables defined in the playbooks or inventory can also be used, just make sure to apply the `|bool` filter to non boolean variables (ex: string variables with content like 'yes', 'on', '1', 'true').  An example may be the execution of a task based on a variable's boolean value::
 
     vars:
       epic: true
+      monumental: "yes"
 
 Then a conditional execution might look like::
 
     tasks:
         - shell: echo "This certainly is epic!"
-          when: epic|bool
+          when: epic or monumental|bool
 
 or::
 
     tasks:
         - shell: echo "This certainly isn't epic!"
-          when: not epic|bool
+          when: not epic
 
 If a required variable has not been set, you can skip or fail using Jinja2's `defined` test. For example::
 


### PR DESCRIPTION
##### SUMMARY
ansible issues a deprecation warning if you are using a bare variable with when, it suggests you filter the expression using the |bool filter

updated doc so it's up to date.

           > [DEPRECATION WARNING]: evaluating xxxxxx as a bare variable, this 
           > behaviour will go away and you might need to add |bool to the expression in the
           >  future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature 
           > will be removed in version 2.12. Deprecation warnings can be disabled by 
           > setting deprecation_warnings=False in ansible.cfg.


##### ISSUE TYPE
- Docs Pull Request

see discussion at https://github.com/ansible/ansible/issues/53428

+label: docsite_pr

