### PR TITLE
Fix iosxr discard_changes netconf rpc issue

### DIFF
--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -26,6 +26,7 @@ from ansible.errors import AnsibleError
 from ansible.plugins import AnsiblePlugin
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.six import string_types
 
 try:
     from ncclient.operations import RPCError
@@ -223,9 +224,9 @@ class NetconfBase(AnsiblePlugin):
         """
         if rpc_command is None:
             raise ValueError('rpc_command value must be provided')
-
-        resp = self.m.dispatch(fromstring(rpc_command), source=source, filter=filter)
-        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+        req = fromstring(rpc_command)
+        resp = self.m.dispatch(req, source=source, filter=filter)
+        return resp.data_xml if resp.data_ele else resp.xml
 
     @ensure_connected
     def lock(self, target="candidate"):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* If dispatch() rpc response has data element
return the xml string from <data> element
else return the complete xml string from
<rpc-reply>.

Depends-On: #57909
Depends-On: #57919
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/__init__.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
