### PR TITLE
Keycloak_client manages client scopes (keycloak 4.0+)

### DIFF
--- a/lib/ansible/module_utils/keycloak.py
+++ b/lib/ansible/module_utils/keycloak.py
@@ -43,8 +43,11 @@ URL_REALM_ROLES = "{url}/admin/realms/{realm}/roles"
 
 URL_CLIENTTEMPLATE = "{url}/admin/realms/{realm}/client-templates/{id}"
 URL_CLIENTTEMPLATES = "{url}/admin/realms/{realm}/client-templates"
+URL_DEFAULT_CLIENT_SCOPES = "{url}/admin/realms/{realm}/clients/{id}/default-client-scopes"
+URL_OPTIONAL_CLIENT_SCOPES = "{url}/admin/realms/{realm}/clients/{id}/optional-client-scopes"
 URL_GROUPS = "{url}/admin/realms/{realm}/groups"
 URL_GROUP = "{url}/admin/realms/{realm}/groups/{groupid}"
+URL_CLIENT_SCOPES = "{url}/admin/realms/{realm}/client-scopes"
 
 
 def keycloak_argument_spec():
@@ -194,6 +197,10 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
+            # Keycloak >=4.0.0 <= 6.0.0 does not update the default
+            # and optional client scope passed in the client
+            # represenation.
+            self._update_scopes(clientrep, realm)
             return open_url(client_url, method='PUT', headers=self.restheaders,
                             data=json.dumps(clientrep), validate_certs=self.validate_certs)
         except Exception as e:
@@ -209,8 +216,13 @@ class KeycloakAPI(object):
         client_url = URL_CLIENTS.format(url=self.baseurl, realm=realm)
 
         try:
