### PR TITLE
[2.8] ipaddr: Handle ipaddress index in network correctly

### DIFF
--- a/changelogs/fragments/57896-fix-ipaddr-cidr-index-handling.yml
+++ b/changelogs/fragments/57896-fix-ipaddr-cidr-index-handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - 'ipaddr: prevent integer indices from being parsed as ip nets (https://github.com/ansible/ansible/issues/57895).'

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -630,7 +630,7 @@ def ipaddr(value, query='', version=False, alias='ipaddr'):
     # address/network is inside that specific subnet
     try:
         # ?? 6to4 and link-local were True here before.  Should they still?
-        if query and (query not in query_func_map or query == 'cidr_lookup') and ipaddr(query, 'network'):
+        if query and (query not in query_func_map or query == 'cidr_lookup') and not str(query).isdigit() and ipaddr(query, 'network'):
             iplist = netaddr.IPSet([netaddr.IPNetwork(query)])
             query = 'cidr_lookup'
     except Exception:

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -270,6 +270,17 @@
       - "'192.168.0.1/24' | ipaddr('network') == '192.168.0.0'"
       - "'fe80::dead:beef/64' | ipaddr('broadcast') == 'fe80::ffff:ffff:ffff:ffff'"
       - "'::1/120' | ipaddr('netmask') == 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00'"
+      - "{{ subnets | ipaddr(1) }} == ['10.1.1.1/24', '10.1.2.1/24']"
+      - "{{ subnets | ipaddr('1') }}  == ['10.1.1.1/24', '10.1.2.1/24']"
+      - "{{ subnets | ipaddr(-1) }} == ['10.1.1.255/24', '10.1.2.255/24']"
+      - "{{ subnets | ipaddr('-1') }} == ['10.1.1.255/24', '10.1.2.255/24']"
+      - "'{{ prefix | ipaddr(1) }}'  == '10.1.1.1/24'"
+      - "'{{ prefix | ipaddr('1') }}' == '10.1.1.1/24'"
+      - "'{{ prefix | ipaddr('network') }}' == '10.1.1.0'"
+      - "'{{ prefix | ipaddr('-1') }}' == '10.1.1.255/24'"
+  vars:
+    subnets: ['10.1.1.0/24', '10.1.2.0/24']
+    prefix: '10.1.1.0/24'
 
 - name: Ensure dict2items works with hostvars
   debug:


### PR DESCRIPTION
##### SUMMARY
* This commit prevents integer indices from being parsed as ip nets
* ipaddr: unit tests for empty string

Fixes #57895

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit e7c39460edfb3e960e8054b1d7eda80a2d666e92)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/57896-fix-ipaddr-cidr-index-handling.yml
lib/ansible/plugins/filter/ipaddr.py
test/integration/targets/filters/tasks/main.yml