### PR TITLE
Add jinja2 support for tag filters in the aws_ec2 inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -585,6 +585,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise AnsibleError("Insufficient boto credentials found. Please provide them in your "
                                "inventory configuration file or set them as environment variables.")
 
+    def _filter_template(self, filters):
+        '''
+            :param filters: the filters to be processed
+            :return filter processed
+        '''
+        processed_filters = {}
+        for key, value in filters.items():
+            if self.templar.is_template(value):
+                value = self.templar.template(value)
+            processed_filters[key] = value
+
+        return processed_filters
+
     def verify_file(self, path):
         '''
             :param loader: an ansible.parsing.dataloader.DataLoader object
@@ -610,7 +623,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # get user specifications
         regions = self.get_option('regions')
-        filters = ansible_dict_to_boto3_filter_list(self.get_option('filters'))
+        filters = ansible_dict_to_boto3_filter_list(self._filter_template(self.get_option('filters')))
         hostnames = self.get_option('hostnames')
         strict_permissions = self.get_option('strict_permissions')
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -45,6 +45,7 @@ DOCUMENTATION = '''
         filters:
           description:
               - A dictionary of filter value pairs.
+              - Values are compatible with jinja2.
               - Available filters are listed here U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).
           type: dict
           default: {}
@@ -98,6 +99,8 @@ filters:
   tag:Environment:
     - dev
     - qa
+  # if you need to, get dynamic values from your machine env
+  tag:Workspace: "{{ lookup('env','AWS_WORKSPACE') }}"
   instance.group-id: sg-xxxxxxxx
 # Ignores 403 errors rather than failing
 strict_permissions: False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some time ago my team and I decided to use workspaces in AWS so each member can test in their own isolated space within the same AWS profile, the integration with ansible was quite easy by setting a tag `Workspace` as shown below:
```yaml
filters:
  tag-key: Managed
  tag:Workspace: diego
```
The problem with this is that we have to remember to set it back to `default` each time before we commit to avoid having other members running into your space, not a big deal, it became a bit annoying, though :). We came up with some hacky solutions just to get by, but then we thought that a better solution would be somehow supporting `ENV` variables, and thus `jinja2` became a natural choice adding more flexibility. Without further ado the inventory filters would look as follows:
```yaml
filters:
  tag-key: Managed
  tag:Workspace: "{{ lookup('env','AWS_WORKSPACE') }}"
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Add jinja2 support for tag filters in the aws_ec2 inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The same output but dynamic input 
```
Thanks for reading and I am open for suggestions.
Looking forward to seeing this on the next release :)