### PR TITLE
Filter on qemu and lxc resources only

### DIFF
--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -78,7 +78,7 @@ class ProxmoxPoolList(list):
 
 class ProxmoxPool(dict):
     def get_members_name(self):
-        return [member['name'] for member in self['members'] if member['type'] == 'qemu' and member['template'] != 1]
+        return [member['name'] for member in self['members'] if (member['type'] == 'qemu' or member['type'] == 'lxc') and member['template'] != 1]
 
 
 class ProxmoxAPI(object):
@@ -98,14 +98,14 @@ class ProxmoxAPI(object):
 
         request_params = urlencode({
             'username': self.options.username,
-            'password': self.options.password,
+            'password': self.options.password
         })
 
         data = json.load(open_url(request_path, data=request_params))
 
         self.credentials = {
             'ticket': data['data']['ticket'],
-            'CSRFPreventionToken': data['data']['CSRFPreventionToken'],
+            'CSRFPreventionToken': data['data']['CSRFPreventionToken']
         }
 
     def get(self, url, data=None):

--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -78,7 +78,7 @@ class ProxmoxPoolList(list):
 
 class ProxmoxPool(dict):
     def get_members_name(self):
-        return [member['name'] for member in self['members'] if member['template'] != 1]
+        return [member['name'] for member in self['members'] if member['type'] == 'qemu' and member['template'] != 1]
 
 
 class ProxmoxAPI(object):


### PR DESCRIPTION
##### SUMMARY
When using `proxmox.py` as a dynamic inventory for Ansible, only VM and lxc must be included in the output. Other resources such as datastores must be excluded.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Proxmox/qemu

##### ADDITIONAL INFORMATION
If a datastore is defined in a pool, the script crashes as the parameter `template` does not apply to datastore objects.
