### PR TITLE
nxos_bgp_neighbor: added local_as attributes

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -78,26 +78,23 @@ options:
         or 'default', which means not to configure it.
   local_as_no_prepend:
     description:
-      - To configure a route to appear as a member of a second autonomous system (AS)
-        in addition to the real AS of the device, use the local-as command.
-        no-prepend - (Optional) Specfies not to prepend the local autonomous system number
-                      to any routes received from the eBGP neighbor.
-        type: boolean
+      - (Optional) Specfies not to prepend the local autonomous system number
+        to any routes received from the eBGP neighbor.
+    type: bool
+    default: False
   local_as_replace_as:
     description:
-      - To configure a route to appear as a member of a second autonomous system (AS)
-        in addition to the real AS of the device, use the local-as command.
-        replace-as - (Optional) Specifies to prepend only the local-as number to updates
-                       to eBGP neighbor.
-        type: boolean
+      - (Optional) Specifies to prepend only the local-as number to updates
+        to eBGP neighbor.
+    type: bool
+    default: False
   local_as_dual_as:
     description:
-      - To configure a route to appear as a member of a second autonomous system (AS)
-        in addition to the real AS of the device, use the local-as command.
-        dual-as    - (Optional) configures the eBGP neighbor to establish a peering
-                      session using the real autonomous system number (from the
-                      local BGP routing process) or by using the autonomous-system number.
-        type: boolean
+      - (Optional) configures the eBGP neighbor to establish a peering
+        session using the real autonomous system number (from the
+        local BGP routing process) or by using the autonomous-system number.
+    type: bool
+    default: False
   log_neighbor_changes:
     description:
       - Specify whether or not to enable log messages for neighbor

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -76,6 +76,25 @@ options:
       - Specify the local-as number for the eBGP neighbor.
         Valid values are String or Integer in ASPLAIN or ASDOT notation,
         or 'default', which means not to configure it.
+  local_as_no_prepend:
+    description:
+      - (Optional) Specfies not to prepend the local autonomous system number
+        to any routes received from the eBGP neighbor.
+    type: bool
+    default: False
+  local_as_replace_as:
+    description:
+      - (Optional) Specifies to prepend only the local-as number to updates
+        to eBGP neighbor.
+    type: bool
+    default: False
+  local_as_dual_as:
+    description:
+      - (Optional) configures the eBGP neighbor to establish a peering
+        session using the real autonomous system number (from the
+        local BGP routing process) or by using the autonomous-system number.
+    type: bool
+    default: False
   log_neighbor_changes:
     description:
       - Specify whether or not to enable log messages for neighbor
@@ -153,6 +172,8 @@ EXAMPLES = '''
     asn: 65535
     neighbor: 192.0.2.3
     local_as: 20
+    local_as_no_prepend: True
+    local_as_replace_as: True
     remote_as: 30
     description: "just a description"
     update_source: Ethernet1/3
@@ -166,7 +187,7 @@ commands:
   type: list
   sample: ["router bgp 65535", "neighbor 192.0.2.3",
            "remote-as 30", "update-source Ethernet1/3",
-           "description just a description", "local-as 20"]
+           "description just a description", "local-as 20 no-prepend replace-as"]
 '''
 
 import re
@@ -194,6 +215,9 @@ PARAM_TO_COMMAND_KEYMAP = {
     'dynamic_capability': 'dynamic-capability',
     'ebgp_multihop': 'ebgp-multihop',
     'local_as': 'local-as',
+    'local_as_no_prepend': 'local-as',
+    'local_as_replace_as': 'local-as',
+    'local_as_dual_as': 'local-as',
     'log_neighbor_changes': 'log-neighbor-changes',
     'low_memory_exempt': 'low-memory exempt',
     'maximum_peers': 'maximum-peers',
@@ -214,7 +238,10 @@ PARAM_TO_DEFAULT_KEYMAP = {
     'shutdown': False,
     'dynamic_capability': True,
     'timers_keepalive': 60,
-    'timers_holdtime': 180
+    'timers_holdtime': 180,
+    'local_as_no_prepend': 'no-prepend',
+    'local_as_replace_as': 'replace-as',
+    'local_as_dual_as': 'dual-as',
 }
 
 
@@ -228,6 +255,19 @@ def get_value(arg, config):
         value = True
         if has_no_command:
             value = False
+    elif command == 'local-as':
+        value = ''
+        if has_command_val:
+            if arg == 'local_as_no_prepend':
+                value = 'no-prepend' in has_command_val.group('value')
+            elif arg == 'local_as_replace_as':
+                value = 'replace-as' in has_command_val.group('value')
+            elif arg == 'local_as_dual_as':
+                value = 'dual-as' in has_command_val.group('value')
+            elif arg == 'local_as':
+                split_value = has_command_val.group('value').split()
+                value = split_value[0]
+
     elif arg in BOOL_PARAMS:
         value = False
         if has_command:
@@ -307,9 +347,23 @@ def state_present(module, existing, proposed, candidate):
     commands = list()
     proposed_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, proposed)
     existing_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, existing)
