### PR TITLE
New Module: Vscan Enable

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -31,9 +31,13 @@ import json
 import os
 import requests
 
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from pprint import pformat
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
+from ansible.module_utils._text import to_native
+
 try:
     from ansible.module_utils.ansible_release import __version__ as ansible_version
 except ImportError:
@@ -46,6 +50,11 @@ except ImportError:
     HAS_NETAPP_LIB = False
 
 import ssl
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
+
 
 HAS_SF_SDK = False
 SF_BYTE_MAP = dict(
@@ -82,7 +91,7 @@ try:
     from solidfire.models import Schedule, ScheduleInfo
 
     HAS_SF_SDK = True
-except:
+except Exception:
     HAS_SF_SDK = False
 
 
@@ -125,7 +134,7 @@ def create_sf_connection(module, port=None):
         try:
             return_val = ElementFactory.create(hostname, username, password, port=port)
             return return_val
-        except:
+        except Exception:
             raise Exception("Unable to create SF connection")
     else:
         module.fail_json(msg="the python SolidFire SDK module is required")
@@ -196,16 +205,236 @@ def setup_ontap_zapi(module, vserver=None):
 
 
 def eseries_host_argument_spec():
-    """Retrieve a base argument specifiation common to all NetApp E-Series modules"""
+    """Retrieve a base argument specification common to all NetApp E-Series modules"""
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_username=dict(type='str', required=True),
         api_password=dict(type='str', required=True, no_log=True),
         api_url=dict(type='str', required=True),
-        ssid=dict(type='str', required=True),
-        validate_certs=dict(type='bool', required=False, default=True),
+        ssid=dict(type='str', required=False, default='1'),
+        validate_certs=dict(type='bool', required=False, default=True)
     ))
     return argument_spec
