### PR TITLE
updates docs reqs to specify Pygments version, remove tornado

### DIFF
--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -62,14 +62,14 @@ If you make multiple changes to the documentation, or add more than a line to it
 
 To work with documentation on your local machine, you need the following packages installed:
 
-- libyaml
-- PyYAML
-- six
-- tornado
-- pyparsing
 - gcc
 - jinja2
+- libyaml
+- Pygments >= 2.4.0
+- pyparsing
+- PyYAML
 - rstcheck
+- six
 - sphinx
 - sphinx-notfound-page
 


### PR DESCRIPTION
##### SUMMARY
Follow-up on #57508 and discussion in the Docs Working Group meeting on [June 18 2019](https://github.com/ansible/community/issues/389#issuecomment-502248647).

Tornado is not required to build the docs locally. Pygments >= 2.4.0 is required. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
community guide
