### PR TITLE
Fix for the devtestlabartifactssource and the integration test

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifactsource.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_devtestlabartifactsource.py
@@ -186,15 +186,9 @@ class AzureRMDevTestLabArtifactsSource(AzureRMModuleBase):
         self.state = None
         self.to_do = Actions.NoAction
 
-        required_if = [
-            ('state', 'present', [
-             'source_type', 'uri', 'security_token'])
-        ]
-
         super(AzureRMDevTestLabArtifactsSource, self).__init__(derived_arg_spec=self.module_arg_spec,
                                                                supports_check_mode=True,
-                                                               supports_tags=True,
-                                                               required_if=required_if)
+                                                               supports_tags=True)
 
     def exec_module(self, **kwargs):
         """Main module execution method"""
@@ -210,8 +204,8 @@ class AzureRMDevTestLabArtifactsSource(AzureRMModuleBase):
         elif self.artifact_source.get('source_type') == 'vso':
             self.artifact_source['source_type'] = 'VsoGit'
 
-        if self.artifact_source.get('status') is not None:
-            self.artifact_source['status'] = 'Enabled' if self.artifact_source.get('status') else 'Disabled'
+        if self.artifact_source.get('is_enabled') is not None:
+            self.artifact_source['status'] = 'Enabled' if self.artifact_source.get('is_enabled') else 'Disabled'
 
         response = None
 
@@ -240,11 +234,13 @@ class AzureRMDevTestLabArtifactsSource(AzureRMModuleBase):
                 else:
                     self.artifact_source['display_name'] = old_response.get('display_name')
 
-                if self.artifact_source.get('source_type').lower() != old_response.get('source_type').lower():
-                    self.to_do = Actions.Update
+                if self.artifact_source.get('source_type') is not None:
+                    if self.artifact_source.get('source_type').lower() != old_response.get('source_type').lower():
+                        self.to_do = Actions.Update
 
-                if self.artifact_source.get('uri') != old_response.get('uri'):
-                    self.to_do = Actions.Update
+                if self.artifact_source.get('uri') is not None:
+                    if self.artifact_source.get('uri') != old_response.get('uri'):
+                        self.to_do = Actions.Update
 
                 if self.artifact_source.get('branch_ref') is not None:
                     if self.artifact_source.get('branch_ref') != old_response.get('branch_ref'):

--- a/test/integration/targets/azure_rm_devtestlab/tasks/main.yml
+++ b/test/integration/targets/azure_rm_devtestlab/tasks/main.yml
@@ -104,7 +104,7 @@
   azure_rm_devtestlabpolicy:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
-    policy_set_name: myDtlPolicySet
+    policy_set_name: default
     name: myDtlPolicy
     fact_name: user_owned_lab_vm_count
     threshold: 5
@@ -120,7 +120,7 @@
   azure_rm_devtestlabpolicy:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
-    policy_set_name: myDtlPolicySet
+    policy_set_name: default
     name: myDtlPolicy
     fact_name: user_owned_lab_vm_count
     threshold: 5
@@ -136,7 +136,7 @@
   azure_rm_devtestlabpolicy:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
-    policy_set_name: myDtlPolicySet
+    policy_set_name: default
     name: myDtlPolicy
     fact_name: user_owned_lab_vm_count
     threshold: 6
@@ -152,7 +152,7 @@
   azure_rm_devtestlabpolicy:
     resource_group: "{{ resource_group }}"
     lab_name: "{{ lab_name }}"
-    policy_set_name: myDtlPolicySet
+    policy_set_name: default
     name: myDtlPolicy
     state: absent
   register: output
@@ -349,10 +349,17 @@
       - output.changed
   when: "github_token | length > 0"
 
+- name: Enable the public environment repo artifact source
+  azure_rm_devtestlabartifactsource:
+    resource_group: "{{ resource_group }}"
+    lab_name: "{{ lab_name }}"
+    name: "public environment repo"
+    is_enabled: true
+
 - name:
   set_fact:
     artifact_source:
-      - source_name: "{{ artifacts_name }}"
+      - source_name: "public repo"
         source_path: "/Artifacts/linux-install-mongodb"
   when: "github_token | length > 0"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
devtestlab service changed the default value of the artifacts source status. A fix for the integration test. Meanwhile, delete require_if in the azure_rm_devtestlabartifactsources because when doing update action, we don't need these field really.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_devtestlabartifactsource

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
