### PR TITLE
rabbitmq_user: Handle non-zero exit codes (#56164)

### DIFF
--- a/changelogs/fragments/57738-rabbitmq_user_handle_non-zero_exit_codes.yaml
+++ b/changelogs/fragments/57738-rabbitmq_user_handle_non-zero_exit_codes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_user - Handle non-zero rabbitmqctl exit codes (https://github.com/ansible/ansible/issues/56164)

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -141,12 +141,12 @@ class RabbitMqUser(object):
         self._permissions = []
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
-    def _exec(self, args, run_in_check_mode=False):
+    def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or run_in_check_mode:
             cmd = [self._rabbitmqctl, '-q']
             if self.node:
                 cmd.extend(['-n', self.node])
-            rc, out, err = self.module.run_command(cmd + args, check_rc=True)
+            rc, out, err = self.module.run_command(cmd + args, check_rc=check_rc)
             return out.splitlines()
         return list()
 
@@ -190,7 +190,8 @@ class RabbitMqUser(object):
         return perms_list
 
     def check_password(self):
-        return self._exec(['authenticate_user', self.username, self.password], True)
+        return self._exec(['authenticate_user', self.username, self.password],
+                          run_in_check_mode=True, check_rc=False)
 
     def add(self):
         if self.password is not None:


### PR DESCRIPTION
##### SUMMARY

Fixes #56164.

When provided with a wrong password `rabbitmqctl authenticate_user` returns a non-zero exit code (65). This seems to be unexpected by the module and it fails when `update_password` is set to 'always'.

To mitigate this behavior we augment the `_exec` method by adding a `check_rc` flag (which defaults to `True`, hence it's backward-compatible) and override it when we need it (in `check_password` method to address #56164).

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
