### PR TITLE
Added vserver to lun_info field to ensure unique LUN dict keys

### DIFF
--- a/changelogs/fragments/58260-na_ontap_gather_facts-lun_info.yaml
+++ b/changelogs/fragments/58260-na_ontap_gather_facts-lun_info.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - na_ontap_gather_facts - Added vserver to lun_info field to ensure unique LUN dict keys

--- a/changelogs/fragments/58260-na_ontap_gather_facts-lun_info.yaml
+++ b/changelogs/fragments/58260-na_ontap_gather_facts-lun_info.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - na_ontap_gather_facts - Added vserver to lun_info field to ensure unique LUN dict keys

--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -207,7 +207,7 @@ class NetAppONTAPGatherFacts(object):
                 'kwargs': {
                     'call': 'lun-get-iter',
                     'attribute': 'lun-info',
-                    'field': 'path',
+                    'field': ('path', 'vserver'),
                     'query': {'max-records': '1024'},
                 },
                 'min_version': '0',

--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -207,7 +207,7 @@ class NetAppONTAPGatherFacts(object):
                 'kwargs': {
                     'call': 'lun-get-iter',
                     'attribute': 'lun-info',
-                    'field': ('path', 'vserver'),
+                    'field': ('vserver', 'path'),
                     'query': {'max-records': '1024'},
                 },
                 'min_version': '0',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
na_ontap_gather_facts lun_info does not return all LUNs when they have same volume name and LUN name, in different SVMs, due to lun_info field using LUN path as key.

Added 'vserver' to LUN path for lun_info field (much the same as field for volume_info). Results in all LUNs having same LUN path being returned properly as dict key is unique.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_gather_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### ANSIBLE VERSION
```
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/jasonl4/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /bin/ansible
  python version = 3.6.8 (default, Apr 25 2019, 21:02:35) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
```

##### CONFIGURATION
```

```

##### OS / ENVIRONMENT
```
CentOS Linux release 7.5.1804 (Core)
NetApp Release 9.4P1: Fri Jul 20 23:17:19 UTC 2018 (ONTAP Select)
```


##### STEPS TO REPRODUCE
<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->

Create two LUNs in separate SVMs with same volume name and same LUN name.

```
cluster1::> lun show
Vserver   Path                            State   Mapped   Type        Size
--------- ------------------------------- ------- -------- -------- --------
svm1      /vol/vol1/lun1                  online  mapped   linux         1GB
svm2      /vol/vol1/lun1                  online  mapped   linux         1GB
2 entries were displayed.

cluster1::>
```

Execute following playbook to retrieve lun_info.
<!--- Paste example playbooks or commands between quotes below -->
```yaml
---
- hosts: localhost
  gather_facts: false
  vars_files:
    - globals.yml
  tasks:
  - na_ontap_gather_facts:
      state: info
      gather_subset:
        - "lun_info"
      hostname: "{{ hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      ontapi: 32
      https: true
      validate_certs: false
  - debug: var=ontap_facts['lun_info']
```

##### EXPECTED RESULTS
<!--- Describe what you expected to happen when running the steps above -->
Expect all LUNs to be returned by na_ontap_gather_facts.

##### ACTUAL RESULTS
<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
Only last LUN is returned due to lun_info dict key being the same for both LUNs. First LUN is overwritten by second LUN.


<!--- Paste verbatim command output between quotes -->
```paste below
PLAY [localhost] ************************************************************************************************************

TASK [na_ontap_gather_facts] ************************************************************************************************
ok: [localhost]

TASK [debug] ****************************************************************************************************************
ok: [localhost] => {
    "ontap_facts['lun_info']": {
        "/vol/vol1/lun1": {
            "alignment": "indeterminate",
            "block_size": "512",
            "class": "regular",
            "comment": null,
            "creation_timestamp": "1561163704",
            "is_clone": "false",
            "is_clone_autodelete_enabled": "false",
            "is_inconsistent_import": "false",
            "is_restore_inaccessible": "false",
            "is_space_alloc_enabled": "false",
            "is_space_reservation_enabled": "false",
            "mapped": "true",
            "multiprotocol_type": "linux",
            "node": "node1",
            "online": "true",
            "path": "/vol/vol1/lun1",
            "prefix_size": "0",
            "qtree": null,
            "read_only": "false",
            "serial_7_mode": null,
            "serial_number": "ZPevK+N7MJ8X",
            "share_state": "none",
            "size": "1073741824",
            "size_used": "0",
            "staging": "false",
            "state": "online",
            "suffix_size": "0",
            "uuid": "49c61b1f-a47d-4650-b724-03f5e7d040b2",
            "volume": "vol1",
            "vserver": "svm2"
        }
    }
}

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

##### PROPOSED FIX

Added vserver to LUN path for lun_info field (much the same as field for volume_info). Results in both LUNs being returned properly as dict key is unique. volume_info uses similar method for key uniqueness.

```
PLAY [localhost] ************************************************************************************************************

TASK [na_ontap_gather_facts] ************************************************************************************************
ok: [localhost]

TASK [debug] ****************************************************************************************************************
ok: [localhost] => {
    "ontap_facts['lun_info']": {
        "/vol/vol1/lun1:svm1": {
            "alignment": "indeterminate",
            "block_size": "512",
            "class": "regular",
            "comment": null,
            "creation_timestamp": "1561163199",
            "is_clone": "false",
            "is_clone_autodelete_enabled": "false",
            "is_inconsistent_import": "false",
            "is_restore_inaccessible": "false",
            "is_space_alloc_enabled": "false",
            "is_space_reservation_enabled": "false",
            "mapped": "true",
            "multiprotocol_type": "linux",
            "node": "node1",
            "online": "true",
            "path": "/vol/vol1/lun1",
            "prefix_size": "0",
            "qtree": null,
            "read_only": "false",
            "serial_7_mode": null,
            "serial_number": "ZPevK+N7MJ8W",
            "share_state": "none",
            "size": "1073741824",
            "size_used": "0",
            "staging": "false",
            "state": "online",
            "suffix_size": "0",
            "uuid": "2f8f3c7e-72ad-496a-bd68-9509929f9366",
            "volume": "vol1",
            "vserver": "svm1"
        },
        "/vol/vol1/lun1:svm2": {
            "alignment": "indeterminate",
            "block_size": "512",
            "class": "regular",
            "comment": null,
            "creation_timestamp": "1561163704",
            "is_clone": "false",
            "is_clone_autodelete_enabled": "false",
            "is_inconsistent_import": "false",
            "is_restore_inaccessible": "false",
            "is_space_alloc_enabled": "false",
            "is_space_reservation_enabled": "false",
            "mapped": "true",
            "multiprotocol_type": "linux",
            "node": "node1",
            "online": "true",
            "path": "/vol/vol1/lun1",
            "prefix_size": "0",
            "qtree": null,
            "read_only": "false",
            "serial_7_mode": null,
            "serial_number": "ZPevK+N7MJ8X",
            "share_state": "none",
            "size": "1073741824",
            "size_used": "0",
            "staging": "false",
            "state": "online",
            "suffix_size": "0",
            "uuid": "49c61b1f-a47d-4650-b724-03f5e7d040b2",
            "volume": "vol1",
            "vserver": "svm2"
        }
    }
}

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
