### PR TITLE
Add include_tags to datadog_monitor

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -132,6 +132,11 @@ options:
           - Effective for sparse values.
         version_added: "2.7"
         type: str
+    include_tags:
+        description:
+          - Whether notifications from this monitor automatically inserts its triggering tags into the title.
+        version_added: "2.9"
+        type: bool
     id:
         description:
           - The ID of the alert.
@@ -211,6 +216,7 @@ def main():
             require_full_window=dict(required=False, default=None, type='bool'),
             new_host_delay=dict(required=False, default=None),
             evaluation_delay=dict(required=False, default=None),
+            include_tags=dict(required=False, default=True, type='bool'),
             id=dict(required=False)
         )
     )
@@ -321,7 +327,8 @@ def install_monitor(module):
         "locked": module.boolean(module.params['locked']),
         "require_full_window": module.params['require_full_window'],
         "new_host_delay": module.params['new_host_delay'],
-        "evaluation_delay": module.params['evaluation_delay']
+        "evaluation_delay": module.params['evaluation_delay'],
+        "include_tags": module.boolean(module.params['include_tags'])
     }
 
     if module.params['type'] == "service check":

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -137,6 +137,7 @@ options:
           - Whether notifications from this monitor automatically inserts its triggering tags into the title.
         version_added: "2.9"
         type: bool
+        default: yes
     id:
         description:
           - The ID of the alert.


### PR DESCRIPTION
##### SUMMARY

- Add `include_tags` to `datadog_monitor` module

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- datadog_monitor

##### ADDITIONAL INFORMATION

- Closes #57441
- https://docs.datadoghq.com/api/?lang=python#create-a-monitor
