### PR TITLE
[stable-2.8] Create new instance of the action plugin per until iteration. Fixes #57886 (#58022)

### DIFF
--- a/changelogs/fragments/te-new-action-until.yml
+++ b/changelogs/fragments/te-new-action-until.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- TaskExecutor - Create new instance of the action plugin on each
+  iteration when using until (https://github.com/ansible/ansible/issues/57886)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -739,6 +739,7 @@ class TaskExecutor:
                         display.debug('Retrying task, attempt %d of %d' % (attempt, retries))
                         self._final_q.put(TaskResult(self._host.name, self._task._uuid, result, task_fields=self._task.dump_attrs()), block=False)
                         time.sleep(delay)
+                        self._handler = self._get_action_handler(connection=self._connection, templar=templar)
         else:
             if retries > 1:
                 # we ran out of attempts, so mark the result as failed


### PR DESCRIPTION
(cherry picked from commit ffd1171)


Co-authored-by: Matt Martz <matt@sivel.net>