### PR TITLE
add a new module ce lacp to manage Eth-Trunk interfaces mode

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -1,0 +1,541 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ce_lacp
+version_added: "2.4"
+short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches.
+description:
+    - Manages Eth-Trunk specific configuration parameters on HUAWEI CloudEngine switches.
+author: QijunPan (@CloudEngine-Ansible)
+notes:
+    - C(state=absent) removes the Eth-Trunk config and interface if it
+      already exists. If members to be removed are not explicitly
+      passed, all existing members (if any), are removed,
+      and Eth-Trunk removed.
+    - Members must be a list.
+options:
+    trunk_id:
+        description:
+            - Eth-Trunk interface number.
+              The value is an integer.
+              The value range depends on the assign forward eth-trunk mode command.
+              When 256 is specified, the value ranges from 0 to 255.
+              When 512 is specified, the value ranges from 0 to 511.
+              When 1024 is specified, the value ranges from 0 to 1023.
+        required: true
+    mode:
+        description:
+            - Specifies the working mode of an Eth-Trunk interface.
+        required: false
+        default: null
+        choices: ['Manual','Dynamic','Static']
+    preempt_enable:
+        description:
+            - Specifies lacp preempt enable of Eth-Trunk lacp.
+              The value is an boolean 'true' or 'false'.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    state_flapping:
+        description:
+            - Lacp dampening state-flapping.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    port_id_extension_enable:
+        description:
+            - Enable the function of extending the LACP negotiation port number.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    unexpected_mac_disable:
+        description:
+            - Lacp dampening unexpected-mac disable.
+        required: false
+        default: false
+        choices: ['true', 'false']
+    system_id:
+        description:
+            - Link Aggregation Control Protocol System ID,interface Eth-Trunk View.
+            - Formate 'X-X-X',X is hex(a,aa,aaa, or aaaa)
+        required: false
+        default: false
+    timeout_type:
+        description:
+            - Lacp timeout type,that may be 'Fast' or 'Slow'.
+        required: false
+        default: false
+    fast_timeout:
+        description:
+            - When lacp timeout type is 'Fast', user-defined time can be a number(3~90).
+        required: false
+        default: false
+    mixed_rate_link_enable:
+        description:
+            - Value of max active linknumber.
+        required: false
+        default: false
+    preempt_delay:
+        description:
+            - Value of preemption delay time.
+        required: false
+        default: false
+    collector_delay:
+        description:
+            - Value of delay time in units of 10 microseconds.
+        required: false
+        default: false
+    max_active_linknumber:
+        description:
+            - Max active linknumber in link aggregation group.
+        required: false
+        default: false
+    select:
+        description:
+            - Select priority or speed to preempt.
+        required: false
+        default: false
+    member_if:
+        description:
+            - The member interface of eth-trunk that is selected is merge priority.
+        required: false
+        default: false
+    priority:
+        description:
+            - The priority of eth-trunk member interface,and 'member_if' is need when priority is not none.
+        required: false
+        default: false
+    global_priority:
+        description:
+            - Configure lacp priority on system-view.
+        required: false
+        default: false
+    state:
+        description:
+            - Manage the state of the resource.
+        required: false
+        default: present
+        choices: ['present','absent']
+'''
+EXAMPLES = '''
+- name: eth_trunk module test
+  hosts: cloudengine
+  connection: local
+  gather_facts: no
+  vars:
+    cli:
+      host: "{{ inventory_hostname }}"
+      port: "{{ ansible_ssh_port }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      transport: cli
+
+  tasks:
+  - name: Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static
+    ce_eth_trunk:
+      trunk_id: 100
+      members: ['10GE1/0/24','10GE1/0/25']
+      mode: 'lacp-static'
+      state: present
+      provider: '{{ cli }}'
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {"trunk_id": "100", "members": ['10GE1/0/24','10GE1/0/25'], "mode": "lacp-static"}
+existing:
+    description: k/v pairs of existing Eth-Trunk
+    returned: always
+    type: dict
+    sample: {"trunk_id": "100", "hash_type": "mac", "members_detail": [
+            {"memberIfName": "10GE1/0/25", "memberIfState": "Down"}],
+            "min_links": "1", "mode": "manual"}
+end_state:
+    description: k/v pairs of Eth-Trunk info after module execution
+    returned: always
+    type: dict
+    sample: {"trunk_id": "100", "hash_type": "mac", "members_detail": [
+            {"memberIfName": "10GE1/0/24", "memberIfState": "Down"},
+            {"memberIfName": "10GE1/0/25", "memberIfState": "Down"}],
+            "min_links": "1", "mode": "lacp-static"}
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: ["interface Eth-Trunk 100",
+             "mode lacp-static",
+             "interface 10GE1/0/25",
+             "eth-trunk 100"]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+import xml.etree.ElementTree as ET
+import re
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
+
+LACP = {'trunk_id': 'ifName',
+        'mode': 'workMode',
+        'preempt_enable': 'isSupportPrmpt',
+        'state_flapping': 'dampStaFlapEn',
+        'port_id_extension_enable': 'trunkPortIdExt',
+        'unexpected_mac_disable': 'dampUnexpMacEn',
+        'system_id': 'trunkSysMac',
+        'timeout_type': 'rcvTimeoutType',
+        'fast_timeout': 'fastTimeoutUserDefinedValue',
+        'mixed_rate_link_enable': 'mixRateEnable',
+        'preempt_delay': 'promptDelay',
+        'collector_delay': 'collectMaxDelay',
+        'max_active_linknumber': 'maxActiveNum',
+        'select': 'selectPortStd',
+        'member_if': 'memberIfName',
+        'weight': 'weight',
+        'priority': 'portPriority',
+        'global_priority': 'priority'
+        }
+
+
+def has_element(parent, xpath):
+    """
+    get or create a element by xpath
+    """
+    ele = parent.find('./' + xpath)
+    if ele is not None:
+        return ele
+    ele = parent
+    lpath = xpath.split('/')
+    for p in lpath:
+        e = parent.find('.//' + p)
+        if e is None:
+            e = ET.SubElement(ele, p)
+        ele = e
+    return ele
+
+
+def bulid_xml(kwargs, operation='get'):
+    """
+    create a xml tree by dictionary with operation,get,merge and delete
+    :param kwargs: tags and values
+    :param operation: get, merge, delete
+    :return: a string
+    """
+    attrib = {'xmlns': "http://www.huawei.com/netconf/vrp",
+              'content-version': "1.0", 'format-version': "1.0"}
+
+    root = ET.Element('ifmtrunk')
+    for key in kwargs.keys():
+        if key in ('global_priority',):
+            xpath = 'lacpSysInfo'
+        elif key in ('member_if',):
+            xpath = 'TrunkIfs/TrunkIf/TrunkMemberIfs/TrunkMemberIf'
+        elif key in ('priority',):
+            xpath = 'TrunkIfs/TrunkIf/TrunkMemberIfs/TrunkMemberIf/lacpPortInfo/lacpPort'
+        elif key in ['preempt_enable', 'timeout_type', 'fast_timeout', 'select', 'preempt_delay',
+                     'max_active_linknumber', 'collector_delay', 'mixed_rate_link_enable',
+                     'state_flapping', 'unexpected_mac_disable', 'system_id',
+                     'port_id_extension_enable']:
+            xpath = 'TrunkIfs/TrunkIf/lacpTrunk'
+        elif key in ('trunk_id', 'mode'):
+            xpath = 'TrunkIfs/TrunkIf'
+        if xpath != '':
+            parent = has_element(root, xpath)
+            element = ET.SubElement(parent, LACP[key])
+            if operation == 'merge':
+                parent.attrib = dict(operation=operation)
+                element.text = str(kwargs[key])
+            if key == 'member_if':
+                element.text = str(kwargs[key])
+            if key == 'mode':
+                element.text = str(kwargs[key])
+            if key == 'trunk_id':
+                element.text = 'Eth-Trunk' + str(kwargs[key])
+    root.attrib = attrib
+    config = ET.tostring(root)
+    if operation == 'merge' or operation == 'delete':
+        return '<config>%s</config>' % config
+    return '<filter type="subtree">%s</filter>' % config
+
+
+def check_param(kwargs):
+    """
+    check args list
+    the boolean or list values cloud not be checked,because they are limit by args list in main
+    """
+
+    for key in kwargs:
+        if kwargs[key] is None:
+            continue
+        if key == 'trunk_id':
+            value = int(kwargs[key])
+            # maximal value is 1024,although the value is limit by command 'assign forward eth-trunk mode '
+            if value < 0 or value > 1024:
+                return 'Error: Wrong Value of Eth-Trunk interface number'
+        elif key == 'system_id':
+            # X-X-X ,X is hex(4 bit)
+            if not re.match(r'[0-9a-f]{1,4}\-[0-9a-f]{1,4}\-[0-9a-f]{1,4}', kwargs[key], re.IGNORECASE):
+                return 'Error: The system-id is invalid.'
+            values = kwargs[key].split('-')
+            flag = 0
+            # all 'X' is 0,that is invalid value
+            for v in values:
+                if len(v.strip('0')) < 1:
+                    flag += 1
+            if flag == 3:
+                return 'Error: The system-id is invalid.'
+        elif key == 'timeout_type':
+            # select a value from choices, choices=['Slow','Fast'],it's checked by AnsibleModule
+            pass
+        elif key == 'fast_timeout':
+            value = int(kwargs[key])
+            if value < 3 or value > 90:
+                return 'Error: Wrong Value of timeout,fast user-defined value<3-90>'
+            rtype = str(kwargs.get('timeout_type'))
+            if rtype == 'Slow':
+                return 'Error: Short timeout period for receiving packets is need,when user define the time.'
+        elif key == 'preempt_delay':
+            value = int(kwargs[key])
+            if value < 0 or value > 180:
+                return 'Error: Value of preemption delay time is from 0 to 180'
+        elif key == 'collector_delay':
+            value = int(kwargs[key])
+            if value < 0 or value > 65535:
+                return 'Error: Value of collector delay time is from 0 to 65535'
+        elif key == 'max_active_linknumber':
+            value = int(kwargs[key])
+            if value < 0 or value > 64:
+                return 'Error: Value of collector delay time is from 0 to 64'
+        elif key == 'priority' or key == 'global_priority':
+            value = int(kwargs[key])
+            if value < 0 or value > 65535:
+                return 'Error: Value of priority is from 0 to 65535'
+    return 'ok'
+
+
+def xml_to_dict(args):
+    """
+    transfer xml string into dict
+    :param args: a xml string
+    :return: dict
+    """
+    rdict = dict()
+    args = re.sub(r'xmlns=\".+?\"', '', args)
+    root = ET.fromstring(args)
+    ifmtrunk = root.find('.//ifmtrunk')
+    if ifmtrunk is not None:
+        for ele in ifmtrunk.iter():
+            if ele.text is not None and len(ele.text.strip()) > 0:
+                rdict[ele.tag] = ele.text
+    return rdict
+
+
+def compare_config(module, kwarg_exist, kwarg_end):
+    """
+    :param kwarg_exist: existing config dictionary
+    :param kwarg_end:  end config dictionary
+    :return: commands update list
+    """
+    dic_command = {'isSupportPrmpt': 'lacp preempt enable',
+                   'rcvTimeoutType': 'lacp timeout',  # lacp timeout fast user-defined 23
+                   'fastTimeoutUserDefinedValue': 'lacp timeout user-defined',
+                   'selectPortStd': 'lacp select',
+                   'promptDelay': 'lacp preempt delay',
+                   'maxActiveNum': 'lacp max active-linknumber',
+                   'collectMaxDelay': 'lacp collector delay',
+                   'mixRateEnable': 'lacp mixed-rate link enable',
+                   'dampStaFlapEn': 'lacp dampening state-flapping',
+                   'dampUnexpMacEn': 'lacp dampening unexpected-mac disable',
+                   'trunkSysMac': 'lacp system-id',
+                   'trunkPortIdExt': 'lacp port-id-extension enable',
+                   'portPriority': 'lacp priority',  # interface 10GE1/0/1
+                   'lacpMlagPriority': 'lacp m-lag priority',
+                   'lacpMlagSysId': 'lacp m-lag system-id',
+                   'priority': 'lacp priority'
+                   }
+    rlist = list()
+    exist = set(kwarg_exist.keys())
+    end = set(kwarg_end.keys())
+    undo = exist - end
+    add = end - exist
+    update = end & exist
+
+    for key in undo:
+        if key in dic_command:
+            rlist.append('undo ' + dic_command[key])
+    for key in add:
+        if key in dic_command:
+            rlist.append(dic_command[key] + ' ' + kwarg_end[key])
+    for key in update:
+        if kwarg_exist[key] != kwarg_end[key] and key in dic_command:
+            if kwarg_exist[key] == 'true' and kwarg_end[key] == 'false':
+                rlist.append('undo ' + dic_command[key])
+            elif kwarg_exist[key] == 'false' and kwarg_end[key] == 'true':
+                rlist.append(dic_command[key])
+            else:
+                rlist.append(dic_command[key] + ' ' + kwarg_end[key].lower())
+    return rlist
+
+
+class Lacp(object):
+    """
+    Manages Eth-Trunk interfaces LACP.
+    """
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.__init_module__()
+
+        # module input info
+        self.trunk_id = self.module.params['trunk_id']
+        self.mode = self.module.params['mode']
+        self.param = dict()
+
+        self.state = self.module.params['state']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+    def __init_module__(self):
+        """ init module """
+
+        self.module = AnsibleModule(
+            argument_spec=self.spec,
+            mutually_exclusive=[['trunk_id', 'global_priority']],
+            required_one_of=[['trunk_id', 'global_priority']],
+            required_together=[['member_if', 'priority']],
+            supports_check_mode=True)
+
+    def check_params(self):
+        """
+        :return:
+        """
+        for key in self.module.params.keys():
+            if key in LACP.keys() and self.module.params[key] is not None:
+                self.param[key] = self.module.params[key]
+        msg = check_param(self.param)
+        # if self.param.get('fast_timeout') is not None and self.param.get('timeout_type') is None:
+        # self.param['timeout_type'] = 'Fast'
+        if msg != 'ok':
+            self.module.fail_json(msg=msg)
+
+    def get_existing(self):
+        """
+        :return:
+        """
+        xml_str = bulid_xml(self.param)
+        xml = get_nc_config(self.module, xml_str)
+        return xml_to_dict(xml)
+
+    def get_proposed(self):
+        """
+        :return:
+        """
+        proposed = dict(state=self.state)
+        proposed.update(self.param)
+        return proposed
+
+    def get_end_state(self):
+        """
+        :return:
+        """
+        xml_str = bulid_xml(self.param)
+        xml = get_nc_config(self.module, xml_str)
+        return xml_to_dict(xml)
+
+    def work(self):
+        """worker"""
+
+        self.check_params()
+        existing = self.get_existing()
+        proposed = self.get_proposed()
+
+        # deal present or absent
+        if self.state == "present":
+            operation = 'merge'
+        else:
+            operation = 'delete'
+
+        xml_str = bulid_xml(self.param, operation=operation)
+        set_nc_config(self.module, xml_str)
+        end_state = self.get_end_state()
+
+        self.results['proposed'] = proposed
+        self.results['existing'] = existing
+        self.results['end_state'] = end_state
+        updates_cmd = compare_config(self.module, existing, end_state)
+        self.results['updates'] = updates_cmd
+        if updates_cmd:
+            self.results['changed'] = True
+        else:
+            self.results['changed'] = False
+
+        self.module.exit_json(**self.results)
+
+
+def main():
+    """Module main"""
+
+    argument_spec = dict(
+        mode=dict(required=False,
+                  choices=['Manual', 'Dynamic', 'Static'],
+                  type='str'),
+        trunk_id=dict(required=False, type='str'),
+        preempt_enable=dict(required=False, choices=['true', 'false']),
+        state_flapping=dict(required=False, choices=['true', 'false']),
+        port_id_extension_enable=dict(required=False, choices=['true', 'false']),
+        unexpected_mac_disable=dict(required=False, choices=['true', 'false']),
+        system_id=dict(required=False, type='str'),
+        timeout_type=dict(required=False, type='str', choices=['Slow', 'Fast']),
+        fast_timeout=dict(required=False, type='int'),
+        mixed_rate_link_enable=dict(required=False, choices=['true', 'false']),
+        preempt_delay=dict(required=False, type='int'),
+        collector_delay=dict(required=False, type='int'),
+        max_active_linknumber=dict(required=False, type='int'),
+        select=dict(required=False, type='str', choices=['Speed', 'Prority']),
+        member_if=dict(required=False, type='str'),
+        priority=dict(required=False, type='int'),
+        global_priority=dict(required=False, type='int'),
+        state=dict(required=False, default='present',
+                   choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ce_argument_spec)
+    module = Lacp(argument_spec)
+    module.work()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ce_lacp
-version_added: "2.4"
+version_added: "2.9"
 short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches.
 description:
     - Manages Eth-Trunk specific configuration parameters on HUAWEI CloudEngine switches.
@@ -73,64 +73,55 @@ options:
         description:
             - Lacp dampening unexpected-mac disable.
         required: false
-        default: false
         choices: ['true', 'false']
     system_id:
         description:
             - Link Aggregation Control Protocol System ID,interface Eth-Trunk View.
             - Formate 'X-X-X',X is hex(a,aa,aaa, or aaaa)
         required: false
-        default: false
     timeout_type:
         description:
             - Lacp timeout type,that may be 'Fast' or 'Slow'.
         required: false
-        default: false
+        choices: ['Slow', 'Fast']
     fast_timeout:
         description:
             - When lacp timeout type is 'Fast', user-defined time can be a number(3~90).
         required: false
-        default: false
     mixed_rate_link_enable:
         description:
             - Value of max active linknumber.
         required: false
-        default: false
+        choices: ['true', 'false']
     preempt_delay:
         description:
             - Value of preemption delay time.
         required: false
-        default: false
     collector_delay:
         description:
             - Value of delay time in units of 10 microseconds.
         required: false
-        default: false
     max_active_linknumber:
         description:
             - Max active linknumber in link aggregation group.
         required: false
-        default: false
     select:
         description:
             - Select priority or speed to preempt.
         required: false
-        default: false
+        choices: ['Speed', 'Prority']
     member_if:
         description:
             - The member interface of eth-trunk that is selected is merge priority.
         required: false
-        default: false
     priority:
         description:
             - The priority of eth-trunk member interface,and 'member_if' is need when priority is not none.
         required: false
-        default: false
     global_priority:
         description:
             - Configure lacp priority on system-view.
         required: false
-        default: false
     state:
         description:
             - Manage the state of the resource.
@@ -158,7 +149,6 @@ EXAMPLES = '''
       members: ['10GE1/0/24','10GE1/0/25']
       mode: 'lacp-static'
       state: present
-      provider: '{{ cli }}'
 '''
 
 RETURN = '''
@@ -193,7 +183,7 @@ updates:
 changed:
     description: check to see if a change was made on the device
     returned: always
-    type: boolean
+    type: bool
     sample: true
 '''
 

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -128,6 +128,10 @@ options:
         required: false
         default: present
         choices: ['present','absent']
+    provider:
+        description:
+            - A dict that will be removed.
+        required: false
 '''
 EXAMPLES = '''
 - name: eth_trunk module test

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -27,7 +27,7 @@ version_added: "2.9"
 short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches.
 description:
     - Manages Eth-Trunk specific configuration parameters on HUAWEI CloudEngine switches.
-author: QijunPan (@CloudEngine-Ansible)
+author: xuxiaowei0512 (@CloudEngine-Ansible)
 notes:
     - C(state=absent) removes the Eth-Trunk config and interface if it
       already exists. If members to be removed are not explicitly
@@ -134,13 +134,6 @@ EXAMPLES = '''
   hosts: cloudengine
   connection: local
   gather_facts: no
-  vars:
-    cli:
-      host: "{{ inventory_hostname }}"
-      port: "{{ ansible_ssh_port }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      transport: cli
 
   tasks:
   - name: Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -130,7 +130,7 @@ options:
         choices: ['present','absent']
     provider:
         description:
-            - A dict that will be removed.
+            - A dict specified some options about connection  that is not required from version 2.9.
         required: false
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -44,12 +44,14 @@ options:
               When 512 is specified, the value ranges from 0 to 511.
               When 1024 is specified, the value ranges from 0 to 1023.
         required: true
+        type: str
     mode:
         description:
             - Specifies the working mode of an Eth-Trunk interface.
         required: false
         default: null
         choices: ['Manual','Dynamic','Static']
+        type: str
     preempt_enable:
         description:
             - Specifies lacp preempt enable of Eth-Trunk lacp.
@@ -57,80 +59,97 @@ options:
         required: false
         default: null
         choices: ['true', 'false']
+        type: str
     state_flapping:
         description:
             - Lacp dampening state-flapping.
         required: false
         default: null
         choices: ['true', 'false']
+        type: str
     port_id_extension_enable:
         description:
             - Enable the function of extending the LACP negotiation port number.
         required: false
         default: null
         choices: ['true', 'false']
+        type: str
     unexpected_mac_disable:
         description:
             - Lacp dampening unexpected-mac disable.
         required: false
         choices: ['true', 'false']
+        type: str
     system_id:
         description:
             - Link Aggregation Control Protocol System ID,interface Eth-Trunk View.
             - Formate 'X-X-X',X is hex(a,aa,aaa, or aaaa)
         required: false
+        type: str
     timeout_type:
         description:
             - Lacp timeout type,that may be 'Fast' or 'Slow'.
         required: false
         choices: ['Slow', 'Fast']
+        type: str
     fast_timeout:
         description:
             - When lacp timeout type is 'Fast', user-defined time can be a number(3~90).
         required: false
+        type: int
     mixed_rate_link_enable:
         description:
             - Value of max active linknumber.
         required: false
         choices: ['true', 'false']
+        type: str
     preempt_delay:
         description:
             - Value of preemption delay time.
         required: false
+        type: int
     collector_delay:
         description:
             - Value of delay time in units of 10 microseconds.
         required: false
+        type: int
     max_active_linknumber:
         description:
             - Max active linknumber in link aggregation group.
         required: false
+        type: int
     select:
         description:
             - Select priority or speed to preempt.
         required: false
         choices: ['Speed', 'Prority']
+        type: str
     member_if:
         description:
             - The member interface of eth-trunk that is selected is merge priority.
         required: false
+        type: str
     priority:
         description:
             - The priority of eth-trunk member interface,and 'member_if' is need when priority is not none.
         required: false
+        type: int
     global_priority:
         description:
             - Configure lacp priority on system-view.
         required: false
+        type: int
     state:
         description:
             - Manage the state of the resource.
         required: false
         default: present
         choices: ['present','absent']
+        type: str
     provider:
+        type: dict
         description:
-            - A dict specified some options about connection  that is not required from version 2.9.
+            - A dict specified some options about connection  that is not required from version 2.9.And provider is unnecessary when using network_cli and will be ignored.
         required: false
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -149,7 +149,8 @@ options:
     provider:
         type: dict
         description:
-            - A dict specified some options about connection  that is not required from version 2.9.And provider is unnecessary when using network_cli and will be ignored.
+            - A dict specified some options about connection  that is not required from version 2.9.
+            - And provider is unnecessary when using network_cli and will be ignored.
         required: false
 '''
 EXAMPLES = '''

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -24,7 +24,7 @@ DOCUMENTATION = r'''
 ---
 module: ce_lacp
 version_added: "2.9"
-short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches.
+short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches
 description:
     - Manages Eth-Trunk specific configuration parameters on HUAWEI CloudEngine switches.
 author: xuxiaowei0512 (@CloudEngine-Ansible)
@@ -76,13 +76,11 @@ options:
     timeout_type:
         description:
             - Lacp timeout type,that may be 'Fast' or 'Slow'.
-        required: false
         choices: ['Slow', 'Fast']
         type: str
     fast_timeout:
         description:
             - When lacp timeout type is 'Fast', user-defined time can be a number(3~90).
-        required: false
         type: int
     mixed_rate_link_enable:
         description:
@@ -91,43 +89,35 @@ options:
     preempt_delay:
         description:
             - Value of preemption delay time.
-        required: false
         type: int
     collector_delay:
         description:
             - Value of delay time in units of 10 microseconds.
-        required: false
         type: int
     max_active_linknumber:
         description:
             - Max active linknumber in link aggregation group.
-        required: false
         type: int
     select:
         description:
             - Select priority or speed to preempt.
-        required: false
         choices: ['Speed', 'Prority']
         type: str
     member_if:
         description:
             - The member interface of eth-trunk that is selected is merge priority.
-        required: false
         type: str
     priority:
         description:
             - The priority of eth-trunk member interface,and 'member_if' is need when priority is not none.
-        required: false
         type: int
     global_priority:
         description:
             - Configure lacp priority on system-view.
-        required: false
         type: int
     state:
         description:
             - Manage the state of the resource.
-        required: false
         default: present
         choices: ['present','absent']
         type: str
@@ -136,7 +126,6 @@ options:
         description:
             - A dict specified some options about connection  that is not required from version 2.9.
             - And provider is unnecessary when using network_cli and will be ignored.
-        required: false
 '''
 EXAMPLES = r'''
 - name: eth_trunk module test

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -149,8 +149,8 @@ EXAMPLES = r'''
       preempt_enable: True,
       state_flapping: True,
       port_id_extension_enable: True,
-      unexpected_mac_disable: True, 
-      timeout_type: 'Fast',
+      unexpected_mac_disable: True,
+      timeout_type: Fast,
       fast_timeout: 123,
       mixed_rate_link_enable: True,
       preempt_delay: 23,
@@ -432,6 +432,8 @@ class Lacp(object):
         for key in self.module.params.keys():
             if key in LACP.keys() and self.module.params[key] is not None:
                 self.param[key] = self.module.params[key]
+                if isinstance(self.module.params[key], bool):
+                    self.param[key] = str(self.module.params[key])
         msg = check_param(self.param)
         # if self.param.get('fast_timeout') is not None and self.param.get('timeout_type') is None:
         # self.param['timeout_type'] = 'Fast'

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -135,9 +135,26 @@ EXAMPLES = r'''
 
   tasks:
   - name: Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static
-    ce_eth_trunk:
+    ce_lacp:
       trunk_id: 100
       mode: 'lacp-static'
+      state: present
+    ce_lacp:
+      trunk_id: 100
+      global_priority: 1231
+      state: present
+    ce_lacp:
+      trunk_id: 100
+      mode: Dynamic
+      preempt_enable: True,
+      state_flapping: True,
+      port_id_extension_enable: True,
+      unexpected_mac_disable: True, 
+      timeout_type: 'Fast',
+      fast_timeout: 123,
+      mixed_rate_link_enable: True,
+      preempt_delay: 23,
+      collector_delay: 33,
       state: present
 '''
 
@@ -170,11 +187,6 @@ updates:
              "mode lacp-static",
              "interface 10GE1/0/25",
              "eth-trunk 100"]
-changed:
-    description: check to see if a change was made on the device
-    returned: always
-    type: bool
-    sample: true
 '''
 
 import xml.etree.ElementTree as ET
@@ -204,9 +216,7 @@ LACP = {'trunk_id': 'ifName',
 
 
 def has_element(parent, xpath):
-    """
-    get or create a element by xpath
-    """
+    """get or create a element by xpath"""
     ele = parent.find('./' + xpath)
     if ele is not None:
         return ele
@@ -265,10 +275,7 @@ def bulid_xml(kwargs, operation='get'):
 
 
 def check_param(kwargs):
-    """
-    check args list
-    the boolean or list values cloud not be checked,because they are limit by args list in main
-    """
+    """check args list,the boolean or list values cloud not be checked,because they are limit by args list in main"""
 
     for key in kwargs:
         if kwargs[key] is None:
@@ -486,7 +493,6 @@ class Lacp(object):
 
 
 def main():
-    """Module main"""
 
     argument_spec = dict(
         mode=dict(required=False,

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -357,7 +357,7 @@ def xml_to_dict(args):
     root = ET.fromstring(args)
     ifmtrunk = root.find('.//ifmtrunk')
     if ifmtrunk is not None:
-        for ele in ifmtrunk.iter():
+        for ele in ifmtrunk.getiterator():
             if ele.text is not None and len(ele.text.strip()) > 0:
                 rdict[ele.tag] = ele.text
     return rdict

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: ce_lacp
 version_added: "2.9"
@@ -43,12 +43,10 @@ options:
               When 256 is specified, the value ranges from 0 to 255.
               When 512 is specified, the value ranges from 0 to 511.
               When 1024 is specified, the value ranges from 0 to 1023.
-        required: true
-        type: str
+        type: int
     mode:
         description:
             - Specifies the working mode of an Eth-Trunk interface.
-        required: false
         default: null
         choices: ['Manual','Dynamic','Static']
         type: str
@@ -56,30 +54,19 @@ options:
         description:
             - Specifies lacp preempt enable of Eth-Trunk lacp.
               The value is an boolean 'true' or 'false'.
-        required: false
-        default: null
-        choices: ['true', 'false']
-        type: str
+        type: bool
     state_flapping:
         description:
             - Lacp dampening state-flapping.
-        required: false
-        default: null
-        choices: ['true', 'false']
-        type: str
+        type: bool
     port_id_extension_enable:
         description:
             - Enable the function of extending the LACP negotiation port number.
-        required: false
-        default: null
-        choices: ['true', 'false']
-        type: str
+        type: bool
     unexpected_mac_disable:
         description:
             - Lacp dampening unexpected-mac disable.
-        required: false
-        choices: ['true', 'false']
-        type: str
+        type: bool
     system_id:
         description:
             - Link Aggregation Control Protocol System ID,interface Eth-Trunk View.
@@ -100,9 +87,7 @@ options:
     mixed_rate_link_enable:
         description:
             - Value of max active linknumber.
-        required: false
-        choices: ['true', 'false']
-        type: str
+        type: bool
     preempt_delay:
         description:
             - Value of preemption delay time.
@@ -153,7 +138,7 @@ options:
             - And provider is unnecessary when using network_cli and will be ignored.
         required: false
 '''
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: eth_trunk module test
   hosts: cloudengine
   connection: local
@@ -163,12 +148,11 @@ EXAMPLES = '''
   - name: Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static
     ce_eth_trunk:
       trunk_id: 100
-      members: ['10GE1/0/24','10GE1/0/25']
       mode: 'lacp-static'
       state: present
 '''
 
-RETURN = '''
+RETURN = r'''
 proposed:
     description: k/v pairs of parameters passed into module
     returned: always
@@ -519,15 +503,15 @@ def main():
         mode=dict(required=False,
                   choices=['Manual', 'Dynamic', 'Static'],
                   type='str'),
-        trunk_id=dict(required=False, type='str'),
-        preempt_enable=dict(required=False, choices=['true', 'false']),
-        state_flapping=dict(required=False, choices=['true', 'false']),
-        port_id_extension_enable=dict(required=False, choices=['true', 'false']),
-        unexpected_mac_disable=dict(required=False, choices=['true', 'false']),
+        trunk_id=dict(required=False, type='int'),
+        preempt_enable=dict(required=False, type='bool'),
+        state_flapping=dict(required=False, type='bool'),
+        port_id_extension_enable=dict(required=False, type='bool'),
+        unexpected_mac_disable=dict(required=False, type='bool'),
         system_id=dict(required=False, type='str'),
         timeout_type=dict(required=False, type='str', choices=['Slow', 'Fast']),
         fast_timeout=dict(required=False, type='int'),
-        mixed_rate_link_enable=dict(required=False, choices=['true', 'false']),
+        mixed_rate_link_enable=dict(required=False, type='bool'),
         preempt_delay=dict(required=False, type='int'),
         collector_delay=dict(required=False, type='int'),
         max_active_linknumber=dict(required=False, type='int'),

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -124,11 +124,6 @@ options:
         default: present
         choices: ['present','absent']
         type: str
-    provider:
-        type: dict
-        description:
-            - A dict specified some options about connection  that is not required from version 2.9.
-            - And provider is unnecessary when using network_cli and will be ignored.
 '''
 EXAMPLES = r'''
 - name: eth_trunk module test

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -433,7 +433,7 @@ class Lacp(object):
             if key in LACP.keys() and self.module.params[key] is not None:
                 self.param[key] = self.module.params[key]
                 if isinstance(self.module.params[key], bool):
-                    self.param[key] = str(self.module.params[key])
+                    self.param[key] = str(self.module.params[key]).lower()
         msg = check_param(self.param)
         # if self.param.get('fast_timeout') is not None and self.param.get('timeout_type') is None:
         # self.param['timeout_type'] = 'Fast'

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -122,12 +122,6 @@ options:
         type: str
 '''
 EXAMPLES = r'''
-- name: eth_trunk module test
-  hosts: cloudengine
-  connection: local
-  gather_facts: no
-
-  tasks:
   - name: Ensure Eth-Trunk100 is created, and set to mode lacp-static
     ce_lacp:
       trunk_id: 100
@@ -227,12 +221,7 @@ def has_element(parent, xpath):
 
 
 def bulid_xml(kwargs, operation='get'):
-    """
-    create a xml tree by dictionary with operation,get,merge and delete
-    :param kwargs: tags and values
-    :param operation: get, merge, delete
-    :return: a string
-    """
+    """create a xml tree by dictionary with operation,get,merge and delete"""
     attrib = {'xmlns': "http://www.huawei.com/netconf/vrp",
               'content-version': "1.0", 'format-version': "1.0"}
 
@@ -319,11 +308,7 @@ def check_param(kwargs):
 
 
 def xml_to_dict(args):
-    """
-    transfer xml string into dict
-    :param args: a xml string
-    :return: dict
-    """
+    """transfer xml string into dict """
     rdict = dict()
     args = re.sub(r'xmlns=\".+?\"', '', args)
     root = ET.fromstring(args)
@@ -336,11 +321,7 @@ def xml_to_dict(args):
 
 
 def compare_config(module, kwarg_exist, kwarg_end):
-    """
-    :param kwarg_exist: existing config dictionary
-    :param kwarg_end:  end config dictionary
-    :return: commands update list
-    """
+    """compare config between exist and end"""
     dic_command = {'isSupportPrmpt': 'lacp preempt enable',
                    'rcvTimeoutType': 'lacp timeout',  # lacp timeout fast user-defined 23
                    'fastTimeoutUserDefinedValue': 'lacp timeout user-defined',
@@ -390,7 +371,7 @@ class Lacp(object):
     def __init__(self, argument_spec):
         self.spec = argument_spec
         self.module = None
-        self.__init_module__()
+        self.init_module()
 
         # module input info
         self.trunk_id = self.module.params['trunk_id']
@@ -407,8 +388,8 @@ class Lacp(object):
         self.existing = dict()
         self.end_state = dict()
 
-    def __init_module__(self):
-        """ init module """
+    def init_module(self):
+        """ init AnsibleModule """
 
         self.module = AnsibleModule(
             argument_spec=self.spec,
@@ -417,17 +398,13 @@ class Lacp(object):
             supports_check_mode=True)
 
     def check_params(self):
-        """
-        :return:
-        """
+        """check module params """
         for key in self.module.params.keys():
             if key in LACP.keys() and self.module.params[key] is not None:
                 self.param[key] = self.module.params[key]
                 if isinstance(self.module.params[key], bool):
                     self.param[key] = str(self.module.params[key]).lower()
         msg = check_param(self.param)
-        # if self.param.get('fast_timeout') is not None and self.param.get('timeout_type') is None:
-        # self.param['timeout_type'] = 'Fast'
         if msg != 'ok':
             self.module.fail_json(msg=msg)
 

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -74,7 +74,6 @@ options:
         description:
             - Link Aggregation Control Protocol System ID,interface Eth-Trunk View.
             - Formate 'X-X-X',X is hex(a,aa,aaa, or aaaa)
-        required: false
         type: str
     timeout_type:
         description:
@@ -409,25 +408,19 @@ class Lacp(object):
             self.module.fail_json(msg=msg)
 
     def get_existing(self):
-        """
-        :return:
-        """
+        """get existing"""
         xml_str = bulid_xml(self.param)
         xml = get_nc_config(self.module, xml_str)
         return xml_to_dict(xml)
 
     def get_proposed(self):
-        """
-        :return:
-        """
+        """get proposed"""
         proposed = dict(state=self.state)
         proposed.update(self.param)
         return proposed
 
     def get_end_state(self):
-        """
-        :return:
-        """
+        """ get end_state"""
         xml_str = bulid_xml(self.param)
         xml = get_nc_config(self.module, xml_str)
         return xml_to_dict(xml)

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: ce_lacp
-version_added: "2.9"
+version_added: "2.10"
 short_description: Manages Eth-Trunk interfaces on HUAWEI CloudEngine switches
 description:
     - Manages Eth-Trunk specific configuration parameters on HUAWEI CloudEngine switches.
@@ -197,7 +197,7 @@ updates:
 import xml.etree.ElementTree as ET
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
+from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config
 
 LACP = {'trunk_id': 'ifName',
         'mode': 'workMode',
@@ -525,7 +525,6 @@ def main():
                    choices=['present', 'absent'])
     )
 
-    argument_spec.update(ce_argument_spec)
     module = Lacp(argument_spec)
     module.work()
 

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -192,6 +192,7 @@ updates:
 import xml.etree.ElementTree as ET
 import re
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config
 
 LACP = {'trunk_id': 'ifName',
@@ -270,8 +271,8 @@ def bulid_xml(kwargs, operation='get'):
     root.attrib = attrib
     config = ET.tostring(root)
     if operation == 'merge' or operation == 'delete':
-        return '<config>%s</config>' % config
-    return '<filter type="subtree">%s</filter>' % config
+        return '<config>%s</config>' % to_native(config)
+    return '<filter type="subtree">%s</filter>' % to_native(config)
 
 
 def check_param(kwargs):

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -134,15 +134,17 @@ EXAMPLES = r'''
   gather_facts: no
 
   tasks:
-  - name: Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static
+  - name: Ensure Eth-Trunk100 is created, and set to mode lacp-static
     ce_lacp:
       trunk_id: 100
       mode: 'lacp-static'
       state: present
+  - name: Ensure Eth-Trunk100 is created, add two members, and set global priority to 1231
     ce_lacp:
       trunk_id: 100
       global_priority: 1231
       state: present
+  - name: Ensure Eth-Trunk100 is created, and set mode to Dynamic and configure other options
     ce_lacp:
       trunk_id: 100
       mode: Dynamic

--- a/lib/ansible/modules/network/cloudengine/ce_lacp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_lacp.py
@@ -106,13 +106,9 @@ options:
             - Select priority or speed to preempt.
         choices: ['Speed', 'Prority']
         type: str
-    member_if:
-        description:
-            - The member interface of eth-trunk that is selected is merge priority.
-        type: str
     priority:
         description:
-            - The priority of eth-trunk member interface,and 'member_if' is need when priority is not none.
+            - The priority of eth-trunk member interface.
         type: int
     global_priority:
         description:
@@ -209,7 +205,6 @@ LACP = {'trunk_id': 'ifName',
         'collector_delay': 'collectMaxDelay',
         'max_active_linknumber': 'maxActiveNum',
         'select': 'selectPortStd',
-        'member_if': 'memberIfName',
         'weight': 'weight',
         'priority': 'portPriority',
         'global_priority': 'priority'
@@ -245,8 +240,6 @@ def bulid_xml(kwargs, operation='get'):
     for key in kwargs.keys():
         if key in ('global_priority',):
             xpath = 'lacpSysInfo'
-        elif key in ('member_if',):
-            xpath = 'TrunkIfs/TrunkIf/TrunkMemberIfs/TrunkMemberIf'
         elif key in ('priority',):
             xpath = 'TrunkIfs/TrunkIf/TrunkMemberIfs/TrunkMemberIf/lacpPortInfo/lacpPort'
         elif key in ['preempt_enable', 'timeout_type', 'fast_timeout', 'select', 'preempt_delay',
@@ -261,8 +254,6 @@ def bulid_xml(kwargs, operation='get'):
             element = ET.SubElement(parent, LACP[key])
             if operation == 'merge':
                 parent.attrib = dict(operation=operation)
-                element.text = str(kwargs[key])
-            if key == 'member_if':
                 element.text = str(kwargs[key])
             if key == 'mode':
                 element.text = str(kwargs[key])
@@ -423,7 +414,6 @@ class Lacp(object):
             argument_spec=self.spec,
             mutually_exclusive=[['trunk_id', 'global_priority']],
             required_one_of=[['trunk_id', 'global_priority']],
-            required_together=[['member_if', 'priority']],
             supports_check_mode=True)
 
     def check_params(self):
@@ -514,7 +504,6 @@ def main():
         collector_delay=dict(required=False, type='int'),
         max_active_linknumber=dict(required=False, type='int'),
         select=dict(required=False, type='str', choices=['Speed', 'Prority']),
-        member_if=dict(required=False, type='str'),
         priority=dict(required=False, type='int'),
         global_priority=dict(required=False, type='int'),
         state=dict(required=False, default='present',

--- a/test/integration/targets/ce_lacp/defaults/main.yaml
+++ b/test/integration/targets/ce_lacp/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "[^_].*"
+test_items: []

--- a/test/integration/targets/ce_lacp/tasks/main.yaml
+++ b/test/integration/targets/ce_lacp/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: netconf.yaml, tags: ['netconf'] }

--- a/test/integration/targets/ce_lacp/tasks/netconf.yaml
+++ b/test/integration/targets/ce_lacp/tasks/netconf.yaml
@@ -1,0 +1,17 @@
+---
+- name: collect all netconf test cases
+  find:
+    paths: "{{ role_path }}/tests/netconf"
+    patterns: "{{ testcase }}.yaml"
+    use_regex: true
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/ce_lacp/tests/netconf/absent.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/absent.yaml
@@ -61,7 +61,7 @@
 - name: Get lacp config by ce_netconf.
   ce_netconf:
     rpc: get
-    cfg_xml: "<filter type="subtree">
+    cfg_xml: "<filter type=\"subtree\">
               <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
                 <lacpSysInfo>
                   <priority></priority>

--- a/test/integration/targets/ce_lacp/tests/netconf/absent.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/absent.yaml
@@ -1,0 +1,95 @@
+---
+- debug:
+    msg: "START ce_lacp merged integration tests on connection={{ ansible_connection }}"
+# befor removing, it should be merged
+- include_tasks: merge.yaml
+
+- name: Merge the provided configuration with the exisiting running configuration
+  ce_lacp: &absent
+    mode: Dynamic
+    trunk_id: 10
+    preempt_enable: True
+    state_flapping: True
+    port_id_extension_enable: True
+    unexpected_mac_disable: True
+    system_id: 1111-2222-3333
+    timeout_type: Fast
+    fast_timeout: 12
+    mixed_rate_link_enable: True
+    preempt_delay: 12
+    collector_delay: 12
+    max_active_linknumber: 2
+    select: Prority
+    priority: 23
+    global_priority: 123
+    state: absent
+  register: result
+
+- name: Assert the configuration is reflected on host
+  assert:
+    that:
+      - "result['changed'] == true"
+
+- name: Get lacp config by ce_netconf.
+  ce_netconf:
+    rpc: get
+    cfg_xml: "<filter type=\"subtree\">
+              <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                <TrunkIfs>
+                  <TrunkIf>
+                    <ifName>Eth-Trunk10</ifName>
+                    <lacpTrunk>
+                      <isSupportPrmpt></isSupportPrmpt>
+                      <rcvTimeoutType></rcvTimeoutType>
+                      <fastTimeoutUserDefinedValue></fastTimeoutUserDefinedValue>
+                      <selectPortStd></selectPortStd>
+                      <promptDelay></promptDelay>
+                      <maxActiveNum></maxActiveNum>
+                      <collectMaxDelay></collectMaxDelay>
+                      <mixRateEnable></mixRateEnable>
+                      <dampStaFlapEn></dampStaFlapEn>
+                      <dampUnexpMacEn></dampUnexpMacEn>
+                      <trunkSysMac></trunkSysMac>
+                      <trunkPortIdExt></trunkPortIdExt>
+                    </lacpTrunk>
+                  </TrunkIf>
+                </TrunkIfs>
+              </ifmtrunk>
+            </filter>"
+  register: result_ifs_merged
+
+- name: Get lacp config by ce_netconf.
+  ce_netconf:
+    rpc: get
+    cfg_xml: "<filter type="subtree">
+              <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                <lacpSysInfo>
+                  <priority></priority>
+                </lacpSysInfo>
+              </ifmtrunk>
+            </filter>"
+  register: result_global_merged
+
+
+- name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+  ce_lacp: *absent
+  register: result_re_merged
+
+- name: Assert that the previous task was idempotent, some become ot default values, others depend on devices.
+  assert:
+    that:
+      - "result_re_merged.changed == false"
+      - "'<isSupportPrmpt>false</isSupportPrmpt>' == result_ifs_merged.end_state.result"
+      - "'<rcvTimeoutType>Slow</rcvTimeoutType>' == result_ifs_merged.end_state.result"
+      - "'<fastTimeoutUserDefinedValue>90</fastTimeoutUserDefinedValue>' == result_ifs_merged.end_state.result"
+      - "'<selectPortStd>Prority</selectPortStd>' == result_ifs_merged.end_state.result"
+      - "'<promptDelay>30</promptDelay>' == result_ifs_merged.end_state.result"
+      - "'<collectMaxDelay>0</collectMaxDelay>' in result_ifs_merged.end_state.result"
+      - "'<mixRateEnable>false</mixRateEnable>' in result_ifs_merged.end_state.result"
+      - "'<dampStaFlapEn>false</dampStaFlapEn>' in result_ifs_merged.end_state.result"
+      - "'<dampUnexpMacEn>false</dampUnexpMacEn>' in result_ifs_merged.end_state.result"
+      - "'<trunkSysMac>false</trunkSysMac>' in result_ifs_merged.end_state.result"
+      - "'<priority>32768</priority>' in result_global_merged.end_state.result"
+
+- debug:
+    msg: "END ce_lacp merged integration tests on connection={{ ansible_connection }}"

--- a/test/integration/targets/ce_lacp/tests/netconf/delete.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/delete.yaml
@@ -1,0 +1,32 @@
+---
+- debug:
+    msg: "START ce_lacp deleted integration tests on connection={{ ansible_connection }}"
+
+- name: Merge the provided configuration with the exisiting running configuration
+  ce_lacp:
+    mode: Dynamic
+    trunk_id: 10
+    preempt_enable: True
+    state_flapping: True
+    port_id_extension_enable: True
+    unexpected_mac_disable: True
+    system_id: 1111-2222-3333
+    timeout_type: Fast
+    fast_timeout: 12
+    mixed_rate_link_enable: True
+    preempt_delay: 12
+    collector_delay: 12
+    max_active_linknumber: 2
+    select: Prority
+    priority: 23
+    global_priority: 123
+    state: absent
+  register: result
+
+- name: Assert the configuration is reflected on host
+  assert:
+    that:
+      - "result['changed'] == true"
+
+- debug:
+    msg: "END ce_lacp deleted integration tests on connection={{ ansible_connection }}"

--- a/test/integration/targets/ce_lacp/tests/netconf/merge.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/merge.yaml
@@ -1,0 +1,31 @@
+---
+- debug:
+    msg: "START ce_lacp merged integration tests on connection={{ ansible_connection }}"
+
+- name: Merge the provided configuration with the exisiting running configuration
+  ce_lacp:
+    mode: Dynamic
+    trunk_id: 10
+    preempt_enable: True
+    state_flapping: True
+    port_id_extension_enable: True
+    unexpected_mac_disable: True
+    system_id: 1111-2222-3333
+    timeout_type: Fast
+    fast_timeout: 12
+    mixed_rate_link_enable: True
+    preempt_delay: 12
+    collector_delay: 12
+    max_active_linknumber: 2
+    select: Prority
+    priority: 23
+    global_priority: 123
+  register: result
+
+- name: Assert the configuration is reflected on host
+  assert:
+    that:
+      - "result['changed'] == true"
+
+- debug:
+    msg: "END ce_lacp merged integration tests on connection={{ ansible_connection }}"

--- a/test/integration/targets/ce_lacp/tests/netconf/present.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/present.yaml
@@ -59,7 +59,7 @@
 - name: Get global lacp config by ce_netconf.
   ce_netconf:
     rpc: get
-    cfg_xml: "<filter type="subtree">
+    cfg_xml: "<filter type=\"subtree\">
               <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
                 <lacpSysInfo>
                   <priority></priority>

--- a/test/integration/targets/ce_lacp/tests/netconf/present.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/present.yaml
@@ -3,7 +3,7 @@
     msg: "START ce_lacp presented integration tests on connection={{ ansible_connection }}"
 
 - name: present the provided configuration with the exisiting running configuration
-  ce_lacp: &presentd
+  ce_lacp: &present
     mode: Dynamic
     trunk_id: 10
     preempt_enable: True
@@ -74,7 +74,7 @@
 
 
 - name: present the provided configuration with the existing running configuration (IDEMPOTENT)
-  ce_lacp: *presentd
+  ce_lacp: *present
   register: result_re_presentd
 
 - name: Assert that the previous task was idempotent
@@ -97,11 +97,7 @@
       - "'<lacpMlagSysId>1111-2222-3333</lacpMlagSysId>' in result_global_presentd.end_state.result"
       - "'<priority>123</priority>' in result_global_presentd.end_state.result"
 
-
-- name: clean-up all
-  ce_lacp: *presentd
-    state: absent
-  register: result_re_presentd
-
+# after present, it should be deleted
+- include_tasks: delete.yaml
 - debug:
     msg: "END ce_lacp presentd integration tests on connection={{ ansible_connection }}"

--- a/test/integration/targets/ce_lacp/tests/netconf/present.yaml
+++ b/test/integration/targets/ce_lacp/tests/netconf/present.yaml
@@ -1,0 +1,107 @@
+---
+- debug:
+    msg: "START ce_lacp presented integration tests on connection={{ ansible_connection }}"
+
+- name: present the provided configuration with the exisiting running configuration
+  ce_lacp: &presentd
+    mode: Dynamic
+    trunk_id: 10
+    preempt_enable: True
+    state_flapping: True
+    port_id_extension_enable: True
+    unexpected_mac_disable: True
+    system_id: 1111-2222-3333
+    timeout_type: Fast
+    fast_timeout: 12
+    mixed_rate_link_enable: True
+    preempt_delay: 12
+    collector_delay: 12
+    max_active_linknumber: 2
+    select: Prority
+    priority: 23
+    global_priority: 123
+  register: result
+
+- name: Assert the configuration is reflected on host
+  assert:
+    that:
+      - "result['changed'] == true"
+
+- name: Get lacp config by ce_netconf.
+  ce_netconf:
+    rpc: get
+    cfg_xml: "<filter type=\"subtree\">
+              <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                <TrunkIfs>
+                  <TrunkIf>
+                    <ifName>Eth-Trunk10</ifName>
+                    <workMode></workMode>
+                    <lacpTrunk>
+                      <isSupportPrmpt></isSupportPrmpt>
+                      <rcvTimeoutType></rcvTimeoutType>
+                      <fastTimeoutUserDefinedValue></fastTimeoutUserDefinedValue>
+                      <selectPortStd></selectPortStd>
+                      <promptDelay></promptDelay>
+                      <maxActiveNum></maxActiveNum>
+                      <collectMaxDelay></collectMaxDelay>
+                      <mixRateEnable></mixRateEnable>
+                      <dampStaFlapEn></dampStaFlapEn>
+                      <dampUnexpMacEn></dampUnexpMacEn>
+                      <trunkSysMac></trunkSysMac>
+                      <trunkPortIdExt></trunkPortIdExt>
+                    </lacpTrunk>
+                  </TrunkIf>
+                </TrunkIfs>
+              </ifmtrunk>
+            </filter>"
+  register: result_ifs_presentd
+
+- name: Get global lacp config by ce_netconf.
+  ce_netconf:
+    rpc: get
+    cfg_xml: "<filter type="subtree">
+              <ifmtrunk xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                <lacpSysInfo>
+                  <priority></priority>
+                  <lacpMlagGlobal>
+                    <lacpMlagPriority></lacpMlagPriority>
+                    <lacpMlagSysId></lacpMlagSysId>
+                  </lacpMlagGlobal>
+                </lacpSysInfo>
+              </ifmtrunk>
+            </filter>"
+  register: result_global_presentd
+
+
+- name: present the provided configuration with the existing running configuration (IDEMPOTENT)
+  ce_lacp: *presentd
+  register: result_re_presentd
+
+- name: Assert that the previous task was idempotent
+  assert:
+    that:
+      - "result_re_presentd.changed == false"
+      - "'<workMode>Dynamic</workMode>' == result_ifs_presentd.end_state.result"
+      - "'<isSupportPrmpt>true</isSupportPrmpt>' == result_ifs_presentd.end_state.result"
+      - "'<rcvTimeoutType>Fast</rcvTimeoutType>' == result_ifs_presentd.end_state.result"
+      - "'<fastTimeoutUserDefinedValue>12</fastTimeoutUserDefinedValue>' == result_ifs_presentd.end_state.result"
+      - "'<selectPortStd>Prority</selectPortStd>' == result_ifs_presentd.end_state.result"
+      - "'<promptDelay>12</promptDelay>' == result_ifs_presentd.end_state.result"
+      - "'<maxActiveNum>2</maxActiveNum>' == result_ifs_presentd.end_state.result"
+      - "'<collectMaxDelay>12</collectMaxDelay>' in result_ifs_presentd.end_state.result"
+      - "'<mixRateEnable>true</mixRateEnable>' in result_ifs_presentd.end_state.result"
+      - "'<dampStaFlapEn>true</dampStaFlapEn>' in result_ifs_presentd.end_state.result"
+      - "'<dampUnexpMacEn>true</dampUnexpMacEn>' in result_ifs_presentd.end_state.result"
+      - "'<trunkSysMac>true</trunkSysMac>' in result_ifs_presentd.end_state.result"
+      - "'<trunkPortIdExt>true</trunkPortIdExt>' in result_ifs_presentd.end_state.result"
+      - "'<lacpMlagSysId>1111-2222-3333</lacpMlagSysId>' in result_global_presentd.end_state.result"
+      - "'<priority>123</priority>' in result_global_presentd.end_state.result"
+
+
+- name: clean-up all
+  ce_lacp: *presentd
+    state: absent
+  register: result_re_presentd
+
+- debug:
+    msg: "END ce_lacp presentd integration tests on connection={{ ansible_connection }}"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -3064,6 +3064,12 @@ lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:doc-c
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:doc-missing-type
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:missing-suboption-docs
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E322
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E324
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E326
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E337
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E338
+lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E340
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py future-import-boilerplate
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py metaclass-boilerplate
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py validate-modules:undocumented-parameter

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -3064,12 +3064,6 @@ lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:doc-c
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:doc-missing-type
 lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:missing-suboption-docs
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E322
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E324
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E326
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E337
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E338
-lib/ansible/modules/network/cloudengine/ce_link_status.py validate-modules:E340
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py future-import-boilerplate
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py metaclass-boilerplate
 lib/ansible/modules/network/cloudengine/ce_mlag_config.py validate-modules:undocumented-parameter

--- a/test/units/modules/network/cloudengine/ce_module.py
+++ b/test/units/modules/network/cloudengine/ce_module.py
@@ -29,6 +29,7 @@ from units.modules.utils import set_module_args as _set_module_args
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}
 
+
 def load_fixture(module_name, name, device=''):
     path = os.path.join(fixture_path, module_name, device, name)
     if not os.path.exists(path):

--- a/test/units/modules/network/cloudengine/ce_module.py
+++ b/test/units/modules/network/cloudengine/ce_module.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2019 Red Hat
+#
+# This file is a part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
+from units.modules.utils import set_module_args as _set_module_args
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+def load_fixture(module_name, name, device=''):
+    path = os.path.join(fixture_path, module_name, device, name)
+    if not os.path.exists(path):
+        path = os.path.join(fixture_path, module_name, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except Exception:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+def set_module_args(args):
+    if 'provider' not in args:
+        args['provider'] = {'transport': args.get('transport') or 'cli'}
+
+    return _set_module_args(args)
+
+
+class TestCloudEngineModule(ModuleTestCase):
+
+    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False):
+
+        self.load_fixtures(commands)
+
+        if failed:
+            result = self.failed()
+            self.assertTrue(result['failed'], result)
+        else:
+            result = self.changed(changed)
+            self.assertEqual(result['changed'], changed, result)
+
+        if commands is not None:
+            if sort:
+                self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
+            else:
+                self.assertEqual(commands, result['commands'], result['commands'])
+
+        return result
+
+    def failed(self):
+        with self.assertRaises(AnsibleFailJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertTrue(result['failed'], result)
+        return result
+
+    def changed(self, changed=False):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], changed, result)
+        return result
+
+    def load_fixtures(self, commands=None):
+        pass

--- a/test/units/modules/network/cloudengine/ce_module.py
+++ b/test/units/modules/network/cloudengine/ce_module.py
@@ -23,7 +23,6 @@ __metaclass__ = type
 import os
 import json
 from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
-from units.modules.utils import set_module_args as _set_module_args
 
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -48,13 +47,6 @@ def load_fixture(module_name, name, device=''):
 
     fixture_data[path] = data
     return data
-
-
-def set_module_args(args):
-    if 'provider' not in args:
-        args['provider'] = {'transport': args.get('transport') or 'cli'}
-
-    return _set_module_args(args)
 
 
 class TestCloudEngineModule(ModuleTestCase):

--- a/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_00.txt
+++ b/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_00.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1024">
+  <data>
+    <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+      <TrunkIfs>
+        <TrunkIf>
+          <ifName>Eth-Trunk10</ifName>
+          <lacpTrunk>
+            <isSupportPrmpt>false</isSupportPrmpt>
+            <rcvTimeoutType>Fast</rcvTimeoutType>
+            <fastTimeoutUserDefinedValue>3</fastTimeoutUserDefinedValue>
+            <selectPortStd>Speed</selectPortStd>
+            <promptDelay>30</promptDelay>
+            <maxActiveNum>1</maxActiveNum>
+            <collectMaxDelay>0</collectMaxDelay>
+            <mixRateEnable>false</mixRateEnable>
+            <dampStaFlapEn>false</dampStaFlapEn>
+            <dampUnexpMacEn>false</dampUnexpMacEn>
+            <trunkSysMac>11-22-33</trunkSysMac>
+            <trunkPortIdExt>false</trunkPortIdExt>
+          </lacpTrunk>
+        </TrunkIf>
+      </TrunkIfs>
+    </ifmtrunk>
+  </data>
+</rpc-reply>

--- a/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_01.txt
+++ b/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_01.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1024">
+  <data>
+    <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+      <TrunkIfs>
+        <TrunkIf>
+          <ifName>Eth-Trunk10</ifName>
+          <lacpTrunk>
+            <isSupportPrmpt>true</isSupportPrmpt>
+            <rcvTimeoutType>Fast</rcvTimeoutType>
+            <fastTimeoutUserDefinedValue>10</fastTimeoutUserDefinedValue>
+            <selectPortStd>Speed</selectPortStd>
+            <promptDelay>130</promptDelay>
+            <maxActiveNum>13</maxActiveNum>
+            <collectMaxDelay>12</collectMaxDelay>
+            <mixRateEnable>true</mixRateEnable>
+            <dampStaFlapEn>true</dampStaFlapEn>
+            <dampUnexpMacEn>true</dampUnexpMacEn>
+            <trunkSysMac>0000-1111-2222</trunkSysMac>
+            <trunkPortIdExt>true</trunkPortIdExt>
+          </lacpTrunk>
+        </TrunkIf>
+      </TrunkIfs>
+    </ifmtrunk>
+  </data>
+</rpc-reply>

--- a/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_10.txt
+++ b/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_10.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1024">
+  <data>
+    <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+      <lacpSysInfo>
+        <priority>32768</priority>
+      </lacpSysInfo>
+    </ifmtrunk>
+  </data>
+</rpc-reply>

--- a/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_11.txt
+++ b/test/units/modules/network/cloudengine/fixtures/ce_lacp/ce_lacp_11.txt
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1024">
+  <data>
+    <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+      <lacpSysInfo>
+        <priority>32769</priority>
+      </lacpSysInfo>
+    </ifmtrunk>
+  </data>
+</rpc-reply>

--- a/test/units/modules/network/cloudengine/test_ce_lacp.py
+++ b/test/units/modules/network/cloudengine/test_ce_lacp.py
@@ -22,7 +22,8 @@ __metaclass__ = type
 
 from units.compat.mock import patch
 from ansible.modules.network.cloudengine import ce_lacp
-from .ce_module import TestCloudEngineModule, load_fixture, set_module_args
+from units.modules.utils import set_module_args 
+from .ce_module import TestCloudEngineModule, load_fixture
 
 
 class TestCloudEngineLacpModule(TestCloudEngineModule):

--- a/test/units/modules/network/cloudengine/test_ce_lacp.py
+++ b/test/units/modules/network/cloudengine/test_ce_lacp.py
@@ -58,22 +58,22 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
                   'lacp timeout user-defined 10',
                   'lacp dampening unexpected-mac disable']
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(mode='Dynamic',
-                             trunk_id='10',
-                             preempt_enable='true',
-                             state_flapping='true',
-                             port_id_extension_enable='true',
-                             unexpected_mac_disable='true',
-                             system_id='0000-1111-2222',
-                             timeout_type='Fast',
-                             fast_timeout='10',
-                             mixed_rate_link_enable='true',
-                             preempt_delay=11,
-                             collector_delay=12,
-                             max_active_linknumber=13,
-                             select='Speed',
-                            state='present')
-                       )
+        set_module_args(dict(
+                        mode='Dynamic',
+                        trunk_id='10',
+                        preempt_enable='true',
+                        state_flapping='true',
+                        port_id_extension_enable='true',
+                        unexpected_mac_disable='true',
+                        system_id='0000-1111-2222',
+                        timeout_type='Fast',
+                        fast_timeout='10',
+                        mixed_rate_link_enable='true',
+                        preempt_delay=11,
+                        collector_delay=12,
+                        max_active_linknumber=13,
+                        select='Speed',
+                        state='present'))
         result = self.execute_module(changed=True)
         self.assertEquals(sorted(result['updates']), sorted(update))
 
@@ -94,23 +94,23 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
                           'lacp system-id 11-22-33',
                           'lacp timeout user-defined 3']
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(mode='Dynamic',
-                             trunk_id='10',
-                             preempt_enable='true',
-                             state_flapping='true',
-                             port_id_extension_enable='true',
-                             unexpected_mac_disable='true',
-                             system_id='0000-1111-2222',
-                             timeout_type='Fast',
-                             fast_timeout='10',
-                             mixed_rate_link_enable='true',
-                             preempt_delay=11,
-                             collector_delay=12,
-                             max_active_linknumber=13,
-                             select='Speed',
-                             state='absent'
-                            )
-                      )
+        set_module_args(dict(
+                        mode='Dynamic',
+                        trunk_id='10',
+                        preempt_enable='true',
+                        state_flapping='true',
+                        port_id_extension_enable='true',
+                        unexpected_mac_disable='true',
+                        system_id='0000-1111-2222',
+                        timeout_type='Fast',
+                        fast_timeout='10',
+                        mixed_rate_link_enable='true',
+                        preempt_delay=11,
+                        collector_delay=12,
+                        max_active_linknumber=13,
+                        select='Speed',
+                        state='absent'
+                        ))
         result = self.execute_module(changed=True)
         self.assertEquals(sorted(result['updates']), sorted(default_values))
 
