### PR TITLE
possible fix for #56716

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -771,10 +771,10 @@ def main():
         res_args['backup_file'] = backup_file
 
     module.params['dest'] = dest
-    if not module.check_mode:
-        file_args = module.load_file_common_arguments(module.params)
-        res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
+    file_args = module.load_file_common_arguments(module.params)
+    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
 
+    if 'path' not in res_args: res_args['path'] = dest
     module.exit_json(**res_args)
 
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -286,11 +286,6 @@ class ActionModule(ActionBase):
             if self._play_context.diff and not raw:
                 result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars))
 
-            if self._play_context.check_mode:
-                self._remove_tempfile_if_content_defined(content, content_tempfile)
-                result['changed'] = True
-                return result
-
             # Define a remote directory that we will copy the file to.
             tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, 'source')
 


### PR DESCRIPTION
##### SUMMARY
Fixes #56716

Removes unnecessary check_mode checks from the copy action/module. The subsequent modules have their own check_mode checks and still return valuable data.

This PR is not perfect but it's far better having a reasonable subset of return values than nothing.
It works for me but please test it before merging.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/files/copy.py
plugins/action/copy.py

##### ADDITIONAL INFORMATION
run the following playbook with `-vvv` and watch the resultset
```yaml
- hosts: localhost
  gather_facts: no
  tasks:
    - copy: content="." dest="/tmp/ansible-copy-test"
      check_mode: yes
    - copy: content="." dest="/tmp/ansible-copy-test"
      check_mode: no
```