### PR TITLE
[WIP] Add initial implementation of RFC 7464 JSON stream

### DIFF
--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -37,6 +37,7 @@ import subprocess
 import sys
 import traceback
 import shutil
+from io import BytesIO
 
 from pathlib import Path
 
@@ -49,9 +50,8 @@ from ansible.plugins.loader import init_plugin_loader
 from ansible.executor import module_common
 import ansible.constants as C
 from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 from ansible.template import Templar
-
-import json
 
 
 def parse():
@@ -229,15 +229,15 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
         invoke = "%s %s" % (invoke, argspath)
 
     cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    (out, err) = cmd.communicate()
-    out, err = to_text(out), to_text(err)
+    (orig_out, err) = cmd.communicate()
+    out, err = to_text(orig_out), to_text(err)
 
     try:
         print("*" * 35)
         print("RAW OUTPUT")
         print(out)
         print(err)
-        results = json.loads(out)
+        results = next(read_json_documents(BytesIO(orig_out)))
     except Exception:
         print("*" * 35)
         print("INVALID OUTPUT FORMAT")

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -200,8 +200,9 @@ def _ansiballz_main():
         runpy.run_module(mod_name=%(module_fqn)r, init_globals=dict(_module_fqn=%(module_fqn)r, _modlib_path=modlib_path),
                          run_name='__main__', alter_sys=True)
 
+        from ansible.module_utils._stdout_utils import write_bytes_to_stdout
         # Ansible modules must exit themselves
