### PR TITLE
[WIP] Add the ability to specify --root.

### DIFF
--- a/changelogs/fragments/systemd_root_n_scope.yml
+++ b/changelogs/fragments/systemd_root_n_scope.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - added ability for systemd to use a 'root' option.
+bugfixes:
+    - scope now only correctly applies to commands using a unit.

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -368,9 +368,6 @@ def main():
         else:
             module.params['scope'] = 'system'
 
-    # if scope is 'system' or None, we can ignore as there is no extra switch.
-    # The other choices match the corresponding switch
-
     if module.params['no_block']:
         systemctl += " --no-block"
 
@@ -408,6 +405,8 @@ def main():
         if module.params['root']:
             systemctl_unit += " --root=%s" % module.params['root']
 
+        # if scope is 'system' or None, we can ignore as there is no extra switch.
+        # The other choices match the corresponding switch
         if module.params['scope'] not in (None, 'system'):
             systemctl_unit += " --%s" % module.params['scope']
 


### PR DESCRIPTION
When systemd is not running but changes has to be made such as enabling or disabling services,
using `--root` allows us to run systemctl without it.
This PR adds the ability to do just that.

(cherry picked from commit 5932c05748024fe4fbad82034396eb2e991e4c10)
rebase and fix for #44690

Also fix how scope is added, it should ony be needed with commands that use a 'unit'


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd