### PR TITLE
Update net_interface.py to fix small typo

### DIFF
--- a/lib/ansible/modules/network/interface/net_interface.py
+++ b/lib/ansible/modules/network/interface/net_interface.py
@@ -109,7 +109,7 @@ EXAMPLES = """
     mtu: 512
 
 - name: Delete interface using aggregate
-  junos_interface:
+  net_interface:
     aggregate:
       - { name: ge-0/0/1 }
       - { name: ge-0/0/2 }


### PR DESCRIPTION
##### SUMMARY
typo in usage example  -- net_interface module accidentally listed as junos_interface


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

junos_interface should be net_interface, changed to reflect correct module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Documentation

##### ADDITIONAL INFORMATION
Small update to documentation for net_interface module.