### PR TITLE
[vars_plugins] gather vars once per unique directory and entities

### DIFF
--- a/changelogs/fragments/run_vars_plugins_once_per_unique_dir_and_entities.yml
+++ b/changelogs/fragments/run_vars_plugins_once_per_unique_dir_and_entities.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - run vars plugins once per unique directory and entities.

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -231,7 +231,6 @@ class VariableManager:
                     C.VARIABLE_PRECEDENCE.index(category + '_plugins_inventory')
                 )
 
-
             def _get_plugin_vars(plugin, path, entities):
                 data = {}
                 try:

--- a/test/integration/targets/plugin_vars_once/aliases
+++ b/test/integration/targets/plugin_vars_once/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group2

--- a/test/integration/targets/plugin_vars_once/aliases
+++ b/test/integration/targets/plugin_vars_once/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/plugin_vars_once/configs/default.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/default.cfg
@@ -1,0 +1,8 @@
+[defaults]
+precedence=
+    all_inventory,
+    groups_inventory,
+    all_plugins_inventory,
+    all_plugins_play,
+    groups_plugins_inventory,
+    groups_plugins_play

--- a/test/integration/targets/plugin_vars_once/configs/no_inventory.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/no_inventory.cfg
@@ -1,0 +1,6 @@
+[defaults]
+precedence=
+    all_inventory,
+    groups_inventory,
+    all_plugins_play,
+    groups_plugins_play

--- a/test/integration/targets/plugin_vars_once/configs/no_play.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/no_play.cfg
@@ -1,0 +1,6 @@
+[defaults]
+precedence=
+    all_inventory,
+    groups_inventory,
+    all_plugins_inventory,
+    groups_plugins_inventory

--- a/test/integration/targets/plugin_vars_once/configs/no_plugins.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/no_plugins.cfg
@@ -1,0 +1,4 @@
+[defaults]
+precedence=
+    all_inventory,
+    groups_inventory

--- a/test/integration/targets/plugin_vars_once/configs/reverse.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/reverse.cfg
@@ -1,0 +1,8 @@
+[defaults]
+precedence=
+    groups_plugins_play,
+    groups_plugins_inventory,
+    all_plugins_play,
+    all_plugins_inventory,
+    groups_inventory,
+    all_inventory

--- a/test/integration/targets/plugin_vars_once/configs/reverse_no_inventory.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/reverse_no_inventory.cfg
@@ -1,0 +1,6 @@
+[defaults]
+precedence=
+    groups_plugins_play,
+    all_plugins_play,
+    groups_inventory,
+    all_inventory

--- a/test/integration/targets/plugin_vars_once/configs/reverse_no_play.cfg
+++ b/test/integration/targets/plugin_vars_once/configs/reverse_no_play.cfg
@@ -1,0 +1,6 @@
+[defaults]
+precedence=
+    groups_plugins_inventory,
+    all_plugins_inventory,
+    groups_inventory,
+    all_inventory

--- a/test/integration/targets/plugin_vars_once/inventory
+++ b/test/integration/targets/plugin_vars_once/inventory
@@ -1,0 +1,1 @@
+../../inventory

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/default.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/default.log
@@ -1,0 +1,3 @@
+PLAY_DIR [all]
+PLAY_DIR [testgroup]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_inventory.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_inventory.log
@@ -1,0 +1,3 @@
+PLAY_DIR [all]
+PLAY_DIR [testgroup]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_play.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_play.log
@@ -1,0 +1,3 @@
+PLAY_DIR [all]
+PLAY_DIR [testgroup]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_plugins.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/no_plugins.log
@@ -1,0 +1,1 @@
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse.log
@@ -1,0 +1,3 @@
+PLAY_DIR [testgroup]
+PLAY_DIR [all]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse_no_inventory.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse_no_inventory.log
@@ -1,0 +1,3 @@
+PLAY_DIR [testgroup]
+PLAY_DIR [all]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse_no_play.log
+++ b/test/integration/targets/plugin_vars_once/logs/inventory_next_to_playbook/reverse_no_play.log
@@ -1,0 +1,3 @@
+PLAY_DIR [testgroup]
+PLAY_DIR [all]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/default.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/default.log
@@ -1,0 +1,6 @@
+INV_DIR [all]
+PLAY_DIR [all]
+INV_DIR [testgroup]
+PLAY_DIR [testgroup]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_inventory.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_inventory.log
@@ -1,0 +1,4 @@
+PLAY_DIR [all]
+PLAY_DIR [testgroup]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_play.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_play.log
@@ -1,0 +1,4 @@
+INV_DIR [all]
+INV_DIR [testgroup]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_plugins.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/no_plugins.log
@@ -1,0 +1,2 @@
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse.log
@@ -1,0 +1,6 @@
+PLAY_DIR [testgroup]
+INV_DIR [testgroup]
+PLAY_DIR [all]
+INV_DIR [all]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse_no_inventory.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse_no_inventory.log
@@ -1,0 +1,4 @@
+PLAY_DIR [testgroup]
+PLAY_DIR [all]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse_no_play.log
+++ b/test/integration/targets/plugin_vars_once/logs/remote_inventory/reverse_no_play.log
@@ -1,0 +1,4 @@
+INV_DIR [testgroup]
+INV_DIR [all]
+INV_DIR [testhost]
+PLAY_DIR [testhost]

