### PR TITLE
Added environment variables to gcp_compute to align with gcp_* modules, fixes #54406

### DIFF
--- a/changelogs/fragments/add-env-variables-to-gcp-compute.yml
+++ b/changelogs/fragments/add-env-variables-to-gcp-compute.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - gcp_compute - Added additional environment variables to the `gcp_compute` inventory plugin to align with the rest of the `gcp_*` modules.

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -48,21 +48,32 @@ DOCUMENTATION = '''
                 - The type of credential used.
             required: True
             choices: ['application', 'serviceaccount', 'machineaccount']
+            env:
+                - name: GCP_AUTH_KIND
+                  version_added: "2.8"
         scopes:
             description: list of authentication scopes
             type: list
             default: ['https://www.googleapis.com/auth/compute']
+            env:
+                - name: GCP_SCOPES
+                  version_added: "2.8"
         service_account_file:
             description:
                 - The path of a Service Account JSON file if serviceaccount is selected as type.
             type: path
             env:
+                - name: GCP_SERVICE_ACCOUNT_FILE
+                  version_added: "2.8"
                 - name: GCE_CREDENTIALS_FILE_PATH
                   version_added: "2.8"
         service_account_email:
             description:
                 - An optional service account email address if machineaccount is selected
                   and the user does not wish to use the default email.
+            env:
+                - name: GCP_SERVICE_ACCOUNT_EMAIL
+                  version_added: "2.8"
         vars_prefix:
             description: prefix to apply to host variables, does not include facts nor params
             default: ''


### PR DESCRIPTION
##### SUMMARY
Added all variables that are also used by the gcp_* modules as described in the docs:
https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html#providing-credentials-as-environment-variables

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute
