### PR TITLE
Update playbooks_strategies.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -16,7 +16,7 @@ the play as fast as it can.::
       tasks:
       ...
 
-Strategy can be changed per play, or globally in ```ansible.cfg```, under the ```defaults``` stanza::
+Strategy can be changed per play, or globally in ``ansible.cfg``, under the ``defaults`` stanza::
 
     [defaults]
     strategy = free

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -6,7 +6,7 @@ Strategies
 Strategies are a way to control play execution. By default, plays run with a  ``linear`` strategy, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize.
 
 The ``serial`` directive can 'batch' this behaviour to a subset of the hosts, which then run to
-completion of the play before the next 'batch' starts.
+completion of the play before the next 'batch' starts. Please note that ```serial``` is not a third strategy, but directive/option of the ```linear``` strategy.
 
 A second ``strategy`` ships with Ansible - ``free`` - which allows each host to run until the end of
 the play as fast as it can.::
@@ -16,6 +16,10 @@ the play as fast as it can.::
       tasks:
       ...
 
+Strategy can be changed per play, or globally in ```ansible.cfg```, under the ```defaults``` stanza::
+
+    [defaults]
+    strategy = free
 
 Strategy Plugins
 `````````````````

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -6,7 +6,7 @@ Strategies
 Strategies are a way to control play execution. By default, plays run with a  ``linear`` strategy, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize.
 
 The ``serial`` directive can 'batch' this behaviour to a subset of the hosts, which then run to
-completion of the play before the next 'batch' starts. Please note that ```serial``` is not a third strategy, but directive/option of the ```linear``` strategy.
+completion of the play before the next 'batch' starts. Please note that ``serial`` is not a third strategy, but directive/option of the ``linear`` strategy.
 
 A second ``strategy`` ships with Ansible - ``free`` - which allows each host to run until the end of
 the play as fast as it can.::

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -1,11 +1,11 @@
 .. _playbooks_strategies:
 
-Strategies
-===========
+Controlling playbook execution: strategies, forks, and ``serial``
+=================================================================
 
-Strategies control play execution. By default, plays run with the :ref:`linear strategy<linear_strategy>`, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize.
+By default, Ansible runs each task on all hosts affected by a play before starting the next task on any host, using 5 forks. If you want to change this default behavior, you can change the number of forks, use a different strategy plugin, or define the ``serial`` keyword.
 
-Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
+The default behavior described above is the :ref:`linear strategy<linear_strategy>`. Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
 each host to run until the end of the play as fast as it can::
 
     - hosts: all
@@ -21,7 +21,7 @@ You can select a different strategy for each play, or set your preferred strateg
 All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
 
 You can also use the play-level :ref:`keyword<playbook_keywords>` ``serial``
-to set the number or percentage of hosts you want to manage at a time with any
+to set the number or percentage of hosts you want to manage at a time. This works with any
 strategy. Ansible will then 'batch' the hosts, completing the play on the specified number or percentage of hosts before starting the next 'batch'.
 This is especially useful for :ref:`rolling updates<rolling_update_batch_size>`. Please note that ``serial`` is not a strategy, but a play-level directive/option.
 

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -1,10 +1,12 @@
 .. _playbooks_strategies:
 
-Controlling playbook execution: strategies, forks, and ``serial``
-=================================================================
+Controlling playbook execution: strategies and more
+===================================================
 
-By default, Ansible runs each task on all hosts affected by a play before starting the next task on any host, using 5 forks. If you want to change this default behavior, you can change the number of forks, use a different strategy plugin, or define the ``serial`` keyword.
+By default, Ansible runs each task on all hosts affected by a play before starting the next task on any host, using 5 forks. If you want to change this default behavior, you can use a different strategy plugin, change the number of forks, or apply one of several play-level keywords like ``serial``.
 
+Selecting a strategy
+--------------------
 The default behavior described above is the :ref:`linear strategy<linear_strategy>`. Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
 each host to run until the end of the play as fast as it can::
 
@@ -13,17 +15,18 @@ each host to run until the end of the play as fast as it can::
       tasks:
       ...
 
-You can select a different strategy for each play, or set your preferred strategy globally in ``ansible.cfg``, under the ``defaults`` stanza::
+You can select a different strategy for each play as shown above, or set your preferred strategy globally in ``ansible.cfg``, under the ``defaults`` stanza::
 
     [defaults]
     strategy = free
 
 All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
 
-You can also use the play-level :ref:`keyword<playbook_keywords>` ``serial``
-to set the number or percentage of hosts you want to manage at a time. This works with any
-strategy. Ansible will then 'batch' the hosts, completing the play on the specified number or percentage of hosts before starting the next 'batch'.
-This is especially useful for :ref:`rolling updates<rolling_update_batch_size>`. Please note that ``serial`` is not a strategy, but a play-level directive/option.
+Using keywords to control execution
+-----------------------------------
+Several play-level :ref:`keyword<playbook_keywords>` also affect play execution. The most common one is ``serial``, which sets a number, a percentage, or a list of numbers of hosts you want to manage at a time. Setting ``serial`` with any strategy directs Ansible to 'batch' the hosts, completing the play on the specified number or percentage of hosts before starting the next 'batch'. This is especially useful for :ref:`rolling updates<rolling_update_batch_size>`.
+
+Other keywords that affect play execution include ``ignore_errors``, ``ignore_unreachable``, and ``any_errors_fatal``. Please note that these keywords are not strategies. They are play-level directives or options.
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -5,6 +5,9 @@ Controlling playbook execution: strategies and more
 
 By default, Ansible runs each task on all hosts affected by a play before starting the next task on any host, using 5 forks. If you want to change this default behavior, you can use a different strategy plugin, change the number of forks, or apply one of several play-level keywords like ``serial``.
 
+.. contents::
+   :local:
+
 Selecting a strategy
 --------------------
 The default behavior described above is the :ref:`linear strategy<linear_strategy>`. Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
@@ -21,6 +24,15 @@ You can select a different strategy for each play as shown above, or set your pr
     strategy = free
 
 All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
+
+Setting the number of forks
+---------------------------
+If you have the processing power available and want to use more forks, you can set the number in ``ansible.cfg``::
+
+    [defaults]
+    forks = 30
+
+or pass it on the command line: `ansible-playbook -f 30 my_playbook.yml`.
 
 Using keywords to control execution
 -----------------------------------

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -3,41 +3,31 @@
 Strategies
 ===========
 
-Strategies are a way to control play execution. By default, plays run with a  ``linear`` strategy, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize.
+Strategies control play execution. By default, plays run with the :ref:`linear strategy<linear_strategy>`, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize. To 'batch' the hosts while using the ``linear`` strategy, set the ``serial`` directive to the number of hosts you want to manage in each batch. Ansible will then
+complete the play on that many hosts before starting the next 'batch'. Please note that ``serial`` is not a separate strategy, but a directive/option of the ``linear`` strategy.
 
-The ``serial`` directive can 'batch' this behaviour to a subset of the hosts, which then run to
-completion of the play before the next 'batch' starts. Please note that ``serial`` is not a third strategy, but directive/option of the ``linear`` strategy.
-
-A second ``strategy`` ships with Ansible - ``free`` - which allows each host to run until the end of
-the play as fast as it can.::
+Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
+each host to run until the end of the play as fast as it can::
 
     - hosts: all
       strategy: free
       tasks:
       ...
 
-Strategy can be changed per play, or globally in ``ansible.cfg``, under the ``defaults`` stanza::
+You can select a different strategy for each play, or set your preferred strategy globally in ``ansible.cfg``, under the ``defaults`` stanza::
 
     [defaults]
     strategy = free
 
-Strategy Plugins
-`````````````````
-
-The strategies are implemented as plugins. In the future, new
-execution strategies can be added, either locally by users or to Ansible itself by
-a code contribution.
-
-One example is ``debug`` strategy. See :doc:`playbooks_debugger` for details.
+All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
 
 .. seealso::
 
