### PR TITLE
gitlab_runner: Fix idempotency when creating runner

### DIFF
--- a/changelogs/fragments/57833-gitlab_runner-Fix-idempotency-on-creation.yml
+++ b/changelogs/fragments/57833-gitlab_runner-Fix-idempotency-on-creation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_runner - Fix idempotency when creating runner (https://github.com/ansible/ansible/issues/57759)

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -259,10 +259,10 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def findRunner(self, description):
-        runners = self._gitlab.runners.all()
+        runners = self._gitlab.runners.list(as_list=False)
         for runner in runners:
-            if (runner['description'] == description):
-                return self._gitlab.runners.get(runner['id'])
+            if (runner.description == description):
+                return self._gitlab.runners.get(runner.id)
 
     '''
     @param description Description of the runner

--- a/test/units/modules/source_control/gitlab.py
+++ b/test/units/modules/source_control/gitlab.py
@@ -519,13 +519,30 @@ def resp_delete_project_hook(url, request):
 
 
 '''
-HOOK API
+RUNNER API
 '''
 
 
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners/all", method="get")
-def resp_find_runners(url, request):
+def resp_find_runners_all(url, request):
     headers = {'content-type': 'application/json'}
+    content = ('[{"active": true,"description": "test-1-20150125","id": 1,'
+               '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
+               '"online": true,"status": "online"},{"active": true,'
+               '"description": "test-2-20150125","id": 2,"ip_address": "127.0.0.1",'
+               '"is_shared": false,"name": null,"online": false,"status": "offline"}]')
+    content = content.encode("utf-8")
+    return response(200, content, headers, None, 5, request)
+
+
+@urlmatch(scheme="http", netloc="localhost", path="/api/v4/runners", method="get")
+def resp_find_runners_list(url, request):
+    headers = {'content-type': 'application/json',
+               "X-Page": 1,
+               "X-Next-Page": 2,
+               "X-Per-Page": 1,
+               "X-Total-Pages": 1,
+               "X-Total": 2}
     content = ('[{"active": true,"description": "test-1-20150125","id": 1,'
                '"is_shared": false,"ip_address": "127.0.0.1","name": null,'
                '"online": true,"status": "online"},{"active": true,'

--- a/test/units/modules/source_control/test_gitlab_runner.py
+++ b/test/units/modules/source_control/test_gitlab_runner.py
@@ -9,7 +9,7 @@ from ansible.modules.source_control.gitlab_runner import GitLabRunner
 
 from .gitlab import (GitlabModuleTestCase,
                      python_version_match_requirement,
-                     resp_find_runners, resp_get_runner,
+                     resp_find_runners_list, resp_get_runner,
                      resp_create_runner, resp_delete_runner)
 
 # Gitlab module requirements
@@ -26,7 +26,7 @@ class TestGitlabRunner(GitlabModuleTestCase):
 
         self.moduleUtil = GitLabRunner(module=self.mock_module, gitlab_instance=self.gitlab_instance)
 
-    @with_httmock(resp_find_runners)
+    @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     def test_runner_exist(self):
         rvalue = self.moduleUtil.existsRunner("test-1-20150125")
@@ -44,7 +44,7 @@ class TestGitlabRunner(GitlabModuleTestCase):
         self.assertEqual(type(runner), Runner)
         self.assertEqual(runner.description, "test-1-20150125")
 
-    @with_httmock(resp_find_runners)
+    @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     def test_update_runner(self):
         runner = self.moduleUtil.findRunner("test-1-20150125")
@@ -60,7 +60,7 @@ class TestGitlabRunner(GitlabModuleTestCase):
         self.assertEqual(changed, False)
         self.assertEqual(newRunner.description, "Runner description")
 
-    @with_httmock(resp_find_runners)
+    @with_httmock(resp_find_runners_list)
     @with_httmock(resp_get_runner)
     @with_httmock(resp_delete_runner)
     def test_delete_runner(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
GitLab pagination default limit is 20 element by page.
When looking for non existing runner before creating one, the module was not looking beyond 20 runner.
Making the module non idempotent with more than 20 runners.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #57759

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

gitlab_runner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
