### PR TITLE
[2.8] Handle vaulted non-ascii characters for Python2 (#58503)

### DIFF
--- a/changelogs/fragments/58351-fix-non-ascii-vault.yml
+++ b/changelogs/fragments/58351-fix-non-ascii-vault.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vault - Fix traceback using Python2 if a vault contains non-ascii characters (https://github.com/ansible/ansible/issues/58351).

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import yaml
 
 from ansible.module_utils.six import text_type
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_bytes, to_text, to_native
 
 
 class AnsibleBaseYAMLObject(object):
@@ -128,7 +128,7 @@ class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):
         return True
 
     def __str__(self):
-        return str(self.data)
+        return to_native(self.data, errors='surrogate_or_strict')
 
     def __unicode__(self):
         return to_text(self.data, errors='surrogate_or_strict')

--- a/test/units/parsing/yaml/test_objects.py
+++ b/test/units/parsing/yaml/test_objects.py
@@ -24,6 +24,8 @@ from units.compat import unittest
 
 from ansible.errors import AnsibleError
 
+from ansible.module_utils._text import to_native
+
 from ansible.parsing import vault
 from ansible.parsing.yaml.loader import AnsibleLoader
 
@@ -155,3 +157,8 @@ class TestAnsibleVaultEncryptedUnicode(unittest.TestCase, YamlTestUtils):
         seq = u"aöffü"
         avu = self._from_plaintext(seq)
         self.assert_values(avu, seq)
+
+    def test_str_vaulted_utf8_value_37258(self):
+        seq = u"aöffü"
+        avu = self._from_plaintext(seq)
+        assert str(avu) == to_native(seq)


### PR DESCRIPTION
* Handle vaulted non-ascii characters for Python2

* Add a test to ensure str() no longer raises UnicodeEncodeError

(cherry picked from commit 826f224f0293dc4e9264b44ecd2d8a07710e89c0)

##### SUMMARY
Backport #58503

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vault
