### PR TITLE
Set _ansible_verbose_override in gather_facts action plugin

### DIFF
--- a/changelogs/fragments/58310-gather-facts-verbosity.yml
+++ b/changelogs/fragments/58310-gather-facts-verbosity.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- gather_facts - Prevent gather_facts from being verbose, just like is done
+  in the normal action plugin for setup (https://github.com/ansible/ansible/issues/58310)

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -119,4 +119,7 @@ class ActionModule(ActionBase):
         # tell executor facts were gathered
         result['ansible_facts']['_ansible_facts_gathered'] = True
 
+        # hack to keep --verbose from showing all the setup module result
+        result['_ansible_verbose_override'] = True
+
         return result


### PR DESCRIPTION
##### SUMMARY
Set `_ansible_verbose_override` in gather_facts action plugin. Fixes #58310

This prevents `gather_facts` from being verbose, matching the logic in `normal.py` for `setup`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/gather_facts.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```