### PR TITLE
Fix junos netconf plugin get_configuration filter

### DIFF
--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -23,6 +23,7 @@ import json
 import re
 
 from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.six import string_types
 from ansible.errors import AnsibleConnectionFailure
 from ansible.plugins.netconf import NetconfBase
 from ansible.plugins.netconf import ensure_connected, ensure_ncclient
@@ -141,8 +142,15 @@ class Netconf(NetconfBase):
         Retrieve all or part of a specified configuration.
         :param format: format in which configuration should be retrieved
         :param filter: specifies the portion of the configuration to retrieve
+               as either xml string rooted in <configuration> element
         :return: Received rpc response from remote host in string format
         """
+        if filter is not None:
+            if not isinstance(filter, string_types):
+                raise AnsibleConnectionFailure("get configuration filter should be of type string,"
+                                               " received value '%s' is of type '%s'" % (filter, type(filter)))
+            filter = to_ele(filter)
+
         return self.m.get_configuration(format=format, filter=filter).data_xml
 
     @ensure_connected


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* junos `get_configuration` netconf api expects the
  filter as instance of ElementTree object hence convert 
  filter in string format to Elementtree node
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/junos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
