### PR TITLE
VMware: vsphere_copy IndexError: tuple index out of range

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -206,7 +206,7 @@ def main():
         try:
             if isinstance(e[0], int):
                 error_code = e[0]
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, IndexError):
             pass
         module.fail_json(msg=to_native(e), status=None, errno=error_code,
                          reason=to_native(e), url=url, exception=traceback.format_exc())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
hotfixes https://github.com/ansible/ansible/issues/58168
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vsphere_copy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```paste below
Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-tmp-1561111440.8274398-36240207362500/AnsiballZ_vsphere_copy.py", line 114, in <module>
    _ansiballz_main()
  File "/home/user/.ansible/tmp/ansible-tmp-1561111440.8274398-36240207362500/AnsiballZ_vsphere_copy.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/user/.ansible/tmp/ansible-tmp-1561111440.8274398-36240207362500/AnsiballZ_vsphere_copy.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_vsphere_copy_payload_Ad8BJj/__main__.py", line 200, in <module>
  File "/tmp/ansible_vsphere_copy_payload_Ad8BJj/__main__.py", line 179, in main
IndexError: tuple index out of range
```

after:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_vsphere_copy_payload_v0wHic/__main__.py", line 179, in main
    if isinstance(e[0], int):
IndexError: tuple index out of range

fatal: [router1.private]: FAILED! => {
    "changed": false,
    "errno": -1,
    "invocation": {
        "module_args": {
            "datacenter": "ha-datacenter",
            "datastore": "live",
            "dest": "cfg/router1.private.iso",
            "host": "10.1.1.10",
            "hostname": "10.1.1.10",
            "login": "ansible",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "path": "cfg/router1.private.iso",
            "src": "/tmp/router1.private/router1.private.iso",
            "timeout": 60,
            "username": "ansible",
            "validate_certs": false
        }
    },
    "msg": "HTTP Error 500: Internal Server Error",
    "reason": "HTTP Error 500: Internal Server Error",
    "status": null,
    "url": "https://10.1.1.10/folder/cfg/router1.private.iso?dcPath=ha-datacenter&dsName=live"
}
```