### PR TITLE
updated zabbix modules to use missing_required_lib helper

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -439,13 +439,17 @@ msg:
     sample: 'Action Deleted: Register webservers, ID: 0001'
 '''
 
+
+import traceback
+
 try:
     from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 class Zapi(object):
@@ -1966,7 +1970,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -75,15 +75,19 @@ EXAMPLES = '''
   when: inventory_hostname==groups['group_name'][0]
 '''
 
+
+import traceback
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import Already_Exists
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 class HostGroup(object):
@@ -146,7 +150,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
@@ -56,7 +56,10 @@ EXAMPLES = '''
     timeout: 10
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
@@ -74,6 +77,7 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
 
@@ -107,7 +111,7 @@ def main():
         module.deprecate("The 'zabbix_group_facts' module has been renamed to 'zabbix_group_info'", version='2.13')
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -223,7 +223,9 @@ EXAMPLES = '''
     tls_psk: 123456789abcdef123456789abcdef12
 '''
 
+
 import copy
+import traceback
 
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
@@ -241,9 +243,10 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 class Host(object):
@@ -657,7 +660,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -95,7 +95,10 @@ EXAMPLES = '''
     remove_duplicate: yes
 '''
 
-from ansible.module_utils.basic import AnsibleModule
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
@@ -113,6 +116,7 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
 
@@ -190,7 +194,7 @@ def main():
         module.deprecate("The 'zabbix_host_facts' module has been renamed to 'zabbix_host_info'", version='2.13')
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -71,6 +71,9 @@ EXAMPLES = '''
     state: present
 '''
 
+
+import traceback
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
@@ -82,9 +85,10 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 class HostMacro(object):
@@ -170,7 +174,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -121,16 +121,19 @@ EXAMPLES = '''
     login_password: pAsSwOrD
 '''
 
+
 import datetime
 import time
+import traceback
 
 try:
     from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 def create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, period, name, desc):
@@ -288,7 +291,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     host_names = module.params['host_names']
     host_groups = module.params['host_groups']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -172,34 +172,41 @@ ANSIBLE_METADATA = {
     'status': ['preview']
 }
 
+
 import base64
+import traceback
+
 from io import BytesIO
 from operator import itemgetter
 from distutils.version import StrictVersion
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 try:
     import pydotplus
     HAS_PYDOTPLUS = True
 except ImportError:
+    PYDOT_IMP_ERR = traceback.format_exc()
     HAS_PYDOTPLUS = False
 
 try:
     import webcolors
     HAS_WEBCOLORS = True
 except ImportError:
+    WEBCOLORS_IMP_ERR = traceback.format_exc()
     HAS_WEBCOLORS = False
 
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
 try:
     from PIL import Image
     HAS_PIL = True
 except ImportError:
+    PIL_IMP_ERR = traceback.format_exc()
     HAS_PIL = False
 
 
@@ -761,13 +768,13 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
     if not HAS_PYDOTPLUS:
-        module.fail_json(msg="Missing required pydotplus module (check docs or install with: pip install pydotplus)")
+        module.fail_json(msg=missing_required_lib('pydotplus', url='https://pypi.org/project/pydotplus/'), exception=PYDOT_IMP_ERR)
     if not HAS_WEBCOLORS:
-        module.fail_json(msg="Missing required webcolors module (check docs or install with: pip install webcolors)")
+        module.fail_json(msg=missing_required_lib('webcolors', url='https://pypi.org/project/webcolors/'), exception=WEBCOLORS_IMP_ERR)
     if not HAS_PIL:
-        module.fail_json(msg="Missing required Pillow module (check docs or install with: pip install Pillow)")
+        module.fail_json(msg=missing_required_lib('Pillow', url='https://pypi.org/project/Pillow/'), exception=PIL_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -125,12 +125,15 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
-from ansible.module_utils.basic import AnsibleModule
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     from zabbix_api import ZabbixAPI
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
 
@@ -260,9 +263,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module" +
-                             " (check docs or install with:" +
-                             " pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -153,6 +153,9 @@ EXAMPLES = '''
   when: inventory_hostname==groups['group_name'][0]
 '''
 
+
+import traceback
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import ZabbixAPIException
@@ -170,9 +173,10 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
 class Screen(object):
@@ -372,7 +376,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module (check docs or install with: pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -194,7 +194,7 @@ template_json:
 '''
 
 from distutils.version import LooseVersion
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 import json
 import traceback
@@ -205,6 +205,7 @@ try:
 
     HAS_ZABBIX_API = True
 except ImportError:
+    ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
 
@@ -467,9 +468,7 @@ def main():
     )
 
     if not HAS_ZABBIX_API:
-        module.fail_json(msg="Missing required zabbix-api module " +
-                             "(check docs or install with: " +
-                             "pip install zabbix-api)")
+        module.fail_json(msg=missing_required_lib('zabbix-api', url='https://pypi.org/project/zabbix-api/'), exception=ZBX_IMP_ERR)
 
     server_url = module.params['server_url']
     login_user = module.params['login_user']


### PR DESCRIPTION
##### SUMMARY
Replaced manually defined error message when required dependency is missing with common `missing_required_lib` helper (reference #57488).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
zabbix_action
zabbix_group
zabbix_group_info
zabbix_host
zabbix_host_info
zabbix_hostmacro
zabbix_maintenance
zabbix_map
zabbix_proxy
zabbix_screen
zabbix_template