### PR TITLE
Added missing SSL parameters to rabbitmq_binding

### DIFF
--- a/changelogs/fragments/58064-rabbitmq_binding_ssl_options.yaml
+++ b/changelogs/fragments/58064-rabbitmq_binding_ssl_options.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_binding - added missing SSL options for HTTP GET and DELETE requests

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py
@@ -137,7 +137,7 @@ class RabbitMqBinding(object):
             201: True,
             204: True,
         }
-        self.api_result = self.request.get(self.url, auth=self.authentication)
+        self.api_result = self.request.get(self.url, auth=self.authentication, verify=self.verify, cert=(self.cert, self.key))
 
     def run(self):
         """
@@ -258,7 +258,7 @@ class RabbitMqBinding(object):
         """
         :return:
         """
-        self.api_result = self.request.delete(self.url, auth=self.authentication)
+        self.api_result = self.request.delete(self.url, auth=self.authentication, verify=self.verify, cert=(self.cert, self.key))
 
     def fail(self):
         """


### PR DESCRIPTION
In rabbitmq_binding.py the SSL parameters ca_cert, client_cert, client_key were only passed to python-requests for post requests.
This change updates the GET and DELETE requests to include these parameters as well.

##### SUMMARY
HTTP GET and DELETE requests in this module did not include SSL-specific module parameters which lead to execution failure e.g. when using self-signed certificates.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py

##### ADDITIONAL INFORMATION
rabbitmq_binding was not passing module parameters ca_cert, client_cert, client_key to requests for HTTP GET and DELETE requests, so the module fails because e.g. SSL certificate validation could not be disabled by setting ca_cert = ''.
