### PR TITLE
Add wait_for task for iosxr prepare tests

### DIFF
--- a/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+# NOTE(pabelanger): We sometime see random failures from iosxr about paramiko
+# establishing the control socket for network_cli. It seems iosxr is closing
+# the socket for some reason.  This is our attempt to ensure the port is open
+# before starting paramiko.
+- name: wait for iosxr SSH connection
+  delegate_to: localhost
+  wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 22
+    search_regex: SSH
+  with_inventory_hostnames: iosxr
+
 - name: Ensure we have loopback 888 for testing
   iosxr_config:
     src: config.j2


### PR DESCRIPTION
This is to actually confirm that iosxr SSH port is open, as we sometimes
see iosxr randomly closing the port.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/158
Signed-off-by: Paul Belanger <pabelanger@redhat.com>