### PR TITLE
[stable-2.8] Set _ansible_verbose_override in gather_facts action plugin. Fixes #58310 (#58339)

### DIFF
--- a/changelogs/fragments/58310-gather-facts-verbosity.yml
+++ b/changelogs/fragments/58310-gather-facts-verbosity.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- gather_facts - Prevent gather_facts from being verbose, just like is done
+  in the normal action plugin for setup (https://github.com/ansible/ansible/issues/58310)

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -115,4 +115,7 @@ class ActionModule(ActionBase):
         # tell executor facts were gathered
         result['ansible_facts']['_ansible_facts_gathered'] = True
 
+        # hack to keep --verbose from showing all the setup module result
+        result['_ansible_verbose_override'] = True
+
         return result


### PR DESCRIPTION
(cherry picked from commit bc25ac2)


Co-authored-by: Matt Martz <matt@sivel.net>