### PR TITLE
Remove required field on service_account_file in gcp_compute plugin inventory (#57345)

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -55,7 +55,6 @@ DOCUMENTATION = '''
         service_account_file:
             description:
                 - The path of a Service Account JSON file if serviceaccount is selected as type.
-            required: True
             type: path
             env:
                 - name: GCE_CREDENTIALS_FILE_PATH


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #57344 on ansible 2.8

Backport of #57345
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

(cherry picked from commit 1d766352066118a5d4cfd6310a69a7ee9221a62a)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute inventory plugin
