### PR TITLE
Backport PR needed to fix the netvisor failure with network_cli connection.

### DIFF
--- a/changelogs/fragments/57447-netvisor-failing-with-network_cli-connection.yaml
+++ b/changelogs/fragments/57447-netvisor-failing-with-network_cli-connection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- To fix the netvisor failure with network_cli connection - https://github.com/ansible/ansible/pull/57938

--- a/lib/ansible/plugins/cliconf/netvisor.py
+++ b/lib/ansible/plugins/cliconf/netvisor.py
@@ -35,7 +35,16 @@ from ansible.plugins.cliconf import CliconfBase
 
 class Cliconf(CliconfBase):
 
-    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None, check_all=False):
+    def get_config(self, source='running', format='text', flags=None):
+        if source not in ('running'):
+            return self.invalid_params("fetching configuration from %s is not supported" % source)
+        cmd = 'show running-config'
+        return self.send_command(cmd)
+
+    def edit_config(self, command):
+        return
+
+    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
         if not command:
             raise ValueError('must provide value of command to execute')
         if output:


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>
(cherry picked from commit d63ccb5bc83ae10aa92d8dea258cb46b7e2d164f)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backports needed to fix the netvisor failure with network_cli connection. Backports for the PR #57447
cherry picked from commit (d63ccb5bc83ae10aa92d8dea258cb46b7e2d164f)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netvisor
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
