### PR TITLE
Use wait_for in prepare_junos_tests.yaml (#57073)

### DIFF
--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -8,6 +8,8 @@
   tags: netconf
 
 - name: wait for netconf server to come up
-  pause:
-    seconds: 10
-  tags: netconf
+  delegate_to: localhost
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/57073 to help improve testing on junos

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test of junos network-integration