### PR TITLE
ce_static_route:  fix some bugs.

### DIFF
--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -271,7 +271,7 @@ def get_cli_config(module, flags=None):
             cfg = rm_config_prefix(cfg)
             break
     if cfg.startwith('display'):
-        linss = cfg.split('\n')
+        lines = cfg.split('\n')
         if len(lines) > 1:
             return '\n'.join(cfg[1:])
         else:

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -248,37 +248,6 @@ def get_config(module, flags=None):
     return conn.get_config(flags)
 
 
-def get_cli_config(module, flags=None):
-    """Retrieves the current config from the device or cache
-    """
-    flags = [] if flags is None else flags
-    if isinstance(flags, str):
-        flags = [flags]
-    elif not isinstance(flags, list):
-        flags = []
-
-    cmd = 'display current-configuration '
-    cmd += ' '.join(flags)
-    cmd = cmd.strip()
-    conn = get_connection(module)
-    rc, out, err = conn.exec_command(cmd)
-    if rc != 0:
-        module.fail_json(msg=err)
-    cfg = str(out).strip()
-    # remove default configuration prefix '~'
-    for flag in flags:
-        if "include-default" in flag:
-            cfg = rm_config_prefix(cfg)
-            break
-    if cfg.startwith('display'):
-        lines = cfg.split('\n')
-        if len(lines) > 1:
-            return '\n'.join(cfg[1:])
-        else:
-            return ''
-    return cfg
-
-
 def run_commands(module, commands, check_rc=True):
     conn = get_connection(module)
     return conn.run_commands(to_command(module, commands), check_rc)

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -255,29 +255,27 @@ def build_config_xml(xmlstr):
     return '<config> ' + xmlstr + ' </config>'
 
 
-def is_valid_v4addr(addr):
-    """check if ipv4 addr is valid"""
-    if addr.find('.') != -1:
-        addr_list = addr.split('.')
-        if len(addr_list) != 4:
-            return False
-        for each_num in addr_list:
-            if not each_num.isdigit():
-                return False
-            if int(each_num) > 255:
-                return False
-        return True
-    return False
-
-
 def is_valid_v6addr(addr):
     """check if ipv6 addr is valid"""
     if addr.find(':') != -1:
         addr_list = addr.split(':')
-        if len(addr_list) > 6:
+        # should not greater than 8 groups
+        if len(addr_list) > 8:
             return False
-        if addr_list[1] != "":
+        #You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.    
+        if addr.count('::') > 1:
             return False
+        # if do not use '::', the length of address should not be less than 8.
+        if addr.count('::') == 0 and len(addr_list) < 8:
+            return False
+        for group in addr_list:
+            if group.strip() == '':
+                continue
+            try:
+                # Each group is represented in 4-digit hexadecimal
+                int(group, base=16)
+            except ValueError:
+                return False
         return True
     return False
 
@@ -407,7 +405,7 @@ class StaticRoute(object):
                 if int(each_num) > 255:
                     return False
             byte_len = 8
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
         else:
             if self.prefix.find(':') == -1:
@@ -422,7 +420,7 @@ class StaticRoute(object):
             if length > 6:
                 return False
             byte_len = 16
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
 
         if self.aftype == "v4":
@@ -571,7 +569,7 @@ class StaticRoute(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         static_routes = root.findall(
-            "data/staticrt/staticrtbase/srRoutes/srRoute")
+            "staticrt/staticrtbase/srRoutes/srRoute")
 
         if static_routes:
             for static_route in static_routes:
@@ -763,6 +761,8 @@ class StaticRoute(object):
 
         self.get_static_route(self.state)
         self.end_state['sroute'] = self.static_routes_info["sroute"]
+        if self.end_state == self.existing:
+            self.changed = False
 
     def work(self):
         """worker"""

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -274,7 +274,8 @@ def is_valid_v6addr(addr):
     """check if ipv6 addr is valid"""
     if addr.find(':') != -1:
         addr_list = addr.split(':')
-        # should not greater than 8 groups
+        # The IPv6 binary system has a length of 128 bits and is grouped by 16 bits.
+        # Each group is separated by a colon ":" and can be divided into 8 groups, each group being represented by 4 hexadecimal
         if len(addr_list) > 8:
             return False
         #You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.    

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -278,7 +278,7 @@ def is_valid_v6addr(addr):
         # Each group is separated by a colon ":" and can be divided into 8 groups, each group being represented by 4 hexadecimal
         if len(addr_list) > 8:
             return False
-        #You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.    
+        # You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.
         if addr.count('::') > 1:
             return False
         # if do not use '::', the length of address should not be less than 8.

--- a/lib/ansible/modules/network/cloudengine/ce_static_route.py
+++ b/lib/ansible/modules/network/cloudengine/ce_static_route.py
@@ -274,10 +274,23 @@ def is_valid_v6addr(addr):
     """check if ipv6 addr is valid"""
     if addr.find(':') != -1:
         addr_list = addr.split(':')
-        if len(addr_list) > 6:
+        # should not greater than 8 groups
+        if len(addr_list) > 8:
             return False
-        if addr_list[1] != "":
+        #You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.    
+        if addr.count('::') > 1:
             return False
+        # if do not use '::', the length of address should not be less than 8.
+        if addr.count('::') == 0 and len(addr_list) < 8:
+            return False
+        for group in addr_list:
+            if group.strip() == '':
+                continue
+            try:
+                # Each group is represented in 4-digit hexadecimal
+                int(group, base=16)
+            except ValueError:
+                return False
         return True
     return False
 
@@ -407,7 +420,7 @@ class StaticRoute(object):
                 if int(each_num) > 255:
                     return False
             byte_len = 8
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
         else:
             if self.prefix.find(':') == -1:
@@ -422,7 +435,7 @@ class StaticRoute(object):
             if length > 6:
                 return False
             byte_len = 16
-            ip_len = int(self.mask) / byte_len
+            ip_len = int(self.mask) // byte_len
             ip_bit = int(self.mask) % byte_len
 
         if self.aftype == "v4":
@@ -571,7 +584,7 @@ class StaticRoute(object):
             replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
         root = ElementTree.fromstring(xml_str)
         static_routes = root.findall(
-            "data/staticrt/staticrtbase/srRoutes/srRoute")
+            "staticrt/staticrtbase/srRoutes/srRoute")
 
         if static_routes:
             for static_route in static_routes:
@@ -763,6 +776,8 @@ class StaticRoute(object):
 
         self.get_static_route(self.state)
         self.end_state['sroute'] = self.static_routes_info["sroute"]
+        if self.end_state == self.existing:
+            self.changed = False
 
     def work(self):
         """worker"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ce_static_route:  fix some bugs.
See ADDITIONAL INFORMATION.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_static_route.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. The IPv6 binary system has a length of 128 bits and is grouped by 16 bits. Each group is separated by a colon ":" and can be divided into 8 groups, each group being represented by 4 hexadecimal.
You can use a double colon "::" to represent a group of 0 or more consecutive 0s, but only once.
2. Divisible compatible with Python2 and Python3.
3. To find all elements, Data root node that is taged 'data' should be removed.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
