### PR TITLE
Fixed the none idempotency for multiple nics

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -681,7 +681,7 @@ def _get_server_state(module, cloud):
         if module.params['security_groups']:
             _exit_hostvars(module, cloud, server,
                            ip_changed or sg_changed or server_changed)
-        else :
+        else:
             _exit_hostvars(module, cloud, server,
                            ip_changed or server_changed)
     if server and state == 'absent':

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -729,7 +729,6 @@ def main():
             ['image', 'boot_volume'],
             ['boot_from_volume', 'boot_volume'],
             ['nics', 'network'],
-            ['nics', 'security_groups'],
         ],
         required_if=[
             ('boot_from_volume', True, ['volume_size', 'image']),


### PR DESCRIPTION
##### SUMMARY
When a server is created with multiple nics which holds security groups, module was applying default SG to the server & remove SG on the nics.

This fixe propose to mutually exclude SG & nics: We can apply SG on nics OR on server directly in order to keep idempotency.

Openstak python library expected no security groups send when this field is not filled and the module was filling the security_groups field with an array which contains the default SG. So during the exchange, library was executing the array by default so it removed all security groups on nics. I modified it for None as a default value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_server module

##### ADDITIONAL INFORMATION

