### PR TITLE
backport/2.8/57270 update vrf to fix bugs (#57270)

### DIFF
--- a/changelogs/fragments/57757-update-vrf-to-fix-bugs.yml
+++ b/changelogs/fragments/57757-update-vrf-to-fix-bugs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - update vrf to fix bugs.(https://github.com/ansible/ansible/pull/57270 )

--- a/lib/ansible/modules/network/cloudengine/ce_vrf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf.py
@@ -214,7 +214,7 @@ class Vrf(object):
 
         root = ElementTree.fromstring(xml_str)
         vpn_instances = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
         if vpn_instances:
             for vpn_instance in vpn_instances:
                 if vpn_instance.find('vrfName').text == self.vrf:

--- a/lib/ansible/modules/network/cloudengine/ce_vrf_af.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf_af.py
@@ -568,7 +568,7 @@ class VrfAf(object):
 
         # get the vpn address family and RD text
         vrf_addr_types = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance/vpnInstAFs/vpnInstAF")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance/vpnInstAFs/vpnInstAF")
         if vrf_addr_types:
             for vrf_addr_type in vrf_addr_types:
                 vrf_af_info = dict()

--- a/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
@@ -353,7 +353,7 @@ class VrfInterface(object):
         for l3vpn_ifinfo in l3vpn_if:
             for ele in l3vpn_ifinfo:
                 if ele.tag in ['ifName']:
-                    if ele.text == self.vpn_interface:
+                    if ele.text.lower() == self.vpn_interface.lower():
                         self.intf_info['vrfName'] = vpn_name
 
     def get_interface_vpn(self):
@@ -371,14 +371,13 @@ class VrfInterface(object):
         # get global vrf interface info
         root = ElementTree.fromstring(xml_str)
         vpns = root.findall(
-            "data/l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
+            "l3vpn/l3vpncomm/l3vpnInstances/l3vpnInstance")
         if vpns:
             for vpnele in vpns:
                 vpn_name = None
                 for vpninfo in vpnele:
                     if vpninfo.tag == 'vrfName':
                         vpn_name = vpninfo.text
-
                     if vpninfo.tag == 'l3vpnIfs':
                         self.get_interface_vpn_name(vpninfo, vpn_name)
 
@@ -408,7 +407,7 @@ class VrfInterface(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
         root = ElementTree.fromstring(xml_str)
-        interface = root.find("data/ifm/interfaces/interface")
+        interface = root.find("ifm/interfaces/interface")
         if interface:
             for eles in interface:
                 if eles.tag in ["isL2SwitchPort"]:


### PR DESCRIPTION
* update vrf

* update vrf

(cherry picked from commit 76e06fa7c2156cbed5726cf0d0d8e12100fe7424)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport/2.8/57270 update vrf to fix bugs (#57270)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

lib/ansible/modules/network/cloudengine/ce_vrf.py
lib/ansible/modules/network/cloudengine/ce_vrf_af.py
lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
First, to find all elements with specified spath, remove the data tag which is a root node of data.
Second, comparison between two strings(vpn_interface) should be ignored. So to lower to compare.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
