### PR TITLE
[2.8] openssl_certificate_info: fix missing doc type

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -45,7 +45,7 @@ options:
             - Valid format is C([+-]timespec | ASN.1 TIME) where timespec can be an integer
               + C([w | d | h | m | s]) (e.g. C(+32w1d2h), and ASN.1 TIME (i.e. pattern C(YYYYMMDDHHMMSSZ)).
               Note that all timestamps will be treated as being in UTC.
-
+        type: dict
     select_crypto_backend:
         description:
             - Determines which crypto backend to use.


### PR DESCRIPTION
##### SUMMARY
Backport of #57884 to stable-2.8. Fixes missing doc type.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
openssl_certificate_info
