### PR TITLE
Fix idempotency when config same as current

### DIFF
--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -25,7 +25,6 @@ $drive = Get-AnsibleParam -obj $params -name "drive" -type "str"
 $fullPath = $drive + ":\pagefile.sys"
 $initialSize = Get-AnsibleParam -obj $params -name "initial_size" -type "int"
 $maximumSize = Get-AnsibleParam -obj $params -name "maximum_size" -type "int"
-#$override = Get-AnsibleParam -obj $params -name "override" -type "bool" -default $true
 $override = Get-AnsibleParam -obj $params -name "override" -type "str" -default "false" -validateset "true", "match", "false"
 $removeAll = Get-AnsibleParam -obj $params -name "remove_all" -type "bool" -default $false
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present", "absent", "query"

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -7,13 +7,11 @@
 
 ########
 
-Function Remove-Pagefile($path, $whatif)
-{
+Function Remove-Pagefile($path, $whatif) {
     Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path } | Remove-WmiObject -WhatIf:$whatif
 }
 
-Function Get-Pagefile($path)
-{
+Function Get-Pagefile($path) {
     Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path }
 }
 
@@ -27,21 +25,25 @@ $drive = Get-AnsibleParam -obj $params -name "drive" -type "str"
 $fullPath = $drive + ":\pagefile.sys"
 $initialSize = Get-AnsibleParam -obj $params -name "initial_size" -type "int"
 $maximumSize = Get-AnsibleParam -obj $params -name "maximum_size" -type "int"
-$override =  Get-AnsibleParam -obj $params -name "override" -type "bool" -default $true
+#$override = Get-AnsibleParam -obj $params -name "override" -type "bool" -default $true
+$override = Get-AnsibleParam -obj $params -name "override" -type "str" -default "false" -validateset "true", "match", "false"
 $removeAll = Get-AnsibleParam -obj $params -name "remove_all" -type "bool" -default $false
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present","absent","query"
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present", "absent", "query"
 $systemManaged = Get-AnsibleParam -obj $params -name "system_managed" -type "bool" -default $false
 $testPath = Get-AnsibleParam -obj $params -name "test_path" -type "bool" -default $true
 
 $result = @{
-    changed = $false
+    changed         = $false
+    reboot_required = $false
 }
+
 
 if ($removeAll) {
     $currentPageFiles = Get-WmiObject Win32_PageFileSetting
     if ($null -ne $currentPageFiles) {
         $currentPageFiles | Remove-WmiObject -WhatIf:$check_mode | Out-Null
         $result.changed = $true
+        $result.reboot_required = $true
     }
 }
 
