### PR TITLE
Fix issues and limitations in account mgmt commands

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -43,7 +43,8 @@ class RedfishUtils(object):
             msg = self._get_extended_message(e)
             return {'ret': False,
                     'msg': "HTTP Error %s on GET request to '%s', extended message: '%s'"
-                           % (e.code, uri, msg)}
+                           % (e.code, uri, msg),
+                    'status': e.code}
         except URLError as e:
             return {'ret': False, 'msg': "URL Error on GET request to '%s': '%s'"
                                          % (uri, e.reason)}
@@ -66,7 +67,8 @@ class RedfishUtils(object):
             msg = self._get_extended_message(e)
             return {'ret': False,
                     'msg': "HTTP Error %s on POST request to '%s', extended message: '%s'"
-                           % (e.code, uri, msg)}
+                           % (e.code, uri, msg),
+                    'status': e.code}
         except URLError as e:
             return {'ret': False, 'msg': "URL Error on POST request to '%s': '%s'"
                                          % (uri, e.reason)}
@@ -100,7 +102,8 @@ class RedfishUtils(object):
             msg = self._get_extended_message(e)
             return {'ret': False,
                     'msg': "HTTP Error %s on PATCH request to '%s', extended message: '%s'"
-                           % (e.code, uri, msg)}
+                           % (e.code, uri, msg),
+                    'status': e.code}
         except URLError as e:
             return {'ret': False, 'msg': "URL Error on PATCH request to '%s': '%s'"
                                          % (uri, e.reason)}
@@ -110,9 +113,10 @@ class RedfishUtils(object):
                     'msg': "Failed PATCH request to '%s': '%s'" % (uri, to_text(e))}
         return {'ret': True, 'resp': resp}
 
-    def delete_request(self, uri, pyld):
+    def delete_request(self, uri, pyld=None):
         try:
