### PR TITLE
Remove needs/ssh alias from callback_default test.

### DIFF
--- a/test/integration/targets/callback_default/aliases
+++ b/test/integration/targets/callback_default/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group3
-needs/ssh


### PR DESCRIPTION
##### SUMMARY

Remove needs/ssh alias from callback_default test.

The test does not require ssh.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

callback_default integration test
