### PR TITLE
More iosxr integration zuul CI test fixes

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -345,8 +345,12 @@ def get_config_diff(module, running=None, candidate=None):
         return response
     elif is_netconf(module):
         if running and candidate:
-            running_data = running.split("\n", 1)[-1].rsplit("\n", 1)[0]
-            candidate_data = candidate.split("\n", 1)[-1].rsplit("\n", 1)[0]
+            # ignore rpc-reply root node and diff from data element onwards
+            running_data_ele = etree.fromstring(to_bytes(running.strip())).getchildren()[0]
+            candidate_data_ele = etree.fromstring(to_bytes(candidate.strip())).getchildren()[0]
+
+            running_data = to_text(etree.tostring(running_data_ele)).strip()
+            candidate_data = to_text(etree.tostring(candidate_data_ele)).strip()
             if running_data != candidate_data:
                 d = Differ()
                 diff = list(d.compare(running_data.splitlines(), candidate_data.splitlines()))

--- a/test/integration/targets/iosxr_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_bgp/tests/cli/basic.yaml
@@ -108,6 +108,14 @@
         that:
           - 'result.changed == false'
 
+    - name: create route-policy as prerequisite for BGP configuration
+      iosxr_config:
+        lines:
+        - no route-policy RMAP_1
+        - route-policy RMAP_1
+        - exit
+      register: result
+
     - name: Configure networks under address family
       iosxr_bgp: &af_net
         operation: merge
@@ -228,7 +236,11 @@
     - assert:
         that:
           - 'result.changed == false'
-  
+
+    - name: delete route-policy configures as prerequisite for BGP configuration (teardown)
+      iosxr_config:
+        lines: no route-policy RMAP_1
+
   when: facts['ansible_facts']['ansible_net_version'].split('[')[0] == '6.1.3'
 
 - debug: msg="END iosxr cli/iosxr_bgp.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Ignore `<rpc-reply>` node from candidate and
  running configuration in xml diff

* Add route-policy as prerequisite to BGP coonfiguration
  in integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/iosxr/iosxr.py
test/integration/targets/iosxr_bgp/tests/cli/basic.yaml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