-            resp = open_url(uri, data=json.dumps(pyld),
+            data = json.dumps(pyld) if pyld else None
+            resp = open_url(uri, data=data,
                             headers=DELETE_HEADERS, method="DELETE",
                             url_username=self.creds['user'],
                             url_password=self.creds['pswd'],
@@ -123,7 +127,8 @@ class RedfishUtils(object):
             msg = self._get_extended_message(e)
             return {'ret': False,
                     'msg': "HTTP Error %s on DELETE request to '%s', extended message: '%s'"
-                           % (e.code, uri, msg)}
+                           % (e.code, uri, msg),
+                    'status': e.code}
         except URLError as e:
             return {'ret': False, 'msg': "URL Error on DELETE request to '%s': '%s'"
                                          % (uri, e.reason)}
@@ -664,6 +669,35 @@ class RedfishUtils(object):
             return response
         return {'ret': True, 'changed': True}
 
+    def _find_account_uri(self, username=None, acct_id=None):
+        if not any((username, acct_id)):
+            return {'ret': False, 'msg':
+                    'Must provide either target_id or target_username'}
+
+        response = self.get_request(self.root_uri + self.accounts_uri)
+        if response['ret'] is False:
+            return response
+        data = response['data']
+
+        uris = [a.get('@odata.id') for a in data.get('Members', []) if a.get('@odata.id')]
+        for uri in uris:
+            response = self.get_request(self.root_uri + uri)
+            if response['ret'] is False:
+                continue
+            data = response['data']
+            headers = response['headers']
+            if username:
+                if username == data.get('UserName'):
+                    return {'ret': True, 'data': data,
+                            'headers': headers, 'uri': uri}
+            if acct_id:
+                if acct_id == data.get('Id'):
+                    return {'ret': True, 'data': data,
+                            'headers': headers, 'uri': uri}
+
+        return {'ret': False, 'no_match': True, 'msg':
+                'No account with the given target_id or target_username found'}
+
     def list_users(self):
         result = {}
         # listing all users has always been slower than other operations, why?
@@ -678,7 +712,7 @@ class RedfishUtils(object):
         result['ret'] = True
         data = response['data']
 
-        for users in data[u'Members']:
+        for users in data.get('Members', []):
             user_list.append(users[u'@odata.id'])   # user_list[] are URIs
 
         # for each user, get details
@@ -697,54 +731,176 @@ class RedfishUtils(object):
         result["entries"] = users_results
         return result
 
-    def add_user(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
-        username = {'UserName': user['username']}
-        pswd = {'Password': user['userpswd']}
-        roleid = {'RoleId': user['userrole']}
-        enabled = {'Enabled': True}
-        for payload in username, pswd, roleid, enabled:
-            response = self.patch_request(uri, payload)
+    def add_user_via_patch(self, user):
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            return response
+        uri = response['uri']
+        payloads = [
+            {'UserName': user.get('new_username')},
+            {'Password': user.get('new_password')},
+            {'RoleId': user.get('roleid')}
+        ]
+        for payload in payloads:
+            response = self.patch_request(self.root_uri + uri, payload)
             if response['ret'] is False:
                 return response
         return {'ret': True}
 
+    def add_user(self, user):
+        if not user.get('new_username'):
+            return {'ret': False, 'msg':
+                    'Must provide new_username for AddUser command'}
+
+        response = self._find_account_uri(username=user.get('new_username'))
+        if response['ret']:
+            # new_username already exists, nothing to do
+            return {'ret': True, 'changed': False}
+
+        response = self.get_request(self.root_uri + self.accounts_uri)
+        if not response['ret']:
+            return response
+        headers = response['headers']
+
+        if 'allow' in headers:
+            methods = [m.strip() for m in headers.get('allow').split(',')]
+            if 'POST' not in methods:
+                # if Allow header present and POST not listed, add via PATCH
+                return self.add_user_via_patch(user)
+
+        payload = {}
+        if user.get('new_username'):
+            payload['UserName'] = user.get('new_username')
+        if user.get('new_password'):
+            payload['Password'] = user.get('new_password')
+        if user.get('roleid'):
+            payload['RoleId'] = user.get('roleid')
+
+        response = self.post_request(self.root_uri + self.accounts_uri, payload)
+        if not response['ret']:
+            if response.get('status') == 405:
+                # if POST returned a 405, try to add via PATCH
+                return self.add_user_via_patch(user)
+            else:
+                return response
+        return {'ret': True}
+
     def enable_user(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            return response
+        uri = response['uri']
+        data = response['data']
+
+        if data.get('Enabled'):
+            # account already enabled, nothing to do
+            return {'ret': True, 'changed': False}
+
         payload = {'Enabled': True}
-        response = self.patch_request(uri, payload)
+        response = self.patch_request(self.root_uri + uri, payload)
+        if response['ret'] is False:
+            return response
+        return {'ret': True}
+
+    def delete_user_via_patch(self, user, uri=None, data=None):
+        if not uri:
+            response = self._find_account_uri(username=user.get('target_username'),
+                                              acct_id=user.get('target_id'))
+            if not response['ret']:
+                return response
+            uri = response['uri']
+            data = response['data']
+
+        if data and data.get('UserName') == '':
+            # account UserName already cleared, nothing to do
+            return {'ret': True, 'changed': False}
+
+        payload = {'UserName': ''}
+        response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True}
 
     def delete_user(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
-        payload = {'UserName': ""}
-        response = self.patch_request(uri, payload)
-        if response['ret'] is False:
-            return response
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            if response.get('no_match'):
+                # account does not exist, nothing to do
+                return {'ret': True, 'changed': False}
+            else:
+                # some error encountered
+                return response
+
+        uri = response['uri']
+        headers = response['headers']
+        data = response['data']
+
+        if 'allow' in headers:
+            methods = [m.strip() for m in headers.get('allow').split(',')]
+            if 'DELETE' not in methods:
+                # if Allow header present and DELETE not listed, del via PATCH
+                return self.delete_user_via_patch(user, uri=uri, data=data)
+
+        response = self.delete_request(self.root_uri + uri)
+        if not response['ret']:
+            if response.get('status') == 405:
+                # if DELETE returned a 405, try to delete via PATCH
+                return self.delete_user_via_patch(user, uri=uri, data=data)
+            else:
+                return response
         return {'ret': True}
 
     def disable_user(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            return response
+        uri = response['uri']
+        data = response['data']
+
+        if not data.get('Enabled'):
+            # account already disabled, nothing to do
+            return {'ret': True, 'changed': False}
+
         payload = {'Enabled': False}
-        response = self.patch_request(uri, payload)
+        response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True}
 
     def update_user_role(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
-        payload = {'RoleId': user['userrole']}
-        response = self.patch_request(uri, payload)
+        if not user.get('roleid'):
+            return {'ret': False, 'msg':
+                    'Must provide roleid for UpdateUserRole command'}
+
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            return response
+        uri = response['uri']
+        data = response['data']
+
+        if data.get('RoleId') == user.get('roleid'):
+            # account already has RoleId , nothing to do
+            return {'ret': True, 'changed': False}
+
+        payload = {'RoleId': user.get('roleid')}
+        response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True}
 
     def update_user_password(self, user):
-        uri = self.root_uri + self.accounts_uri + "/" + user['userid']
-        payload = {'Password': user['userpswd']}
-        response = self.patch_request(uri, payload)
+        response = self._find_account_uri(username=user.get('target_username'),
+                                          acct_id=user.get('target_id'))
+        if not response['ret']:
+            return response
+        uri = response['uri']
+        payload = {'Password': user['new_password']}
+        response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True}

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -672,7 +672,7 @@ class RedfishUtils(object):
     def _find_account_uri(self, username=None, acct_id=None):
         if not any((username, acct_id)):
             return {'ret': False, 'msg':
-                    'Must provide either target_id or target_username'}
+                    'Must provide either account_id or account_username'}
 
         response = self.get_request(self.root_uri + self.accounts_uri)
         if response['ret'] is False:
@@ -696,7 +696,7 @@ class RedfishUtils(object):
                             'headers': headers, 'uri': uri}
 
         return {'ret': False, 'no_match': True, 'msg':
-                'No account with the given target_id or target_username found'}
+                'No account with the given account_id or account_username found'}
 
     def list_users(self):
         result = {}
