### PR TITLE
default value for become= should be False

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -338,7 +338,7 @@
 #unparsed_is_failed=False
 
 [privilege_escalation]
-#become=True
+#become=False
 #become_method=sudo
 #become_user=root
 #become_ask_pass=False


### PR DESCRIPTION
##### SUMMARY
The default value for `DEFAULT_BECOME` is `False` but default config file doesn't reflect this behavior.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Default config file.

##### ADDITIONAL INFORMATION

```console
$ ansible-config dump /etc/ansible/ansible.cfg | grep DEFAULT_BECOME
DEFAULT_BECOME(default) = False
[..]
$ grep "become=" /etc/ansible/ansible.cfg
#become=True
```
