### PR TITLE
vcenter provider: set default values

### DIFF
--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -211,7 +211,10 @@ class VcenterProvider(CloudProvider):
                              provider='vmware')
 
     def _setup_static(self):
-        parser = ConfigParser()
+        parser = ConfigParser({
+            'vcenter_port': '443',
+            'vmware_proxy_host': None,
+            'vmware_proxy_port': None})
         parser.read(self.config_static_path)
 
         self.endpoint = parser.get('DEFAULT', 'vcenter_hostname')


### PR DESCRIPTION
##### SUMMARY

Today, we must define all the value of `test/integration/cloud-config-vcenter.ini` before we start `ansible-test`. Otherwise, we get an error. This patch defines a default value for the following keys:

- vcenter_port
- vmware_proxy_host
- vmware_proxy_port

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware