### PR TITLE
Add hostname options concatenation in aws_ec2

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -509,11 +509,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for preference in hostnames:
             if isinstance(preference, list):
                 for preference_element in preference:
-                    pereference_hostname = self._get_hostname(instance, [preference_element])
+                    preference_hostname = self._get_hostname(instance, [preference_element])
                     if hostname:
-                        hostname += '_' + pereference_hostname
+                        hostname += '_' + preference_hostname
                     else:
-                        hostname = pereference_hostname
+                        hostname = preference_hostname
             elif 'tag' in preference:
                 if not preference.startswith('tag:'):
                     raise AnsibleError("To name a host by tags name_value, use 'tag:name=value'.")

--- a/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
+++ b/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
@@ -10,4 +10,3 @@ filters:
 hostnames:
   - tag:Name
   - dns-name
-  - [ "tag:Name", private-ip-address ]

--- a/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
+++ b/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
@@ -10,3 +10,4 @@ filters:
 hostnames:
   - tag:Name
   - dns-name
+  - [ "tag:Name", private_ip_address ]

--- a/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
+++ b/test/integration/targets/inventory_aws_ec2/templates/inventory.yml
@@ -10,4 +10,4 @@ filters:
 hostnames:
   - tag:Name
   - dns-name
-  - [ "tag:Name", private_ip_address ]
+  - [ "tag:Name", private-ip-address ]

--- a/test/units/plugins/inventory/test_aws_ec2.py
+++ b/test/units/plugins/inventory/test_aws_ec2.py
@@ -102,7 +102,7 @@ instances = {
          u'RootDeviceType': 'ebs',
          u'RootDeviceName': '/dev/xvda',
          u'VirtualizationType': 'hvm',
-         u'Tags': [{u'Value': 'test', u'Key': 'ansible'}, {u'Value': 'aws_ec2', u'Key': 'name'}],
+         u'Tags': [{u'Value': 'test', u'Key': 'ansible'}, {u'Value': 'aws_ec2', u'Key': 'Name'}],
          u'AmiLaunchIndex': 0}],
     u'ReservationId': 'r-01234567890000000',
     u'Groups': [],
@@ -149,6 +149,12 @@ def test_get_hostname(inventory):
     hostnames = ['ip-address', 'dns-name']
     instance = instances['Instances'][0]
     assert inventory._get_hostname(instance, hostnames) == "12.345.67.890"
+
+
+def test_get_hostname_dict(inventory):
+    hostnames = [{'name': 'private-ip-address', 'separator': '_', 'prefix': 'tag:Name'}]
+    instance = instances['Instances'][0]
+    assert inventory._get_hostname(instance, hostnames) == "aws_ec2_098.76.54.321"
 
 
 def test_set_credentials(inventory):


### PR DESCRIPTION
##### SUMMARY
Adds hostname options concatenation in the aws_ec2 inventory plugin. 

This change adds support for list of options, that will be concatenated with an underscore to create the inventory name.

Example:
```yml
hostnames:
 - [ "tag:Name", private-ip-address ] #=> myinstance_10.10.10.10
```

Fixes https://github.com/ansible/ansible/issues/55911

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.inventory.plugins.aws_ec2

##### ADDITIONAL INFORMATION
[Amazon Auto Scaling Groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) allow to have a group of one or multiple instances, that scales depending of policies.
However, they all share the same tags and dns name. If the ASG includes several instances, only 1 will be targeted when using this options. IPs and Instance IDs are unique, but using them isn't user-friendly.

In order to still use the tag:Name, an unique identifier like an IP or an Instance ID has to be appended.