### PR TITLE
document problem when removing something from a dictionary

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -40,6 +40,12 @@ extends_documentation_fragment:
   - k8s_resource_options
   - k8s_auth_options
 
+notes:
+  - If you are trying to remove an item from an associative array/dictionary,
+    for example a label or an annotation, you will need to explicitly set the
+    value of the item to be removed to `null`. Simply deleting the entry in the
+    dictionary will not remove it from openshift or kubernetes.
+
 options:
   merge_type:
     description:


### PR DESCRIPTION
##### SUMMARY
Document a problem with the k8s module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION
The problem is described at https://github.com/ansible/ansible/pull/49053#issuecomment-480427406 . This simply documents the problem so other people don't spend time trying to debug why labels or annotations they're deleting don't actually get deleted in openshift/kubernetes when they use the k8s module.
