### PR TITLE
PR to fix the netvisor failure with network_cli connection

### DIFF
--- a/lib/ansible/plugins/cliconf/netvisor.py
+++ b/lib/ansible/plugins/cliconf/netvisor.py
@@ -35,6 +35,15 @@ from ansible.plugins.cliconf import CliconfBase
 
 class Cliconf(CliconfBase):
 
+    def get_config(self, source='running', format='text', flags=None):
+        if source not in ('running'):
+            return self.invalid_params("fetching configuration from %s is not supported" % source)
+        cmd = 'show running-config'
+        return self.send_command(cmd)
+
+    def edit_config(self, command):
+        return
+
     def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
         if not command:
             raise ValueError('must provide value of command to execute')


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To resolve the bug raised in #57447, which was happening coz `edit_config` and `get_config` methods are made abstract in CliconfBase class and it's implementation was missing in netvisor Cliconf plugin resulting into failure of instantiation abstract class Cliconf.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netvisor
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
