### PR TITLE
[nmcli] Fix issue with argument conversion for run_command

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -575,7 +575,7 @@ except (ImportError, ValueError):
     HAVE_NM_CLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 
 class Nmcli(object):
@@ -679,6 +679,10 @@ class Nmcli(object):
         self.dhcp_client_id = module.params['dhcp_client_id']
 
     def execute_command(self, cmd, use_unsafe_shell=False, data=None):
+        if isinstance(cmd, list):
+            cmd = [to_text(item, nonstring='strict') for item in cmd]
+        else:
+            cmd = to_text(cmd, nonstring='strict')
         return self.module.run_command(cmd, use_unsafe_shell=use_unsafe_shell, data=data)
 
     def merge_secrets(self, proxy, config, setting_name):
@@ -860,7 +864,7 @@ class Nmcli(object):
         # format for modifying team-slave interface
         if self.mtu is not None:
             cmd.append('802-3-ethernet.mtu')
-            cmd.append(self.mtu)
+            cmd.append(to_text(self.mtu))
         return cmd
 
     def create_connection_bond(self):
@@ -884,10 +888,10 @@ class Nmcli(object):
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
-            'miimon': self.miimon,
-            'downdelay': self.downdelay,
-            'updelay': self.updelay,
-            'arp-interval': self.arp_interval,
+            'miimon': to_text(self.miimon),
+            'downdelay': to_text(self.downdelay),
+            'updelay': to_text(self.updelay),
+            'arp-interval': to_text(self.arp_interval),
             'arp-ip-target': self.arp_ip_target,
             'primary': self.primary,
             'ipv4.dhcp-client-id': self.dhcp_client_id,
@@ -912,10 +916,10 @@ class Nmcli(object):
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
-            'miimon': self.miimon,
-            'downdelay': self.downdelay,
-            'updelay': self.updelay,
-            'arp-interval': self.arp_interval,
+            'miimon': to_text(self.miimon),
+            'downdelay': to_text(self.downdelay),
+            'updelay': to_text(self.updelay),
+            'arp-interval': to_text(self.arp_interval),
             'arp-ip-target': self.arp_ip_target,
             'ipv4.dhcp-client-id': self.dhcp_client_id,
         }
@@ -1002,7 +1006,7 @@ class Nmcli(object):
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
-            '802-3-ethernet.mtu': self.mtu,
+            '802-3-ethernet.mtu': to_text(self.mtu),
             'ipv4.dhcp-client-id': self.dhcp_client_id,
         }
 
@@ -1036,12 +1040,12 @@ class Nmcli(object):
             'ip6': self.ip6,
             'gw6': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
-            'bridge.ageing-time': self.ageingtime,
-            'bridge.forward-delay': self.forwarddelay,
-            'bridge.hello-time': self.hellotime,
+            'bridge.ageing-time': to_text(self.ageingtime),
+            'bridge.forward-delay': to_text(self.forwarddelay),
+            'bridge.hello-time': to_text(self.hellotime),
             'bridge.mac-address': self.mac,
-            'bridge.max-age': self.maxage,
-            'bridge.priority': self.priority,
+            'bridge.max-age': to_text(self.maxage),
+            'bridge.priority': to_text(self.priority),
             'bridge.stp': self.bool_to_string(self.stp)
         }
 
@@ -1064,12 +1068,12 @@ class Nmcli(object):
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
-            'bridge.ageing-time': self.ageingtime,
-            'bridge.forward-delay': self.forwarddelay,
-            'bridge.hello-time': self.hellotime,
+            'bridge.ageing-time': to_text(self.ageingtime),
+            'bridge.forward-delay': to_text(self.forwarddelay),
+            'bridge.hello-time': to_text(self.hellotime),
             'bridge.mac-address': self.mac,
-            'bridge.max-age': self.maxage,
-            'bridge.priority': self.priority,
+            'bridge.max-age': to_text(self.maxage),
+            'bridge.priority': to_text(self.priority),
             'bridge.stp': self.bool_to_string(self.stp)
         }
 
