### PR TITLE
Fix junos integration zuul CI failures

### DIFF
--- a/changelogs/fragments/junos_fix_netconf_test_failures.yaml
+++ b/changelogs/fragments/junos_fix_netconf_test_failures.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix junos integration test failures (https://github.com/ansible/ansible/pull/57309)
+  - Fix in netconf plugin when data element is empty in xml response (https://github.com/ansible/ansible/pull/57981)

--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -50,7 +50,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "result.msg == 'Subset must be one of [config, default, hardware, interfaces, ofacts], got test'"
+      - "'Subset must be one of' in result.msg"
 
 - name: Collect config facts from device in set format
   junos_facts:

--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -1,119 +1,138 @@
 ---
 - debug: msg="START junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"
 
-- name: setup - Disable lldp and remove it's configuration
-  junos_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: Enable lldp
-  junos_lldp:
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: Enable lldp (idempotent)
-  junos_lldp:
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
 
-- assert:
-    that:
-      - "result.changed == false"
+- block:
+  - name: setup - Disable lldp and remove it's configuration
+    junos_lldp:
+      state: absent
+      provider: "{{ netconf }}"
 
-- name: configure lldp parameters and enable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp
+    junos_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *advertisement-interval 10")
-      - result.diff.prepared is search("\+ *transmit-delay 2")
-      - result.diff.prepared is search("\+ *hold-multiplier 5")
+  - assert:
+      that:
+        - "result.changed == true"
 
-- name: configure lldp parameters and enable lldp(idempotent)
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp (idempotent)
+    junos_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: configure lldp parameters and disable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: disabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
-      - "'advertisement-interval 10;' not in result.diff.prepared"
-      - "'transmit-delay 2;' not in result.diff.prepared"
-      - "'hold-multiplier 5;' not in result.diff.prepared"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *advertisement-interval 10")
+        - result.diff.prepared is search("\+ *transmit-delay 2")
+        - result.diff.prepared is search("\+ *hold-multiplier 5")
 
-- name: configure lldp parameters and enable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: enabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp(idempotent)
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *disable")
-      - "'advertisement-interval 10;' not in result.diff.prepared"
-      - "'transmit-delay 2;' not in result.diff.prepared"
-      - "'hold-multiplier 5;' not in result.diff.prepared"
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: Remove lldp configuration and diable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and disable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: disabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
-      - result.diff.prepared is search("\- *advertisement-interval 10")
-      - result.diff.prepared is search("\- *transmit-delay 2")
-      - result.diff.prepared is search("\- *hold-multiplier 5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
+        - "'advertisement-interval 10;' not in result.diff.prepared"
+        - "'transmit-delay 2;' not in result.diff.prepared"
+        - "'hold-multiplier 5;' not in result.diff.prepared"
 
-- name: Remove lldp (idempotent)
-  junos_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: enabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *disable")
+        - "'advertisement-interval 10;' not in result.diff.prepared"
+        - "'transmit-delay 2;' not in result.diff.prepared"
+        - "'hold-multiplier 5;' not in result.diff.prepared"
+
+  - name: Remove lldp configuration and diable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
+        - result.diff.prepared is search("\- *advertisement-interval 10")
+        - result.diff.prepared is search("\- *transmit-delay 2")
+        - result.diff.prepared is search("\- *hold-multiplier 5")
+
+  - name: Remove lldp (idempotent)
+    junos_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+
+  when: lldp_supported
 
 - debug: msg="END junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp/tests/netconf/net_lldp.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/net_lldp.yaml
@@ -3,25 +3,42 @@
 
 # Add minimal testcase to check args are passed correctly to
 # implementation module and module run is successful.
-
-- name: setup - Disable lldp - setup
-  net_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: Enable lldp using platform agnostic module
-  net_lldp:
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: setup - Disable lldp - teardown
-  net_lldp:
-    state: absent
-    provider: "{{ netconf }}"
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
+
+- block:
+  - name: setup - Disable lldp - setup
+    net_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+
+  - name: Enable lldp using platform agnostic module
+    net_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+
+  - name: setup - Disable lldp - teardown
+    net_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+  when: lldp_supported
 
 - debug: msg="START junos netconf/net_lldp.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
@@ -1,106 +1,124 @@
 ---
 - debug: msg="START junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"
 
-- name: setup - Remove lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *interface ge-0/0/5")
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: lldp interface configuration (idempotent)
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
 
-- assert:
-    that:
-      - "result.changed == false"
+- block:
+  - name: setup - Remove lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
 
-- name: Deactivate lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    active: False
-    provider: "{{ netconf }}"
-  register: result
+  - name: lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *interface ge-0/0/5")
 
-- name: Activate lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    active: True
-    provider: "{{ netconf }}"
-  register: result
+  - name: lldp interface configuration (idempotent)
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: Disable lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: disabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: Deactivate lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      active: False
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
 
-- name: Enable lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: enabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: Activate lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      active: True
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *disable")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
 
-- name: Delete lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: Disable lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: disabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
 
-- name: Delete lldp on particular interface (idempotent)
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: enabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *disable")
+
+  - name: Delete lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *interface ge-0/0/5")
+
+  - name: Delete lldp on particular interface (idempotent)
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+  when: lldp_supported
 
 - debug: msg="END junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/net_lldp_interface.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/net_lldp_interface.yaml
@@ -4,28 +4,46 @@
 # Add minimal testcase to check args are passed correctly to
 # implementation module and module run is successful.
 
-- name: setup - Remove lldp interface configuration
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: lldp interface configuration using platform agnostic module
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *interface ge-0/0/5")
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: teardown - Remove lldp interface configuration
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
+
+- block:
+  - name: setup - Remove lldp interface configuration
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+
+  - name: lldp interface configuration using platform agnostic module
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *interface ge-0/0/5")
+
+  - name: teardown - Remove lldp interface configuration
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+  when: lldp_supported
 
 - debug: msg="END junos netconf/net_lldp_interface.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
+++ b/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
@@ -10,14 +10,14 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'<name>\nem0\n</name>' in result['xml']"
+      - "'<interface-information' in result['xml']"
       - "result.output is defined"
 
 - name: Execute RPC with args on device
   junos_rpc:
     rpc: get-interface-information
     args:
-      interface-name: em0
+      interface-name: lo0
       media: True
     provider: "{{ netconf }}"
   register: result
@@ -25,8 +25,9 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'<name>\nem0\n</name>' in result['xml']"
-      - "'<name>\nlo0\n</name>' not in result['xml']"
+      - "'<name>\nlo0\n</name>' in result['xml']"
+      - "'<name>\nem0\n</name>' not in result['xml']"
+      - "'<name>\fxp0\n</name>' not in result['xml']"
 
 - name: Execute RPC on device and get output in text format
   junos_rpc:
@@ -40,14 +41,14 @@
       - "result.changed == false"
       - "result.output is defined"
       - "result.output_lines is defined"
-      - "'Physical interface: em0' in result['output']"
+      - "'Physical interface' in result['output']"
 
 - name: Execute RPC on device and get output in json format
   junos_rpc:
     rpc: get-interface-information
     output: json
     args:
-      interface-name: em0
+      interface-name: lo0
       media: True
     provider: "{{ netconf }}"
   register: result
@@ -56,7 +57,7 @@
     that:
       - "result.changed == false"
       - "result.output is defined"
-      - "result['output']['interface-information'][0]['physical-interface'][0]['name'][0]['data'] == \"em0\""
+      - "result['output']['interface-information'][0]['physical-interface'][0]['name'][0]['data'] == \"lo0\""
 
 - name: Execute invalid RPC
   junos_rpc:

--- a/test/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -27,10 +27,21 @@
     that:
       - "result.changed == false"
 
-- name: configure syslog file replace
+- name: replace default operation fail
   netconf_config:
     content: "{{ syslog_config_replace }}"
     default_operation: 'replace'
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'Missing mandatory statement' in result.msg"
+
+- name: replace syslog config with operation key in content
+  netconf_config:
+    content: "{{ syslog_config_replace }}"
   register: result
 
 - assert:
@@ -55,7 +66,7 @@
 - name: save config
   netconf_config:
     backup: yes
-    register: result
+  register: result
 
 - assert:
     that:

--- a/test/integration/targets/netconf_config/tests/junos/fixtures/config.yml
+++ b/test/integration/targets/netconf_config/tests/junos/fixtures/config.yml
@@ -24,7 +24,7 @@ syslog_config_replace: |
             <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
               <configuration>
                 <system>
-                  <syslog>
+                  <syslog operation="replace">
                     <file>
                       <name>test_netconf_config</name>
                       <contents>


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix netconf plugin to return `data_xml` object if present for the device handler object or else return raw xml

* Add check to run lldp integration test cases only if lldp is supported on the target host

Merged to devel https://github.com/ansible/ansible/pull/57309
(cherry picked from commit 0957835a4814bfc0c7649675963de5e88df5060e)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/init.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
