### PR TITLE
Fixes NoneType error in Systemd module

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -341,9 +341,10 @@ def main():
     )
 
     unit = module.params['name']
-    for globpattern in (r"*", r"?", r"["):
-        if globpattern in unit:
-            module.fail_json(msg="This module does not currently support using glob patterns, found '%s' in service name: %s" % (globpattern, unit))
+    if unit is not None:
+        for globpattern in (r"*", r"?", r"["):
+            if globpattern in unit:
+                module.fail_json(msg="This module does not currently support using glob patterns, found '%s' in service name: %s" % (globpattern, unit))
 
     systemctl = module.get_bin_path('systemctl', True)
 


### PR DESCRIPTION
* fixes bug introduced by commit 8cb73720f0599b08794cb7a3fbdf36d430214446:
"TypeError: argument of type 'NoneType' is not iterable" when using module systemd without param 'name' (e.g. with daemon_reload)

##### SUMMARY

Pull request #56645 introduced the mentioned TypeError when systemd_module is used without the parameter 'name'.

Fixes #55476

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module systemd

##### ADDITIONAL INFORMATION
None