### PR TITLE
cope with an AWS Auto Scaling Group containing instances not having a launch config any more

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1382,7 +1382,7 @@ def get_instances_by_launch_config(props, lc_check, initial_instances):
             # Check if migrating from launch_template to launch_config first
             if 'launch_template' in props['instance_facts'][i]:
                 old_instances.append(i)
-            elif props['instance_facts'][i]['launch_config_name'] == props['launch_config_name']:
+            elif props['instance_facts'][i].get('launch_config_name') == props['launch_config_name']:
                 new_instances.append(i)
             else:
                 old_instances.append(i)
@@ -1409,7 +1409,7 @@ def get_instances_by_launch_template(props, lt_check, initial_instances):
             # Check if migrating from launch_config_name to launch_template_name first
             if 'launch_config_name' in props['instance_facts'][i]:
                 old_instances.append(i)
-            elif props['instance_facts'][i]['launch_template'] == props['launch_template']:
+            elif props['instance_facts'][i].get('launch_template') == props['launch_template']:
                 new_instances.append(i)
             else:
                 old_instances.append(i)


### PR DESCRIPTION
##### SUMMARY
We ran into a corner case:
* Create an ASG with a launch config.
* Create some instances in it.
* Now, change the ASG's launch config, but do not remove the existing instances from the old LC.
* Delete the old launch config.
* Now, you'll have instances in the ASG which amazon reports as not having a launch config.

Due to the changes in 2.8.0 to support launch templates, this falls into a hole in get_properties(). Since the instance does not have a "LaunchConfigurationName" or "LaunchTemplate" key, it ends up with neither launch_config_name nor launch_template set, so does not set a value in the dict.

Later on, get_instances_by_launch_template assumes it the dict DOES have a launch_config_name, and you get a failure (see below for example).

It would be good to get this into 2.8.x as a bugfix as well. We found this during a production deploy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg

##### ADDITIONAL INFORMATION
Example error trace:
```Traceback (most recent call last):
  File \"<stdin>\", line 114, in <module>
  File \"<stdin>\", line 106, in _ansiballz_main
  File \"<stdin>\", line 49, in invoke_module
  File \"/home/teamcity/agent/temp/buildTmp/ansible_ec2_asg_payload_p7LfUo/__main__.py\", line 1677, in <module>
  File \"/home/teamcity/agent/temp/buildTmp/ansible_ec2_asg_payload_p7LfUo/__main__.py\", line 1670, in main
  File \"/home/teamcity/agent/temp/buildTmp/ansible_ec2_asg_payload_p7LfUo/__main__.py\", line 1312, in replace
  File \"/home/teamcity/agent/temp/buildTmp/ansible_ec2_asg_payload_p7LfUo/__main__.py\", line 1385, in get_instances_by_launch_config
KeyError: 'launch_config_name'
```
