### PR TITLE
Fix onepassword lookup plugin and onepassword_facts module when a field has no name.

### DIFF
--- a/changelogs/fragments/fix_onepassword_failing_on_field_with_no_name.yaml
+++ b/changelogs/fragments/fix_onepassword_failing_on_field_with_no_name.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - onepassword - fix onepassword lookup plugin failing on fields without a name or t property (https://github.com/ansible/ansible/pull/58308)
+  - onepassword_facts - fix onepassword_facts module failing on fields without a name or t property (https://github.com/ansible/ansible/pull/58308)

--- a/lib/ansible/modules/identity/onepassword_facts.py
+++ b/lib/ansible/modules/identity/onepassword_facts.py
@@ -206,7 +206,7 @@ class OnePasswordFacts(object):
             else:
                 if section_title is None:
                     for field_data in data['details'].get('fields', []):
-                        if field_data.get('name').lower() == field_name.lower():
+                        if field_data.get('name', '').lower() == field_name.lower():
                             return {field_name: field_data.get('value', '')}
 
                 # Not found it yet, so now lets see if there are any sections defined
@@ -216,7 +216,7 @@ class OnePasswordFacts(object):
                     if section_title is not None and section_title.lower() != section_data['title'].lower():
                         continue
                     for field_data in section_data.get('fields', []):
-                        if field_data.get('t').lower() == field_name.lower():
+                        if field_data.get('t', '').lower() == field_name.lower():
                             return {field_name: field_data.get('v', '')}
 
         # We will get here if the field could not be found in any section and the item wasn't a document to be downloaded.

--- a/lib/ansible/plugins/lookup/onepassword.py
+++ b/lib/ansible/plugins/lookup/onepassword.py
@@ -203,13 +203,13 @@ class OnePass(object):
         data = json.loads(data_json)
         if section_title is None:
             for field_data in data['details'].get('fields', []):
-                if field_data.get('name').lower() == field_name.lower():
+                if field_data.get('name', '').lower() == field_name.lower():
                     return field_data.get('value', '')
         for section_data in data['details'].get('sections', []):
             if section_title is not None and section_title.lower() != section_data['title'].lower():
                 continue
             for field_data in section_data.get('fields', []):
-                if field_data.get('t').lower() == field_name.lower():
+                if field_data.get('t', '').lower() == field_name.lower():
                     return field_data.get('v', '')
         return ''
 

--- a/test/units/plugins/lookup/test_onepassword.py
+++ b/test/units/plugins/lookup/test_onepassword.py
@@ -95,7 +95,8 @@ MOCK_ENTRIES = [
                     {
                         'name': 'password',
                         'value': 'vauxhall'
-                    }
+                    },
+                    {},
                 ]
             }
         }
