### PR TITLE
docker_container: Change expected config source

### DIFF
--- a/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
+++ b/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - "docker_container: switch to Config data source for images (API>=1.21)"
+    - "docker_container - switch to ``Config`` data source for images (API>=1.21)."

--- a/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
+++ b/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - docker_container: switch to Config data source for images (API>=1.21)
+    - "docker_container: switch to Config data source for images (API>=1.21)"

--- a/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
+++ b/changelogs/fragments/57969-docker_container-change-expected-config-source.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - docker_container: switch to Config data source for images (API>=1.21)

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2099,7 +2099,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_binds')
         image_vols = []
         if image:
-            image_vols = self._get_image_binds(image[self.parameters.client.inspect_source].get('Volumes'))
+            image_vols = self._get_image_binds(image[self.parameters.client.image_inspect_source].get('Volumes'))
         param_vols = []
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2149,8 +2149,8 @@ class Container(DockerBaseClass):
     def _get_expected_volumes(self, image):
         self.log('_get_expected_volumes')
         expected_vols = dict()
-        if image and image[self.parameters.client.inspect_source].get('Volumes'):
-            expected_vols.update(image[self.parameters.client.inspect_source].get('Volumes'))
+        if image and image[self.parameters.client.image_inspect_source].get('Volumes'):
+            expected_vols.update(image[self.parameters.client.image_inspect_source].get('Volumes'))
 
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2180,8 +2180,8 @@ class Container(DockerBaseClass):
     def _get_expected_env(self, image):
         self.log('_get_expected_env')
         expected_env = dict()
-        if image and image[self.parameters.client.inspect_source].get('Env'):
-            for env_var in image[self.parameters.client.inspect_source]['Env']:
+        if image and image[self.parameters.client.image_inspect_source].get('Env'):
+            for env_var in image[self.parameters.client.image_inspect_source]['Env']:
                 parts = env_var.split('=', 1)
                 expected_env[parts[0]] = parts[1]
         if self.parameters.env:
@@ -2195,7 +2195,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_exposed')
         image_ports = []
         if image:
-            image_exposed_ports = image[self.parameters.client.inspect_source].get('ExposedPorts') or {}
+            image_exposed_ports = image[self.parameters.client.image_inspect_source].get('ExposedPorts') or {}
             image_ports = [self._normalize_port(p) for p in image_exposed_ports.keys()]
         param_ports = []
         if self.parameters.ports:
@@ -2875,9 +2875,9 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             **kwargs
         )
 
-        self.inspect_source = 'Config'
+        self.image_inspect_source = 'Config'
         if self.docker_api_version < LooseVersion('1.21'):
-            self.inspect_source = 'ContainerConfig'
+            self.image_inspect_source = 'ContainerConfig'
 
         self._get_additional_minimal_versions()
         self._parse_comparisons()

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2099,7 +2099,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_binds')
         image_vols = []
         if image:
-            image_vols = self._get_image_binds(image['Config'].get('Volumes'))
+            image_vols = self._get_image_binds(image[self.parameters.client.inspect_source].get('Volumes'))
         param_vols = []
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2149,8 +2149,8 @@ class Container(DockerBaseClass):
     def _get_expected_volumes(self, image):
         self.log('_get_expected_volumes')
         expected_vols = dict()
-        if image and image['Config'].get('Volumes'):
-            expected_vols.update(image['Config'].get('Volumes'))
+        if image and image[self.parameters.client.inspect_source].get('Volumes'):
+            expected_vols.update(image[self.parameters.client.inspect_source].get('Volumes'))
 
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2180,8 +2180,8 @@ class Container(DockerBaseClass):
     def _get_expected_env(self, image):
         self.log('_get_expected_env')
         expected_env = dict()
-        if image and image['Config'].get('Env'):
-            for env_var in image['Config']['Env']:
+        if image and image[self.parameters.client.inspect_source].get('Env'):
+            for env_var in image[self.parameters.client.inspect_source]['Env']:
                 parts = env_var.split('=', 1)
                 expected_env[parts[0]] = parts[1]
         if self.parameters.env:
@@ -2195,7 +2195,8 @@ class Container(DockerBaseClass):
         self.log('_get_expected_exposed')
         image_ports = []
         if image:
