### PR TITLE
[WIP] fix use of AnsibleError for inventory plugins

### DIFF
--- a/lib/ansible/plugins/inventory/docker_swarm.py
+++ b/lib/ansible/plugins/inventory/docker_swarm.py
@@ -140,7 +140,7 @@ keyed_groups:
     prefix: label
 '''
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_native
 from ansible.module_utils.docker.common import update_tls_hostname, get_connect_params
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
@@ -249,8 +249,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_DOCKER:
-            raise AnsibleError('The Docker swarm dynamic inventory plugin requires the Docker SDK for Python: '
-                               'https://github.com/docker/docker-py.')
+            raise AnsibleParserError('The Docker swarm dynamic inventory plugin requires the Docker SDK for Python: '
+                                     'https://github.com/docker/docker-py.')
         super(InventoryModule, self).parse(inventory, loader, path, cache)
         self._read_config_data(path)
         self._populate()

--- a/lib/ansible/plugins/inventory/gitlab_runners.py
+++ b/lib/ansible/plugins/inventory/gitlab_runners.py
@@ -72,7 +72,7 @@ keyed_groups:
     prefix: tag
 '''
 
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 
@@ -124,7 +124,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_GITLAB:
-            raise AnsibleError('The Gitlab runners dynamic inventory plugin requires python-gitlab: https://python-gitlab.readthedocs.io/en/stable/')
+            raise AnsibleParserError('The Gitlab runners dynamic inventory plugin requires python-gitlab: https://python-gitlab.readthedocs.io/en/stable/')
         super(InventoryModule, self).parse(inventory, loader, path, cache)
         self._read_config_data(path)
         self._populate()

--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -86,15 +86,16 @@ keyed_groups:
 """
 
 import os
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_native
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.release import __version__
 
 try:
     from hcloud import hcloud
+    HAS_HCLOUD = True
 except ImportError:
-    raise AnsibleError("The Hetzner Cloud dynamic inventory plugin requires hcloud-python.")
+    HAS_HCLOUD = False
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):
@@ -187,7 +188,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         )
 
     def parse(self, inventory, loader, path, cache=True):
+        if not HAS_HCLOUD:
+            raise AnsibleParserError("The Hetzner Cloud dynamic inventory plugin requires hcloud-python.")
+
         super(InventoryModule, self).parse(inventory, loader, path, cache)
+
         self._read_config_data(path)
         self._configure_hcloud_client()
         self._test_hcloud_token()

--- a/lib/ansible/plugins/inventory/k8s.py
+++ b/lib/ansible/plugins/inventory/k8s.py
@@ -114,7 +114,7 @@ connections:
 
 import json
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.k8s.common import K8sAnsibleMixin, HAS_K8S_MODULE_HELPER, k8s_import_exception
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
@@ -135,7 +135,7 @@ def format_dynamic_api_exc(exc):
         return '%s Reason: %s' % (exc.status, exc.reason)
 
 
-class K8sInventoryException(Exception):
+class K8sInventoryException(AnsibleParserError):
     pass
 
 

--- a/lib/ansible/plugins/inventory/linode.py
+++ b/lib/ansible/plugins/inventory/linode.py
@@ -182,7 +182,7 @@ class InventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=True):
         """Dynamically parse Linode the cloud inventory."""
         if not HAS_LINODE_API4:
-            raise AnsibleParserError('the Linode dynamic inventory plugin requires linode_api4.')
+            raise AnsibleParserError('The Linode dynamic inventory plugin requires linode_api4.')
 
         super(InventoryModule, self).parse(inventory, loader, path)
 


### PR DESCRIPTION
##### SUMMARY
Use AnsibleError for fatal errors that should exclude a source from being parsed by any inventory. Use AnsibleParserError for non-fatal errors so other plugins can attempt to parse.

needs:
- [ ] inventory/manager.py fix
- [ ] docs/porting guide

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins