### PR TITLE
routeros_command: support spaces in device identity

### DIFF
--- a/lib/ansible/plugins/terminal/routeros.py
+++ b/lib/ansible/plugins/terminal/routeros.py
@@ -47,7 +47,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"\x1b<"),
-        re.compile(br"\[\w+\@[\w\-\.]+\] ?> ?$"),
+        re.compile(br"\[\w+\@[\w\s\-\.]+\] ?> ?$"),
         re.compile(br"Please press \"Enter\" to continue!"),
         re.compile(br"Do you want to see the software license\? \[Y\/n\]: ?"),
     ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #53199.

Previously when a RouterOS device had spaces in its identity string the connection would fail with a timeout. This PR fixes this behaviour and adds support for spaces in identity strings.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
routeros_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
