### PR TITLE
Wrap Get-MachineSid's body in a try/catch

### DIFF
--- a/changelogs/fragments/58483-win_setup_resilience.yml
+++ b/changelogs/fragments/58483-win_setup_resilience.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup (Windows) - prevent setup module failure if Get-MachineSid fails (https://github.com/ansible/ansible/issues/47813)


### PR DESCRIPTION
##### SUMMARY

`Get-MachineSid` has failed in a multitude of ways over the years, and #47813 describes at least two more scenarios. A [comment](https://github.com/ansible/ansible/issues/29524#issuecomment-328521732) on an earlier issue suggested just wrapping it in a try/catch. Sounded good to me!

Fixes: #47813

Also see: #38257 and #29524

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
modules/windows/setup.ps1

