### PR TITLE
VMware: vmware_guest lookup maxMksConnections in correct location

### DIFF
--- a/changelogs/fragments/58060-vmware_guest-make_max_connections_work.yml
+++ b/changelogs/fragments/58060-vmware_guest-make_max_connections_work.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Make max_connections parameter work again in vmware_guest module (https://github.com/ansible/ansible/pull/58061).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1101,7 +1101,7 @@ class PyVmomiHelper(PyVmomi):
             if 'max_connections' in self.params['hardware']:
                 # maxMksConnections == max_connections
                 self.configspec.maxMksConnections = int(self.params['hardware']['max_connections'])
-                if vm_obj is None or self.configspec.maxMksConnections != vm_obj.config.hardware.maxMksConnections:
+                if vm_obj is None or self.configspec.maxMksConnections != vm_obj.config.maxMksConnections:
                     self.change_detected = True
 
             if 'nested_virt' in self.params['hardware']:

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -91,6 +91,7 @@
     # Failing, see: https://github.com/ansible/ansible/issues/57653
     # - include: clone_with_convert.yml
     # - include: clone_customize_guest_test.yml
+    - include: max_connections.yml
   always:
     - name: Remove VM
       vmware_guest:
@@ -107,6 +108,8 @@
         - newvm_DC0_H0_VM1
         - newvm_efi_DC0_H0_VM0
         - newvm_efi_DC0_H0_VM1
+        - newvm_mk_conn_DC0_H0_VM0
+        - newvm_mk_conn_DC0_H0_VM1
         - thin_DC0_H0_VM0
         - thin_DC0_H0_VM1
         - thick_DC0_H0_VM0

--- a/test/integration/targets/vmware_guest/tasks/max_connections.yml
+++ b/test/integration/targets/vmware_guest/tasks/max_connections.yml
@@ -1,0 +1,46 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+    - &add_mk_conn
+      name: Create new VMs again with max_connections as 4
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ 'newvm_mk_conn_' + item.name }}"
+        guest_id: centos64Guest
+        datacenter: "{{ dc1 }}"
+        hardware:
+          num_cpus: 4
+          memory_mb: 512
+          max_connections: 4
+        disk:
+          - size: 1gb
+            type: thin
+            autoselect_datastore: True
+        state: present
+        folder: "{{ item.folder }}"
+      with_items: "{{ virtual_machines }}"
+      register: mk_conn_result_0001
+
+    - debug: var=mk_conn_result_0001
+
+    - name: Assert that changes were made
+      assert:
+        that:
+          - "mk_conn_result_0001.results|map(attribute='changed')|unique|list == [true]"
+    
+    - <<: *add_mk_conn
+      name: Again create new VMs again with max_connections as 4
+      register: mk_conn_result_0002
+    
+    - debug: var=mk_conn_result_0002
+
+    - name: Assert that changes were not made
+      assert:
+        that:
+          - "mk_conn_result_0002.results|map(attribute='changed')|unique|list == [false]"


### PR DESCRIPTION
maxMksConnections is contained in vim.vm.ConfigInfo not vim.vm.VirtualHardware

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/58060
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

