### PR TITLE
win_acl no longer needs SeSecurityPrivilege

### DIFF
--- a/changelogs/fragments/57804-win_acl-no-longer-needs-SeSecurityPrivilege.yml
+++ b/changelogs/fragments/57804-win_acl-no-longer-needs-SeSecurityPrivilege.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_acl - Fixed error when setting rights on directory for which inheritance from parent directory has been disabled.

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -188,7 +188,7 @@ Try {
     If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            Set-ACL -LiteralPath $path -AclObject $objACL
+            (Get-Item $path).SetAccessControl($objACL)
             $result.changed = $true
         }
         Catch {
@@ -198,7 +198,7 @@ Try {
     ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            Set-ACL -LiteralPath $path -AclObject $objACL
+            (Get-Item $path).SetAccessControl($objACL)
             $result.changed = $true
         }
         Catch {

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -188,7 +188,7 @@ Try {
     If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            (Get-Item $path).SetAccessControl($objACL)
+            (Get-Item -LiteralPath $path).SetAccessControl($objACL)
             $result.changed = $true
         }
         Catch {
@@ -198,7 +198,7 @@ Try {
     ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            (Get-Item $path).SetAccessControl($objACL)
+            (Get-Item -LiteralPath $path).SetAccessControl($objACL)
             $result.changed = $true
         }
         Catch {

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -188,7 +188,11 @@ Try {
     If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            If ($path_item.PSProvider.Name -eq "Registry") {
+                Set-ACL -LiteralPath $path -AclObject $objACL
+            } else {
+                (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            }
             $result.changed = $true
         }
         Catch {
@@ -198,7 +202,11 @@ Try {
     ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            If ($path_item.PSProvider.Name -eq "Registry") {
+                Set-ACL -LiteralPath $path -AclObject $objACL
+            } else {
+                (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            }
             $result.changed = $true
         }
         Catch {


### PR DESCRIPTION
Set-ACL raises missing SeSecurityPrivilege error when the inheritance
from the parent directory is disabled.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Replacing Set-ACL commandlet by Get-Item commandlet and SetAccessControl method no longer needs the SeSecurityPrivilege if the inheritance from parent directory is disabled.

Fixes #57753

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

win_acl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
