### PR TITLE
aci_epg_to_domain - Add switching_mode support

### DIFF
--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -56,8 +56,14 @@ options:
     description:
     - The ecapsulataion method to be used.
     - The APIC defaults to C(auto) when unset during creation.
+    - If vxlan is slected, switching_mode must be "AVE".
     type: str
     choices: [ auto, vlan, vxlan ]
+  switching_mode:
+    description:
+    - Switching Mode used by the switch
+    type: str
+    choices: [ AVE, native ]
   epg:
     description:
     - Name of the end point group.
@@ -296,6 +302,7 @@ def main():
         domain_type=dict(type='str', choices=['l2dom', 'phys', 'vmm'], aliases=['type']),  # Not required for querying all objects
         encap=dict(type='int'),
         encap_mode=dict(type='str', choices=['auto', 'vlan', 'vxlan']),
+        switching_mode=dict(type='str', default='native', choices=['AVE', 'native']),
         epg=dict(type='str', aliases=['name', 'epg_name']),  # Not required for querying all objects
         netflow=dict(type='bool'),
         primary_encap=dict(type='int'),
@@ -330,6 +337,7 @@ def main():
         else:
             module.fail_json(msg='Valid VLAN assigments are from 1 to 4096')
     encap_mode = module.params['encap_mode']
+    switching_mode = module.params['switching_mode']
     epg = module.params['epg']
     netflow = aci.boolean(module.params['netflow'], 'enabled', 'disabled')
     primary_encap = module.params['primary_encap']
@@ -391,6 +399,7 @@ def main():
                 classPref=allow_useg,
                 encap=encap,
                 encapMode=encap_mode,
+                switchingMode=switching_mode,
                 instrImedcy=deploy_immediacy,
                 netflowPref=netflow,
                 primaryEncap=primary_encap,

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -65,6 +65,7 @@ options:
     type: str
     choices: [ AVE, native ]
     default: native
+    version_added: '2.9'
   epg:
     description:
     - Name of the end point group.

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -64,6 +64,7 @@ options:
     - Switching Mode used by the switch
     type: str
     choices: [ AVE, native ]
+    default: native
   epg:
     description:
     - Name of the end point group.


### PR DESCRIPTION
##### SUMMARY
When deploying an AVE with VXLAN, the switching mode cannot be native and must be AVE.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aci_epg_to_domain
