### PR TITLE
Get minor version number for CentOS and Debian

### DIFF
--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -16,6 +16,7 @@ import json
 import sys
 
 from ansible.module_utils import distro
+from ansible.module_utils._text import to_text
 
 
 filelist = [
@@ -53,14 +54,15 @@ dist = distro.linux_distribution(full_distribution_name=False)
 facts = ['distribution', 'distribution_version', 'distribution_release', 'distribution_major_version', 'os_family']
 
 try:
-    ansible_out = subprocess.check_output(
+    b_ansible_out = subprocess.check_output(
         ['ansible', 'localhost', '-m', 'setup'])
 except subprocess.CalledProcessError as e:
     print("ERROR: ansible run failed, output was: \n")
     print(e.output)
     sys.exit(e.returncode)
 
-parsed = json.loads(ansible_out[ansible_out.index(b'{'):])
+ansible_out = to_text(b_ansible_out)
+parsed = json.loads(ansible_out[ansible_out.index('{'):])
 ansible_facts = {}
 for fact in facts:
     try:

--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -60,7 +60,7 @@ except subprocess.CalledProcessError as e:
     print(e.output)
     sys.exit(e.returncode)
 
-parsed = json.loads(ansible_out[ansible_out.index('{'):])
+parsed = json.loads(ansible_out[ansible_out.index(b'{'):])
 ansible_facts = {}
 for fact in facts:
     try:
@@ -72,6 +72,13 @@ nicename = ansible_facts['distribution'] + ' ' + ansible_facts['distribution_ver
 
 output = {
     'name': nicename,
+    'distro': {
+        'codename': distro.codename(),
+        'id': distro.id(),
+        'name': distro.name(),
+        'version': distro.version(),
+        'version_best': distro.version(best=True),
+    },
     'input': fcont,
     'platform.dist': dist,
     'result': ansible_facts,

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -51,7 +51,7 @@ def get_distribution_version():
     '''
     version = None
     if platform.system() == 'Linux':
-        version = distro.version()
+        version = distro.version(best=True)
     return version
 
 

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -51,12 +51,28 @@ def get_distribution_version():
     '''
     version = None
 
-    if platform.system() == 'Linux':
-        version = distro.version(best=True)
+    needs_best_version = set([
+        'centos',
+        'debian',
+    ])
 
-        if version:
-            if distro.id() in ['centos', 'ubuntu']:
-                version = '.'.join(version.split('.')[:2])
+    if platform.system() == 'Linux':
+        version = distro.version()
+        distro_id = distro.id()
+
+        if version is not None:
+            if distro_id in needs_best_version:
+                version_best = distro.version(best=True)
+
+                # CentoOS maintainers believe only the major version is appropriate
+                # but Ansible users desire minor version information, e.g., 7.5
+                if distro_id == 'centos':
+                    version = '.'.join(version_best.split('.')[:2])
+
+                # Debian does not include minor version in /etc/os-release. This could
+                # change if Debian maintainers are convinced to include this information.
+                if distro_id == 'debian':
+                    version = version_best
 
         else:
             version = ''

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -49,20 +49,18 @@ def get_distribution_version():
     :returns: A string representation of the version of the distribution. If it cannot determine
         the version, it returns empty string. If this is not run on a Linux machine it returns None
     '''
-    needs_munging = set([
-        'centos',
-        'ubuntu'
-    ])
     version = None
+
     if platform.system() == 'Linux':
-        distribution = distro.id()
         version = distro.version(best=True)
+
         if version:
-            if distribution in needs_munging:
-                if distribution in ['centos', 'ubuntu']:
-                    version = '.'.join(version.split('.')[:2])
+            if distro.id() in ['centos', 'ubuntu']:
+                version = '.'.join(version.split('.')[:2])
+
         else:
             version = ''
+
     return version
 
 

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -51,10 +51,10 @@ def get_distribution_version():
     '''
     version = None
 
-    needs_best_version = set([
-        'centos',
-        'debian',
-    ])
+    needs_best_version = frozenset((
+        u'centos',
+        u'debian',
+    ))
 
     if platform.system() == 'Linux':
         version = distro.version()
@@ -65,17 +65,19 @@ def get_distribution_version():
                 version_best = distro.version(best=True)
 
                 # CentoOS maintainers believe only the major version is appropriate
-                # but Ansible users desire minor version information, e.g., 7.5
-                if distro_id == 'centos':
-                    version = '.'.join(version_best.split('.')[:2])
+                # but Ansible users desire minor version information, e.g., 7.5.
+                # https://github.com/ansible/ansible/issues/50141#issuecomment-449452781
+                if distro_id == u'centos':
+                    version = u'.'.join(version_best.split(u'.')[:2])
 
-                # Debian does not include minor version in /etc/os-release. This could
-                # change if Debian maintainers are convinced to include this information.
-                if distro_id == 'debian':
+                # Debian does not include minor version in /etc/os-release.
+                # Bug report filed upstream requesting this be added to /etc/os-release
+                # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=931197
+                if distro_id == u'debian':
                     version = version_best
 
         else:
-            version = ''
+            version = u''
 
     return version
 

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -49,9 +49,20 @@ def get_distribution_version():
     :returns: A string representation of the version of the distribution. If it cannot determine
         the version, it returns empty string. If this is not run on a Linux machine it returns None
     '''
+    needs_munging = set([
+        'centos',
+        'ubuntu'
+    ])
     version = None
     if platform.system() == 'Linux':
+        distribution = distro.id()
         version = distro.version(best=True)
+        if version:
+            if distribution in needs_munging:
+                if distribution in ['centos', 'ubuntu']:
+                    version = '.'.join(version.split('.')[:2])
+        else:
+            version = ''
     return version
 
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 
 from itertools import product
 
-import mock
 import pytest
 
 from ansible.module_utils.six.moves import builtins
@@ -185,24 +184,13 @@ TESTSETS = [
     {
         "name": "openSUSE Leap 42.1",
         "input": {
-            "/etc/os-release": """
-NAME="openSUSE Leap"
-VERSION="42.1"
-VERSION_ID="42.1"
-PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
-ID=opensuse
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
-BUG_REPORT_URL="https://bugs.opensuse.org"
-HOME_URL="https://opensuse.org/"
-ID_LIKE="suse"
-""",
-            "/etc/SuSE-release": """
-openSUSE 42.1 (x86_64)
-VERSION = 42.1
-CODENAME = Malachite
-# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
-"""
+            "/etc/os-release": (
+                'NAME="openSUSE Leap"\nVERSION="42.1"\nVERSION_ID="42.1"\nPRETTY_NAME="openSUSE Leap 42.1 (x86_64)"\nID=opensuse\n'
+                'ANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:opensuse:opensuse:42.1"\nBUG_REPORT_URL="https://bugs.opensuse.org"\n'
+                'HOME_URL="https://opensuse.org/"\nID_LIKE="suse"'),
+            "/etc/SuSE-release": (
+                'openSUSE 42.1 (x86_64)\nVERSION = 42.1\nCODENAME = Malachite\n# /etc/SuSE-release is deprecated and will be removed in the future, '
+                'use /etc/os-release instead'),
         },
         "platform.dist": ['SuSE', '42.1', 'x86_64'],
         'distro': {
@@ -223,22 +211,13 @@ CODENAME = Malachite
     {
         'name': 'openSUSE 13.2',
         'input': {
-            '/etc/SuSE-release': """openSUSE 13.2 (x86_64)
-VERSION = 13.2
-CODENAME = Harlequin
-# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
-""",
-            '/etc/os-release': """NAME=openSUSE
-VERSION="13.2 (Harlequin)"
-VERSION_ID="13.2"
-PRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"
-ID=opensuse
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:opensuse:opensuse:13.2"
-BUG_REPORT_URL="https://bugs.opensuse.org"
-HOME_URL="https://opensuse.org/"
-ID_LIKE="suse"
-"""
+            '/etc/SuSE-release': (
+                'openSUSE 13.2 (x86_64)\nVERSION = 13.2\nCODENAME = Harlequin\n'
+                '# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead'),
+            '/etc/os-release': (
+                'NAME=openSUSE\nVERSION="13.2 (Harlequin)"\nVERSION_ID="13.2"\nPRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"\nID=opensuse\n'
+                'ANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:opensuse:opensuse:13.2"\nBUG_REPORT_URL="https://bugs.opensuse.org"\n'
+                'HOME_URL="https://opensuse.org/"\nID_LIKE="suse"'),
         },
         'platform.dist': ('SuSE', '13.2', 'x86_64'),
         'distro': {
@@ -317,11 +296,7 @@ ID_LIKE="suse"
     {  # see https://github.com/ansible/ansible/issues/14837
         "name": "SLES 11.3",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 11 (x86_64)
-VERSION = 11
-PATCHLEVEL = 3
-"""
+            "/etc/SuSE-release": "SUSE Linux Enterprise Server 11 (x86_64)\nVERSION = 11\nPATCHLEVEL = 3"
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
         'distro': {
@@ -342,20 +317,10 @@ PATCHLEVEL = 3
     {  # see https://github.com/ansible/ansible/issues/14837
         "name": "SLES 11.4",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 11 (x86_64)
-VERSION = 11
-PATCHLEVEL = 4
-""",
-            "/etc/os-release": """
-NAME="SLES"
-VERSION="11.4"
-VERSION_ID="11.4"
-PRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"
-ID="sles"
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles:11:4"
-""",
+            "/etc/SuSE-release": "\nSUSE Linux Enterprise Server 11 (x86_64)\nVERSION = 11\nPATCHLEVEL = 4",
+            "/etc/os-release": (
+                'NAME="SLES"\nVERSION="11.4"\nVERSION_ID="11.4"\nPRETTY_NAME="SUSE Linux Enterprise Server 11 SP4"\nID="sles"\n'
+                'ANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles:11:4"'),
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
         'distro': {
@@ -376,22 +341,13 @@ CPE_NAME="cpe:/o:suse:sles:11:4"
     {  # see https://github.com/ansible/ansible/issues/14837
         "name": "SLES 12 SP0",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 12 (x86_64)
-VERSION = 12
-PATCHLEVEL = 0
-# This file is deprecated and will be removed in a future service pack or release.
-# Please check /etc/os-release for details about this release.
-""",
-            "/etc/os-release": """
-NAME="SLES"
-VERSION="12"
-VERSION_ID="12"
-PRETTY_NAME="SUSE Linux Enterprise Server 12"
-ID="sles"
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles:12"
-""",
+            "/etc/SuSE-release": (
+                '\nSUSE Linux Enterprise Server 12 (x86_64)\nVERSION = 12\nPATCHLEVEL = 0\n'
+                '# This file is deprecated and will be removed in a future service pack or release.\n'
+                '# Please check /etc/os-release for details about this release.'),
+            "/etc/os-release": (
+                'NAME="SLES"\nVERSION="12"\nVERSION_ID="12"\nPRETTY_NAME="SUSE Linux Enterprise Server 12"\nID="sles"\n'
+                'ANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles:12"'),
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
@@ -412,22 +368,13 @@ CPE_NAME="cpe:/o:suse:sles:12"
     {  # see https://github.com/ansible/ansible/issues/14837
         "name": "SLES 12 SP1",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 12 (x86_64)
-VERSION = 12
-PATCHLEVEL = 0
-# This file is deprecated and will be removed in a future service pack or release.
-# Please check /etc/os-release for details about this release.
-""",
-            "/etc/os-release": """
-NAME="SLES"
-VERSION="12-SP1"
-VERSION_ID="12.1"
-PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
-ID="sles"
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles:12:sp1"
-            """,
+            "/etc/SuSE-release": (
+                '\nSUSE Linux Enterprise Server 12 (x86_64)\nVERSION = 12\nPATCHLEVEL = 0\n'
+                '# This file is deprecated and will be removed in a future service pack or release.\n'
+                '# Please check /etc/os-release for details about this release.'),
+            "/etc/os-release": (
+                'NAME="SLES"\nVERSION="12-SP1"\nVERSION_ID="12.1"\nPRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"\nID="sles"\n'
+                'ANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles:12:sp1"'),
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
@@ -448,22 +395,13 @@ CPE_NAME="cpe:/o:suse:sles:12:sp1"
     {
         "name": "SLES4SAP 12 SP2",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 12 (x86_64)
-VERSION = 12
-PATCHLEVEL = 2
-# This file is deprecated and will be removed in a future service pack or release.
-# Please check /etc/os-release for details about this release.
-""",
-            "/etc/os-release": """
-NAME="SLES_SAP"
-VERSION="12-SP2"
-VERSION_ID="12.2"
-PRETTY_NAME="SUSE Linux Enterprise Server for SAP Applications 12 SP2"
-ID="sles_sap"
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"
-            """,
+            "/etc/SuSE-release": (
+                'SUSE Linux Enterprise Server 12 (x86_64)\nVERSION = 12\nPATCHLEVEL = 2\n'
+                '# This file is deprecated and will be removed in a future service pack or release.\n'
+                '# Please check /etc/os-release for details about this release.'),
+            "/etc/os-release": (
+                'NAME="SLES_SAP"\nVERSION="12-SP2"\nVERSION_ID="12.2"\nPRETTY_NAME="SUSE Linux Enterprise Server for SAP Applications 12 SP2"\n'
+                'ID="sles_sap"\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles_sap:12:sp2"'),
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
@@ -484,22 +422,13 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"
     {
         "name": "SLES4SAP 12 SP3",
         "input": {
-            "/etc/SuSE-release": """
-SUSE Linux Enterprise Server 12 (x86_64)
-VERSION = 12
-PATCHLEVEL = 3
-# This file is deprecated and will be removed in a future service pack or release.
-# Please check /etc/os-release for details about this release.
-""",
-            "/etc/os-release": """
-NAME="SLES"
-VERSION="12-SP3"
-VERSION_ID="12.3"
-PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"
-ID="sles"
-ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles_sap:12:sp3"
-            """,
+            "/etc/SuSE-release": (
+                'SUSE Linux Enterprise Server 12 (x86_64)VERSION = 12PATCHLEVEL = 3'
+                '\n# This file is deprecated and will be removed in a future service pack or release.\n'
+                '# Please check /etc/os-release for details about this release.'),
+            "/etc/os-release": (
+                'NAME="SLES"\nVERSION="12-SP3"\nVERSION_ID="12.3"\nPRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"\n'
+                'ID="sles"\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles_sap:12:sp3"'),
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
@@ -520,17 +449,10 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp3"
     {
         "name": "Debian stretch/sid",
         "input": {
-            "/etc/os-release": """
-PRETTY_NAME="Debian GNU/Linux stretch/sid"
-NAME="Debian GNU/Linux"
-ID=debian
-HOME_URL="https://www.debian.org/"
-SUPPORT_URL="https://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"
-""",
-            "/etc/debian_version": """
-            stretch/sid
-            """,
+            "/etc/os-release": (
+                'PRETTY_NAME="Debian GNU/Linux stretch/sid"\nNAME="Debian GNU/Linux"\nID=debian\nHOME_URL="https://www.debian.org/"\n'
+                'SUPPORT_URL="https://www.debian.org/support"\nBUG_REPORT_URL="https://bugs.debian.org/"'),
+            "/etc/debian_version": 'stretch/sid\n',
         },
         "platform.dist": ('debian', 'stretch/sid', ''),
         'distro': {
@@ -551,16 +473,9 @@ BUG_REPORT_URL="https://bugs.debian.org/"
     {
         'name': "Debian 7.9",
         'input': {
-            '/etc/os-release': """PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
-NAME="Debian GNU/Linux"
-VERSION_ID="7"
-VERSION="7 (wheezy)"
-ID=debian
-ANSI_COLOR="1;31"
-HOME_URL="http://www.debian.org/"
-SUPPORT_URL="http://www.debian.org/support/"
-BUG_REPORT_URL="http://bugs.debian.org/"
-"""
+            '/etc/os-release': (
+                'PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"\nNAME="Debian GNU/Linux"\nVERSION_ID="7"\nVERSION="7 (wheezy)"\nID=debian\nANSI_COLOR="1;31"\n'
+                'HOME_URL="http://www.debian.org/"\nSUPPORT_URL="http://www.debian.org/support/"\nBUG_REPORT_URL="http://bugs.debian.org/"'),
         },
         'platform.dist': ('debian', '7.9', ''),
         'distro': {
@@ -581,21 +496,11 @@ BUG_REPORT_URL="http://bugs.debian.org/"
     {
         'name': "SteamOS 2.0",
         'input': {
-            '/etc/os-release': """PRETTY_NAME="SteamOS GNU/Linux 2.0 (brewmaster)"
-NAME="SteamOS GNU/Linux"
-VERSION_ID="2"
-VERSION="2 (brewmaster)"
-ID=steamos
-ID_LIKE=debian
-HOME_URL="http://www.steampowered.com/"
-SUPPORT_URL="http://support.steampowered.com/"
-BUG_REPORT_URL="http://support.steampowered.com/"
-""",
-            '/etc/lsb-release': """DISTRIB_ID=SteamOS
-DISTRIB_RELEASE=2.0
-DISTRIB_CODENAME=brewmaster
-DISTRIB_DESCRIPTION="SteamOS 2.0"
-"""
+            '/etc/os-release': (
+                'PRETTY_NAME="SteamOS GNU/Linux 2.0 (brewmaster)"\nNAME="SteamOS GNU/Linux"\nVERSION_ID="2"\nVERSION="2 (brewmaster)"\n'
+                'ID=steamos\nID_LIKE=debian\nHOME_URL="http://www.steampowered.com/"\nSUPPORT_URL="http://support.steampowered.com/"\n'
+                'BUG_REPORT_URL="http://support.steampowered.com/"'),
+            '/etc/lsb-release': 'DISTRIB_ID=SteamOS\nDISTRIB_RELEASE=2.0\nDISTRIB_CODENAME=brewmaster\nDISTRIB_DESCRIPTION="SteamOS 2.0"',
         },
         'platform.dist': ('Steamos', '2.0', 'brewmaster'),
         'distro': {
@@ -616,15 +521,8 @@ DISTRIB_DESCRIPTION="SteamOS 2.0"
     {
         'name': "Devuan",
         'input': {
-            '/etc/os-release': """PRETTY_NAME="Devuan GNU/Linux 1 (jessie)"
-NAME="Devuan GNU/Linux"
-VERSION_ID="1"
-VERSION="1 (jessie)"
-ID=devuan
-HOME_URL="http://www.devuan.org/"
-SUPPORT_URL="http://www.devuan.org/support/"
-BUG_REPORT_URL="https://bugs.devuan.org/"
-"""
+            '/etc/os-release': ('PRETTY_NAME="Devuan GNU/Linux 1 (jessie)"\nNAME="Devuan GNU/Linux"\nVERSION_ID="1"\nVERSION="1 (jessie)"\n'
+                'ID=devuan\nHOME_URL="http://www.devuan.org/"\nSUPPORT_URL="http://www.devuan.org/support/"\nBUG_REPORT_URL="https://bugs.devuan.org/"'),
         },
         'platform.dist': ('', '', ''),
         'distro': {
@@ -645,13 +543,9 @@ BUG_REPORT_URL="https://bugs.devuan.org/"
     {
         'name': "Devuan",
         'input': {
-            '/etc/os-release': """PRETTY_NAME="Devuan GNU/Linux ascii"
-NAME="Devuan GNU/Linux"
-ID=devuan
-HOME_URL="https://www.devuan.org/"
-SUPPORT_URL="https://devuan.org/os/community"
-BUG_REPORT_URL="https://bugs.devuan.org/"
-"""
+            '/etc/os-release': (
+                'PRETTY_NAME="Devuan GNU/Linux ascii"\nNAME="Devuan GNU/Linux"\nID=devuan\nHOME_URL="https://www.devuan.org/"\n'
+                'SUPPORT_URL="https://devuan.org/os/community"\nBUG_REPORT_URL="https://bugs.devuan.org/"'),
         },
         'platform.dist': ('', '', ''),
         'distro': {
@@ -703,11 +597,7 @@ BUG_REPORT_URL="https://bugs.devuan.org/"
         'name': "Ubuntu 10.04 guess",
         'input':
             {
-                '/etc/lsb-release': """DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=10.04
-DISTRIB_CODENAME=lucid
-DISTRIB_DESCRIPTION="Ubuntu 10.04.4 LTS
-"""
+                '/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=10.04\nDISTRIB_CODENAME=lucid\nDISTRIB_DESCRIPTION="Ubuntu 10.04.4 LTS',
             },
         'platform.dist': ('Ubuntu', '10.04', 'lucid'),
         'distro': {
@@ -729,21 +619,10 @@ DISTRIB_DESCRIPTION="Ubuntu 10.04.4 LTS
     {
         'name': "Ubuntu 14.04",
         'input': {
-            '/etc/lsb-release': """DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=14.04
-DISTRIB_CODENAME=trusty
-DISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"
-""",
-            '/etc/os-release': """NAME="Ubuntu"
-VERSION="14.04.4 LTS, Trusty Tahr"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 14.04.4 LTS"
-VERSION_ID="14.04"
-HOME_URL="http://www.ubuntu.com/"
-SUPPORT_URL="http://help.ubuntu.com/"
-BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
-"""
+            '/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=14.04\nDISTRIB_CODENAME=trusty\nDISTRIB_DESCRIPTION="Ubuntu 14.04.4 LTS"',
+            '/etc/os-release': (
+                'NAME="Ubuntu"\nVERSION="14.04.4 LTS, Trusty Tahr"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME="Ubuntu 14.04.4 LTS"\nVERSION_ID="14.04"\n'
+                'HOME_URL="http://www.ubuntu.com/"\nSUPPORT_URL="http://help.ubuntu.com/"\nBUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"'),
         },
         'platform.dist': ('Ubuntu', '14.04', 'trusty'),
         'distro': {
@@ -763,18 +642,12 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
     },
     {
         'name': "Ubuntu 12.04",
-        'input': {'/etc/lsb-release': """DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=12.04
-DISTRIB_CODENAME=precise
-DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"
-""",
-                  '/etc/os-release': """NAME="Ubuntu"
-VERSION="12.04.5 LTS, Precise Pangolin"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
-VERSION_ID="12.04"
-"""},
+        'input': {
+            '/etc/lsb-release': 'DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=12.04\nDISTRIB_CODENAME=precise\nDISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"',
+            '/etc/os-release': (
+                'NAME="Ubuntu"\nVERSION="12.04.5 LTS, Precise Pangolin"\nID=ubuntu\nID_LIKE=debian\n'
+                'PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"\nVERSION_ID="12.04"'),
+        },
         'platform.dist': ('Ubuntu', '12.04', 'precise'),
         'distro': {
             'codename': 'precise',
@@ -852,22 +725,11 @@ VERSION_ID="12.04"
     {
         'name': 'Core OS',
         'input': {
-            '/etc/os-release': """
-NAME=CoreOS
-ID=coreos
-VERSION=976.0.0
-VERSION_ID=976.0.0
-BUILD_ID=2016-03-03-2324
-PRETTY_NAME="CoreOS 976.0.0 (Coeur Rouge)"
-ANSI_COLOR="1;32"
-HOME_URL="https://coreos.com/"
-BUG_REPORT_URL="https://github.com/coreos/bugs/issues"
-""",
-            '/etc/lsb-release': """DISTRIB_ID=CoreOS
-DISTRIB_RELEASE=976.0.0
-DISTRIB_CODENAME="Coeur Rouge"
-DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
-""",
+            '/etc/os-release': (
+                'NAME=CoreOS\nID=coreos\nVERSION=976.0.0\nVERSION_ID=976.0.0\nBUILD_ID=2016-03-03-2324\nPRETTY_NAME="CoreOS 976.0.0 (Coeur Rouge)"\n'
+                'ANSI_COLOR="1;32"\nHOME_URL="https://coreos.com/"\nBUG_REPORT_URL="https://github.com/coreos/bugs/issues"'),
+            '/etc/lsb-release': (
+                'DISTRIB_ID=CoreOS\nDISTRIB_RELEASE=976.0.0\nDISTRIB_CODENAME="Coeur Rouge"\nDISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"'),
         },
         'platform.dist': ('', '', ''),
         'distro': {
@@ -1341,56 +1203,38 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
     },
 
     # ClearLinux https://github.com/ansible/ansible/issues/31501#issuecomment-340861535
-{
-    "platform.dist": [
-        "Clear Linux OS",
-        "26580",
-        "clear-linux-os"
-    ],
-    'distro': {
-        'codename': '',
-        'id': 'clear-linux-os',
-        'name': 'Clear Linux OS',
-        'version': '26580',
-        'version_best': '26580',
+    {
+        "platform.dist": [
+            "Clear Linux OS",
+            "26580",
+            "clear-linux-os"
+        ],
+        'distro': {
+            'codename': '',
+            'id': 'clear-linux-os',
+            'name': 'Clear Linux OS',
+            'version': '26580',
+            'version_best': '26580',
+        },
+        "input": {
+            "/etc/os-release": (
+                'NAME="Clear Linux OS"\nVERSION=1\nID=clear-linux-os\nID_LIKE=clear-linux-os\nVERSION_ID=26580\nPRETTY_NAME="Clear Linux OS"\n'
+                'ANSI_COLOR="1;35"\nHOME_URL="https://clearlinux.org"\nSUPPORT_URL="https://clearlinux.org"\n'
+                'BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"\nPRIVACY_POLICY_URL="http://www.intel.com/privacy"'),
+            "/usr/lib/os-release": (
+                'NAME="Clear Linux OS"\nVERSION=1\nID=clear-linux-os\nID_LIKE=clear-linux-os\nVERSION_ID=26580\nPRETTY_NAME="Clear Linux OS"\n'
+                'ANSI_COLOR="1;35"\nHOME_URL="https://clearlinux.org"\nSUPPORT_URL="https://clearlinux.org"\n'
+                'BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"\nPRIVACY_POLICY_URL="http://www.intel.com/privacy"'),
+        },
+        "name": "ClearLinux 26580",
+        "result": {
+            "distribution_release": "clear-linux-os",
+            "distribution": "Clear Linux OS",
+            "distribution_major_version": "26580",
+            "os_family": "ClearLinux",
+            "distribution_version": "26580"
+        }
     },
-    "input": {
-        "/etc/os-release": '''
-NAME="Clear Linux OS"
-VERSION=1
-ID=clear-linux-os
-ID_LIKE=clear-linux-os
-VERSION_ID=26580
-PRETTY_NAME="Clear Linux OS"
-ANSI_COLOR="1;35"
-HOME_URL="https://clearlinux.org"
-SUPPORT_URL="https://clearlinux.org"
-BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
-PRIVACY_POLICY_URL="http://www.intel.com/privacy"
-''',
-        "/usr/lib/os-release": '''
-NAME="Clear Linux OS"
-VERSION=1
-ID=clear-linux-os
-ID_LIKE=clear-linux-os
-VERSION_ID=26580
-PRETTY_NAME="Clear Linux OS"
-ANSI_COLOR="1;35"
-HOME_URL="https://clearlinux.org"
-SUPPORT_URL="https://clearlinux.org"
-BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
-PRIVACY_POLICY_URL="http://www.intel.com/privacy"
-'''
-    },
-    "name": "ClearLinux 26580",
-    "result": {
-        "distribution_release": "clear-linux-os",
-        "distribution": "Clear Linux OS",
-        "distribution_major_version": "26580",
-        "os_family": "ClearLinux",
-        "distribution_version": "26580"
-    }
-},
     # ArchLinux with no /etc/arch-release but with a /etc/os-release with NAME=Arch Linux
     # The fact needs to map 'Arch Linux' to 'Archlinux' for compat with 2.3 and earlier facts
     {
@@ -1421,16 +1265,10 @@ PRIVACY_POLICY_URL="http://www.intel.com/privacy"
     {
         'name': "Cumulus Linux 3.7.3",
         'input': {
-            '/etc/os-release': """NAME="Cumulus Linux"
-VERSION_ID=3.7.3
-VERSION="Cumulus Linux 3.7.3"
-PRETTY_NAME="Cumulus Linux"
-ID=cumulus-linux
-ID_LIKE=debian
-CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.7.3
-HOME_URL="http://www.cumulusnetworks.com/"
-SUPPORT_URL="http://support.cumulusnetworks.com/"
-"""
+            '/etc/os-release': (
+                'NAME="Cumulus Linux"\nVERSION_ID=3.7.3\nVERSION="Cumulus Linux 3.7.3"\nPRETTY_NAME="Cumulus Linux"\nID=cumulus-linux\n'
+                'ID_LIKE=debian\nCPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:3.7.3\nHOME_URL="http://www.cumulusnetworks.com/"\n'
+                'SUPPORT_URL="http://support.cumulusnetworks.com/"'),
         },
         'platform.dist': ('debian', '8.11', ''),
         'distro': {
@@ -1451,16 +1289,10 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
     {
         'name': "Cumulus Linux 2.5.4",
         'input': {
-            '/etc/os-release': """NAME="Cumulus Linux"
-VERSION_ID=2.5.4
-VERSION="2.5.4-6dc6e80-201510091936-build"
-PRETTY_NAME="Cumulus Linux"
-ID=cumulus-linux
-ID_LIKE=debian
-CPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:2.5.4-6dc6e80-201510091936-build
-HOME_URL="http://www.cumulusnetworks.com/"
-SUPPORT_URL="http://support.cumulusnetworks.com/"
-"""
+            '/etc/os-release': (
+                'NAME="Cumulus Linux"\nVERSION_ID=2.5.4\nVERSION="2.5.4-6dc6e80-201510091936-build"\nPRETTY_NAME="Cumulus Linux"\nID=cumulus-linux\n'
+                'ID_LIKE=debian\nCPE_NAME=cpe:/o:cumulusnetworks:cumulus_linux:2.5.4-6dc6e80-201510091936-build\nHOME_URL="http://www.cumulusnetworks.com/"\n'
+                'SUPPORT_URL="http://support.cumulusnetworks.com/"'),
         },
         'platform.dist': ('', '', ''),
         'distro': {
@@ -1485,8 +1317,14 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
             "sonya"
         ],
         "input": {
-            "/etc/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.2 (Sonya)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.2\"\nVERSION_ID=\"18.2\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n",
-            "/usr/lib/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.2 (Sonya)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.2\"\nVERSION_ID=\"18.2\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n",
+            "/etc/os-release": (
+                'NAME="Linux Mint"\nVERSION="18.2 (Sonya)"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME="Linux Mint 18.2"\n'
+                'VERSION_ID="18.2"\nHOME_URL="http://www.linuxmint.com/"\nSUPPORT_URL="http://forums.linuxmint.com/"\n'
+                'BUG_REPORT_URL="http://bugs.launchpad.net/linuxmint/"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n'),
+            "/usr/lib/os-release": (
+                'NAME="Linux Mint"\nVERSION="18.2 (Sonya)"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME="Linux Mint 18.2"\n'
+                'VERSION_ID="18.2"\nHOME_URL="http://www.linuxmint.com/"\nSUPPORT_URL="http://forums.linuxmint.com/"\n'
+                'BUG_REPORT_URL="http://bugs.launchpad.net/linuxmint/"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n'),
             "/etc/lsb-release": "DISTRIB_ID=LinuxMint\nDISTRIB_RELEASE=18.2\nDISTRIB_CODENAME=sonya\nDISTRIB_DESCRIPTION=\"Linux Mint 18.2 Sonya\"\n"
         },
         "result": {

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1480,29 +1480,31 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
     },
     {
         "platform.dist": [
-            "LinuxMint",
-            "18.3",
-            "sylvia",
+            "linuxmint",
+            "18.2",
+            "sonya"
         ],
-        'distro': {
-            'codename': 'Sylvia',
-            'id': 'linuxmint',
-            'name': 'Linux Mint',
-            'version': '18.3',
-            'version_best': '18.3',
-        },
         "input": {
-            "/etc/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.3 (Sylvia)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.3\"\nVERSION_ID=\"18.3\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sylvia\nUBUNTU_CODENAME=xenial",  # noqa
+            "/etc/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.2 (Sonya)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.2\"\nVERSION_ID=\"18.2\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n",
+            "/usr/lib/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.2 (Sonya)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.2\"\nVERSION_ID=\"18.2\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sonya\nUBUNTU_CODENAME=xenial\n",
+            "/etc/lsb-release": "DISTRIB_ID=LinuxMint\nDISTRIB_RELEASE=18.2\nDISTRIB_CODENAME=sonya\nDISTRIB_DESCRIPTION=\"Linux Mint 18.2 Sonya\"\n"
         },
-        "name": "Linux Mint 18.3",
         "result": {
-            "distribution_release": "Sylvia",
+            "distribution_release": "sonya",
             "distribution": "Linux Mint",
             "distribution_major_version": "18",
             "os_family": "Debian",
-            "distribution_version": "18.3"
-        }
-    }
+            "distribution_version": "18.2"
+        },
+        "name": "Linux Mint 18.2",
+        "distro": {
+            "codename": "sonya",
+            "version": "18.2",
+            "id": "linuxmint",
+            "version_best": "18.2",
+            "name": "Linux Mint"
+        },
+    },
 ]
 
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -24,6 +24,13 @@ TESTSETS = [
             "7.2.1511",
             "Core"
         ],
+        'distro': {
+            'codename': 'Core',
+            'id': 'centos',
+            'name': 'CentOS Linux',
+            'version': '7',
+            'version_best': '7.2.1511',
+        },
         "input": {
             "/etc/redhat-release": "CentOS Linux release 7.2.1511 (Core) \n",
             "/etc/os-release": (
@@ -40,7 +47,7 @@ TESTSETS = [
             "distribution": "CentOS",
             "distribution_major_version": "7",
             "os_family": "RedHat",
-            "distribution_version": "7.2.1511",
+            "distribution_version": "7.2",
         }
     },
     {
@@ -50,6 +57,13 @@ TESTSETS = [
             "6.7",
             "Final"
         ],
+        'distro': {
+            'codename': 'Core',
+            'id': 'centos',
+            'name': 'CentOS Linux',
+            'version': '6',
+            'version_best': '6.7',
+        },
         "input": {
             "/etc/redhat-release": "CentOS release 6.7 (Final)\n",
             "/etc/lsb-release": (
@@ -73,6 +87,13 @@ TESTSETS = [
             "7.2",
             "Maipo"
         ],
+        'distro': {
+            'codename': 'Maipo',
+            'id': 'rhel',
+            'name': 'RedHat Enterprise Linux',
+            'version': '7.2',
+            'version_best': '7.2',
+        },
         "input": {
             "/etc/redhat-release": "Red Hat Enterprise Linux Server release 7.2 (Maipo)\n",
             "/etc/os-release": (
@@ -100,6 +121,13 @@ TESTSETS = [
             "6.7",
             "Santiago"
         ],
+        'distro': {
+            'codename': 'Santiago',
+            'id': 'rhel',
+            'name': 'RedHat Enterprise Linux',
+            'version': '6.7',
+            'version_best': '6.7',
+        },
         "input": {
             "/etc/redhat-release": "Red Hat Enterprise Linux Server release 6.7 (Santiago)\n",
             "/etc/lsb-release": (
@@ -123,6 +151,13 @@ TESTSETS = [
             "7.3",
             ""
         ],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'virtuozzo',
+            'name': 'Virtuozzo Linux',
+            'version': '7.3',
+            'version_best': '7.3',
+        },
         "input": {
             "/etc/redhat-release": "Virtuozzo Linux release 7.3\n",
             "/etc/os-release": (
@@ -170,6 +205,13 @@ CODENAME = Malachite
 """
         },
         "platform.dist": ['SuSE', '42.1', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'opensuse-leap',
+            'name': 'openSUSE Leap',
+            'version': '42.1',
+            'version_best': '42.1',
+        },
         "result": {
             "distribution": "openSUSE Leap",
             "distribution_major_version": "42",
@@ -199,6 +241,13 @@ ID_LIKE="suse"
 """
         },
         'platform.dist': ('SuSE', '13.2', 'x86_64'),
+        'distro': {
+            'codename': 'n/a',
+            'id': 'opensuse-leap',
+            'name': 'openSUSE Harlequin',
+            'version': '13.2',
+            'version_best': '13.2',
+        },
         'result': {
             'distribution': u'openSUSE',
             'distribution_major_version': u'13',
@@ -213,6 +262,13 @@ ID_LIKE="suse"
             "",
             ""
         ],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'opensuse-leap',
+            'name': 'openSUSE Tumbleweed',
+            'version': '20160917',
+            'version_best': '20160917',
+        },
         "input": {
             "/etc/os-release": (
                 "NAME=\"openSUSE Tumbleweed\"\n# VERSION=\"20160917\"\nID=opensuse\nID_LIKE=\"suse\"\nVERSION_ID=\"20160917\"\n"
@@ -235,6 +291,13 @@ ID_LIKE="suse"
             "",
             ""
         ],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'opensuse-leap',
+            'name': 'openSUSE Leap',
+            'version': '15.0',
+            'version_best': '15.0',
+        },
         "input": {
             "/etc/os-release": (
                 "NAME=\"openSUSE Leap\"\n# VERSION=\"15.0\"\nID=opensuse-leap\nID_LIKE=\"suse opensuse\"\nVERSION_ID=\"15.0\"\n"
@@ -261,6 +324,13 @@ PATCHLEVEL = 3
 """
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '11.3',
+            'version_best': '11.3',
+        },
         "result": {
             "distribution": "SLES",
             "distribution_major_version": "11",
@@ -288,6 +358,13 @@ CPE_NAME="cpe:/o:suse:sles:11:4"
 """,
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '11.4',
+            'version_best': '11.4',
+        },
         "result":{
             "distribution": "SLES",
             "distribution_major_version": "11",
@@ -317,6 +394,13 @@ CPE_NAME="cpe:/o:suse:sles:12"
 """,
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '12',
+            'version_best': '12',
+        },
         "result": {
             "distribution": "SLES",
             "distribution_major_version": "12",
@@ -346,6 +430,13 @@ CPE_NAME="cpe:/o:suse:sles:12:sp1"
             """,
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '12.1',
+            'version_best': '12.1',
+        },
         "result":{
             "distribution": "SLES",
             "distribution_major_version": "12",
@@ -375,6 +466,13 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"
             """,
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '12.2',
+            'version_best': '12.2',
+        },
         "result":{
             "distribution": "SLES_SAP",
             "distribution_major_version": "12",
@@ -404,6 +502,13 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp3"
             """,
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
+        'distro': {
+            'codename': 'n/a',
+            'id': 'sles',
+            'name': 'SUSE Linux Enterprise Server',
+            'version': '12.3',
+            'version_best': '12.3',
+        },
         "result":{
             "distribution": "SLES_SAP",
             "distribution_major_version": "12",
@@ -428,6 +533,13 @@ BUG_REPORT_URL="https://bugs.debian.org/"
             """,
         },
         "platform.dist": ('debian', 'stretch/sid', ''),
+        'distro': {
+            'codename': 'stretch',
+            'id': 'debian',
+            'name': 'Debian GNU/Linux',
+            'version': '9',
+            'version_best': '9.8',
+        },
         "result": {
             "distribution": "Debian",
             "distribution_major_version": "stretch/sid",
@@ -451,6 +563,13 @@ BUG_REPORT_URL="http://bugs.debian.org/"
 """
         },
         'platform.dist': ('debian', '7.9', ''),
+        'distro': {
+            'codename': 'wheezy',
+            'id': 'debian',
+            'name': 'Debian GNU/Linux',
+            'version': '7',
+            'version_best': '7.9',
+        },
         'result': {
             'distribution': u'Debian',
             'distribution_major_version': u'7',
@@ -1230,13 +1349,15 @@ def test_distribution_version(am, mocker, testcase):
         return testcase.get('platform.version', '')
 
     def mock_distro_name():
-        return testcase['platform.dist'][0]
+        return testcase['distro']['name']
 
-    def mock_distro_version():
-        return testcase['platform.dist'][1]
+    def mock_distro_version(best=False):
+        if best:
+            return testcase['distro']['version_best']
+        return testcase['distro']['version']
 
     def mock_distro_codename():
-        return testcase['platform.dist'][2]
+        return testcase['distro']['codename']
 
     def mock_open(filename, mode='r'):
         if filename in testcase['input']:

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -58,10 +58,10 @@ TESTSETS = [
             "Final"
         ],
         'distro': {
-            'codename': 'Core',
+            'codename': 'Final',
             'id': 'centos',
             'name': 'CentOS Linux',
-            'version': '6',
+            'version': '6.7',
             'version_best': '6.7',
         },
         "input": {
@@ -152,7 +152,7 @@ TESTSETS = [
             ""
         ],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'virtuozzo',
             'name': 'Virtuozzo Linux',
             'version': '7.3',
@@ -206,7 +206,7 @@ CODENAME = Malachite
         },
         "platform.dist": ['SuSE', '42.1', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'opensuse-leap',
             'name': 'openSUSE Leap',
             'version': '42.1',
@@ -242,8 +242,8 @@ ID_LIKE="suse"
         },
         'platform.dist': ('SuSE', '13.2', 'x86_64'),
         'distro': {
-            'codename': 'n/a',
-            'id': 'opensuse-leap',
+            'codename': '',
+            'id': 'opensuse-harlequin',
             'name': 'openSUSE Harlequin',
             'version': '13.2',
             'version_best': '13.2',
@@ -263,8 +263,8 @@ ID_LIKE="suse"
             ""
         ],
         'distro': {
-            'codename': 'n/a',
-            'id': 'opensuse-leap',
+            'codename': '',
+            'id': 'opensuse-tumbleweed',
             'name': 'openSUSE Tumbleweed',
             'version': '20160917',
             'version_best': '20160917',
@@ -292,7 +292,7 @@ ID_LIKE="suse"
             ""
         ],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'opensuse-leap',
             'name': 'openSUSE Leap',
             'version': '15.0',
@@ -325,11 +325,11 @@ PATCHLEVEL = 3
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
-            'version': '11.3',
-            'version_best': '11.3',
+            'version': '11',
+            'version_best': '11',
         },
         "result": {
             "distribution": "SLES",
@@ -359,13 +359,13 @@ CPE_NAME="cpe:/o:suse:sles:11:4"
         },
         "platform.dist": ['SuSE', '11', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
             'version': '11.4',
             'version_best': '11.4',
         },
-        "result":{
+        "result": {
             "distribution": "SLES",
             "distribution_major_version": "11",
             "distribution_release": "4",
@@ -395,7 +395,7 @@ CPE_NAME="cpe:/o:suse:sles:12"
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
             'version': '12',
@@ -431,13 +431,13 @@ CPE_NAME="cpe:/o:suse:sles:12:sp1"
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
             'version': '12.1',
             'version_best': '12.1',
         },
-        "result":{
+        "result": {
             "distribution": "SLES",
             "distribution_major_version": "12",
             "distribution_release": "1",
@@ -467,13 +467,13 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp2"
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
             'version': '12.2',
             'version_best': '12.2',
         },
-        "result":{
+        "result": {
             "distribution": "SLES_SAP",
             "distribution_major_version": "12",
             "distribution_release": "2",
@@ -503,13 +503,13 @@ CPE_NAME="cpe:/o:suse:sles_sap:12:sp3"
         },
         "platform.dist": ['SuSE', '12', 'x86_64'],
         'distro': {
-            'codename': 'n/a',
+            'codename': '',
             'id': 'sles',
             'name': 'SUSE Linux Enterprise Server',
             'version': '12.3',
             'version_best': '12.3',
         },
-        "result":{
+        "result": {
             "distribution": "SLES_SAP",
             "distribution_major_version": "12",
             "distribution_release": "3",
@@ -542,10 +542,10 @@ BUG_REPORT_URL="https://bugs.debian.org/"
         },
         "result": {
             "distribution": "Debian",
-            "distribution_major_version": "stretch/sid",
-            "distribution_release": "NA",
+            "distribution_major_version": "9",
+            "distribution_release": "stretch",
             "os_family": "Debian",
-            "distribution_version": "stretch/sid",
+            "distribution_version": "9.8",
         }
     },
     {
@@ -598,6 +598,13 @@ DISTRIB_DESCRIPTION="SteamOS 2.0"
 """
         },
         'platform.dist': ('Steamos', '2.0', 'brewmaster'),
+        'distro': {
+            'codename': 'brewmaster',
+            'id': 'steamos',
+            'name': 'SteamOS GNU/Linux',
+            'version': '2.0',
+            'version_best': '2.0',
+        },
         'result': {
             'distribution': u'SteamOS',
             'distribution_major_version': u'2',
@@ -620,6 +627,13 @@ BUG_REPORT_URL="https://bugs.devuan.org/"
 """
         },
         'platform.dist': ('', '', ''),
+        'distro': {
+            'codename': 'jessie',
+            'id': 'devuan',
+            'name': 'Devuan GNU/Linux',
+            'version': '1',
+            'version_best': '1',
+        },
         'result': {
             'distribution': u'Devuan',
             'distribution_major_version': u'1',
@@ -640,6 +654,13 @@ BUG_REPORT_URL="https://bugs.devuan.org/"
 """
         },
         'platform.dist': ('', '', ''),
+        'distro': {
+            'codename': '',
+            'id': 'devuan',
+            'name': 'Devuan GNU/Linux',
+            'version': '',
+            'version_best': '',
+        },
         'result': {
             'distribution': u'Devuan',
             'distribution_major_version': u'NA',
@@ -654,6 +675,13 @@ BUG_REPORT_URL="https://bugs.devuan.org/"
             "16.04",
             "xenial"
         ],
+        'distro': {
+            'codename': 'xenial',
+            'id': 'ubuntu',
+            'name': 'Ubuntu',
+            'version': '16.04',
+            'version_best': '16.04.6',
+        },
         "input": {
             "/etc/os-release": (
                 "NAME=\"Ubuntu\"\nVERSION=\"16.04 LTS (Xenial Xerus)\"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME=\"Ubuntu 16.04 LTS\"\n"
@@ -682,6 +710,13 @@ DISTRIB_DESCRIPTION="Ubuntu 10.04.4 LTS
 """
             },
         'platform.dist': ('Ubuntu', '10.04', 'lucid'),
+        'distro': {
+            'codename': 'lucid',
+            'id': 'ubuntu',
+            'name': 'Ubuntu',
+            'version': '10.04',
+            'version_best': '10.04.1',
+        },
         'result':
             {
                 'distribution': u'Ubuntu',
@@ -711,6 +746,13 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 """
         },
         'platform.dist': ('Ubuntu', '14.04', 'trusty'),
+        'distro': {
+            'codename': 'trusty',
+            'id': 'ubuntu',
+            'name': 'Ubuntu',
+            'version': '14.04',
+            'version_best': '14.04.4',
+        },
         'result': {
             'distribution': u'Ubuntu',
             'distribution_major_version': u'14',
@@ -734,6 +776,13 @@ PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
 VERSION_ID="12.04"
 """},
         'platform.dist': ('Ubuntu', '12.04', 'precise'),
+        'distro': {
+            'codename': 'precise',
+            'id': 'ubuntu',
+            'name': 'Ubuntu',
+            'version': '12.04',
+            'version_best': '12.04.5',
+        },
         'result': {'distribution': u'Ubuntu',
                    'distribution_major_version': u'12',
                    'distribution_release': u'precise',
@@ -757,6 +806,13 @@ VERSION_ID="12.04"
             '2019.1',
             ''
         ],
+        'distro': {
+            'codename': 'kali-rolling',
+            'id': 'kali',
+            'name': 'Kali GNU/Linux Rolling',
+            'version': '2019.1',
+            'version_best': '2019.1',
+        },
         'result': {
             'distribution': 'Kali',
             'distribution_version': '2019.1',
@@ -771,6 +827,13 @@ VERSION_ID="12.04"
             "16.04",
             "xenial"
         ],
+        'distro': {
+            'codename': 'xenial',
+            'id': 'neon',
+            'name': 'KDE neon',
+            'version': '16.04',
+            'version_best': '16.04',
+        },
         "input": {
             "/etc/os-release": ("NAME=\"KDE neon\"\nVERSION=\"5.8\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.8\"\n"
                                 "VERSION_ID=\"16.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\n"
@@ -807,11 +870,17 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
 """,
         },
         'platform.dist': ('', '', ''),
+        'distro': {
+            'codename': 'Coeur Rouge',
+            'id': 'coreos',
+            'name': 'CoreOS',
+            'version': '976.0.0',
+            'version_best': '976.0.0',
+        },
         'platform.release': '',
         'result': {
             "distribution": "CoreOS",
-            "distribution_major_version": "NA",
-            "distribution_release": "NA",
+            "distribution_major_version": "976",
             "distribution_version": "976.0.0",
         }
     },
@@ -830,6 +899,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                       SmartOS 20160330T234717Z x86_64\n"
                              "              Copyright 2010 Sun Microsystems, Inc.  All Rights Reserved.\n"
@@ -866,6 +942,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                                SmartOS x86_64\n              Copyright 2010 Sun Microsystems, Inc.  All Rights Reserved.\n"
                              "              Copyright 2010-2013 Joyent, Inc.  All Rights Reserved.\n                        Use is subject to license terms.\n"
@@ -888,6 +971,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("             OpenIndiana Development oi_151.1.9 X86 (powered by illumos)\n        Copyright 2011 Oracle and/or its affiliates. "
                              "All rights reserved.\n                        Use is subject to license terms.\n                           "
@@ -909,6 +999,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         #        "platform.release": 'OmniOS',
         "input": {
             "/etc/release": (
@@ -931,6 +1028,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "platform.release:": "",
         "input": {
             "/etc/release": ("                         Open Storage Appliance v3.1.6\n           Copyright (c) 2014 Nexenta Systems, Inc.  "
@@ -953,6 +1057,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                        Open Storage Appliance 4.0.3-FP2\n           Copyright (c) 2014 Nexenta Systems, Inc.  "
                              "All Rights Reserved.\n           Copyright (c) 2010 Oracle.  All Rights Reserved.\n                        "
@@ -976,6 +1087,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                       Solaris 10 10/09 s10x_u8wos_08a X86\n           Copyright 2009 Sun Microsystems, Inc.  "
                              "All Rights Reserved.\n                        Use is subject to license terms.\n                           "
@@ -999,6 +1117,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                           Oracle Solaris 11 11/11 X86\n  Copyright (c) 1983, 2011, Oracle and/or its affiliates.  "
                              "All rights reserved.\n                            Assembled 18 October 2011\n")
@@ -1013,6 +1138,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": (
                 "                             Oracle Solaris 11.3 X86\n  Copyright (c) 1983, 2018, Oracle and/or its affiliates.  "
@@ -1036,6 +1168,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": (
                 "                            Oracle Solaris 11.4 SPARC\n    Copyright (c) 1983, 2018, Oracle and/or its affiliates."
@@ -1059,6 +1198,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': '',
+            'name': '',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/release": ("                    Oracle Solaris 10 1/13 s10x_u11wos_24a X86\n  Copyright (c) 1983, 2013, Oracle and/or its affiliates. "
                              "All rights reserved.\n                            Assembled 17 January 2013\n")
@@ -1079,6 +1225,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "22",
             "Twenty Two"
         ],
+        'distro': {
+            'codename': 'Twenty Two',
+            'id': 'fedora',
+            'name': 'Fedora',
+            'version': '22',
+            'version_best': '22',
+        },
         "input": {
             "/etc/redhat-release": "Fedora release 22 (Twenty Two)\n",
             "/etc/os-release": (
@@ -1104,6 +1257,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "25",
             "Rawhide"
         ],
+        'distro': {
+            'codename': 'Rawhide',
+            'id': 'fedora',
+            'name': 'Fedora',
+            'version': '25',
+            'version_best': '25',
+        },
         "input": {
             "/etc/redhat-release": "Fedora release 25 (Rawhide)\n",
             "/etc/os-release": (
@@ -1131,6 +1291,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': 'smgl',
+            'name': 'Source Mage GNU/Linux',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/sourcemage-release": ("Source Mage GNU/Linux x86_64-pc-linux-gnu\nInstalled from tarball using chroot image (Grimoire 0.61-rc) "
                                         "on Thu May 17 17:31:37 UTC 2012\n")
@@ -1152,6 +1319,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': 'arch',
+            'name': 'Arch Linux',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/os-release": "NAME=\"Arch Linux\"\nPRETTY_NAME=\"Arch Linux\"\nID=arch\nID_LIKE=archlinux\nANSI_COLOR=\"0;36\"\nHOME_URL=\"https://www.archlinux.org/\"\nSUPPORT_URL=\"https://bbs.archlinux.org/\"\nBUG_REPORT_URL=\"https://bugs.archlinux.org/\"\n\n",  # noqa
             "/etc/arch-release": "",
@@ -1173,6 +1347,13 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         "26580",
         "clear-linux-os"
     ],
+    'distro': {
+        'codename': '',
+        'id': 'clear-linux-os',
+        'name': 'Clear Linux OS',
+        'version': '26580',
+        'version_best': '26580',
+    },
     "input": {
         "/etc/os-release": '''
 NAME="Clear Linux OS"
@@ -1218,6 +1399,13 @@ PRIVACY_POLICY_URL="http://www.intel.com/privacy"
             "",
             ""
         ],
+        'distro': {
+            'codename': '',
+            'id': 'arch',
+            'name': 'Arch Linux',
+            'version': '',
+            'version_best': '',
+        },
         "input": {
             "/etc/os-release": "NAME=\"Arch Linux\"\nPRETTY_NAME=\"Arch Linux\"\nID=arch\nID_LIKE=archlinux\nANSI_COLOR=\"0;36\"\nHOME_URL=\"https://www.archlinux.org/\"\nSUPPORT_URL=\"https://bbs.archlinux.org/\"\nBUG_REPORT_URL=\"https://bugs.archlinux.org/\"\n\n",  # noqa
         },
@@ -1245,6 +1433,13 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
 """
         },
         'platform.dist': ('debian', '8.11', ''),
+        'distro': {
+            'codename': '',
+            'id': 'cumulus-linux',
+            'name': 'Cumulus Linux',
+            'version': '3.7.3',
+            'version_best': '3.7.3',
+        },
         'result': {
             'distribution': 'Cumulus Linux',
             'distribution_major_version': '3',
@@ -1268,6 +1463,13 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
 """
         },
         'platform.dist': ('', '', ''),
+        'distro': {
+            'codename': '',
+            'id': 'cumulus-linux',
+            'name': 'Cumulus Linux',
+            'version': '2.5.4',
+            'version_best': '2.5.4',
+        },
         'result': {
             'distribution': 'Cumulus Linux',
             'distribution_major_version': '2',
@@ -1282,12 +1484,19 @@ SUPPORT_URL="http://support.cumulusnetworks.com/"
             "18.3",
             "sylvia",
         ],
+        'distro': {
+            'codename': 'Sylvia',
+            'id': 'linuxmint',
+            'name': 'Linux Mint',
+            'version': '18.3',
+            'version_best': '18.3',
+        },
         "input": {
             "/etc/os-release": "NAME=\"Linux Mint\"\nVERSION=\"18.3 (Sylvia)\"\nID=linuxmint\nID_LIKE=ubuntu\nPRETTY_NAME=\"Linux Mint 18.3\"\nVERSION_ID=\"18.3\"\nHOME_URL=\"http://www.linuxmint.com/\"\nSUPPORT_URL=\"http://forums.linuxmint.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/linuxmint/\"\nVERSION_CODENAME=sylvia\nUBUNTU_CODENAME=xenial",  # noqa
         },
         "name": "Linux Mint 18.3",
         "result": {
-            "distribution_release": "sylvia",
+            "distribution_release": "Sylvia",
             "distribution": "Linux Mint",
             "distribution_major_version": "18",
             "os_family": "Debian",
@@ -1351,6 +1560,9 @@ def test_distribution_version(am, mocker, testcase):
     def mock_distro_name():
         return testcase['distro']['name']
 
+    def mock_distro_id():
+        return testcase['distro']['id']
+
     def mock_distro_version(best=False):
         if best:
             return testcase['distro']['version_best']
@@ -1376,7 +1588,7 @@ def test_distribution_version(am, mocker, testcase):
     mocker.patch('ansible.module_utils.facts.system.distribution.get_uname', mock_get_uname)
     mocker.patch('ansible.module_utils.facts.system.distribution._file_exists', mock_file_exists)
     mocker.patch('ansible.module_utils.distro.name', mock_distro_name)
-    mocker.patch('ansible.module_utils.distro.id', mock_distro_name)
+    mocker.patch('ansible.module_utils.distro.id', mock_distro_id)
     mocker.patch('ansible.module_utils.distro.version', mock_distro_version)
     mocker.patch('ansible.module_utils.distro.codename', mock_distro_codename)
     mocker.patch('os.path.isfile', mock_os_path_is_file)


### PR DESCRIPTION
##### SUMMARY
By default, `distro.version()` returns the _first_ version information it finds. In `/etc/os-release` on many distributions, this does not include minor version information. Prior to Ansible 2.8.0, `ansible_facts['distribution_version']` included major and minor version information:

Fixes #57463

```
# Ansible 2.7.11
lab-deb9 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Debian",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "stretch",
        "ansible_distribution_version": "9.8"
    },
    "changed": false
}
lab-centos7 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "CentOS",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "Core",
        "ansible_distribution_version": "7.5.1804"
    },
    "changed": false
}
lab-ub1804 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Ubuntu",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "18",
        "ansible_distribution_release": "bionic",
        "ansible_distribution_version": "18.04"
    },
    "changed": false
}
```

```
# Ansible 2.8.1
lab-deb9 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Debian",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "stretch",
        "ansible_distribution_version": "9",
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false
}
lab-centos7 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "CentOS",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "Core",
        "ansible_distribution_version": "7"
    },
    "changed": false
}
lab-ub1804 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Ubuntu",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "18",
        "ansible_distribution_release": "bionic",
        "ansible_distribution_version": "18.04"
    },
    "changed": false
}
```

We can get more detailed version information from `distro` by using `distro.version(best=True)`. This gets the minor version back for CentOS and Debian but returns _more_ information for Ubuntu and potentially other distributions as well.

```
# Output with this patch
lab-ub1804 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Ubuntu",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "18",
        "ansible_distribution_release": "bionic",
        "ansible_distribution_version": "18.04.2"
    },
    "changed": false
}
lab-centos7 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "CentOS",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "Core",
        "ansible_distribution_version": "7.5.1804"
    },
    "changed": false
}
lab-deb9 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "Debian",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "stretch",
        "ansible_distribution_version": "9.8",
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false
}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/common/sys_info.py`

##### ADDITIONAL INFORMATION
This [came up during the 2.8 beta](https://github.com/ansible/ansible/issues/50141#issuecomment-449452781) and for CentOS it was deemed appropriate by the CentOS maintainers that not including the minor version was ok. Since the 2.8.0 release, several issues have been opened and the absence of this information is causing issues for Ansible users. I feel this is a loss of valuable data that we need to provide and have historically provided.