### PR TITLE
Mark number as required

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -44,6 +44,7 @@ options:
       that will be created.
     - Required when performing any action on the disk, except fetching information.
     type: int
+    required: True
   unit:
     description:
     - Selects the current default unit that Parted will use to display


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
While used the parted module, I received this error:

FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: number"}

This leads me to believe that the number attribute is required; however, the documentation does not currently reflect this.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
