### PR TITLE
Use atexit to logout after zabbix module run

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -440,6 +440,7 @@ msg:
 '''
 
 
+import atexit
 import traceback
 
 try:
@@ -2002,6 +2003,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user,
                         passwd=http_login_password, validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -76,6 +76,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 try:
@@ -169,6 +170,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
@@ -57,6 +57,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -128,6 +129,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -276,6 +276,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import copy
 import traceback
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -96,6 +96,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
@@ -218,6 +219,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -72,6 +72,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 try:
@@ -200,6 +201,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -122,6 +122,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import datetime
 import time
 import traceback
@@ -317,6 +318,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     # zabbix_api can call sys.exit() so we need to catch SystemExit here
     except (Exception, SystemExit) as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -173,6 +173,7 @@ ANSIBLE_METADATA = {
 }
 
 
+import atexit
 import base64
 import traceback
 
@@ -791,6 +792,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -219,6 +219,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 
@@ -585,6 +586,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -154,6 +154,7 @@ EXAMPLES = '''
 '''
 
 
+import atexit
 import traceback
 
 try:
@@ -393,6 +394,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -196,6 +196,7 @@ template_json:
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
+import atexit
 import json
 import traceback
 
@@ -492,6 +493,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout,
                         user=http_login_user, passwd=http_login_password, validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except ZabbixAPIException as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Run zbx.logout() after every run.
Fixes #58459
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zabbix_action
zabbix_group_info
zabbix_group
zabbix_host_info
zabbix_hostmacro
zabbix_host
zabbix_maintenance
zabbix_map
zabbix_mediatype
zabbix_screen
zabbix_template
