### PR TITLE
2.8: Actually run valid_include_keywords test (#57687)

### DIFF
--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -101,3 +101,6 @@ test "$(egrep -c 'Templating the path of the parent include_tasks failed.' test_
 
 # https://github.com/ansible/ansible/issues/54618
 ansible-playbook test_loop_var_bleed.yaml "$@"
+
+# https://github.com/ansible/ansible/issues/56580
+ansible-playbook valid_include_keywords/playbook.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/57687

(cherry picked from commit e8948f7655d2a37032821b61dc76951132e8fe10)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/include_import/runme.sh`