### PR TITLE
vmware_guest: assign device keys from a sequence generator

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -609,6 +609,7 @@ class PyVmomiKeyHelper(object):
         PyVmomiKeyHelper.current_key -= 1
         return PyVmomiKeyHelper.current_key
 
+
 class PyVmomiDeviceHelper(object):
     """ This class is a helper to create easily VMWare Objects for PyVmomiHelper """
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -645,7 +645,7 @@ class PyVmomiDeviceHelper(object):
         ide_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         ide_ctl.device = vim.vm.device.VirtualIDEController()
         ide_ctl.device.deviceInfo = vim.Description()
-        ide_ctl.device.key = PyVmomiDeviceHelper.next_key()
+        ide_ctl.device.key = PyVmomiKeyHelper.next_key()
         ide_ctl.device.busNumber = 0
 
         return ide_ctl


### PR DESCRIPTION


##### SUMMARY

This PR adds a new class which contains a staticmethod that generates a sequence of integers for use as temporary client defined keys. I'm not convinced that the current system of ranges of random numbers will cope with assigning keys to disks and disks will need keys when we start using storage policies.

I'm using this PR to help discuss what we want to do.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION

1. The most important thing is assigning keys to disks. The storage policy API doesn't work if keys aren't specified even though the API doesn't refer to the keys directly. 
2. I kind of like the staticmethod for generating keys because it makes keys that look like the keys made by the VMware client.
3. I don't care at all what class the staticmethod is part of and there is no good reason for making the new class PyVmomiKeyHelper.
