### PR TITLE
Add note about delegate_facts to run_once

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -279,7 +279,7 @@ As always with delegation, the action will be executed on the delegated host, bu
     Any conditional (i.e `when:`) will use the variables of the 'first host' to decide if the task runs or not, no other hosts will be tested.
 
 .. note::
-    If you want to avoid the default behaviour of setting the fact for all hosts `delegate_facts: True` also needs to be specified for the specific task or block.
+    If you want to avoid the default behaviour of setting the fact for all hosts, set `delegate_facts: True` for the specific task or block.
 
 .. _local_playbooks:
 

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -278,6 +278,9 @@ As always with delegation, the action will be executed on the delegated host, bu
 .. note::
     Any conditional (i.e `when:`) will use the variables of the 'first host' to decide if the task runs or not, no other hosts will be tested.
 
+.. note::
+    If facts should *not* be set for all hosts `delegate_facts: True` also needs to be specified for the specific task or block.
+
 .. _local_playbooks:
 
 Local Playbooks

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -279,7 +279,7 @@ As always with delegation, the action will be executed on the delegated host, bu
     Any conditional (i.e `when:`) will use the variables of the 'first host' to decide if the task runs or not, no other hosts will be tested.
 
 .. note::
-    If facts should *not* be set for all hosts `delegate_facts: True` also needs to be specified for the specific task or block.
+    If you want to avoid the default behaviour of setting the fact for all hosts `delegate_facts: True` also needs to be specified for the specific task or block.
 
 .. _local_playbooks:
 


### PR DESCRIPTION
##### SUMMARY
If set_fact is used with run_once the fact gets applied to all hosts. This is counter intuitive in some scenarios.
I also asked on IRC and was told it should behave otherwise. There is clearly some confusion right now. From rereading the documentation after creating the issue #58240 it was clear, that that is in fact intended behaviour. Therefore I propose to add a note to the section in the documentation.

Fixes: #58240

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
run_once
delegate_facts
