### PR TITLE
Fix "no matches for wildcard" error in env-setup.fish script.

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -65,8 +65,9 @@ set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
 # Do the work in a fuction
 function gen_egg_info
-
-    if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
+    # Cannot use `test` on wildcards. 
+    # @see https://github.com/fish-shell/fish-shell/issues/5960
+    if count $PREFIX_PYTHONPATH/ansible*.egg-info > /dev/null
         rm -rf "$PREFIX_PYTHONPATH/ansible*.egg-info"
     end
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -68,7 +68,7 @@ function gen_egg_info
     # Cannot use `test` on wildcards. 
     # @see https://github.com/fish-shell/fish-shell/issues/5960
     if count $PREFIX_PYTHONPATH/ansible*.egg-info > /dev/null
-        rm -rf "$PREFIX_PYTHONPATH/ansible*.egg-info"
+        rm -rf $PREFIX_PYTHONPATH/ansible*.egg-info
     end
 
     if [ $QUIET ]


### PR DESCRIPTION
##### SUMMARY
Fix "no matches for wildcard" error in env-setup.fish script. See https://github.com/fish-shell/fish-shell/issues/5960

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/env-setup.fish

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**Before**
```paste below
> ❯ source ./hacking/env-setup.fish
./hacking/env-setup.fish (line 69): No matches for wildcard “$PREFIX_PYTHONPATH/ansible*.egg-info”. See `help expand`.
    if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
               ^
in function “gen_egg_info”
        called on line 88 of file ./hacking/env-setup.fish
from sourcing file ./hacking/env-setup.fish
        called on standard input
```
**After**
```

> ❯ source ./hacking/env-setup.fish                                      
> Appending PYTHONPATH                                                   
> running egg_info 
...
```