+
+
+class NetAppESeriesModule(object):
+    """Base class for all NetApp E-Series modules.
+
+    Provides a set of common methods for NetApp E-Series modules, including version checking, mode (proxy, embedded)
+    verification, http requests, secure http redirection for embedded web services, and logging setup.
+
+    Be sure to add the following lines in the module's documentation section:
+    extends_documentation_fragment:
+        - netapp.eseries
+
+    :param dict(dict) ansible_options: dictionary of ansible option definitions
+    :param str web_services_version: minimally required web services rest api version (default value: "02.00.0000.0000")
+    :param bool supports_check_mode: whether the module will support the check_mode capabilities (default=False)
+    :param list(list) mutually_exclusive: list containing list(s) of mutually exclusive options (optional)
+    :param list(list) required_if: list containing list(s) containing the option, the option value, and then
+    a list of required options. (optional)
+    :param list(list) required_one_of: list containing list(s) of options for which at least one is required. (optional)
+    :param list(list) required_together: list containing list(s) of options that are required together. (optional)
+    :param bool log_requests: controls whether to log each request (default: True)
+    """
+    DEFAULT_TIMEOUT = 60
+    DEFAULT_SECURE_PORT = "8443"
+    DEFAULT_REST_API_PATH = "devmgr/v2"
+    DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json",
+                       "netapp-client-type": "Ansible-%s" % ansible_version}
+    HTTP_AGENT = "Ansible / %s" % ansible_version
+    SIZE_UNIT_MAP = dict(bytes=1, b=1, kb=1024, mb=1024**2, gb=1024**3, tb=1024**4,
+                         pb=1024**5, eb=1024**6, zb=1024**7, yb=1024**8)
+
+    def __init__(self, ansible_options, web_services_version=None, supports_check_mode=False,
+                 mutually_exclusive=None, required_if=None, required_one_of=None, required_together=None,
+                 log_requests=True):
+        argument_spec = eseries_host_argument_spec()
+        argument_spec.update(ansible_options)
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=supports_check_mode,
+                                    mutually_exclusive=mutually_exclusive, required_if=required_if,
+                                    required_one_of=required_one_of, required_together=required_together)
+
+        args = self.module.params
+        self.web_services_version = web_services_version if web_services_version else "02.00.0000.0000"
+        self.url = args["api_url"]
+        self.ssid = args["ssid"]
+        self.creds = dict(url_username=args["api_username"],
+                          url_password=args["api_password"],
+                          validate_certs=args["validate_certs"])
+        self.log_requests = log_requests
+
+        self.is_embedded_mode = None
+        self.web_services_validate = None
+
+        self._tweak_url()
+
+    @property
+    def _about_url(self):
+        """Generates the about url based on the supplied web services rest api url.
+
+        :raise AnsibleFailJson: raised when supplied web services rest api is an invalid url.
+        :return: proxy or embedded about url.
+        """
+        about = list(urlparse(self.url))
+        about[2] = "devmgr/utils/about"
+        return urlunparse(about)
+
+    def _force_secure_url(self):
+        """Modifies supplied web services rest api to use secure https.
+
+        raise: AnsibleFailJson: raised when the url already utilizes the secure protocol
+        """
+        url_parts = list(urlparse(self.url))
+        if "https://" in self.url and ":8443" in self.url:
+            self.module.fail_json(msg="Secure HTTP protocol already used. URL path [%s]" % self.url)
+
+        url_parts[0] = "https"
+        url_parts[1] = "%s:8443" % url_parts[1].split(":")[0]
+
+        self.url = urlunparse(url_parts)
+        if not self.url.endswith("/"):
+            self.url += "/"
+
+        self.module.warn("forced use of the secure protocol: %s" % self.url)
+
+    def _tweak_url(self):
+        """Adjust the rest api url is necessary.
+
+        :raise AnsibleFailJson: raised when self.url fails to have a hostname or ipv4 address.
+        """
+        # ensure the protocol is either http or https
+        if self.url.split("://")[0] not in ["https", "http"]:
+
+            self.url = self.url.split("://")[1] if "://" in self.url else self.url
+
+            if ":8080" in self.url:
+                self.url = "http://%s" % self.url
+            else:
+                self.url = "https://%s" % self.url
+
+        # parse url and verify protocol, port and path are consistent with required web services rest api url.
+        url_parts = list(urlparse(self.url))
+        if url_parts[1] == "":
+            self.module.fail_json(msg="Failed to provide a valid hostname or IP address. URL [%s]." % self.url)
+
+        split_hostname = url_parts[1].split(":")
+        if url_parts[0] not in ["https", "http"] or (len(split_hostname) == 2 and split_hostname[1] != "8080"):
+            if len(split_hostname) == 2 and split_hostname[1] == "8080":
+                url_parts[0] = "http"
+                url_parts[1] = "%s:8080" % split_hostname[0]
+            else:
+                url_parts[0] = "https"
+                url_parts[1] = "%s:8443" % split_hostname[0]
+        elif len(split_hostname) == 1:
+            if url_parts[0] == "https":
+                url_parts[1] = "%s:8443" % split_hostname[0]
+            elif url_parts[0] == "http":
+                url_parts[1] = "%s:8080" % split_hostname[0]
+
+        if url_parts[2] == "" or url_parts[2] != self.DEFAULT_REST_API_PATH:
+            url_parts[2] = self.DEFAULT_REST_API_PATH
+
+        self.url = urlunparse(url_parts)
+        if not self.url.endswith("/"):
+            self.url += "/"
+
+        self.module.log("valid url: %s" % self.url)
+
+    def _is_web_services_valid(self):
+        """Verify proxy or embedded web services meets minimum version required for module.
+
+        The minimum required web services version is evaluated against version supplied through the web services rest
+        api. AnsibleFailJson exception will be raised when the minimum is not met or exceeded.
+
+        :raise AnsibleFailJson: raised when the contacted api service does not meet the minimum required version.
+        """
+        if not self.web_services_validate:
+            self.is_embedded()
+            try:
+                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
+                                   headers=self.DEFAULT_HEADERS, **self.creds)
+                major, minor, other, revision = data["version"].split(".")
+                minimum_major, minimum_minor, other, minimum_revision = self.web_services_version.split(".")
+
+                if not (major > minimum_major or
+                        (major == minimum_major and minor > minimum_minor) or
+                        (major == minimum_major and minor == minimum_minor and revision >= minimum_revision)):
+                    self.module.fail_json(
+                        msg="Web services version does not meet minimum version required. Current version: [%s]."
+                            " Version required: [%s]." % (data["version"], self.web_services_version))
+            except Exception as error:
+                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
+                                          " Error [%s]." % (self.ssid, to_native(error)))
+
+            self.module.warn("Web services rest api version met the minimum required version.")
+            self.web_services_validate = True
+
+        return self.web_services_validate
+
+    def is_embedded(self, retry=True):
+        """Determine whether web services server is the embedded web services.
+
+        If web services about endpoint fails based on an URLError then the request will be attempted again using
+        secure http.
+
+        :raise AnsibleFailJson: raised when web services about endpoint failed to be contacted.
+        :return bool: whether contacted web services is running from storage array (embedded) or from a proxy.
+        """
+        if self.is_embedded_mode is None:
+            try:
+                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
+                                   headers=self.DEFAULT_HEADERS, **self.creds)
+                self.is_embedded_mode = not data["runningAsProxy"]
+            except URLError as error:
+                if not retry:
+                    self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
+                                              " Error [%s]." % (self.ssid, to_native(error)))
+                self.module.warn("Failed to retrieve the webservices about information! Will retry using secure"
+                                 " http. Array Id [%s]." % self.ssid)
+                self._force_secure_url()
+                return self.is_embedded(retry=False)
+            except Exception as error:
+                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
+                                          " Error [%s]." % (self.ssid, to_native(error)))
+
+        return self.is_embedded_mode
+
+    def request(self, path, data=None, method='GET', ignore_errors=False):
+        """Issue an HTTP request to a url, retrieving an optional JSON response.
+
+        :param str path: web services rest api endpoint path (Example: storage-systems/1/graph). Note that when the
+        full url path is specified then that will be used without supplying the protocol, hostname, port and rest path.
+        :param data: data required for the request (data may be json or any python structured data)
+        :param str method: request method such as GET, POST, DELETE.
+        :param bool ignore_errors: forces the request to ignore any raised exceptions.
+        """
+        if self._is_web_services_valid():
+            url = list(urlparse(path.strip("/")))
+            if url[2] == "":
+                self.module.fail_json(msg="Web services rest api endpoint path must be specified. Path [%s]." % path)
+
+            # if either the protocol or hostname/port are missing then add them.
+            if url[0] == "" or url[1] == "":
+                url[0], url[1] = list(urlparse(self.url))[:2]
+
+            # add rest api path if the supplied path does not begin with it.
+            if not all([word in url[2].split("/")[:2] for word in self.DEFAULT_REST_API_PATH.split("/")]):
+                if not url[2].startswith("/"):
+                    url[2] = "/" + url[2]
+                url[2] = self.DEFAULT_REST_API_PATH + url[2]
+
+            # ensure data is json formatted
+            if not isinstance(data, str):
+                data = json.dumps(data)
+
+            if self.log_requests:
+                self.module.log(pformat(dict(url=urlunparse(url), data=data, method=method)))
+
+            return request(url=urlunparse(url), data=data, method=method, headers=self.DEFAULT_HEADERS, use_proxy=True,
+                           force=False, last_mod_time=None, timeout=self.DEFAULT_TIMEOUT, http_agent=self.HTTP_AGENT,
+                           force_basic_auth=True, ignore_errors=ignore_errors, **self.creds)
 
 
 def request(url, data=None, headers=None, method='GET', use_proxy=True,
@@ -214,15 +443,11 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
     """Issue an HTTP request to a url, retrieving an optional JSON response."""
 
     if headers is None:
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-
-        }
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
     headers.update({"netapp-client-type": "Ansible-%s" % ansible_version})
 
     if not http_agent:
