### PR TITLE
vmware_guest: do not use infra.vm_list

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
@@ -9,7 +9,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: new_vm_1
-    template: "{{ infra.vm_list[0] }}"
+    template: "{{ virtual_machines[0].name }}"
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     folder: D1/C1/F0
@@ -32,7 +32,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: new_vm_2
-    template: "{{ infra.vm_list[0] }}"
+    template: "{{ virtual_machines[0].name }}"
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     folder: D1/C1/F0


### PR DESCRIPTION
##### SUMMARY

Update the functional tests of `vmware_guest` to use the
`virtual_machines` data structure.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest
<!--- Write the short name of the module, plugin, task or feature below -->