@@ -105,8 +106,8 @@ MOCK_ENTRIES = [
 
 def get_mock_query_generator(require_field=None):
     def _process_field(field, section_title=None):
-        field_name = field.get('name', field.get('t'))
-        field_value = field.get('value', field.get('v'))
+        field_name = field.get('name', field.get('t', ''))
+        field_value = field.get('value', field.get('v', ''))
 
         if require_field is None or field_name == require_field:
             return entry, query, section_title, field_name, field_value


### PR DESCRIPTION
##### SUMMARY

In the `onepassword` lookup plugin and the `onepassword_facts` module, there are two calls in `_parse_field`: `field_data.get('name').lower()` and `field_data.get('t').lower()`, that fail with `'NoneType' object has no attribute 'lower'` when a field without a `name` or `t` property is tested.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

onepassword
onepassword_facts

##### ADDITIONAL INFORMATION

1Password item to reproduce the issue (save in a file called `data.1pif`, and in 1Password (7.3 as of this writing), choose File -> Import… > Other > Import a 1PIF File):

```
{"uuid":"kc37kxl6kvfgdctkzxl4dy5b4b","updatedAt":1559828272,"locationKey":"doodle.com","securityLevel":"SL5","contentsHash":"a730ed03","title":"ansible_test_item","location":"https:\/\/doodle.com","secureContents":{"URLs":[{"label":"website","url":"https:\/\/doodle.com"}],"htmlMethod":"LB1","fields":[{"id":";opid=__0","value":"Retour","type":"B"},{"id":";opid=__1","value":"","name":"email","type":"T"},{"id":";opid=__2","value":"SetecAstronomy","name":"password","type":"P"},{"id":";opid=__3","value":"Toggle Password Visibility","type":"B"},{"id":";opid=__4","value":"Se connecter","type":"I"},{"id":";opid=__5","value":"Mot de passe oublié ?","type":"B"},{"id":";opid=__6","value":"Retour","type":"B"},{"id":";opid=__7","value":"Ansible","name":"name","type":"T"},{"id":";opid=__8","value":"ansible@example.com","name":"email","type":"T","designation":"username"},{"id":";opid=__9","value":"SetecAstronomy","name":"password","type":"P","designation":"password"},{"id":";opid=__10","value":"Toggle Password Visibility","type":"B"},{"id":";opid=__11","value":"S'inscrire","type":"I"},{"id":";opid=__12","value":"Continuer avec Microsoft","type":"B"},{"id":";opid=__13","value":"Continuer avec Google","type":"B"},{"id":";opid=__14","value":"Continuer avec Facebook","type":"B"}]},"createdAt":1559828258,"typeName":"webforms.WebForm"}
***5642bee8-a5ff-11dc-8314-0800200c9a66***
```

I tried creating a minimal failing item using the `op` command, but I didn’t succeed.

Steps to reproduce:

1. Sign in to the 1Password CLI tool;

2. Run the following playbook:

```yaml
- name:
  hosts: localhost
  tasks:
  - name: Retrieve password for ansible_test_item when already signed in to 1Password
    debug:
      var: lookup('onepassword', 'ansible_test_item')
    tags: lookup

  - name: Get ansible_test_item password
    onepassword_facts:
      search_terms: ansible_test_item
    register: onepassword_result
    tags: module

  - debug:
      var: onepassword_result
    tags: module
```

with:

```sh
ansible-playbook 1p.yml --tags=lookup
```

which fails with:

```
TASK [Retrieve password for ansible_test_item when already signed in to 1Password] ************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'onepassword'. Error was a <class 'AttributeError'>, original message: 'NoneType' object has no attribute 'lower'"}
```

or:

```sh
ansible-playbook 1p.yml --tags=module
```

which fails with:

```
TASK [Get ansible_test_item password] *********************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'lower'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/Users/olivier/.ansible/tmp/ansible-tmp-1561417431.060097-139851445115750/AnsiballZ_onepassword_facts.py\", line 125, in <module>\n    _ansiballz_main()\n  File \"/Users/olivier/.ansible/tmp/ansible-tmp-1561417431.060097-139851445115750/AnsiballZ_onepassword_facts.py\", line 117, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/Users/olivier/.ansible/tmp/ansible-tmp-1561417431.060097-139851445115750/AnsiballZ_onepassword_facts.py\", line 51, in invoke_module\n    spec.loader.exec_module(module)\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/var/folders/wv/9whpc7fn1gd2lyb9zg1_yp0h0000gn/T/ansible_onepassword_facts_payload_1k76ideu/__main__.py\", line 370, in <module>\n  File \"/var/folders/wv/9whpc7fn1gd2lyb9zg1_yp0h0000gn/T/ansible_onepassword_facts_payload_1k76ideu/__main__.py\", line 364, in main\n  File \"/var/folders/wv/9whpc7fn1gd2lyb9zg1_yp0h0000gn/T/ansible_onepassword_facts_payload_1k76ideu/__main__.py\", line 334, in run\n  File \"/var/folders/wv/9whpc7fn1gd2lyb9zg1_yp0h0000gn/T/ansible_onepassword_facts_payload_1k76ideu/__main__.py\", line 260, in get_field\n  File \"/var/folders/wv/9whpc7fn1gd2lyb9zg1_yp0h0000gn/T/ansible_onepassword_facts_payload_1k76ideu/__main__.py\", line 209, in _parse_field\nAttributeError: 'NoneType' object has no attribute 'lower'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After fix:

```sh
ansible-playbook 1p.yml
```

succeeds:

```
TASK [Retrieve password for ansible_test_item when already signed in to 1Password] ************************************************************
ok: [localhost] => {
    "lookup('onepassword', 'ansible_test_item')": "SetecAstronomy"
}

TASK [Get ansible_test_item password] *********************************************************************************************************
ok: [localhost]

TASK [debug] **********************************************************************************************************************************
ok: [localhost] => {
    "onepassword_result": {
        "ansible_facts": {
            "onepassword": {
                "ansible_test_item": {
                    "password": "SetecAstronomy"
                }
            }
        },
        "changed": false,
        "failed": false
    }
}
```

It’s an edge case. I had trouble reproducing it. But it happened on the first item I tested the plugin and module with (I know, I’m lucky that way ;-), and the fix is very simple and won’t hurt: without the call to `lower()`, the field would be skipped the same way as with the default to an empty string.

I don’t have a sample 1Password item that demonstrates a failure on a field without a `t` property, but I don’t think it hurts to include the default there too.
