### PR TITLE
This comment is no longer needed, as the calculation is done in the '…

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -390,9 +390,7 @@ def main():
             module.fail_json(changed=False, msg="module does not support resizing %s filesystem yet." % fstype)
 
         out = filesystem.grow(dev)
-        # Sadly there is no easy way to determine if this has changed. For now, just say "true" and move on.
-        #  in the future, you would have to parse the output to determine this.
-        #  thankfully, these are safe operations if no change is made.
+
         module.exit_json(changed=True, msg=out)
     elif fs and not force:
         module.fail_json(msg="'%s' is already used as %s, use force=yes to overwrite" % (dev, fs), rc=rc, err=err)


### PR DESCRIPTION
…grow' method

##### SUMMARY
The comment relating to growing filesystems is no longer needed, as this is handled elsewhere in the module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
filesystem

##### ADDITIONAL INFORMATION
Lines 151 to 157 (https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/filesystem.py#L151-L157)  will check whether the filesystem needs resizing before performing the operation, and return the correct response code. The comment removed here was added before this function was in place, and is no longer relevant
