### PR TITLE
facts: fix double-counting of CPUs on POWER systems

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -239,8 +239,9 @@ class LinuxHardware(Hardware):
 
         # The fields for ARM CPUs do not always include 'vendor_id' or 'model name',
         # and sometimes includes both 'processor' and 'Processor'.
-        # Always use 'processor' count for ARM systems
-        if collected_facts.get('ansible_architecture', '').startswith(('armv', 'aarch')):
+        # The fields for Power CPUs include 'processor' and 'cpu'.
+        # Always use 'processor' count for ARM and Power systems
+        if collected_facts.get('ansible_architecture', '').startswith(('armv', 'aarch', 'ppc')):
             i = processor_occurence
 
         # FIXME

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -495,9 +495,9 @@ CPU_INFO_TEST_SCENARIOS = [
                 '7', 'POWER7 (architected), altivec supported'
             ],
             'processor_cores': 1,
-            'processor_count': 16,
+            'processor_count': 8,
             'processor_threads_per_core': 1,
-            'processor_vcpus': 16
+            'processor_vcpus': 8
         },
     },
     {
@@ -531,9 +531,9 @@ CPU_INFO_TEST_SCENARIOS = [
                 '23', 'POWER8 (architected), altivec supported',
             ],
             'processor_cores': 1,
-            'processor_count': 48,
+            'processor_count': 24,
             'processor_threads_per_core': 1,
-            'processor_vcpus': 48
+            'processor_vcpus': 24
         },
     },
     {

--- a/test/units/module_utils/facts/hardware/test_linux_get_cpu_info.py
+++ b/test/units/module_utils/facts/hardware/test_linux_get_cpu_info.py
@@ -26,13 +26,13 @@ def test_get_cpu_info_missing_arch(mocker):
     module = mocker.Mock()
     inst = linux.LinuxHardware(module)
 
-    # ARM will report incorrect processor count if architecture is not available
+    # ARM and Power will report incorrect processor count if architecture is not available
     mocker.patch('os.path.exists', return_value=False)
     mocker.patch('os.access', return_value=True)
     for test in CPU_INFO_TEST_SCENARIOS:
         mocker.patch('ansible.module_utils.facts.hardware.linux.get_file_lines', side_effect=[[], test['cpuinfo']])
         test_result = inst.get_cpu_facts()
-        if test['architecture'].startswith(('armv', 'aarch')):
+        if test['architecture'].startswith(('armv', 'aarch', 'ppc')):
             assert test['expected_result'] != test_result
         else:
             assert test['expected_result'] == test_result


### PR DESCRIPTION
On POWER systems, /proc/cpuinfo provides a 'processor' entry as a
counter, and a 'cpu' entry with a description (similar to 'model name'
on x86). Support for POWER in get_cpu_facts was added via the 'cpu'
entry in commit 8746e692c121d7081e5c545de8e98908a95b510b.  Subsequent
support for ARM64 in commit ce4ada93f9daae4e1806c612b5c2f96727dc3de5
used the 'processor' entry, resulting in double-counting of cores on
POWER systems.

Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
On a ppc64le node, `ansible_processor_vcpus` currently shows ansible_processor_vcpus twice the number listed in `/proc/cpuinfo`.  With this patch, the count matches.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ansible all -v -m setup -a 'filter=ansible_processor_vcpus'
Using /etc/ansible/ansible.cfg as config file
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_processor_vcpus": 352, 
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false
}

$ grep '^processor[[:space:]]*:' /proc/cpuinfo
processor	: 0
[snip]
processor	: 175
```

After:
```
$ ansible all -v -m setup -a 'filter=ansible_processor_vcpus'
Using /etc/ansible/ansible.cfg as config file
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_processor_vcpus": 176, 
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false
}
```
