### PR TITLE
ce_snmp_location: fix for out of array index.

### DIFF
--- a/changelogs/fragments/57903-ce_snmp_location_fix_for_out_of_array_index.yml
+++ b/changelogs/fragments/57903-ce_snmp_location_fix_for_out_of_array_index.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix bug - out of array index.There should be a judgement about array length before the value of the array is taken out.

--- a/lib/ansible/modules/network/cloudengine/ce_snmp_location.py
+++ b/lib/ansible/modules/network/cloudengine/ce_snmp_location.py
@@ -171,8 +171,9 @@ class SnmpLocation(object):
         tmp_cfg = self.cli_get_config()
         if tmp_cfg:
             temp_data = tmp_cfg.split(r"location ")
-            self.cur_cfg["location"] = temp_data[1]
-            self.existing["location"] = temp_data[1]
+            if len(temp_data) > 1:
+                self.cur_cfg["location"] = temp_data[1]
+                self.existing["location"] = temp_data[1]
 
     def get_end_state(self):
         """ Get end state """
@@ -180,7 +181,8 @@ class SnmpLocation(object):
         tmp_cfg = self.cli_get_config()
         if tmp_cfg:
             temp_data = tmp_cfg.split(r"location ")
-            self.end_state["location"] = temp_data[1]
+            if len(temp_data) > 1:
+                self.end_state["location"] = temp_data[1]
 
     def cli_load_config(self, commands):
         """ Load config by cli """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix bug: out of array index.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_snmp_location.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
line 173 & line 184
It may be out of array index.
There should be a judgement about array length  before the value of the array is taken out.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
