### PR TITLE
vmware_host_ipv6: only changed when changed

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_ipv6.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ipv6.py
@@ -136,7 +136,6 @@ class VmwareHostIPv6(PyVmomi):
                         results['result'][host.name]['msg'] = "IPv6 is already enabled and active for host '%s'" % \
                                                               host.name
                     if not host_network_info.ipV6Enabled:
-                        changed = True
                         results['result'][host.name]['msg'] = ("IPv6 is already enabled for host '%s', but a reboot"
                                                                " is required!" % host.name)
                 # Enable IPv6


### PR DESCRIPTION
vmware_host_ipv6: only changed when changed
  
##### SUMMARY

Do not return the `changed` status when a reboot is required. The
configuration is applied and so the configuration changed has already been
done.

This is a problem if we want to run the same test role two times in a row.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_ipv6