### PR TITLE
Clean up iosxr_user tests

### DIFF
--- a/test/integration/targets/iosxr_user/tests/common/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/common/auth.yaml
@@ -38,10 +38,7 @@
     connection: network_cli
 
   - name: test login with private key
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
-      responses:
-        (?i)password: 'pass123'
+    command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
     connection: network_cli
 
   - name: remove user and key
@@ -52,13 +49,15 @@
     connection: network_cli
 
   - name: test login with private key (should fail, no user)
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
-      responses:
-        (?i)password: 'pass123'
+    command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
     ignore_errors: yes
     connection: network_cli
     register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
 
   - name: create user with private key (path input)
     iosxr_user:
@@ -69,11 +68,7 @@
     connection: network_cli
 
   - name: test login with private key
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
-      responses:
-        (?i)password: 'pass123'
-    ignore_errors: yes
+    command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
     connection: network_cli
 
   - name: change private key for user
@@ -86,10 +81,7 @@
 
   # FIXME: pexpect fails with OSError: [Errno 5] Input/output error
   - name: test login with invalid private key (should fail)
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
-      responses:
-        (?i)password: "pass123"
+    command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ role_path }}/files/private show version"
     ignore_errors: yes
     connection: network_cli
     register: results


### PR DESCRIPTION
This should hopefully make things a little more robust. Also validate
that public / private keys are working as expected.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>