@@ -732,15 +732,15 @@ class RedfishUtils(object):
         return result
 
     def add_user_via_patch(self, user):
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             return response
         uri = response['uri']
         payloads = [
-            {'UserName': user.get('new_username')},
-            {'Password': user.get('new_password')},
-            {'RoleId': user.get('roleid')}
+            {'UserName': user.get('account_username')},
+            {'Password': user.get('account_password')},
+            {'RoleId': user.get('account_roleid')}
         ]
         for payload in payloads:
             response = self.patch_request(self.root_uri + uri, payload)
@@ -749,13 +749,13 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def add_user(self, user):
-        if not user.get('new_username'):
+        if not user.get('account_username'):
             return {'ret': False, 'msg':
-                    'Must provide new_username for AddUser command'}
+                    'Must provide account_username for AddUser command'}
 
-        response = self._find_account_uri(username=user.get('new_username'))
+        response = self._find_account_uri(username=user.get('account_username'))
         if response['ret']:
-            # new_username already exists, nothing to do
+            # account_username already exists, nothing to do
             return {'ret': True, 'changed': False}
 
         response = self.get_request(self.root_uri + self.accounts_uri)
@@ -770,12 +770,12 @@ class RedfishUtils(object):
                 return self.add_user_via_patch(user)
 
         payload = {}
-        if user.get('new_username'):
-            payload['UserName'] = user.get('new_username')
-        if user.get('new_password'):
-            payload['Password'] = user.get('new_password')
-        if user.get('roleid'):
-            payload['RoleId'] = user.get('roleid')
+        if user.get('account_username'):
+            payload['UserName'] = user.get('account_username')
+        if user.get('account_password'):
+            payload['Password'] = user.get('account_password')
+        if user.get('account_roleid'):
+            payload['RoleId'] = user.get('account_roleid')
 
         response = self.post_request(self.root_uri + self.accounts_uri, payload)
         if not response['ret']:
@@ -787,8 +787,8 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def enable_user(self, user):
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             return response
         uri = response['uri']
@@ -806,8 +806,8 @@ class RedfishUtils(object):
 
     def delete_user_via_patch(self, user, uri=None, data=None):
         if not uri:
-            response = self._find_account_uri(username=user.get('target_username'),
-                                              acct_id=user.get('target_id'))
+            response = self._find_account_uri(username=user.get('account_username'),
+                                              acct_id=user.get('account_id'))
             if not response['ret']:
                 return response
             uri = response['uri']
@@ -824,8 +824,8 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def delete_user(self, user):
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             if response.get('no_match'):
                 # account does not exist, nothing to do
@@ -854,8 +854,8 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def disable_user(self, user):
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             return response
         uri = response['uri']
