### PR TITLE
2.8 Backport: Fix ansible-vault cipher_whitelist

### DIFF
--- a/changelogs/fragments/57272-fix-ansible-vault-whitelist-after-44320.yml
+++ b/changelogs/fragments/57272-fix-ansible-vault-whitelist-after-44320.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove lingering ansible vault cipher (AES) after it beeing removed in #44320

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -82,7 +82,7 @@ display = Display()
 
 
 b_HEADER = b'$ANSIBLE_VAULT'
-CIPHER_WHITELIST = frozenset((u'AES', u'AES256'))
+CIPHER_WHITELIST = frozenset((u'AES256',))
 CIPHER_WRITE_WHITELIST = frozenset((u'AES256',))
 # See also CIPHER_MAPPING at the bottom of the file which maps cipher strings
 # (used in VaultFile header) to a cipher class
@@ -288,6 +288,7 @@ def verify_secret_is_not_empty(secret, msg=None):
 
 class VaultSecret:
     '''Opaque/abstract objects for a single vault secret. ie, a password or a key.'''
+
     def __init__(self, _bytes=None):
         # FIXME: ? that seems wrong... Unset etc?
         self._bytes = _bytes


### PR DESCRIPTION
* Fix ansible-vault cipher_whitelist Fixes: #57271
* Add changelog for #57272

##### SUMMARY

Backports #57272

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/parsing/vault/__init__.py`

##### ADDITIONAL INFORMATION
Backport of #57272