### PR TITLE
Ansiballz explicit module name

### DIFF
--- a/changelogs/fragments/ansiballz-explicit-module-name.yaml
+++ b/changelogs/fragments/ansiballz-explicit-module-name.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- basic - Make Ansiballz pass the module name explicitly to basic for
+  an intermediate module name until arguments can be parsed. This should
+  be correct in almost all cases, but will fall back to ansible-module-basic
+  in the event arguments are not parsed, and the _name attribute is needed.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -203,6 +203,8 @@ def _ansiballz_main():
         # Monkeypatch the parameters into basic
         from ansible.module_utils import basic
         basic._ANSIBLE_ARGS = json_params
+        # Monkeypatch the module name into basic
+        basic._MODULE_NAME = '%(ansible_module)s'
 %(coverage)s
         # Run the module!  By importing it as '__main__', it thinks it is executing as a script
         if sys.version_info >= (3,):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -226,6 +226,12 @@ _literal_eval = literal_eval
 # is an internal implementation detail
 _ANSIBLE_ARGS = None
 
+# Internal global holding the name of the module. Do not use or rely on
+# this variable from other code as it is an internal implementation detail.
+# This variable is an internal mechanism for relaying the module name for
+# intermediate use in AnsibleModule until module arguments are parsed
+_MODULE_NAME = None
+
 FILE_COMMON_ARGUMENTS = dict(
     # These are things we want. About setting metadata (mode, ownership, permissions in general) on
     # created files (these are used by set_fs_attributes_if_different and included in
@@ -588,7 +594,10 @@ class AnsibleModule(object):
         and :ref:`developing_program_flow_modules` for more detailed explanation.
         '''
 
-        self._name = os.path.basename(__file__)  # initialize name until we can parse from options
+        # initialize name until we can parse from options
+        # we'll fall back to ansible-module-basic as a last resort
+        self._name = _MODULE_NAME or 'ansible-module-basic'
+
         self.argument_spec = argument_spec
         self.supports_check_mode = supports_check_mode
         self.check_mode = False

--- a/test/units/modules/network/slxos/test_slxos_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_interface.py
@@ -147,7 +147,7 @@ class TestSlxosInterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: aggregate, '
             'delay, description, enabled, mtu, name, neighbors, '
             'rx_rate, speed, state, tx_rate',

--- a/test/units/modules/network/slxos/test_slxos_l2_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_l2_interface.py
@@ -164,7 +164,7 @@ class TestSlxosL2InterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: access_vlan, aggregate, '
             'mode, name, native_vlan, state, trunk_allowed_vlans, trunk_vlans',
             result['msg']

--- a/test/units/modules/network/slxos/test_slxos_l3_interface.py
+++ b/test/units/modules/network/slxos/test_slxos_l3_interface.py
@@ -95,7 +95,7 @@ class TestSlxosL3InterfaceModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: aggregate, ipv4, ipv6, '
             'name, state',
             result['msg']

--- a/test/units/modules/network/slxos/test_slxos_linkagg.py
+++ b/test/units/modules/network/slxos/test_slxos_linkagg.py
@@ -152,7 +152,7 @@ class TestSlxosLinkaggModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.pyc|basic.py)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: aggregate, group, '
             'members, mode, purge, state',
             result['msg']

--- a/test/units/modules/network/slxos/test_slxos_lldp.py
+++ b/test/units/modules/network/slxos/test_slxos_lldp.py
@@ -89,7 +89,7 @@ class TestSlxosLldpModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: state',
             result['msg']
         ), 'Output did not match. Got: %s' % result['msg'])

--- a/test/units/modules/network/slxos/test_slxos_vlan.py
+++ b/test/units/modules/network/slxos/test_slxos_vlan.py
@@ -137,7 +137,7 @@ class TestSlxosVlanModule(TestSlxosModule):
         result = self.execute_module(failed=True)
         self.assertEqual(result['failed'], True)
         self.assertTrue(re.match(
-            r'Unsupported parameters for \((basic.py|basic.pyc)\) module: '
+            r'Unsupported parameters for \(ansible-module-basic\) module: '
             'shawshank Supported parameters include: aggregate, delay, '
             'interfaces, name, purge, state, vlan_id',
             result['msg']


### PR DESCRIPTION
##### SUMMARY
Make Ansiballz pass the module name explicitly to basic for
an intermediate module name until arguments can be parsed. This should
be correct in almost all cases, but will fall back to ansible-module-basic
in the event arguments are not parsed, and the _name attribute is needed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```