### PR TITLE
Fix issue in netconf plugin dispatch for junos and iosxr

### DIFF
--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -29,7 +29,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 try:
     from ncclient.operations import RPCError
-    from ncclient.xml_ import to_xml, to_ele
+    from ncclient.xml_ import to_xml, to_ele, NCElement
     HAS_NCCLIENT = True
     NCCLIENT_IMP_ERR = None
 except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
@@ -225,7 +225,20 @@ class NetconfBase(AnsiblePlugin):
             raise ValueError('rpc_command value must be provided')
 
         resp = self.m.dispatch(fromstring(rpc_command), source=source, filter=filter)
-        return resp.data_xml if hasattr(resp, 'data_xml') else resp.xml
+
+        if isinstance(resp, NCElement):
+            # In case xml reply is transformed or namespace is removed in
+            # ncclient device specific handler return modified xml response
+            result = resp.data_xml
+        elif hasattr(resp, 'data_ele') and resp.data_ele:
+            # if data node is present in xml response return the xml string
+            # with data node as root
+            result = resp.data_xml
+        else:
+            # return raw xml string received from host with rpc-reply as the root node
+            result = resp.xml
+
+        return result
 
     @ensure_connected
     def lock(self, target="candidate"):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  If case xml reply is transformed or namespace is removed in ncclient
   device specific handler return modified xml response as string

*  If data xml node is present in xml response return the xml string
   with data node as root node

*  If none above is true return raw xml string received from host
   with rpc-reply as the root node
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Depends-On: https://github.com/ansible/ansible/pull/57966