### PR TITLE
Add Fedora 30 to test matrix

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -71,8 +71,8 @@ matrix:
     - env: T=freebsd/12.0/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
-    - env: T=linux/fedora28/1
     - env: T=linux/fedora29/1
+    - env: T=linux/fedora30/1
     - env: T=linux/opensuse15py2/1
     - env: T=linux/opensuse15/1
     - env: T=linux/ubuntu1604/1
@@ -85,8 +85,8 @@ matrix:
     - env: T=freebsd/12.0/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
-    - env: T=linux/fedora28/2
     - env: T=linux/fedora29/2
+    - env: T=linux/fedora30/2
     - env: T=linux/opensuse15py2/2
     - env: T=linux/opensuse15/2
     - env: T=linux/ubuntu1604/2
@@ -99,8 +99,8 @@ matrix:
     - env: T=freebsd/12.0/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
-    - env: T=linux/fedora28/3
     - env: T=linux/fedora29/3
+    - env: T=linux/fedora30/3
     - env: T=linux/opensuse15py2/3
     - env: T=linux/opensuse15/3
     - env: T=linux/ubuntu1604/3
@@ -113,8 +113,8 @@ matrix:
     - env: T=freebsd/12.0/4
     - env: T=linux/centos6/4
     - env: T=linux/centos7/4
-    - env: T=linux/fedora28/4
     - env: T=linux/fedora29/4
+    - env: T=linux/fedora30/4
     - env: T=linux/opensuse15py2/4
     - env: T=linux/opensuse15/4
     - env: T=linux/ubuntu1604/4

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,8 +1,8 @@
 default name=quay.io/ansible/default-test-container:1.8.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
-fedora28 name=quay.io/ansible/fedora28-test-container:1.8.0 python=2.7
 fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7
+fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.8.0 python=2.7
 opensuse15 name=quay.io/ansible/opensuse15-test-container:1.8.0 python=3.6
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.8.0 python=2.7 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY
Add Fedora 30 and remove Fedora 29 from test matrix

Fixes #51160

#58081 needs to be merged before these tests will pass.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
`shippable.yml`
`test/runner/completion/docker.txt`

##### ADDITIONAL INFORMATION
After discussing in the [public IRC meeting](https://meetbot.fedoraproject.org/ansible-meeting/2019-06-11/ansible_core_irc_public_meeting.2019-06-11-19.00.log.html#l-133), it was decided not to test Python 2 on Fedora since Python 2 on Fedora is in maintenance mode at this point and will be deprecated in Fedora 32.