### PR TITLE
Ignore the google-auth library warning for user credentials

### DIFF
--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -22,6 +22,7 @@ from ansible.module_utils._text import to_text
 import ast
 import os
 import json
+import warnings
 
 
 def navigate_hash(source, path, default=None):
@@ -80,7 +81,11 @@ class GcpSession(object):
     def get(self, url, body=None, **kwargs):
         kwargs.update({'json': body, 'headers': self._headers()})
         try:
-            return self.session().get(url, **kwargs)
+            # Ignore the google-auth library warning for user credentials. More
+            # details: https://github.com/googleapis/google-auth-library-python/issues/271
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
+                return self.session().get(url, **kwargs)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 


### PR DESCRIPTION
##### SUMMARY
In the PR https://github.com/ansible/ansible/pull/57730, I guess by a mistake, filtering google-auth lib user credentials warnings was removed, so I'm returning it back. More details about the reasoning to remove this warning can be found here: https://github.com/googleapis/google-auth-library-python/issues/271

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute