### PR TITLE
Use the filename from AnsibleFileNotFound instead of the included file

### DIFF
--- a/changelogs/fragments/58436-include-correct-error.yml
+++ b/changelogs/fragments/58436-include-correct-error.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- includes - Ensure to use the correct filename when AnsibleFileNotFound is
+  encountered (https://github.com/ansible/ansible/issues/58436)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -814,7 +814,7 @@ class StrategyBase:
 
         except AnsibleError as e:
             if isinstance(e, AnsibleFileNotFound):
-                reason = "Could not find or access '%s' on the Ansible Controller." % to_text(included_file._filename)
+                reason = "Could not find or access '%s' on the Ansible Controller." % to_text(e.file_name)
             else:
                 reason = to_text(e)
 


### PR DESCRIPTION
##### SUMMARY
Use the filename from AnsibleFileNotFound instead of the included file. Fixes #58436

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/strategy/__init__.py
```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```