### PR TITLE
Detect virtualization facts when VM on Nutanix AHV hypervisor

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -85,7 +85,7 @@ class LinuxVirtual(Virtual):
 
         product_name = get_file_content('/sys/devices/virtual/dmi/id/product_name')
 
-        if product_name in ('KVM', 'Bochs'):
+        if product_name in ('KVM', 'Bochs', 'AHV'):
             virtual_facts['virtualization_type'] = 'kvm'
             return virtual_facts
 
@@ -117,7 +117,7 @@ class LinuxVirtual(Virtual):
 
         sys_vendor = get_file_content('/sys/devices/virtual/dmi/id/sys_vendor')
 
-        KVM_SYS_VENDORS = ('QEMU', 'oVirt', 'Amazon EC2', 'DigitalOcean', 'Google', 'Scaleway')
+        KVM_SYS_VENDORS = ('QEMU', 'oVirt', 'Amazon EC2', 'DigitalOcean', 'Google', 'Scaleway', 'Nutanix')
         if sys_vendor in KVM_SYS_VENDORS:
             virtual_facts['virtualization_type'] = 'kvm'
             return virtual_facts


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Virtualization facts: detect when vm guest is running nutanix ahv hypervisor (https://github.com/ansible/ansible/issues/57732)
(module_utils/facts/virtual/linux.py). 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module_utils/facts/virtual/linux.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

https://github.com/ansible/ansible/issues/57732

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