@@ -119,9 +119,7 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
         xml_end_state = load_fixture('ce_lacp', 'ce_lacp_11.txt')
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
         set_module_args(dict(global_priority=32769,
-                             state='present'
-                             )
-                        )
+                             state='present'))
         result = self.execute_module(changed=True)
         self.assertEquals(result['updates'], ['lacp priority 32769'])
 
@@ -130,9 +128,7 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
         xml_end_state = load_fixture('ce_lacp', 'ce_lacp_10.txt')
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
         set_module_args(dict(global_priority=32769,
-                             state='absent'
-                            )
-                        )
+                             state='absent'))
         result = self.execute_module(changed=True)
         # excpect: lacp priority is set to default value(32768)
         self.assertEquals(result['updates'], ['lacp priority 32768'])

--- a/test/units/modules/network/cloudengine/test_ce_lacp.py
+++ b/test/units/modules/network/cloudengine/test_ce_lacp.py
@@ -1,0 +1,142 @@
+# (c) 2019 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.cloudengine import ce_lacp
+from .ce_module import TestCloudEngineModule, load_fixture, set_module_args
+
+
+class TestCloudEngineLacpModule(TestCloudEngineModule):
+    module = ce_lacp
+
+    def setUp(self):
+        super(TestCloudEngineLacpModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.cloudengine.ce_lacp.get_nc_config')
+        self.get_nc_config = self.mock_get_config.start()
+
+        self.mock_set_config = patch('ansible.modules.network.cloudengine.ce_lacp.set_nc_config')
+        self.set_nc_config = self.mock_set_config.start()
+        self.set_nc_config.return_value = None
+
+    def tearDown(self):
+        super(TestCloudEngineLacpModule, self).tearDown()
+        self.mock_set_config.stop()
+        self.mock_get_config.stop()
+
+    def test_lacp_eturnk_present(self):
+        xml_existing = load_fixture('ce_lacp', 'ce_lacp_00.txt')
+        xml_end_state = load_fixture('ce_lacp', 'ce_lacp_01.txt')
+        update = ['lacp max active-linknumber 13',
+                  'lacp dampening state-flapping',
+                  'lacp port-id-extension enable',
+                  'lacp collector delay 12',
+                  'lacp preempt enable',
+                  'lacp system-id 0000-1111-2222',
+                  'lacp mixed-rate link enable',
+                  'lacp preempt delay 130',
+                  'lacp timeout user-defined 10',
+                  'lacp dampening unexpected-mac disable']
+        self.get_nc_config.side_effect = (xml_existing, xml_end_state)
+        set_module_args(dict(
+            mode='Dynamic',
+            trunk_id='10',
+            preempt_enable='true',
+            state_flapping='true',
+            port_id_extension_enable='true',
+            unexpected_mac_disable='true',
+            system_id='0000-1111-2222',
+            timeout_type='Fast',
+            fast_timeout='10',
+            mixed_rate_link_enable='true',
+            preempt_delay=11,
+            collector_delay=12,
+            max_active_linknumber=13,
+            select='Speed',
+            state='present'
+        )
+        )
+        result = self.execute_module(changed=True)
+        self.assertEquals(sorted(result['updates']), sorted(update))
+
+    def test_lacp_eturnk_absent(self):
+        xml_existing = load_fixture('ce_lacp', 'ce_lacp_10.txt')
+        xml_end_state = load_fixture('ce_lacp', 'ce_lacp_00.txt')
+        default_values = ['undo lacp priority',
+                          'lacp timeout Fast',
+                          'lacp max active-linknumber 1',
+                          'lacp collector delay 0',
+                          'lacp preempt enable false',
+                          'lacp dampening state-flapping false',
+                          'lacp dampening unexpected-mac disable false',
+                          'lacp mixed-rate link enable false',
+                          'lacp port-id-extension enable false',
+                          'lacp preempt delay 30',
+                          'lacp select Speed',
+                          'lacp system-id 11-22-33',
+                          'lacp timeout user-defined 3']
+        self.get_nc_config.side_effect = (xml_existing, xml_end_state)
+        set_module_args(dict(
+            mode='Dynamic',
+            trunk_id='10',
+            preempt_enable='true',
+            state_flapping='true',
+            port_id_extension_enable='true',
+            unexpected_mac_disable='true',
+            system_id='0000-1111-2222',
+            timeout_type='Fast',
+            fast_timeout='10',
+            mixed_rate_link_enable='true',
+            preempt_delay=11,
+            collector_delay=12,
+            max_active_linknumber=13,
+            select='Speed',
+            state='absent'
+        )
+        )
+        result = self.execute_module(changed=True)
+        self.assertEquals(sorted(result['updates']), sorted(default_values))
+
+    def test_lacp_global_present(self):
+        xml_existing = load_fixture('ce_lacp', 'ce_lacp_10.txt')
+        xml_end_state = load_fixture('ce_lacp', 'ce_lacp_11.txt')
+        self.get_nc_config.side_effect = (xml_existing, xml_end_state)
+        set_module_args(dict(
+            global_priority=32769,
+            state='present'
+        )
+        )
+        result = self.execute_module(changed=True)
+        self.assertEquals(result['updates'], ['lacp priority 32769'])
+
+    def test_lacp_global_absent(self):
+        xml_existing = load_fixture('ce_lacp', 'ce_lacp_11.txt')
+        xml_end_state = load_fixture('ce_lacp', 'ce_lacp_10.txt')
+        self.get_nc_config.side_effect = (xml_existing, xml_end_state)
+        set_module_args(dict(
+            global_priority=32769,
+            state='absent'
+        )
+        )
+        result = self.execute_module(changed=True)
+        # excpect: lacp priority is set to default value(32768)
+        self.assertEquals(result['updates'], ['lacp priority 32768'])

--- a/test/units/modules/network/cloudengine/test_ce_lacp.py
+++ b/test/units/modules/network/cloudengine/test_ce_lacp.py
@@ -58,24 +58,22 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
                   'lacp timeout user-defined 10',
                   'lacp dampening unexpected-mac disable']
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(
-            mode='Dynamic',
-            trunk_id='10',
-            preempt_enable='true',
-            state_flapping='true',
-            port_id_extension_enable='true',
-            unexpected_mac_disable='true',
-            system_id='0000-1111-2222',
-            timeout_type='Fast',
-            fast_timeout='10',
-            mixed_rate_link_enable='true',
-            preempt_delay=11,
-            collector_delay=12,
-            max_active_linknumber=13,
-            select='Speed',
-            state='present'
-        )
-        )
+        set_module_args(dict(mode='Dynamic',
+                             trunk_id='10',
+                             preempt_enable='true',
+                             state_flapping='true',
+                             port_id_extension_enable='true',
+                             unexpected_mac_disable='true',
+                             system_id='0000-1111-2222',
+                             timeout_type='Fast',
+                             fast_timeout='10',
+                             mixed_rate_link_enable='true',
+                             preempt_delay=11,
+                             collector_delay=12,
+                             max_active_linknumber=13,
+                             select='Speed',
+                            state='present')
+                       )
         result = self.execute_module(changed=True)
         self.assertEquals(sorted(result['updates']), sorted(update))
 
