### PR TITLE
removes link from 404 content, explains options

### DIFF
--- a/docs/docsite/rst/404.rst
+++ b/docs/docsite/rst/404.rst
@@ -4,9 +4,9 @@
 Oops!
 *****
 
-This page does not exist in this version of the Ansible documentation.
+The version of the Ansible documentation you were looking at doesn't contain that page.
 
 .. image:: images/cow.png
    :alt: Cowsay 404
 
-Return to the :ref:`nearest table of contents in this version <ansible_documentation>` or use the navigation at left to explore our latest release.
+Use the back button to return to the version you were browsing, or use the navigation at left to explore our latest release. Once you're on a non-404 page, you can use the version-changer to select a version.


### PR DESCRIPTION
##### SUMMARY
The link in the 404 content was to `index.html#ansible-documentation` - that's neither relative (`href="../index.html#ansible-documentation">`) nor absolute (`href="/ansible/latest/index.html#ansible-documentation">`) so it gave unexpected results. 

Removing the internal link in favor of the simplest fix. If we see ways to improve on this, we can add them in future.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
