### PR TITLE
Documentation error in the Test if a list contains a value section

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -119,7 +119,7 @@ Test if a list contains a value
 .. versionadded:: 2.8
 
 Ansible includes a ``contains`` test which operates similarly, but in reverse of the Jinja2 provided ``in`` test.
-This is designed with the ability to allow use of ``contains`` with filters such as ``map`` and ``selectattr``::
+This is designed with the ability to allow use of ``contains`` with filters such as ``select`` or ``reject`` and ``selectattr`` or ``rejectattr``::
 
     vars:
       lacp_groups:

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -119,7 +119,7 @@ Test if a list contains a value
 .. versionadded:: 2.8
 
 Ansible includes a ``contains`` test which operates similarly, but in reverse of the Jinja2 provided ``in`` test.
-This is designed with the ability to allow use of ``contains`` with filters such as ``select`` or ``reject`` and ``selectattr`` or ``rejectattr``::
+The ``contains`` test is designed to work with the ``select``, ``reject``, ``selectattr``, and ``rejectattr`` filters::
 
     vars:
       lacp_groups:


### PR DESCRIPTION
##### SUMMARY
Corrected Test if a list contains a value section. Allowed filters are 'select/reject' and 'selectattr/rejectattr'.

Fixes #56644

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr