### PR TITLE
validate-modules - Better fix for invalid data in 'options' field

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1178,13 +1178,13 @@ class ModuleValidator(Validator):
                 deprecated_args_from_argspec.add(arg)
                 deprecated_args_from_argspec.update(data.get('aliases', []))
             if arg == 'provider' and self.object_path.startswith('lib/ansible/modules/network/'):
-                if data.get('options') and not isinstance(data.get('options'), Mapping):
+                if data.get('options') is not None and not isinstance(data.get('options'), Mapping):
                     self.reporter.error(
                         path=self.object_path,
                         code=331,
                         msg="Argument 'options' in argument_spec['provider'] must be a dictionary/hash when used",
                     )
-                else:
+                elif data.get('options'):
                     # Record provider options from network modules, for later comparison
                     for provider_arg, provider_data in data.get('options', {}).items():
                         provider_args.add(provider_arg)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was not entirely fixed by #58078 since an empty string evaluates to `False` bypassing the warning and going into the code that is expecting a dictionary.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`test/sanity/validate-modules/main.py`