### PR TITLE
Backport/2.8/57257 option is marked as required but specifies a default

### DIFF
--- a/changelogs/fragments/57750-option-is-marked-as-required-but-specifies-a-default.yml
+++ b/changelogs/fragments/57750-option-is-marked-as-required-but-specifies-a-default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - option is marked as required but specifies a default.(https://github.com/ansible/ansible/pull/57257)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -34,7 +34,7 @@ options:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         type: bool
-        default: false
+        required: true
     save_config:
         description:
             - Flag indicating whether to save the configuration.
@@ -134,8 +134,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool', default='false'),
-        save_config=dict(required=False, type='bool', default='false')
+        confirm=dict(required=True, type='bool'),
+        save_config=dict(default=False, type='bool')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -464,7 +464,6 @@ lib/ansible/modules/network/cloudengine/ce_ntp.py E322
 lib/ansible/modules/network/cloudengine/ce_ntp_auth.py E322
 lib/ansible/modules/network/cloudengine/ce_ospf.py E322
 lib/ansible/modules/network/cloudengine/ce_ospf_vrf.py E322
-lib/ansible/modules/network/cloudengine/ce_reboot.py E317
 lib/ansible/modules/network/cloudengine/ce_reboot.py E322
 lib/ansible/modules/network/cloudengine/ce_rollback.py E322
 lib/ansible/modules/network/cloudengine/ce_sflow.py E322


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 Option is marked as required but specifies a default
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
(cherry picked from commit 05e6339)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_reboot.py
test/sanity/validate-modules/ignore.txt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Option is marked as required but specifies a default. Arguments with a default should not be marked as required. E3173
- As I shipit the PR,it failed again and again. E317 passed test in fact. So update ignore.txt and remove line 453.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
