### PR TITLE
removes last :doc: links in the dev guide

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -113,11 +113,11 @@ command line tools (``lib/ansible/cli/``) is `available on GitHub <https://githu
 
 .. seealso::
 
-   :doc:`developing_inventory`
+   :ref:`developing_inventory`
        Developing dynamic inventory integrations
-   :doc:`developing_modules`
-       How to develop modules
-   :doc:`developing_plugins`
+   :ref:`developing_modules_general`
+       Getting started on developing a module
+   :ref:`developing_plugins`
        How to develop plugins
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics

--- a/docs/docsite/rst/dev_guide/developing_core.rst
+++ b/docs/docsite/rst/dev_guide/developing_core.rst
@@ -14,9 +14,9 @@ those pieces work together.
 
 .. seealso::
 
-   :doc:`developing_api`
+   :ref:`developing_api`
        Learn about the Python API for task execution
-   :doc:`developing_plugins`
+   :ref:`developing_plugins`
        Learn about developing plugins
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -422,11 +422,11 @@ An easy way to see how this should look is using :ref:`ansible-inventory`, which
 
 .. seealso::
 
-   :doc:`developing_api`
+   :ref:`developing_api`
        Python API to Playbooks and Ad Hoc Task Execution
-   :doc:`developing_modules`
-       How to develop modules
-   :doc:`developing_plugins`
+   :ref:`developing_modules_general`
+       Get started with developing a module
+   :ref:`developing_plugins`
        How to develop plugins
    `Ansible Tower <https://www.ansible.com/products/tower>`_
        REST API endpoint and GUI for Ansible, syncs with dynamic inventory

--- a/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
@@ -285,9 +285,9 @@ Example code
                 ),
             ],
         )
-        
+
         aci.get_diff(aci_class='<object APIC class>')
-        
+
         aci.post_config()
 
 
@@ -324,7 +324,7 @@ You can test your ``construct_url()`` and ``payload()`` arguments without access
     #!/usr/bin/python
     import json
     from ansible.module_utils.network.aci.aci import ACIModule
-    
+
     # Just another class mimicking a bare AnsibleModule class for construct_url() and payload() methods
     class AltModule():
         params = dict(
@@ -334,21 +334,21 @@ You can test your ``construct_url()`` and ``payload()`` arguments without access
             state='present',
             output_level='debug',
         )
-    
+
     # A sub-class of ACIModule to overload __init__ (we don't need to log into APIC)
     class AltACIModule(ACIModule):
         def __init__(self):
             self.result = dict(changed=False)
             self.module = AltModule()
             self.params = self.module.params
-    
+
     # Instantiate our version of the ACI module
     aci = AltACIModule()
-    
+
     # Define the variables you need below
     aep = 'AEP'
     aep_domain = 'uni/phys-DOMAIN'
-    
+
     # Below test the construct_url() arguments to see if it produced correct results
     aci.construct_url(
         root_class=dict(
@@ -364,13 +364,13 @@ You can test your ``construct_url()`` and ``payload()`` arguments without access
             module_object=aep_domain,
         ),
     )
-    
+
     # Below test the payload arguments to see if it produced correct results
     aci.payload(
         aci_class='infraRsDomP',
         class_config=dict(tDn=aep_domain),
     )
-    
+
     # Print the URL and proposed payload
     print 'URL:', json.dumps(aci.url, indent=4)
     print 'PAYLOAD:', json.dumps(aci.proposed, indent=4)
@@ -399,7 +399,7 @@ You can run from your fork something like:
 
 .. seealso::
 
-   :doc:`testing_sanity`
+   :ref:`testing_sanity`
         Information on how to build sanity tests.
 
 
@@ -423,13 +423,13 @@ You may want to edit the used inventory at *test/integration/inventory.networkin
     aci_password=my-password
     aci_use_ssl=yes
     aci_use_proxy=no
-    
+
     [aci]
     localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
 
 .. seealso::
 
-   :doc:`testing_integration`
+   :ref:`testing_integration`
        Information on how to build integration tests.
 
 

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -23,14 +23,14 @@ Before you start coding
 
 Although it's tempting to get straight into coding, there are a few things to be aware of first. This list of prerequisites is designed to help ensure that you develop high-quality modules that flow easily through the review process and get into Ansible more quickly.
 
