### PR TITLE
Display specific tasks when the `display_ok_hosts` configuration is defined as `false`

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -113,7 +113,7 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_CHANGED
         else:
             if not self.display_ok_hosts:
-                if not 'print_action' in result._task.tags:
+                if 'print_action' not in result._task.tags:
                     return
 
             if self._last_task_banner != result._task._uuid:
@@ -273,7 +273,7 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_CHANGED
         else:
             if not self.display_ok_hosts:
-                if not 'print_action' in result._task.tags:
+                if 'print_action' not in result._task.tags:
                     return
 
             if self._last_task_banner != result._task._uuid:

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -113,7 +113,8 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_CHANGED
         else:
             if not self.display_ok_hosts:
-                return
+                if not 'print_action' in result._task.tags:
+                    return
 
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
@@ -272,7 +273,8 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_CHANGED
         else:
             if not self.display_ok_hosts:
-                return
+                if not 'print_action' in result._task.tags:
+                    return
 
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
@@ -320,10 +322,11 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        if 'item' in included_file._args:
-            msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
-        self._display.display(msg, color=C.COLOR_SKIP)
+        if self.display_ok_hosts:
+            msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+            if 'item' in included_file._args:
+                msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
+            self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):
         self._display.banner("PLAY RECAP")


### PR DESCRIPTION
##### SUMMARY
I think would be very helpful to have a way to display specific tasks when the `display_ok_hosts` configuration is defined as `false`.

Based on the behaviour of another callback plugin, `selective`, I changed the `default` plugin to show tasks tagged with `print_action`, so that irrelevant stuff displayed for every task don't show, while a few selected tasks be printed.

The purpose of this change is not to make the default plugin work like the selective plugin, just this behaviour. Furthermore, this allows to use other, more specific plugins, like `yaml`, with this behaviour.

I also made it so that included tasks and roles are not shown when `display_ok_hosts` is `false` (because they behave like `ok` subtasks).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
default
