### PR TITLE
[nxos] New parameter vrf in nxos_file_copy

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -116,6 +116,7 @@ options:
   vrf:
     description:
       - The VRF used to pull the file. Useful when no vrf management is defined
+    default: "management"
     version_added: "2.9"
 '''
 

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -113,6 +113,9 @@ options:
       - The remote scp server password which is used to pull the file.
         This is required if file_pull is True.
     version_added: "2.7"
+  vrf:
+    description:
+      - The VRF used to pull the file. Useful when no vrf management is defined
 '''
 
 EXAMPLES = '''
@@ -133,6 +136,7 @@ EXAMPLES = '''
       remote_scp_server: "192.168.0.1"
       remote_scp_server_user: "myUser"
       remote_scp_server_password: "myPassword"
+      vrf: "management"
 '''
 
 RETURN = '''
@@ -308,7 +312,7 @@ def copy_file_from_remote(module, local, local_file_directory, file_system='boot
         ruser = module.params['remote_scp_server_user'] + '@'
         rserver = module.params['remote_scp_server']
         rfile = module.params['remote_file'] + ' '
-        vrf = ' vrf management'
+        vrf = ' vrf ' + module.params['vrf']
         command = (cmdroot + ruser + rserver + rfile + file_system + ldir + local + vrf)
 
         child.sendline(command)
@@ -362,6 +366,7 @@ def main():
         remote_scp_server=dict(type='str'),
         remote_scp_server_user=dict(type='str'),
         remote_scp_server_password=dict(no_log=True),
+        vrf=dict(required=False, type='str', default='management'),
     )
 
     argument_spec.update(nxos_argument_spec)

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -116,6 +116,7 @@ options:
   vrf:
     description:
       - The VRF used to pull the file. Useful when no vrf management is defined
+    version_added: "2.9"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
New parameter VRF for module nxos_file_copy
By default, the nxos_file_copy module uses the "vrf management" in its command:
`copy scp://username@server/path bootflash: vrf management`
If vrf management does not exist, this will return a no route to host.

This new parameter vrf will override 'vrf management' when needed.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/nxos/nxos_file_copy.py

##### ADDITIONAL INFORMATION
When using poap script, I'm having the very minimal configuration on my nxos. Moreover, I can also have specific cases where I don't use the management interface (int mgmt0) which means I'm using 'vrf default'.