--- a/test/integration/targets/plugin_vars_once/playbook.yml
+++ b/test/integration/targets/plugin_vars_once/playbook.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: dummy
+      ping:

--- a/test/integration/targets/plugin_vars_once/runme.sh
+++ b/test/integration/targets/plugin_vars_once/runme.sh
@@ -20,8 +20,8 @@ function fail {
     let EXIT_CODE++
 }
 
-PLAY_DIR="$PWD"
-EXIT_CODE=
+PLAY_DIR="/test/integration/targets/plugin_vars_once"
+EXIT_CODE=0
 
 PLUGIN_VARS_LOG_PATH=$(mktemp)
 export PLUGIN_VARS_LOG_PATH
@@ -31,11 +31,11 @@ for ANSIBLE_CONFIG in configs/* ; do
     LOG_NAME=$(basename -s .cfg "$ANSIBLE_CONFIG").log
 
     ## inventory dir == playbook dir
-    INV_DIR="$PWD"
-    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory
+    INV_DIR="$PLAY_DIR"
+    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory >&2
 
     clear_log
-    ansible-playbook playbook.yml -i inventory > /dev/null
+    ansible-playbook playbook.yml -i inventory "$@"
 
     TEMPLATE=logs/inventory_next_to_playbook/"$LOG_NAME"
 
@@ -44,11 +44,11 @@ for ANSIBLE_CONFIG in configs/* ; do
     fi
 
     ## inventory dir != playbook dir
-    INV_DIR=$(dirname "$(readlink -f inventory)")
-    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory
+    INV_DIR="/test/integration"
+    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory >&2
 
     clear_log
-    ansible-playbook playbook.yml -i ../../inventory > /dev/null
+    ansible-playbook playbook.yml -i ../../inventory "$@"
 
     TEMPLATE=logs/remote_inventory/"$LOG_NAME"
 

--- a/test/integration/targets/plugin_vars_once/runme.sh
+++ b/test/integration/targets/plugin_vars_once/runme.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+function cleanup {
+    rm -f ${PLUGIN_VARS_LOG_PATH}
+}
+trap cleanup EXIT
+
+function clear_log {
+    truncate --size=0 ${PLUGIN_VARS_LOG_PATH}
+}
+function fill_template {
+    sed "s#PLAY_DIR#$PLAY_DIR#;s#INV_DIR#$INV_DIR#" $1
+}
+
+function fail {
+    echo --- >&2
+    echo Full log: >&2
+    cat ${PLUGIN_VARS_LOG_PATH} >&2
+    echo --- >&2
+    let EXIT_CODE++
+}
+
+PLAY_DIR=${PWD}
+EXIT_CODE=
+
+export PLUGIN_VARS_LOG_PATH=$(mktemp)
+
+for ANSIBLE_CONFIG in configs/* ; do
+    export ANSIBLE_CONFIG
+    LOG_NAME=$(basename -s .cfg ${ANSIBLE_CONFIG}).log
+
+    ## inventory dir == playbook dir
+    INV_DIR=${PWD}
+    echo CONFIG: ${ANSIBLE_CONFIG} INVENTORY: ${INV_DIR}/inventory
+
+    clear_log
+    ansible-playbook playbook.yml -i inventory > /dev/null
+
+    TEMPLATE=logs/inventory_next_to_playbook/${LOG_NAME}
+
+    if ! diff ${PLUGIN_VARS_LOG_PATH} <(fill_template ${TEMPLATE}) >&2; then
+        fail
+    fi
+
+    ## inventory dir != playbook dir
+    INV_DIR=$(dirname $(readlink -f inventory))
+    echo CONFIG: ${ANSIBLE_CONFIG} INVENTORY: ${INV_DIR}/inventory
+
+    clear_log
+    ansible-playbook playbook.yml -i ../../inventory > /dev/null
+
+    TEMPLATE=logs/remote_inventory/${LOG_NAME}
+
+    if ! diff ${PLUGIN_VARS_LOG_PATH} <(fill_template ${TEMPLATE}) >&2; then
+        fail
+    fi
+done
+
+exit ${EXIT_CODE}

--- a/test/integration/targets/plugin_vars_once/runme.sh
+++ b/test/integration/targets/plugin_vars_once/runme.sh
@@ -26,9 +26,20 @@ EXIT_CODE=0
 PLUGIN_VARS_LOG_PATH=$(mktemp)
 export PLUGIN_VARS_LOG_PATH
 
-for ANSIBLE_CONFIG in configs/* ; do
+CASES="
+default
+no_inventory
+no_play
+no_plugins
+reverse
+reverse_no_inventory
+reverse_no_play
+"
+
+for CASE in ${CASES}; do
+    ANSIBLE_CONFIG="configs/$CASE.cfg"
     export ANSIBLE_CONFIG
-    LOG_NAME=$(basename -s .cfg "$ANSIBLE_CONFIG").log
+    LOG_NAME="$CASE.log"
 
     ## inventory dir == playbook dir
     INV_DIR="$PLAY_DIR"

--- a/test/integration/targets/plugin_vars_once/runme.sh
+++ b/test/integration/targets/plugin_vars_once/runme.sh
@@ -1,59 +1,60 @@
 #!/usr/bin/env bash
 
 function cleanup {
-    rm -f ${PLUGIN_VARS_LOG_PATH}
+    rm -f "$PLUGIN_VARS_LOG_PATH"
 }
 trap cleanup EXIT
 
 function clear_log {
-    truncate --size=0 ${PLUGIN_VARS_LOG_PATH}
+    truncate --size=0 "$PLUGIN_VARS_LOG_PATH"
 }
 function fill_template {
-    sed "s#PLAY_DIR#$PLAY_DIR#;s#INV_DIR#$INV_DIR#" $1
+    sed "s#PLAY_DIR#$PLAY_DIR#;s#INV_DIR#$INV_DIR#" "$1"
 }
 
 function fail {
     echo --- >&2
     echo Full log: >&2
-    cat ${PLUGIN_VARS_LOG_PATH} >&2
+    cat "$PLUGIN_VARS_LOG_PATH" >&2
     echo --- >&2
     let EXIT_CODE++
 }
 
-PLAY_DIR=${PWD}
+PLAY_DIR="$PWD"
 EXIT_CODE=
 
-export PLUGIN_VARS_LOG_PATH=$(mktemp)
+PLUGIN_VARS_LOG_PATH=$(mktemp)
+export PLUGIN_VARS_LOG_PATH
 
 for ANSIBLE_CONFIG in configs/* ; do
     export ANSIBLE_CONFIG
-    LOG_NAME=$(basename -s .cfg ${ANSIBLE_CONFIG}).log
+    LOG_NAME=$(basename -s .cfg "$ANSIBLE_CONFIG").log
 
     ## inventory dir == playbook dir
-    INV_DIR=${PWD}
-    echo CONFIG: ${ANSIBLE_CONFIG} INVENTORY: ${INV_DIR}/inventory
+    INV_DIR="$PWD"
+    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory
 
     clear_log
     ansible-playbook playbook.yml -i inventory > /dev/null
 
-    TEMPLATE=logs/inventory_next_to_playbook/${LOG_NAME}
+    TEMPLATE=logs/inventory_next_to_playbook/"$LOG_NAME"
 
-    if ! diff ${PLUGIN_VARS_LOG_PATH} <(fill_template ${TEMPLATE}) >&2; then
+    if ! diff "$PLUGIN_VARS_LOG_PATH" <(fill_template "$TEMPLATE") >&2; then
         fail
     fi
 
     ## inventory dir != playbook dir
-    INV_DIR=$(dirname $(readlink -f inventory))
-    echo CONFIG: ${ANSIBLE_CONFIG} INVENTORY: ${INV_DIR}/inventory
+    INV_DIR=$(dirname "$(readlink -f inventory)")
+    echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory
 
     clear_log
     ansible-playbook playbook.yml -i ../../inventory > /dev/null
 
-    TEMPLATE=logs/remote_inventory/${LOG_NAME}
+    TEMPLATE=logs/remote_inventory/"$LOG_NAME"
 
-    if ! diff ${PLUGIN_VARS_LOG_PATH} <(fill_template ${TEMPLATE}) >&2; then
+    if ! diff "$PLUGIN_VARS_LOG_PATH" <(fill_template "$TEMPLATE") >&2; then
         fail
     fi
 done
 
-exit ${EXIT_CODE}
+exit "$EXIT_CODE"

--- a/test/integration/targets/plugin_vars_once/runme.sh
+++ b/test/integration/targets/plugin_vars_once/runme.sh
@@ -5,8 +5,10 @@ function cleanup {
 }
 trap cleanup EXIT
 
-function clear_log {
-    truncate --size=0 "$PLUGIN_VARS_LOG_PATH"
+function new_log {
+    cleanup
+    PLUGIN_VARS_LOG_PATH=$(mktemp)
+    export PLUGIN_VARS_LOG_PATH
 }
 function fill_template {
     sed "s#PLAY_DIR#$PLAY_DIR#;s#INV_DIR#$INV_DIR#" "$1"
@@ -23,8 +25,7 @@ function fail {
 PLAY_DIR="/test/integration/targets/plugin_vars_once"
 EXIT_CODE=0
 
-PLUGIN_VARS_LOG_PATH=$(mktemp)
-export PLUGIN_VARS_LOG_PATH
+PLUGIN_VARS_LOG_PATH=
 
 CASES="
 default
@@ -45,7 +46,7 @@ for CASE in ${CASES}; do
     INV_DIR="$PLAY_DIR"
     echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory >&2
 
-    clear_log
+    new_log
     ansible-playbook playbook.yml -i inventory "$@"
 
     TEMPLATE=logs/inventory_next_to_playbook/"$LOG_NAME"
@@ -58,7 +59,7 @@ for CASE in ${CASES}; do
     INV_DIR="/test/integration"
     echo CONFIG: "$ANSIBLE_CONFIG" INVENTORY: "$INV_DIR"/inventory >&2
 
-    clear_log
+    new_log
     ansible-playbook playbook.yml -i ../../inventory "$@"
 
     TEMPLATE=logs/remote_inventory/"$LOG_NAME"

--- a/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
+++ b/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
@@ -1,0 +1,13 @@
+import os
+
+class VarsModule(object):
+    @staticmethod
+    def _log(line):
+        with open(os.environ['PLUGIN_VARS_LOG_PATH'], 'a') as logger:
+            logger.write(line + '\n')
+
+    def get_vars(self, loader, path, entities, cache=True):
+        entry = str(path) + ' ' + repr(entities)
+
+        self._log(entry)
+        return {}

--- a/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
+++ b/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
@@ -1,4 +1,9 @@
 import os
+from os.path import dirname
+
+from ansible.module_utils._text import to_text
+
+TEST_ROOT = to_text(dirname(dirname(dirname(dirname(dirname(dirname(__file__)))))))
 
 
 class VarsModule(object):
@@ -8,7 +13,8 @@ class VarsModule(object):
             logger.write(line + '\n')
 
     def get_vars(self, loader, path, entities, cache=True):
-        entry = str(path) + ' ' + repr(entities)
+        entry = to_text(path).replace(TEST_ROOT, '')
+        entry += ' ' + repr(entities)
 
         self._log(entry)
         return {}

--- a/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
+++ b/test/integration/targets/plugin_vars_once/vars_plugins/logger.py
@@ -1,5 +1,6 @@
 import os
 
+
 class VarsModule(object):
     @staticmethod
     def _log(line):


### PR DESCRIPTION
##### SUMMARY
The inventory may sit next to the playbook. Inventory directory and
 playbook directory overlap in this case. Causing a duplicate run.

Depending on the configured loading sequence a given directory may be
 loaded as an inventory directory or as a playbook directory.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vars_plugins

##### ADDITIONAL INFORMATION

Reduces the invocation count in #47249 from 36 to 18:

36 = `3 nodes` * (`gather facts` + `ls-task`) * (`all-group` + `nodes-group` + `host`) * (`inventory-dir` + `playbook-dir`)

Playbook directory and inventory directory are the same, we can drop the duplicate call.

---

Output of the new integration test without the patch
<details>

```
$ REPO=$PWD; cd ./test/integration/targets/plugin_vars_once && ./runme.sh 2>&1 | sed "s#${REPO}#REPO#g"; cd "$REPO"
CONFIG: configs/default.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
2d1
< REPO/test/integration/targets/plugin_vars_once [all]
4,5d2
< REPO/test/integration/targets/plugin_vars_once [testgroup]
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/default.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/no_inventory.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
4d3
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/no_inventory.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/no_play.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
4d3
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/no_play.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/no_plugins.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
2d1
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/no_plugins.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/reverse.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
2d1
< REPO/test/integration/targets/plugin_vars_once [testgroup]
4,5d2
< REPO/test/integration/targets/plugin_vars_once [all]
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/reverse.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/reverse_no_inventory.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
4d3
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/reverse_no_inventory.cfg INVENTORY: REPO/test/integration/inventory
CONFIG: configs/reverse_no_play.cfg INVENTORY: REPO/test/integration/targets/plugin_vars_once/inventory
4d3
< REPO/test/integration/targets/plugin_vars_once [testhost]
---
Full log:
REPO/test/integration/targets/plugin_vars_once [testgroup]
REPO/test/integration/targets/plugin_vars_once [all]
REPO/test/integration/targets/plugin_vars_once [testhost]
REPO/test/integration/targets/plugin_vars_once [testhost]
---
CONFIG: configs/reverse_no_play.cfg INVENTORY: REPO/test/integration/inventory
```
</details>