### PR TITLE
Backport/2.8/57848

### DIFF
--- a/changelogs/fragments/add-env-variables-to-gcp-compute.yml
+++ b/changelogs/fragments/add-env-variables-to-gcp-compute.yml
@@ -1,2 +1,2 @@
 minor_changes:
-    - gcp_compute - Added additional environment variables to the `gcp_compute` inventory plugin to align with the rest of the `gcp_*` modules.
+    - gcp_compute - Added additional environment variables to the ``gcp_compute`` inventory plugin to align with the rest of the ``gcp_*`` modules.

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -67,6 +67,14 @@ DOCUMENTATION = '''
                   version_added: "2.8"
                 - name: GCE_CREDENTIALS_FILE_PATH
                   version_added: "2.8"
+        service_account_contents:
+            description:
+                - A string representing the contents of a Service Account JSON file. This should not be passed in as a dictionary,
+                  but a string that has the exact contents of a service account json file (valid JSON).
+            type: string
+            env:
+                - name: GCP_SERVICE_ACCOUNT_CONTENTS
+                  version_added: "2.8"
         service_account_email:
             description:
                 - An optional service account email address if machineaccount is selected
@@ -434,6 +442,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'zones': self.get_option('zones'),
             'auth_kind': self.get_option('auth_kind'),
             'service_account_file': self.get_option('service_account_file'),
+            'service_account_contents': self.get_option('service_account_contents'),
             'service_account_email': self.get_option('service_account_email'),
         }
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -50,21 +50,21 @@ DOCUMENTATION = '''
             choices: ['application', 'serviceaccount', 'machineaccount']
             env:
                 - name: GCP_AUTH_KIND
-                  version_added: "2.8"
+                  version_added: "2.8.2"
         scopes:
             description: list of authentication scopes
             type: list
             default: ['https://www.googleapis.com/auth/compute']
             env:
                 - name: GCP_SCOPES
-                  version_added: "2.8"
+                  version_added: "2.8.2"
         service_account_file:
             description:
                 - The path of a Service Account JSON file if serviceaccount is selected as type.
             type: path
             env:
                 - name: GCP_SERVICE_ACCOUNT_FILE
-                  version_added: "2.8"
+                  version_added: "2.8.2"
                 - name: GCE_CREDENTIALS_FILE_PATH
                   version_added: "2.8"
         service_account_contents:
@@ -74,14 +74,14 @@ DOCUMENTATION = '''
             type: string
             env:
                 - name: GCP_SERVICE_ACCOUNT_CONTENTS
-                  version_added: "2.8"
+                  version_added: "2.8.2"
         service_account_email:
             description:
                 - An optional service account email address if machineaccount is selected
                   and the user does not wish to use the default email.
             env:
                 - name: GCP_SERVICE_ACCOUNT_EMAIL
-                  version_added: "2.8"
+                  version_added: "2.8.2"
         vars_prefix:
             description: prefix to apply to host variables, does not include facts nor params
             default: ''


### PR DESCRIPTION
##### SUMMARY
This is the last parameter/env variable that was missing so that the gcp_compute inventory plugin is not 100% aligned with the rest of `gcp_*` modules.

I also updated the changelog fragment and version added to reflect the real version which should be 2.8.2. Will make a separate PR about this in devel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gcp_compute
