### PR TITLE
Add exception handling to win_domain_controller

### DIFF
--- a/changelogs/fragments/win_domain-exceptions.yaml
+++ b/changelogs/fragments/win_domain-exceptions.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_domain_controller - Do not fail the play without the user being able to catch dcpromo failing because of a pending reboot within a playbook using ignore_error or retry logic.
+- win_domain_controller - Do not fail the play without the user being able to catch domain dns resolution errors within the playbook using ignore_error or retry logic.

--- a/changelogs/fragments/win_domain-exceptions.yaml
+++ b/changelogs/fragments/win_domain-exceptions.yaml
@@ -1,3 +1,2 @@
 bugfixes:
 - win_domain_controller - Do not fail the play without the user being able to catch dcpromo failing because of a pending reboot within a playbook using ignore_error or retry logic.
-- win_domain_controller - Do not fail the play without the user being able to catch domain dns resolution errors within the playbook using ignore_error or retry logic.

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -214,7 +214,7 @@ Try {
                 }
                 try
                 {
-                    $install_result = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
+                    $null = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
                 } catch [Microsoft.DirectoryServices.Deployment.DCPromoExecutionException] {
                     # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
                     # DCPromo exit codes details can be found at https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -223,19 +223,9 @@ Try {
                     } else {
                         Fail-Json -obj $result -message "Failed to install ADDSDomainController with DCPromo: $($_.Exception.Message)"
                     }
-                } catch {
-                    # We cannot directly catch Microsoft.ADRoles.Deployment.Common.Tests.TestFailedException
-                    # As the type is within an internal flagged class of Microsoft.ADRoles.Deployment.Common
-                    if (
-                        ($_.FullyQualifiedErrorId -eq 'Test.VerifyUserCredentialPermissions.DCPromo.General.25,Microsoft.DirectoryServices.Deployment.PowerShell.Commands.InstallADDSDomainControllerCommand') -and
-                        ($_.CategroyInfo.Reason -eq "TestFailedException") -and
-                        ($_.Exception.ErrorCode -eq 25)
-                    ) {
-                        Fail-Json -obj $result -message "Failed to resolve domain name $($dns_domain_name): $($_.Exception.Message)"
-                    } else {
-                        throw
-                    }
                 }
+                # If $_.FullyQualifiedErrorId -eq 'Test.VerifyUserCredentialPermissions.DCPromo.General.25,Microsoft.DirectoryServices.Deployment.PowerShell.Commands.InstallADDSDomainControllerCommand'
+                # the module failed to resolve the given dns domain name
 
                 Write-DebugLog "Installation complete, trying to start the Netlogon service"
                 # The Netlogon service is set to auto start but is not started. This is


### PR DESCRIPTION
##### SUMMARY
Add error handling for two exceptions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_controller

##### ADDITIONAL INFORMATION

If a user specifies a domain to join that cannot be resolved by dns, the Install-ADDSDomainController command throws an Microsoft.ADRoles.Deployment.Common.Tests.TestFailedException exception.

If the module is either invoked twice without a reboot, or a reboot is pending for another reason the Install-ADDSDomainController command throws an Microsoft.DirectoryServices.Deployment.DCPromoExecutionException exception with Errorcode 15.

I added error handling for both of them, so that a user can handle them from within the playbook.