### PR TITLE
[stable-2.6] also allow None Type for safe eval (#58269)

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -50,6 +50,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # also add back some builtins we do need
         'True': True,
         'False': False,
+        'None': None
     }
 
     # this is the whitelist of AST nodes we are going to


### PR DESCRIPTION
(cherry picked from commit 8555b72)

Co-authored-by: markafarrell <mark.andrew.farrell@gmail.com>

##### SUMMARY
Fix a regression in the security fix for safe_eval

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/safe_eval.py

##### ADDITIONAL INFORMATION