-        http_agent = "Ansible / %s" % (ansible_version)
+        http_agent = "Ansible / %s" % ansible_version
 
     try:
         r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
@@ -238,7 +463,7 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
             data = json.loads(raw_data)
         else:
             raw_data = None
-    except:
+    except Exception:
         if ignore_errors:
             pass
         else:
@@ -284,7 +509,6 @@ def get_cserver(server):
     vserver_list = attribute_list.get_child_by_name('vserver-info')
     return vserver_list.get_child_content('vserver-name')
 
-
 class OntapRestAPI(object):
     def __init__(self, username, password, hostname, verify):
         self.username = username
@@ -320,4 +544,3 @@ class OntapRestAPI(object):
             return True
         else:
             return False
-

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -29,14 +29,11 @@
 
 import json
 import os
+import requests
 
-from pprint import pformat
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
-from ansible.module_utils._text import to_native
-
 try:
     from ansible.module_utils.ansible_release import __version__ as ansible_version
 except ImportError:
@@ -49,11 +46,6 @@ except ImportError:
     HAS_NETAPP_LIB = False
 
 import ssl
-try:
-    from urlparse import urlparse, urlunparse
-except ImportError:
-    from urllib.parse import urlparse, urlunparse
-
 
 HAS_SF_SDK = False
 SF_BYTE_MAP = dict(
@@ -90,7 +82,7 @@ try:
     from solidfire.models import Schedule, ScheduleInfo
 
     HAS_SF_SDK = True
-except Exception:
+except:
     HAS_SF_SDK = False
 
 
@@ -133,7 +125,7 @@ def create_sf_connection(module, port=None):
         try:
             return_val = ElementFactory.create(hostname, username, password, port=port)
             return return_val
-        except Exception:
+        except:
             raise Exception("Unable to create SF connection")
     else:
         module.fail_json(msg="the python SolidFire SDK module is required")
@@ -204,236 +196,16 @@ def setup_ontap_zapi(module, vserver=None):
 
 
 def eseries_host_argument_spec():
-    """Retrieve a base argument specification common to all NetApp E-Series modules"""
+    """Retrieve a base argument specifiation common to all NetApp E-Series modules"""
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
         api_username=dict(type='str', required=True),
         api_password=dict(type='str', required=True, no_log=True),
         api_url=dict(type='str', required=True),
-        ssid=dict(type='str', required=False, default='1'),
-        validate_certs=dict(type='bool', required=False, default=True)
+        ssid=dict(type='str', required=True),
+        validate_certs=dict(type='bool', required=False, default=True),
     ))
     return argument_spec
