### PR TITLE
backport/2.8/57187 update ce_facts to fix array out of range bug (#57187)

### DIFF
--- a/changelogs/fragments/57698-update-ce_facts-to-fix-array-out-of-range-bug.yml
+++ b/changelogs/fragments/57698-update-ce_facts-to-fix-array-out-of-range-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - update ce_facts to fix array out of range bug(https://github.com/ansible/ansible/pull/57187).

--- a/lib/ansible/modules/network/cloudengine/ce_facts.py
+++ b/lib/ansible/modules/network/cloudengine/ce_facts.py
@@ -324,7 +324,10 @@ class Interfaces(FactsBase):
             tmp_neighbors = neighbors[2:]
             for item in tmp_neighbors:
                 tmp_item = item.split()
-                neighbors_dict[tmp_item[0]] = tmp_item[3]
+                if len(tmp_item) > 3:
+                    neighbors_dict[tmp_item[0]] = tmp_item[3]
+                else:
+                    neighbors_dict[tmp_item[0]] = None
             self.facts['neighbors'] = neighbors_dict
 
 


### PR DESCRIPTION
(cherry picked from commit 229d20b6d9ebbb7c2bd1732a0eecda4f00d6e757)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
update ce_facts to fix array out of range bug (#57187)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_facts.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
