### PR TITLE
fix azure_rm_subnet_info when listing all subnets

### DIFF
--- a/changelogs/fragments/58491-fix-azure_rm_subnet_info-when-listing-all-subnets.yml
+++ b/changelogs/fragments/58491-fix-azure_rm_subnet_info-when-listing-all-subnets.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- azure_rm_subnet_info - fix listing all subnets.

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet_info.py
@@ -53,7 +53,6 @@ EXAMPLES = '''
     azure_rm_subnet_info:
       resource_group: myResourceGroup
       virtual_network_name: myVirtualNetwork
-      name: mySubnet
 '''
 
 RETURN = '''
@@ -211,7 +210,7 @@ class AzureRMSubnetInfo(AzureRMModuleBase):
         response = None
         results = []
         try:
-            response = self.network_client.subnets.get(resource_group_name=self.resource_group,
+            response = self.network_client.subnets.list(resource_group_name=self.resource_group,
                                                        virtual_network_name=self.virtual_network_name)
             self.log("Response : {0}".format(response))
         except CloudError as e:
@@ -219,22 +218,21 @@ class AzureRMSubnetInfo(AzureRMModuleBase):
 
         if response is not None:
             for item in response:
-                results.append(self.format_item(item))
+                results.append(self.format_response(item))
 
         return results
 
     def format_response(self, item):
-        d = item.as_dict()
         d = {
             'resource_group': self.resource_group,
-            'virtual_network_name': self.parse_resource_to_dict(d.get('id')).get('name'),
-            'name': d.get('name'),
-            'id': d.get('id'),
-            'address_prefix_cidr': d.get('address_prefix'),
-            'route_table': d.get('route_table', {}).get('id'),
-            'security_group': d.get('network_security_group', {}).get('id'),
-            'provisioning_state': d.get('provisioning_state'),
-            'service_endpoints': d.get('service_endpoints')
+            'virtual_network_name': self.virtual_network_name,
+            'name': item.name,
+            'id': item.id,
+            'address_prefix_cidr': item.address_prefix,
+            'route_table': item.route_table,
+            'security_group': item.network_security_group,
+            'provisioning_state': item.provisioning_state,
+            'service_endpoints': item.service_endpoints
         }
         return d
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet_info.py
@@ -211,7 +211,7 @@ class AzureRMSubnetInfo(AzureRMModuleBase):
         results = []
         try:
             response = self.network_client.subnets.list(resource_group_name=self.resource_group,
-                                                       virtual_network_name=self.virtual_network_name)
+                                                        virtual_network_name=self.virtual_network_name)
             self.log("Response : {0}".format(response))
         except CloudError as e:
             self.fail('Could not get facts for Subnet.')


### PR DESCRIPTION
##### SUMMARY
- fix the following error :
 An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: get() takes at least 4 arguments (3 given)

- fix ansible_facts variable

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_subnet_facts.py
