### PR TITLE
Fix issue with displaying error about unreachable hosts when using Unixy Callback

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -142,6 +142,8 @@ class CallbackModule(CallbackBase):
         self.v2_runner_on_ok(result)
 
     def v2_runner_on_unreachable(self, result):
+        self._preprocess_result(result)
+
         msg = "unreachable"
         display_color = C.COLOR_UNREACHABLE
         task_result = self._process_result_output(result, msg)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes an issue with the Unixy Callback plugin not displaying the error properly for unreachable hosts.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Unixy Callback Plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Use the unixy callback plugin
- Attempt to run a playbook against a host with the wrong ssh key pair
- Notice the error


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# BEFORE:
- all -
Gathering Facts...
<qa-discovery2-admin-0> ESTABLISH SSH CONNECTION FOR USER: root
<qa-discovery2-admin-0> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/bgoad/.ansible/cp/ce22a88902 qa-discovery2-admin-0 '/bin/sh -c '"'"'echo ~root && sleep 0'"'"''
<qa-discovery2-admin-0> (255, '', 'ssh: Could not resolve hostname qa-discovery2-admin-0: Temporary failure in name resolution\r\n')
 [WARNING]: Failure using method (v2_runner_on_unreachable) in callback plugin (<ansible.plugins.callback.unixy.CallbackModule object at
0x7f94a831cf50>): 'CallbackModule' object has no attribute 'delegated_vars'

Callback Exception: 
  File "/home/bgoad/digitalsmiths/git/config-management/ansible-base/venv/local/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 375, in send_callback
    method(*new_args, **kwargs)
   File "/home/bgoad/digitalsmiths/git/config-management/ansible-base/venv/local/lib/python2.7/site-packages/ansible/plugins/callback/unixy.py", line 137, in v2_runner_on_unreachable
    task_result = self._process_result_output(result, msg)
   File "/home/bgoad/digitalsmiths/git/config-management/ansible-base/venv/local/lib/python2.7/site-packages/ansible/plugins/callback/unixy.py", line 75, in _process_result_output
    if self.delegated_vars:

  Ran out of hosts!

- Play recap -
  qa-discovery2-admin-0      : ok=0    changed=0    unreachable=1    failed=0   
Playbook run took 0 days, 0 hours, 0 minutes, 0 seconds

###########################

# AFTER

- all -
Gathering Facts...
<qa-discovery2-admin-0> ESTABLISH SSH CONNECTION FOR USER: root
<qa-discovery2-admin-0> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/home/bgoad/.ansible/cp/ce22a88902 qa-discovery2-admin-0 '/bin/sh -c '"'"'echo ~root && sleep 0'"'"''
<qa-discovery2-admin-0> (255, '', 'ssh: Could not resolve hostname qa-discovery2-admin-0: Temporary failure in name resolution\r\n')
  qa-discovery2-admin-0 unreachable: {
    "changed": false, 
    "msg": "Failed to connect to the host via ssh: ssh: Could not resolve hostname qa-discovery2-admin-0: Temporary failure in name resolution", 
    "unreachable": true
} | msg: Failed to connect to the host via ssh: ssh: Could not resolve hostname qa-discovery2-admin-0: Temporary failure in name resolution
  Ran out of hosts!

- Play recap -
  qa-discovery2-admin-0      : ok=0    changed=0    unreachable=1    failed=0   
Playbook run took 0 days, 0 hours, 0 minutes, 5 seconds
```
