### PR TITLE
NxosCmdRef: fix python2 ordereddict import

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -49,7 +49,7 @@ except ImportError:
     HAS_YAML = False
 
 try:
-    if sys.version_info[:2] < (2,7):
+    if sys.version_info[:2] < (2, 7):
         from ordereddict import OrderedDict
     else:
         from collections import OrderedDict
@@ -1116,7 +1116,7 @@ def nxosCmdRef_import_check():
     """Return import error messages or empty string"""
     msg = ''
     if PY2:
-        if not HAS_ORDEREDDICT and sys.version_info[:2] < (2,7):
+        if not HAS_ORDEREDDICT and sys.version_info[:2] < (2, 7):
             msg += "Mandatory python library 'ordereddict' is not present, try 'pip install ordereddict'\n"
         if not HAS_YAML:
             msg += "Mandatory python library 'yaml' is not present, try 'pip install yaml'\n"

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -31,6 +31,7 @@
 import collections
 import json
 import re
+import sys
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
@@ -48,10 +49,10 @@ except ImportError:
     HAS_YAML = False
 
 try:
-    if PY3:
-        from collections import OrderedDict
-    else:
+    if sys.version_info[:2] < (2,7):
         from ordereddict import OrderedDict
+    else:
+        from collections import OrderedDict
     HAS_ORDEREDDICT = True
 except ImportError:
     HAS_ORDEREDDICT = False
@@ -1115,7 +1116,7 @@ def nxosCmdRef_import_check():
     """Return import error messages or empty string"""
     msg = ''
     if PY2:
-        if not HAS_ORDEREDDICT:
+        if not HAS_ORDEREDDICT and sys.version_info[:2] < (2,7):
             msg += "Mandatory python library 'ordereddict' is not present, try 'pip install ordereddict'\n"
         if not HAS_YAML:
             msg += "Mandatory python library 'yaml' is not present, try 'pip install yaml'\n"


### PR DESCRIPTION
##### SUMMARY
NxosCmdRef has an unnecessary dependency on the `ordereddict` module for python2 versions 2.7+.

Current code has all python2 versions doing an import for `OrderedDict` from `ordereddict`.
This import should be restricted to python versions 2.6 and older, since 2.7 and newer should use `OrderedDict` from the `collections` module.

This issue was raised by @pabelanger in PR #56317.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos`

