### PR TITLE
[stable-2.8] Omit -A and -G options in local mode since luseradd does not support these (#55401)

### DIFF
--- a/changelogs/fragments/user-local-mode-group-append.yaml
+++ b/changelogs/fragments/user-local-mode-group-append.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - omit incompatible options when operating in local mode (https://github.com/ansible/ansible/issues/48722)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -60,12 +60,14 @@ options:
               C(null), or C(~), the user is removed from all groups except the
               primary group. (C(~) means C(null) in YAML)
             - Before Ansible 2.3, the only input format allowed was a comma separated string.
+            - Has no effect when C(local) is C(True)
         type: list
     append:
         description:
             - If C(yes), add the user to the groups specified in C(groups).
             - If C(no), user will only be added to the groups specified in C(groups),
               removing them from all other groups.
+            - Has no effect when C(local) is C(True)
         type: bool
         default: no
     shell:
@@ -616,7 +618,7 @@ class User(object):
             else:
                 cmd.append('-N')
 
-        if self.groups is not None and len(self.groups):
+        if self.groups is not None and not self.local and len(self.groups):
             groups = self.get_groups_set()
             cmd.append('-G')
             cmd.append(','.join(groups))
@@ -737,7 +739,7 @@ class User(object):
                     else:
                         groups_need_mod = True
 
-            if groups_need_mod:
+            if groups_need_mod and not self.local:
                 if self.append and not has_append:
                     cmd.append('-A')
                     cmd.append(','.join(group_diff))

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -60,14 +60,14 @@ options:
               C(null), or C(~), the user is removed from all groups except the
               primary group. (C(~) means C(null) in YAML)
             - Before Ansible 2.3, the only input format allowed was a comma separated string.
-            - Has no effect when C(local) is C(True)
+            - Mutually exclusive with C(local)
         type: list
     append:
         description:
             - If C(yes), add the user to the groups specified in C(groups).
             - If C(no), user will only be added to the groups specified in C(groups),
               removing them from all other groups.
-            - Has no effect when C(local) is C(True)
+            - Mutually exclusive with C(local)
         type: bool
         default: no
     shell:
@@ -211,6 +211,7 @@ options:
             - This will check C(/etc/passwd) for an existing account before invoking commands. If the local account database
               exists somewhere other than C(/etc/passwd), this setting will not work properly.
             - This requires that the above commands as well as C(/etc/passwd) must exist on the target host, otherwise it will be a fatal error.
+            - Mutually exclusive with C(groups) and C(append)
         type: bool
         default: no
         version_added: "2.4"
@@ -2854,7 +2855,11 @@ def main():
             authorization=dict(type='str'),
             role=dict(type='str'),
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ('local', 'groups'),
+            ('local', 'append')
+        ]
     )
 
     user = User(module)

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -853,7 +853,7 @@
     state: absent
     remove: yes
     local: yes
-  register: local_user_test_3
+  register: local_user_test_remove_1
   tags:
     - user_test_local_mode
 
@@ -863,16 +863,68 @@
     state: absent
     remove: yes
     local: yes
+  register: local_user_test_remove_2
+  tags:
+    - user_test_local_mode
+
+- name: Create test group
+  group:
+    name: testgroup
+  tags:
+    - user_test_local_mode
+
+- name: Create local_ansibulluser with groups
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    groups: testgroup
+  register: local_user_test_3
+  tags:
+    - user_test_local_mode
+
+- name: Create local_ansibulluser with groups again
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    groups: testgroup
   register: local_user_test_4
   tags:
     - user_test_local_mode
 
-- name: Ensure local user accounts were created
+- name: Remove local_ansibulluser with groups
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+    groups: testgroup
+  register: local_user_test_remove_3
+  tags:
+    - user_test_local_mode
+
+- name: Remove local_ansibulluser with groups again
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+    groups: testgroup
+  register: local_user_test_remove_4
+  tags:
+    - user_test_local_mode
+
+- name: Ensure local user accounts were created and removed properly
   assert:
     that:
       - local_user_test_1 is changed
       - local_user_test_2 is not changed
       - local_user_test_3 is changed
       - local_user_test_4 is not changed
+      - local_user_test_remove_1 is changed
+      - local_user_test_remove_2 is not changed
+      - local_user_test_remove_3 is changed
+      - local_user_test_remove_4 is not changed
   tags:
     - user_test_local_mode

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -880,38 +880,18 @@
     local: yes
     groups: testgroup
   register: local_user_test_3
+  ignore_errors: yes
   tags:
     - user_test_local_mode
 
-- name: Create local_ansibulluser with groups again
+- name: Append groups for local_ansibulluser
   user:
     name: local_ansibulluser
     state: present
     local: yes
-    groups: testgroup
+    append: yes
   register: local_user_test_4
-  tags:
-    - user_test_local_mode
-
-- name: Remove local_ansibulluser with groups
-  user:
-    name: local_ansibulluser
-    state: absent
-    remove: yes
-    local: yes
-    groups: testgroup
-  register: local_user_test_remove_3
-  tags:
-    - user_test_local_mode
-
-- name: Remove local_ansibulluser with groups again
-  user:
-    name: local_ansibulluser
-    state: absent
-    remove: yes
-    local: yes
-    groups: testgroup
-  register: local_user_test_remove_4
+  ignore_errors: yes
   tags:
     - user_test_local_mode
 
@@ -920,11 +900,19 @@
     that:
       - local_user_test_1 is changed
       - local_user_test_2 is not changed
-      - local_user_test_3 is changed
-      - local_user_test_4 is not changed
+      - local_user_test_3 is failed
+      - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
+      - local_user_test_4 is failed
+      - "local_user_test_4['msg'] is search('parameters are mutually exclusive: groups|append')"
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
-      - local_user_test_remove_3 is changed
-      - local_user_test_remove_4 is not changed
   tags:
     - user_test_local_mode
+
+- name: Ensure warnings were displayed
+  assert:
+    that:
+      - local_user_test_1['warnings'] | length > 0
+      - "'user was not found in /etc/passwd. The local user account may already exist if the local account
+        database exists somewhere other than /etc/passwd.' in local_user_test_1['warnings'][0]"
+  when: ansible_facts.system in ['Linux']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #55401 for Ansible 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/user.py`