### PR TITLE
[WIP] Add documentation on setting locale when running ansible

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -141,6 +141,10 @@ For example, to run tests for the ``ping`` module on a Ubuntu 14.04 container::
 
     ansible-test integration -v ping --docker ubuntu1404
 
+.. note:: Running ansible-test in a container
+
+    When running ``ansible-test`` inside a container, be sure te set ``LC_ALL`` to a utf-8 locale, e.g., ``en_US.UTF-8``. If no locale is set within the container, errors will occur when non-ASCII characters are encountered.
+
 Container Images
 ----------------
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

It is important to have an appropriate locale defined in the environment where Ansible is running. Ansible uses the system locale when decoding strings. If it is set to a non-UTF-8 locale and non-ASCII characters are encountered, there will be stack traces.

This comes up most commonly when running Ansible inside of containers since the environment inside a container may not have a locale defined.

Fixes #56587
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`docs/docsite/rst/dev_guide/testing_integration.rst`