### PR TITLE
Use to_text on value to activate _fail_with_undefined_error

### DIFF
--- a/changelogs/fragments/regex-tests-undefined.yml
+++ b/changelogs/fragments/regex-tests-undefined.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- regex tests - Fail with undefined error if the value is
+  undefined (https://github.com/ansible/ansible/issues/12186)

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -24,6 +24,7 @@ import operator as py_operator
 from distutils.version import LooseVersion, StrictVersion
 
 from ansible import errors
+from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import MutableMapping, MutableSequence
 from ansible.utils.display import Display
 
@@ -114,6 +115,7 @@ def regex(value='', pattern='', ignorecase=False, multiline=False, match_type='s
         This is likely only useful for `search` and `match` which already
         have their own filters.
     '''
+    value = to_text(value, errors='surrogate_or_strict')
     flags = 0
     if ignorecase:
         flags |= re.I

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -115,6 +115,8 @@ def regex(value='', pattern='', ignorecase=False, multiline=False, match_type='s
         This is likely only useful for `search` and `match` which already
         have their own filters.
     '''
+    # In addition to ensuring the correct type, to_text here will ensure
+    # _fail_with_undefined_error happens if the value is Undefined
     value = to_text(value, errors='surrogate_or_strict')
     flags = 0
     if ignorecase:


### PR DESCRIPTION
##### SUMMARY
Use to_text on value to activate _fail_with_undefined_error

`jinja2.StrictUndefined` sets many dunder methods to `Undefined._fail_with_undefined_error`, but if none of those dunder methods are called in the process of using the value, the undefined error will not occur. 

This just calls `to_text` on the value, to trigger the error.

Fixes https://github.com/ansible/ansible/issues/12186
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/test/core.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```