### PR TITLE
ipaddr: Handle ipaddress index in network correctly

### DIFF
--- a/changelogs/fragments/57896-fix-ipaddr-cidr-index-handling.yml
+++ b/changelogs/fragments/57896-fix-ipaddr-cidr-index-handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'ipaddr: prevent integer indices from being parsed as ip nets'

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -630,7 +630,7 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
     # address/network is inside that specific subnet
     try:
         # ?? 6to4 and link-local were True here before.  Should they still?
-        if query and (query not in query_func_map or query == 'cidr_lookup') and ipaddr(query, 'network'):
+        if query and (query not in query_func_map or query == 'cidr_lookup') and not str(query).isdigit() and ipaddr(query, 'network'):
             iplist = netaddr.IPSet([netaddr.IPNetwork(query)])
             query = 'cidr_lookup'
     except Exception:


### PR DESCRIPTION
This commit prevents integer indices from being parsed  as ip nets 

Fixes #57895

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>

##### SUMMARY
Identifies queries representing an ip address index in a subnet and prevents it from being parsed as a subnet/ip address itself.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipaddr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #57895 for further details.
