### PR TITLE
Fix junos modules persistent connection check

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -22,12 +22,10 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible import constants as C
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.junos.junos import junos_provider_spec
-from ansible.plugins.loader import connection_loader, module_loader
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.utils.display import Display
 
@@ -42,10 +40,6 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         self._config_module = True if self._task.action == 'junos_config' else False
-        module = module_loader._load_module_source(self._task.action, module_loader.find_plugin(self._task.action))
-        if not getattr(module, 'USE_PERSISTENT_CONNECTION', False):
-            return super(ActionModule, self).run(task_vars=task_vars)
-
         socket_path = None
 
         if self._play_context.connection == 'local':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #57985
*  The check `USE_PERSISTENT_CONNECTION` flag is no longer
    required in action plugin as the junos modules in the galaxy are renamed to start with `juniper_`.

 ~~* `_load_module_source()` in junos action plugin used
  to check if `USE_PERSISTENT_CONNECTION` flag is set
  in module, code results in trying to execute the module
  import statement. This results in import failure if in case
  junos_* module is present in role and import's from
  module_utils directory present within the role.~~

~~* This fix uses ast module to parse the module
  code and determine if `USE_PERSISTENT_CONNECTION` flag is set
  within the module without executing the import statement.~~

~~* This fix requires all the modules starting with `junos_`
  to set `USE_PERSISTENT_CONNECTION` flag to True in order to 
  use a persistent connection framework. This behavior is in sync 
 with junos modules shipped with `ansible/ansible`~~


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/junos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ansible-playbook test_facts.yaml

PLAY [junos] *****************************************************************************************

TASK [get interfaces facts] **************************************************************************
 An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named facts.facts
fatal: [junos02]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}

PLAY RECAP *******************************************************************************************
junos02                    : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0
```

After:
```
$ansible-playbook test_facts.yaml

PLAY [junos] *****************************************************************************************

TASK [get interfaces facts] **************************************************************************
 [WARNING]: default value for `gather_subset`                 will be changed to `min` from `!config`
v2.11 onwards

ok: [junos02]

PLAY RECAP *******************************************************************************************
junos02                    : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```