### PR TITLE
Recognize module tracebacks on stdout and stderr.

### DIFF
--- a/changelogs/fragments/module-exceptions.yaml
+++ b/changelogs/fragments/module-exceptions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Module tracebacks are now recognized on stdout and stderr, intead of just on stderr.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -992,6 +992,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 if res['stderr'].startswith(u'Traceback'):
                     data['exception'] = res['stderr']
 
+            # in some cases a traceback will arrive on stdout instead of stderr, such as when using ssh with -tt
+            if 'exception' not in data and data['module_stdout'].startswith(u'Traceback'):
+                data['exception'] = data['module_stdout']
+
             # The default
             data['msg'] = "MODULE FAILURE"
 

--- a/test/integration/targets/module_tracebacks/aliases
+++ b/test/integration/targets/module_tracebacks/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group4
+needs/ssh

--- a/test/integration/targets/module_tracebacks/inventory
+++ b/test/integration/targets/module_tracebacks/inventory
@@ -1,0 +1,5 @@
+testhost_local ansible_connection=local
+testhost_ssh   ansible_connection=ssh   ansible_host=localhost
+
+[all:vars]
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/module_tracebacks/runme.sh
+++ b/test/integration/targets/module_tracebacks/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook traceback.yml -i inventory "$@"

--- a/test/integration/targets/module_tracebacks/traceback.yml
+++ b/test/integration/targets/module_tracebacks/traceback.yml
@@ -1,0 +1,21 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: intentionally fail module execution
+      ping:
+        data: crash
+      ignore_errors: yes
+      register: ping
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: verify exceptions were properly captured
+      assert:
+        that:
+          - hostvars.testhost_local.ping is failed
+          - "'boom' in hostvars.testhost_local.ping.exception"
+          - "'boom' in hostvars.testhost_local.ping.module_stderr"
+          - hostvars.testhost_ssh.ping is failed
+          - "'boom' in hostvars.testhost_ssh.ping.exception"
+          - "'boom' in hostvars.testhost_ssh.ping.module_stdout"


### PR DESCRIPTION
##### SUMMARY

Recognize module tracebacks on stdout and stderr.

Module tracebacks may be reported on stdout instead of stderr when using some connection plugins. For example, the ssh connection plugin will report tracebacks on stdout due to use of the -tt option.

This change results in tracebacks being recognized on both stdout and stderr, instead of the previous behavior of just stderr.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ActionBase