@@ -1094,9 +1098,9 @@ class Nmcli(object):
 
         options = {
             'master': self.master,
-            'bridge-port.path-cost': self.path_cost,
+            'bridge-port.path-cost': to_text(self.path_cost),
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
-            'bridge-port.priority': self.slavepriority,
+            'bridge-port.priority': to_text(self.slavepriority),
         }
 
         for key, value in options.items():
@@ -1110,9 +1114,9 @@ class Nmcli(object):
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
         options = {
             'master': self.master,
-            'bridge-port.path-cost': self.path_cost,
+            'bridge-port.path-cost': to_text(self.path_cost),
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
-            'bridge-port.priority': self.slavepriority,
+            'bridge-port.priority': to_text(self.slavepriority),
         }
 
         for key, value in options.items():
@@ -1134,7 +1138,7 @@ class Nmcli(object):
         elif self.ifname is not None:
             cmd.append(self.ifname)
         else:
-            cmd.append('vlan%s' % self.vlanid)
+            cmd.append('vlan%s' % to_text(self.vlanid))
 
         cmd.append('ifname')
         if self.ifname is not None:
@@ -1142,10 +1146,10 @@ class Nmcli(object):
         elif self.conn_name is not None:
             cmd.append(self.conn_name)
         else:
-            cmd.append('vlan%s' % self.vlanid)
+            cmd.append('vlan%s' % to_text(self.vlanid))
 
         params = {'dev': self.vlandev,
-                  'id': str(self.vlanid),
+                  'id': to_text(self.vlanid),
                   'ip4': self.ip4 or '',
                   'gw4': self.gw4 or '',
                   'ip6': self.ip6 or '',
@@ -1167,10 +1171,10 @@ class Nmcli(object):
         elif self.ifname is not None:
             cmd.append(self.ifname)
         else:
-            cmd.append('vlan%s' % self.vlanid)
+            cmd.append('vlan%s' % to_text(self.vlanid))
 
         params = {'vlan.parent': self.vlandev,
-                  'vlan.id': str(self.vlanid),
+                  'vlan.id': to_text(self.vlanid),
                   'ipv4.address': self.ip4 or '',
                   'ipv4.gateway': self.gw4 or '',
                   'ipv4.dns': self.dns4 or '',
@@ -1193,7 +1197,7 @@ class Nmcli(object):
         elif self.ifname is not None:
             cmd.append(self.ifname)
         else:
-            cmd.append('vxlan%s' % self.vxlanid)
+            cmd.append('vxlan%s' % to_text(self.vxlan_id))
 
         cmd.append('ifname')
         if self.ifname is not None:
@@ -1201,9 +1205,9 @@ class Nmcli(object):
         elif self.conn_name is not None:
             cmd.append(self.conn_name)
         else:
-            cmd.append('vxan%s' % self.vxlanid)
+            cmd.append('vxan%s' % to_text(self.vxlan_id))
 
-        params = {'vxlan.id': self.vxlan_id,
+        params = {'vxlan.id': to_text(self.vxlan_id),
                   'vxlan.local': self.vxlan_local,
                   'vxlan.remote': self.vxlan_remote,
                   'autoconnect': self.bool_to_string(self.autoconnect)
@@ -1221,9 +1225,9 @@ class Nmcli(object):
         elif self.ifname is not None:
             cmd.append(self.ifname)
         else:
-            cmd.append('vxlan%s' % self.vxlanid)
+            cmd.append('vxlan%s' % to_text(self.vxlan_id))
 
-        params = {'vxlan.id': self.vxlan_id,
+        params = {'vxlan.id': to_text(self.vxlan_id),
                   'vxlan.local': self.vxlan_local,
                   'vxlan.remote': self.vxlan_remote,
                   'autoconnect': self.bool_to_string(self.autoconnect)

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -374,7 +374,7 @@ def test_create_bridge(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'bridge.max-age', 100, 'bridge.stp', 'yes']:
+    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
         assert param in args[0]
 
 
@@ -395,7 +395,7 @@ def test_mod_bridge(mocked_generic_connection_modify):
     assert args[0][1] == 'con'
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
-    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'bridge.max-age', 100, 'bridge.stp', 'yes']:
+    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'bridge.max-age', '100', 'bridge.stp', 'yes']:
         assert param in args[0]
 
 
@@ -420,7 +420,7 @@ def test_create_bridge_slave(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['bridge-port.path-cost', 100]:
+    for param in ['bridge-port.path-cost', '100']:
         assert param in args[0]
 
 
@@ -442,7 +442,7 @@ def test_mod_bridge_slave(mocked_generic_connection_modify):
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
 
-    for param in ['bridge-port.path-cost', 100]:
+    for param in ['bridge-port.path-cost', '100']:
         assert param in args[0]
 
 
@@ -514,7 +514,7 @@ def test_create_vxlan(mocked_generic_connection_create):
     assert args[0][6] == 'non_existent_nw_device'
     assert args[0][7] == 'ifname'
 
-    for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', 11]:
+    for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', '11']:
         assert param in args[0]
 
 
@@ -535,7 +535,7 @@ def test_vxlan_mod(mocked_generic_connection_modify):
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
 
-    for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', 11]:
+    for param in ['vxlan.local', '192.168.225.5', 'vxlan.remote', '192.168.225.6', 'vxlan.id', '11']:
         assert param in args[0]
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes in this PR are fixing the issue where nmcli module would throw an error when executing `self.module.run_command`. Arguments passed to `run_command` are expected to be a list of strings (or single string). In the case of `nmcli` module, sometimes integer value was present in the list which caused `run_command` to fail.

I've also noticed that there are references to undefined variable `self.vxlanid`. I've replaced them with `self.vxlan_id`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

I've noticed this bug when running following task:
```
- name: Add bridge connection for virtual machines.
  nmcli:
    type: bridge
    autoconnect: no
    conn_name: '{{ qemu_network_manager_bridge_name }}'
    ifname: '{{ qemu_network_manager_bridge_name }}'
    ip4: '{{ qemu_network_manager_bridge_ip4 }}'
    stp: no
    state: present
```
And it gave me following error:
```
TASK [qemu : Add bridge connection for virtual machines.] *********************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: expected str, bytes or os.PathLike object, not int
fatal: [host]: FAILED! => changed=false 
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 114, in <module>
      File "<stdin>", line 106, in _ansiballz_main
      File "<stdin>", line 49, in invoke_module
      File "/usr/lib64/python3.6/imp.py", line 235, in load_module
        return load_source(name, filename, file)
      File "/usr/lib64/python3.6/imp.py", line 170, in load_source
        module = _exec(spec, sys.modules[name])
      File "<frozen importlib._bootstrap>", line 618, in _exec
      File "<frozen importlib._bootstrap_external>", line 678, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/tmp/ansible_nmcli_payload_oi1b0db1/__main__.py", line 1549, in <module>
      File "/tmp/ansible_nmcli_payload_oi1b0db1/__main__.py", line 1527, in main
      File "/tmp/ansible_nmcli_payload_oi1b0db1/__main__.py", line 1425, in modify_connection
      File "/tmp/ansible_nmcli_payload_oi1b0db1/__main__.py", line 682, in execute_command
      File "/tmp/ansible_nmcli_payload_oi1b0db1/ansible_nmcli_payload.zip/ansible/module_utils/basic.py", line 2477, in run_command
      File "/tmp/ansible_nmcli_payload_oi1b0db1/ansible_nmcli_payload.zip/ansible/module_utils/basic.py", line 2477, in <listcomp>
      File "/usr/lib/python-exec/python3.6/../../../lib64/python3.6/posixpath.py", line 281, in expandvars
        path = os.fspath(path)
    TypeError: expected str, bytes or os.PathLike object, not int
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

I'm using Ansible 2.8.0.