-
+    attribute_string = ''
     for key, value in proposed_commands.items():
-        if value is True:
+        if key == "local-as":
+            # If local_as arg is passed to module execution -- build command string
+            if module.params['local_as'] is not None:
+                local_as_attributes = ['local_as_no_prepend', 'local_as_replace_as', 'local_as_dual_as']
+                attribute_string = ' '.join([PARAM_TO_DEFAULT_KEYMAP.get(x) for x in local_as_attributes if module.params[x] is True])
+                command = 'local-as {0} {1}'.format(module.params['local_as'], attribute_string).strip()
+                # this will loop for each local_as_attribute -- only append one time.
+                if command not in commands:
+                    commands.append(command)
+            # If local_as arg is NOT passed to module execution -- only remove if it existed originally
+            elif module.params['local_as'] is None and existing.get('local_as'):
+                command = 'no local-as {0}'.format(existing.get('local_as'))
+                if command not in commands:
+                    commands.append(command)
+        elif value is True:
             commands.append(key)
         elif value is False:
             commands.append('no {0}'.format(key))
@@ -366,7 +420,7 @@ def state_present(module, existing, proposed, candidate):
         parents.append('neighbor {0}'.format(module.params['neighbor']))
 
         # make sure that local-as is the last command in the list.
-        local_as_command = 'local-as {0}'.format(module.params['local_as'])
+        local_as_command = 'local-as {0} {1}'.format(module.params['local_as'], attribute_string).strip()
         if local_as_command in commands:
             commands.remove(local_as_command)
             commands.append(local_as_command)
@@ -394,6 +448,9 @@ def main():
         dynamic_capability=dict(required=False, type='bool'),
         ebgp_multihop=dict(required=False, type='str'),
         local_as=dict(required=False, type='str'),
+        local_as_no_prepend=dict(required=False, type='bool', default=False),
+        local_as_replace_as=dict(required=False, type='bool', default=False),
+        local_as_dual_as=dict(required=False, type='bool', default=False),
         log_neighbor_changes=dict(required=False, type='str', choices=['enable', 'disable', 'inherit']),
         low_memory_exempt=dict(required=False, type='bool'),
         maximum_peers=dict(required=False, type='str'),

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -76,6 +76,28 @@ options:
       - Specify the local-as number for the eBGP neighbor.
         Valid values are String or Integer in ASPLAIN or ASDOT notation,
         or 'default', which means not to configure it.
+  local_as_no_prepend:
+    description:
+      - To configure a route to appear as a member of a second autonomous system (AS)
+        in addition to the real AS of the device, use the local-as command.
+        no-prepend - (Optional) Specfies not to prepend the local autonomous system number
+                      to any routes received from the eBGP neighbor.
+        type: boolean
+  local_as_replace_as:
+    description:
+      - To configure a route to appear as a member of a second autonomous system (AS)
+        in addition to the real AS of the device, use the local-as command.
+        replace-as - (Optional) Specifies to prepend only the local-as number to updates
+                       to eBGP neighbor.
+        type: boolean
+  local_as_dual_as:
+    description:
+      - To configure a route to appear as a member of a second autonomous system (AS)
+        in addition to the real AS of the device, use the local-as command.
+        dual-as    - (Optional) configures the eBGP neighbor to establish a peering
+                      session using the real autonomous system number (from the
+                      local BGP routing process) or by using the autonomous-system number.
+        type: boolean
   log_neighbor_changes:
     description:
       - Specify whether or not to enable log messages for neighbor