@@ -872,34 +872,34 @@ class RedfishUtils(object):
         return {'ret': True}
 
     def update_user_role(self, user):
-        if not user.get('roleid'):
+        if not user.get('account_roleid'):
             return {'ret': False, 'msg':
-                    'Must provide roleid for UpdateUserRole command'}
+                    'Must provide account_roleid for UpdateUserRole command'}
 
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             return response
         uri = response['uri']
         data = response['data']
 
-        if data.get('RoleId') == user.get('roleid'):
+        if data.get('RoleId') == user.get('account_roleid'):
             # account already has RoleId , nothing to do
             return {'ret': True, 'changed': False}
 
-        payload = {'RoleId': user.get('roleid')}
+        payload = {'RoleId': user.get('account_roleid')}
         response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response
         return {'ret': True}
 
     def update_user_password(self, user):
-        response = self._find_account_uri(username=user.get('target_username'),
-                                          acct_id=user.get('target_id'))
+        response = self._find_account_uri(username=user.get('account_username'),
+                                          acct_id=user.get('account_id'))
         if not response['ret']:
             return response
         uri = response['uri']
-        payload = {'Password': user['new_password']}
+        payload = {'Password': user['account_password']}
         response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:
             return response

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -203,7 +203,7 @@ EXAMPLES = '''
       password: "{{ password }}"
       target_username: "{{ target_username }}"
 
- - name: Enable user
+  - name: Enable user
     redfish_command:
       category: Accounts
       command: EnableUser
@@ -212,7 +212,7 @@ EXAMPLES = '''
       password: "{{ password }}"
       target_username: "{{ target_username }}"
 
- - name: Add and enable user
+  - name: Add and enable user
     redfish_command:
       category: Accounts
       command: AddUser,EnableUser
@@ -307,7 +307,7 @@ def main():
 
     # user to add/modify/delete
     user = {'target_id': module.params['id'],
-            'target_username':  module.params['target_username'],
+            'target_username': module.params['target_username'],
             'new_username': module.params['new_username'],
             'new_password': module.params['new_password'],
             'roleid': module.params['roleid']}

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -41,7 +41,7 @@ options:
   username:
     required: true
     description:
-      - User for authentication with OOB controller
+      - Username for authentication with OOB controller
     type: str
     version_added: "2.8"
   password:
@@ -51,26 +51,33 @@ options:
     type: str
   id:
     required: false
+    aliases: [ target_id ]
     description:
-      - ID of user to add/delete/modify
+      - ID of account to delete/modify
     type: str
     version_added: "2.8"
+  target_username:
+    required: false
+    description:
+      - Username of account to delete/modify
+    type: str
+    version_added: "2.9"
   new_username:
     required: false
     description:
-      - name of user to add/delete/modify
+      - Username of account to add
     type: str
     version_added: "2.8"
   new_password:
     required: false
     description:
-      - password of user to add/delete/modify
+      - New password of account to add/modify
     type: str
     version_added: "2.8"
   roleid:
     required: false
     description:
-      - role of user to add/delete/modify
+      - Role of account to add/modify
     type: str
     version_added: "2.8"
   bootdevice:
@@ -146,26 +153,74 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Add and enable user
+  - name: Add user
+    redfish_command:
+      category: Accounts
+      command: AddUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      new_username: "{{ new_username }}"
+      new_password: "{{ new_password }}"
+      roleid: "{{ roleid }}"
+
+  - name: Add user on service where existing account Id needs to be PATCHed
+    redfish_command:
+      category: Accounts
+      command: AddUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_id: "{{ target_id }}"
+      new_username: "{{ new_username }}"
+      new_password: "{{ new_password }}"
+      roleid: "{{ roleid }}"
+
+  - name: Delete user
+    redfish_command:
+      category: Accounts
+      command: DeleteUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_username: "{{ target_username }}"
+
+  - name: Delete user with Id property of target_id
+    redfish_command:
+      category: Accounts
+      command: DeleteUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_id: "{{ target_id }}"
+
+  - name: Disable user
+    redfish_command:
+      category: Accounts
+      command: DisableUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_username: "{{ target_username }}"
+
+ - name: Enable user
+    redfish_command:
+      category: Accounts
+      command: EnableUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_username: "{{ target_username }}"
+
+ - name: Add and enable user
     redfish_command:
       category: Accounts
       command: AddUser,EnableUser
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
-      new_username: "{{ new_username }}"
-      new_password: "{{ new_password }}"
+      target_username: "{{ target_username }}"
       roleid: "{{ roleid }}"
