### PR TITLE
Change 'dhcp' to 'static' in example

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -463,7 +463,7 @@ EXAMPLES = r'''
       - 192.168.1.1
       - 192.168.1.2
     - vlan: 1234
-      type: dhcp
+      type: static
     customization:
       autologon: yes
       dns_servers:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Change "type: dhcp" to "type: static" in example "Clone a virtual machine from Windows template and customize"

Because "ip: 192.168.1.100" is defined, and the ip attribute is for static IP address, the type attribute should be "static" or it does not make sense.



##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
