### PR TITLE
Correcting the documentation for win_package return value[log]

### DIFF
--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -243,7 +243,7 @@ EXAMPLES = r'''
 RETURN = r'''
 log:
   description: The contents of the MSI log.
-  returned: failure during install and package is an MSI
+  returned: installation/uninstallation failure for MSI packages
   type: str
   sample: Installation completed successfully
 rc:

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -243,7 +243,7 @@ EXAMPLES = r'''
 RETURN = r'''
 log:
   description: The contents of the MSI log.
-  returned: change occured and package is an MSI
+  returned: failure during install and package is an MSI
   type: str
   sample: Installation completed successfully
 rc:


### PR DESCRIPTION
##### SUMMARY
win_package module document says the return value contains log when change occurred for an msi package.
Fixes: #57792 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
[win_package](https://docs.ansible.com/ansible/latest/modules/win_package_module.html)