-            image_ports = [self._normalize_port(p) for p in (image['Config'].get('ExposedPorts') or {}).keys()]
+            image_exposed_ports = image[self.parameters.client.inspect_source].get('ExposedPorts') or {}
+            image_ports = [self._normalize_port(p) for p in image_exposed_ports.keys()]
         param_ports = []
         if self.parameters.ports:
             param_ports = [str(p[0]) + '/' + p[1] for p in self.parameters.ports]
@@ -2873,6 +2874,11 @@ class AnsibleDockerClientContainer(AnsibleDockerClient):
             option_minimal_versions_ignore_params=self.__NON_CONTAINER_PROPERTY_OPTIONS,
             **kwargs
         )
+
+        self.inspect_source = 'Config'
+        if self.docker_api_version < LooseVersion('1.21'):
+            self.inspect_source = 'ContainerConfig'
+
         self._get_additional_minimal_versions()
         self._parse_comparisons()
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2099,7 +2099,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_binds')
         image_vols = []
         if image:
-            image_vols = self._get_image_binds(image['ContainerConfig'].get('Volumes'))
+            image_vols = self._get_image_binds(image['Config'].get('Volumes'))
         param_vols = []
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2149,8 +2149,8 @@ class Container(DockerBaseClass):
     def _get_expected_volumes(self, image):
         self.log('_get_expected_volumes')
         expected_vols = dict()
-        if image and image['ContainerConfig'].get('Volumes'):
-            expected_vols.update(image['ContainerConfig'].get('Volumes'))
+        if image and image['Config'].get('Volumes'):
+            expected_vols.update(image['Config'].get('Volumes'))
 
         if self.parameters.volumes:
             for vol in self.parameters.volumes:
@@ -2180,8 +2180,8 @@ class Container(DockerBaseClass):
     def _get_expected_env(self, image):
         self.log('_get_expected_env')
         expected_env = dict()
-        if image and image['ContainerConfig'].get('Env'):
-            for env_var in image['ContainerConfig']['Env']:
+        if image and image['Config'].get('Env'):
+            for env_var in image['Config']['Env']:
                 parts = env_var.split('=', 1)
                 expected_env[parts[0]] = parts[1]
         if self.parameters.env:
@@ -2195,7 +2195,7 @@ class Container(DockerBaseClass):
         self.log('_get_expected_exposed')
         image_ports = []
         if image:
-            image_ports = [self._normalize_port(p) for p in (image['ContainerConfig'].get('ExposedPorts') or {}).keys()]
+            image_ports = [self._normalize_port(p) for p in (image['Config'].get('ExposedPorts') or {}).keys()]
         param_ports = []
         if self.parameters.ports:
             param_ports = [str(p[0]) + '/' + p[1] for p in self.parameters.ports]


### PR DESCRIPTION
##### SUMMARY
According to https://github.com/moby/moby/issues/18880 ContainerConfig section is for historical data while Config should be used to get image expected config.

