### PR TITLE
nxos_bgp_neighbor - add local_as attributes [no-prepend | [replace-as |dual-as]]

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -175,6 +175,8 @@ EXAMPLES = '''
     asn: 65535
     neighbor: 192.0.2.3
     local_as: 20
+    local_as_no_prepend: true
+    local_as_replace_as: true
     remote_as: 30
     description: "just a description"
     update_source: Ethernet1/3
@@ -188,7 +190,7 @@ commands:
   type: list
   sample: ["router bgp 65535", "neighbor 192.0.2.3",
            "remote-as 30", "update-source Ethernet1/3",
-           "description just a description", "local-as 20"]
+           "description just a description", "local-as 20 no-prepend replace-as"]
 '''
 
 import re

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -175,8 +175,8 @@ EXAMPLES = '''
     asn: 65535
     neighbor: 192.0.2.3
     local_as: 20
-    local_as_no_prepend: true
-    local_as_replace_as: true
+    local_as_no_prepend: True
+    local_as_replace_as: True
     remote_as: 30
     description: "just a description"
     update_source: Ethernet1/3

--- a/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -304,6 +304,42 @@
 
   - assert: *false
 
+  - name: "Configure BGP Neighbor Local AS"
+    nxos_bgp_neighbor: &configure_local_as
+      asn: 65535
+      neighbor: 192.0.2.3/32
+      vrf: "{{ item }}"
+      local_as: 65523
+      local_as_no_prepend: true
+      local_as_replace_as: true
+      local_as_dual_as: false
+      state: present
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence"
+    nxos_bgp_neighbor: *configure_local_as
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *false
+
+  - name: "Remove BGP"
+    nxos_bgp_neighbor: *removenp
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence"
+    nxos_bgp_neighbor: *removenp
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *false
+
   rescue:
   - name: "Cleanup BGP"
     nxos_bgp_neighbor: *remove

--- a/test/units/modules/network/nxos/fixtures/nxos_bgp/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_bgp/config.cfg
@@ -12,3 +12,5 @@ router bgp 65535
   neighbor 3.3.3.5
     address-family ipv4 unicast
       maximum-prefix 30 30
+  neighbor 3.3.3.6
+   local-as 65523 no-prepend replace-as

--- a/test/units/modules/network/nxos/test_nxos_bgp_neighbor.py
+++ b/test/units/modules/network/nxos/test_nxos_bgp_neighbor.py
@@ -57,3 +57,23 @@ class TestNxosBgpNeighborModule(TestNxosModule):
     def test_nxos_bgp_neighbor_remove_private_as_changed(self):
         set_module_args(dict(asn=65535, neighbor='3.3.3.4', remove_private_as='replace-as'))
         self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.4', 'remove-private-as replace-as'])
+
+    # Idempotence
+    def test_nxos_bgp_neighbor_local_as_no_prepend_replace_as(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523', local_as_no_prepend=True, local_as_replace_as=True))
+        self.execute_module(changed=False, commands=[])
+
+    # Remote all Local AS Attributes
+    def test_nxos_bgp_neighbor_local_as_remove(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6'))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'no local-as 65523'])
+
+    # Remove Subset of Local AS Attributes (ie. reapply without extras)
+    def test_nxos_bgp_neighbor_local_as_changed(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523'))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'local-as 65523'])
+
+    # Add Additional Extras
+    def test_nxos_bgp_neighbor_local_as_no_prepend_dual_as_changed(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523', local_as_no_prepend=True, local_as_replace_as=True, local_as_dual_as=True))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'local-as 65523 no-prepend replace-as dual-as'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added functionality to utilise additional attributes with the **local-as** command in ```nxos_bgp_neighbor``` module.

> **local-as** *autonomous-system-number* **[ no-prepend | replace-as [ dual-as ]]**

This functionality has been implemented through the following boolean variables ```(default: False)```
- local_as_no_prepend
- local_as_replace_as
- local_as_dual_as

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_bgp_neighbor
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I came across a use case that required these addditional attributes to convert our NXOS infrastructure BGP configuration to IaC using core ansible modules.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example pulled from integration test:
```paste below
  - name: "Configure BGP Neighbor Local AS"
    nxos_bgp_neighbor: &configure_local_as
      asn: 65535
      neighbor: 192.0.2.3/32
      vrf: "{{ item }}"
      local_as: 65523
      local_as_no_prepend: true
      local_as_replace_as: true
      local_as_dual_as: false
      state: present
    with_items: "{{ vrfs }}"
    register: result
```
