### PR TITLE
[2.8] docker_* modules: improve error message when docker-py is missing

### DIFF
--- a/changelogs/fragments/57914-docker-py-missing.yaml
+++ b/changelogs/fragments/57914-docker-py-missing.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_* modules - improve error message when docker-py is missing / has wrong version."

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -17,12 +17,14 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import platform
 import re
+import sys
 from datetime import timedelta
 from distutils.version import LooseVersion
 
 
-from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils.basic import AnsibleModule, env_fallback, missing_required_lib
 from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib.parse import urlparse
@@ -258,7 +260,7 @@ DOCKERPYUPGRADE_SWITCH_TO_DOCKER = "Try `pip uninstall docker-py` followed by `p
 DOCKERPYUPGRADE_UPGRADE_DOCKER = "Use `pip install --upgrade docker` to upgrade."
 DOCKERPYUPGRADE_RECOMMEND_DOCKER = ("Use `pip install --upgrade docker-py` to upgrade. "
                                     "Hint: if you do not need Python 2.6 support, try "
-                                    "`pip uninstall docker-py` instead followed by `pip install docker`.")
+                                    "`pip uninstall docker-py` instead, followed by `pip install docker`.")
 
 
 class AnsibleDockerClient(Client):
@@ -303,19 +305,21 @@ class AnsibleDockerClient(Client):
             self.fail("Cannot have both the docker-py and docker python modules (old and new version of Docker "
                       "SDK for Python) installed together as they use the same namespace and cause a corrupt "
                       "installation. Please uninstall both packages, and re-install only the docker-py or docker "
-                      "python module. It is recommended to install the docker module if no support for Python 2.6 "
-                      "is required. Please note that simply uninstalling one of the modules can leave the other "
-                      "module in a broken state.")
+                      "python module (for %s's Python %s). It is recommended to install the docker module if no "
+                      "support for Python 2.6 is required. Please note that simply uninstalling one of the modules "
+                      "can leave the other module in a broken state." % (platform.node(), sys.executable))
 
         if not HAS_DOCKER_PY:
             if NEEDS_DOCKER_PY2:
-                msg = "Failed to import docker (Docker SDK for Python) - %s. Try `pip install docker`."
+                msg = missing_required_lib("Docker SDK for Python: docker")
+                msg = msg + ", for example via `pip install docker`. The error was: %s"
             else:
-                msg = "Failed to import docker or docker-py (Docker SDK for Python) - %s. Try `pip install docker` or `pip install docker-py` (Python 2.6)."
+                msg = missing_required_lib("Docker SDK for Python: docker (Python >= 2.7) or docker-py (Python 2.6)")
+                msg = msg + ", for example via `pip install docker` or `pip install docker-py` (Python 2.6). The error was: %s"
             self.fail(msg % HAS_DOCKER_ERROR)
 
         if self.docker_py_version < LooseVersion(min_docker_version):
-            msg = "Error: Docker SDK for Python version is %s. Minimum version required is %s. "
+            msg = "Error: Docker SDK for Python version is %s (%s's Python %s). Minimum version required is %s."
             if not NEEDS_DOCKER_PY2:
                 # The minimal required version is < 2.0 (and the current version as well).
                 # Advertise docker (instead of docker-py) for non-Python-2.6 users.
@@ -324,7 +328,7 @@ class AnsibleDockerClient(Client):
                 msg += DOCKERPYUPGRADE_SWITCH_TO_DOCKER
             else:
                 msg += DOCKERPYUPGRADE_UPGRADE_DOCKER
-            self.fail(msg % (docker_version, min_docker_version))
+            self.fail(msg % (docker_version, platform.node(), sys.executable, min_docker_version))
 
         self.debug = self.module.params.get('debug')
         self.check_mode = self.module.check_mode
@@ -477,14 +481,14 @@ class AnsibleDockerClient(Client):
                         msg = 'Docker API version is %s. Minimum version required is %s to %s.'
                         msg = msg % (self.docker_api_version_str, data['docker_api_version'], usg)
                     elif not support_docker_py:
-                        msg = "Docker SDK for Python version is %s. Minimum version required is %s to %s. "
+                        msg = "Docker SDK for Python version is %s (%s's Python %s). Minimum version required is %s to %s. "
                         if LooseVersion(data['docker_py_version']) < LooseVersion('2.0.0'):
                             msg += DOCKERPYUPGRADE_RECOMMEND_DOCKER
                         elif self.docker_py_version < LooseVersion('2.0.0'):
                             msg += DOCKERPYUPGRADE_SWITCH_TO_DOCKER
                         else:
                             msg += DOCKERPYUPGRADE_UPGRADE_DOCKER
-                        msg = msg % (docker_version, data['docker_py_version'], usg)
+                        msg = msg % (docker_version, platform.node(), sys.executable, data['docker_py_version'], usg)
                     else:
                         # should not happen
                         msg = 'Cannot %s with your configuration.' % (usg, )

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -42,7 +42,8 @@
 - assert:
     that:
     - auto_remove_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.1.0') in auto_remove_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in auto_remove_1.msg"
