### PR TITLE
the env argument for docker_container wants a dict, not a list

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -835,8 +835,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: "true"
-      - arg2: "whatever"
+      arg1: "true"
+      arg2: "whatever"
     volumes:
       - /tmp:/tmp
     comparisons:
@@ -849,8 +849,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: "true"
-      - arg2: "whatever"
+      arg1: "true"
+      arg2: "whatever"
     comparisons:
       '*': ignore  # by default, ignore *all* options (including image)
       env: strict   # except for environment variables; there, we want to be strict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The examples showed using docker_container with a list for `env:` instead of a dict.  The module **only** accepts a dict.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docker_container
