### PR TITLE
validate-modules - Check that provider['options'] is a dictionary

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1177,10 +1177,17 @@ class ModuleValidator(Validator):
                 deprecated_args_from_argspec.add(arg)
                 deprecated_args_from_argspec.update(data.get('aliases', []))
             if arg == 'provider' and self.object_path.startswith('lib/ansible/modules/network/'):
-                # Record provider options from network modules, for later comparison
-                for provider_arg, provider_data in data.get('options', {}).items():
-                    provider_args.add(provider_arg)
-                    provider_args.update(provider_data.get('aliases', []))
+                if data.get('options') and not isinstance(data.get('options'), dict):
+                    self.reporter.error(
+                        path=self.object_path,
+                        code=331,
+                        msg="Argument 'options' in argument_spec['provider'] must be a dictionary/hash when used",
+                    )
+                else:
+                    # Record provider options from network modules, for later comparison
+                    for provider_arg, provider_data in data.get('options', {}).items():
+                        provider_args.add(provider_arg)
+                        provider_args.update(provider_data.get('aliases', []))
 
             if data.get('required') and data.get('default', object) != object:
                 self.reporter.error(


### PR DESCRIPTION
##### SUMMARY
PRs #57932, #57906, #57353 introduced a default value of `''` in `provider['options']`. This value was assumed to be a dictionary by `validate-modules`, which caused a stack trace.

https://github.com/ansible/ansible/blob/ddd464b2d54b4ac2d9945dc1588ccbf361d799a6/lib/ansible/module_utils/network/eric_eccli/eric_eccli.py#L16

Improve `validate-modules` so it checks that this field is a dictionary and reports an error if it is not.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/sanity/validate-modules/validate-modules`