@@ -96,24 +94,23 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
                           'lacp system-id 11-22-33',
                           'lacp timeout user-defined 3']
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(
-            mode='Dynamic',
-            trunk_id='10',
-            preempt_enable='true',
-            state_flapping='true',
-            port_id_extension_enable='true',
-            unexpected_mac_disable='true',
-            system_id='0000-1111-2222',
-            timeout_type='Fast',
-            fast_timeout='10',
-            mixed_rate_link_enable='true',
-            preempt_delay=11,
-            collector_delay=12,
-            max_active_linknumber=13,
-            select='Speed',
-            state='absent'
-        )
-        )
+        set_module_args(dict(mode='Dynamic',
+                             trunk_id='10',
+                             preempt_enable='true',
+                             state_flapping='true',
+                             port_id_extension_enable='true',
+                             unexpected_mac_disable='true',
+                             system_id='0000-1111-2222',
+                             timeout_type='Fast',
+                             fast_timeout='10',
+                             mixed_rate_link_enable='true',
+                             preempt_delay=11,
+                             collector_delay=12,
+                             max_active_linknumber=13,
+                             select='Speed',
+                             state='absent'
+                            )
+                      )
         result = self.execute_module(changed=True)
         self.assertEquals(sorted(result['updates']), sorted(default_values))
 
