### PR TITLE
Only add 'credential' parameter to the lookup fields if configured while using tower_job_launch module

### DIFF
--- a/changelogs/fragments/58367-tower-job-launch-credential-conditional.yml
+++ b/changelogs/fragments/58367-tower-job-launch-credential-conditional.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - tower_job_launch - handle credential parameter conditionally.

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -125,6 +125,7 @@ def main():
 
     json_output = {}
     tags = module.params.get('tags')
+    credential = module.params.get('credential')
 
     tower_auth = tower_auth_config(module)
     with settings.runtime_values(**tower_auth):
@@ -135,7 +136,10 @@ def main():
                 params['tags'] = ','.join(tags)
             job = tower_cli.get_resource('job')
 
-            lookup_fields = ('job_template', 'inventory', 'credential')
+            lookup_fields = ['job_template', 'inventory']
+            if credential is not None:
+                lookup_fields.append('credential')
+
             for field in lookup_fields:
                 try:
                     name = params.pop(field)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using tower_job_launch module, if parameter credential is not passed, don't add to the lookup fields list. 

By default it is added and hence invoking credential resource lookup. Due to this GET credentials request  is initiated (shown below in section **Before Change Output** )


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tower_job_launch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1.  Create a sample job template with credentials and unchecked **prompt on launch** option
2.  Create a sample project for inventory and inventory with sources.  
3.  Create a inventory with sources as type = source from a project (2).
4. A sample Ansible playbook with below task

```
- name: Launch the sample job template
  tower_job_launch:
    job_template: "my-sample-job-template"
    limit: "my-host"
    inventory: "my-sample-inventory"
    tower_verify_ssl: no
```


<!--- Paste verbatim command output below, e.g. before and after your change -->
#####  Before Change Output
```
  module_stderr: |-
    *** DETAILS: Getting the record. **********************************************
    GET https://woah-nonprod-tower.sdpamp.com/api/v2/job_templates/
    Params: [('name', 'my-sample-job-template')]
  
    *** DETAILS: Getting the record. **********************************************
    GET https://woah-nonprod-tower.sdpamp.com/api/v2/inventories/
    Params: [('name', 'my-sample-inventory')]
  
    *** DETAILS: Getting the record. **********************************************
    GET https://woah-nonprod-tower.sdpamp.com/api/v2/credentials/
    Params: []
  
    Traceback (most recent call last):
      File "/root/.ansible/tmp/ansible-tmp-1561513427.78-182021178072793/AnsiballZ_tower_job_launch.py", line 113, in <module>
        _ansiballz_main()
      File "/root/.ansible/tmp/ansible-tmp-1561513427.78-182021178072793/AnsiballZ_tower_job_launch.py", line 105, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/root/.ansible/tmp/ansible-tmp-1561513427.78-182021178072793/AnsiballZ_tower_job_launch.py", line 48, in invoke_module
        imp.load_module('__main__', mod, module, MOD_DESC)
      File "/tmp/ansible_tower_job_launch_payload_5Ljs29/__main__.py", line 149, in <module>
      File "/tmp/ansible_tower_job_launch_payload_5Ljs29/__main__.py", line 133, in main
      File "/data/.venv/lib/python2.7/site-packages/tower_cli/models/base.py", line 499, in get
        response = self.read(pk=pk, fail_on_no_results=True, fail_on_multiple_results=True, **kwargs)
      File "/data/.venv/lib/python2.7/site-packages/tower_cli/models/base.py", line 325, in read
        'fields. Please tighten your criteria.' % resp['count'])
    tower_cli.exceptions.MultipleResults: Expected one result, got 2. Possibly caused by not providing required fields. Please tighten your criteria.
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```
##### After Change Output
```
No error and job is successfully launched in Ansible Tower
```
