### PR TITLE
'zabbix_action' module minor improvements

### DIFF
--- a/changelogs/fragments/58379-zabbix_action_minor_improvements.yml
+++ b/changelogs/fragments/58379-zabbix_action_minor_improvements.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_action - ``esc_period`` is now required to reflect actual Zabbix API call
+  - zabbix_action - support for new condition operators (``matches``, ``does not match``, ``Yes``, ``No``) added in Zabbix 4.0 and Zabbix 4.2 (https://www.zabbix.com/documentation/4.2/manual/api/reference/action/object#action_filter_condition)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -63,7 +63,7 @@ options:
     esc_period:
         description:
             - Default operation step duration. Must be greater than 60 seconds. Accepts seconds, time unit with suffix and user macro.
-        default: '60'
+        required: true
     conditions:
         type: list
         description:
@@ -127,6 +127,7 @@ options:
                 description:
                     - Condition operator.
                     - When I(type) is set to C(time_period), the choices are C(in), C(not in).
+                    - C(matches), C(does not match), C(Yes) and C(No) condition operators work only with >= Zabbix 4.0
                 choices:
                     - '='
                     - '<>'
@@ -136,6 +137,10 @@ options:
                     - '>='
                     - '<='
                     - 'not in'
+                    - 'matches'
+                    - 'does not match'
+                    - 'Yes'
+                    - 'No'
             formulaid:
                 description:
                     - Arbitrary unique ID that is used to reference the condition from a custom expression.
@@ -1186,8 +1191,6 @@ class RecoveryOperations(Operations):
         Returns:
             list: constructed recovery operations data
         """
-        if operations is None:
-            return None
         constructed_data = []
         for op in operations:
             operation_type = self._construct_operationtype(op)
@@ -1253,8 +1256,6 @@ class AcknowledgeOperations(Operations):
         Returns:
             list: constructed acknowledge operations data
         """
-        if operations is None:
-            return None
         constructed_data = []
         for op in operations:
             operation_type = self._construct_operationtype(op)
@@ -1396,7 +1397,11 @@ class Filter(object):
                 "in",
                 ">=",
                 "<=",
-                "not in"], _condition['operator']
+                "not in",
+                "matches",
+                "does not match",
+                "Yes",
+                "No"], _condition['operator']
             )
         except Exception as e:
             self._module.fail_json(msg="Unsupported value '%s' for operator." % _condition['operator'])
@@ -1662,7 +1667,7 @@ def main():
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
-            esc_period=dict(type='int', required=False, default=60),
+            esc_period=dict(type='int', required=True),
             timeout=dict(type='int', default=10),
             name=dict(type='str', required=True),
             event_source=dict(type='str', required=True, choices=['trigger', 'discovery', 'auto_registration', 'internal']),
@@ -1678,6 +1683,7 @@ def main():
             conditions=dict(
                 type='list',
                 required=False,
+                default=[],
                 elements='dict',
                 options=dict(
                     formulaid=dict(type='str', required=False),
@@ -1692,6 +1698,7 @@ def main():
             operations=dict(
                 type='list',
                 required=False,
+                default=[],
                 elements='dict',
                 options=dict(
                     type=dict(


### PR DESCRIPTION
##### SUMMARY
- Zabbix 4.2 API has 4 new types of operators, zabbix actions module needs to be updated in order to support them.
- Update mandatory fields in accordance with Zabbix documentation.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action

##### ADDITIONAL INFORMATION
Current implementation doesn't allow to create a potentially correct rule because of failed validation on Ansible's side. For example, I can't create an action with empty "operations" field. Zabbix API allows to do that because there are cases when "operations" field is empty but "operations_recovery" field contains some data.
