### PR TITLE
Backport/2.8/57264 update vxlan to fix bugs

### DIFF
--- a/changelogs/fragments/57264-update-vxlan-to-fix-bugs.yml
+++ b/changelogs/fragments/57264-update-vxlan-to-fix-bugs.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - ce_dldp - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
+  - ce_dldp_interface - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
+  - ce_vxlan_arp - override 'get_config' to show specific configuration.
+  - ce_vxlan_gateway - override 'get_config' to show specific configuration.
+  - ce_vxlan_global - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
+  - ce_vxlan_tunnel - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
+  - ce_vxlan_vap - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.

--- a/changelogs/fragments/57889-update-scmp-to-fix-bugs.yml
+++ b/changelogs/fragments/57889-update-scmp-to-fix-bugs.yml
@@ -7,4 +7,3 @@ bugfixes:
   - ce_vxlan_global - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
   - ce_vxlan_tunnel - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
   - ce_vxlan_vap - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
-

--- a/changelogs/fragments/57889-update-scmp-to-fix-bugs.yml
+++ b/changelogs/fragments/57889-update-scmp-to-fix-bugs.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - update scmp to fix bugs.(https://github.com/ansible/ansible/pull/57264)
+  - ce_dldp - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
+  - ce_dldp_interface - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
+  - ce_vxlan_arp - override 'get_config' to show specific configuration.
+  - ce_vxlan_gateway - override 'get_config' to show specific configuration.
+  - ce_vxlan_global - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
+  - ce_vxlan_tunnel - Netwrok_cli and netconf should be not mixed together, otherwise something bad will happen. Function get_nc_config uses netconf and load_config uses network_cli.
+  - ce_vxlan_vap - tag named data of a xpath is unnecessay for old sotfware version to find a element from xml tree, but element can not be found with 'data' tag for new version, so remove.
+

--- a/lib/ansible/modules/network/cloudengine/ce_dldp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp.py
@@ -321,7 +321,7 @@ class Dldp(object):
 
         # get global DLDP info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/dldp/dldpSys")
+        topo = root.find("dldp/dldpSys")
         if not topo:
             self.module.fail_json(
                 msg="Error: Get current DLDP configration failed.")

--- a/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
@@ -454,7 +454,7 @@ class DldpInterface(object):
 
         # get global DLDP info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/dldp/dldpInterfaces/dldpInterface")
+        topo = root.find("dldp/dldpInterfaces/dldpInterface")
         if topo is None:
             self.module.fail_json(
                 msg="Error: Get current DLDP configration failed.")

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
@@ -150,8 +150,9 @@ changed:
 
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import load_config
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
+from ansible.module_utils.connection import exec_command
 
 
 def is_config_exist(cmp_cfg, test_cfg):
@@ -265,6 +266,22 @@ class VxlanArp(object):
         if not self.module.check_mode:
             load_config(self.module, commands)
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_current_config(self):
         """get current configuration"""
 
@@ -277,9 +294,14 @@ class VxlanArp(object):
             exp += "|^bridge-domain %s$" % self.bridge_domain_id
 
         flags.append(exp)
-        config = get_config(self.module, flags)
+        cfg_str = self.get_config(flags)
+        config = cfg_str.split("\n")
 
-        return config
+        exist_config = ""
+        for cfg in config:
+            if not cfg.startswith("display"):
+                exist_config += cfg
+        return exist_config
 
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
@@ -123,23 +123,10 @@ changed:
 '''
 
 import re
-from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config, get_nc_config
+from ansible.module_utils.network.cloudengine.ce import load_config
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
-
-
-CE_NC_GET_BRIDGE_DOMAIN = """
-    <filter type="subtree">
-      <evc xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-        <bds>
-          <bd>
-            <bdId></bdId>
-          </bd>
-        </bds>
-      </evc>
-    </filter>
-"""
+from ansible.module_utils.connection import exec_command
 
 
 def is_config_exist(cmp_cfg, test_cfg):
@@ -206,13 +193,29 @@ class VxlanGlobal(object):
         if not self.module.check_mode:
             load_config(self.module, commands)
 
+    def get_config(self, flags=None):
+        """Retrieves the current config from the device or cache
+        """
+        flags = [] if flags is None else flags
+
+        cmd = 'display current-configuration '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+        rc, out, err = exec_command(self.module, cmd)
+        if rc != 0:
+            self.module.fail_json(msg=err)
+        cfg = str(out).strip()
+
+        return cfg
+
     def get_current_config(self):
         """get current configuration"""
 
         flags = list()
         exp = " include-default | include vxlan|assign | exclude undo"
         flags.append(exp)
-        return get_config(self.module, flags)
+        return self.get_config(flags)
 
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""
@@ -228,27 +231,15 @@ class VxlanGlobal(object):
 
     def get_bd_list(self):
         """get bridge domain list"""
-
+        flags = list()
         bd_info = list()
-        conf_str = CE_NC_GET_BRIDGE_DOMAIN
-        xml_str = get_nc_config(self.module, conf_str)
-        if "<data/>" in xml_str:
+        exp = " include-default | include bridge-domain | exclude undo"
+        flags.append(exp)
+        bd_str = self.get_config(flags)
+        if not bd_str:
             return bd_info
-
-        xml_str = xml_str.replace('\r', '').replace('\n', '').\
-            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
-            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
-
-        # get bridge domain info
-        root = ElementTree.fromstring(xml_str)
-        bds = root.findall("data/evc/bds/bd/bdId")
-        if not bds:
-            return bd_info
-
-        for bridge_domain in bds:
-            if bridge_domain.tag == "bdId":
-                bd_info.append(bridge_domain.text)
-
+        bd_num = re.findall(r'bridge-domain\s*([0-9]+)', bd_str)
+        bd_info.append(bd_num)
         return bd_info
 
     def config_bridge_domain(self):

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
@@ -451,9 +451,6 @@ class VxlanVap(object):
         conf_str = CE_NC_GET_BD_VAP % self.bridge_domain_id
         xml_str = get_nc_config(self.module, conf_str)
 
-        if "<data/>" in xml_str:
-            return vap_info
-
         xml_str = xml_str.replace('\r', '').replace('\n', '').\
             replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
@@ -462,8 +459,7 @@ class VxlanVap(object):
         vap_info["bdId"] = self.bridge_domain_id
         root = ElementTree.fromstring(xml_str)
         vap_info["vlanList"] = ""
-        vap_vlan = root.find("data/evc/bds/bd/bdBindVlan")
-        vap_info["vlanList"] = ""
+        vap_vlan = root.find("evc/bds/bd/bdBindVlan")
         if vap_vlan:
             for ele in vap_vlan:
                 if ele.tag == "vlanList":
@@ -471,7 +467,7 @@ class VxlanVap(object):
 
         # get vap: l2 su-interface
         vap_ifs = root.findall(
-            "data/evc/bds/bd/servicePoints/servicePoint/ifName")
+            "evc/bds/bd/servicePoints/servicePoint/ifName")
         if_list = list()
         if vap_ifs:
             for vap_if in vap_ifs:
@@ -500,7 +496,7 @@ class VxlanVap(object):
 
         # get l2 sub interface encapsulation info
         root = ElementTree.fromstring(xml_str)
-        bds = root.find("data/ethernet/servicePoints/servicePoint")
+        bds = root.find("ethernet/servicePoints/servicePoint")
         if not bds:
             return intf_info
 
@@ -510,7 +506,7 @@ class VxlanVap(object):
 
         if intf_info.get("flowType") == "dot1q":
             ce_vid = root.find(
-                "data/ethernet/servicePoints/servicePoint/flowDot1qs")
+                "ethernet/servicePoints/servicePoint/flowDot1qs")
             intf_info["dot1qVids"] = ""
             if ce_vid:
                 for ele in ce_vid:
@@ -518,7 +514,7 @@ class VxlanVap(object):
                         intf_info["dot1qVids"] = ele.text
         elif intf_info.get("flowType") == "qinq":
             vids = root.find(
-                "data/ethernet/servicePoints/servicePoint/flowQinqs/flowQinq")
+                "ethernet/servicePoints/servicePoint/flowQinqs/flowQinq")
             if vids:
                 for ele in vids:
                     if ele.tag in ["peVlanId", "ceVids"]:
@@ -707,9 +703,6 @@ class VxlanVap(object):
 
     def config_vap_vlan(self):
         """configure a VLAN as a service access point"""
-
-        if not self.vap_info:
-            self.module.fail_json(msg="Error: Bridge domain %s does not exist." % self.bridge_domain_id)
 
         xml_str = ""
         if self.state == "present":


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit 5bddd55)
<!--- Describe the change below, including rationale and design decisions -->
Backport/2.8/57264 update vxlan to fix bugs
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_dldp.py
lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
lib/ansible/modules/network/cloudengine/ce_vxlan_arp.py
lib/ansible/modules/network/cloudengine/ce_vxlan_gateway.py
lib/ansible/modules/network/cloudengine/ce_vxlan_global.py
lib/ansible/modules/network/cloudengine/ce_vxlan_tunnel.py
lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Some test logs.
tasks:

name: "Gather_subset is config"
ce_facts:
gather_subset: config
<---Before modify-->
<172.101.14.11> using connection plugin network_cli (was local)
<172.101.14.11> ESTABLISH LOCAL CONNECTION FOR USER: root
<172.101.14.11> EXEC /bin/sh -c 'echo ~root && sleep 0'
<172.101.14.11> EXEC /bin/sh -c '( umask 77 && mkdir -p "echo /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832" && echo ansible-tmp-1555571807.65-165202209042832="echo /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832" ) && sleep 0'
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/network/cloudengine/ce_facts.py
<172.101.14.11> PUT /root/.ansible/tmp/ansible-local-10275HeLSGN/tmpVC5ANl TO /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py
<172.101.14.11> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/ /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py && sleep 0'
<172.101.14.11> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py && sleep 0'
<172.101.14.11> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 113, in
_ansiballz_main()
File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 105, in _ansiballz_main
invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 48, in invoke_module
imp.load_module('main', mod, module, MOD_DESC)
File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 411, in
File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 396, in main
File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 327, in populate
IndexError: list index out of range
fatal: [Friend-XYS-CCM-AZ2-TP&TS-KVM-TOR-CE6850-SW1]: FAILED! => {
"changed": false,
"module_stderr": "Traceback (most recent call last):\n File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 113, in \n _ansiballz_main()\n File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 105, in _ansiballz_main\n invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n File "/root/.ansible/tmp/ansible-tmp-1555571807.65-165202209042832/AnsiballZ_ce_facts.py", line 48, in invoke_module\n imp.load_module('main', mod, module, MOD_DESC)\n File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 411, in \n File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 396, in main\n File "/tmp/ansible_ce_facts_payload_eBI4g1/main.py", line 327, in populate\nIndexError: list index out of range\n",
"module_stdout": "",
"msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
"rc": 1
}

<----After-->
ok: [10.130.200.118] => {
"ansible_facts": {
"BIOS Version": "433",
"Board Type": "CE5855-48T4S2Q-EI",
"CPLD1 Version": "102",
"MAB Version": "1",
"PCB Version": "CEM48T4S2QP03 VER B",
"config": [
"#",
"sysname 130.20",
"#",
"port split dimension interface 40GE1/0/1",
"port split dimension interface 40GE2/0/1",
"#",
"vlan batch 100 4060 to 4062",
"#",
"arp static 1.1.8.2 0008-0008-0008 interface Eth-Trunk1",
"#",
"lldp enable",
"#",
"return"
],
"discovered_interpreter_python": "/usr/bin/python",
"gather_subset": [
"default",
"config"
],
"hostname": "130.20"
},
"changed": false,
"invocation": {
"module_args": {
"gather_subset": [
"config"
],
"host": "10.130.200.118",
"password": null,
"port": 10066,
"provider": {
"host": "10.130.200.118",
"password": null,
"port": 10066,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "rsa_user",
"validate_certs": null
},
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "rsa_user",
"validate_certs": null
}
}
}

changed: [10.130.200.118] => {
"ansible_facts": {
"discovered_interpreter_python": "/usr/bin/python"
},
"changed": true,
"end_state": {
"arp_suppress": "disable",
"evn_bgp": "enable",
"evn_peer_ip": [
"7.7.7.7"
],
"evn_reflect_client": null,
"evn_server": "disable",
"evn_source_ip": "6.6.6.6",
"host_collect_protocol": null
},
"existing": {
"arp_suppress": "disable",
"evn_bgp": "disable",
"host_collect_protocol": null
},
"invocation": {
"module_args": {
"arp_collect_host": null,
"arp_suppress": null,
"bridge_domain_id": null,
"evn_bgp": "enable",
"evn_peer_ip": "7.7.7.7",
"evn_reflect_client": null,
"evn_server": null,
"evn_source_ip": "6.6.6.6",
"host": "10.130.200.118",
"host_collect_protocol": null,
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null,
"vbdif_name": null
}
},
"proposed": {
"evn_bgp": "enable",
"evn_peer_ip": "7.7.7.7",
"evn_source_ip": "6.6.6.6",
"state": "present"
},
"updates": [
"evn bgp",
"source-address 6.6.6.6",
"peer 7.7.7.7"
]
}
TASK [test the bridge_domain_id] *************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:26
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "echo /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158" && echo ansible-tmp-1556004587.56-77734157287158="echo /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158" ) && sleep 0'
<10.130.200.118> Attempting python interpreter discovery
<10.130.200.118> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54387KNgHE5/tmp81OBZ9 TO /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/ /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/AnsiballZ_ce_evpn_bd_vni.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004587.56-77734157287158/ > /dev/null 2>&1 && sleep 0'
[WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

[DEPRECATION WARNING]: Param 'transport' is deprecated. See the module docs for more information. This feature will be removed in
version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.130.200.118] => {
"ansible_facts": {
"discovered_interpreter_python": "/usr/bin/python"
},
"changed": true,
"end_state": {
"bridge_domain_id": "100",
"evpn": "enable",
"route_distinguisher": null,
"vpn_target_both": [],
"vpn_target_export": [],
"vpn_target_import": []
},
"existing": {
"bridge_domain_id": "100",
"evpn": "disable",
"route_distinguisher": null,
"vpn_target_both": [],
"vpn_target_export": [],
"vpn_target_import": []
},
"invocation": {
"module_args": {
"bridge_domain_id": "100",
"evpn": "enable",
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"route_distinguisher": null,
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null,
"vpn_target_both": null,
"vpn_target_export": null,
"vpn_target_import": null
}
},
"proposed": {
"bridge_domain_id": "100",
"evpn": "enable",
"route_distinguisher": null,
"state": "present",
"vpn_target_both": [],
"vpn_target_export": [],
"vpn_target_import": []
},
"updates": [
"bridge-domain 100",
" evpn"
]
}

TASK [test the interface] ********************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:31
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "echo /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495" && echo ansible-tmp-1556004589.29-3954101342495="echo /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_interface.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54387KNgHE5/tmpTxXDW8 TO /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/ /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/AnsiballZ_ce_interface.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004589.29-3954101342495/ > /dev/null 2>&1 && sleep 0'
changed: [10.130.200.118] => {
"changed": true,
"end_state": {
"admin_state": "down",
"description": "12121qwq",
"interface": "Vlanif3111"
},
"existing": {
"admin_state": "up",
"description": "12121qwq",
"interface": "Vlanif3111"
},
"invocation": {
"module_args": {
"admin_state": "down",
"description": null,
"host": "10.130.200.118",
"interface": "vlanif 3111",
"interface_type": null,
"l2sub": false,
"mode": null,
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
}
},
"proposed": {
"admin_state": "down",
"interface": "vlanif 3111",
"l2sub": false,
"state": "present"
},
"updates": [
"interface vlanif 3111",
"shutdown"
]
}

changed: [10.130.200.118] => {
"ansible_facts": {
"discovered_interpreter_python": "/usr/bin/python"
},
"changed": true,
"end_state": {
"arp_suppress": "disable",
"evn_bgp": "enable",
"evn_peer_ip": [
"7.7.7.7"
],
"evn_reflect_client": null,
"evn_server": "disable",
"evn_source_ip": "6.6.6.6",
"host_collect_protocol": null
},
"existing": {
"arp_suppress": "disable",
"evn_bgp": "disable",
"host_collect_protocol": null
},
"invocation": {
"module_args": {
"arp_collect_host": null,
"arp_suppress": null,
"bridge_domain_id": null,
"evn_bgp": "enable",
"evn_peer_ip": "7.7.7.7",
"evn_reflect_client": null,
"evn_server": null,
"evn_source_ip": "6.6.6.6",
"host": "10.130.200.118",
"host_collect_protocol": null,
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null,
"vbdif_name": null
}
},
"proposed": {
"evn_bgp": "enable",
"evn_peer_ip": "7.7.7.7",
"evn_source_ip": "6.6.6.6",
"state": "present"
},
"updates": [
"evn bgp",
"source-address 6.6.6.6",
"peer 7.7.7.7"
]
}

TASK [test the vni_id] **********************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:22
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "echo /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393" && echo ansible-tmp-1556004310.25-206399494407393="echo /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393" ) && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_vxlan_tunnel.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-53767vAtgrn/tmp0QNpCa TO /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/ /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/AnsiballZ_ce_vxlan_tunnel.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004310.25-206399494407393/ > /dev/null 2>&1 && sleep 0'
[WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

ok: [10.130.200.118] => {
"changed": false,
"end_state": {
"nve_interface_name": "Nve1",
"nve_mode": "mode-l2",
"source_ip": null,
"vni_peer_list_ip": [],
"vni_peer_list_protocol": [
{
"protocol": "bgp",
"vniId": "100"
}
]
},
"existing": {
"nve_interface_name": "Nve1",
"nve_mode": "mode-l2",
"source_ip": null,
"vni_peer_list_ip": [],
"vni_peer_list_protocol": [
{
"protocol": "bgp",
"vniId": "100"
}
]
},
"invocation": {
"module_args": {
"bridge_domain_id": null,
"host": "10.130.200.118",
"nve_mode": null,
"nve_name": "Nve1",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"peer_list_ip": null,
"port": 10088,
"protocol_type": "bgp",
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"source_ip": null,
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null,
"vni_id": "100"
}
},
"proposed": {
"nve_name": "Nve1",
"state": "present",
"vni_id": "100"
},
"updates": []
}

TASK [test the bridge_domain_id] ************************************************************************************************
task path: /usr/huawei/xuyuandong/test_playbook/test_ce_vxlan_global.yml:37
<10.130.200.118> using connection plugin netconf (was local)
<10.130.200.118> ESTABLISH NETCONF SSH CONNECTION FOR USER: huawei on PORT 10088 TO 10.130.200.118
<10.130.200.118> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.130.200.118> EXEC /bin/sh -c 'echo ~root && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '( umask 77 && mkdir -p "echo /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001" && echo ansible-tmp-1556004738.93-48991297696001="echo /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001" ) && sleep 0'
<10.130.200.118> Attempting python interpreter discovery
<10.130.200.118> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
Using module file /usr/local/lib/python2.7/dist-packages/ansible-2.9.0.dev0-py2.7.egg/ansible/modules/network/cloudengine/ce_vxlan_vap.py
<10.130.200.118> PUT /root/.ansible/tmp/ansible-local-54847YBeSzT/tmpTTTdXY TO /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py
<10.130.200.118> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/ /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/AnsiballZ_ce_vxlan_vap.py && sleep 0'
<10.130.200.118> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1556004738.93-48991297696001/ > /dev/null 2>&1 && sleep 0'
[WARNING]: The value 100 (type int) in a string field was converted to u'100' (type string). If this does not look like what you
expect, quote the entire value to ensure it does not change.

[DEPRECATION WARNING]: Param 'transport' is deprecated. See the module docs for more information. This feature will be removed in
version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.130.200.118] => {
"ansible_facts": {
"discovered_interpreter_python": "/usr/bin/python"
},
"changed": true,
"end_state": {
"bind_intf_list": [],
"bind_vlan_list": [
"100"
],
"bridge_domain_id": "100"
},
"existing": {
"bind_intf_list": [],
"bind_vlan_list": [],
"bridge_domain_id": "100"
},
"invocation": {
"module_args": {
"bind_vlan_id": "100",
"bridge_domain_id": "100",
"ce_vid": null,
"encapsulation": null,
"host": "10.130.200.118",
"l2_sub_interface": null,
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"pe_vid": null,
"port": 10088,
"provider": {
"host": "10.130.200.118",
"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
"port": 10088,
"ssh_keyfile": null,
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
},
"ssh_keyfile": null,
"state": "present",
"timeout": null,
"transport": "cli",
"use_ssl": null,
"username": "huawei",
"validate_certs": null
}
},
"proposed": {
"bind_vlan_id": "100",
"bridge_domain_id": "100",
"state": "present"
},
"updates": [
"bridge-domain 100",
"l2 binding vlan 100"
]
}
META: ran handlers
META: ran handlers
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