-
-  - name: Disable and delete user
-    redfish_command:
-      category: Accounts
-      command: ["DisableUser", "DeleteUser"]
-      baseuri: "{{ baseuri }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      id: "{{ id }}"
 
   - name: Update user password
     redfish_command:
@@ -174,8 +229,18 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      id: "{{ id }}"
+      target_username: "{{ target_username }}"
       new_password: "{{ new_password }}"
+
+  - name: Update user role
+    redfish_command:
+      category: Accounts
+      command: UpdateUserRole
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      target_username: "{{ target_username }}"
+      roleid: "{{ roleid }}"
 
   - name: Clear Manager Logs with a timeout of 20 seconds
     redfish_command:
@@ -220,7 +285,8 @@ def main():
             baseuri=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
-            id=dict(),
+            id=dict(aliases=["target_id"]),
+            target_username=dict(),
             new_username=dict(),
             new_password=dict(no_log=True),
             roleid=dict(),
@@ -240,10 +306,11 @@ def main():
              'pswd': module.params['password']}
 
     # user to add/modify/delete
-    user = {'userid': module.params['id'],
-            'username': module.params['new_username'],
-            'userpswd': module.params['new_password'],
-            'userrole': module.params['roleid']}
+    user = {'target_id': module.params['id'],
+            'target_username':  module.params['target_username'],
+            'new_username': module.params['new_username'],
+            'new_password': module.params['new_password'],
+            'roleid': module.params['roleid']}
 
     # timeout
     timeout = module.params['timeout']

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -51,31 +51,28 @@ options:
     type: str
   id:
     required: false
-    aliases: [ target_id ]
+    aliases: [ account_id ]
     description:
       - ID of account to delete/modify
     type: str
     version_added: "2.8"
-  target_username:
-    required: false
-    description:
-      - Username of account to delete/modify
-    type: str
-    version_added: "2.9"
   new_username:
     required: false
+    aliases: [ account_username ]
     description:
-      - Username of account to add
+      - Username of account to add/delete/modify
     type: str
     version_added: "2.8"
   new_password:
     required: false
+    aliases: [ account_password ]
     description:
       - New password of account to add/modify
     type: str
     version_added: "2.8"
   roleid:
     required: false
+    aliases: [ account_roleid ]
     description:
       - Role of account to add/modify
     type: str
@@ -164,6 +161,17 @@ EXAMPLES = '''
       new_password: "{{ new_password }}"
       roleid: "{{ roleid }}"
 
+  - name: Add user using new option aliases
+    redfish_command:
+      category: Accounts
+      command: AddUser
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      account_username: "{{ account_username }}"
+      account_password: "{{ account_password }}"
+      account_roleid: "{{ account_roleid }}"
+
   - name: Add user on service where existing account Id needs to be PATCHed
     redfish_command:
       category: Accounts
@@ -171,7 +179,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_id: "{{ target_id }}"
+      account_id: "{{ account_id }}"
       new_username: "{{ new_username }}"
       new_password: "{{ new_password }}"
       roleid: "{{ roleid }}"
@@ -183,16 +191,16 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
+      account_username: "{{ account_username }}"
 
-  - name: Delete user with Id property of target_id
+  - name: Delete user with Id property of account_id
     redfish_command:
       category: Accounts
       command: DeleteUser
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_id: "{{ target_id }}"
+      account_id: "{{ account_id }}"
 
   - name: Disable user
     redfish_command:
@@ -201,7 +209,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
+      account_username: "{{ account_username }}"
 
   - name: Enable user
     redfish_command:
@@ -210,7 +218,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
+      account_username: "{{ account_username }}"
 
   - name: Add and enable user
     redfish_command:
@@ -219,7 +227,8 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
+      new_username: "{{ new_username }}"
+      new_password: "{{ new_password }}"
       roleid: "{{ roleid }}"
 
   - name: Update user password
@@ -229,8 +238,8 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
-      new_password: "{{ new_password }}"
+      account_username: "{{ account_username }}"
+      account_password: "{{ account_password }}"
 
   - name: Update user role
     redfish_command:
@@ -239,7 +248,7 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
-      target_username: "{{ target_username }}"
+      account_username: "{{ account_username }}"
       roleid: "{{ roleid }}"
 
   - name: Clear Manager Logs with a timeout of 20 seconds
@@ -285,11 +294,10 @@ def main():
             baseuri=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
-            id=dict(aliases=["target_id"]),
-            target_username=dict(),
-            new_username=dict(),
-            new_password=dict(no_log=True),
-            roleid=dict(),
+            id=dict(aliases=["account_id"]),
+            new_username=dict(aliases=["account_username"]),
+            new_password=dict(aliases=["account_password"], no_log=True),
+            roleid=dict(aliases=["account_roleid"]),
             bootdevice=dict(),
             timeout=dict(type='int', default=10),
             uefi_target=dict(),
@@ -306,11 +314,10 @@ def main():
              'pswd': module.params['password']}
 
     # user to add/modify/delete
-    user = {'target_id': module.params['id'],
-            'target_username': module.params['target_username'],
-            'new_username': module.params['new_username'],
-            'new_password': module.params['new_password'],
-            'roleid': module.params['roleid']}
+    user = {'account_id': module.params['id'],
+            'account_username': module.params['new_username'],
+            'account_password': module.params['new_password'],
+            'account_roleid': module.params['roleid']}
 
     # timeout
     timeout = module.params['timeout']

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -172,18 +172,6 @@ EXAMPLES = '''
       account_password: "{{ account_password }}"
       account_roleid: "{{ account_roleid }}"
 
