### PR TITLE
add 'only_transfers_as_changes' option to synchronize module

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -183,6 +183,7 @@ options:
       - Only files really transfered are considered as changes. Changing of permissions, ownership or times is NOT considered a change
     type: bool
     default: no
+    version_added: "2.9"
 notes:
    - rsync must be installed on both the local and remote host.
    - For the C(synchronize) module, the "local host" is the host `the synchronize task originates on`, and the "destination host" is the host
@@ -454,7 +455,7 @@ def main():
     link_dest = module.params['link_dest']
     only_transfers_as_changes = module.params['only_transfers_as_changes']
     if only_transfers_as_changes:
-      checksum = True
+        checksum = True
 
     if '/' not in rsync:
         rsync = module.get_bin_path(rsync, required=True)

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -181,9 +181,8 @@ options:
   only_transfers_as_changes:
     description:
       - Only files really transfered are considered as changes. Changing of permissions, ownership or times is NOT considered a change
-      - sets "checksum: yes"
     type: bool
-    default: 0
+    default: no
 notes:
    - rsync must be installed on both the local and remote host.
    - For the C(synchronize) module, the "local host" is the host `the synchronize task originates on`, and the "destination host" is the host
@@ -414,7 +413,7 @@ def main():
             verify_host=dict(type='bool', default=False),
             mode=dict(type='str', default='push', choices=['pull', 'push']),
             link_dest=dict(type='list'),
-            only_transfers_as_changes=dict(type=bool, default=False)
+            only_transfers_as_changes=dict(type='bool', default=False)
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -183,7 +183,7 @@ options:
       - Only files really transfered are considered as changes. Changing of permissions, ownership or times is NOT considered a change
     type: bool
     default: no
-    version_added: "2.9"
+    version_added: "2.10"
 notes:
    - rsync must be installed on both the local and remote host.
    - For the C(synchronize) module, the "local host" is the host `the synchronize task originates on`, and the "destination host" is the host


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds a new option 'only_transfers_as_changes' to the synchronize module.

**Rationale**
When managing configurations to be deployed with ansible in git the time stamps of the files aren't preserved. When working with a distributed team this means time stamps of config files are always local to the member's computers. This together with the usage of the synchronize module often results in ansible detecting changes where there actually aren't any and in consequence unnecessary restarts of services at deploy time - often services the person wasn't even working on.

This PR adds a new boolean option 'only_transfers_as_changes' to the synchronize module that does the following:
- enforces the 'checksum' mode on rsync
- sets the 'changed' flag with in the module solely depending on real transfers TO the destination (as indicated by the '<' flag in rsync's response)

While setting the 'checksum' option may have an impact on synchronize's performance this should be negligible considering the main use would be for relatively small text files.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sychronize

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
