### PR TITLE
openssh_keypair: bugfix make regenerating keypairs via force possible…

### DIFF
--- a/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
+++ b/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - openssh_keypair - make regeneration of valid keypairs with force possible, add better handling for invalid files
+  - openssh_keypair - make regeneration of valid keypairs with the ```force``` option possible, add better handling for invalid files

--- a/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
+++ b/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - openssh_keypair - make regeneration of valid keypairs with force possible, add better handling for invalid files

--- a/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
+++ b/changelogs/fragments/57801-openssh_keypair-fix-make-regenerating-valid-files-possible.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - openssh_keypair - make regeneration of valid keypairs with the ```force``` option possible, add better handling for invalid files
+  - openssh_keypair - make regeneration of valid keypairs with the ``force`` option possible, add better handling for invalid files

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -212,7 +212,7 @@ class Keypair(object):
                 if os.access(self.path, os.W_OK) and not self.force:
                     module.fail_json(
                             msg='%s seems not to be a valid key file. If you want this module to overwrite '
-                                'the file at %s please specify the force parameter.' % (self.path, self.path))
+                            'the file at %s please specify the force parameter.' % (self.path, self.path))
                 else:
                     return False
 

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -209,12 +209,7 @@ class Keypair(object):
                 if os.path.isdir(self.path):
                     module.fail_json(msg='%s is a directory. Please specify a path to a file.' % (self.path))
 
-                if os.access(self.path, os.W_OK) and not self.force:
-                    module.fail_json(
-                        msg='%s seems not to be a valid key file. If you want this module to overwrite '
-                        'the file at %s please specify the force parameter.' % (self.path, self.path))
-                else:
-                    return False
+                return False
 
             fingerprint = proc[1].split()
             pubkey = module.run_command([module.get_bin_path('ssh-keygen', True), '-yf', self.path])

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -116,6 +116,7 @@ public_key:
 '''
 
 import os
+import stat
 import errno
 
 from ansible.module_utils.basic import AnsibleModule
@@ -216,7 +217,7 @@ class Keypair(object):
                             msg='%s seems not to be write-able. If you want this module to (re)generate the '
                                 'keypair anyways please specify the force parameter.' % (self.path))
                     else:
-                        os.remove(self.path)
+                        os.chmod(self.path, stat.S_IWUSR + stat.S_IRUSR)
                         return False
                 else:
                     module.fail_json(msg='%s is a directory. Please specify a path to a file.' % (self.path))

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -211,8 +211,8 @@ class Keypair(object):
 
                 if os.access(self.path, os.W_OK) and not self.force:
                     module.fail_json(
-                            msg='%s seems not to be a valid key file. If you want this module to overwrite '
-                            'the file at %s please specify the force parameter.' % (self.path, self.path))
+                        msg='%s seems not to be a valid key file. If you want this module to overwrite '
+                        'the file at %s please specify the force parameter.' % (self.path, self.path))
                 else:
                     return False
 

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -204,7 +204,7 @@ class Keypair(object):
             return os.path.exists(self.path)
 
         if _check_state():
-            proc = module.run_command([module.get_bin_path('ssh-keygen', True), '-lf', self.path])
+            proc = module.run_command([module.get_bin_path('ssh-keygen', True), '-lf', self.path], check_rc=False)
             if not proc[0] == 0:
                 if os.path.isdir(self.path):
                     module.fail_json(msg='%s is a directory. Please specify a path to a file.' % (self.path))

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -184,7 +184,10 @@ class Keypair(object):
                 if os.path.exists(self.path) and not os.access(self.path, os.W_OK):
                     os.chmod(self.path, stat.S_IWUSR + stat.S_IRUSR)
                 self.changed = True
-                module.run_command(args, data="y")
+                stdin_data = None
+                if os.path.exists(self.path):
+                    stdin_data = 'y'
+                module.run_command(args, data=stdin_data)
                 proc = module.run_command([module.get_bin_path('ssh-keygen', True), '-lf', self.path])
                 self.fingerprint = proc[1].split()
                 pubkey = module.run_command([module.get_bin_path('ssh-keygen', True), '-yf', self.path])

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -27,4 +27,44 @@
     path: '{{ output_dir }}/privatekey5'
   register: publickey_gen
 
+- name: Generate privatekey6
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey6'
+    type: rsa
+
+- name: Regenerate privatekey6 via force
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekey6'
+    type: rsa
+    force: yes
+  register: output_regenerated_via_force
+
+- name: Create broken key
+  copy:
+    dest: '{{ item }}'
+    content: ''
+    mode: '0700'
+  loop:
+    - '{{ output_dir }}/privatekeybroken'
+    - '{{ output_dir }}/privatekeybroken.pub'
+
+- name: Regenerate broken key
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekeybroken'
+    type: rsa
+  register: output_broken
+
+- name: Generate read-only private key
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekeyreadonly'
+    type: rsa
+    mode: '0200'
+
+- name: Regenerate read-only private key via force
+  openssh_keypair:
+    path: '{{ output_dir }}/privatekeyreadonly'
+    type: rsa
+    force: yes
+  register: output_read_only
+
 - import_tasks: ../tests/validate.yml

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -52,7 +52,6 @@
   openssh_keypair:
     path: '{{ output_dir }}/privatekeybroken'
     type: rsa
-    force: yes
   register: output_broken
 
 - name: Generate read-only private key

--- a/test/integration/targets/openssh_keypair/tasks/main.yml
+++ b/test/integration/targets/openssh_keypair/tasks/main.yml
@@ -52,6 +52,7 @@
   openssh_keypair:
     path: '{{ output_dir }}/privatekeybroken'
     type: rsa
+    force: yes
   register: output_broken
 
 - name: Generate read-only private key

--- a/test/integration/targets/openssh_keypair/tests/validate.yml
+++ b/test/integration/targets/openssh_keypair/tests/validate.yml
@@ -1,3 +1,4 @@
+---
 - name: Log privatekey1 return values
   debug:
     var: privatekey1_result
@@ -73,3 +74,20 @@
   assert:
     that:
       - "publickey_gen.public_key == lookup('file', output_dir ~ '/privatekey5.pub').strip('\n')"
+
+- name: Verify that privatekey6 will be regenerated via force
+  assert:
+    that:
+      - output_regenerated_via_force is changed
+
+
+- name: Verify that broken key will be regenerated
+  assert:
+    that:
+      - output_broken is changed
+
+
+- name: Verify that read-only key will be regenerated
+  assert:
+    that:
+      - output_read_only is changed


### PR DESCRIPTION
… / add invalid file handling

##### SUMMARY

openssh_keypair can't regenerate files because ssh-keygen asks for user input, it also handles corrupt files incorrectly. This pull requests fixes those issues.

Fixes #57677 
Fixes #56607 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

openssh_keypair