-  - name: Add user on service where existing account Id needs to be PATCHed
-    redfish_command:
-      category: Accounts
-      command: AddUser
-      baseuri: "{{ baseuri }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      account_id: "{{ account_id }}"
-      new_username: "{{ new_username }}"
-      new_password: "{{ new_password }}"
-      roleid: "{{ roleid }}"
-
   - name: Delete user
     redfish_command:
       category: Accounts
@@ -192,15 +180,6 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       account_username: "{{ account_username }}"
-
-  - name: Delete user with Id property of account_id
-    redfish_command:
-      category: Accounts
-      command: DeleteUser
-      baseuri: "{{ baseuri }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      account_id: "{{ account_id }}"
 
   - name: Disable user
     redfish_command:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR makes the following updates to the account management commands:

1. The original code assumed the account URI path was formatted as`self.root_uri + self.accounts_uri + "/" + id`. This is not generally correct. Updated to lookup the proper URI.
2.  The `AddUser` and `DeleteUser` commands assumed a Redfish service that has a fixed set of account members that need to be PATCHed. Updated `AddUser` to POST to the Accounts collection by default and fallback to PATCH if the `Allow` header indicates POST is not supported or if the POST returns a 405. Updated DeleteUser to DELETE the account resource by default and fallback to PATCH if the `Allow` header indicates DELETE is not supported or if the DELETE returns a 405.
3. Updated the AddUser logic in the PATCH scenario to search for the first unused account slot rather than requiring the operator to specify the account slot by Id. (Though if the account Id is specified, it is honored as before.)
4. Added aliases to three of the existing account-related options to make it more clear that they apply to Account resource properties: `target_id` as an alias for `id`; `account_username` as an alias for `new_username`; `account_password` as an alias for `new_password`
5. Added additional playbook example snippets in the redfish_command module EXAMPLES docstring.
6. Idempotency: Added checks to see if the resource is already in the target state (account created, account in the specified role, etc.) and if so return success with `changed` set to `False`.
7. Cleaned up the variable names in the `user` dict that is passed to the utility methods to match the module option names/aliases for consistency and to avoid confusion.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For Redfish services that create accounts by POSTing to the `Accounts` collection (which is the standard approach), it was impossible to use the `AddUser` command to do so. An existing, but unused account had to be specified by `Id` and that account would be PATCHed with the new `UserName`. After this PR, the module still works as before for services that need to PATCH for `AddUser` and `DeleteUser`. And it now also works for services that use POST for `AddUser` and DELETE for `DeleteUser`. 

Also, for Redfish services that did not follow the hard-coded URI pattern (`self.root_uri + self.accounts_uri + "/" + id`), the commands would fail with a 404 status. That is now fixed.