-        sys.stdout.buffer.write(
+        write_bytes_to_stdout(
             b''.join((
                 RS_DELIMITER,
                 b'{"msg": "New-style module did not '
@@ -297,8 +298,9 @@ def _ansiballz_main():
             # Run the module!  By importing it as '__main__', it thinks it is executing as a script
             runpy.run_module(mod_name=%(module_fqn)r, init_globals=None, run_name='__main__', alter_sys=True)
 
+            from ansible.module_utils._stdout_utils import write_bytes_to_stdout
             # Ansible modules must exit themselves
-            sys.stdout.buffer.write(
+            write_bytes_to_stdout(
                 b''.join((
                     RS_DELIMITER,
                     b'{"msg": "New-style module did not '

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -77,6 +77,8 @@ _MODULE_UTILS_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils
 ANSIBALLZ_TEMPLATE = u"""%(shebang)s
 %(coding)s
 _ANSIBALLZ_WRAPPER = True # For test-module.py script to tell this is a ANSIBALLZ_WRAPPER
+RS_DELIMITER = b'\\x1E'  # double slash is because this code is in a string
+LF_DELIMITER = b'\\x0A'  # ==LF==\n
 # This code is part of Ansible, but is an independent component.
 # The code in this particular templatable string, and this templatable string
 # only, is BSD licensed.  Modules which end up using this snippet, which is
@@ -199,7 +201,14 @@ def _ansiballz_main():
                          run_name='__main__', alter_sys=True)
 
         # Ansible modules must exit themselves
-        print('{"msg": "New-style module did not handle its own exit", "failed": true}')
+        sys.stdout.buffer.write(
+            b''.join((
+                RS_DELIMITER,
+                b'{"msg": "New-style module did not '
+                b'handle its own exit", "failed": true}',
+                LF_DELIMITER,
+            )),
+        )
         sys.exit(1)
 
     def debug(command, zipped_mod, json_params):
@@ -289,7 +298,15 @@ def _ansiballz_main():
             runpy.run_module(mod_name=%(module_fqn)r, init_globals=None, run_name='__main__', alter_sys=True)
 
             # Ansible modules must exit themselves
-            print('{"msg": "New-style module did not handle its own exit", "failed": true}')
+            sys.stdout.buffer.write(
+                b''.join((
+                    RS_DELIMITER,
+                    b'{"msg": "New-style module did not '
+                    b'handle its own exit", '
+                    b'"failed": true}',
+                    LF_DELIMITER,
+                )),
+            )
             sys.exit(1)
 
         else:

--- a/lib/ansible/module_utils/_json_streams_rfc7464.py
+++ b/lib/ansible/module_utils/_json_streams_rfc7464.py
@@ -1,0 +1,107 @@
+"""RFC 7464 implementation of JSON documents streaming."""
+
+from __future__ import annotations
+
+import json
+
+
+CHUNK_SIZE = 2 ** 16  # 64KB
+RS_DELIMITER = b'\x1E'
+RS_DELIMITER_ORD = ord(RS_DELIMITER)
+LF_DELIMITER = b'\x0A'  # ==LF==\n
+LF_DELIMITER_ORD = ord(LF_DELIMITER)
+
+
+def find_documents_in_chunk(chunk, doc_start=None):
+    """Emit subchunk positions of JSON record delimiters."""
+    for pos, char in enumerate(chunk):
+        if char == RS_DELIMITER_ORD:
+            doc_start = pos
+
+        if char == LF_DELIMITER_ORD and doc_start is not None:
+            yield doc_start, pos
+            doc_start = None
+
+    if doc_start is not None:
+        # last doc chunk is hanging
+        yield doc_start, None
+
+
+def get_chunk_positions(input_mv):
+    """Emit chunks for stream processing."""
+    return (
+        (n * CHUNK_SIZE, (n + 1) * CHUNK_SIZE)
+        for n in range((input_mv.nbytes // CHUNK_SIZE) + 1)
+    )
+
+
+def find_absolute_doc_positions_in_stream(input_mv):
+    """Emit absolute positions of document boundaries in stream."""
+    hanging_doc_pos = None
+    for stream_chunk_start, stream_chunk_end in get_chunk_positions(input_mv):
+        if hanging_doc_pos is not None:
+            hanging_doc_pos -= CHUNK_SIZE
+
+        b_stream_chunk = input_mv[stream_chunk_start: stream_chunk_end].tobytes()
+        stream_chunk_pos_iter = find_documents_in_chunk(
+            b_stream_chunk,
+            hanging_doc_pos,
+        )
+        document_positions = (c for c in stream_chunk_pos_iter if c)
+
+        for doc_chunk_start, doc_chunk_end in document_positions:
+            hanging_doc_pos = None
+            if doc_chunk_end is None:
+                hanging_doc_pos = doc_chunk_start
+                break
+            yield doc_chunk_start + stream_chunk_start + 1, doc_chunk_end + stream_chunk_start
+
+
+def read_json_document_strings(input_byte_stream):
+    """Emit document strings as they are found in the stream."""
+    input_mv = memoryview(input_byte_stream.read())
+
+    def get_text_from_mv_slice(start, end):
+        return input_mv[start:end].tobytes().decode('utf-8')
+
+    return (
+        get_text_from_mv_slice(*doc_pos)
+        for doc_pos in find_absolute_doc_positions_in_stream(input_mv)
+    )
+
+
+def read_json_documents(input_byte_stream):
+    """Load JSON objects from the given stream."""
+    return (
+        json.loads(d)
+        for d in read_json_document_strings(input_byte_stream)
+    )
+
+
+def write_json_documents_to_stream(objects, output_byte_stream):
+    """Write RS-delimited UTF8-encoded JSON-strings to the stream.
+
+    This follows :rfc:`7464`. It writes <RS> before
+    the JSON string and puts <LF> after it.
+    """
+    def dump_object(obj):
+        return b''.join(
+            (
+                RS_DELIMITER,
+                json.dumps(obj).encode('utf-8'),
+                LF_DELIMITER,
+            ),
+        )
+
+    def write_marked_object(obj):
+        bytes_written = 0
+        bytes_written += output_byte_stream.write(RS_DELIMITER)
+        bytes_written += output_byte_stream.write(obj)
+        bytes_written += output_byte_stream.write(LF_DELIMITER)
+        output_byte_stream.flush()
+        return bytes_written
+
+    return sum(
+        write_marked_object(dump_object(o))
+        for o in objects
+    )

--- a/lib/ansible/module_utils/_stdout_utils.py
+++ b/lib/ansible/module_utils/_stdout_utils.py
@@ -1,0 +1,14 @@
+"""Utils for supplying bytes to stdout."""
+
+from __future__ import annotations
+
+import sys
+
+
+__all__ = ('write_bytes_to_stdout', )
+
+
+def write_bytes_to_stdout(*args, **kwargs):
+    """Write bytes to stdout and flush immediately."""
+    sys.stdout.buffer.write(*args, **kwargs)
+    sys.stdout.flush()

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -9,13 +9,14 @@ import sys
 import typing as t
 
 from ._json_streams_rfc7464 import LF_DELIMITER, RS_DELIMITER
+from ._stdout_utils import write_bytes_to_stdout
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
 _PY_MIN = (3, 8)
 
 if sys.version_info < _PY_MIN:
-    sys.stdout.buffer.write(
+    write_bytes_to_stdout(
         b''.join((
             RS_DELIMITER,
             json.dumps(dict(
@@ -339,7 +340,7 @@ def _load_params():
         params = json.loads(buffer.decode('utf-8'))
     except ValueError:
         # This helper is used too early for fail_json to work.
-        sys.stdout.buffer.write(
+        write_bytes_to_stdout(
             b''.join((
                 RS_DELIMITER,
                 b'{"msg": "Error: Module unable to decode stdin/parameters as '
@@ -355,7 +356,7 @@ def _load_params():
     except KeyError:
         # This helper does not have access to fail_json so we have to print
         # json output on our own.
-        sys.stdout.buffer.write(
+        write_bytes_to_stdout(
             b''.join((
                 RS_DELIMITER,
                 b'{"msg": "Error: Module unable to locate '
@@ -1463,7 +1464,7 @@ class AnsibleModule(object):
         # return preserved
         kwargs.update(preserved)
 
-        sys.stdout.buffer.write(
+        write_bytes_to_stdout(
             b'\n%s%s%s'
             % (
                 RS_DELIMITER,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -8,15 +8,23 @@ import json
 import sys
 import typing as t
 
+from ._json_streams_rfc7464 import LF_DELIMITER, RS_DELIMITER
+
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
 _PY_MIN = (3, 8)
 
 if sys.version_info < _PY_MIN:
-    print(json.dumps(dict(
-        failed=True,
-        msg=f"ansible-core requires a minimum of Python version {'.'.join(map(str, _PY_MIN))}. Current version: {''.join(sys.version.splitlines())}",
-    )))
+    sys.stdout.buffer.write(
+        b''.join((
+            RS_DELIMITER,
+            json.dumps(dict(
+                failed=True,
+                msg=f"ansible-core requires a minimum of Python version {'.'.join(map(str, _PY_MIN))}. Current version: {''.join(sys.version.splitlines())}",
+            )).encode('utf-8'),
+            LF_DELIMITER,
+        )),
+    )
     sys.exit(1)
 
 # Ansible modules can be written in any language.
@@ -70,6 +78,7 @@ except ImportError:
 
 # Python2 & 3 way to get NoneType
 NoneType = type(None)
+
 
 from ._text import to_native, to_bytes, to_text
 from ansible.module_utils.common.text.converters import (
@@ -330,7 +339,15 @@ def _load_params():
         params = json.loads(buffer.decode('utf-8'))
     except ValueError:
         # This helper is used too early for fail_json to work.
-        print('\n{"msg": "Error: Module unable to decode stdin/parameters as valid JSON. Unable to parse what parameters were passed", "failed": true}')
+        sys.stdout.buffer.write(
+            b''.join((
+                RS_DELIMITER,
+                b'{"msg": "Error: Module unable to decode stdin/parameters as '
+                b'valid JSON.  Unable to parse what parameters were passed", '
+                b'"failed": true}',
+                LF_DELIMITER,
+            )),
+        )
         sys.exit(1)
 
     try:
@@ -338,8 +355,16 @@ def _load_params():
     except KeyError:
         # This helper does not have access to fail_json so we have to print
         # json output on our own.
-        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in JSON data from stdin. Unable to figure out what parameters were passed", '
-              '"failed": true}')
+        sys.stdout.buffer.write(
+            b''.join((
+                RS_DELIMITER,
+                b'{"msg": "Error: Module unable to locate '
+                b'ANSIBLE_MODULE_ARGS in JSON data from '
+                b'stdin. Unable to figure out what '
+                b'parameters were passed", "failed": true}',
+                LF_DELIMITER,
+            )),
+        )
         sys.exit(1)
 
 
@@ -1438,7 +1463,14 @@ class AnsibleModule(object):
         # return preserved
         kwargs.update(preserved)
 
-        print('\n%s' % self.jsonify(kwargs))
+        sys.stdout.buffer.write(
+            b'\n%s%s%s'
+            % (
+                RS_DELIMITER,
+                to_bytes(self.jsonify(kwargs)),
+                LF_DELIMITER,
+            ),
+        )
 
     def exit_json(self, **kwargs) -> t.NoReturn:
         """ return from the module, without error """

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -1351,7 +1351,7 @@ namespace Ansible.Basic
             if (Diff.Count > 0 && DiffMode)
                 result["diff"] = Diff;
 
-            return ToJson(result);
+            return "" + ToJson(result);
         }
 
         private string FormatLogData(object data, int indentLevel)

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -45,7 +45,7 @@ Function Exit-Json($obj) {
         Set-Attr -obj $obj -name "changed" -value $false
     }
 
-    Write-Output $obj | ConvertTo-Json -Compress -Depth 99
+    Write-Output "$($obj | ConvertTo-Json -Compress -Depth 99)"
     Exit
 }
 
@@ -81,7 +81,7 @@ Function Fail-Json($obj, $message = $null) {
         Set-Attr -obj $obj -name "changed" -value $false
     }
 
-    Write-Output $obj | ConvertTo-Json -Compress -Depth 99
+    Write-Output "$($obj | ConvertTo-Json -Compress -Depth 99)"
     Exit 1
 }
 

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -189,6 +189,12 @@ def _run_module(wrapped_cmd, jid):
         )
 
         (outdata, stderr) = script.communicate()
+        if outdata.startswith((b'{', b'[')):
+            # old-style binary module
+            outdata = b''.join((RS_DELIMITER, outdata))
+        if not outdata.endswith(LF_DELIMITER):
+            # old-style binary module
+            outdata = b''.join((outdata, LF_DELIMITER))
 
         json_warnings = ()
         result = next(read_json_documents(BytesIO(outdata.encode())))

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -26,6 +26,7 @@ from ansible.module_utils._json_streams_rfc7464 import (
     RS_DELIMITER,
     read_json_documents,
 )
+from ansible.module_utils._stdout_utils import write_bytes_to_stdout
 
 syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % " ".join(sys.argv[1:]))
@@ -42,7 +43,7 @@ def notice(msg):
 
 def end(res=None, exit_msg=0):
     if res is not None:
-        sys.stdout.buffer.write(
+        write_bytes_to_stdout(
             b''.join((
                 RS_DELIMITER,
                 to_bytes(json.dumps(res)),

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -18,8 +18,14 @@ import signal
 import time
 import syslog
 import multiprocessing
+from io import BytesIO
 
 from ansible.module_utils.common.text.converters import to_text, to_bytes
+from ansible.module_utils._json_streams_rfc7464 import (
+    LF_DELIMITER,
+    RS_DELIMITER,
+    read_json_documents,
+)
 
 syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % " ".join(sys.argv[1:]))
@@ -36,7 +42,13 @@ def notice(msg):
 
 def end(res=None, exit_msg=0):
     if res is not None:
-        print(json.dumps(res))
+        sys.stdout.buffer.write(
+            b''.join((
+                RS_DELIMITER,
+                to_bytes(json.dumps(res)),
+                LF_DELIMITER,
+            ))
+        )
     sys.stdout.flush()
     sys.exit(exit_msg)
 
@@ -157,7 +169,6 @@ def _run_module(wrapped_cmd, jid):
     ipc_notifier.close()
 
     outdata = ''
-    filtered_outdata = ''
     stderr = ''
     try:
         cmd = [to_bytes(c, errors='surrogate_or_strict') for c in shlex.split(wrapped_cmd)]
@@ -179,9 +190,8 @@ def _run_module(wrapped_cmd, jid):
 
         (outdata, stderr) = script.communicate()
 
-        (filtered_outdata, json_warnings) = _filter_non_json_lines(outdata)
-
-        result = json.loads(filtered_outdata)
+        json_warnings = ()
+        result = next(read_json_documents(BytesIO(outdata.encode())))
 
         if json_warnings:
             # merge JSON junk warnings with any existing module warnings

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1215,7 +1215,7 @@ class ActionBase(ABC):
 
     def _parse_returned_data(self, res):
         try:
-            filtered_output = read_json_documents(BytesIO(res.get('stdout', u'').encode()))
+            filtered_output = read_json_documents(BytesIO(to_bytes(res.get('stdout', u''), errors='surrogate_or_strict')))
             try:
                 data = next(filtered_output)
             except StopIteration:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -16,6 +16,7 @@ import tempfile
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from io import BytesIO
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleActionSkip, AnsibleActionFail, AnsibleAuthenticationFailure
@@ -25,6 +26,7 @@ from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.errors import UnsupportedError
 from ansible.module_utils.json_utils import _filter_non_json_lines
 from ansible.module_utils.six import binary_type, string_types, text_type
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.release import __version__
@@ -1213,11 +1215,14 @@ class ActionBase(ABC):
 
     def _parse_returned_data(self, res):
         try:
-            filtered_output, warnings = _filter_non_json_lines(res.get('stdout', u''), objects_only=True)
-            for w in warnings:
-                display.warning(w)
-
-            data = json.loads(filtered_output)
+            filtered_output = read_json_documents(BytesIO(res.get('stdout', u'').encode()))
+            try:
+                data = next(filtered_output)
+            except StopIteration:
+                filtered_output, warnings = _filter_non_json_lines(res.get('stdout', u''), objects_only=True)
+                for w in warnings:
+                    display.warning(w)
+                data = json.loads(filtered_output)
 
             if C.MODULE_STRICT_UTF8_RESPONSE and not data.pop('_ansible_trusted_utf8', None):
                 try:

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -182,7 +182,6 @@
     - async_result.changed == true
     - async_result is changed
     - async_result is successful
-    - async_result.warnings[0] is search('trailing junk after module output')
 
 - name: test stderr handling
   async_test:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -8,7 +8,6 @@ lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
 lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
-lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required
 lib/ansible/modules/async_wrapper.py use-argspec-type-path
 lib/ansible/modules/command.py validate-modules:doc-default-does-not-match-spec  # _uses_shell is undocumented
 lib/ansible/modules/command.py validate-modules:doc-missing-type

--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -24,6 +24,8 @@ from ansible.plugins.loader import init_plugin_loader
 
 MODULE_UTILS_BASIC_FILES = frozenset(('ansible/__init__.py',
                                       'ansible/module_utils/__init__.py',
+                                      'ansible/module_utils/_json_streams_rfc7464.py',
+                                      'ansible/module_utils/_stdout_utils.py',
                                       'ansible/module_utils/_text.py',
                                       'ansible/module_utils/basic.py',
                                       'ansible/module_utils/six/__init__.py',
@@ -80,16 +82,20 @@ class TestRecursiveFinder(object):
     def test_module_utils_with_syntax_error(self, finder_containers):
         name = 'fake_module'
         data = b'#!/usr/bin/python\ndef something(:\n   pass\n'
-        with pytest.raises(ansible.errors.AnsibleError) as exec_info:
+        with pytest.raises(
+                ansible.errors.AnsibleError,
+                match='Unable to import fake_module due to invalid syntax',
+        ):
             recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'fake_module.py'), data, *finder_containers)
-        assert 'Unable to import fake_module due to invalid syntax' in str(exec_info.value)
 
     def test_module_utils_with_identation_error(self, finder_containers):
         name = 'fake_module'
         data = b'#!/usr/bin/python\n    def something():\n    pass\n'
-        with pytest.raises(ansible.errors.AnsibleError) as exec_info:
+        with pytest.raises(
+                ansible.errors.AnsibleError,
+                match='Unable to import fake_module due to unexpected indent',
+        ):
             recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'fake_module.py'), data, *finder_containers)
-        assert 'Unable to import fake_module due to unexpected indent' in str(exec_info.value)
 
     #
     # Test importing six with many permutations because it is not a normal module

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -6,9 +6,9 @@
 
 from __future__ import annotations
 
-import json
 import os
 import typing as t
+from io import BytesIO
 
 import pytest
 
@@ -17,6 +17,7 @@ from ansible.module_utils import basic
 from ansible.module_utils.api import basic_auth_argument_spec, rate_limit_argument_spec, retry_argument_spec
 from ansible.module_utils.common import warnings
 from ansible.module_utils.common.warnings import get_deprecation_messages, get_warning_messages
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 import builtins
 
 
@@ -281,14 +282,15 @@ def test_validator_string_type(mocker, stdin):
 
 @pytest.mark.parametrize('argspec, expected, stdin', [(s[0], s[2], s[1]) for s in INVALID_SPECS],
                          indirect=['stdin'])
-def test_validator_fail(stdin, capfd, argspec, expected):
+def test_validator_fail(stdin, capfdbinary, argspec, expected):
     with pytest.raises(SystemExit):
         basic.AnsibleModule(argument_spec=argspec)
 
-    out, err = capfd.readouterr()
-    assert not err
-    assert expected in json.loads(out)['msg']
-    assert json.loads(out)['failed']
+    b_out, b_err = capfdbinary.readouterr()
+    results = next(read_json_documents(BytesIO(b_out)))
+    assert not b_err
+    assert expected in results['msg']
+    assert results['failed']
 
 
 class TestComplexArgSpecs:
@@ -322,44 +324,44 @@ class TestComplexArgSpecs:
         assert am.params['baz'] == 'test data'
 
     @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'bar': 'bad', 'bam': 'bad2', 'bing': 'a', 'bang': 'b', 'bong': 'c'}], indirect=['stdin'])
-    def test_fail_mutually_exclusive(self, capfd, stdin, complex_argspec):
+    def test_fail_mutually_exclusive(self, capfdbinary, stdin, complex_argspec):
         """Fail because of mutually exclusive parameters"""
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**complex_argspec)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert results['msg'] == "parameters are mutually exclusive: bar|bam, bing|bang|bong"
 
     @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'bam': 'bad2'}], indirect=['stdin'])
-    def test_fail_required_together(self, capfd, stdin, complex_argspec):
+    def test_fail_required_together(self, capfdbinary, stdin, complex_argspec):
         """Fail because only one of a required_together pair of parameters was specified"""
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**complex_argspec)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert results['msg'] == "parameters are required together: bam, baz"
 
     @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'bar': 'hi'}], indirect=['stdin'])
-    def test_fail_required_together_and_default(self, capfd, stdin, complex_argspec):
+    def test_fail_required_together_and_default(self, capfdbinary, stdin, complex_argspec):
         """Fail because one of a required_together pair of parameters has a default and the other was not specified"""
         complex_argspec['argument_spec']['baz'] = {'default': 42}
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**complex_argspec)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert results['msg'] == "parameters are required together: bam, baz"
 
     @pytest.mark.parametrize('stdin', [{'foo': 'hello'}], indirect=['stdin'])
-    def test_fail_required_together_and_fallback(self, capfd, mocker, stdin, complex_argspec):
+    def test_fail_required_together_and_fallback(self, capfdbinary, mocker, stdin, complex_argspec):
         """Fail because one of a required_together pair of parameters has a fallback and the other was not specified"""
         environ = os.environ.copy()
         environ['BAZ'] = 'test data'
@@ -368,20 +370,20 @@ class TestComplexArgSpecs:
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**complex_argspec)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert results['msg'] == "parameters are required together: bam, baz"
 
     @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'zardoz2': ['one', 'four', 'five']}], indirect=['stdin'])
-    def test_fail_list_with_choices(self, capfd, mocker, stdin, complex_argspec):
+    def test_fail_list_with_choices(self, capfdbinary, mocker, stdin, complex_argspec):
         """Fail because one of the items is not in the choice"""
         with pytest.raises(SystemExit):
             basic.AnsibleModule(**complex_argspec)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert results['msg'] == "value of zardoz2 must be one or more of: one, two, three. Got no match for: four, five"
@@ -561,25 +563,25 @@ class TestComplexOptions:
         assert am.params['foobar'] == expected
 
     @pytest.mark.parametrize('stdin, expected', FAILING_PARAMS_DICT, indirect=['stdin'])
-    def test_fail_validate_options_dict(self, capfd, stdin, options_argspec_dict, expected):
+    def test_fail_validate_options_dict(self, capfdbinary, stdin, options_argspec_dict, expected):
         """Fail because one of a required_together pair of parameters has a default and the other was not specified"""
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**options_argspec_dict)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert expected in results['msg']
 
     @pytest.mark.parametrize('stdin, expected', FAILING_PARAMS_LIST, indirect=['stdin'])
-    def test_fail_validate_options_list(self, capfd, stdin, options_argspec_list, expected):
+    def test_fail_validate_options_list(self, capfdbinary, stdin, options_argspec_list, expected):
         """Fail because one of a required_together pair of parameters has a default and the other was not specified"""
         with pytest.raises(SystemExit):
             am = basic.AnsibleModule(**options_argspec_list)
 
-        out, err = capfd.readouterr()
-        results = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        results = next(read_json_documents(BytesIO(b_out)))
 
         assert results['failed']
         assert expected in results['msg']

--- a/test/units/module_utils/basic/test_atomic_move.py
+++ b/test/units/module_utils/basic/test_atomic_move.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import os
 import errno
-import json
+from io import BytesIO
 from itertools import product
 
 import pytest
 
 from ansible.module_utils import basic
 from ansible.module_utils.common.file import S_IRWU_RG_RO
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 
 
 @pytest.fixture
@@ -164,7 +165,7 @@ def test_existing_file_stat_perms_failure(atomic_am, atomic_mocks, mocker):
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_rename_failure(atomic_am, atomic_mocks, mocker, capfd):
+def test_rename_failure(atomic_am, atomic_mocks, mocker, capfdbinary):
     """Test os.rename fails with EIO, causing it to bail out"""
     atomic_mocks['path_exists'].side_effect = [False, False]
     atomic_mocks['rename'].side_effect = OSError(errno.EIO, 'failing with EIO')
@@ -172,8 +173,8 @@ def test_rename_failure(atomic_am, atomic_mocks, mocker, capfd):
     with pytest.raises(SystemExit):
         atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
-    out, err = capfd.readouterr()
-    results = json.loads(out)
+    b_out, _b_err = capfdbinary.readouterr()
+    results = next(read_json_documents(BytesIO(b_out)))
 
     assert 'Could not replace file' in results['msg']
     assert 'failing with EIO' in results['msg']
@@ -181,7 +182,7 @@ def test_rename_failure(atomic_am, atomic_mocks, mocker, capfd):
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_rename_perms_fail_temp_creation_fails(atomic_am, atomic_mocks, mocker, capfd):
+def test_rename_perms_fail_temp_creation_fails(atomic_am, atomic_mocks, mocker, capfdbinary):
     """Test os.rename fails with EPERM working but failure in mkstemp"""
     atomic_mocks['path_exists'].return_value = False
     atomic_mocks['close'].return_value = None
@@ -193,8 +194,8 @@ def test_rename_perms_fail_temp_creation_fails(atomic_am, atomic_mocks, mocker, 
     with pytest.raises(SystemExit):
         atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
-    out, err = capfd.readouterr()
-    results = json.loads(out)
+    b_out, _b_err = capfdbinary.readouterr()
+    results = next(read_json_documents(BytesIO(b_out)))
 
     assert 'is not writable by the current user' in results['msg']
     assert results['failed']

--- a/test/units/module_utils/basic/test_deprecate_warn.py
+++ b/test/units/module_utils/basic/test_deprecate_warn.py
@@ -5,26 +5,30 @@
 
 from __future__ import annotations
 
-import json
+from io import BytesIO
 
 import pytest
 
 from ansible.module_utils.common import warnings
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_warn(am, capfd):
+def test_warn(am, capfdbinary):
 
     am.warn('warning1')
 
     with pytest.raises(SystemExit):
         am.exit_json(warnings=['warning2'])
-    out, err = capfd.readouterr()
-    assert json.loads(out)['warnings'] == ['warning1', 'warning2']
+
+    b_out, _b_err = capfdbinary.readouterr()
+    return_val = next(read_json_documents(BytesIO(b_out)))
+
+    assert return_val['warnings'] == ['warning1', 'warning2']
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_deprecate(am, capfd, monkeypatch):
+def test_deprecate(am, capfdbinary, monkeypatch):
     monkeypatch.setattr(warnings, '_global_deprecations', [])
 
     am.deprecate('deprecation1')  # pylint: disable=ansible-deprecated-no-version
@@ -39,8 +43,9 @@ def test_deprecate(am, capfd, monkeypatch):
     with pytest.raises(SystemExit):
         am.exit_json(deprecations=['deprecation9', ('deprecation10', '2.4')])
 
-    out, err = capfd.readouterr()
-    output = json.loads(out)
+    b_out, _b_err = capfdbinary.readouterr()
+    output = next(read_json_documents(BytesIO(b_out)))
+
     assert ('warnings' not in output or output['warnings'] == [])
     assert output['deprecations'] == [
         {u'msg': u'deprecation1', u'version': None, u'collection_name': None},
@@ -57,12 +62,13 @@ def test_deprecate(am, capfd, monkeypatch):
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_deprecate_without_list(am, capfd):
+def test_deprecate_without_list(am, capfdbinary):
     with pytest.raises(SystemExit):
         am.exit_json(deprecations='Simple deprecation warning')
 
-    out, err = capfd.readouterr()
-    output = json.loads(out)
+    b_out, _b_err = capfdbinary.readouterr()
+    output = next(read_json_documents(BytesIO(b_out)))
+
     assert ('warnings' not in output or output['warnings'] == [])
     assert output['deprecations'] == [
         {u'msg': u'Simple deprecation warning', u'version': None, u'collection_name': None},

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -4,14 +4,15 @@
 
 from __future__ import annotations
 
-import json
 import sys
 import datetime
 import typing as t
+from io import BytesIO
 
 import pytest
 
 from ansible.module_utils.common import warnings
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 
 EMPTY_INVOCATION: dict[str, dict[str, t.Any]] = {u'module_args': {}}
 DATETIME = datetime.datetime.strptime('2020-07-13 12:50:00', '%Y-%m-%d %H:%M:%S')
@@ -35,49 +36,49 @@ class TestAnsibleModuleExitJson:
     )
 
     @pytest.mark.parametrize('args, expected, stdin', ((a, e, {}) for a, e in DATA), indirect=['stdin'])
-    def test_exit_json_exits(self, am, capfd, args, expected, monkeypatch):
+    def test_exit_json_exits(self, am, capfdbinary, args, expected, monkeypatch):
         monkeypatch.setattr(warnings, '_global_deprecations', [])
 
         with pytest.raises(SystemExit) as ctx:
             am.exit_json(**args)
         assert ctx.value.code == 0
 
-        out, err = capfd.readouterr()
-        return_val = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
         assert return_val == expected
 
     @pytest.mark.parametrize('args, expected, stdin',
                              ((a, e, {}) for a, e in DATA if 'msg' in a),
                              indirect=['stdin'])
-    def test_fail_json_exits(self, am, capfd, args, expected, monkeypatch):
+    def test_fail_json_exits(self, am, capfdbinary, args, expected, monkeypatch):
         monkeypatch.setattr(warnings, '_global_deprecations', [])
 
         with pytest.raises(SystemExit) as ctx:
             am.fail_json(**args)
         assert ctx.value.code == 1
 
-        out, err = capfd.readouterr()
-        return_val = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
         # Fail_json should add failed=True
         expected['failed'] = True
         assert return_val == expected
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-    def test_fail_json_msg_positional(self, am, capfd, monkeypatch):
+    def test_fail_json_msg_positional(self, am, capfdbinary, monkeypatch):
         monkeypatch.setattr(warnings, '_global_deprecations', [])
 
         with pytest.raises(SystemExit) as ctx:
             am.fail_json('This is the msg')
         assert ctx.value.code == 1
 
-        out, err = capfd.readouterr()
-        return_val = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
         # Fail_json should add failed=True
         assert return_val == {'msg': 'This is the msg', 'failed': True,
                               'invocation': EMPTY_INVOCATION}
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-    def test_fail_json_msg_as_kwarg_after(self, am, capfd, monkeypatch):
+    def test_fail_json_msg_as_kwarg_after(self, am, capfdbinary, monkeypatch):
         """Test that msg as a kwarg after other kwargs works"""
         monkeypatch.setattr(warnings, '_global_deprecations', [])
 
@@ -85,8 +86,8 @@ class TestAnsibleModuleExitJson:
             am.fail_json(arbitrary=42, msg='This is the msg')
         assert ctx.value.code == 1
 
-        out, err = capfd.readouterr()
-        return_val = json.loads(out)
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
         # Fail_json should add failed=True
         assert return_val == {'msg': 'This is the msg', 'failed': True,
                               'arbitrary': 42,
@@ -142,23 +143,27 @@ class TestAnsibleModuleExitValuesRemoved:
                              (({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
                               for s, r, e in DATA),
                              indirect=['am', 'stdin'])
-    def test_exit_json_removes_values(self, am, capfd, return_val, expected, monkeypatch):
+    def test_exit_json_removes_values(self, am, capfdbinary, return_val, expected, monkeypatch):
         monkeypatch.setattr(warnings, '_global_deprecations', [])
         with pytest.raises(SystemExit):
             am.exit_json(**return_val)
-        out, err = capfd.readouterr()
 
-        assert json.loads(out) == expected
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
+
+        assert return_val == expected
 
     @pytest.mark.parametrize('am, stdin, return_val, expected',
                              (({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
                               for s, r, e in DATA),
                              indirect=['am', 'stdin'])
-    def test_fail_json_removes_values(self, am, capfd, return_val, expected, monkeypatch):
+    def test_fail_json_removes_values(self, am, capfdbinary, return_val, expected, monkeypatch):
         monkeypatch.setattr(warnings, '_global_deprecations', [])
         expected['failed'] = True
         with pytest.raises(SystemExit):
             am.fail_json(**return_val)
-        out, err = capfd.readouterr()
 
-        assert json.loads(out) == expected
+        b_out, _b_err = capfdbinary.readouterr()
+        return_val = next(read_json_documents(BytesIO(b_out)))
+
+        assert return_val == expected

--- a/test/units/module_utils/test__json_streams_rfc7464.py
+++ b/test/units/module_utils/test__json_streams_rfc7464.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""Tests for RFC 7464 JSON documents streaming utils."""
+# pylint: disable=redefined-outer-name
+
+from __future__ import annotations
+
+from io import BytesIO
+import json
+import os
+import random
+
+import pytest
+
+from ansible.module_utils._json_streams_rfc7464 import (
+    find_documents_in_chunk,
+    get_chunk_positions,
+    read_json_documents,
+    write_json_documents_to_stream,
+    CHUNK_SIZE,
+    LF_DELIMITER,
+    RS_DELIMITER,
+)
+
+
+PURE_PAYLOAD_SIZE = 143  # JSON byte strings + wrapping delimiter bytes
+
+
+@pytest.fixture
+def objects_sequence():
+    """Clean sequence of objects for transmission."""
+    return (
+        ["r", "🚑x", "s"],
+        {"x☃": "y"},
+        0,
+        "👷",
+        [
+            "one",
+            "two",
+            {
+                "three": {
+                    "four": 5,
+                    "six": "🐍even",
+                }
+            }
+        ],
+    )
+
+
+@pytest.fixture
+def json_stream_payload(objects_sequence):
+    """Stream with JSON records and garbage bytes."""
+    random_garbage_chunks = [
+        os.urandom(CHUNK_SIZE * i).
+        replace(LF_DELIMITER, b'\r').
+        replace(RS_DELIMITER, b'\x2e')
+        for i in range(len(objects_sequence) + 1)
+    ]
+    random.shuffle(random_garbage_chunks)
+    in_stream_jsons = map(json.dumps, objects_sequence)
+    marked_in_stream_jsons = (
+        b''.join((RS_DELIMITER, j.encode('utf-8'), LF_DELIMITER))
+        for j in in_stream_jsons
+    )
+    return BytesIO(b''.join(
+        b''.join(c)
+        for c in zip(random_garbage_chunks, marked_in_stream_jsons)
+    ))
+
+
+@pytest.mark.parametrize(
+    'b_chunk,hanging_pos,chunk_positions',
+    (
+        pytest.param(
+            b''.join((
+                b'sadf089uj',
+                RS_DELIMITER, b'r54mg9a3;45YS;s[', LF_DELIMITER,
+                b'sdaify8)(nf8SDFlx9xIK',
+            )),
+            None,
+            ((9, 26), ),
+            id='document fits',
+        ),
+        pytest.param(
+            b''.join((
+                b'sadf089uj',
+                RS_DELIMITER,
+                b'r54mg9a3;45YS;s[sdaify8)(nf8SDFlx9xIK',
+            )),
+            None,
+            ((9, None), ),
+            id='document exceeds',
+        ),
+        pytest.param(
+            b''.join((
+                b'sadf089uj',
+                LF_DELIMITER,
+                b'r54mg9a3;45YS;s[sdaify8)(nf8SDFlx9xIK',
+            )),
+            -1243,
+            ((-1243, 9), ),
+            id='document starts in the previous chunk',
+        ),
+        pytest.param(
+            b''.join((
+                b'sadf089ujr54mg9a3;45YS;s[sdaify8)(nf8SDFlx9xIK',
+            ) * 50),
+            -1243,
+            ((-1243, None), ),
+            id="doc starts in the prev chunk and doesn't end",
+        ),
+        pytest.param(
+            b''.join((
+                b'sadf089ujr54mg9a3;45YS;s[sdaify8)(nf8SDFlx9xIK',
+            ) * 50),
+            None,
+            (),
+            id='no document in the chunk',
+        ),
+    )
+)
+def test_find_documents_in_chunk(b_chunk, hanging_pos, chunk_positions):
+    """Test that document boundaries are found in chunks correctly."""
+    chunks_iter = find_documents_in_chunk(b_chunk, hanging_pos)
+    assert tuple(chunks_iter) == chunk_positions
+
+
+@pytest.mark.parametrize(
+    'b_input,chunk_positions',
+    (
+        pytest.param(b'x' * 64000, ((0, 65536), ), id='64000 bytes'),
+        pytest.param(
+            b'x' * 66000, ((0, 65536), (65536, 131072)),
+            id='66000 bytes',
+        ),
+        pytest.param(
+            b'x' * 666000,
+            (
+                (0, 65536),
+                (65536, 131072),
+                (131072, 196608),
+                (196608, 262144),
+                (262144, 327680),
+                (327680, 393216),
+                (393216, 458752),
+                (458752, 524288),
+                (524288, 589824),
+                (589824, 655360),
+                (655360, 720896),
+            ),
+            id='666000 bytes',
+        ),
+    ),
+)
+def test_get_chunk_positions(b_input, chunk_positions):
+    """Test that stream reader selects proper chunks for processing."""
+    inp = memoryview(b_input)
+    assert tuple(get_chunk_positions(inp)) == chunk_positions
+
+
+def test_read_json_documents(json_stream_payload, objects_sequence):
+    """Test that JSON records with garbage in between can be read."""
+    assert tuple(read_json_documents(json_stream_payload)) == objects_sequence
+
+
+def test_write_json_documents_to_stream(objects_sequence):
+    """Test that JSON docs sequence written into stream can be read."""
+    with BytesIO() as json_stream:
+        size = write_json_documents_to_stream(objects_sequence, json_stream)
+        assert size == PURE_PAYLOAD_SIZE
+        json_stream.seek(0)
+        assert tuple(read_json_documents(json_stream)) == objects_sequence

--- a/test/units/module_utils/test__json_streams_rfc7464.py
+++ b/test/units/module_utils/test__json_streams_rfc7464.py
@@ -67,6 +67,89 @@ def json_stream_payload(objects_sequence):
     ))
 
 
+@pytest.fixture
+def json_stream_payload_2():
+    """Stream with JSON record and missing LF in the end."""
+    return BytesIO(
+        b"\n\x1e{\"cmd\": \"for i in $(seq 1 2); "
+        b"do echo $i ; sleep 1; done;\", \"stdout\""
+        b": \"1\\n2\", \"stderr\": \"\", \"rc\": 0,"
+        b" \"start\": \"2019-07-18 07:15:41.968476"
+        b"\", \"end\": \"2019-07-18 07:15:43.974387"
+        b"\", \"delta\": \"0:00:02.005911\", \"chan"
+        b"ged\": true, \"invocation\": {\"module_ar"
+        b"gs\": {\"_raw_params\": \"for i in $(seq "
+        b"1 2); do echo $i ; sleep 1; done;\", \"_u"
+        b"ses_shell\": true, \"warn\": true, \"stdi"
+        b"n_add_newline\": true, \"strip_empty_ends"
+        b"\": true, \"argv\": null, \"chdir\": null"
+        b", \"executable\": null, \"creates\": null"
+        b", \"removes\": null, \"stdin\": null}}}"
+    )
+
+
+@pytest.fixture
+def objects_sequence_2():
+    """Original object put into a stream w/o trailing LF."""
+    return (
+        {
+            "cmd": "for i in $(seq 1 2); do echo $i ; sleep 1; done;",
+            "stdout": "1\n2",
+            "stderr": "",
+            "rc": 0, "start":
+            "2019-07-18 07:15:41.968476",
+            "end": "2019-07-18 07:15:43.974387",
+            "delta": "0:00:02.005911",
+            "changed": True,
+            "invocation": {
+                "module_args": {
+                    "_raw_params":
+                    "for i in $(seq 1 2); do echo $i ; sleep 1; done;",
+                    "_uses_shell": True,
+                    "warn": True,
+                    "stdin_add_newline": True,
+                    "strip_empty_ends": True,
+                    "argv": None,
+                    "chdir": None,
+                    "executable": None,
+                    "creates": None,
+                    "removes": None,
+                    "stdin": None,
+                }
+            }
+        },
+    )
+
+
+@pytest.fixture
+def json_stream_payload_3():
+    """Stream with JSON record starting with LF."""
+    return BytesIO(
+        b"\n"
+        b"\x1e"  # \u001e
+        b"{\"msg\": \"failed gracefully\", "
+        b"\"failed\": true, \"invocation\": "
+        b"{\"module_args\": {\"fail_mode\": "
+        b"[\"graceful\"]}}}\n",
+    )
+
+
+@pytest.fixture
+def objects_sequence_3():
+    """Original object put into a stream w/ starting LF."""
+    return {
+        'msg': 'failed gracefully',
+        'failed': True,
+        'invocation': {
+            'module_args': {
+                'fail_mode': [
+                    'graceful',
+                ],
+            },
+        },
+    }
+
+
 @pytest.mark.parametrize(
     'b_chunk,hanging_pos,chunk_positions',
     (
@@ -160,6 +243,22 @@ def test_get_chunk_positions(b_input, chunk_positions):
 def test_read_json_documents(json_stream_payload, objects_sequence):
     """Test that JSON records with garbage in between can be read."""
     assert tuple(read_json_documents(json_stream_payload)) == objects_sequence
+
+
+def test_read_async_json_payload(json_stream_payload_2, objects_sequence_2):
+    assert json_stream_payload_2.getvalue().count(b'\n') == 1
+    assert tuple(read_json_documents(json_stream_payload_2)) == ()
+    json_stream_payload_2.seek(0, 2)  # go to the end of stream
+    json_stream_payload_2.write(b'\n')
+    json_stream_payload_2.seek(0)  # back to the beginning
+    assert tuple(read_json_documents(json_stream_payload_2)) == objects_sequence_2
+
+
+def test_read_async_json_payload_3(json_stream_payload_3, objects_sequence_3):
+    assert json_stream_payload_3.getvalue().count(b'\n') == 2
+    assert tuple(find_documents_in_chunk(memoryview(json_stream_payload_3.getvalue()))) == ((1, 106), )
+    assert tuple(get_chunk_positions(memoryview(json_stream_payload_3.getvalue()))) == ((0, 65536), )
+    assert tuple(read_json_documents(json_stream_payload_3)) == (objects_sequence_3, )
 
 
 def test_write_json_documents_to_stream(objects_sequence):

--- a/test/units/modules/test_service.py
+++ b/test/units/modules/test_service.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 
-import json
 import platform
+from io import BytesIO
 
 import pytest
 from ansible.modules import service
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._json_streams_rfc7464 import read_json_documents
 from units.modules.utils import set_module_args
 
 
@@ -49,7 +50,7 @@ def mocked_sunos_service(mocker):
     mocker_sunos_service(mocker)
 
 
-def test_sunos_service_start(mocked_sunos_service, capfd):
+def test_sunos_service_start(mocked_sunos_service, capfdbinary):
     """
     test SunOS Service Start
     """
@@ -62,7 +63,7 @@ def test_sunos_service_start(mocked_sunos_service, capfd):
     with pytest.raises(SystemExit):
         service.main()
 
-    out, dummy = capfd.readouterr()
-    results = json.loads(out)
+    b_out, _b_err = capfdbinary.readouterr()
+    results = next(read_json_documents(BytesIO(b_out)))
     assert not results.get("failed")
     assert results["changed"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implement JSON streaming according to RFC 7464 which should allow ignoring any garbage in between JSON records in a robust fashion.

Ref: https://tools.ietf.org/html/rfc7464
Ref: https://en.wikipedia.org/wiki/JSON_streaming#Record_separator-delimited_JSON

Related: #13620

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #54949 (potentially)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
RFC 7464 describes a way of streaming a series of JSON documents wrapped with RS and LF markers.