### PR TITLE
Add two new Azure groups to prevent timeouts

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -150,6 +150,12 @@ matrix:
     - env: T=azure/2.7/8
     - env: T=azure/3.6/8
 
+    - env: T=azure/2.7/9
+    - env: T=azure/3.6/9
+
+    - env: T=azure/2.7/10
+    - env: T=azure/3.6/10
+
     - env: T=vcenter/2.7/1
     - env: T=vcenter/3.6/1
 

--- a/test/integration/targets/azure_rm_keyvault/aliases
+++ b/test/integration/targets/azure_rm_keyvault/aliases
@@ -1,5 +1,5 @@
 cloud/azure
 destructive
-shippable/azure/group3
+shippable/azure/group9
 azure_rm_keyvaultkey
 azure_rm_keyvaultsecret

--- a/test/integration/targets/azure_rm_mariadbserver/aliases
+++ b/test/integration/targets/azure_rm_mariadbserver/aliases
@@ -1,6 +1,6 @@
 cloud/azure
 destructive
-shippable/azure/group3
+shippable/azure/group9
 azure_rm_mariadbserver_facts
 azure_rm_mariadbdatabase
 azure_rm_mariadbdatabase_facts

--- a/test/integration/targets/azure_rm_sqlserver/aliases
+++ b/test/integration/targets/azure_rm_sqlserver/aliases
@@ -1,6 +1,6 @@
 cloud/azure
 destructive
-shippable/azure/group4
+shippable/azure/group9
 azure_rm_sqlserver_facts
 azure_rm_sqldatabase
 azure_rm_sqldatabase_facts

--- a/test/integration/targets/azure_rm_virtualmachinescaleset/aliases
+++ b/test/integration/targets/azure_rm_virtualmachinescaleset/aliases
@@ -1,5 +1,5 @@
 cloud/azure
-shippable/azure/group4
+shippable/azure/group10
 destructive
 azure_rm_virtualmachinescaleset_facts
 azure_rm_virtualmachinescalesetinstance_facts


### PR DESCRIPTION
##### SUMMARY
New tests were added to shippable/azure/group4 recently that push it over the 45 minute time limit regularly. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`shippable.yml`
`test/integration/targets/azure_rm_keyvault/aliases`
`test/integration/targets/azure_rm_mariadbserver/aliases`
`test/integration/targets/azure_rm_sqlserver/aliases`
`test/integration/targets/azure_rm_virtualmachinescaleset/aliases`