+    - "'Minimum version required is 2.1.0 ' in auto_remove_1.msg"
   when: docker_py_version is version('2.1.0', '<')
 
 ####################################################################
@@ -679,7 +680,8 @@
 - assert:
     that:
     - device_read_bps_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_bps_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_read_bps_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_read_bps_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -758,7 +760,8 @@
 - assert:
     that:
     - device_read_iops_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_iops_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_read_iops_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_read_iops_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -827,7 +830,8 @@
 - assert:
     that:
     - device_write_limit_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_write_limit_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_write_limit_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_write_limit_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -899,7 +903,8 @@
 - assert:
     that:
     - dns_opts_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in dns_opts_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in dns_opts_1.msg"
+    - "'Minimum version required is 1.10.0 ' in dns_opts_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -1602,7 +1607,8 @@
 - assert:
     that:
     - healthcheck_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in healthcheck_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in healthcheck_1.msg"
+    - "'Minimum version required is 2.0.0 ' in healthcheck_1.msg"
   when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
@@ -1701,7 +1707,8 @@
 - assert:
     that:
     - init_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in init_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in init_1.msg"
+    - "'Minimum version required is 2.2.0 ' in init_1.msg"
   when: docker_py_version is version('2.2.0', '<')
 
 ####################################################################
@@ -2699,7 +2706,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - pids_limit_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in pids_limit_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in pids_limit_1.msg"
+    - "'Minimum version required is 1.10.0 ' in pids_limit_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -2992,7 +3000,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - runtime_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.4.0') in runtime_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in runtime_1.msg"
+    - "'Minimum version required is 2.4.0 ' in runtime_1.msg"
   when: docker_py_version is version('2.4.0', '<')
 
 ####################################################################
@@ -3287,7 +3296,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - sysctls_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in sysctls_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in sysctls_1.msg"
+    - "'Minimum version required is 1.10.0 ' in sysctls_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -3561,7 +3571,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - userns_mode_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in userns_mode_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in userns_mode_1.msg"
+    - "'Minimum version required is 1.10.0 ' in userns_mode_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -3615,7 +3626,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - uts_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.5.0') in uts_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in uts_1.msg"
+    - "'Minimum version required is 3.5.0 ' in uts_1.msg"
   when: docker_py_version is version('3.5.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -199,7 +199,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.2.0 ' in output.msg"
     when: docker_py_version is version('2.2.0', '<')
 
   - name: Get info on Docker host and get disk usage with verbose output
@@ -223,7 +224,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.2.0 ' in output.msg"
     when: docker_py_version is version('2.2.0', '<')
 
   - name: Get info on Docker host, disk usage and get all lists together

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -321,5 +321,6 @@
 - assert:
     that:
       - network_1 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in network_1.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in network_1.msg"
+      - "'Minimum version required is 2.0.0 ' in network_1.msg"
   when: docker_py_version is version('2.0.0', '<')

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -187,7 +187,8 @@
 - assert:
     that:
     - attachable_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in attachable_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in attachable_1.msg"
+    - "'Minimum version required is 2.0.0 ' in attachable_1.msg"
   when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
@@ -147,7 +147,8 @@
   - assert:
       that:
       - output_1 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+      - "'Minimum version required is 2.6.0 ' in output_1.msg"
     when: docker_py_version is version('2.6.0', '<')
 
   when: pyopenssl_version.stdout is version('0.15', '>=') or cryptography_version.stdout is version('1.6', '>=')

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -112,7 +112,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -201,7 +202,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -695,7 +697,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -149,7 +149,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.7.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.7.0 ' in output.msg"
     when: docker_py_version is version('2.7.0', '<')
 
   - name: Update swarm cluster to be locked
@@ -178,7 +179,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.7.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.7.0 ' in output.msg"
     when: docker_py_version is version('2.7.0', '<')
 
   always:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1753,7 +1753,8 @@
       - resolve_image_1 is changed
       - resolve_image_2 is not changed
       - resolve_image_3 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.2.0') in resolve_image_3.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in resolve_image_3.msg"
+      - "'Minimum version required is 3.2.0 ' in resolve_image_3.msg"
   when: docker_api_version is version('1.30', '<') or docker_py_version is version('3.2.0', '<')
 
 ###################################################################

--- a/test/units/modules/cloud/docker/test_docker_volume.py
+++ b/test/units/modules/cloud/docker/test_docker_volume.py
@@ -28,4 +28,5 @@ def test_create_volume_on_invalid_docker_version(mocker, capfd):
     out, dummy = capfd.readouterr()
     results = json.loads(out)
     assert results['failed']
-    assert 'Error: Docker SDK for Python version is 1.8.0. Minimum version required is 1.10.0.' in results['msg']
+    assert 'Error: Docker SDK for Python version is 1.8.0 ' in results['msg']
+    assert 'Minimum version required is 1.10.0.' in results['msg']


### PR DESCRIPTION
##### SUMMARY
Backport of #57914 to stable-2.8. Improves error messages when docker-py is missing. Now includes the `missing_required_lib()` output.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker/common.py
