### PR TITLE
Updated the section under "Aborting the play" in the Error Handling In Playbooks page

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -152,7 +152,7 @@ Aborting the play
 
 Sometimes it's desirable to abort the entire play on failure, not just skip remaining tasks for a host.
 
-The ``any_errors_fatal`` play option will end the play when any tasks results in an error, causing an immediate execution of the play::
+The ``any_errors_fatal`` play option will end the play when any tasks results in an error and stop execution of the play::
 
      - hosts: somehosts
        any_errors_fatal: true

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -152,7 +152,7 @@ Aborting the play
 
 Sometimes it's desirable to abort the entire play on failure, not just skip remaining tasks for a host.
 
-The ``any_errors_fatal`` play option will mark all hosts as failed if any fails, causing an immediate abort::
+The ``any_errors_fatal`` play option will end the play when any tasks results in an error, causing an immediate execution of the play::
 
      - hosts: somehosts
        any_errors_fatal: true


### PR DESCRIPTION
Updated "Aborting the play" section in the Error Handling In Playbooks page. Removed the reference to marking all hosts as failed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request