### PR TITLE
win_shell - fix space escaping for custom executable (#57455) - 2.8

### DIFF
--- a/changelogs/fragments/win_shell-arg-space.yaml
+++ b/changelogs/fragments/win_shell-arg-space.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_shell - Fix bug when setting ``args.executable`` to a pace with a space

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -93,7 +93,7 @@ Else {
     $exec_args = "/c $raw_command_line"
 }
 
-$command = "$exec_application $exec_args"
+$command = "`"$exec_application`" $exec_args"
 $run_command_arg = @{
     command = $command
 }

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -269,7 +269,7 @@
     - no_profile is changed
     - no_profile.cmd == "[System.Environment]::CommandLine"
     - no_profile.rc == 0
-    - no_profile.stdout is match ('^powershell.exe -noninteractive -encodedcommand')
+    - no_profile.stdout is match ('^"powershell.exe" -noninteractive -encodedcommand')
 
 - name: execute powershell with no_profile
   win_shell: '[System.Environment]::CommandLine'
@@ -284,4 +284,33 @@
     - no_profile is changed
     - no_profile.cmd == "[System.Environment]::CommandLine"
     - no_profile.rc == 0
-    - no_profile.stdout is match ('^powershell.exe -noprofile -noninteractive -encodedcommand')
+    - no_profile.stdout is match ('^"powershell.exe" -noprofile -noninteractive -encodedcommand')
+
+- name: create symbolic link with space in the path
+  win_command: cmd.exe /c mklink /d "C:\ansible test link" C:\Windows\System32\WindowsPowerShell\v1.0
+  args:
+    creates: C:\ansible test link
+
+- block:
+  - name: run with space in the executable path
+    win_shell: '[System.Environment]::CommandLine'
+    args:
+      executable: C:\ansible test link\powershell
+    register: space_exe
+
+  - debug:
+      var: space_exe.stdout|trim
+
+  - name: assert run with space in the executable path
+    assert:
+      that:
+      - space_exe is successful
+      - space_exe is changed
+      - space_exe.cmd == '[System.Environment]::CommandLine'
+      - space_exe.rc == 0
+      - space_exe.stdout|trim == '"C:\\ansible test link\\powershell.exe" /c [System.Environment]::CommandLine'
+  always:
+  - name: remove test symbolic link
+    win_file:
+      path: C:\ansible test link
+      state: absent


### PR DESCRIPTION
(cherry picked from commit d0c49144691a35c192d5a144c61e39fbb3b48f38)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/57455

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_shell