### PR TITLE
Meraki - Improve type information in module documentation

### DIFF
--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -80,10 +80,6 @@ options:
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
         aliases: ['organization']
         type: str
-    org_id:
-        description:
-        - ID of organization.
-        type: str
 author:
     - Kevin Breit (@kbreit)
 extends_documentation_fragment: meraki

--- a/lib/ansible/modules/network/meraki/meraki_config_template.py
+++ b/lib/ansible/modules/network/meraki/meraki_config_template.py
@@ -33,9 +33,11 @@ options:
     org_name:
         description:
         - Name of organization containing the configuration template.
+        type: str
     org_id:
         description:
         - ID of organization associated to a configuration template.
+        type: str
     config_template:
         description:
         - Name of the configuration template within an organization to manipulate.
@@ -43,9 +45,11 @@ options:
     net_name:
         description:
         - Name of the network to bind or unbind configuration template to.
+        type: str
     net_id:
         description:
         - ID of the network to bind or unbind configuration template to.
+        type: str
     auto_bind:
         description:
         - Optional boolean indicating whether the network's switches should automatically bind to profiles of the same model.

--- a/lib/ansible/modules/network/meraki/meraki_content_filtering.py
+++ b/lib/ansible/modules/network/meraki/meraki_content_filtering.py
@@ -35,14 +35,6 @@ options:
         description:
         - ID number of a network.
         type: str
-    org_name:
-        description:
-        - Name of organization associated to a network.
-        type: str
-    org_id:
-        description:
-        - ID of organization associated to a network.
-        type: str
     state:
         description:
         - States that a policy should be created or modified.

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -30,47 +30,49 @@ options:
         - Query an organization.
         choices: [absent, present, query]
         default: query
-    org_name:
-        description:
-        - Name of organization.
-        - If C(clone) is specified, C(org_name) is the name of the new organization.
-        aliases: [ organization ]
-    org_id:
-        description:
-        - ID of organization.
+        type: str        
     net_name:
         description:
         - Name of a network.
         aliases: [network]
+        type: str
     net_id:
         description:
         - ID of a network.
+        type: str
     serial:
         description:
         - Serial number of a device to query.
+        type: str
     hostname:
         description:
         - Hostname of network device to search for.
         aliases: [name]
+        type: str
     model:
         description:
         - Model of network device to search for.
+        type: str
     tags:
         description:
         - Space delimited list of tags to assign to device.
+        type: str
     lat:
         description:
         - Latitude of device's geographic location.
         - Use negative number for southern hemisphere.
         aliases: [latitude]
+        type: float
     lng:
         description:
         - Longitude of device's geographic location.
         - Use negative number for western hemisphere.
         aliases: [longitude]
+        type: float
     address:
         description:
         - Postal address of device's location.
+        type: str
     move_map_marker:
         description:
         - Whether or not to set the latitude and longitude of a device based on the new address.
@@ -79,18 +81,22 @@ options:
     serial_lldp_cdp:
         description:
         - Serial number of device to query LLDP/CDP information from.
+        type: str
     lldp_cdp_timespan:
         description:
         - Timespan, in seconds, used to query LLDP and CDP information.
         - Must be less than 1 month.
+        type: int
     serial_uplink:
         description:
         - Serial number of device to query uplink information from.
+        type: str
     note:
         description:
         - Informational notes about a device.
         - Limited to 255 characters.
         version_added: '2.8'
+        type: str
 
 
 author:

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -30,7 +30,7 @@ options:
         - Query an organization.
         choices: [absent, present, query]
         default: query
-        type: str        
+        type: str
     net_name:
         description:
         - Name of a network.

--- a/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py
@@ -28,14 +28,6 @@ options:
         type: str
         choices: [ present, query ]
         default: present
-    org_name:
-        description:
-        - Name of organization.
-        type: str
-    org_id:
-        description:
-        - ID of organization.
-        type: int
     net_name:
         description:
         - Name of network containing access points.

--- a/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py
@@ -29,13 +29,6 @@ options:
         - Create or modify an organization.
         choices: ['present', 'query']
         default: present
-    org_name:
-        description:
-        - Name of organization.
-        - If C(clone) is specified, C(org_name) is the name of the new organization.
-    org_id:
-        description:
-        - ID of organization.
     net_name:
         description:
         - Name of network which MX firewall is in.

--- a/lib/ansible/modules/network/meraki/meraki_network.py
+++ b/lib/ansible/modules/network/meraki/meraki_network.py
@@ -22,9 +22,6 @@ description:
 - Allows for creation, management, and visibility into networks within Meraki.
 
 options:
-    auth_key:
-        description:
-        - Authentication key provided by the dashboard. Required if environmental variable MERAKI_KEY is not set.
     state:
         description:
         - Create or modify an organization.
@@ -37,12 +34,6 @@ options:
     net_id:
         description:
         - ID number of a network.