-* Read though all the pages linked off :doc:`developing_modules`; paying particular focus to the :doc:`developing_modules_checklist`.
-* New modules must be PEP 8 compliant. See :doc:`testing_pep8` for more information.
+* Read though all the pages linked off :ref:`developing_modules_general`; paying particular focus to the :ref:`developing_modules_checklist`.
+* New modules must be PEP 8 compliant. See :ref:`testing_pep8` for more information.
 * Starting with Ansible version 2.7, all new modules must :ref:`support Python 2.7+ and Python 3.5+ <developing_python_3>`. If this is an issue, please contact us (see the "Speak to us" section later in this document to learn how).
 * Have a look at the existing modules and how they've been named in the :ref:`all_modules`, especially in the same functional area (such as cloud, networking, databases).
 * Shared code can be placed into ``lib/ansible/module_utils/``
 * Shared documentation (for example describing common arguments) can be placed in ``lib/ansible/plugins/doc_fragments/``.
 * With great power comes great responsibility: Ansible module maintainers have a duty to help keep modules up to date. As with all successful community projects, module maintainers should keep a watchful eye for reported issues and contributions.
-* Although not required, unit and/or integration tests are strongly recommended. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :doc:`testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+* Although not required, unit and/or integration tests are strongly recommended. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
   * Starting with Ansible 2.4 all :ref:`network_modules` MUST have unit tests.
 
 
@@ -94,7 +94,7 @@ The first PR should include the following files:
 
 And that's it.
 
-Before pushing your PR to GitHub it's a good idea to review the :doc:`developing_modules_checklist` again.
+Before pushing your PR to GitHub it's a good idea to review the :ref:`developing_modules_checklist` again.
 
 After publishing your PR to https://github.com/ansible/ansible, a Shippable CI test should run within a few minutes. Check the results (at the end of the PR page) to ensure that it's passing (green). If it's not passing, inspect each of the results. Most of the errors should be self-explanatory and are often related to badly formatted documentation (see :ref:`yaml_syntax`) or code that isn't valid Python 2.6  or valid Python 3.5 (see :ref:`developing_python_3`). If you aren't sure what a Shippable test message means, copy it into the PR along with a comment and we will review.
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -453,11 +453,11 @@ For example vars plugins, see the source code for the `vars plugins included wit
 
    :ref:`all_modules`
        List of all modules
-   :doc:`developing_api`
+   :ref:`developing_api`
        Learn about the Python API for task execution
-   :doc:`developing_inventory`
+   :ref:`developing_inventory`
        Learn about how to develop dynamic inventory sources
-   :doc:`developing_modules`
+   :ref:`developing_modules_general`
        Learn about how to write Ansible modules
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -207,7 +207,7 @@ The code coverage reports only cover the ``devel`` branch of Ansible where new f
 development takes place.  Pull requests and new code will be missing from the codecov.io
 coverage reports so local reporting is needed.  Most ``ansible-test`` commands allow you
 to collect code coverage, this is particularly useful to indicate where to extend
-testing. See :doc:`testing_running_locally` for more information.
+testing. See :ref:`testing_running_locally` for more information.
 
 
 Want to know more about testing?

--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -1,4 +1,4 @@
 Sanity Tests » compile
 ======================
 
-See :doc:`../../testing_compile` for more information.
+See :ref:`testing_compile` for more information.

--- a/docs/docsite/rst/dev_guide/testing/sanity/pep8.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/pep8.rst
@@ -3,4 +3,4 @@ Sanity Tests » pep8
 
 Python static analysis for PEP 8 style guideline compliance.
 
-See :doc:`../../testing_pep8` for more information.
+See :ref:`testing_pep8` for more information.

--- a/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
@@ -3,4 +3,4 @@ Sanity Tests » validate-modules
 
 Analyze modules for common issues in code and documentation.
 
-See :doc:`../../testing_validate-modules` for more information.
+See :ref:`testing_validate-modules` for more information.

--- a/docs/docsite/rst/dev_guide/testing_httptester.rst
+++ b/docs/docsite/rst/dev_guide/testing_httptester.rst
@@ -9,7 +9,7 @@ httptester
 Overview
 ========
 
