### PR TITLE
Make win_domain_user idempotent for password changes

### DIFF
--- a/changelogs/fragments/58246-win_domain_user-idempotency.yaml
+++ b/changelogs/fragments/58246-win_domain_user-idempotency.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+minor_changes:
   - "win_domain_user - Allow to only set password when it actually changed (https://github.com/ansible/ansible/issues/58246)"

--- a/changelogs/fragments/58246-win_domain_user-idempotency.yaml
+++ b/changelogs/fragments/58246-win_domain_user-idempotency.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "win_domain_user - Allow to only set password when it actually changed (https://github.com/ansible/ansible/issues/58246)"

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -201,7 +201,7 @@ If ($state -eq 'present') {
         If ($new_user -or ($update_password -eq "always")) {
             $set_new_credentials = $true
         } elseif ($update_password -eq "when_changed") {
-            $set_new_credentials = -not (Test-Credential -Username $username -Password $password)
+            $set_new_credentials = -not (Test-Credential -Username $user_obj.UserPrincipalName -Password $password)
         } else {
             $set_new_credentials = $false
         }

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -203,7 +203,7 @@ If ($state -eq 'present') {
         } elif ($update_password -eq "when_changed") {
             $set_new_credentials = -not (Test-Credential -Username $username -Password $password)
         } else {
-            $set_net_credentials = $false
+            $set_new_credentials = $false
         }
         If ($set_new_credentials) {
             $secure_password = ConvertTo-SecureString $password -AsPlainText -Force

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -16,13 +16,14 @@ Function Test-Credential {
         # UserPrincipalName
         $Username = ($Username -split '@')[0]
         $Domain = ($Username -split '@')[1]
-    } elif (($Username.ToCharArray()) -contains [char]'\') {
+    } else if (($Username.ToCharArray()) -contains [char]'\') {
         # Pre Win2k Account Name
         $Username = ($Username -split '\')[0]
         $Domain = ($Username -split '\')[1]
     } else {
         # No domain provided, so maybe local user?
     }
+    $null = $Domain # Make CI-Check happy...
 
     # More information about LogonUser at https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-logonusera
     $platform_util = @'

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -16,7 +16,7 @@ Function Test-Credential {
         # UserPrincipalName
         $Username = ($Username -split '@')[0]
         $Domain = ($Username -split '@')[1]
-    } else if (($Username.ToCharArray()) -contains [char]'\') {
+    } elseif (($Username.ToCharArray()) -contains [char]'\') {
         # Pre Win2k Account Name
         $Username = ($Username -split '\')[0]
         $Domain = ($Username -split '\')[1]

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -200,7 +200,7 @@ If ($state -eq 'present') {
         # so we don't need to differentiate between this two states.
         If ($new_user -or ($update_password -eq "always")) {
             $set_new_credentials = $true
-        } elif ($update_password -eq "when_changed") {
+        } elseif ($update_password -eq "when_changed") {
             $set_new_credentials = -not (Test-Credential -Username $username -Password $password)
         } else {
             $set_new_credentials = $false

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -73,9 +73,9 @@ options:
     type: str
   update_password:
     description:
-      - C(always) will update passwords if they differ.
+      - C(always) will always update passwords.
       - C(on_create) will only set the password for newly created users.
-      - C(when_changed) will only set the password when it differs.
+      - C(when_changed) will only set the password when changed (added in ansible 2.9).
     type: str
     choices: [ always, on_create, when_changed ]
     default: always

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -75,11 +75,9 @@ options:
     description:
       - C(always) will update passwords if they differ.
       - C(on_create) will only set the password for newly created users.
-      - Note that C(always) will always report an Ansible status of 'changed'
-        because we cannot determine whether the new password differs from
-        the old password.
+      - C(when_changed) will only set the password when it differs.
     type: str
-    choices: [ always, on_create ]
+    choices: [ always, on_create, when_changed ]
     default: always
   password_expired:
     description:


### PR DESCRIPTION
##### SUMMARY
win_domain_user always returns changed if a password is specified.
This pr implements an additional option to not only update the password "on_create" or "always", but also "when_changed"

Fixes #58246 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user


_OT side note I just learned, that GitHub does not allow to reopen PRs after you force pushed to the branche._