### PR TITLE
Fix CloudStorageAccount import on azure

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -157,7 +157,10 @@ try:
     from azure.mgmt.containerservice import ContainerServiceClient
     from azure.mgmt.marketplaceordering import MarketplaceOrderingAgreements
     from azure.mgmt.trafficmanager import TrafficManagerManagementClient
-    from azure.storage.cloudstorageaccount import CloudStorageAccount
+    try:
+        from azure.storage.common.cloudstorageaccount import CloudStorageAccount
+    except ImportError:
+        from azure.storage.cloudstorageaccount import CloudStorageAccount
     from azure.storage.blob import PageBlobService, BlockBlobService
     from adal.authentication_context import AuthenticationContext
     from azure.mgmt.sql import SqlManagementClient

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -207,7 +207,10 @@ state:
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.storage.cloudstorageaccount import CloudStorageAccount
+    try:
+        from azure.storage.common.cloudstorageaccount import CloudStorageAccount
+    except ImportError:
+        from azure.storage.cloudstorageaccount import CloudStorageAccount
     from azure.common import AzureMissingResourceHttpError
 except ImportError:
     # This is handled in azure_rm_common


### PR DESCRIPTION
Fixes: #58024

##### SUMMARY
Location of CloudStorageAccount was moved in azure libraries and this change is fixing the
silent failed import.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
azure

##### ADDITIONAL INFORMATION
See https://azure-storage.readthedocs.io/_modules/azure/storage/common/cloudstorageaccount.html
