### PR TITLE
Error Handling for Tenant Remove

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
+++ b/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
@@ -495,6 +495,7 @@ class ModuleManager(object):
             self.client.provider['server_port'],
             self.want.tenants
         )
+        resp = self.client.api.delete(uri)
         if resp.status != 200:
             result = resp.json()
             errors = self._get_errors_from_response(result)

--- a/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
+++ b/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
@@ -495,10 +495,20 @@ class ModuleManager(object):
             self.client.provider['server_port'],
             self.want.tenants
         )
-        response = self.client.api.delete(uri)
-        if response.status == 200:
+        if resp.status != 200:
+            result = resp.json()
+            errors = self._get_errors_from_response(result)
+            if errors:
+                message = "{0}".format('. '.join(errors))
+                raise F5ModuleError(message)
+            raise F5ModuleError(resp.content)
+        else:
+            result = resp.json()
+            errors = self._get_errors_from_response(result)
+            if errors:
+                message = "{0}".format('. '.join(errors))
+                raise F5ModuleError(message)
             return True
-        raise F5ModuleError(response.content)
 
 
 class ArgumentSpec(object):


### PR DESCRIPTION
##### SUMMARY
This proposed fix corrects an AttributeError that is thrown on the method `remove_from_device()` which is part of the `ModuleManager` class. The proposed fix copied the error handling method that is used from line 407 to 419 with the additional return True to complete provide the needed return value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
bigip_appsvcs_extension

##### ADDITIONAL INFORMATION
Here is an example of the output before the change
```
fatal: [bigip1 -> localhost]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 548, in <module>
        main()
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 541, in main
        results = mm.exec_module()
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 351, in exec_module
        changed = self.absent()
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 487, in absent
        return self.remove()
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 367, in remove
        self.remove_from_device()
      File "/tmp/ansible_8Kwfds/ansible_module_bigip_appsvcs_extension.py", line 499, in remove_from_device
        raise F5ModuleError(result.content)
    AttributeError: 'dict' object has no attribute 'content'
  module_stdout: ''
  msg: MODULE FAILURE
  rc: 1
```
Here is the proposed output:
```
fatal: [bigip1 -> localhost]: FAILED! => changed=false
  invocation:
    module_args:
      content: null
      force: false
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      provider:
        password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
        server: bigip1
        server_port: null
        ssh_keyfile: null
        timeout: null
        transport: rest
        user: admin
        validate_certs: false
      server: bigip1
      server_port: null
      state: absent
      tenants:
      - Origin
      transport: null
      user: admin
      validate_certs: false
  msg: '01070110:3: Node address ''/Common/_auto_192.168.1.50'' is referenced by a member of pool ''/Common/Pool-bigip1-443''.'
```