### PR TITLE
[WIP] Add new filter options to ec2 inventory plugin

### DIFF
--- a/changelogs/fragments/58132-ec2-inventory-filters.yml
+++ b/changelogs/fragments/58132-ec2-inventory-filters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2 inventory plugin: The plugin now supports a filter syntax for OR filters. This facilitates migration from the ec2.py script.

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -46,14 +46,6 @@ DOCUMENTATION = '''
               - Complex filter combinations similar to contrib/scripts/ec2.py are possible.  See examples.
           type: list
           default: []
-        filter_syntax:
-          description:
-              - Specifies whether to enable legacy-style contrib/scripts/inventory/ec2.ini filter behaviour.
-              - This makes AND/OR filters possible.
-              - To enable, use 'ec2_ini'. Any other value results in the standard plugin behaviour, which is inclusive AND.
-              - AND filters must be provided to the filters key in subkey ec2ini_filters
-          type: string
-          default: boto3
         include_extra_api_calls:
           description:
               - Add two additional API calls for every instance to include 'persistent' and 'events' host variables.
@@ -625,10 +617,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 cache_needs_update = True
 
         if not cache or cache_needs_update:
-            if isinstance(filters, AnsibleSequence):
-                results = self._ec2_ini_query(regions, filters, strict_permissions)
-            else:
-                results = self._query(regions, filters, strict_permissions)
+            results = self._query(regions, filters, strict_permissions)
 
         self._populate(results, hostnames)
 


### PR DESCRIPTION
Add filter options to enable filter syntax and functionality similar to
the AND/OR filter types available to the contrib/inventory/ec2.py script.
A new key, filter_syntax, is added to toggle the new behaviour and a special
subkey to filters is recognized to handle additional filter types when used
with filter_syntax: ec2_ini.

##### SUMMARY
ec2.py inventory script supports AND/OR filters, the plugin currently only takes AND filters.  This difference can impede migrating to the plugin.  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/aws_ec2.py

##### ADDITIONAL INFORMATION
```
# Example aws_ec2.yml
# Use ec2_ini AND/OR filters
# This filter in the script would have looked like:
# EC2_INSTANCE_FILTERS='availability-zone=us-west-2b,hypervisor=xen,availability-zone=us-east1b&instance-type=t2.micro'
plugin: aws_ec2
filter_syntax: ec2_ini   ## toggles filters being AND/OR type instead of default AND type
filters:
  availability-zone: us-west-2b  ## Will match us-west-2b OR
  hypervisor: xen  ## xen hypervisor OR
  ec2ini_filters: {availability-zone: us-east-1b, instance-type: t2.micro}  ## us-east-1b AND type t2.micro

```
