### PR TITLE
docker_swarm_service: Make secret_id and config_id optional

### DIFF
--- a/changelogs/fragments/58299-docker_swarm_service-remove-required-config-secret-id.yml
+++ b/changelogs/fragments/58299-docker_swarm_service-remove-required-config-secret-id.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_swarm_service - Remove requirement of ``secret_id`` on ``secrets`` and ``config_id`` on ``configs``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -991,8 +991,7 @@ EXAMPLES = '''
     name: myservice
     image: alpine:edge
     configs:
-      - config_id: myconfig_id
-        config_name: myconfig_name
+      - config_name: myconfig_name
         filename: "/tmp/config.txt"
 
 - name: Set networks
@@ -1007,8 +1006,7 @@ EXAMPLES = '''
     name: myservice
     image: alpine:edge
     secrets:
-      - secret_id: mysecret_id
-        secret_name: mysecret_name
+      - secret_name: mysecret_name
         filename: "/run/secrets/secret.txt"
 
 - name: Start service with healthcheck

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2338,11 +2338,11 @@ class DockerServiceManager(object):
         if not secret_names:
             return {}
         secrets = self.client.secrets(filters={'name': secret_names})
-        secrets = {
-            secret['Spec']['Name']: secret['ID']
+        secrets = dict(
+            (secret['Spec']['Name'], secret['ID'])
             for secret in secrets
             if secret['Spec']['Name'] in secret_names
-        }
+        )
         for secret_name in secret_names:
             if secret_name not in secrets:
                 self.client.fail(
@@ -2362,11 +2362,11 @@ class DockerServiceManager(object):
         if not config_names:
             return {}
         configs = self.client.configs(filters={'name': config_names})
-        configs = {
-            config['Spec']['Name']: config['ID']
+        configs = dict(
+            (config['Spec']['Name'], config['ID'])
             for config in configs
             if config['Spec']['Name'] in config_names
-        }
+        )
         for config_name in config_names:
             if config_name not in configs:
                 self.client.fail(

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -48,8 +48,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
-      - config_id: "{{ config_result_1.config_id|default('') }}"
-        config_name: "{{ config_name_1 }}"
+      - config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
   register: configs_2
   ignore_errors: yes
@@ -64,10 +63,23 @@
       - config_id: "{{ config_result_1.config_id|default('') }}"
         config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
-      - config_id: "{{ config_result_2.config_id|default('') }}"
-        config_name: "{{ config_name_2 }}"
+      - config_name: "{{ config_name_2 }}"
         filename: "/tmp/{{ config_name_2 }}.txt"
   register: configs_3
+  ignore_errors: yes
+
+- name: configs (add idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+      - config_name: "{{ config_name_2 }}"
+        filename: "/tmp/{{ config_name_2 }}.txt"
+  register: configs_4
   ignore_errors: yes
 
 - name: configs (empty)
@@ -77,7 +89,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
-  register: configs_4
+  register: configs_5
   ignore_errors: yes
 
 - name: configs (empty idempotency)
@@ -87,7 +99,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
-  register: configs_5
+  register: configs_6
   ignore_errors: yes
 
 - name: cleanup
@@ -101,8 +113,9 @@
     - configs_1 is changed
     - configs_2 is not changed
     - configs_3 is changed
-    - configs_4 is changed
-    - configs_5 is not changed
+    - configs_4 is not changed
+    - configs_5 is changed
+    - configs_6 is not changed
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - assert:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -77,9 +77,24 @@
     configs:
       - config_name: "{{ config_name_1 }}"
         filename: "/tmp/{{ config_name_1 }}.txt"
-      - config_name: "{{ config_name_2 }}"
+      - config_id: "{{ config_result_2.config_id|default('') }}"
+        config_name: "{{ config_name_2 }}"
         filename: "/tmp/{{ config_name_2 }}.txt"
   register: configs_4
+  ignore_errors: yes
+
+- name: configs (add idempotency no id)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    configs:
+      - config_name: "{{ config_name_1 }}"
+        filename: "/tmp/{{ config_name_1 }}.txt"
+      - config_name: "{{ config_name_2 }}"
+        filename: "/tmp/{{ config_name_2 }}.txt"
+  register: configs_5
   ignore_errors: yes
 
 - name: configs (empty)
@@ -89,7 +104,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
-  register: configs_5
+  register: configs_6
   ignore_errors: yes
 
 - name: configs (empty idempotency)
@@ -99,7 +114,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
-  register: configs_6
+  register: configs_7
   ignore_errors: yes
 
 - name: cleanup
@@ -114,8 +129,9 @@
     - configs_2 is not changed
     - configs_3 is changed
     - configs_4 is not changed
-    - configs_5 is changed
-    - configs_6 is not changed
+    - configs_5 is not changed
+    - configs_6 is changed
+    - configs_7 is not changed
   when: docker_api_version is version('1.30', '>=') and docker_py_version is version('2.6.0', '>=')
 
 - assert:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -48,8 +48,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
-      - secret_id: "{{ secret_result_1.secret_id|default('') }}"
-        secret_name: "{{ secret_name_1 }}"
+      - secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
   register: secrets_2
   ignore_errors: yes
@@ -64,10 +63,23 @@
       - secret_id: "{{ secret_result_1.secret_id|default('') }}"
         secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
-      - secret_id: "{{ secret_result_2.secret_id|default('') }}"
-        secret_name: "{{ secret_name_2 }}"
+      - secret_name: "{{ secret_name_2 }}"
         filename: "/run/secrets/{{ secret_name_2 }}.txt"
   register: secrets_3
+  ignore_errors: yes
+
+- name: secrets (add idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_name: "{{ secret_name_1 }}"
+        filename: "/run/secrets/{{ secret_name_1 }}.txt"
+      - secret_name: "{{ secret_name_2 }}"
+        filename: "/run/secrets/{{ secret_name_2 }}.txt"
+  register: secrets_4
   ignore_errors: yes
 
 - name: secrets (empty)
@@ -77,7 +89,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
-  register: secrets_4
+  register: secrets_5
   ignore_errors: yes
 
 - name: secrets (empty idempotency)
@@ -87,7 +99,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
-  register: secrets_5
+  register: secrets_6
   ignore_errors: yes
 
 - name: cleanup
@@ -101,8 +113,9 @@
       - secrets_1 is changed
       - secrets_2 is not changed
       - secrets_3 is changed
-      - secrets_4 is changed
-      - secrets_5 is not changed
+      - secrets_4 is not changed
+      - secrets_5 is changed
+      - secrets_6 is not changed
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
 - assert:
     that:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -77,9 +77,24 @@
     secrets:
       - secret_name: "{{ secret_name_1 }}"
         filename: "/run/secrets/{{ secret_name_1 }}.txt"
-      - secret_name: "{{ secret_name_2 }}"
+      - secret_id: "{{ secret_result_2.secret_id|default('') }}"
+        secret_name: "{{ secret_name_2 }}"
         filename: "/run/secrets/{{ secret_name_2 }}.txt"
   register: secrets_4
+  ignore_errors: yes
+
+- name: secrets (add idempotency no id)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    secrets:
+      - secret_name: "{{ secret_name_1 }}"
+        filename: "/run/secrets/{{ secret_name_1 }}.txt"
+      - secret_name: "{{ secret_name_2 }}"
+        filename: "/run/secrets/{{ secret_name_2 }}.txt"
+  register: secrets_5
   ignore_errors: yes
 
 - name: secrets (empty)
@@ -89,7 +104,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
-  register: secrets_5
+  register: secrets_6
   ignore_errors: yes
 
 - name: secrets (empty idempotency)
@@ -99,7 +114,7 @@
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
-  register: secrets_6
+  register: secrets_7
   ignore_errors: yes
 
 - name: cleanup
@@ -114,8 +129,9 @@
       - secrets_2 is not changed
       - secrets_3 is changed
       - secrets_4 is not changed
-      - secrets_5 is changed
-      - secrets_6 is not changed
+      - secrets_5 is not changed
+      - secrets_6 is changed
+      - secrets_7 is not changed
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR removes the requirement of parameters `secret_id` for `secrets` and `config_id` for `configs`. If these parameters are not set the `*_name` will be used to look up the `*_id`.

Not really sure if something should be added to make the documentation bit clearer.

The lookups is made in the `DockerServiceManager` and then passed to `DockerService` through `from_ansible_params` instead of directly in `DockerService` . This is because `DockerService` is written to not have a dependency on the docker client. 

It should be fine to not have any version checks in `get_missing_secret_ids` and `get_missing_config_ids` as it will exit early if `secrets` and `configs` are not set and this will be the case if a user is running a docker version not supporting configs / secrets.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #55009

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
