### PR TITLE
[2.8] docker_network: remove from sanity ignores

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -303,7 +303,7 @@ class TaskParameters(DockerBaseClass):
         super(TaskParameters, self).__init__()
         self.client = client
 
-        self.network_name = None
+        self.name = None
         self.connected = None
         self.driver = None
         self.driver_options = None
@@ -400,7 +400,7 @@ class DockerNetworkManager(object):
             self.results['diff'] = self.diff_result
 
     def get_existing_network(self):
-        return self.client.get_network(name=self.parameters.network_name)
+        return self.client.get_network(name=self.parameters.name)
 
     def has_different_config(self, net):
         '''
@@ -544,18 +544,18 @@ class DockerNetworkManager(object):
                 params['labels'] = self.parameters.labels
 
             if not self.check_mode:
-                resp = self.client.create_network(self.parameters.network_name, **params)
+                resp = self.client.create_network(self.parameters.name, **params)
                 self.client.report_warnings(resp, ['Warning'])
                 self.existing_network = self.client.get_network(id=resp['Id'])
-            self.results['actions'].append("Created network %s with driver %s" % (self.parameters.network_name, self.parameters.driver))
+            self.results['actions'].append("Created network %s with driver %s" % (self.parameters.name, self.parameters.driver))
             self.results['changed'] = True
 
     def remove_network(self):
         if self.existing_network:
             self.disconnect_all_containers()
             if not self.check_mode:
-                self.client.remove_network(self.parameters.network_name)
-            self.results['actions'].append("Removed network %s" % (self.parameters.network_name,))
+                self.client.remove_network(self.parameters.name)
+            self.results['actions'].append("Removed network %s" % (self.parameters.name,))
             self.results['changed'] = True
 
     def is_container_connected(self, container_name):
@@ -565,7 +565,7 @@ class DockerNetworkManager(object):
         for name in self.parameters.connected:
             if not self.is_container_connected(name):
                 if not self.check_mode:
-                    self.client.connect_container_to_network(name, self.parameters.network_name)
+                    self.client.connect_container_to_network(name, self.parameters.name)
                 self.results['actions'].append("Connected container %s" % (name,))
                 self.results['changed'] = True
                 self.diff_tracker.add('connected.{0}'.format(name),
@@ -584,7 +584,7 @@ class DockerNetworkManager(object):
                 self.disconnect_container(name)
 
     def disconnect_all_containers(self):
-        containers = self.client.get_network(name=self.parameters.network_name)['Containers']
+        containers = self.client.get_network(name=self.parameters.name)['Containers']
         if not containers:
             return
         for cont in containers.values():
@@ -592,7 +592,7 @@ class DockerNetworkManager(object):
 
     def disconnect_container(self, container_name):
         if not self.check_mode:
-            self.client.disconnect_container_from_network(container_name, self.parameters.network_name)
+            self.client.disconnect_container_from_network(container_name, self.parameters.name)
         self.results['actions'].append("Disconnected container %s" % (container_name,))
         self.results['changed'] = True
         self.diff_tracker.add('connected.{0}'.format(container_name),
@@ -633,7 +633,7 @@ class DockerNetworkManager(object):
 
 def main():
     argument_spec = dict(
-        network_name=dict(type='str', required=True, aliases=['name']),
+        name=dict(type='str', required=True, aliases=['network_name']),
         connected=dict(type='list', default=[], elements='str', aliases=['containers']),
         state=dict(type='str', default='present', choices=['present', 'absent']),
         driver=dict(type='str', default='bridge'),


### PR DESCRIPTION
##### SUMMARY
Backport of #57911 to stable-2.8. The sanity check doesn't exist in stable-2.8, but having the same code in stable-2.8 and devel IMO warrants to backport this change. This should have no visible effect to the end-user, that's why there's no changelog. It simply switches option name and alias in `argument_spec` so that `argument_spec` equals what is documented.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_network