-   :doc:`playbooks`
+   :ref:`about_playbooks`
        An introduction to playbooks
-   :doc:`playbooks_reuse_roles`
+   :ref:`playbooks_reuse_roles`
        Playbook organization by roles
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -20,7 +20,7 @@ You can select a different strategy for each play, or set your preferred strateg
 
 All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
 
-You can also use the play-level :ref:`keyword<playbooks_keywords>` ``serial``
+You can also use the play-level :ref:`keyword<playbook_keywords>` ``serial``
 to set the number or percentage of hosts you want to manage at a time with any
 strategy. Ansible will then 'batch' the hosts, completing the play on the specified number or percentage of hosts before starting the next 'batch'.
 This is especially useful for :ref:`rolling updates<rolling_update_batch_size>`. Please note that ``serial`` is not a strategy, but a play-level directive/option.

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -3,8 +3,7 @@
 Strategies
 ===========
 
-Strategies control play execution. By default, plays run with the :ref:`linear strategy<linear_strategy>`, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize. To 'batch' the hosts while using the ``linear`` strategy, set the ``serial`` directive to the number of hosts you want to manage in each batch. Ansible will then
-complete the play on that many hosts before starting the next 'batch'. Please note that ``serial`` is not a separate strategy, but a directive/option of the ``linear`` strategy.
+Strategies control play execution. By default, plays run with the :ref:`linear strategy<linear_strategy>`, in which all hosts will run each task before any host starts the next task, using the number of forks (default 5) to parallelize.
 
 Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows
 each host to run until the end of the play as fast as it can::
@@ -20,6 +19,11 @@ You can select a different strategy for each play, or set your preferred strateg
     strategy = free
 
 All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Please review the documentation for each strategy plugin for details on how it works.
+
+You can also use the play-level :ref:`keyword<playbooks_keywords>` ``serial``
+to set the number or percentage of hosts you want to manage at a time with any
+strategy. Ansible will then 'batch' the hosts, completing the play on the specified number or percentage of hosts before starting the next 'batch'.
+This is especially useful for :ref:`rolling updates<rolling_update_batch_size>`. Please note that ``serial`` is not a strategy, but a play-level directive/option.
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
The `Strategies` page is very confusing and may suggest, that there is still a `serial` strategy (like it used to), but now it is actually just a directive of `linear` strategy. Multiple people reported this to me and it needs change.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr