### PR TITLE
docker_* modules: adjust tests to new error messages for older docker-py versions

### DIFF
--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -42,7 +42,8 @@
 - assert:
     that:
     - auto_remove_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.1.0') in auto_remove_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in auto_remove_1.msg"
+    - "'Minimum version required is 2.1.0 ' in auto_remove_1.msg"
   when: docker_py_version is version('2.1.0', '<')
 
 ####################################################################
@@ -679,7 +680,8 @@
 - assert:
     that:
     - device_read_bps_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_bps_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_read_bps_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_read_bps_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -758,7 +760,8 @@
 - assert:
     that:
     - device_read_iops_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_read_iops_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_read_iops_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_read_iops_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -827,7 +830,8 @@
 - assert:
     that:
     - device_write_limit_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.9.0') in device_write_limit_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in device_write_limit_1.msg"
+    - "'Minimum version required is 1.9.0 ' in device_write_limit_1.msg"
   when: docker_py_version is version('1.9.0', '<')
 
 ####################################################################
@@ -899,7 +903,8 @@
 - assert:
     that:
     - dns_opts_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in dns_opts_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in dns_opts_1.msg"
+    - "'Minimum version required is 1.10.0 ' in dns_opts_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -1602,7 +1607,8 @@
 - assert:
     that:
     - healthcheck_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in healthcheck_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in healthcheck_1.msg"
+    - "'Minimum version required is 2.0.0 ' in healthcheck_1.msg"
   when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################
@@ -1701,7 +1707,8 @@
 - assert:
     that:
     - init_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in init_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in init_1.msg"
+    - "'Minimum version required is 2.2.0 ' in init_1.msg"
   when: docker_py_version is version('2.2.0', '<')
 
 ####################################################################
@@ -2699,7 +2706,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - pids_limit_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in pids_limit_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in pids_limit_1.msg"
+    - "'Minimum version required is 1.10.0 ' in pids_limit_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -2992,7 +3000,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - runtime_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.4.0') in runtime_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in runtime_1.msg"
+    - "'Minimum version required is 2.4.0 ' in runtime_1.msg"
   when: docker_py_version is version('2.4.0', '<')
 
 ####################################################################
@@ -3287,7 +3296,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - sysctls_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in sysctls_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in sysctls_1.msg"
+    - "'Minimum version required is 1.10.0 ' in sysctls_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -3561,7 +3571,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - userns_mode_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 1.10.0') in userns_mode_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in userns_mode_1.msg"
+    - "'Minimum version required is 1.10.0 ' in userns_mode_1.msg"
   when: docker_py_version is version('1.10.0', '<')
 
 ####################################################################
@@ -3615,7 +3626,8 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - assert:
     that:
     - uts_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.5.0') in uts_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in uts_1.msg"
+    - "'Minimum version required is 3.5.0 ' in uts_1.msg"
   when: docker_py_version is version('3.5.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -199,7 +199,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.2.0 ' in output.msg"
     when: docker_py_version is version('2.2.0', '<')
 
   - name: Get info on Docker host and get disk usage with verbose output
@@ -223,7 +224,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.2.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.2.0 ' in output.msg"
     when: docker_py_version is version('2.2.0', '<')
 
   - name: Get info on Docker host, disk usage and get all lists together

--- a/test/integration/targets/docker_network/tasks/tests/ipam.yml
+++ b/test/integration/targets/docker_network/tasks/tests/ipam.yml
@@ -321,5 +321,6 @@
 - assert:
     that:
       - network_1 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in network_1.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in network_1.msg"
+      - "'Minimum version required is 2.0.0 ' in network_1.msg"
   when: docker_py_version is version('2.0.0', '<')

--- a/test/integration/targets/docker_network/tasks/tests/options.yml
+++ b/test/integration/targets/docker_network/tasks/tests/options.yml
@@ -187,7 +187,8 @@
 - assert:
     that:
     - attachable_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.0.0') in attachable_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in attachable_1.msg"
+    - "'Minimum version required is 2.0.0 ' in attachable_1.msg"
   when: docker_py_version is version('2.0.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options-ca.yml
@@ -147,7 +147,8 @@
   - assert:
       that:
       - output_1 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+      - "'Minimum version required is 2.6.0 ' in output_1.msg"
     when: docker_py_version is version('2.6.0', '<')
 
   when: pyopenssl_version.stdout is version('0.15', '>=') or cryptography_version.stdout is version('1.6', '>=')

--- a/test/integration/targets/docker_swarm/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm/tasks/tests/options.yml
@@ -112,7 +112,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -201,7 +202,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################
@@ -695,7 +697,8 @@
 - assert:
     that:
     - output_1 is failed
-    - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.6.0') in output_1.msg"
+    - "('version is ' ~ docker_py_version ~ ' ') in output_1.msg"
+    - "'Minimum version required is 2.6.0 ' in output_1.msg"
   when: docker_py_version is version('2.6.0', '<')
 
 ####################################################################

--- a/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
+++ b/test/integration/targets/docker_swarm_info/tasks/test_swarm_info.yml
@@ -149,7 +149,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.7.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.7.0 ' in output.msg"
     when: docker_py_version is version('2.7.0', '<')
 
   - name: Update swarm cluster to be locked
@@ -178,7 +179,8 @@
   - assert:
       that:
         - output is failed
-        - "('version is ' ~ docker_py_version ~'. Minimum version required is 2.7.0') in output.msg"
+        - "('version is ' ~ docker_py_version ~ ' ') in output.msg"
+        - "'Minimum version required is 2.7.0 ' in output.msg"
     when: docker_py_version is version('2.7.0', '<')
 
   always:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1753,7 +1753,8 @@
       - resolve_image_1 is changed
       - resolve_image_2 is not changed
       - resolve_image_3 is failed
-      - "('version is ' ~ docker_py_version ~'. Minimum version required is 3.2.0') in resolve_image_3.msg"
+      - "('version is ' ~ docker_py_version ~ ' ') in resolve_image_3.msg"
+      - "'Minimum version required is 3.2.0 ' in resolve_image_3.msg"
   when: docker_api_version is version('1.30', '<') or docker_py_version is version('3.2.0', '<')
 
 ###################################################################


### PR DESCRIPTION
##### SUMMARY
Fixes tests so they again run with older docker-py / docker versions if possible. Follow-up to #57914. This is a test-only PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_host_info
docker_network
docker_swarm
docker_swarm_info
docker_swarm_service
