### PR TITLE
Stable 2.8: Remove backup from iosxr replace_config test (#57830)

### DIFF
--- a/test/integration/targets/iosxr_config/tests/cli/replace_config.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/replace_config.yaml
@@ -10,7 +10,6 @@
   iosxr_config: &addreplace
     src: "{{ role_path }}/fixtures/config_add_interface.txt"
     replace: config
-    backup: yes
   register: result
 
 - assert:
@@ -29,7 +28,6 @@
   iosxr_config: &delreplace
     src: "{{ role_path }}/fixtures/config_del_interface.txt"
     replace: config
-    backup: yes
   register: result
 
 - assert:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit af25274d6a44a000fd1224616d8433c2554b25a1)

##### SUMMARY
- backup is taken care of in the network.py action plugin which runs before the module executes.
- So, for the first task, since interface preconfigure GigabitEthernet0/0/0/3 section is not in the running 
   config, the backup file would not have it.
- For the second idempotent task, since the previous task has already executed and configured the 
  interface preconfigure GigabitEthernet0/0/0/3 section, the backup file would contain it.
- Thereby, rendering difference in the contents of the backup file.
- With #50801 we started invoking copy action plugin within network.py which actually checks for diff 
   in backup files. Hence, causing the idempotence test to fail.
- This is working absolutely as expected and we don't require backup option in this test file. We 
   already have two different test files for backup.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_config/replace_config.yaml