@@ -153,6 +175,8 @@ EXAMPLES = '''
     asn: 65535
     neighbor: 192.0.2.3
     local_as: 20
+    local_as_no_prepend: True
+    local_as_replace_as: True
     remote_as: 30
     description: "just a description"
     update_source: Ethernet1/3
@@ -166,7 +190,7 @@ commands:
   type: list
   sample: ["router bgp 65535", "neighbor 192.0.2.3",
            "remote-as 30", "update-source Ethernet1/3",
-           "description just a description", "local-as 20"]
+           "description just a description", "local-as 20 no-prepend replace-as"]
 '''
 
 import re
@@ -194,6 +218,9 @@ PARAM_TO_COMMAND_KEYMAP = {
     'dynamic_capability': 'dynamic-capability',
     'ebgp_multihop': 'ebgp-multihop',
     'local_as': 'local-as',
+    'local_as_no_prepend': 'local-as',
+    'local_as_replace_as': 'local-as',
+    'local_as_dual_as': 'local-as',
     'log_neighbor_changes': 'log-neighbor-changes',
     'low_memory_exempt': 'low-memory exempt',
     'maximum_peers': 'maximum-peers',
@@ -214,7 +241,10 @@ PARAM_TO_DEFAULT_KEYMAP = {
     'shutdown': False,
     'dynamic_capability': True,
     'timers_keepalive': 60,
-    'timers_holdtime': 180
+    'timers_holdtime': 180,
+    'local_as_no_prepend': 'no-prepend',
+    'local_as_replace_as': 'replace-as',
+    'local_as_dual_as': 'dual-as',
 }
 
 
@@ -228,6 +258,19 @@ def get_value(arg, config):
         value = True
         if has_no_command:
             value = False
+    elif command == 'local-as':
+        value = ''
+        if has_command_val:
+            if arg == 'local_as_no_prepend':
+                value = 'no-prepend' in has_command_val.group('value')
+            elif arg == 'local_as_replace_as':
+                value = 'replace-as' in has_command_val.group('value')
+            elif arg == 'local_as_dual_as':
+                value = 'dual-as' in has_command_val.group('value')
+            elif arg == 'local_as':
+                split_value = has_command_val.group('value').split()
+                value = split_value[0]
+
     elif arg in BOOL_PARAMS:
         value = False
         if has_command:
@@ -307,9 +350,23 @@ def state_present(module, existing, proposed, candidate):
     commands = list()
     proposed_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, proposed)
     existing_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, existing)
-
+    attribute_string = ''
     for key, value in proposed_commands.items():
-        if value is True:
+        if key == "local-as":
+            # If local_as arg is passed to module execution -- build command string
+            if module.params['local_as'] is not None:
+                local_as_attributes = ['local_as_no_prepend', 'local_as_replace_as', 'local_as_dual_as']
+                attribute_string = ' '.join([PARAM_TO_DEFAULT_KEYMAP.get(x) for x in local_as_attributes if module.params[x] is True])
+                command = 'local-as {0} {1}'.format(module.params['local_as'], attribute_string).strip()
+                # this will loop for each local_as_attribute -- only append one time.
+                if command not in commands:
+                    commands.append(command)
+            # If local_as arg is NOT passed to module execution -- only remove if it existed originally
+            elif module.params['local_as'] is None and existing.get('local_as'):
+                command = 'no local-as {0}'.format(existing.get('local_as'))
+                if command not in commands:
+                    commands.append(command)
+        elif value is True:
             commands.append(key)
         elif value is False:
             commands.append('no {0}'.format(key))
@@ -366,7 +423,7 @@ def state_present(module, existing, proposed, candidate):
         parents.append('neighbor {0}'.format(module.params['neighbor']))
 
         # make sure that local-as is the last command in the list.
-        local_as_command = 'local-as {0}'.format(module.params['local_as'])
+        local_as_command = 'local-as {0} {1}'.format(module.params['local_as'], attribute_string).strip()
         if local_as_command in commands:
             commands.remove(local_as_command)
             commands.append(local_as_command)
