### PR TITLE
[2.8] the env argument for docker_container wants a dict, not a list

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -835,8 +835,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: "true"
-      - arg2: "whatever"
+      arg1: "true"
+      arg2: "whatever"
     volumes:
       - /tmp:/tmp
     comparisons:
@@ -849,8 +849,8 @@ EXAMPLES = '''
     name: test
     image: ubuntu:18.04
     env:
-      - arg1: "true"
-      - arg2: "whatever"
+      arg1: "true"
+      arg2: "whatever"
     comparisons:
       '*': ignore  # by default, ignore *all* options (including image)
       env: strict   # except for environment variables; there, we want to be strict


### PR DESCRIPTION
##### SUMMARY
Backport of #58475 to stable-2.8. Fixes a small docs issue, so no changelog.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_container