@@ -49,121 +51,155 @@ if ($null -ne $automatic) {
     # change autmoatic managed pagefile 
     try {
         $computerSystem = Get-WmiObject -Class win32_computersystem -EnableAllPrivileges
-    } catch {
+    }
+    catch {
         Fail-Json $result "Failed to query WMI computer system object $($_.Exception.Message)"
     }
     if ($computerSystem.AutomaticManagedPagefile -ne $automatic) {
         $computerSystem.AutomaticManagedPagefile = $automatic
         if (-not $check_mode) {
             try {
-            	$computerSystem.Put() | Out-Null
-            } catch {
+                $computerSystem.Put() | Out-Null
+            }
+            catch {
                 Fail-Json $result "Failed to set AutomaticManagedPagefile $($_.Exception.Message)"
             }
         }
         $result.changed = $true
+        $result.reboot_required = $true
     }
 }
 
 if ($state -eq "absent") {
     # Remove pagefile
-    if ($null -ne (Get-Pagefile $fullPath))
-    {
+    if ($null -ne (Get-Pagefile $fullPath)) {
         try {
             Remove-Pagefile $fullPath -whatif:$check_mode
-        } catch {
+        }
+        catch {
             Fail-Json $result "Failed to remove pagefile $($_.Exception.Message)"
         }
         $result.changed = $true
-    }
-} elseif ($state -eq "present") {
-    # Remove current pagefile
-    if ($override) {
-        if ($null -ne (Get-Pagefile $fullPath))
-        {
-            try {
-                Remove-Pagefile $fullPath -whatif:$check_mode
-            } catch {
-                Fail-Json $result "Failed to remove current pagefile $($_.Exception.Message)"
-            }
-            $result.changed = $true
-        }
-    }
-
-    # Make sure drive is accessible
-    if (($testPath) -and (-not (Test-Path "${drive}:"))) {
-        Fail-Json $result "Unable to access '${drive}:' drive"
-    }
-
-    # Set pagefile
-    if ($null -eq (Get-Pagefile $fullPath)) {
-        try {
-            $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0} -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result "Failed to create pagefile $($_.Exception.Message)"
-        }
-        if (-not ($systemManaged -or $check_mode)) {
-            $pagefile.InitialSize = $initialSize
-            $pagefile.MaximumSize = $maximumSize
-            try {
-                $pagefile.Put() | out-null
-            } catch {
-                $originalExceptionMessage = $($_.Exception.Message)
-                # Try workaround before failing
-                try {
-                    Remove-Pagefile $fullPath -whatif:$check_mode
-                } catch {
-                    Fail-Json $result "Failed to remove pagefile before workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
-                }
-                try {
-                    $pagingFilesValues = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management").PagingFiles
-                } catch {
-                    Fail-Json $result "Failed to get pagefile settings from the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
-                }
-                $pagingFilesValues += "$fullPath $initialSize $maximumSize"
-                try {
-                    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" "PagingFiles" $pagingFilesValues
-                } catch {
-                    Fail-Json $result "Failed to set pagefile settings to the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
-                }
-            }
-        }
-        $result.changed = $true
-    }
-} elseif ($state -eq "query") {
-    $result.pagefiles = @()
-
-    if ($null -eq $drive) {
-        try {
-            $pagefiles = Get-WmiObject Win32_PageFileSetting
-        } catch {
-            Fail-Json $result "Failed to query all pagefiles $($_.Exception.Message)"
-        }
-    } else {
-        try {
-            $pagefiles = Get-Pagefile $fullPath
-        } catch {
-            Fail-Json $result "Failed to query specific pagefile $($_.Exception.Message)"
-        }
-    }
-
-    # Get all pagefiles
-    foreach ($currentPagefile in $pagefiles) {
-        $currentPagefileObject = @{
-            name = $currentPagefile.Name
-            initial_size = $currentPagefile.InitialSize
-            maximum_size = $currentPagefile.MaximumSize
-            caption = $currentPagefile.Caption
-            description = $currentPagefile.Description
-        }
-        $result.pagefiles += $currentPagefileObject
-    }
-
-    # Get automatic managed pagefile state
-    try {
-        $result.automatic_managed_pagefiles = (Get-WmiObject -Class win32_computersystem).AutomaticManagedPagefile
-    } catch {
-        Fail-Json $result "Failed to query automatic managed pagefile state $($_.Exception.Message)"
+        $result.reboot_required = $true
     }
 }
