### PR TITLE
Support large folder size comparisons for win_find

### DIFF
--- a/changelogs/fragments/58466-FIX_win_find-Bug-Get-FileStat_fails_on_large_files.yml
+++ b/changelogs/fragments/58466-FIX_win_find-Bug-Get-FileStat_fails_on_large_files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_find - Get-FileStat used [int] instead of [int64] for file size calculations"

--- a/lib/ansible/modules/windows/win_find.ps1
+++ b/lib/ansible/modules/windows/win_find.ps1
@@ -177,7 +177,7 @@ Function Assert-Size($info) {
         $size_pattern = '^(-?\d+)(b|k|m|g|t)?$'
         $match = $size -match $size_pattern
         if ($match) {
-            [int]$specified_size = $matches[1]
+            [int64]$specified_size = $matches[1]
             if ($null -eq $matches[2]) {
                 $chosen_byte = 'b'
             } else {


### PR DESCRIPTION
Changed [int] to [int64] to support larger folders. Otherwise module fails as soon as a large folder is encountered.
##### SUMMARY

It appears that large folders break win_find when the size is too large to fit inside a System.Int32.
Further, win_find breaks as soon as a warning is encountered, causing it to no longer process folders.

Fixes #58463

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME

win_find.ps1

##### ANSIBLE VERSION

2.8.0

##### STEPS TO REPRODUCE

```
---
- name: Search for folders
  win_find:
    paths: C:\ProgramData
    file_type: directory
```



##### ADDITIONAL INFO

Example of using the Get-FileStat function on a large folder.

PS C:\Windows\system32> $file = Get-Item -LiteralPath C:\ProgramData\Anaconda2 -Force

PS C:\Windows\system32> Get-FileStat -file $file
Cannot convert value "4444553383" to type "System.Int32". Error: "Value was either too large or too small for an Int32."
At line:186 char:13
            [int]$specified_size = $matches[1]
     CategoryInfo          : InvalidArgument: (:) [], ParentContainsErrorRecordException
     FullyQualifiedErrorId : InvalidCastFromStringToInteger




##### ACTUAL RESULTS

```
win_find failed to check some files, these files were ignored and will not be part of the result output
```