-``httptester`` is a docker container used to host certain resources required by :doc:`testing_integration`. This is to avoid CI tests requiring external resources (such as git or package repos) which, if temporarily unavailable, would cause tests to fail.
+``httptester`` is a docker container used to host certain resources required by :ref:`testing_integration`. This is to avoid CI tests requiring external resources (such as git or package repos) which, if temporarily unavailable, would cause tests to fail.
 
 HTTP Testing endpoint which provides the following capabilities:
 

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -65,7 +65,7 @@ Code Coverage
 
 Code coverage reports make it easy to identify untested code for which more tests should
 be written.  Online reports are available but only cover the ``devel`` branch (see
-:doc:`testing`).  For new code local reports are needed.
+:ref:`developing_testing`).  For new code local reports are needed.
 
 Add the ``--coverage`` option to any test command to collect code coverage data.  If you
 aren't using the ``--tox`` or ``--docker`` options which create an isolated python

--- a/docs/docsite/rst/dev_guide/testing_units.rst
+++ b/docs/docsite/rst/dev_guide/testing_units.rst
@@ -178,7 +178,7 @@ If you are simulating APIs you may find that python placebo is useful.  See
 
 Code Coverage For New or Updated Unit Tests
 ```````````````````````````````````````````
-New code will be missing from the codecov.io coverage reports (see :doc:`testing`), so
+New code will be missing from the codecov.io coverage reports (see :ref:`developing_testing`), so
 local reporting is needed.  Most ``ansible-test`` commands allow you to collect code
 coverage; this is particularly useful when to indicate where to extend testing.
 
@@ -206,7 +206,7 @@ reports.
 
    :ref:`testing_units_modules`
        Special considerations for unit testing modules
-   :doc:`testing_running_locally`
+   :ref:`testing_running_locally`
        Running tests locally including gathering and reporting coverage data
    `Python 3 documentation - 26.4. unittest — Unit testing framework <https://docs.python.org/3/library/unittest.html>`_
        The documentation of the unittest framework in python 3

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -16,7 +16,7 @@ Introduction
 This document explains why, how and when you should use unit tests for Ansible modules.
 The document doesn't apply to other parts of Ansible for which the recommendations are
 normally closer to the Python standard.  There is basic documentation for Ansible unit
-tests in the developer guide :doc:`testing_units`.  This document should
+tests in the developer guide :ref:`testing_units`.  This document should
 be readable for a new Ansible module author. If you find it incomplete or confusing,
 please open a bug or ask for help on Ansible IRC.
 
@@ -294,9 +294,9 @@ handled through the :class:`AnsibleModule` object in the basic section of the ut
 this accepts input on ``STDIN``, which is not convenient for unit testing. When the special
 variable is set it will be treated as if the input came on ``STDIN`` to the module. Simply call that function before setting up your module::
 
-    import json 
-    from units.modules.utils import set_module_args 
-    from ansible.module_utils._text import to_bytes 
+    import json
+    from units.modules.utils import set_module_args
+    from ansible.module_utils._text import to_bytes
 
     def test_already_registered(self):
         set_module_args({
@@ -538,12 +538,12 @@ the code in Ansible to trigger that failure.
 
 .. seealso::
 
-   :doc:`testing_units`
+   :ref:`testing_units`
        Ansible unit tests documentation
-   :doc:`testing_running_locally`
+   :ref:`testing_running_locally`
        Running tests locally including gathering and reporting coverage data
-   :doc:`developing_modules`
-       How to develop modules
+   :ref:`developing_modules_general`
+       Get started developing a module
    `Python 3 documentation - 26.4. unittest — Unit testing framework <https://docs.python.org/3/library/unittest.html>`_
        The documentation of the unittest framework in python 3
    `Python 2 documentation - 25.3. unittest — Unit testing framework <https://docs.python.org/3/library/unittest.html>`_

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _testing_validate-modules:
+
 ****************
 validate-modules
 ****************
@@ -8,7 +10,7 @@ validate-modules
 
 Python program to help test or validate Ansible modules.
 
-``validate-modules`` is one of the ``ansible-test`` Sanity Tests, see :doc:`testing_sanity` for more information.
+``validate-modules`` is one of the ``ansible-test`` Sanity Tests, see :ref:`testing_sanity` for more information.
 
 Originally developed by Matt Martz (@sivel)
 


### PR DESCRIPTION
##### SUMMARY
We want all links within the documentation to use the `:ref:` syntax, so links do not break if a page moves. 

This brings us into compliance with our own [style guide](https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#adding-internal-links).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
