### PR TITLE
Fix junos module transport check

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -22,18 +22,20 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible import constants as C
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.junos.junos import junos_provider_spec
-from ansible.plugins.loader import connection_loader, module_loader
+from ansible.plugins.loader import module_loader
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.utils.display import Display
 
 display = Display()
 
-CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
+NETCONF_SUPPORTED_MODULES = frozenset(('junos_banner', 'junos_command', 'junos_config', 'junos_facts', 'junos_interface',
+                                       'junos_l2_interface', 'junos_l3_interface', 'junos_linkagg', 'junos_lldp',
+                                       'junos_lldp_interface', 'junos_logging', 'junos_package', 'junos_rpc', 'junos_scp',
+                                       'junos_static_route', 'junos_system', 'junos_user', 'junos_vlan', 'junos_vrf'))
 
 
 class ActionModule(ActionNetworkModule):
@@ -49,15 +51,22 @@ class ActionModule(ActionNetworkModule):
         socket_path = None
 
         if self._play_context.connection == 'local':
+            args_provider = self._task.args.get('provider', {})
             provider = load_provider(junos_provider_spec, self._task.args)
             pc = copy.deepcopy(self._play_context)
             pc.network_os = 'junos'
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
 
-            if provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES:
-                return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
-                                               "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
-                                               % (provider['transport'], self._task.action)}
+            if self._task.action in ['junos_netconf', 'junos_ping']:
+                if args_provider.get('transport') == 'netconf':
+                    return {'failed': True, 'msg': "Transport type 'netconf' is not valid for '%s' module. "
+                                                   "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                                   % self._task.action}
+            else:
+                if provider['transport'] == 'netconf' and self._task.action not in NETCONF_SUPPORTED_MODULES:
+                    return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
+                                                   "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
+                                                   % (provider['transport'], self._task.action)}
 
             if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
                 pc.connection = 'network_cli'
@@ -93,8 +102,7 @@ class ActionModule(ActionNetworkModule):
                     display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                     del self._task.args['provider']
 
-            if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
-                    (self._play_context.connection == 'netconf' and self._task.action == 'junos_netconf'):
+            if self._play_context.connection == 'netconf' and self._task.action not in NETCONF_SUPPORTED_MODULES:
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, self._task.action)}


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Since new junos resource modules will
   support only network_cli connection type
   modify the transport check from network_cli
   connection netconf as netconf only supported modules
   is a frozen set.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/junos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