-    org_name:
-        description:
-        - Name of organization associated to a network.
-    org_id:
-        description:
-        - ID of organization associated to a network.
     type:
         description:
         - Type of network device network manages.

--- a/lib/ansible/modules/network/meraki/meraki_ssid.py
+++ b/lib/ansible/modules/network/meraki/meraki_ssid.py
@@ -38,14 +38,6 @@ options:
         description:
         - Name of SSID.
         type: str
-    org_name:
-        description:
-        - Name of organization.
-        type: str
-    org_id:
-        description:
-        - ID of organization.
-        type: int
     net_name:
         description:
         - Name of network.

--- a/lib/ansible/modules/network/meraki/meraki_static_route.py
+++ b/lib/ansible/modules/network/meraki/meraki_static_route.py
@@ -22,11 +22,6 @@ description:
 - Allows for creation, management, and visibility into static routes within Meraki.
 
 options:
-    auth_key:
-        description:
-        - Authentication key provided by the dashboard.
-        - Required if environmental variable MERAKI_KEY is not set.
-        type: str
     state:
         description:
         - Create or modify an organization.
@@ -40,14 +35,6 @@ options:
     net_id:
         description:
         - ID number of a network.
-        type: str
-    org_name:
-        description:
-        - Name of organization associated to a network.
-        type: str
-    org_id:
-        description:
-        - ID of organization associated to a network.
         type: str
     name:
         description:

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -26,6 +26,7 @@ options:
         - Specifies whether a switchport should be queried or modified.
         choices: [query, present]
         default: query
+        type: str
     access_policy_number:
         description:
         - Number of the access policy to apply.

--- a/lib/ansible/modules/network/meraki/meraki_syslog.py
+++ b/lib/ansible/modules/network/meraki/meraki_syslog.py
@@ -44,14 +44,6 @@ options:
         description:
         - ID number of a network.
         type: str
-    org_name:
-        description:
-        - Name of organization associated to a network.
-        type: str
-    org_id:
-        description:
-        - ID of organization associated to a network.
-        type: str
     servers:
         description:
         - List of syslog server settings

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -30,41 +30,52 @@ options:
       - Specifies whether object should be queried, created/modified, or removed.
       choices: [absent, present, query]
       default: query
+      type: str
     net_name:
       description:
       - Name of network which VLAN is in or should be in.
       aliases: [network]
+      type: str
     net_id:
       description:
       - ID of network which VLAN is in or should be in.
+      type: str
     vlan_id:
       description:
       - ID number of VLAN.
       - ID should be between 1-4096.
+      type: int
     name:
       description:
       - Name of VLAN.
       aliases: [vlan_name]
+      type: str
     subnet:
       description:
       - CIDR notation of network subnet.
+      type: str
     appliance_ip:
       description:
       - IP address of appliance.
       - Address must be within subnet specified in C(subnet) parameter.
+      type: str
     dns_nameservers:
       description:
       - Semi-colon delimited list of DNS IP addresses.
       - Specify one of the following options for preprogrammed DNS entries opendns, google_dns, upstream_dns
+      type: str
     reserved_ip_range:
       description:
       - IP address ranges which should be reserve and not distributed via DHCP.
+      type: list
     vpn_nat_subnet:
       description:
       - The translated VPN subnet if VPN and VPN subnet translation are enabled on the VLAN.
+      type: str
     fixed_ip_assignments:
       description:
       - Static IP address assignements to be distributed via DHCP by MAC address.
+      type: list
 author:
 - Kevin Breit (@kbreit)
 extends_documentation_fragment: meraki

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -2652,7 +2652,6 @@ lib/ansible/modules/network/junos/junos_vrf.py E337
 lib/ansible/modules/network/junos/junos_vrf.py E338
 lib/ansible/modules/network/meraki/meraki_admin.py E337
 lib/ansible/modules/network/meraki/meraki_config_template.py E337
-lib/ansible/modules/network/meraki/meraki_device.py E337
 lib/ansible/modules/network/meraki/meraki_malware.py E337
 lib/ansible/modules/network/meraki/meraki_mr_l3_firewall.py E325
 lib/ansible/modules/network/meraki/meraki_mx_l3_firewall.py E337
@@ -2662,7 +2661,6 @@ lib/ansible/modules/network/meraki/meraki_snmp.py E337
 lib/ansible/modules/network/meraki/meraki_ssid.py E325
 lib/ansible/modules/network/meraki/meraki_switchport.py E337
 lib/ansible/modules/network/meraki/meraki_syslog.py E337
-lib/ansible/modules/network/meraki/meraki_vlan.py E337
 lib/ansible/modules/network/netact/netact_cm_command.py E326
 lib/ansible/modules/network/netact/netact_cm_command.py E337
 lib/ansible/modules/network/netconf/netconf_config.py E326


### PR DESCRIPTION
##### SUMMARY
- Removed some duplicate documentation
- Ensure org_id is always string
- Add type information for items which don't have it

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki
