### PR TITLE
Docs: add Pygments lexer for Ansible output (#50318)

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -582,4 +582,3 @@ Be aware of the following limitations with ``become`` on Windows:
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `webchat.freenode.net <https://webchat.freenode.net>`_
        #ansible IRC chat channel
-


### PR DESCRIPTION
* Add specialized lexer for Ansible output.

* Make linter happy.

* Use different tokens.

(cherry picked from commit 9657a21438acb94d8fa2015df1491fc24e887bbb)

##### SUMMARY
Take Two on backporting the lexer fixes. 

Backports fixes to support better code examples in the documentation.

Related to #58101.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
