### PR TITLE
Allow passing through of (almost) all params available …

### DIFF
--- a/changelogs/fragments/58118-aws_api_gateway-params.yml
+++ b/changelogs/fragments/58118-aws_api_gateway-params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow all params that boto support in aws_api_gateway module

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -89,11 +89,11 @@ options:
   stage_canary_settings:
     description:
       - Canary settings for the deployment of the stage.
-      - Dict with following settings:
-      - percentTraffic: The percent (0-100) of traffic diverted to a canary deployment.
-      - deploymentId: The ID of the canary deployment.
-      - stageVariableOverrides: Stage variables overridden for a canary release deployment.
-      - useStageCache: A Boolean flag to indicate whether the canary deployment uses the stage cache or not.
+      - 'Dict with following settings:'
+      - 'percentTraffic: The percent (0-100) of traffic diverted to a canary deployment.'
+      - 'deploymentId: The ID of the canary deployment.'
+      - 'stageVariableOverrides: Stage variables overridden for a canary release deployment.'
+      - 'useStageCache: A Boolean flag to indicate whether the canary deployment uses the stage cache or not.'
       - See docs U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html#APIGateway.Client.create_stage)
     type: dict
     version_added: '2.10'

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -154,7 +154,11 @@ deploy_response:
     returned: success
     type: dict
     sample: { created_date: "2020-01-01T11:36:59+00:00", id: "rptv4b", description: "Automatic deployment by Ansible." }
-
+resource_actions
+    description: Actions performed against AWS API
+    returned: always
+    type: list
+    sample: ["apigateway:CreateRestApi", "apigateway:CreateDeployment", "apigateway:PutRestApi"]
 '''
 
 import json

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -98,7 +98,9 @@ options:
     version_added: '2.10'
   endpoint_type:
     description:
-      - Type of endpoint configuration, use EDGE for edge optomized API endpoint, REGIONAL for just regional deploy or PRIVATE for private API.
+      - Type of endpoint configuration, use EDGE for an edge optomized API endpoint,
+      - REGIONAL for just a regional deploy or PRIVATE for a private API.
+      - This will flag will only be used when creating a new API Gateway setup, not for updates.
     choices: ['EDGE', 'REGIONAL', 'PRIVATE']
     type: str
     default: EDGE

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -139,17 +139,22 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-output:
-  description: the data returned by put_restapi in boto3
-  returned: success
-  type: dict
-  sample:
-    'data':
-      {
-          "id": "abc123321cba",
-          "name": "MY REST API",
-          "createdDate": 1484233401
-      }
+api_id:
+    description: API id of the API endpoint created
+    returned: success
+    type: str
+    sample: '0ln4zq7p86'
+configure_response:
+    description: AWS response from the API configure call
+    returned: success
+    type: dict
+    sample: { api_key_source: "HEADER", created_at: "2020-01-01T11:37:59+00:00", id: "0ln4zq7p86" }
+deploy_response:
+    description: AWS responce from the API deploy call
+    returned: success
+    type: dict
+    sample: { created_date: "2020-01-01T11:36:59+00:00", id: "rptv4b", description: "Automatic deployment by Ansible." }
+
 '''
 
 import json

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -37,8 +37,7 @@ options:
       - The ID of the API you want to manage.
     type: str
   state:
-    description:
-      - NOT IMPLEMENTED Create or delete API - currently we always create.
+    description: Create or delete API Gateway.
     default: present
     choices: [ 'present', 'absent' ]
     type: str
