### PR TITLE
Add Python 3 support to ovirt4 inventory script.

### DIFF
--- a/changelogs/fragments/57824-python-3-support-ovirt-dynamic-inv.yml
+++ b/changelogs/fragments/57824-python-3-support-ovirt-dynamic-inv.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ovirt3 inventory - Updated the dynamic inventory script for Python 3 support

--- a/changelogs/fragments/57824-python-3-support-ovirt-dynamic-inv.yml
+++ b/changelogs/fragments/57824-python-3-support-ovirt-dynamic-inv.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ovirt3 inventory - Updated the dynamic inventory script for Python 3 support
+  - ovirt4 inventory - Updated the dynamic inventory script for Python 3 support

--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -121,7 +121,7 @@ def create_connection():
             'ovirt_url': os.environ.get('OVIRT_URL'),
             'ovirt_username': os.environ.get('OVIRT_USERNAME'),
             'ovirt_password': os.environ.get('OVIRT_PASSWORD'),
-            'ovirt_ca_file': os.environ.get('OVIRT_CAFILE'),
+            'ovirt_ca_file': os.environ.get('OVIRT_CAFILE', ''),
         }
     )
     if not config.has_section('ovirt'):
@@ -133,8 +133,8 @@ def create_connection():
         url=config.get('ovirt', 'ovirt_url'),
         username=config.get('ovirt', 'ovirt_username'),
         password=config.get('ovirt', 'ovirt_password', raw=True),
-        ca_file=config.get('ovirt', 'ovirt_ca_file'),
-        insecure=config.get('ovirt', 'ovirt_ca_file') is None,
+        ca_file=config.get('ovirt', 'ovirt_ca_file') or None,
+        insecure=not config.get('ovirt', 'ovirt_ca_file'),
     )
 
 


### PR DESCRIPTION
##### SUMMARY
Python 3 only allows strings through the config parser. This is fine for 
the URL, Username, and Password since these values are required. The CA 
File is optional so an empty string is used in lieu of None in the 
config dictionary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ovirt4

##### ADDITIONAL INFORMATION