-
-
-class NetAppESeriesModule(object):
-    """Base class for all NetApp E-Series modules.
-
-    Provides a set of common methods for NetApp E-Series modules, including version checking, mode (proxy, embedded)
-    verification, http requests, secure http redirection for embedded web services, and logging setup.
-
-    Be sure to add the following lines in the module's documentation section:
-    extends_documentation_fragment:
-        - netapp.eseries
-
-    :param dict(dict) ansible_options: dictionary of ansible option definitions
-    :param str web_services_version: minimally required web services rest api version (default value: "02.00.0000.0000")
-    :param bool supports_check_mode: whether the module will support the check_mode capabilities (default=False)
-    :param list(list) mutually_exclusive: list containing list(s) of mutually exclusive options (optional)
-    :param list(list) required_if: list containing list(s) containing the option, the option value, and then
-    a list of required options. (optional)
-    :param list(list) required_one_of: list containing list(s) of options for which at least one is required. (optional)
-    :param list(list) required_together: list containing list(s) of options that are required together. (optional)
-    :param bool log_requests: controls whether to log each request (default: True)
-    """
-    DEFAULT_TIMEOUT = 60
-    DEFAULT_SECURE_PORT = "8443"
-    DEFAULT_REST_API_PATH = "devmgr/v2"
-    DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json",
-                       "netapp-client-type": "Ansible-%s" % ansible_version}
-    HTTP_AGENT = "Ansible / %s" % ansible_version
-    SIZE_UNIT_MAP = dict(bytes=1, b=1, kb=1024, mb=1024**2, gb=1024**3, tb=1024**4,
-                         pb=1024**5, eb=1024**6, zb=1024**7, yb=1024**8)
-
-    def __init__(self, ansible_options, web_services_version=None, supports_check_mode=False,
-                 mutually_exclusive=None, required_if=None, required_one_of=None, required_together=None,
-                 log_requests=True):
-        argument_spec = eseries_host_argument_spec()
-        argument_spec.update(ansible_options)
-
-        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=supports_check_mode,
-                                    mutually_exclusive=mutually_exclusive, required_if=required_if,
-                                    required_one_of=required_one_of, required_together=required_together)
-
-        args = self.module.params
-        self.web_services_version = web_services_version if web_services_version else "02.00.0000.0000"
-        self.url = args["api_url"]
-        self.ssid = args["ssid"]
-        self.creds = dict(url_username=args["api_username"],
-                          url_password=args["api_password"],
-                          validate_certs=args["validate_certs"])
-        self.log_requests = log_requests
-
-        self.is_embedded_mode = None
-        self.web_services_validate = None
-
-        self._tweak_url()
-
-    @property
-    def _about_url(self):
-        """Generates the about url based on the supplied web services rest api url.
-
-        :raise AnsibleFailJson: raised when supplied web services rest api is an invalid url.
-        :return: proxy or embedded about url.
-        """
-        about = list(urlparse(self.url))
-        about[2] = "devmgr/utils/about"
-        return urlunparse(about)
-
-    def _force_secure_url(self):
-        """Modifies supplied web services rest api to use secure https.
-
-        raise: AnsibleFailJson: raised when the url already utilizes the secure protocol
-        """
-        url_parts = list(urlparse(self.url))
-        if "https://" in self.url and ":8443" in self.url:
-            self.module.fail_json(msg="Secure HTTP protocol already used. URL path [%s]" % self.url)
-
-        url_parts[0] = "https"
-        url_parts[1] = "%s:8443" % url_parts[1].split(":")[0]
-
-        self.url = urlunparse(url_parts)
-        if not self.url.endswith("/"):
-            self.url += "/"
-
-        self.module.warn("forced use of the secure protocol: %s" % self.url)
-
-    def _tweak_url(self):
-        """Adjust the rest api url is necessary.
-
-        :raise AnsibleFailJson: raised when self.url fails to have a hostname or ipv4 address.
-        """
-        # ensure the protocol is either http or https
-        if self.url.split("://")[0] not in ["https", "http"]:
-
-            self.url = self.url.split("://")[1] if "://" in self.url else self.url
-
-            if ":8080" in self.url:
-                self.url = "http://%s" % self.url
-            else:
-                self.url = "https://%s" % self.url
-
-        # parse url and verify protocol, port and path are consistent with required web services rest api url.
-        url_parts = list(urlparse(self.url))
-        if url_parts[1] == "":
-            self.module.fail_json(msg="Failed to provide a valid hostname or IP address. URL [%s]." % self.url)
-
-        split_hostname = url_parts[1].split(":")
-        if url_parts[0] not in ["https", "http"] or (len(split_hostname) == 2 and split_hostname[1] != "8080"):
-            if len(split_hostname) == 2 and split_hostname[1] == "8080":
-                url_parts[0] = "http"
-                url_parts[1] = "%s:8080" % split_hostname[0]
-            else:
-                url_parts[0] = "https"
-                url_parts[1] = "%s:8443" % split_hostname[0]
-        elif len(split_hostname) == 1:
-            if url_parts[0] == "https":
-                url_parts[1] = "%s:8443" % split_hostname[0]
-            elif url_parts[0] == "http":
-                url_parts[1] = "%s:8080" % split_hostname[0]
-
-        if url_parts[2] == "" or url_parts[2] != self.DEFAULT_REST_API_PATH:
-            url_parts[2] = self.DEFAULT_REST_API_PATH
-
-        self.url = urlunparse(url_parts)
-        if not self.url.endswith("/"):
-            self.url += "/"
-
-        self.module.log("valid url: %s" % self.url)
-
-    def _is_web_services_valid(self):
-        """Verify proxy or embedded web services meets minimum version required for module.
-
-        The minimum required web services version is evaluated against version supplied through the web services rest
-        api. AnsibleFailJson exception will be raised when the minimum is not met or exceeded.
-
-        :raise AnsibleFailJson: raised when the contacted api service does not meet the minimum required version.
-        """
-        if not self.web_services_validate:
-            self.is_embedded()
-            try:
-                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
-                                   headers=self.DEFAULT_HEADERS, **self.creds)
-                major, minor, other, revision = data["version"].split(".")
-                minimum_major, minimum_minor, other, minimum_revision = self.web_services_version.split(".")
-
-                if not (major > minimum_major or
-                        (major == minimum_major and minor > minimum_minor) or
-                        (major == minimum_major and minor == minimum_minor and revision >= minimum_revision)):
-                    self.module.fail_json(
-                        msg="Web services version does not meet minimum version required. Current version: [%s]."
-                            " Version required: [%s]." % (data["version"], self.web_services_version))
-            except Exception as error:
-                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                          " Error [%s]." % (self.ssid, to_native(error)))
-
-            self.module.warn("Web services rest api version met the minimum required version.")
-            self.web_services_validate = True
-
-        return self.web_services_validate
-
-    def is_embedded(self, retry=True):
-        """Determine whether web services server is the embedded web services.
-
-        If web services about endpoint fails based on an URLError then the request will be attempted again using
-        secure http.
-
-        :raise AnsibleFailJson: raised when web services about endpoint failed to be contacted.
-        :return bool: whether contacted web services is running from storage array (embedded) or from a proxy.
-        """
-        if self.is_embedded_mode is None:
-            try:
-                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
-                                   headers=self.DEFAULT_HEADERS, **self.creds)
-                self.is_embedded_mode = not data["runningAsProxy"]
-            except URLError as error:
-                if not retry:
-                    self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                              " Error [%s]." % (self.ssid, to_native(error)))
-                self.module.warn("Failed to retrieve the webservices about information! Will retry using secure"
-                                 " http. Array Id [%s]." % self.ssid)
-                self._force_secure_url()
-                return self.is_embedded(retry=False)
-            except Exception as error:
-                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                          " Error [%s]." % (self.ssid, to_native(error)))
-
-        return self.is_embedded_mode
-
-    def request(self, path, data=None, method='GET', ignore_errors=False):
-        """Issue an HTTP request to a url, retrieving an optional JSON response.
-
-        :param str path: web services rest api endpoint path (Example: storage-systems/1/graph). Note that when the
-        full url path is specified then that will be used without supplying the protocol, hostname, port and rest path.
-        :param data: data required for the request (data may be json or any python structured data)
-        :param str method: request method such as GET, POST, DELETE.
-        :param bool ignore_errors: forces the request to ignore any raised exceptions.
-        """
-        if self._is_web_services_valid():
-            url = list(urlparse(path.strip("/")))
-            if url[2] == "":
-                self.module.fail_json(msg="Web services rest api endpoint path must be specified. Path [%s]." % path)
-
-            # if either the protocol or hostname/port are missing then add them.
-            if url[0] == "" or url[1] == "":
-                url[0], url[1] = list(urlparse(self.url))[:2]
-
-            # add rest api path if the supplied path does not begin with it.
-            if not all([word in url[2].split("/")[:2] for word in self.DEFAULT_REST_API_PATH.split("/")]):
-                if not url[2].startswith("/"):
-                    url[2] = "/" + url[2]
-                url[2] = self.DEFAULT_REST_API_PATH + url[2]
-
-            # ensure data is json formatted
-            if not isinstance(data, str):
-                data = json.dumps(data)
-
-            if self.log_requests:
-                self.module.log(pformat(dict(url=urlunparse(url), data=data, method=method)))
-
-            return request(url=urlunparse(url), data=data, method=method, headers=self.DEFAULT_HEADERS, use_proxy=True,
-                           force=False, last_mod_time=None, timeout=self.DEFAULT_TIMEOUT, http_agent=self.HTTP_AGENT,
-                           force_basic_auth=True, ignore_errors=ignore_errors, **self.creds)
 
 
 def request(url, data=None, headers=None, method='GET', use_proxy=True,
@@ -442,11 +214,15 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
     """Issue an HTTP request to a url, retrieving an optional JSON response."""
 
     if headers is None:
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+
+        }
     headers.update({"netapp-client-type": "Ansible-%s" % ansible_version})
 
     if not http_agent:
