### PR TITLE
Daemonize service start on OpenBSD, fixes #50460

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1157,7 +1157,7 @@ class OpenBsdService(Service):
 
     def service_control(self):
         if self.enable_cmd:
-            return self.execute_command("%s -f %s %s" % (self.svc_cmd, self.action, self.name))
+            return self.execute_command("%s -f %s %s" % (self.svc_cmd, self.action, self.name), daemonize=True)
         else:
             return self.execute_command("%s -f %s" % (self.svc_cmd, self.action))
 


### PR DESCRIPTION
##### SUMMARY
This pull request changes the OpenBSDService class so that `rcctl start $SERVICE` is daemonized.

Fixes #50460.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service