### PR TITLE
documentation Backport of #58279: Coherence between example and text (use of to_native)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -25,7 +25,7 @@ You must write your plugin in Python so it can be loaded by the ``PluginLoader``
 Raising errors
 ==============
 
-You should return errors encountered during plugin execution by raising ``AnsibleError()`` or a similar class with a message describing the error. When wrapping other exceptions into error messages, you should always use the ``to_text`` Ansible function to ensure proper string compatibility across Python versions:
+You should return errors encountered during plugin execution by raising ``AnsibleError()`` or a similar class with a message describing the error. When wrapping other exceptions into error messages, you should always use the ``to_native`` Ansible function to ensure proper string compatibility across Python versions:
 
 .. code-block:: python
 


### PR DESCRIPTION
(cherry picked from commit 4376e88849a7cf3be2613d0d12a49fa839ab2bd3)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current documentation is not coherent between example and text. In the example, the to_native function is used whereas the to_text function is mentioned in the text. This PR correct this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

    developing_plugins.rst.


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
