### PR TITLE
2.8: Fix --diff to produce output when creating a new file (#57744)

### DIFF
--- a/changelogs/fragments/57618-fix-diff-on-absent-files.yaml
+++ b/changelogs/fragments/57618-fix-diff-on-absent-files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix --diff to produce output when creating a new file (https://github.com/ansible/ansible/issues/57618)"

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1104,7 +1104,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         if not peek_result.get('failed', False) or peek_result.get('rc', 0) == 0:
 
-            if peek_result.get('state') == 'absent':
+            if peek_result.get('state') in (None, 'absent'):
                 diff['before'] = u''
             elif peek_result.get('appears_binary'):
                 diff['dst_binary'] = 1

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -61,6 +61,19 @@
     - import_tasks: acls.yml
       when: ansible_system == 'Linux'
 
+    # https://github.com/ansible/ansible/issues/57618
+    - name: Test diff contents
+      copy:
+        content: 'Ansible managed\n'
+        dest: "{{ local_temp_dir }}/file.txt"
+      diff: yes
+      register: diff_output
+
+    - assert:
+        that:
+          - 'diff_output.diff[0].before == ""'
+          - '"Ansible managed" in diff_output.diff[0].after'
+
   always:
     - name: Cleaning
       file:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #57744

(cherry picked from commit 1fa7bfcd5d6c6fb9e0d1f9b1dfe0f2860f3fb5a0)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/action/__init__.py`
