### PR TITLE
Delete podman containers leftovers in CI tests

### DIFF
--- a/test/integration/targets/podman_container/tasks/main.yml
+++ b/test/integration/targets/podman_container/tasks/main.yml
@@ -3,6 +3,16 @@
     - ansible_facts.virtualization_type != 'docker'
     - ansible_facts.distribution in ['RedHat', 'Fedora']
   block:
+
+    - name: Delete all container leftovers from tests if exist
+      podman_container:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "alpine:3.7"
+        - "container"
+        - "container2"
+
     - name: Test no image with default action
       podman_container:
         name: container
@@ -324,3 +334,12 @@
             '/tmp' in test.ansible_facts.podman_container['Mounts'] | map(attribute='Source') | list
         fail_msg: Parameters container test failed!
         success_msg: Parameters container test passed!
+
+    - name: Delete all container leftovers from tests
+      podman_container:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "alpine:3.7"
+        - "container"
+        - "container2"


### PR DESCRIPTION
Fixes #58416

Add removing of all containers in the end of integration tests to not leave leftovers.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
podman_container

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```


```
