### PR TITLE
Allow to configure paths to module default groupings

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1538,6 +1538,14 @@ MAX_FILE_SIZE_FOR_DIFF:
   ini:
   - {key: max_diff_size, section: defaults}
   type: int
+MODULE_DEFAULTS_PATH:
+  name: Module Defaults Grouping Path
+  description: Colon separated paths to files in which Ansible will search for additional Module default groupings.
+  default: ""
+  env: [{name: ANSIBLE_MODULE_DEFAULTS_PATH}]
+  ini:
+  - {key: module_defaults, section: defaults}
+  type: pathspec
 NETWORK_GROUP_MODULES:
   name: Network module families
   default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf]


### PR DESCRIPTION
##### SUMMARY
Modules can be grouped in ansible to allow setting default parameters for the whole group. ATM those group definitions are only located in the ansible source. This PR allows to define more locations where ansible reads those groupings.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
If `module_defaults = module_defaults.yml` is in `ansible.cfg`, and you add a file `module_defaults.yml`
with the content
```paste below
version: '1.0'
groupings:
  group_module_one:
    - grp
  group_module_two:
    - grp
```
you can use
```paste below
module_defaults:
  group/grp:
    param1: value1
    param2: value2
```
in your playbook.