### PR TITLE
Fixed heading link password field in user module

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -91,7 +91,7 @@ options:
             - Optionally set the user's password to this crypted value.
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
-            - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module)
+            - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str
     state:


### PR DESCRIPTION
##### SUMMARY
In the [user module](https://docs.ansible.com/ansible/latest/modules/user_module.html#user-module) documentation, the password field links to `https://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module`, but the actual link is `https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module` as it was modified in d27d956d71428315397b855e1b094a9caddfa3fd.

So I corrected the link in the user module to the actual link to display the heading. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
user

+label: docsite_pr