### PR TITLE
aws: Fix typo in deprecation warning

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
@@ -545,7 +545,7 @@ def main():
                            supports_check_mode=True
                            )
     if module._name == 'ec2_instance_facts':
-        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_information'", version='2.13')
+        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", version='2.13')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')


### PR DESCRIPTION
##### SUMMARY
Changed "ec2_instance_information" to "ec2_instance_info" in deprecation warning.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_instance_info.py