@@ -121,11 +118,10 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
         xml_existing = load_fixture('ce_lacp', 'ce_lacp_10.txt')
         xml_end_state = load_fixture('ce_lacp', 'ce_lacp_11.txt')
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(
-            global_priority=32769,
-            state='present'
-        )
-        )
+        set_module_args(dict(global_priority=32769,
+                             state='present'
+                             )
+                        )
         result = self.execute_module(changed=True)
         self.assertEquals(result['updates'], ['lacp priority 32769'])
 
@@ -133,11 +129,10 @@ class TestCloudEngineLacpModule(TestCloudEngineModule):
         xml_existing = load_fixture('ce_lacp', 'ce_lacp_11.txt')
         xml_end_state = load_fixture('ce_lacp', 'ce_lacp_10.txt')
         self.get_nc_config.side_effect = (xml_existing, xml_end_state)
-        set_module_args(dict(
-            global_priority=32769,
-            state='absent'
-        )
-        )
+        set_module_args(dict(global_priority=32769,
+                             state='absent'
+                            )
+                        )
         result = self.execute_module(changed=True)
         # excpect: lacp priority is set to default value(32768)
         self.assertEquals(result['updates'], ['lacp priority 32768'])

--- a/test/units/modules/network/cloudengine/test_ce_lacp.py
+++ b/test/units/modules/network/cloudengine/test_ce_lacp.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 
 from units.compat.mock import patch
 from ansible.modules.network.cloudengine import ce_lacp