-            return open_url(client_url, method='POST', headers=self.restheaders,
+            resp = open_url(client_url, method='POST', headers=self.restheaders,
                             data=json.dumps(clientrep), validate_certs=self.validate_certs)
+            # Keycloak >=4.0.0 <= 6.0.0 does not update the default
+            # and optional client scope passed in the client
+            # represenation.
+            self._update_scopes(clientrep, realm)
+            return resp
         except Exception as e:
             self.module.fail_json(msg='Could not create client %s in realm %s: %s'
                                       % (clientrep['clientId'], realm, str(e)))
@@ -472,3 +484,55 @@ class KeycloakAPI(object):
 
         except Exception as e:
             self.module.fail_json(msg="Unable to delete group %s: %s" % (groupid, str(e)))
+
+    def _update_scopes(self, clientrep, realm):
+        """ Update the client's default client scopes and optional client scopes.
+
+        :@param clientrep: the client representation.
+        :@param realm: the client's realm.
+        """
+        client_scopes = None
+        for scope_type, url in (('defaultClientScopes', URL_DEFAULT_CLIENT_SCOPES),
+                                ('optionalClientScopes', URL_OPTIONAL_CLIENT_SCOPES)):
+            if scope_type in clientrep:
+                client_scopes = client_scopes or self.get_client_scopes(realm)
+                self._update_scope_type(clientrep[scope_type], url,
+                                        client_scopes, clientrep['id'], realm)
+
+    def _update_scope_type(self, scopes, url, client_scopes, client_id, realm):
+        """ Update the client's default client scopes or optional client scopes.
+
+        :@param scopes: list of scopes to set. All other scopes will be removed. Scopes
+                        that do not exist in the realm will be silently ignored.
+        :@param url: the url pattern (default or optional scope url) to PUT the scope to.
+        :@param client_scopes: list of realm client scopes.
+        :@param realm: the client's realm.
+        """
+        current_scopes_url = url.format(url=self.baseurl,
+                                        realm=realm, id=client_id)
+        # Get the id of the scopes we want to set
+        scopes = set([scope['id'] for scope in client_scopes if scope['name'] in scopes])
+
+        current_scopes = set(map(lambda x: x['id'],
+                                 json.load(open_url(current_scopes_url, method='GET',
+                                                    headers=self.restheaders,
+                                                    validate_certs=self.validate_certs))))
+
+        # add missing and remove extra scopes
+        for scope in (scopes ^ current_scopes):
+            request_url = (url + '/{clientScopeId}').format(url=self.baseurl,
+                                                            realm=realm, id=client_id,
+                                                            clientScopeId=scope)
+            action = 'PUT' if scope in scopes else 'DELETE'
+            open_url(request_url, method=action, headers=self.restheaders,
+                     validate_certs=self.validate_certs)
+
+    def get_client_scopes(self, realm="master"):
+        """ Get all the client scopes for the realm.
+
+        :@param realm: Realm to obtain the client scopes for.
+        """
+        return json.load(
+            open_url(URL_CLIENT_SCOPES.format(url=self.baseurl, realm=realm),
+                     method='GET', headers=self.restheaders,
+                     validate_certs=self.validate_certs))

--- a/lib/ansible/modules/identity/keycloak/keycloak_client.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client.py
@@ -257,6 +257,7 @@ options:
             - Client template to use for this client. If it does not exist this field will silently
               be dropped.
               This is 'clientTemplate' in the Keycloak REST API.
+              This was replaced by defaultClientScopes and optionalClientScopes in Keycloak >=4.0.0
         aliases:
             - clientTemplate
 
@@ -473,6 +474,16 @@ options:
                 description:
                     - For OpenID-Connect clients, client certificate for validating JWT issued by
                       client and signed by its key, base64-encoded.
+    default_client_scopes:
+        description:
+            - The scopes the client requires by default. (KeyCloak >= 4.0.0, replaces client templates)
+        aliases:
+            - defaultClientScopes
+    optional_client_scopes:
+        description:
+            - The scopes the client can add based on the request. (KeyCloak >= 4.0.0, replaces client templates)
+        aliases:
+            - optionalClientScopes
 
 extends_documentation_fragment:
     - keycloak
@@ -590,6 +601,11 @@ EXAMPLES = '''
       use.jwks.url: true
       jwks.url: JWKS_URL_FOR_CLIENT_AUTH_JWT
       jwt.credential.certificate: JWT_CREDENTIAL_CERTIFICATE_FOR_CLIENT_AUTH
+    default_client_scopes:
+      - email
+      - openid
+    optional_client_scopes:
+      - profile
 '''
 
 RETURN = '''
@@ -705,6 +721,8 @@ def main():
         use_template_mappers=dict(type='bool', aliases=['useTemplateMappers']),
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
         authorization_settings=dict(type='dict', aliases=['authorizationSettings']),
+        default_client_scopes=dict(type='list', aliases=['defaultClientScopes']),
+        optional_client_scopes=dict(type='list', aliases=['defaultClientScopes']),
     )
     argument_spec.update(meta_args)
 

--- a/lib/ansible/modules/identity/keycloak/keycloak_client.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_client.py
@@ -479,11 +479,13 @@ options:
             - The scopes the client requires by default. (KeyCloak >= 4.0.0, replaces client templates)
         aliases:
             - defaultClientScopes
+        version_added: "2.9"
     optional_client_scopes:
         description:
             - The scopes the client can add based on the request. (KeyCloak >= 4.0.0, replaces client templates)
         aliases:
             - optionalClientScopes
+        version_added: "2.9"
 
 extends_documentation_fragment:
     - keycloak
@@ -722,7 +724,7 @@ def main():
         protocol_mappers=dict(type='list', elements='dict', options=protmapper_spec, aliases=['protocolMappers']),
         authorization_settings=dict(type='dict', aliases=['authorizationSettings']),
         default_client_scopes=dict(type='list', aliases=['defaultClientScopes']),
-        optional_client_scopes=dict(type='list', aliases=['defaultClientScopes']),
+        optional_client_scopes=dict(type='list', aliases=['optionalClientScopes']),
     )
     argument_spec.update(meta_args)
 


### PR DESCRIPTION
##### SUMMARY
Feature addition:

Update the keycloak_client module to set/remove default client scopes and optional client scopes from clients. This feature was introduced in Keycloak 4.0 and replaces client templates.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
keycloak_client

##### ADDITIONAL INFORMATION
Keycloak 4.0 removed client_templates as a way to manage client settings when creating a new client. Instead, there are "default client scopes" and "optional client scopes". This update adds two parameter to manage the default client scopes and optional client scopes in clients for Keycloak 4.0 and above.

There are also realm level "default default client scopes" and "default optional client scopes" which set the respective "default client scopes" and "optional client scopes" of newly created clients where these are not specified. Since it is a realm feature, it is not managed here.