### PR TITLE
to support fortios firmware upgrade with local firmware file

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -70,7 +70,6 @@ options:
     system_firmware:
         description:
             - Perform firmware upgrade with local firmware file.
-        type: dict
         default: null
         type: dict
         suboptions:

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -17,7 +17,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-from ansible.module_utils.basic import AnsibleModule
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
@@ -155,7 +154,6 @@ EXAMPLES = '''
       var:
         # please check the following status to confirm
         fortios_system_firmware_upgrade_result.meta.results.status
-
 '''
 
 RETURN = '''
@@ -199,10 +197,13 @@ version:
   returned: always
   type: str
   sample: "v5.6.3"
+
 '''
 
+from ansible.module_utils.basic import AnsibleModule
 import os
 import base64
+
 
 def login(data, fos):
     host = data['host']

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -70,6 +70,7 @@ options:
     system_firmware:
         description:
             - Perform firmware upgrade with local firmware file.
+        type: dict
         default: null
         type: dict
         suboptions:

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+import os
+import base64
+
+from ansible.module_utils.basic import AnsibleModule
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_firmware_upgrade
+short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS by allowing the
+      user to set and modify system feature and firmware category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.8"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+       description:
+            - FortiOS or FortiGate ip address.
+       required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS
+              protocol
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object
+        choices:
+            - present
+            - absent
+    system_firmware:
+        description:
+            - Perform firmware upgrade with local firmware file.
+        default: null
+        suboptions:
+            filename:
+                description:
+                    - Name and path of the local firmware file.
+            format_partition:
+                description:
+                    - Set to true to format boot partition before upgrade.
+            source:
+                description:
+                    - Firmware file data source [upload].
+                required: true
+                choices:
+                    - upload
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Perform firmware upgrade with local firmware file.
+    fortios_system_firmware_upgrade:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_firmware:
+        filename: "<your_own_value>"
+        source: "upload"
+    register: fortios_system_firmware_upgrade_result
+
+  - debug:
+      var: 
+        # please check the following status to confirm
+        fortios_system_firmware_upgrade_result.meta.results.status
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_system_firmware_data(json):
+    option_list = ['filename', 'format_partition', 'source']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    return data
+
+
+def system_firmware(data, fos, check_mode=False):
+    vdom = data['vdom']
+
+    system_firmware_data = data['system_firmware']
+
+    filtered_data = {}
+    filtered_data['source'] = system_firmware_data['source']
+    try:
+        filtered_data['file_content'] = base64.b64encode(open(system_firmware_data['filename'], 'rb').read()).decode('utf-8')
+    except Exception:
+        filtered_data['file_content'] = ''
+
+    return fos.execute('system',
+                       'firmware/upgrade',
+                       data=filtered_data,
+                       vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos, check_mode=False):
+    login(data, fos)
+
+    if data['system_firmware']:
+        resp = system_firmware(data, fos, check_mode)
+
+    fos.logout()
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "system_firmware": {
+            "required": True, "type": "dict",
+            "options": {
+                "filename": {"required": True, "type": "str"},
+                "format_partition": {"required": False, "type": "str"},
+                "source": {"required": True, "type": "str",
+                           "choices": ["upload"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=True)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        module.fail_json(msg="fortiosapi module is required")
+
+    fos = FortiOSAPI()
+
+    is_error, has_changed, result = fortios_system(module.params, fos, module.check_mode)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_ha_checksums_select.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_ha_checksums_select.py
@@ -23,11 +23,11 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: fortios_system_firmware_upgrade
-short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
+module: fortios_system_ha_checksums_select
+short_description: List of checksums for members of HA cluster in Fortinet's FortiOS and FortiGate.
 description:
     - This module is able to configure a FortiGate or FortiOS device by allowing the
-      user to set and modify system feature and firmware category.
+      user to set and modify system feature and ha_checksums category.
       Examples include all parameters and values need to be adjusted to datasources before usage.
       Tested with FOS v6.0.2
 version_added: "2.9"
@@ -67,30 +67,13 @@ options:
             - Indicates if the requests towards FortiGate must use HTTPS protocol.
         type: bool
         default: true
-    system_firmware:
+    system_ha_checksums:
         description:
-            - Perform firmware upgrade with local firmware file.
+            - List of checksums for members of HA cluster.
         type: dict
         default: null
         type: dict
         suboptions:
-            filename:
-                description:
-                    - Name and path of the local firmware file.
-                type: str
-            format_partition:
-                description:
-                    - Set to true to format boot partition before upgrade.
-                type: bool
-            source:
-                description:
-                    - Firmware file data source [upload|usb|fortiguard].
-                type: str
-                required: true
-                choices:
-                    - upload
-                    - usb
-                    - fortiguard
 '''
 
 EXAMPLES = '''
@@ -101,59 +84,14 @@ EXAMPLES = '''
    password: ""
    vdom: "root"
   tasks:
-  - name: Perform firmware upgrade with local firmware file.
-    fortios_system_firmware_upgrade:
+  - name: List of checksums for members of HA cluster.
+    fortios_system_ha_checksums_select:
       host:  "{{ host }}"
       username: "{{ username }}"
       password: "{{ password }}"
       vdom:  "{{ vdom }}"
       https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "upload"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
-
-  - name: Perform firmware upgrade with firmware file on USB.
-    fortios_system_firmware_upgrade:
-      host:  "{{ host }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      vdom:  "{{ vdom }}"
-      https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "usb"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
-
-  - name: Perform firmware upgrade from FortiGuard.
-    fortios_system_firmware_upgrade:
-      host:  "{{ host }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      vdom:  "{{ vdom }}"
-      https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "fortiguard"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
+      system_ha_checksums:
 '''
 
 RETURN = '''
@@ -166,12 +104,12 @@ http_method:
   description: Last method used to provision the content into FortiGate
   returned: always
   type: str
-  sample: 'POST'
+  sample: 'GET'
 name:
   description: Name of the table used to fulfill the request
   returned: always
   type: str
-  sample: "firmware"
+  sample: "ha_checksums"
 path:
   description: Path of the table used to fulfill the request
   returned: always
@@ -209,8 +147,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.fortios.fortios import FortiOSHandler
 from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-import os
-import base64
 
 
 def login(data, fos):
@@ -227,8 +163,8 @@ def login(data, fos):
     fos.login(host, username, password)
 
 
-def filter_system_firmware_data(json):
-    option_list = ['filename', 'format_partition', 'source']
+def filter_system_ha_checksums_data(json):
+    option_list = []
     dictionary = {}
 
     for attribute in option_list:
@@ -242,26 +178,11 @@ def underscore_to_hyphen(data):
     return data
 
 
-def system_firmware(data, fos, check_mode=False):
+def system_ha_checksums(data, fos, check_mode=False):
     vdom = data['vdom']
 
-    system_firmware_data = data['system_firmware']
-
-    filtered_data = {}
-    filtered_data['source'] = system_firmware_data['source']
-    if hasattr(system_firmware_data, 'format_partition'):
-        filtered_data['format_partition'] = system_firmware_data['format_partition']
-    if filtered_data['source'] == 'upload':
-        try:
-            filtered_data['file_content'] = base64.b64encode(open(system_firmware_data['filename'], 'rb').read()).decode('utf-8')
-        except Exception:
-            filtered_data['file_content'] = ''
-    else:
-        filtered_data['filename'] = system_firmware_data['filename']
-
-    return fos.execute('system',
-                       'firmware/upgrade',
-                       data=filtered_data,
+    return fos.monitor('system',
+                       'ha-checksums/select',
                        vdom=vdom)
 
 
@@ -272,8 +193,7 @@ def is_successful_status(status):
 
 def fortios_system(data, fos):
 
-    if data['system_firmware']:
-        resp = system_firmware(data, fos)
+    resp = system_ha_checksums(data, fos)
 
     return not is_successful_status(resp), \
         resp['status'] == "success", \
@@ -287,13 +207,9 @@ def main():
         "password": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
         "https": {"required": False, "type": "bool", "default": True},
-        "system_firmware": {
-            "required": True, "type": "dict",
+        "system_ha_checksums": {
+            "required": False, "type": "dict",
             "options": {
-                "filename": {"required": True, "type": "str"},
-                "format_partition": {"required": False, "type": "bool"},
-                "source": {"required": True, "type": "str",
-                           "choices": ["upload", "usb", "fortiguard"]}
 
             }
         }

--- a/lib/ansible/modules/network/fortios/fortios_system_status_select.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_status_select.py
@@ -23,11 +23,11 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: fortios_system_firmware_upgrade
-short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
+module: fortios_system_status_select
+short_description: Retrieve basic system status in Fortinet's FortiOS and FortiGate.
 description:
     - This module is able to configure a FortiGate or FortiOS device by allowing the
-      user to set and modify system feature and firmware category.
+      user to set and modify system feature and status category.
       Examples include all parameters and values need to be adjusted to datasources before usage.
       Tested with FOS v6.0.2
 version_added: "2.9"
@@ -67,30 +67,13 @@ options:
             - Indicates if the requests towards FortiGate must use HTTPS protocol.
         type: bool
         default: true
-    system_firmware:
+    system_status:
         description:
-            - Perform firmware upgrade with local firmware file.
+            - Retrieve basic system status.
         type: dict
         default: null
         type: dict
         suboptions:
-            filename:
-                description:
-                    - Name and path of the local firmware file.
-                type: str
-            format_partition:
-                description:
-                    - Set to true to format boot partition before upgrade.
-                type: bool
-            source:
-                description:
-                    - Firmware file data source [upload|usb|fortiguard].
-                type: str
-                required: true
-                choices:
-                    - upload
-                    - usb
-                    - fortiguard
 '''
 
 EXAMPLES = '''
@@ -101,59 +84,14 @@ EXAMPLES = '''
    password: ""
    vdom: "root"
   tasks:
-  - name: Perform firmware upgrade with local firmware file.
-    fortios_system_firmware_upgrade:
+  - name: Retrieve basic system status.
+    fortios_system_status_select:
       host:  "{{ host }}"
       username: "{{ username }}"
       password: "{{ password }}"
       vdom:  "{{ vdom }}"
       https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "upload"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
-
-  - name: Perform firmware upgrade with firmware file on USB.
-    fortios_system_firmware_upgrade:
-      host:  "{{ host }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      vdom:  "{{ vdom }}"
-      https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "usb"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
-
-  - name: Perform firmware upgrade from FortiGuard.
-    fortios_system_firmware_upgrade:
-      host:  "{{ host }}"
-      username: "{{ username }}"
-      password: "{{ password }}"
-      vdom:  "{{ vdom }}"
-      https: "False"
-      system_firmware:
-        filename: "<your_own_value>"
-        format_partition: "<your_own_value>"
-        source: "fortiguard"
-    register: fortios_system_firmware_upgrade_result
-
-  - debug:
-      var:
-        # please check the following status to confirm
-        fortios_system_firmware_upgrade_result.meta.results.status
+      system_status:
 '''
 
 RETURN = '''
@@ -166,12 +104,12 @@ http_method:
   description: Last method used to provision the content into FortiGate
   returned: always
   type: str
-  sample: 'POST'
+  sample: 'GET'
 name:
   description: Name of the table used to fulfill the request
   returned: always
   type: str
-  sample: "firmware"
+  sample: "status"
 path:
   description: Path of the table used to fulfill the request
   returned: always
@@ -209,8 +147,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.fortios.fortios import FortiOSHandler
 from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
-import os
-import base64
 
 
 def login(data, fos):
@@ -227,8 +163,8 @@ def login(data, fos):
     fos.login(host, username, password)
 
 
-def filter_system_firmware_data(json):
-    option_list = ['filename', 'format_partition', 'source']
+def filter_system_status_data(json):
+    option_list = []
     dictionary = {}
 
     for attribute in option_list:
@@ -242,26 +178,11 @@ def underscore_to_hyphen(data):
     return data
 
 
-def system_firmware(data, fos, check_mode=False):
+def system_status(data, fos, check_mode=False):
     vdom = data['vdom']
 
-    system_firmware_data = data['system_firmware']
-
-    filtered_data = {}
-    filtered_data['source'] = system_firmware_data['source']
-    if hasattr(system_firmware_data, 'format_partition'):
-        filtered_data['format_partition'] = system_firmware_data['format_partition']
-    if filtered_data['source'] == 'upload':
-        try:
-            filtered_data['file_content'] = base64.b64encode(open(system_firmware_data['filename'], 'rb').read()).decode('utf-8')
-        except Exception:
-            filtered_data['file_content'] = ''
-    else:
-        filtered_data['filename'] = system_firmware_data['filename']
-
-    return fos.execute('system',
-                       'firmware/upgrade',
-                       data=filtered_data,
+    return fos.monitor('system',
+                       'status/select',
                        vdom=vdom)
 
 
@@ -272,8 +193,7 @@ def is_successful_status(status):
 
 def fortios_system(data, fos):
 
-    if data['system_firmware']:
-        resp = system_firmware(data, fos)
+    resp = system_status(data, fos)
 
     return not is_successful_status(resp), \
         resp['status'] == "success", \
@@ -287,13 +207,9 @@ def main():
         "password": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
         "https": {"required": False, "type": "bool", "default": True},
-        "system_firmware": {
-            "required": True, "type": "dict",
+        "system_status": {
+            "required": False, "type": "dict",
             "options": {
-                "filename": {"required": True, "type": "str"},
-                "format_partition": {"required": False, "type": "bool"},
-                "source": {"required": True, "type": "str",
-                           "choices": ["upload", "usb", "fortiguard"]}
 
             }
         }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fortinet is adding this firmware upgrade module to support firmware upgrade on FortiOS and FortiGate products with local firmware file. 
Firmware upgrade module is one of the high demand modules from our end users. 
This module follows the same format as other already approved FortiOS modules in Ansible 2.8 release.
I've tested this module thoroughly in my lab with real FortiGate VM and FortiGate appliance.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
fortios_system_firmware_upgrade

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
