### PR TITLE
More iosxr integration zuul CI test fixes (#57909)

### DIFF
--- a/changelogs/fragments/iosxr_fix_netconf_test_failures.yaml
+++ b/changelogs/fragments/iosxr_fix_netconf_test_failures.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix iosxr netconf config diff and integration test failures (https://github.com/ansible/ansible/pull/57909)
+  - Fix issues in iosxr integration test (https://github.com/ansible/ansible/pull/57882)

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -345,8 +345,12 @@ def get_config_diff(module, running=None, candidate=None):
         return response
     elif is_netconf(module):
         if running and candidate:
-            running_data = running.split("\n", 1)[1].rsplit("\n", 1)[0]
-            candidate_data = candidate.split("\n", 1)[1].rsplit("\n", 1)[0]
+            # ignore rpc-reply root node and diff from data element onwards
+            running_data_ele = etree.fromstring(to_bytes(running.strip())).getchildren()[0]
+            candidate_data_ele = etree.fromstring(to_bytes(candidate.strip())).getchildren()[0]
+
+            running_data = to_text(etree.tostring(running_data_ele)).strip()
+            candidate_data = to_text(etree.tostring(candidate_data_ele)).strip()
             if running_data != candidate_data:
                 d = Differ()
                 diff = list(d.compare(running_data.splitlines(), candidate_data.splitlines()))

--- a/test/integration/targets/iosxr_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_bgp/tests/cli/basic.yaml
@@ -108,6 +108,14 @@
         that:
           - 'result.changed == false'
 
+    - name: create route-policy as prerequisite for BGP configuration
+      iosxr_config:
+        lines:
+        - no route-policy RMAP_1
+        - route-policy RMAP_1
+        - exit
+      register: result
+
     - name: Configure networks under address family
       iosxr_bgp: &af_net
         operation: merge
@@ -228,7 +236,11 @@
     - assert:
         that:
           - 'result.changed == false'
-  
+
+    - name: delete route-policy configures as prerequisite for BGP configuration (teardown)
+      iosxr_config:
+        lines: no route-policy RMAP_1
+
   when: facts['ansible_facts']['ansible_net_version'].split('[')[0] == '6.1.3'
 
 - debug: msg="END iosxr cli/iosxr_bgp.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -5,6 +5,7 @@
   netconf_config:
     backup: yes
   register: result
+  connection: netconf
 
 - assert:
     that:

--- a/test/integration/targets/netconf_get/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_get/tests/iosxr/basic.yaml
@@ -114,7 +114,7 @@
 
 - assert:
     that:
-      - "{{ result['output']['rpc-reply']['data']['aaa'] is defined}}"
+      - "{{ result['output']['data']['aaa'] is defined}}"
 
 - name: get configuration data in xml pretty format
   netconf_get:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Ignore `<rpc-reply>` node from candidate and
  running configuration in xml diff

* Add route-policy as prerequisite to BGP coonfiguration
  in integration test

(cherry picked from commit 4a3e14f90b95108e56a670a11ca66afdfd93ef09)
Merged to devel
https://github.com/ansible/ansible/pull/57909
https://github.com/ansible/ansible/pull/57882
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
