### PR TITLE
ansible-test: ios_command cli test should only be network_cli (#56955)

### DIFF
--- a/test/integration/targets/ios_command/tests/cli/cli_command.yaml
+++ b/test/integration/targets/ios_command/tests/cli/cli_command.yaml
@@ -2,25 +2,27 @@
 - debug:
     msg: "START cli/cli_command.yaml on connection={{ ansible_connection }}"
 
-- name: get output for single command
-  cli_command:
-    command: show version
-  register: result
+- block:
+  - name: get output for single command
+    cli_command:
+      command: show version
+    register: result
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.stdout is defined"
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
 
-- name: send invalid command
-  cli_command:
-    command: 'show foo'
-  register: result
-  ignore_errors: yes
+  - name: send invalid command
+    cli_command:
+      command: 'show foo'
+    register: result
+    ignore_errors: yes
 
-- assert:
-    that:
-      - "result.failed == true"
-      - "result.msg is defined"
+  - assert:
+      that:
+        - "result.failed == true"
+        - "result.msg is defined"
+  when: "ansible_connection == 'network_cli'"
 
 - debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
Backport https://github.com/ansible/ansible/pull/56955

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_command