### PR TITLE
Delete the check for the resource group

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -364,8 +364,6 @@ class AzureRMRecordSet(AzureRMModuleBase):
         for key in self.module_arg_spec.keys():
             setattr(self, key, kwargs[key])
 
-        # retrieve resource group to make sure it exists
-        self.get_resource_group(self.resource_group)
         zone = self.dns_client.zones.get(self.resource_group, self.zone_name)
         if not zone:
             self.fail('The zone {0} does not exist in the resource group {1}'.format(self.zone_name, self.resource_group))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The call to self.get_resource_group(self.resource_group) assumes greater authorization than a caller may actually have. A caller can have full owner permission on a DNS record set, but lack read permission on the resource group.
Ref: https://github.com/Azure/azure_preview_modules/pull/282
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_dnsrecordset

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
