### PR TITLE
Fix junos integration zuul CI failures

### DIFF
--- a/changelogs/fragments/junos_integration_test_fixes.yaml
+++ b/changelogs/fragments/junos_integration_test_fixes.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- netconf - Make netconf_get python3 compatible (https://github.com/ansible/ansible/pull/57639).
+- Remove hardcoded ansible user for junos_user integration tests (https://github.com/ansible/ansible/pull/57650).
+- Fix junos integration zuul CI failures (https://github.com/ansible/ansible/pull/57309).
+- Fix in netconf plugin when data element is empty in xml response (https://github.com/ansible/ansible/pull/57981).

--- a/changelogs/fragments/junos_integration_test_fixes.yaml
+++ b/changelogs/fragments/junos_integration_test_fixes.yaml
@@ -3,3 +3,4 @@ bugfixes:
 - Remove hardcoded ansible user for junos_user integration tests (https://github.com/ansible/ansible/pull/57650).
 - Fix junos integration zuul CI failures (https://github.com/ansible/ansible/pull/57309).
 - Fix in netconf plugin when data element is empty in xml response (https://github.com/ansible/ansible/pull/57981).
+- Fixes netconf_config single parameter bug (https://github.com/ansible/ansible/pull/56138).

--- a/changelogs/fragments/junos_integration_test_fixes.yaml
+++ b/changelogs/fragments/junos_integration_test_fixes.yaml
@@ -4,3 +4,6 @@ bugfixes:
 - Fix junos integration zuul CI failures (https://github.com/ansible/ansible/pull/57309).
 - Fix in netconf plugin when data element is empty in xml response (https://github.com/ansible/ansible/pull/57981).
 - Fixes netconf_config single parameter bug (https://github.com/ansible/ansible/pull/56138).
+- Remove pause logic form junos_netconf tests (https://github.com/ansible/ansible/pull/57966).
+- Use wait_for over pause for junos tests (https://github.com/ansible/ansible/pull/57073).
+- Fix iosxr netconf integration test (https://github.com/ansible/ansible/pull/57882).

--- a/lib/ansible/module_utils/network/netconf/netconf.py
+++ b/lib/ansible/module_utils/network/netconf/netconf.py
@@ -76,7 +76,7 @@ def locked_config(module, target=None):
         unlock_configuration(module, target=target)
 
 
-def get_config(module, source, filter, lock=False):
+def get_config(module, source, filter=None, lock=False):
     conn = get_connection(module)
     try:
         locked = False

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -349,7 +349,7 @@ def main():
             if not module.check_mode:
                 conn.commit()
             result['changed'] = True
-        else:
+        elif config:
             if module.check_mode and not supports_commit:
                 module.warn("check mode not supported as Netconf server doesn't support candidate capability")
                 result['changed'] = True

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -220,6 +220,11 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.network.netconf.netconf import get_capabilities, get_config, sanitize_xml
 
+try:
+    from lxml.etree import tostring
+except ImportError:
+    from xml.etree.ElementTree import tostring
+
 
 def main():
     """ main entry point for module execution
@@ -328,7 +333,7 @@ def main():
     try:
         if module.params['backup']:
             response = get_config(module, target, lock=execute_lock)
-            before = to_text(response, errors='surrogate_then_replace').strip()
+            before = to_text(tostring(response), errors='surrogate_then_replace').strip()
             result['__backup__'] = before.strip()
         if validate:
             conn.validate(target)

--- a/lib/ansible/modules/network/netconf/netconf_get.py
+++ b/lib/ansible/modules/network/netconf/netconf_get.py
@@ -158,6 +158,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.netconf.netconf import get_capabilities, locked_config, get_config, get
 from ansible.module_utils.network.common.netconf import remove_namespaces
+from ansible.module_utils._text import to_text
 
 try:
     import jxmlease
@@ -234,7 +235,7 @@ def main():
     else:
         response = get(module, filter_spec, execute_lock)
 
-    xml_resp = tostring(response)
+    xml_resp = to_text(tostring(response))
     output = None
 
     if display == 'xml':
@@ -245,7 +246,7 @@ def main():
         except:
             raise ValueError(xml_resp)
     elif display == 'pretty':
-        output = tostring(response, pretty_print=True)
+        output = to_text(tostring(response, pretty_print=True))
 
     result = {
         'stdout': xml_resp,

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -219,9 +219,9 @@ class NetconfBase(AnsiblePlugin):
         """
         if rpc_command is None:
             raise ValueError('rpc_command value must be provided')
-        req = fromstring(rpc_command)
-        resp = self.m.dispatch(req, source=source, filter=filter)
-        return resp.data_xml if resp.data_ele else resp.xml
+
+        resp = self.m.dispatch(fromstring(rpc_command), source=source, filter=filter)
+        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
 
     @ensure_connected
     def lock(self, target="candidate"):

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -28,7 +28,7 @@ from ansible.module_utils._text import to_native
 
 try:
     from ncclient.operations import RPCError
-    from ncclient.xml_ import to_xml, to_ele
+    from ncclient.xml_ import to_xml, to_ele, NCElement
     HAS_NCCLIENT = True
     NCCLIENT_IMP_ERR = None
 except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
@@ -221,7 +221,20 @@ class NetconfBase(AnsiblePlugin):
             raise ValueError('rpc_command value must be provided')
 
         resp = self.m.dispatch(fromstring(rpc_command), source=source, filter=filter)
-        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+
+        if isinstance(resp, NCElement):
+            # In case xml reply is transformed or namespace is removed in
+            # ncclient device specific handler return modified xml response
+            result = resp.data_xml
+        elif hasattr(resp, 'data_ele') and resp.data_ele:
+            # if data node is present in xml response return the xml string
+            # with data node as root
+            result = resp.data_xml
+        else:
+            # return raw xml string received from host with rpc-reply as the root node
+            result = resp.xml
+
+        return result
 
     @ensure_connected
     def lock(self, target="candidate"):

--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -50,7 +50,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "result.msg == 'Subset must be one of [hardware, default, ofacts, config, interfaces], got test'"
+      - "'Subset must be one of' in result.msg"
 
 - name: Collect config facts from device in set format
   junos_facts:

--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -1,119 +1,138 @@
 ---
 - debug: msg="START junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"
 
-- name: setup - Disable lldp and remove it's configuration
-  junos_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: Enable lldp
-  junos_lldp:
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: Enable lldp (idempotent)
-  junos_lldp:
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
 
-- assert:
-    that:
-      - "result.changed == false"
+- block:
+  - name: setup - Disable lldp and remove it's configuration
+    junos_lldp:
+      state: absent
+      provider: "{{ netconf }}"
 
-- name: configure lldp parameters and enable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp
+    junos_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *advertisement-interval 10")
-      - result.diff.prepared is search("\+ *transmit-delay 2")
-      - result.diff.prepared is search("\+ *hold-multiplier 5")
+  - assert:
+      that:
+        - "result.changed == true"
 
-- name: configure lldp parameters and enable lldp(idempotent)
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp (idempotent)
+    junos_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: configure lldp parameters and disable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: disabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
-      - "'advertisement-interval 10;' not in result.diff.prepared"
-      - "'transmit-delay 2;' not in result.diff.prepared"
-      - "'hold-multiplier 5;' not in result.diff.prepared"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *advertisement-interval 10")
+        - result.diff.prepared is search("\+ *transmit-delay 2")
+        - result.diff.prepared is search("\+ *hold-multiplier 5")
 
-- name: configure lldp parameters and enable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: enabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp(idempotent)
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *disable")
-      - "'advertisement-interval 10;' not in result.diff.prepared"
-      - "'transmit-delay 2;' not in result.diff.prepared"
-      - "'hold-multiplier 5;' not in result.diff.prepared"
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: Remove lldp configuration and diable lldp
-  junos_lldp:
-    interval: 10
-    hold_multiplier: 5
-    transmit_delay: 2
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and disable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: disabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
-      - result.diff.prepared is search("\- *advertisement-interval 10")
-      - result.diff.prepared is search("\- *transmit-delay 2")
-      - result.diff.prepared is search("\- *hold-multiplier 5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
+        - "'advertisement-interval 10;' not in result.diff.prepared"
+        - "'transmit-delay 2;' not in result.diff.prepared"
+        - "'hold-multiplier 5;' not in result.diff.prepared"
 
-- name: Remove lldp (idempotent)
-  junos_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: configure lldp parameters and enable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: enabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *disable")
+        - "'advertisement-interval 10;' not in result.diff.prepared"
+        - "'transmit-delay 2;' not in result.diff.prepared"
+        - "'hold-multiplier 5;' not in result.diff.prepared"
+
+  - name: Remove lldp configuration and diable lldp
+    junos_lldp:
+      interval: 10
+      hold_multiplier: 5
+      transmit_delay: 2
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
+        - result.diff.prepared is search("\- *advertisement-interval 10")
+        - result.diff.prepared is search("\- *transmit-delay 2")
+        - result.diff.prepared is search("\- *hold-multiplier 5")
+
+  - name: Remove lldp (idempotent)
+    junos_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+
+  when: lldp_supported
 
 - debug: msg="END junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp/tests/netconf/net_lldp.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/net_lldp.yaml
@@ -3,25 +3,42 @@
 
 # Add minimal testcase to check args are passed correctly to
 # implementation module and module run is successful.
-
-- name: setup - Disable lldp - setup
-  net_lldp:
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: Enable lldp using platform agnostic module
-  net_lldp:
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: setup - Disable lldp - teardown
-  net_lldp:
-    state: absent
-    provider: "{{ netconf }}"
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
+
+- block:
+  - name: setup - Disable lldp - setup
+    net_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+
+  - name: Enable lldp using platform agnostic module
+    net_lldp:
+      state: present
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+
+  - name: setup - Disable lldp - teardown
+    net_lldp:
+      state: absent
+      provider: "{{ netconf }}"
+  when: lldp_supported
 
 - debug: msg="START junos netconf/net_lldp.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
@@ -1,106 +1,124 @@
 ---
 - debug: msg="START junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"
 
-- name: setup - Remove lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *interface ge-0/0/5")
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: lldp interface configuration (idempotent)
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
-  register: result
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
 
-- assert:
-    that:
-      - "result.changed == false"
+- block:
+  - name: setup - Remove lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
 
-- name: Deactivate lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    active: False
-    provider: "{{ netconf }}"
-  register: result
+  - name: lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *interface ge-0/0/5")
 
-- name: Activate lldp interface configuration
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    active: True
-    provider: "{{ netconf }}"
-  register: result
+  - name: lldp interface configuration (idempotent)
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == false"
 
-- name: Disable lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: disabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: Deactivate lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      active: False
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *disable")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
 
-- name: Enable lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: enabled
-    provider: "{{ netconf }}"
-  register: result
+  - name: Activate lldp interface configuration
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      active: True
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *disable")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
 
-- name: Delete lldp on particular interface
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: Disable lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: disabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\- *interface ge-0/0/5")
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *disable")
 
-- name: Delete lldp on particular interface (idempotent)
-  junos_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-  register: result
+  - name: Enable lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: enabled
+      provider: "{{ netconf }}"
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *disable")
+
+  - name: Delete lldp on particular interface
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\- *interface ge-0/0/5")
+
+  - name: Delete lldp on particular interface (idempotent)
+    junos_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+  when: lldp_supported
 
 - debug: msg="END junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/net_lldp_interface.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/net_lldp_interface.yaml
@@ -4,28 +4,46 @@
 # Add minimal testcase to check args are passed correctly to
 # implementation module and module run is successful.
 
-- name: setup - Remove lldp interface configuration
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
-
-- name: lldp interface configuration using platform agnostic module
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: present
-    provider: "{{ netconf }}"
+- name: get supported protocols
+  junos_command:
+    commands: show lldp
   register: result
+  ignore_errors: yes
 
-- assert:
-    that:
-      - "result.changed == true"
-      - result.diff.prepared is search("\+ *interface ge-0/0/5")
+- name: lldp supported
+  set_fact:
+    lldp_supported: True
+  when: not result.failed
 
-- name: teardown - Remove lldp interface configuration
-  net_lldp_interface:
-    name: ge-0/0/5
-    state: absent
-    provider: "{{ netconf }}"
+- name: lldp not supported
+  set_fact:
+    lldp_supported: False
+  when: result.failed
+
+- block:
+  - name: setup - Remove lldp interface configuration
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+
+  - name: lldp interface configuration using platform agnostic module
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: present
+      provider: "{{ netconf }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - result.diff.prepared is search("\+ *interface ge-0/0/5")
+
+  - name: teardown - Remove lldp interface configuration
+    net_lldp_interface:
+      name: ge-0/0/5
+      state: absent
+      provider: "{{ netconf }}"
+  when: lldp_supported
 
 - debug: msg="END junos netconf/net_lldp_interface.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -4,9 +4,9 @@
 - name: Setup
   junos_netconf:
     state: present
-  register: result
 
 ###################################
+
 - name: Change port
   junos_netconf:
     state: present
@@ -27,17 +27,24 @@
     that:
       - "result.changed == false"
 
-- name: wait for netconf server to come up
-  pause:
-    seconds: 10
+- name: wait for netconf port tcp/8022 to be open
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 8022
+  with_inventory_hostnames: junos
+
+- name: Reset ansible connections
+  meta: reset_connection
 
 - name: Ensure we can communicate over 8022
   include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=8022 is_ignore_errors=false"
 
-- name: wait for persistent socket to timeout
-  pause:
-    seconds: 120
-
+- name: wait for netconf port tcp/830 to be closed
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+    state: stopped
+  with_inventory_hostnames: junos
 
 # This protects against the port override above not being honoured and a bug setting the port
 - name: Ensure we can NOT communicate over default port
@@ -50,11 +57,15 @@
 - name: Set back netconf to default port
   junos_netconf:
     state: present
-  register: result
 
-- name: wait for persistent socket to timeout
-  pause:
-    seconds: 120
+- name: wait for netconf port tcp/830 to be open
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos
+
+- name: Reset ansible connections
+  meta: reset_connection
 
 - name: Ensure we can communicate over netconf
   include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=false"

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -1,11 +1,9 @@
 ---
 - debug: msg="START netconf/netconf.yaml on connection={{ ansible_connection }}"
 
-
 - name: Ensure netconf is enabled
   junos_netconf:
     state: present
-  register: result
 
 - name: idempotent tests
   junos_netconf:
@@ -18,9 +16,14 @@
 
 ###################################
 
-- name: wait for netconf server to come up
-  pause:
-    seconds: 10
+- name: wait for netconf port tcp/830 to be open
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos
+
+- name: Reset ansible connections
+  meta: reset_connection
 
 - name: Ensure we can communicate over netconf
   include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=false"
@@ -44,9 +47,15 @@
     that:
       - "result.changed == false"
 
-- name: wait for persistent socket to timeout
-  pause:
-    seconds: 120
+- name: wait for netconf port tcp/830 to be closed
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+    state: stopped
+  with_inventory_hostnames: junos
+
+- name: Reset ansible connections
+  meta: reset_connection
 
 - name: Ensure we can NOT talk via netconf
   include: "{{ role_path }}/tests/utils/junos_command.yaml ansible_connection=netconf ansible_port=830 is_ignore_errors=true"
@@ -58,6 +67,5 @@
 - name: re-enable netconf
   junos_netconf:
     state: present
-  register: result
 
 - debug: msg="END netconf/netconfg.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
+++ b/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
@@ -10,14 +10,14 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'<name>\nem0\n</name>' in result['xml']"
+      - "'<interface-information' in result['xml']"
       - "result.output is defined"
 
 - name: Execute RPC with args on device
   junos_rpc:
     rpc: get-interface-information
     args:
-      interface-name: em0
+      interface-name: lo0
       media: True
     provider: "{{ netconf }}"
   register: result
@@ -25,8 +25,9 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'<name>\nem0\n</name>' in result['xml']"
-      - "'<name>\nlo0\n</name>' not in result['xml']"
+      - "'<name>\nlo0\n</name>' in result['xml']"
+      - "'<name>\nem0\n</name>' not in result['xml']"
+      - "'<name>\fxp0\n</name>' not in result['xml']"
 
 - name: Execute RPC on device and get output in text format
   junos_rpc:
@@ -40,14 +41,14 @@
       - "result.changed == false"
       - "result.output is defined"
       - "result.output_lines is defined"
-      - "'Physical interface: em0' in result['output']"
+      - "'Physical interface' in result['output']"
 
 - name: Execute RPC on device and get output in json format
   junos_rpc:
     rpc: get-interface-information
     output: json
     args:
-      interface-name: em0
+      interface-name: lo0
       media: True
     provider: "{{ netconf }}"
   register: result
@@ -56,7 +57,7 @@
     that:
       - "result.changed == false"
       - "result.output is defined"
-      - "result['output']['interface-information'][0]['physical-interface'][0]['name'][0]['data'] == \"em0\""
+      - "result['output']['interface-information'][0]['physical-interface'][0]['name'][0]['data'] == \"lo0\""
 
 - name: Execute invalid RPC
   junos_rpc:

--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -172,7 +172,8 @@
 - name: Create list of users
   junos_user:
     aggregate:
-      - name: ansible
+      # NOTE(pabelanger): We noop our ansible-test user, as not to lose SSH access
+      - name: "{{ ansible_user|default('ansible') }}"
       - {name: test_user1, full_name: test_user2, role: operator}
       - {name: test_user2, full_name: test_user2, role: read-only}
     provider: "{{ netconf }}"
@@ -181,7 +182,8 @@
 - name: Purge users except the users in aggregate
   junos_user:
     aggregate:
-      - name: ansible
+      # NOTE(pabelanger): We noop our ansible-test user, as not to lose SSH access
+      - name: "{{ ansible_user|default('ansible') }}"
     purge: True
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -1,0 +1,13 @@
+---
+- debug: msg="START netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"
+
+- name: save config test
+  netconf_config:
+    backup: yes
+  register: result
+
+- assert:
+    that:
+      - "'backup_path' in result"
+
+- debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -5,6 +5,7 @@
   netconf_config:
     backup: yes
   register: result
+  connection: netconf
 
 - assert:
     that:

--- a/test/integration/targets/netconf_config/tests/junos/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/junos/basic.yaml
@@ -27,10 +27,21 @@
     that:
       - "result.changed == false"
 
-- name: configure syslog file replace
+- name: replace default operation fail
   netconf_config:
     content: "{{ syslog_config_replace }}"
     default_operation: 'replace'
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'Missing mandatory statement' in result.msg"
+
+- name: replace syslog config with operation key in content
+  netconf_config:
+    content: "{{ syslog_config_replace }}"
   register: result
 
 - assert:
@@ -51,5 +62,14 @@
   junos_config:
     lines:
     - delete system syslog file test_netconf_config
+
+- name: save config
+  netconf_config:
+    backup: yes
+  register: result
+
+- assert:
+    that:
+      - "'backup_path' in result"
 
 - debug: msg="END netconf_config junos/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/netconf_config/tests/junos/fixtures/config.yml
+++ b/test/integration/targets/netconf_config/tests/junos/fixtures/config.yml
@@ -24,7 +24,7 @@ syslog_config_replace: |
             <config xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0">
               <configuration>
                 <system>
-                  <syslog>
+                  <syslog operation="replace">
                     <file>
                       <name>test_netconf_config</name>
                       <contents>

--- a/test/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -114,7 +114,7 @@
 
 - assert:
     that:
-      - "{{ result['output']['rpc-reply']['data']['aaa'] is defined}}"
+      - "{{ result['output']['data']['aaa'] is defined}}"
 
 - name: get configuration data in xml pretty format
   netconf_get:

--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -8,6 +8,8 @@
   tags: netconf
 
 - name: wait for netconf server to come up
-  pause:
-    seconds: 10
-  tags: netconf
+  delegate_to: localhost
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Convert the ElementTree object to string
   before dumping the configuration in file.

* Fix netconf plugin to return data_xml object
  if present for the device handler object or else return raw xml.

* Add check to run lldp integration test cases only if lldp is
  supported on the target host

Merged PR to devel
https://github.com/ansible/ansible/pull/57309
https://github.com/ansible/ansible/pull/57578
https://github.com/ansible/ansible/pull/56452
https://github.com/ansible/ansible/pull/56138

(cherry picked from commit 9c5745ad2133549c7fcdd21411c98c7223e19200)
(cherry picked from commit 0957835a4814bfc0c7649675963de5e88df5060e)
(cherry picked from commit 2ca324bc521cc8f7fdaf00479b987e07dc9513b7)
(cherry picked from commit 647ed207afaa662cb700eee95f50f1a3a016b550)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/__init__.py
netconf_config
netconf_get
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
