### PR TITLE
Fixes #57948: Fixed device query type

### DIFF
--- a/changelogs/fragments/netbox_interface-fixed-device-search.yml
+++ b/changelogs/fragments/netbox_interface-fixed-device-search.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netbox_interface - Fixes (57948) device search query type from defaulting to ``q`` due to incorrect key for ``device`` within ``QUERY_TYPES`` - was ``devices`` now ``device`` to match required key.

--- a/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
+++ b/lib/ansible/module_utils/net_tools/netbox/netbox_utils.py
@@ -27,7 +27,7 @@ API_APPS_ENDPOINTS = dict(
 
 QUERY_TYPES = dict(
     cluster="name",
-    devices="name",
+    device="name",
     device_role="slug",
     device_type="slug",
     manufacturer="slug",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #57948 
The issue was due to a typo within the `QUERY_TYPES` for device. It was `devices` instead of `device` that matches the key required within the netbox_interface module so it was defaulting to using `q` for the search. If there is more than one device that contains the configured `device`, it would return all results.

ex. `device: R1`
site-1-R1
site-2-R1

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netbox_interface.py
