### PR TITLE
Backport/2.8/57366

### DIFF
--- a/changelogs/fragments/57366-allow-multiple-schedules-for-snapshot-policy
+++ b/changelogs/fragments/57366-allow-multiple-schedules-for-snapshot-policy
@@ -1,0 +1,2 @@
+bugfixes:
+  - na_ontap_snapshot_policy - allow for multiple schedules to be set for a snapshot policy


### PR DESCRIPTION
##### SUMMARY
Allow for more than 1 scheduled to be set for a snapshot policy

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_snapshot_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
