### PR TITLE
Validate required prefix variable is not empty

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_static_route.py
+++ b/lib/ansible/modules/network/nxos/nxos_static_route.py
@@ -201,7 +201,9 @@ def normalize_prefix(module, prefix):
     splitted_prefix = prefix.split('/')
 
     address = splitted_prefix[0]
-    if len(splitted_prefix) > 2:
+    if not address:
+        module.fail_json(msg='Prefix cannot be empty.', prefix=prefix)
+    elif len(splitted_prefix) > 2:
         module.fail_json(msg='Incorrect address format.', address=address)
     elif len(splitted_prefix) == 2:
         mask = splitted_prefix[1]


### PR DESCRIPTION
##### SUMMARY
This fixes a validation bug with the nxos_static_route module, where it accepts an empty prefix variable passed, even though it's required.

Currently, if an empty string is passed as the prefix, this module attempts to configure the following line on NX-OS switches:
```
ip route /32 x.x.x.x
```
where x.x.x.x is the next_hop passed.  This throws an invalid command error on the switch.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_static_route

##### ADDITIONAL INFORMATION
To recreate the issue, call the following function:
```
- nxos_static_route:
    state: present
    prefix: ''
    next_hop: '10.0.0.1'
```

Error output:
```
"msg": "ip route /32 10.0.0.1\r\r\n                                ^\r\n% Invalid ip address at '^' marker.\r\n\rswitch-hostname(config)# "
```