[SO discussion](https://stackoverflow.com/questions/36216220/what-is-different-of-config-and-containerconfig-of-docker-inspect)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container.py

##### ADDITIONAL INFORMATION
The issue pops up with [Kaniko](https://github.com/GoogleContainerTools/kaniko)-built multi stage images: Ansible expects Env to match ContainerConfig's one but container is created with Config's values. Could not reproduce with `docker build`.

`docker inspect` output for affected image:
```
[
    {
        "Id": "sha256:bdbe122c6bc21fcd7c96c19341d9e29fc611cfcf8502e2d190d5649748d0cad3",
        "RepoTags": [
            "registry.local/testimage:latest"
        ],
        "RepoDigests": [
            "registry.local/testimage@sha256:1c6722247b3fafa4c5f9944134b69315783d5d4697bc22dbff3e2518df507e3d"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2019-04-02T15:59:59.752275529Z",
        "Container": "94772adb8869651410d18062838667884a555cf1878d567734e99dc695d6f5bf",
        "ContainerConfig": {
            "Hostname": "94772adb8869",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "/bin/sh",
                "-c",
                "#(nop) ",
                "CMD [\"/bin/bash\"]"
            ],
            "ArgsEscaped": true,
            "Image": "sha256:881686baf75637792ebd93d88243b6f5bb89833ce325f9e32e2e70208f0efb64",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": null,
            "OnBuild": null,
            "Labels": {}
        },
        "DockerVersion": "18.06.1-ce",
        "Author": "",
        "Config": {
            "Hostname": "",
            "Domainname": "",
            "User": "",
            "AttachStdin": false,
            "AttachStdout": false,
            "AttachStderr": false,
            "ExposedPorts": {
                "443/tcp": {},
                "80/tcp": {},
                "9909/tcp": {}
            },
            "Tty": false,
            "OpenStdin": false,
            "StdinOnce": false,
            "Env": [
                "PATH=/opt/openresty/bin:/opt/openresty/nginx/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [],
            "ArgsEscaped": true,
            "Image": "sha256:881686baf75637792ebd93d88243b6f5bb89833ce325f9e32e2e70208f0efb64",
            "Volumes": null,
            "WorkingDir": "",
            "Entrypoint": [
                "/entrypoint"
            ],
            "OnBuild": null,
            "Labels": null
        },
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 203022405,
        "VirtualSize": 203022405,
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/0f0067b169c56d0c730a80adc68e6283749209ead4ee8735317a8f84dc272233/diff:/var/lib/docker/overlay2/3fa2298d11f96d0fd4133ad75f087fcf15bb4044741b01b26356f65e7e6fb4ca/diff:/var/lib/docker/overlay2/c78ac12a0847acc37b7cf5ca9cb7578f2a795bcfa9c6fef31fe727fc46808120/diff:/var/lib/docker/overlay2/1d503e9737cd68c59fafe80a2b9e41684895df71f3bc3031265fb7d881b5052c/diff:/var/lib/docker/overlay2/c66224ca72f3a178295c9c59737c5ae5de3f9527fce81fe2cd62db90b71c909d/diff:/var/lib/docker/overlay2/1b912d259f77c292eec3213e775935a9c87854d2d08412bed31704ac77d99403/diff:/var/lib/docker/overlay2/1a73f8c31b8db1d3a8a6e7682025193a415d8b39b2eea794cf811aae2cd7a4ff/diff:/var/lib/docker/overlay2/6f8b1fc9b5efa94e33854e13c5c073b89b8e77c71f8ab26877a3ecaef2a2158d/diff:/var/lib/docker/overlay2/c2faf666103e0e03c35b8602eab8cb1e58f5c151ab5b32eae7f19cc852bc066e/diff:/var/lib/docker/overlay2/9ddd9057f68672a06adf9bf77d6daf58fe5c07933fd042a3219f50547fe2a89e/diff:/var/lib/docker/overlay2/cc0919c613932b77c244480dbfe86a2b830d4da1b3f798207bb088722601926e/diff:/var/lib/docker/overlay2/9bea0718089b30b648bc17aa40c4eb34df717673db85cd007b160c6dc25223d3/diff:/var/lib/docker/overlay2/6784be64aeac73bb3dc133c39a7b07ddacb1fabebaac6f25c68c9df989624303/diff:/var/lib/docker/overlay2/9c53c2094eb82719fcc17efc152c5af1382f36889e6eb5182be33833c9247294/diff:/var/lib/docker/overlay2/8efa83e58bb3b0ad6188400c9b3045153859c44a444eef7312bab796003ac698/diff:/var/lib/docker/overlay2/b959d1fa8dd7e3aee34f58258174d58dd9a94441cf83a4ceb1b6cdb00b608034/diff:/var/lib/docker/overlay2/c211cd79baa2b50b1b981a027c50627244082437d6a416b9824d380621e8fb19/diff:/var/lib/docker/overlay2/c0da40d084e6d8f6fba652d0703d38337db8cb1f7010517a8471db28c2ad60dc/diff:/var/lib/docker/overlay2/e67a2138fbee87667f4d474c274678abd50a16edb60d08f19b4e4eb2ffd94af7/diff:/var/lib/docker/overlay2/5ff0af1ad81b65f94dbdbd276f2406b507e3e48e4b51c36268dba48eaa27aacf/diff:/var/lib/docker/overlay2/1f47f692f6499e68e28ffd7437bf663030a3e681c1c25b1a92c6ad8ab5fcf1fb/diff:/var/lib/docker/overlay2/a5a8e8402c8f4dd2f31b0531572dea73b0cdb40d3063f28e6f37959ce9fb5f78/diff:/var/lib/docker/overlay2/91bb4aae4dd8a505060c9879897691bdafdb10832ccc0b434ea97570869d549e/diff",
                "MergedDir": "/var/lib/docker/overlay2/727ae041a7c7f590b6268b8bf8816639b2ccd1966372748610ab0c8b89336008/merged",
                "UpperDir": "/var/lib/docker/overlay2/727ae041a7c7f590b6268b8bf8816639b2ccd1966372748610ab0c8b89336008/diff",
                "WorkDir": "/var/lib/docker/overlay2/727ae041a7c7f590b6268b8bf8816639b2ccd1966372748610ab0c8b89336008/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:762d8e1a60542b83df67c13ec0d75517e5104dee84d8aa7fe5401113f89854d9",
                "sha256:e45cfbc98a505924878945fdb23138b8be5d2fbe8836c6a5ab1ac31afd28aa69",
                "sha256:d60e01b37e74f12aa90456c74e161f3a3e7c690b056c2974407c9e1f4c51d25b",
                "sha256:b57c79f4a9f3f7e87b38c17ab61a55428d3391e417acaa5f2f761c0e7e3af409",
                "sha256:fb26b87db8775c0d76184c7baf0a184ef99e341e51f443178d7a23248cfb9f79",
                "sha256:7c77a733000eef26c7646291449e878b4a73d79656ca35977604926d1b472346",
                "sha256:b8e184566cfcf8451e4d311175613b9fa5cc67ef5e57866226bc9a940e25cf5c",
                "sha256:fef22d9b7e97c96983a4ba054fe6700fb78c118e7e9a2328a708af25baff356e",
                "sha256:efef41a5da3b37117fff5c771d66df0940248723210927376fbbfd2ebed5d1a7",
                "sha256:dd7a2b73ca9845db329bac69aa24f0abdb802b23918249e433cb03fbb9df01af",
                "sha256:59a8e95726a8ad7d891b47306a9e5bc334b86e32e37ba5d83b664ad516034083",
                "sha256:55a0f56c5fbaf76972af35139a95529021d31b4e3f8fb20c0ebe9ab125ca6d71",
                "sha256:97e6bb82fa568792c86d9fcf678e3864ecd8dd6c48d0978119389e1117399e7f",
                "sha256:679372f19ca6f8cbc4bed7464768eabac97cf66ceb8116f0cdf82842d740b0ae",
                "sha256:0ca085cf5387133d50fb6fa63fc17621192c486a00b2ae4577d7e30434b8f66f",
                "sha256:2fba0316ce15f8fd0cec55935860c73014fdd10f58344bba339e4fe74add0079",
                "sha256:dffe4f085fa494a93d67162d5aa12da57845908f1d3d240d550c9a6c6bc0f5fd",
                "sha256:bce96efe369c41d6e669fb28d8fd7bd906b4ebc249f31e0f1b9cfd186e1a8e72",
                "sha256:b2d65405463cf5eefd396ea9c2045c4ff8e873f69fb42e0f0a689320c9dba4b4",
                "sha256:14c4f9cb7e3b8b1a71c8fbd5c2549092aeef78d62664e9dd36e86f6cde08cd11",
                "sha256:edc3d90c41577885402bf088810d2463a245b0448ba2abe3b79ef93266668279",
                "sha256:ff652e8f2aecadf4c937c2a66d96dbd2893dd67aad3b8ea4656dd0b5c3724aa0",
                "sha256:60a8f936147dbbe70a7668d40b4011873efc82bf2b1d8af50d8ea35571ff8292",
                "sha256:2d52bfe9dad81bee89f2ab81959f69a9bf8ea1cbde503babfe0904e4446101d9"
            ]
        },
        "Metadata": {
            "LastTagTime": "2019-06-17T12:51:48.522596457Z"
        }
    }
]
```

Related Ansible output:
```
    "diff": {
        "differences": [
            {
                "expected_env": {
                    "container": [
                        "PATH=/opt/openresty/bin:/opt/openresty/nginx/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
                    ],
                    "parameter": [
                        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
                    ]
                }
            }
        ]
    },
```