### PR TITLE
Updated Notes section of the meta

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -44,6 +44,7 @@ notes:
     - C(meta) is not really a module nor action_plugin as such it cannot be overwritten.
     - C(clear_facts) will remove the persistent facts from M(set_fact) using C(cacheable=True),
       but not the current host variable it creates for the current run.
+    - Looping on meta tasks is not supported.
     - This module is also supported for Windows targets.
 seealso:
 - module: assert


### PR DESCRIPTION
Meta tasks are handled differently internally than 'normal tasks' so looping on meta tasks is not supported. Editing this in the Notes section.

+label: docsite_pr

Fixes #57427

##### ISSUE TYPE
- Docs Pull Request
