### PR TITLE
Allow None Type for safe_eval

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -50,6 +50,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # also add back some builtins we do need
         'True': True,
         'False': False,
+        'None': None
     }
 
     # this is the whitelist of AST nodes we are going to


### PR DESCRIPTION
##### SUMMARY
In some scenarios safe_eval fails with the error `NameError("name 'None' is not defined")`. This causes valid JSON to not be correctly evaluated into a python dictionary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
safe_eval

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
