### PR TITLE
Simplify ansible-test target expansion.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -79,7 +79,6 @@ from lib.ansible_util import (
 
 from lib.target import (
     IntegrationTarget,
-    walk_external_targets,
     walk_internal_targets,
     walk_posix_integration_targets,
     walk_network_integration_targets,
@@ -1302,7 +1301,7 @@ def command_units(args):
     """
     changes = get_changes_filter(args)
     require = args.require + changes
-    include, exclude = walk_external_targets(walk_units_targets(), args.include, args.exclude, require)
+    include = walk_internal_targets(walk_units_targets(), args.include, args.exclude, require)
 
     if not include:
         raise AllTargetsSkipped()
@@ -1338,9 +1337,6 @@ def command_units(args):
 
         if args.verbosity:
             cmd.append('-' + ('v' * args.verbosity))
-
-        if exclude:
-            cmd += ['--ignore=%s' % target.path for target in exclude]
 
         cmd += [target.path for target in include]
 

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -27,7 +27,6 @@ from lib.ansible_util import (
 )
 
 from lib.target import (
-    walk_external_targets,
     walk_internal_targets,
     walk_sanity_targets,
 )
@@ -204,7 +203,6 @@ class SanityTargets(object):
         self.all = not include
         self.targets = tuple(sorted(walk_sanity_targets()))
         self.include = walk_internal_targets(self.targets, include, exclude, require)
-        self.include_external, self.exclude_external = walk_external_targets(self.targets, include, exclude, require)
 
 
 class SanityTest(ABC):

--- a/test/runner/lib/sanity/ansible_doc.py
+++ b/test/runner/lib/sanity/ansible_doc.py
@@ -52,9 +52,7 @@ class AnsibleDocTest(SanityMultipleVersion):
             'test',
         ])
 
-        modules = sorted(set(m for i in targets.include_external for m in i.modules) -
-                         set(m for i in targets.exclude_external for m in i.modules) -
-                         skip_modules)
+        modules = sorted(set(m for i in targets.include for m in i.modules) - skip_modules)
 
         plugins = [os.path.splitext(i.path)[0].split('/')[-2:] + [i.path] for i in targets.include if os.path.splitext(i.path)[1] == '.py' and
                    os.path.basename(i.path) != '__init__.py' and

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -84,56 +84,6 @@ def walk_internal_targets(targets, includes=None, excludes=None, requires=None):
     return tuple(sorted(internal_targets, key=lambda t: t.name))
 
 
-def walk_external_targets(targets, includes=None, excludes=None, requires=None):
-    """
-    :type targets: collections.Iterable[CompletionTarget]
-    :type includes: list[str]
-    :type excludes: list[str]
-    :type requires: list[str]
-    :rtype: tuple[CompletionTarget], tuple[CompletionTarget]
-    """
-    targets = tuple(targets)
-
-    if requires:
-        include_targets = list(filter_targets(targets, includes, errors=True, directories=False))
-        require_targets = set(filter_targets(targets, requires, errors=True, directories=False))
-        includes = [target.name for target in include_targets if target in require_targets]
-
-        if includes:
-            include_targets = sorted(filter_targets(targets, includes, errors=True), key=lambda t: t.name)
-        else:
-            include_targets = []
-    else:
-        include_targets = sorted(filter_targets(targets, includes, errors=True), key=lambda t: t.name)
-
-    if excludes:
-        exclude_targets = sorted(filter_targets(targets, excludes, errors=True), key=lambda t: t.name)
-    else:
-        exclude_targets = []
-
-    previous = None
-    include = []
-    for target in include_targets:
-        if isinstance(previous, DirectoryTarget) and isinstance(target, DirectoryTarget) \
-                and previous.name == target.name:
-            previous.modules = tuple(set(previous.modules) | set(target.modules))
-        else:
-            include.append(target)
-            previous = target
-
-    previous = None
-    exclude = []
-    for target in exclude_targets:
-        if isinstance(previous, DirectoryTarget) and isinstance(target, DirectoryTarget) \
-                and previous.name == target.name:
-            previous.modules = tuple(set(previous.modules) | set(target.modules))
-        else:
-            exclude.append(target)
-            previous = target
-
-    return tuple(include), tuple(exclude)
-
-
 def filter_targets(targets, patterns, include=True, directories=True, errors=True):
     """
     :type targets: collections.Iterable[CompletionTarget]


### PR DESCRIPTION
##### SUMMARY

Simplify ansible-test target expansion.

Targets are always expanded to full lists now instead of optimizing for shorter lists by collapsing directories.

This change only affects unit tests and the ansible-doc sanity test, as they were the only remaining tests using the old behavior.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
