### PR TITLE
Make nuage_vspk test more reliable

### DIFF
--- a/test/integration/targets/nuage_vspk/tasks/main.yml
+++ b/test/integration/targets/nuage_vspk/tasks/main.yml
@@ -1,9 +1,19 @@
----
-
 - block:
     - name: run test case
       include: "{{ test_case_to_run }}"
-      with_fileglob: "{{ role_path }}/tests/{{ testcase }}.yaml"
+      with_fileglob: tests/{{ testcase }}.yaml
       loop_control:
         loop_var: test_case_to_run
+
+  always:
+    - name: Get nuage-vsd-sim pid
+      shell: ps -A | grep '[n]'uage-vsd-sim | cut -d ' ' -f 1
+      register: vsim_pid
+      changed_when: no
+      ignore_errors: yes
+
+    - name: Stop-nuage-vsd-sim
+      command: kill {{ vsim_pid.stdout }}
+      changed_when: no
+      ignore_errors: yes
   when: "ansible_python_version is version('2.7', '>=')"

--- a/test/integration/targets/prepare_nuage_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nuage_tests/tasks/main.yml
@@ -1,16 +1,19 @@
----
 - block:
     - name: Install Nuage VSD API Simulator
       pip:
         name: nuage-vsd-sim
 
     - name: Start Nuage VSD API Simulator
-      shell: "(cd /; nuage-vsd-sim >/dev/null 2>&1 &)"
-      async: 10
+      shell: "(cd /; nuage-vsd-sim >/dev/null 2>&1)"
+      async: 1800
       poll: 0
 
     - name: Wait for API to be ready
-      wait_for:
-        port: 5000
+      uri:
+        url: http://localhost:5000
+      register: api
+      delay: 3
+      retries: 10
+      until: api.status == 200
 
   when: "ansible_python_version is version('2.7', '>=')"


### PR DESCRIPTION
##### SUMMARY
- don't background the `nuage-vsd-sim`
- increase the async timeout
- use `uri` to actually query the simulator API to make sure it is ready for connections
- kill the `nuage-vsd-sim` process when the test is complete

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/nuage_vspk/tasks/main.yml`
`test/integration/targets/prepare_nuage_tests/tasks/main.yml`