### PR TITLE
prepapre_vmware_tests: add a common vars file

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
+
+- name: load vmware common vars
+  include_vars:
+    file: common.yml
+
 - when: vcsim is not defined
-  import_tasks: init_real_lab.yml
+  include_tasks: init_real_lab.yml
 
 - when: vcsim is defined
-  import_tasks: init_vcsim.yml
+  include_tasks: init_vcsim.yml

--- a/test/integration/targets/prepare_vmware_tests/vars/common.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/common.yml
@@ -1,0 +1,12 @@
+---
+dc1: DC0
+ccr1: DC0_C0
+ds1: LocalDS_0
+ds2: LocalDS_1
+f0: F0
+switch1: switch1
+esxi1: '{{ esxi_hosts[0] }}'
+esxi2: '{{ esxi_hosts[1] }}'
+esxi3: '{{ esxi_hosts[2] }}'
+dvswitch1: DVS0
+esxi_user: root

--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -1,22 +1,8 @@
 ---
-dc1: DC0
-ccr1: DC0_C0
-ds1: LocalDS_0
-ds2: LocalDS_1
-f0: F0
-switch1: switch1
-dvswitch1: DVS0
-# The ESXi entries in the inventory
-vcenter_hostname: vcenter.test
-vcenter_username: administrator@vsphere.local
-vcenter_password: blablabla
 esxi_hosts:
   - esxi1.test
   - esxi2.test
-esxi_user: root
-esxi_password: balbalbla
-esxi1: "{{ esxi_hosts[0] }}"
-esxi2: "{{ esxi_hosts[1] }}"
+esxi_password: '{{ esxi1_password }}'
 infra:
   datastores:
     LocalDS_0:

--- a/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
@@ -1,18 +1,8 @@
 ---
-dc1: DC0
-ccr1: DC0_C0
-ds1: LocalDS_0
-ds2: LocalDS_1
-f0: F0
 esxi_hosts:
   - DC0_C0_H0
   - DC0_C0_H1
   - DC0_C0_H2
-esxi1: '{{ esxi_hosts[0] }}'
-esxi2: '{{ esxi_hosts[1] }}'
-esxi3: '{{ esxi_hosts[2] }}'
-switch1: switch1
-dvswitch1: DVS0
 virtual_machines:
   - name: DC0_H0_VM0
     folder: /F0/DC0/vm/F0


### PR DESCRIPTION
##### SUMMARY

Add a new file to record the variables that are shared with the two
scenarios (real_lab and vcsim).

The goal is to reduce the the amount of boilerplate configuration from
a user perspective.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->