-from units.modules.utils import set_module_args 
+from units.modules.utils import set_module_args
 from .ce_module import TestCloudEngineModule, load_fixture
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Specifies the working mode of an Eth-Trunk interface.
Specifies lacp preempt enable of Eth-Trunk lacp.
And other lcap options.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_lacp.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
### test case
```paste below
---

- name: test ce_lacp
  gather_facts: no
  hosts: switch6

  tasks:

  - name: "test the correct trunk_id"
    ce_lacp:
      trunk_id: 20
      mode: Dynamic
      state: present
```
### test log
```
changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "collectMaxDelay": "0",
        "dampStaFlapEn": "false",
        "dampUnexpMacEn": "true",
        "fastTimeoutUserDefinedValue": "90",
        "hashType": "Enhanced",
        "ifMac": "0005-c096-2e01",
        "ifName": "Eth-Trunk20",
        "isSupportPrmpt": "false",
        "maxActiveNum": "16",
        "maxBandWidth": "0",
        "maxUpNum": "16",
        "memberIfNum": "0",
        "minUpNum": "1",
        "mixRateEnable": "false",
        "onlineMemberIfNum": "0",
        "portUpNum": "0",
        "promptDelay": "30",
        "rcvTimeoutType": "Slow",
        "selectPortStd": "Prority",
        "trunkPortIdExt": "false",
        "trunkType": "EthTrunk",
        "upMemberIfNum": "0",
        "workMode": "Dynamic"
    },
    "existing": {
        "hashType": "Enhanced",
        "ifMac": "0005-c096-2e01",
        "ifName": "Eth-Trunk20",
        "maxBandWidth": "0",
        "maxUpNum": "16",
        "memberIfNum": "0",
        "minUpNum": "1",
        "onlineMemberIfNum": "0",
        "trunkType": "EthTrunk",
        "upMemberIfNum": "0",
        "workMode": "Manual"
    },
    "invocation": {
        "module_args": {
            "collector_delay": null,
            "fast_timeout": null,
            "global_priority": null,
            "max_active_linknumber": null,
            "member_if": null,
            "mixed_rate_link_enable": null,
            "mode": "Dynamic",
            "port_id_extension_enable": null,
            "preempt_delay": null,
            "preempt_enable": null,
            "priority": null,
            "select": null,
            "state": "present",
            "state_flapping": null,
            "system_id": null,
            "trunk_id": "20",
            "unexpected_mac_disable": null,
        }
    },
    "proposed": {
        "mode": "Dynamic",
        "state": "present",
        "trunk_id": "20"
    },
    "updates": [
        "lacp select Prority",
        "lacp mixed-rate link enable false",
        "lacp port-id-extension enable false",
        "lacp timeout Slow",
        "lacp dampening unexpected-mac disable true",
        "lacp timeout user-defined 90",
        "lacp max active-linknumber 16",
        "lacp dampening state-flapping false",
        "lacp preempt delay 30",
        "lacp preempt enable false",
        "lacp collector delay 0"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
### show on device.
```
[~8850_130.12-Eth-Trunk20]di th
#
interface Eth-Trunk20
 undo portswitch
 ip address 30.2.2.6 255.255.255.0
 isis enable 3
 isis circuit-type p2p
 isis circuit-level level-2
 isis cost 50 level-1
 isis cost 40 level-2
 isis ppp-negotiation 2-way
 isis peer-ip-ignore
 isis ppp-osicp-check
 mode lacp-dynamic
