### PR TITLE
win_partition - Fix handling of maximum partition size

### DIFF
--- a/changelogs/fragments/58225-win_partition-maximum-partition-size.yml
+++ b/changelogs/fragments/58225-win_partition-maximum-partition-size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_partition - don't resize partitions if size difference is < 1 MiB


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/56910

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_partition

##### ADDITIONAL INFORMATION
Doesn't resize the partition if the difference is ~1MiB +/- from the original partition size according to my post here: https://github.com/ansible/ansible/issues/56910#issuecomment-504634853 This issue is prevalent in partitions with large disk sizes so it's still not covered by these integration tests.

I've also removed `-UseMaximumSize` and specified the maximum supported size directly.