### PR TITLE
Remove redundant line in os_port

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -356,8 +356,7 @@ def main():
 
         # Neutron API accept 'binding:vnic_type' as an argument
         # for the port type.
-        module.params['binding:vnic_type'] = module.params['vnic_type']
-        module.params.pop('vnic_type', None)
+        module.params['binding:vnic_type'] = module.params.pop('vnic_type')
 
         port = None
         network_id = None

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -162,6 +162,7 @@ EXAMPLES = '''
       password: admin
       project_name: admin
     name: port1
+    network: foo
     vnic_type: direct
 '''
 


### PR DESCRIPTION
The renaming of the key 'vnic_type' to 'binding:vnic_type'
is reduced to a single line.
The old key is removed to avoid to possibility of
inconsistency.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Just a code improvement, no change in behavior.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### COMPONENT NAME
os_port