-        http_agent = "Ansible / %s" % ansible_version
+        http_agent = "Ansible / %s" % (ansible_version)
 
     try:
         r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
@@ -462,7 +238,7 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
             data = json.loads(raw_data)
         else:
             raw_data = None
-    except Exception:
+    except:
         if ignore_errors:
             pass
         else:
@@ -507,3 +283,41 @@ def get_cserver(server):
     attribute_list = result.get_child_by_name('attributes-list')
     vserver_list = attribute_list.get_child_by_name('vserver-info')
     return vserver_list.get_child_content('vserver-name')
+
+
+class OntapRestAPI(object):
+    def __init__(self, username, password, hostname, verify):
+        self.username = username
+        self.password = password
+        self.hostname = hostname
+        self.verify = verify
+        self.url = 'https://' + hostname + '/api/'
+
+    def get(self, api, params):
+        url = self.url + api
+        req = requests.get(url, verify=self.verify, auth=(self.username, self.password), params=params)
+        return req.json()
+
+    def post(self, api, data, params=None):
+        url = self.url + api
+        req = requests.post(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
+        return req.json()
+
+    def patch(self, api, data, params=None):
+        url = self.url + api
+        req = requests.patch(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
+        return req.json()
+
+    def delete(self, api, data, params=None):
+        url = self.url + api
+        req = requests.delete(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
+        return req.json()
+
+    def is_rest(self):
+        url = self.url + 'cluster/software'
+        req = requests.head(url, verify=self.verify, auth=(self.username, self.password))
+        if req.status_code == 200:
+            return True
+        else:
+            return False
+

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -29,10 +29,9 @@
 
 import json
 import os
-import requests
 
 from pprint import pformat
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
@@ -48,6 +47,12 @@ try:
     HAS_NETAPP_LIB = True
 except ImportError:
     HAS_NETAPP_LIB = False
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 
 import ssl
 try:
@@ -497,7 +502,7 @@ def ems_log_event(source, server, name="Ansible", id="12345", version=ansible_ve
     server.invoke_successfully(ems_log, True)
 
 
-def get_cserver(server):
+def get_cserver_zapi(server):
     vserver_info = zapi.NaElement('vserver-get-iter')
     query_details = zapi.NaElement.create_node_with_children('vserver-info', **{'vserver-type': 'admin'})
     query = zapi.NaElement('query')
@@ -509,38 +514,116 @@ def get_cserver(server):
     vserver_list = attribute_list.get_child_by_name('vserver-info')
     return vserver_list.get_child_content('vserver-name')
 
+
+def get_cserver(connection, is_rest=False):
+    if not is_rest:
+        return get_cserver_zapi(connection)
+
+    params = {'fields': 'type'}
+    api = "private/cli/vserver"
+    json, error = connection.get(api, params)
+    if json is None or error is not None:
+        # exit if there is an error or no data
+        return None
+    vservers = json.get('records')
+    if vservers is not None:
+        for vserver in vservers:
+             if vserver['type'] == 'admin':     # cluster admin
+                 return vserver['vserver']
+        if len(vservers) == 1:                  # assume vserver admin
+            return vservers[0]['vserver']
+
+    return None
+
 class OntapRestAPI(object):
-    def __init__(self, username, password, hostname, verify):
-        self.username = username
-        self.password = password
-        self.hostname = hostname
-        self.verify = verify
-        self.url = 'https://' + hostname + '/api/'
+    def __init__(self, module, timeout=60):
+        self.module = module
+        self.username = self.module.params['username']
+        self.password = self.module.params['password']
+        self.hostname = self.module.params['hostname']
+        self.verify = self.module.params['validate_certs']
+        self.timeout = timeout
+        self.url = 'https://' + self.hostname + '/api/'
+        self.errors = list()
+        self.debug_logs = list()
+        self.check_required_library()
+
+    def check_required_library(self):
+        if not HAS_REQUESTS:
+            self.module.fail_json(msg=missing_required_lib('requests'))
+
+    def send_request(self, method, api, params, json=None, return_status_code=False):
+        ''' send http request and process reponse, including error conditions '''
+        url = self.url + api
+        status_code = None
+        content = None
+        json_dict = None
+        json_error = None
+        error_details = None
+
+        def get_json(response):
+            ''' extract json, and error message if present '''
+            try:
+                json = response.json()
+            except ValueError:
+                return None, None
+            error = json.get('error')
+            return json, error
+
+        try:
+            response = requests.request(method, url, verify=self.verify, auth=(self.username, self.password), params=params, timeout=self.timeout, json=json)
+            content = response.content  # for debug purposes
+            status_code = response.status_code
+            # If the response was successful, no Exception will be raised
+            response.raise_for_status()
+            json_dict, json_error = get_json(response)
+        except requests.exceptions.HTTPError as err:
+            _, json_error = get_json(response)
+            if json_error is None:
+                self.log_error(status_code, 'HTTP error: %s' % err)
+                error_details = str(err)
+            # If an error was reported in the json payload, it is handled below
+        except requests.exceptions.ConnectionError as err:
+            self.log_error(status_code, 'Connection error: %s' % err)
+            error_details = str(err)
+        except Exception as err:
+            self.log_error(status_code, 'Other error: %s' % err)
+            error_details = str(err)
+        if json_error is not None:
+            self.log_error(status_code, 'Endpoint error: %d: %s' % (status_code, json_error))
+            error_details = json_error
+        self.log_debug(status_code, content)
+        if return_status_code:
+            return status_code, error_details
+        return json_dict, error_details
 
     def get(self, api, params):
-        url = self.url + api
-        req = requests.get(url, verify=self.verify, auth=(self.username, self.password), params=params)
-        return req.json()
+        method = 'GET'
+        return self.send_request(method, api, params)
 
     def post(self, api, data, params=None):
-        url = self.url + api
-        req = requests.post(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
-        return req.json()
+        method = 'POST'
+        return self.send_request(method, api, params, json=data)
 
     def patch(self, api, data, params=None):
-        url = self.url + api
-        req = requests.patch(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
-        return req.json()
+        method = 'PATCH'
+        return self.send_request(method, api, params, json=data)
 
     def delete(self, api, data, params=None):
-        url = self.url + api
-        req = requests.delete(url, verify=self.verify, auth=(self.username, self.password), params=params, json=data)
-        return req.json()
+        method = 'DELETE'
+        return self.send_request(method, api, params, json=data)
 
     def is_rest(self):
-        url = self.url + 'cluster/software'
-        req = requests.head(url, verify=self.verify, auth=(self.username, self.password))
-        if req.status_code == 200:
+        method = 'HEAD'
+        api = 'cluster/software'
+        status_code, _ = self.send_request(method, api, params=None, return_status_code=True)
+        if status_code == 200:
             return True
-        else:
-            return False
+        return False
+
+    def log_error(self, status_code, message):
+        self.errors.append(message)
+        self.debug_logs.append((status_code, message))
+
+    def log_debug(self, status_code, content):
+        self.debug_logs.append((status_code, content))

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -528,12 +528,13 @@ def get_cserver(connection, is_rest=False):
     vservers = json.get('records')
     if vservers is not None:
         for vserver in vservers:
-             if vserver['type'] == 'admin':     # cluster admin
-                 return vserver['vserver']
+            if vserver['type'] == 'admin':     # cluster admin
+                return vserver['vserver']
         if len(vservers) == 1:                  # assume vserver admin
             return vservers[0]['vserver']
 
     return None
+
 
 class OntapRestAPI(object):
     def __init__(self, module, timeout=60):
@@ -578,7 +579,7 @@ class OntapRestAPI(object):
             response.raise_for_status()
             json_dict, json_error = get_json(response)
         except requests.exceptions.HTTPError as err:
-            _, json_error = get_json(response)
+            junk, json_error = get_json(response)
             if json_error is None:
                 self.log_error(status_code, 'HTTP error: %s' % err)
                 error_details = str(err)
@@ -616,7 +617,7 @@ class OntapRestAPI(object):
     def is_rest(self):
         method = 'HEAD'
         api = 'cluster/software'
-        status_code, _ = self.send_request(method, api, params=None, return_status_code=True)
+        status_code, junk = self.send_request(method, api, params=None, return_status_code=True)
         if status_code == 200:
             return True
         return False

--- a/lib/ansible/modules/storage/netapp/na_ontap_vscan.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vscan.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+
+# (c) 2018-2019, NetApp Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = '''
+module: na_ontap_vscan
+short_description: NetApp ONTAP Vscan enable/disable.
+extends_documentation_fragment:
+    - netapp.na_ontap
+version_added: '2.9'
+author: NetApp Ansible Team (@carchi8py) <ng-ansibleteam@netapp.com>
+notes:
+- on demand task, on_access_policy and scanner_pools must be set up before running this module
+description:
+- Enable and Disable Vscan
+options:
+  enable:
+    description:
+    - Whether to enable to disable a Vscan
+    type: bool
+    default: True
+
+  vserver:
+    description:
+    - the name of the data vserver to use.
+    required: true
+'''
+
+EXAMPLES = """
+    - name: Enable Vscan
+      na_ontap_vscan:
+        enable: True
+        username: '{{ netapp_username }}'
+        password: '{{ netapp_password }}'
+        hostname: '{{ netapp_hostname }}'
+        vserver: trident_svm
+
+    - name: Disable Vscan
+      na_ontap_vscan:
+        enable: False
+        username: '{{ netapp_username }}'
+        password: '{{ netapp_password }}'
+        hostname: '{{ netapp_hostname }}'
+        vserver: trident_svm
+"""
+
+RETURN = """
+
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+import ansible.module_utils.netapp as netapp_utils
+from ansible.module_utils.netapp import OntapRestAPI
+from ansible.module_utils.netapp_module import NetAppModule
+
+HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
+
+
+class NetAppOntapVscan(object):
+    def __init__(self):
+        self.use_rest = False
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
+        self.argument_spec.update(dict(
+            enable=dict(type='bool', default=True),
+            vserver=dict(required=True, type='str'),
+        ))
+        self.module = AnsibleModule(
+            argument_spec=self.argument_spec,
+            supports_check_mode=True
+        )
+        self.na_helper = NetAppModule()
+        self.parameters = self.na_helper.set_parameters(self.module.params)
+
+        # API should be used for ONTAP 9.6 or higher, Zapi for lower version
+        self.restApi = OntapRestAPI(self.parameters['username'], self.parameters['password'], self.parameters['hostname'], self.parameters['validate_certs'])
+        if self.restApi.is_rest():
+            self.use_rest = True
+        else:
+            if HAS_NETAPP_LIB is False:
+                self.module.fail_json(msg="the python NetApp-Lib module is required")
+            else:
+                self.server = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=self.parameters['vserver'])
+
+    def get_vscan(self):
+        if self.use_rest:
+            params = {'fields': '*',
+                      "svm.name": self.parameters['vserver']}
+            api = "protocols/vscan"
+            message = self.restApi.get(api, params)
+            if message.get('error'):
+                self.module.fail_json(msg="%s" % message)
+            return message['records'][0]
+        else:
+            vscan_status_iter = netapp_utils.zapi.NaElement('vscan-status-get-iter')
+            vscan_status_info = netapp_utils.zapi.NaElement('vscan-status-info')
+            vscan_status_info.add_new_child('vserver', self.parameters['vserver'])
+            query = netapp_utils.zapi.NaElement('query')
+            query.add_child_elem(vscan_status_info)
+            vscan_status_iter.add_child_elem(query)
+            try:
+                result = self.server.invoke_successfully(vscan_status_iter, True)
+            except netapp_utils.zapi.NaApiError as error:
+                self.module.fail_json(msg='Error getting Vscan info for Vserver %s: %s' %
+                                          (self.parameters['vserver'], to_native(error)),
+                                      exception=traceback.format_exc())
+            if result.get_child_by_name('num-records') and int(result.get_child_content('num-records')) >= 1:
+                return result.get_child_by_name('attributes-list').get_child_by_name('vscan-status-info')
+
+    def enable_vscan(self, uuid=None):
+        if self.use_rest:
+            params = {"svm.name": self.parameters['vserver']}
+            data = {"enabled": self.parameters['enable']}
+            api = "protocols/vscan/" + uuid
+            message = self.restApi.patch(api, data, params)
+            if message.get('error'):
+                self.module.fail_json(msg="%s" % message)
+            return message
+        else:
+            vscan_status_obj = netapp_utils.zapi.NaElement("vscan-status-modify")
+            vscan_status_obj.add_new_child('is-vscan-enabled', str(self.parameters['enable']))
+            try:
+                result = self.server.invoke_successfully(vscan_status_obj, True)
+            except netapp_utils.zapi.NaApiError as error:
+                self.module.fail_json(msg="Error Enable/Disabling Vscan: %s" % to_native(error), exception=traceback.format_exc())
+
+    def asup_log(self):
+        if self.use_rest:
+            # TODO: logging for Rest
+            return
+        else:
+            netapp_utils.ems_log_event("na_ontap_volume_autosize", self.server)
+
+    def apply(self):
+        self.asup_log()
+        current = self.get_vscan()
+        if self.use_rest:
+            if current['enabled'] != self.parameters['enable']:
+                self.enable_vscan(current['svm']['uuid'])
+        else:
+            if current.get_child_by_name('is-vscan-enabled') != str(self.parameters['enable']).lower():
+                self.enable_vscan()
+        self.module.exit_json(changed=self.na_helper.changed)
+
+
+def main():
+    """
+    Execute action from playbook
+    """
+    command = NetAppOntapVscan()
+    command.apply()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/netapp/na_ontap_vscan.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vscan.py
@@ -33,6 +33,7 @@ options:
     description:
     - the name of the data vserver to use.
     required: true
+    type: str
 '''
 
 EXAMPLES = """

--- a/test/units/modules/storage/netapp/test_na_ontap_vscan.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_vscan.py
@@ -1,0 +1,124 @@
+# (c) 2018, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+''' unit tests for Ansible module: na_ontap_vscan'''
+
+from __future__ import print_function
+import json
+import pytest
+
+from units.compat import unittest
+from units.compat.mock import patch, Mock
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+import ansible.module_utils.netapp as netapp_utils
+
+from ansible.modules.storage.netapp.na_ontap_vscan \
+    import NetAppOntapVscan as vscan_module  # module under test
+
+if not netapp_utils.has_netapp_lib():
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
+HAS_NETAPP_ZAPI_MSG = "pip install netapp_lib is required"
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation"""
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the test case"""
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the test case"""
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an exception"""
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an exception"""
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class MockONTAPConnection(object):
+    ''' mock server connection to ONTAP host '''
+
+    def __init__(self, kind=None, data=None):
+        ''' save arguments '''
+        self.kind = kind
+        self.params = data
+        self.xml_in = None
+        self.xml_out = None
+
+    def invoke_successfully(self, xml, enable_tunneling):  # pylint: disable=unused-argument
+        ''' mock invoke_successfully returning xml data '''
+        self.xml_in = xml
+        if self.kind == 'vscan':
+            xml = self.build_access_policy_info(self.params)
+        self.xml_out = xml
+        return xml
+
+    @staticmethod
+    def build_access_policy_info(policy_details):
+        xml = netapp_utils.zapi.NaElement('xml')
+        attributes = {'num-records': 1,
+                      'attributes-list': {'vscan-on-access-policy-info': {'policy-name': policy_details['policy_name']}}}
+        xml.translate_struct(attributes)
+        return xml
+
+
+class TestMyModule(unittest.TestCase):
+    ''' Unit tests for na_ontap_job_schedule '''
+
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.mock_vscan = {
+            'enable': 'False',
+            'vserver': 'test_vserver',
+        }
+
+    def mock_args(self):
+        return {
+            'enable': self.mock_vscan['enable'],
+            'vserver': self.mock_vscan['vserver'],
+            'hostname': 'test',
+            'username': 'test_user',
+            'password': 'test_pass!'
+        }
+
+    def get_vscan_mock_object(self, kind=None):
+        vscan_obj = vscan_module()
+        if kind is None:
+            vscan_obj.server = MockONTAPConnection()
+        else:
+            vscan_obj.server = MockONTAPConnection(kind='vscan', data=self.mock_vscan)
+        return vscan_obj
+
+    def test_module_fail_when_required_args_missing(self):
+        ''' required arguments are reported as errors '''
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            vscan_module()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    def test_successfully_enable(self):
+        data = self.mock_args()
+        data['enable'] = 'True'
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_vscan_mock_object().apply()
+        assert not exc.value.args[0]['changed']


### PR DESCRIPTION
##### SUMMARY
Vscan Enable -- This is our first module that supports both Ontap 9.6+ rest API, and the existing zapi. The module checks to see if the Rest api is available. If it is it will make all the calls using the rest API. If it isn't the module will default back to the zapi.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
- na_ontap_vscan.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