@@ -249,7 +248,7 @@ def get_api_definitions(module, swagger_file=None, swagger_dict=None, swagger_te
         apidata = swagger_text
 
     if apidata is None:
-        module.fail_json(msg='module error - failed to get API data')
+        module.fail_json(msg='module error - no swagger info provided')
     return apidata
 
 

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -74,37 +74,36 @@ options:
       - Enable API GW caching of backend responses. Defaults to false
     type: bool
     default: false
-    version_added: '2.9'
+    version_added: '2.10'
   cache_size:
     description:
       - Size in GB of the API GW cache, becomes effective when cache_enabled is true.
     choices: ['0.5', '1.6', '6.1', '13.5', '28.4', '58.2', '118', '237']
     type: str
     default: '0.5'
-    version_added: '2.9'
+    version_added: '2.10'
   stage_variables:
     description:
       - ENV variables for the stage. Define a dict of key values pairs for variables.
     type: dict
-    version_added: '2.9'
+    version_added: '2.10'
   stage_canary_settings:
     description:
       - Canary settings for the deployment of the stage
     type: dict
-    version_added: '2.9'
+    version_added: '2.10'
   tracing_enabled:
     description:
       - Specifies whether active tracing with X-ray is enabled for the API GW stage.
     type: bool
-    version_added: '2.9'
+    version_added: '2.10'
   endpoint_type:
     description:
       - Type of endpoint configuration, use EDGE for edge optomized API endpoint, REGIONAL for just regional deploy or PRIVATE for private API.
     choices: ['EDGE', 'REGIONAL', 'PRIVATE']
     type: str
     default: EDGE
-    version_added: '2.9'
-
+    version_added: '2.10'
 author:
     - 'Michael De La Rue (@mikedlr)'
 extends_documentation_fragment:

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -154,7 +154,7 @@ deploy_response:
     returned: success
     type: dict
     sample: { created_date: "2020-01-01T11:36:59+00:00", id: "rptv4b", description: "Automatic deployment by Ansible." }
-resource_actions
+resource_actions:
     description: Actions performed against AWS API
     returned: always
     type: list

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -65,14 +65,14 @@
 
     # ============================================================
 
-    - name: build API file 
+    - name: build API file
       template:
         src: minimal-swagger-api.yml.j2
         dest: "{{output_dir}}/minimal-swagger-api.yml"
       tags: new_api,api,api_file
 
     - name: deploy new API
-      aws_api_gateway: 
+      aws_api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
         region: '{{ec2_region}}'
@@ -103,7 +103,7 @@
       register: bad_uri_result
       ignore_errors: true
 
-    - name: assert 
+    - name: assert
       assert:
         that:
           - bad_uri_result is failed
@@ -174,7 +174,7 @@
     - name: test state=absent (expect changed=false)
       aws_api_gateway:
         state: absent
-        api_id: '{{create_result.api_id}}'        
+        api_id: '{{create_result.api_id}}'
         ec2_region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
         aws_secret_key: '{{ec2_secret_key}}'

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -61,19 +61,26 @@
     - name: assert deploy new API worked
       assert:
         that:
-           - 'create_result.changed == True'
-           - '"api_id" in create_result'
+          - 'create_result.changed == True'
+          - 'create_update.failed == False'
+          - 'create_result.deploy_response.description == "Automatic deployment by Ansible."'
+          - 'create_result.configure_response.id == create_result.api_id'
+          - '"apigateway:CreateRestApi" in create_result.resource_actions'
 
-    - name: check API works
+    - name: Wait for API to be persisted
+      pause:
+        seconds: 2
+
+    - name: check if API endpoint works
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/minimal"
       register: uri_result
 
     - name: assert API works success
       assert:
         that:
-           - 'uri_result.status == 200'
+          - 'uri_result.status == 200'
 
-    - name: check nonexistent endpoints cause errors
+    - name: check if nonexistent endpoint causes error
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/nominal"
       register: bad_uri_result
       ignore_errors: true
@@ -82,6 +89,29 @@
       assert:
         that:
           - bad_uri_result is failed
+
+    - name: Update API to test params effect
+      aws_api_gateway:
+        api_id: '{{create_result.api_id}}'
+        cache_enabled: true
+        cache_size: '1.6'
+        tracing_enabled: true
+        endpoint_type: 'REGIONAL'
+        state: present
+        region: '{{ec2_region}}'
+        aws_access_key: '{{ec2_access_key}}'
+        aws_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: update_result
+
+    - name: assert update result
+      assert:
+        that:
+          - 'create_update.changed == True'
+          - 'create_update.failed == False'
+          - 'create_update.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
+
+    # ==== additional create/delete tests ====
 
     - name: deploy first API
       aws_api_gateway:
@@ -106,10 +136,6 @@
         security_token: '{{security_token}}'
       register: create_result_2
 
-    - name: DEBUG create result
-      debug:
-        var: create_result_1
-
     - name: assert both APIs deployed successfully
       assert:
         that:
@@ -117,31 +143,6 @@
            - 'create_result_2.changed == True'
            - '"api_id" in create_result_1'
            - '"api_id" in create_result_1'
-
-    - name: Update first API to test params effect
-      aws_api_gateway:
-        api_id: '{{create_result_1.api_id}}'
-        cache_enabled: true
-        cache_size: '1.6'
-        tracing_enabled: true
-        endpoint_type: 'REGIONAL'
-        state: present
-        region: '{{ec2_region}}'
-        aws_access_key: '{{ec2_access_key}}'
-        aws_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-      register: update_result_1
-
-    - name: DEBUG update result
-      debug:
-        var: update_result_1
-
-    - name: assert update result
-      assert:
-        that:
-          - 'create_update_1.changed == True'
-          - 'create_update_1.failed == False'
-          - 'create_update_1.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     - name: destroy first API
       aws_api_gateway:
@@ -168,6 +169,8 @@
         that:
            - 'destroy_result_1.changed == True'
            - 'destroy_result_2.changed == True'
+           - '"apigateway:DeleteRestApi" in destroy_result_1.resource_actions'
+           - '"apigateway:DeleteRestApi" in destroy_result_2.resource_actions'
 
     # ================= end testing ====================================
 

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -107,7 +107,8 @@
         that:
           - 'update_result.changed == True'
           - 'update_result.failed == False'
-          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
+          - '"REGIONAL" in update_result.configure_response.endpoint_configuration.types'
+          - '"apigateway:PutRestApi" in update_result.resource_actions'
 
     # ==== additional create/delete tests ====
 

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -62,7 +62,7 @@
       assert:
         that:
           - 'create_result.changed == True'
-          - 'create_update.failed == False'
+          - 'create_result.failed == False'
           - 'create_result.deploy_response.description == "Automatic deployment by Ansible."'
           - 'create_result.configure_response.id == create_result.api_id'
           - '"apigateway:CreateRestApi" in create_result.resource_actions'
@@ -107,9 +107,9 @@
     - name: assert update result
       assert:
         that:
-          - 'create_update.changed == True'
-          - 'create_update.failed == False'
-          - 'create_update.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
+          - 'update_result.changed == True'
+          - 'update_result.failed == False'
+          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     # ==== additional create/delete tests ====
 

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -106,12 +106,14 @@
         security_token: '{{security_token}}'
       register: create_result_2
 
+    - name: DEBUG create result
+      debug:
+        var: create_result_1
+
     - name: assert both APIs deployed successfully
       assert:
         that:
            - 'create_result_1.changed == True'
-           - 'create_result_1.cache_enabled == False'
-           - 'create_result_1.stage == "minimal"'
            - 'create_result_2.changed == True'
            - '"api_id" in create_result_1'
            - '"api_id" in create_result_1'
@@ -122,6 +124,7 @@
         cache_enabled: true
         cache_size: '1.6'
         tracing_enabled: true
+        endpoint_type: 'REGIONAL'
         state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
@@ -129,14 +132,16 @@
         security_token: '{{security_token}}'
       register: update_result_1
 
+    - name: DEBUG update result
+      debug:
+        var: update_result_1
+
     - name: assert update result
       assert:
         that:
           - 'create_update_1.changed == True'
           - 'create_update_1.failed == False'
-          - 'create_update_1.cache_enabled == True'
-          - 'create_update_1.cache_size == "1.6"'
-          - 'create_update_1.tracing_enabled == True'
+          - 'create_update_1.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     - name: destroy first API
       aws_api_gateway:

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -138,10 +138,10 @@
     - name: assert both APIs deployed successfully
       assert:
         that:
-           - 'create_result_1.changed == True'
-           - 'create_result_2.changed == True'
-           - '"api_id" in create_result_1'
-           - '"api_id" in create_result_1'
+          - 'create_result_1.changed == True'
+          - 'create_result_2.changed == True'
+          - '"api_id" in create_result_1'
+          - '"api_id" in create_result_1'
           - 'create_result_1.configure_response.endpoint_configuration.types.0 == "EDGE"'
 
     - name: destroy first API

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -52,6 +52,7 @@
       aws_api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
+        state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
         aws_secret_key: '{{ec2_secret_key}}'
@@ -89,10 +90,11 @@
     - name: Update API to test params effect
       aws_api_gateway:
         api_id: '{{create_result.api_id}}'
+        api_file: "{{output_dir}}/minimal-swagger-api.yml"
         cache_enabled: true
         cache_size: '1.6'
         tracing_enabled: true
-#        endpoint_type: 'REGIONAL'
+        endpoint_type: 'REGIONAL'
         state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
@@ -105,7 +107,7 @@
         that:
           - 'update_result.changed == True'
           - 'update_result.failed == False'
-#          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
+          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     # ==== additional create/delete tests ====
 

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -67,10 +67,6 @@
           - 'create_result.configure_response.id == create_result.api_id'
           - '"apigateway:CreateRestApi" in create_result.resource_actions'
 
-    - name: Wait for API to be persisted
-      pause:
-        seconds: 2
-
     - name: check if API endpoint works
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/minimal"
       register: uri_result
@@ -96,7 +92,7 @@
         cache_enabled: true
         cache_size: '1.6'
         tracing_enabled: true
-        endpoint_type: 'REGIONAL'
+#        endpoint_type: 'REGIONAL'
         state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
@@ -109,7 +105,7 @@
         that:
           - 'update_result.changed == True'
           - 'update_result.failed == False'
-          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
+#          - 'update_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     # ==== additional create/delete tests ====
 

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -1,6 +1,7 @@
 - block:
 
-    # ============================================================
+    # ====================== testing failure cases: ==================================
+
     - name: test with no parameters
       aws_api_gateway:
       register: result
@@ -12,7 +13,6 @@
            - 'result.failed'
            - 'result.msg.startswith("The aws_api_gateway module requires a region")'
 
-    # ============================================================
     - name: test with minimal parameters but no region
       aws_api_gateway:
         api_id: 'fake-api-doesnt-exist'
@@ -25,11 +25,10 @@
            - 'result.failed'
            - 'result.msg.startswith("The aws_api_gateway module requires a region")'
 
-    # ============================================================
-    - name: test disallow multiple swagger sources
+    - name: test for disallowing multiple swagger sources
       aws_api_gateway:
         api_id: 'fake-api-doesnt-exist'
-        region: 'fake_region'
+        region: '{{ec2_region}}'
         swagger_file: foo.yml
         swagger_text: "this is not really an API"
       register: result
@@ -41,35 +40,13 @@
            - 'result.failed'
            - 'result.msg.startswith("parameters are mutually exclusive")'
 
-    # This fails with
 
-    # msg": "There is an issue in the code of the module. You must
-    # specify either both, resource or client to the conn_type
-    # parameter in the boto3_conn function call"
-
-    # even though the call appears to include conn_type='client'
-
-    # # ============================================================
-    # - name: test invalid region parameter
-    #   aws_api_gateway:
-    #     api_id: 'fake-api-doesnt-exist'
-    #     region: 'asdf querty 1234'
-    #   register: result
-    #   ignore_errors: true
-
-    # - name: assert invalid region parameter
-    #   assert:
-    #     that:
-    #        - 'result.failed'
-    #        - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available ")'
-
-    # ============================================================
+    # ====================== regular testing: ===================================
 
     - name: build API file
       template:
         src: minimal-swagger-api.yml.j2
         dest: "{{output_dir}}/minimal-swagger-api.yml"
-      tags: new_api,api,api_file
 
     - name: deploy new API
       aws_api_gateway:
@@ -86,8 +63,6 @@
         that:
            - 'create_result.changed == True'
            - '"api_id" in create_result'
-#           - '"created_response.created_date" in create_result'
-#           - '"deploy_response.created_date" in create_result'
 
     - name: check API works
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/minimal"
@@ -96,7 +71,7 @@
     - name: assert API works success
       assert:
         that:
-           - 'uri_result'
+           - 'uri_result.status == 200'
 
     - name: check nonexistent endpoints cause errors
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/nominal"
@@ -108,12 +83,12 @@
         that:
           - bad_uri_result is failed
 
-    # ============================================================
-
     - name: deploy first API
       aws_api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
+        cache_enabled: false
+        state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
         aws_secret_key: '{{ec2_secret_key}}'
@@ -124,6 +99,7 @@
       aws_api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
+        state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
         aws_secret_key: '{{ec2_secret_key}}'
@@ -134,11 +110,33 @@
       assert:
         that:
            - 'create_result_1.changed == True'
+           - 'create_result_1.cache_enabled == False'
+           - 'create_result_1.stage == "minimal"'
            - 'create_result_2.changed == True'
            - '"api_id" in create_result_1'
            - '"api_id" in create_result_1'
-#           - '"created_response.created_date" in create_result'
-#           - '"deploy_response.created_date" in create_result'
+
+    - name: Update first API to test params effect
+      aws_api_gateway:
+        api_id: '{{create_result_1.api_id}}'
+        cache_enabled: true
+        cache_size: '1.6'
+        tracing_enabled: true
+        state: present
+        region: '{{ec2_region}}'
+        aws_access_key: '{{ec2_access_key}}'
+        aws_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: update_result_1
+
+    - name: assert update result
+      assert:
+        that:
+          - 'create_update_1.changed == True'
+          - 'create_update_1.failed == False'
+          - 'create_update_1.cache_enabled == True'
+          - 'create_update_1.cache_size == "1.6"'
+          - 'create_update_1.tracing_enabled == True'
 
     - name: destroy first API
       aws_api_gateway:
@@ -165,13 +163,12 @@
         that:
            - 'destroy_result_1.changed == True'
            - 'destroy_result_2.changed == True'
-#           - '"created_response.created_date" in create_result'
-#           - '"deploy_response.created_date" in create_result'
+
+    # ================= end testing ====================================
 
   always:
 
-    # ============================================================
-    - name: test state=absent (expect changed=false)
+    - name: Ensure cleanup of API deploy
       aws_api_gateway:
         state: absent
         api_id: '{{create_result.api_id}}'
@@ -179,4 +176,24 @@
         aws_access_key: '{{ec2_access_key}}'
         aws_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
-      register: destroy_result
+      ignore_errors: true
+
+    - name: Ensure cleanup of API deploy 1
+      aws_api_gateway:
+        state: absent
+        api_id: '{{create_result_1.api_id}}'
+        ec2_region: '{{ec2_region}}'
+        aws_access_key: '{{ec2_access_key}}'
+        aws_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      ignore_errors: true
+
+    - name: Ensure cleanup of API deploy 2
+      aws_api_gateway:
+        state: absent
+        api_id: '{{create_result_2.api_id}}'
+        ec2_region: '{{ec2_region}}'
+        aws_access_key: '{{ec2_access_key}}'
+        aws_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      ignore_errors: true

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -52,6 +52,7 @@
       aws_api_gateway:
         api_file: "{{output_dir}}/minimal-swagger-api.yml"
         stage: "minimal"
+        endpoint_type: 'REGIONAL'
         state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
@@ -67,6 +68,7 @@
           - 'create_result.deploy_response.description == "Automatic deployment by Ansible."'
           - 'create_result.configure_response.id == create_result.api_id'
           - '"apigateway:CreateRestApi" in create_result.resource_actions'
+          - 'create_result.configure_response.endpoint_configuration.types.0 == "REGIONAL"'
 
     - name: check if API endpoint works
       uri: url="https://{{create_result.api_id}}.execute-api.{{ec2_region}}.amazonaws.com/minimal"
@@ -94,7 +96,6 @@
         cache_enabled: true
         cache_size: '1.6'
         tracing_enabled: true
-        endpoint_type: 'REGIONAL'
         state: present
         region: '{{ec2_region}}'
         aws_access_key: '{{ec2_access_key}}'
@@ -107,7 +108,6 @@
         that:
           - 'update_result.changed == True'
           - 'update_result.failed == False'
-          - '"REGIONAL" in update_result.configure_response.endpoint_configuration.types'
           - '"apigateway:PutRestApi" in update_result.resource_actions'
 
     # ==== additional create/delete tests ====
@@ -142,6 +142,7 @@
            - 'create_result_2.changed == True'
            - '"api_id" in create_result_1'
            - '"api_id" in create_result_1'
+          - 'create_result_1.configure_response.endpoint_configuration.types.0 == "EDGE"'
 
     - name: destroy first API
       aws_api_gateway:


### PR DESCRIPTION
…on boto3 methods for aws_api_gateway.

##### SUMMARY
The boto methods in use for aws_api_gateway allow more params. So this PR allows to set them through the Ansible module too. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html#client

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_api_gateway module.

##### ADDITIONAL INFORMATION

Simple extension of module params.