-Exit-Json $result
+elseif ($state -eq "present") {
+    # Check if the input matches with current configration
+    if ($override -eq "match") {
+        $CheckMatch = Get-WmiObject -Class Win32_PageFile | Select-Object -Property * | Where-Object { $_."drive" -eq "$drive" }
+        $CheckMatchSystemManaged = (Get-WmiObject -Class win32_computersystem).AutomaticManagedPagefile
+       
+        if (($CheckMatch.InitialSize -ne $initialSize) -or ($CheckMatch.MaximumSize -ne $maximumSize) -or ($CheckMatchSystemManaged -ne $systemManaged)) {
+            $override = $true          
+        }
+        else {
+            $result.changed = $false
+        }
+    }
+        # Remove current pagefile
+        elseif ($override -eq "true") {
+            if ($null -ne (Get-Pagefile $fullPath)) {
+                try {
+                    Remove-Pagefile $fullPath -whatif:$check_mode
+                }
+                catch {
+                    Fail-Json $result "Failed to remove current pagefile $($_.Exception.Message)"
+                }
+                $result.changed = $true
+                $result.reboot_required = $true
+            }
+        
+        
+        }
+
+        # Make sure drive is accessible
+        if (($testPath) -and (-not (Test-Path "${drive}:"))) {
+            Fail-Json $result "Unable to access '${drive}:' drive"
+        }
+
+        # Set pagefile
+        if ($null -eq (Get-Pagefile $fullPath)) {
+            try {
+                $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0 } -WhatIf:$check_mode
+            }
+            catch {
+                Fail-Json $result "Failed to create pagefile $($_.Exception.Message)"
+            }
+            if (-not ($systemManaged -or $check_mode)) {
+                $pagefile.InitialSize = $initialSize
+                $pagefile.MaximumSize = $maximumSize
+                try {
+                    $pagefile.Put() | out-null
+                }
+                catch {
+                    $originalExceptionMessage = $($_.Exception.Message)
+                    # Try workaround before failing
+                    try {
+                        Remove-Pagefile $fullPath -whatif:$check_mode
+                    }
+                    catch {
+                        Fail-Json $result "Failed to remove pagefile before workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
+                    }
+                    try {
+                        $pagingFilesValues = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management").PagingFiles
+                    }
+                    catch {
+                        Fail-Json $result "Failed to get pagefile settings from the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
+                    }
+                    $pagingFilesValues += "$fullPath $initialSize $maximumSize"
+                    try {
+                        Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" "PagingFiles" $pagingFilesValues
+                    }
+                    catch {
+                        Fail-Json $result "Failed to set pagefile settings to the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
+                    }
+                }
+            }
+            $result.changed = $true
+            $result.reboot_required = $true
+        }
+    }
+    elseif ($state -eq "query") {
+        $result.pagefiles = @()
+
+        if ($null -eq $drive) {
+            try {
+                $pagefiles = Get-WmiObject Win32_PageFileSetting
+            }
+            catch {
+                Fail-Json $result "Failed to query all pagefiles $($_.Exception.Message)"
+            }
+        }
+        else {
+            try {
+                $pagefiles = Get-Pagefile $fullPath
+            }
+            catch {
+                Fail-Json $result "Failed to query specific pagefile $($_.Exception.Message)"
+            }
+        }
+
+        # Get all pagefiles
+        foreach ($currentPagefile in $pagefiles) {
+            $currentPagefileObject = @{
+                name         = $currentPagefile.Name
+                initial_size = $currentPagefile.InitialSize
+                maximum_size = $currentPagefile.MaximumSize
+                caption      = $currentPagefile.Caption
+                description  = $currentPagefile.Description
+            }
+            $result.pagefiles += $currentPagefileObject
+        }
+
+        # Get automatic managed pagefile state
+        try {
+            $result.automatic_managed_pagefiles = (Get-WmiObject -Class win32_computersystem).AutomaticManagedPagefile
+        }
+        catch {
+            Fail-Json $result "Failed to query automatic managed pagefile state $($_.Exception.Message)"
+        }
+    }
+    if ($result.changed -eq $true) {
+        $result.reboot_required = $true
+    }
+    Exit-Json $result

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -97,7 +97,7 @@ EXAMPLES = r'''
     override: yes
     state: present
 
-- name: Set C pagefile, don't override if input matches current configuration
+- name: Set C pagefile, don't override if input matches current configuration.
   win_pagefile:
     drive: C
     initial_size: 1024

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -36,8 +36,9 @@ options:
   override:
     description:
       - Override the current pagefile on the drive.
-    type: bool
-    default: yes
+    type: str
+    choices: [ yes, no, match ]
+    default: match
   system_managed:
     description:
       - Configures current pagefile to be managed by the system.
@@ -93,6 +94,14 @@ EXAMPLES = r'''
     drive: C
     initial_size: 1024
     maximum_size: 1024
+    override: yes
+    state: present
+
+- name: Set C pagefile, don't override if input matches current configuration
+  win_pagefile:
+    drive: C
+    initial_size: 1024
+    maximum_size: 1024
     state: present
 
 - name: Remove C pagefile
@@ -135,5 +144,9 @@ pagefiles:
     sample:
       [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"},
        {"caption": "d:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ d:\\", "initial_size": 1024, "maximum_size": 1024, "name": "d:\\pagefile.sys"}]
-
+reboot_required:
+    description: True when there is a change in the configuration of pagefile and target needs a reboot for the effect to take place.
+    returned: always
+    type: bool
+    sample: true
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 "match" option added to override flag
"reboot_required" added as return value if there is change in config. A reboot is necessary, if there is any change in pagefile. Without  reboot changes won't be effective and  if pester is used it wont be able to catch the change. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixed bug with "override" flag.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_pagefile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The "override" flag was set to true by default. So in this case even if the config is same as given input, the pagefile was getting overridden.

In this current pull request, above described bug is fixed.
"match" option has been added to "override" flag. So by this it compares the input with current config, in case of mismatch the page file is updated.

"reboot_required" added as return value. It helps for easy decision making in playbook. Reboot is necessary if there is a change in pagefile. In many scenario pester is used to catch the change, so it may fail without reboot. 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

https://github.com/ansible/ansible/issues/57836

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