@@ -394,6 +451,9 @@ def main():
         dynamic_capability=dict(required=False, type='bool'),
         ebgp_multihop=dict(required=False, type='str'),
         local_as=dict(required=False, type='str'),
+        local_as_no_prepend=dict(required=False, type='bool', default=False),
+        local_as_replace_as=dict(required=False, type='bool', default=False),
+        local_as_dual_as=dict(required=False, type='bool', default=False),
         log_neighbor_changes=dict(required=False, type='str', choices=['enable', 'disable', 'inherit']),
         low_memory_exempt=dict(required=False, type='bool'),
         maximum_peers=dict(required=False, type='str'),

--- a/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -304,6 +304,42 @@
 
   - assert: *false
 
+  - name: "Configure BGP Neighbor Local AS"
+    nxos_bgp_neighbor: &configure_local_as
+      asn: 65535
+      neighbor: 192.0.2.3/32
+      vrf: "{{ item }}"
+      local_as: 65523
+      local_as_no_prepend: True
+      local_as_replace_as: True
+      local_as_dual_as: False
+      state: present
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence"
+    nxos_bgp_neighbor: *configure_local_as
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *false
+
+  - name: "Remove BGP"
+    nxos_bgp_neighbor: *removenp
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence"
+    nxos_bgp_neighbor: *removenp
+    with_items: "{{ vrfs }}"
+    register: result
+
+  - assert: *false
+
   rescue:
   - name: "Cleanup BGP"
     nxos_bgp_neighbor: *remove

--- a/test/units/modules/network/nxos/fixtures/nxos_bgp/config.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_bgp/config.cfg
@@ -12,3 +12,5 @@ router bgp 65535
   neighbor 3.3.3.5
     address-family ipv4 unicast
       maximum-prefix 30 30
+  neighbor 3.3.3.6
+    local-as 65523 no-prepend replace-as

--- a/test/units/modules/network/nxos/test_nxos_bgp_neighbor.py
+++ b/test/units/modules/network/nxos/test_nxos_bgp_neighbor.py
@@ -57,3 +57,23 @@ class TestNxosBgpNeighborModule(TestNxosModule):
     def test_nxos_bgp_neighbor_remove_private_as_changed(self):
         set_module_args(dict(asn=65535, neighbor='3.3.3.4', remove_private_as='replace-as'))
         self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.4', 'remove-private-as replace-as'])
+
+    # Idempotence
+    def test_nxos_bgp_neighbor_local_as_no_prepend_replace_as(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523', local_as_no_prepend=True, local_as_replace_as=True))
+        self.execute_module(changed=False, commands=[])
+
+    # Remote all Local AS Attributes
+    def test_nxos_bgp_neighbor_local_as_remove(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6'))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'no local-as 65523'])
+
+    # Remove Subset of Local AS Attributes (ie. reapply without extras)
+    def test_nxos_bgp_neighbor_local_as_changed(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523'))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'local-as 65523'])
+
+    # Add Additional Extras
+    def test_nxos_bgp_neighbor_local_as_no_prepend_dual_as_changed(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.6', local_as='65523', local_as_no_prepend=True, local_as_replace_as=True, local_as_dual_as=True))
+        self.execute_module(changed=True, commands=['router bgp 65535', 'neighbor 3.3.3.6', 'local-as 65523 no-prepend replace-as dual-as'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added functionality to utilise additional attributes with the **local-as** command in ```nxos_bgp_neighbor``` module.

> **local-as** *autonomous-system-number* **[ no-prepend | replace-as [ dual-as ]]**

This functionality has been implemented through the following boolean variables ```(default: False)```
- local_as_no_prepend
- local_as_replace_as
- local_as_dual_as
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_bgp_neighbor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I came across a use case that required these addditional attributes to convert our NXOS infrastructure BGP configuration to IaC using core ansible modules.

Example pulled from integration test:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: "Configure BGP Neighbor Local AS"
    nxos_bgp_neighbor: &configure_local_as
      asn: 65535
      neighbor: 192.0.2.3/32
      vrf: "{{ item }}"
      local_as: 65523
      local_as_no_prepend: True
      local_as_replace_as: True
      local_as_dual_as: False
      state: present
    with_items: "{{ vrfs }}"
    register: result
```
