### PR TITLE
Fix RDS test suite and minor bugs revealed

### DIFF
--- a/hacking/aws_config/testing_policies/database-policy.json
+++ b/hacking/aws_config/testing_policies/database-policy.json
@@ -2,61 +2,69 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName":"rds.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Sid": "AllowRDSReadEverywhere",
+            "Effect": "Allow",
+            "Action": [
+                "rds:ListTagsForResource",
+                "rds:DescribeDBInstances",
+                "rds:DescribeDBParameterGroups",
+                "rds:DescribeDBParameters",
+                "rds:DescribeDBSnapshots"
+            ],
+            "Resource": ["*"]
+        },
+        {
             "Sid": "AllowRDSModuleTests",
             "Effect": "Allow",
             "Action": [
-                "rds:DescribeDBInstances",
+                "rds:AddTagsToResource",
                 "rds:CreateDBInstance",
+                "rds:DeleteDBInstance",
                 "rds:ModifyDBInstance",
-                "rds:ListTagsForResource",
-                "rds:DeleteDBInstance"
+                "rds:PromoteReadReplica",
+                "rds:RebootDBInstance",
+                "rds:RemoveTagsFromResource",
+                "rds:StartDBInstance",
+                "rds:StopDBInstance"
             ],
             "Resource": [
-                "arn:aws:rds:{{aws_region}}:{{aws_account}}:db:ansible-testing*"
-            ]
-        },
-        {
-            "Sid": "AllowRDSInstanceManageOwnInstance",
-            "Effect": "Allow",
-            "Action": [
-                "rds:CreateDBInstance",
-                "rds:ModifyDBInstance",
-                "rds:ListTagsForResource",
-                "rds:DescribeDBInstances"
-            ],
-            "Resource": [
-                "arn:aws:rds:{{aws_region}}:{{aws_account}}:db:rds-*"
+                "arn:aws:rds:{{aws_region}}:{{aws_account}}:db:ansible-test*"
             ]
         },
         {
             "Sid": "AllowRDSSnapshotManageSnapshots",
             "Effect": "Allow",
             "Action": [
-                "rds:DescribeDBSnapshots",
-                "rds:DescribeDBInstances",
-                "rds:DescribeDBSnapshots",
-                "rds:DeleteDBInstance",
+                "rds:AddTagsToResource",
                 "rds:CreateDBSnapshot",
+                "rds:DeleteDBInstance",
                 "rds:DeleteDBSnapshot",
+                "rds:RemoveTagsFromResource",
                 "rds:RestoreDBInstanceFromDBSnapshot",
                 "rds:CreateDBInstanceReadReplica"
             ],
             "Resource": [
-                "arn:aws:rds:{{aws_region}}:{{aws_account}}:snapshot:snapshot-*",
-                "arn:aws:rds:{{aws_region}}:{{aws_account}}:snapshot:rds-*",
-                "arn:aws:rds:{{aws_region}}:{{aws_account}}:db:rds-*"
-            ]
+                "arn:aws:rds:{{aws_region}}:{{aws_account}}:snapshot:ansible-test*",
+                "arn:aws:rds:{{aws_region}}:{{aws_account}}:db:ansible-test*"
+           ]
         },
         {
             "Sid": "AllowRDSParameterGroupManagement",
             "Effect": "Allow",
             "Action": [
-                "rds:DescribeDBParameterGroups",
-                "rds:DescribeDBParameters",
                 "rds:CreateDBParameterGroup",
                 "rds:DeleteDBParameterGroup",
                 "rds:ModifyDBParameterGroup",
-                "rds:ListTagsForResource",
                 "rds:AddTagsToResource",
                 "rds:RemoveTagsFromResource"
             ],

--- a/test/integration/targets/rds_instance/tasks/main.yml
+++ b/test/integration/targets/rds_instance/tasks/main.yml
@@ -2,15 +2,26 @@
 - block:
 
     - include: ./credential_tests.yml
+      tags: credentials
     - include: ./test_states.yml
+      tags: states
     - include: ./test_tags.yml
+      tags: tags
     - include: ./test_modification.yml  # TODO: test availability_zone and multi_az
+      tags: modification
     - include: ./test_bad_options.yml
+      tags: bad_options
     - include: ./test_processor_features.yml
+      tags: processor_features
     - include: ./test_encryption.yml
+      tags: encryption
     - include: ./test_final_snapshot.yml
+      tags: final_snapshot
     - include: ./test_read_replica.yml
+      tags: read_replica
     - include: ./test_vpc_security_groups.yml
+      tags: vpc_security_groups
+
     #- include: ./test_restore_instance.yml  # TODO: point-in-time, snapshot, s3
     # TODO: uncomment after adding rds_cluster module
     #- include: ./test_aurora.yml

--- a/test/integration/targets/rds_instance/tasks/test_modification.yml
+++ b/test/integration/targets/rds_instance/tasks/test_modification.yml
@@ -27,6 +27,7 @@
           id: "{{ instance_id }}"
           state: present
           engine: mariadb
+          engine_version: "10.1.26"
           username: "{{ username }}"
           password: "{{ password }}"
           db_instance_class: "{{ db_instance_class }}"
@@ -122,7 +123,7 @@
           backup_retention_period: 2
           preferred_backup_window: "05:00-06:00"
           preferred_maintenance_window: "mon:06:20-mon:06:50"
-          engine_version: "10.1.26"
+          engine_version: "10.2.21"
           allow_major_version_upgrade: true
           auto_minor_version_upgrade: false
           port: 1150
@@ -133,10 +134,10 @@
       - assert:
           that:
             - result.changed
-            - result.pending_modified_values.allocated_storage == 30
-            - result.pending_modified_values.port == 1150
-            - 'result.pending_modified_values.db_instance_class == "db.t2.medium"'
-            - 'result.pending_modified_values.engine_version == "10.1.26"'
+            - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == 30'
+            - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
+            - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
+            - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'
 
       - name: Idempotence modifying several pending attributes
         rds_instance:
@@ -147,7 +148,7 @@
           backup_retention_period: 2
           preferred_backup_window: "05:00-06:00"
           preferred_maintenance_window: "mon:06:20-mon:06:50"
-          engine_version: "10.1.26"
+          engine_version: "10.2.21"
           allow_major_version_upgrade: true
           auto_minor_version_upgrade: false
           port: 1150
@@ -163,16 +164,7 @@
             - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == 30'
             - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
             - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
-            - '"engine_version" in result.pending_modified_values or result.engine_version == "10.1.26"'
-
-      - name: Reboot the instance to update the modified values and add tags
-        rds_instance:
-          id: '{{ instance_id }}'
-          state: rebooted
-          tags:
-            Created_by: Ansible rds_instance tests
-          <<: *aws_connection_info
-        register: result
+            - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'
 
       - name: Delete the instance
         rds_instance:

--- a/test/integration/targets/rds_instance/tasks/test_read_replica.yml
+++ b/test/integration/targets/rds_instance/tasks/test_read_replica.yml
@@ -4,7 +4,7 @@
       - name: set the two regions for the source DB and the replica
         set_fact:
           region_src: "{{ aws_region }}"
-          region_dest: "us-east-2"
+          region_dest: "{{ aws_region }}"
 
       - name: set up aws connection info
         set_fact:


### PR DESCRIPTION
##### SUMMARY

* Update testing policy to be correct for RDS test suite
* Fix Iops bug when Iops is not present
* Create read replica in same region to avoid more permissions being
  required
* Ensure modifying DB doesn't try to downgrade engine version
* Add tags to main test suite to limit number of tests run for problem
  solving


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
rds_instance

