### PR TITLE
Describe minimum password length of 16 chars

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_container_cluster.py
+++ b/lib/ansible/modules/cloud/google/gcp_container_cluster.py
@@ -218,7 +218,7 @@ options:
         description:
         - The password to use for HTTP basic authentication to the master endpoint.
           Because the master endpoint is open to the Internet, you should create a
-          strong password.
+          strong password with a minimum of 16 characters.
         required: false
       client_certificate_config:
         description:


### PR DESCRIPTION
Describe minimum password length of 16 chars under master_auth. If password is shorter an error message is shown when running ansible-playbook.

##### SUMMARY
Describe minimum password length of 16 chars under master_auth. If password is shorter an error message is shown when running ansible-playbook.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_container_cluster

##### ADDITIONAL INFORMATION
An ansible-playbook run containing a task with module gcp_container_cluster throws an error if the
provided password is too short. Would be awesome to find this information in the documentation beforehand.

```
ansible-playbook playbooks/gke-cluster.yml
PLAY [gcp_container_cluster - Creates a GCP Cluster] **************************************************************************************************************************************************************************************************************************

TASK [gke : Create a GCP cluster] *********************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "GCP returned error: {'error': {'code': 400, 'message': 'Cluster.master_auth.password must be at least length 16.', 'status': 'INVALID_ARGUMENT'}}"}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```