### PR TITLE
Enable adjacent collections for ansible-doc

### DIFF
--- a/changelogs/fragments/doc_adj_coll.yml
+++ b/changelogs/fragments/doc_adj_coll.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Enable ansible-doc to work with 'adjacent' collections via --playbook-dir option.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -26,9 +26,9 @@ from ansible.parsing.metadata import extract_metadata
 from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.loader import action_loader, fragment_loader
+from ansible.utils.collection_loader import set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import BLACKLIST, get_docstring
-
 display = Display()
 
 
@@ -53,6 +53,7 @@ class DocCLI(CLI):
             epilog="See man pages for Ansible CLI options or website for tutorials https://docs.ansible.com"
         )
         opt_help.add_module_options(self.parser)
+        opt_help.add_basedir_options(self.parser)
 
         self.parser.add_argument('args', nargs='*', help='Plugin', metavar='plugin')
         self.parser.add_argument("-t", "--type", action="store", default='module', dest='type',
@@ -88,7 +89,11 @@ class DocCLI(CLI):
         else:
             raise AnsibleOptionsError("Unknown or undocumentable plugin type: %s" % plugin_type)
 
-        # add to plugin path from command line
+        # add to plugin paths from command line
+        basedir = context.CLIARGS['basedir']
+        if basedir:
+            set_collection_playbook_paths(basedir)
+            loader.add_directory(basedir, with_subdir=True)
         if context.CLIARGS['module_path']:
             for path in context.CLIARGS['module_path']:
                 if path:


### PR DESCRIPTION
Adds --playbook-dir option, so it will also get adjacent 'other plugins' dirs

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc