### PR TITLE
[2.8]  acme_*: upgrade test container

### DIFF
--- a/test/runner/lib/cloud/acme.py
+++ b/test/runner/lib/cloud/acme.py
@@ -44,7 +44,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.5.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.6.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Backport of #58294 to stable-2.8. Bumps test container version which includes more strict checking for RFC conformance of `acme_certificate` module.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/runner/lib/cloud/acme.py
