### PR TITLE
Backports related to network-integration testing for Cisco IOS

### DIFF
--- a/changelogs/fragments/55223-python3-compat-fix-for-re.yaml
+++ b/changelogs/fragments/55223-python3-compat-fix-for-re.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix python3 compat issue with network/common/config.py - https://github.com/ansible/ansible/pull/55223

--- a/changelogs/fragments/56956-Adding-missing-scp-dependency-for-ios_file.yaml
+++ b/changelogs/fragments/56956-Adding-missing-scp-dependency-for-ios_file.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Adds missing scp dependency for ios_file tests - https://github.com/ansible/ansible/pull/56956

--- a/changelogs/fragments/57665-ios-smoke-tc-failure-fix.yaml
+++ b/changelogs/fragments/57665-ios-smoke-tc-failure-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixes the IOS_SMOKE integration TC failure - https://github.com/ansible/ansible/pull/57665.

--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -41,6 +41,12 @@ DEFAULT_IGNORE_LINES_RE = set([
 ])
 
 
+try:
+    Pattern = re._pattern_type
+except AttributeError:
+    Pattern = re.Pattern
+
+
 class ConfigLine(object):
 
     def __init__(self, raw):
@@ -162,7 +168,7 @@ class NetworkConfig(object):
 
         if ignore_lines:
             for item in ignore_lines:
-                if not isinstance(item, re._pattern_type):
+                if not isinstance(item, Pattern):
                     item = re.compile(item)
                 DEFAULT_IGNORE_LINES_RE.add(item)
 

--- a/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/misc_tests.yaml
@@ -27,6 +27,7 @@
     - show running-config all
   vars:
     ansible_command_timeout: 1
+    ansible_buffer_read_timeout: 2
   ignore_errors: True
   register: result
   when: ansible_connection == 'network_cli'
@@ -34,7 +35,7 @@
 - assert:
     that:
       - 'result.failed == true'
-      - "'command timeout triggered' in result.msg"
+      - "'timeout value 1 seconds reached' in result.msg"
   when: ansible_connection == 'network_cli'
 
 - debug: msg="END ios_smoke cli/misc_tests.yaml on connection={{ ansible_connection }}"

--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -5,6 +5,5 @@ paramiko
 pyyaml
 pexpect # for _user test
 scp # for Cisco ios
-selectors2 # for ncclient
 ncclient # for Junos
 jxmlease # for Junos

--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -4,5 +4,7 @@ junit-xml
 paramiko
 pyyaml
 pexpect # for _user test
+scp # for Cisco ios
+selectors2 # for ncclient
 ncclient # for Junos
 jxmlease # for Junos


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backports needed to fix ios network-integration tests. Backports for the PR #55223, #57665 and #56956
cherry picked from commit (0ee673a5583d2fa7c171c9347a502180340a0ddc)
cherry picked from commit (07e1bd8fe73e5cd8c607b665d4492ab308f688e9)
cherry picked from commit (6f1ff8eb8ecb7816cc85ca8be15544b96c66eaaf)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Depends-On: https://github.com/ansible/ansible/pull/57180
Depends-On: https://github.com/ansible/ansible/pull/58131