### PR TITLE
ios_config: Handle confirmation prompt after version change (#57745)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -393,9 +393,12 @@ def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
         try:
-            get_connection(module).send_command(command='copy running-config startup-config\r', prompt="Overwrite the previous NVRAM configuration\?\[confirm\]", answer="\n")
+            get_connection(module).send_command(command='copy running-config startup-config\r',
+                                                prompt='Overwrite the previous NVRAM configuration?[confirm]',
+                                                answer='\n')
         except ConnectionError as exc:
             module.fail_json(msg=to_text(exc))
+
     else:
         module.warn('Skipping command `copy running-config startup-config` '
                     'due to check_mode.  Configuration not copied to '

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -392,7 +392,10 @@ def get_running_config(module, current_config=None, flags=None):
 def save_config(module, result):
     result['changed'] = True
     if not module.check_mode:
-        run_commands(module, 'copy running-config startup-config\r')
+        try:
+            get_connection(module).send_command(command='copy running-config startup-config\r', prompt="Overwrite the previous NVRAM configuration\?\[confirm\]", answer="\n")
+        except ConnectionError as exc:
+            module.fail_json(msg=to_text(exc))
     else:
         module.warn('Skipping command `copy running-config startup-config` '
                     'due to check_mode.  Configuration not copied to '


### PR DESCRIPTION
##### SUMMARY
Handle "Warning different version" prompt when saving config to Non-Volatile RAM on Cisco iOS devices.
Fixes #57745


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_config

##### ADDITIONAL INFORMATION
First time contributer to ansible. Has no idea what he's doing.