### PR TITLE
Bugfix: Creating two IPs in single run of netbox_ip_address (#56550)

### DIFF
--- a/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
+++ b/changelogs/fragments/netbox_ip_address-fix-duplicate-ip.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+- >
+  netbox_ip_address - Fixed issue where it would create duplicate IP addresses when trying to serialize the IP address object
+  which doesn't have the ``.serialize()`` method. This should also prevent future duplicate objects being created if they don't
+  have the ``.serialize()`` method as well.

--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -197,10 +197,11 @@ def create_netbox_object(nb_endpoint, data, check_mode):
     if check_mode:
         serialized_nb_obj = data
     else:
+        nb_obj = nb_endpoint.create(data)
         try:
-            serialized_nb_obj = nb_endpoint.create(data).serialize()
+            serialized_nb_obj = nb_obj.serialize()
         except AttributeError:
-            serialized_nb_obj = nb_endpoint.create(data)
+            serialized_nb_obj = nb_obj
 
     diff = _build_diff(before={"state": "absent"}, after={"state": "present"})
     return serialized_nb_obj, diff


### PR DESCRIPTION
* Found bug, fixed by moving the serialization of objects out of try while creating objects

* Added changelog to document fix

(cherry picked from commit d07d3947794b10b35dab9a7b0fdcf31a4b0e1e56)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is to backport the changes from PR #56550 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/net_tools/netbox/netbox_utils.py