### PR TITLE
Default value should be str

### DIFF
--- a/changelogs/fragments/57720-fix-lvg-warning-int-to-str-conversion.yml
+++ b/changelogs/fragments/57720-fix-lvg-warning-int-to-str-conversion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed warning shown when using default value for pesize about conversion from int to str

--- a/changelogs/fragments/57720-fix-lvg-warning-int-to-str-conversion.yml
+++ b/changelogs/fragments/57720-fix-lvg-warning-int-to-str-conversion.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixed warning shown when using default value for pesize about conversion from int to str
+  - lvg - Fixed warning shown when using default value for pesize about conversion from int to str.

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -38,7 +38,7 @@ options:
     - The size of the physical extent. pesize must be a power of 2, or multiple of 128KiB.
     - Since Ansible 2.6, pesize can be optionally suffixed by a UNIT (k/K/m/M/g/G), default unit is megabyte.
     type: str
-    default: 4
+    default: "4"
   pv_options:
     description:
     - Additional options to pass to C(pvcreate) when creating the volume group.
@@ -53,8 +53,8 @@ options:
     description:
     - Control if the volume group exists.
     type: str
-    choices: [ absent, present ]
-    default: present
+    choices: [ "absent", "present" ]
+    default: "present"
   force:
     description:
     - If C(yes), allows to remove volume group with logical volumes.
@@ -143,7 +143,7 @@ def main():
         argument_spec=dict(
             vg=dict(type='str', required=True),
             pvs=dict(type='list'),
-            pesize=dict(type='str', default=4),
+            pesize=dict(type='str', default='4'),
             pv_options=dict(type='str', default=''),
             vg_options=dict(type='str', default=''),
             state=dict(type='str', default='present', choices=['absent', 'present']),

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -53,8 +53,8 @@ options:
     description:
     - Control if the volume group exists.
     type: str
-    choices: [ "absent", "present" ]
-    default: "present"
+    choices: [ absent, present ]
+    default: present
   force:
     description:
     - If C(yes), allows to remove volume group with logical volumes.


### PR DESCRIPTION
##### SUMMARY
Fixes #57720

Embedded documentation specifies value as string, but default code passes 4 as int. Which spits a warning.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvg module

##### ADDITIONAL INFORMATION
None