#
return
[~8850_130.12-Eth-Trunk20]

```
### test case
```

  - name: "test the correct preempt_enable"
    ce_lacp:
      trunk_id: 20
      preempt_enable: true
      state_flapping: true
      port_id_extension_enable: true
      unexpected_mac_disable: true
      state: present

```
### test log
```

changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "dampStaFlapEn": "true",
        "dampUnexpMacEn": "true",
        "ifName": "Eth-Trunk20",
        "isSupportPrmpt": "true",
        "trunkPortIdExt": "true"
    },
    "existing": {
        "dampStaFlapEn": "false",
        "dampUnexpMacEn": "true",
        "ifName": "Eth-Trunk20",
        "isSupportPrmpt": "false",
        "trunkPortIdExt": "false"
    },
    "invocation": {
        "module_args": {
            "collector_delay": null,
            "fast_timeout": null,
            "global_priority": null,
            "host": "10.190.121.125",
            "max_active_linknumber": null,
            "member_if": null,
            "mixed_rate_link_enable": null,
            "mode": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "port_id_extension_enable": "true",
            "preempt_delay": null,
            "preempt_enable": "true",
            "priority": null,
            "select": null,
            "state": "present",
            "state_flapping": "true",
            "system_id": null,
            "transport": "cli",
            "trunk_id": "20",
            "unexpected_mac_disable": "true",
        }
    },
    "proposed": {
        "port_id_extension_enable": "true",
        "preempt_enable": "true",
        "state": "present",
        "state_flapping": "true",
        "trunk_id": "20",
        "unexpected_mac_disable": "true"
    },
    "updates": [
        "lacp port-id-extension enable",
        "lacp preempt enable",
        "lacp dampening state-flapping"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
### show on device.
```
[~8850_130.12-Eth-Trunk20]di th
#
interface Eth-Trunk20
 undo portswitch
 ip address 30.2.2.6 255.255.255.0
 isis enable 3
 isis circuit-type p2p
 isis circuit-level level-2
 isis cost 50 level-1
 isis cost 40 level-2
 isis ppp-negotiation 2-way
 isis peer-ip-ignore
 isis ppp-osicp-check
 mode lacp-dynamic
 lacp dampening state-flapping
 lacp preempt enable
 lacp port-id-extension enable
#
return
[~8850_130.12-Eth-Trunk20]
```
### test case
```

  - name: "Step7.1.1 test the correct system_id"
    ce_lacp:
      trunk_id: 20
      system_id: a-a-a
      timeout_type: Fast
      fast_timeout: 3
      preempt_delay: 180
      collector_delay: 65535
      state: present

```
### test log
```

changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "collectMaxDelay": "65535",
        "fastTimeoutUserDefinedValue": "3",
        "ifName": "Eth-Trunk20",
        "promptDelay": "180",
        "rcvTimeoutType": "Fast",
        "trunkSysMac": "000a-000a-000a"
    },
    "existing": {
        "collectMaxDelay": "0",
        "fastTimeoutUserDefinedValue": "90",
        "ifName": "Eth-Trunk20",
        "promptDelay": "30",
        "rcvTimeoutType": "Slow"
    },
    "invocation": {
        "module_args": {
            "collector_delay": 65535,
            "fast_timeout": 3,
            "global_priority": null,
            "max_active_linknumber": null,
            "member_if": null,
            "mixed_rate_link_enable": null,
            "mode": null,
            "port_id_extension_enable": null,
            "preempt_delay": 180,
            "preempt_enable": null,
            "priority": null,
            "select": null,
            "state": "present",
            "state_flapping": null,
            "system_id": "a-a-a",
            "timeout_type": "Fast",
            "trunk_id": "20",
            "unexpected_mac_disable": null,
        }
    },
    "proposed": {
        "collector_delay": 65535,
        "fast_timeout": 3,
        "preempt_delay": 180,
        "state": "present",
        "system_id": "a-a-a",
        "timeout_type": "Fast",
        "trunk_id": "20"
    },
    "updates": [
        "lacp system-id 000a-000a-000a",
        "lacp preempt delay 180",
        "lacp timeout fast",
        "lacp collector delay 65535",
        "lacp timeout user-defined 3"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
### show on device.
```
[~8850_130.12-Eth-Trunk20]di th
#
interface Eth-Trunk20
 undo portswitch
 ip address 30.2.2.6 255.255.255.0
 isis enable 3
 isis circuit-type p2p
 isis circuit-level level-2
 isis cost 50 level-1
 isis cost 40 level-2
 isis ppp-negotiation 2-way
 isis peer-ip-ignore
 isis ppp-osicp-check
 mode lacp-dynamic
 lacp timeout fast
 lacp dampening state-flapping
 lacp preempt enable
 lacp preempt delay 180
 lacp collector delay 65535
 lacp system-id 000a-000a-000a
 lacp port-id-extension enable
#
return
[~8850_130.12-Eth-Trunk20]

```
### test case
```

  - name: "Step15.1.1 test the correct member_if"
    ce_lacp:
      trunk_id: 21
      mode: Static
      member_if: 100GE1/0/23
      priority: 10
      state: present
```
### test log
```

changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "ifName": "Eth-Trunk21",
        "memberIfName": "100GE1/0/23",
        "portPriority": "10",
        "workMode": "Static"
    },
    "existing": {},
    "invocation": {
        "module_args": {
            "collector_delay": null,
            "fast_timeout": null,
            "global_priority": null,
            "host": "10.190.121.125",
            "max_active_linknumber": null,
            "member_if": "100GE1/0/23",
            "mixed_rate_link_enable": null,
            "mode": "Static",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "port_id_extension_enable": null,
            "preempt_delay": null,
            "preempt_enable": null,
            "priority": 10,
            "select": null,
            "ssh_keyfile": null,
            "state": "present",
            "state_flapping": null,
            "system_id": null,
            "timeout": null,
            "timeout_type": null,
            "trunk_id": "21",
            "unexpected_mac_disable": null,
        }
    },
    "proposed": {
        "member_if": "100GE1/0/23",
        "mode": "Static",
        "priority": 10,
        "state": "present",
        "trunk_id": "21"
    },
    "updates": [
        "lacp priority 10"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ******************************************************************************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
### show on device.
```
[~8850_130.12-Eth-Trunk21]di th
#
interface Eth-Trunk21
 mode lacp-static
#
return
[~8850_130.12-Eth-Trunk21]

[~8850_130.12-100GE1/0/23]di th
#
interface 100GE1/0/23
 eth-trunk 21
 lacp priority 10
#
return
[~8850_130.12-100GE1/0/23]
```
