### PR TITLE
Improve speed of the gcp_compute dynamic inventory (#57591)

### DIFF
--- a/changelogs/fragments/57591-speed-up-gcp-compute-dynamic-inventory.yaml
+++ b/changelogs/fragments/57591-speed-up-gcp-compute-dynamic-inventory.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "gcp_compute - Speed up dynamic invetory up to 30x."

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -76,7 +76,12 @@ class GcpSession(object):
     def get(self, url, body=None, **kwargs):
         kwargs.update({'json': body, 'headers': self._headers()})
         try:
-            return self.session().get(url, **kwargs)
+            # Ignore the google-auth library warning for user credentials. More
+            # details: https://github.com/googleapis/google-auth-library-python/issues/271
+            import warnings
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
+                return self.session().get(url, **kwargs)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 


### PR DESCRIPTION
To get all instances gcp_compute made a call to the Google API for each
zone separately. Because of this if all zones needed to be queried
fetching hosts lasted 30+ seconds. Now the module will use a single
query that will return all the instances, so the execution should last
just a few seconds.

This commit also suppresses a warning from the google-auth library about
using user credentials because if an Ansible user wants to use user
credentials, there is no need to warn him about it.

(cherry picked from commit f6a0f9874ddeb4b79012272eb5a4a92c0da76756)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute