### PR TITLE
Backport/2.8/57904 ce_snmp_target_host: update to fix bug: None has no 'lower()' functio…

### DIFF
--- a/changelogs/fragments/57904-ce_snmp_target_host.yml
+++ b/changelogs/fragments/57904-ce_snmp_target_host.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ce_snmp_target_host - None has no 'lower()' attribute.

--- a/lib/ansible/modules/network/cloudengine/ce_snmp_target_host.py
+++ b/lib/ansible/modules/network/cloudengine/ce_snmp_target_host.py
@@ -493,7 +493,10 @@ class SnmpTargetHost(object):
                                 same_flag = False
 
                         if "interface-name" in tmp.keys():
-                            if tmp["interface-name"].lower() != self.interface_name.lower():
+                            if tmp.get("interface-name") is not None:
+                                if tmp["interface-name"].lower() != self.interface_name.lower():
+                                    same_flag = False
+                            else:
                                 same_flag = False
 
                         if same_flag:


### PR DESCRIPTION
…n. (#57904)

* update to fix bug: None has not 'lower()' function.

* add a changelog fragment.

* update changlog fragment.

* Update 57904-ce_snmp_target_host.yml

(cherry picked from commit 78c8ee9261827b991579835dcf69babd3d42ff03)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
update to fix bug: None has not 'lower()'  attribute.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_snmp_target_host.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
There is a changelog fragment that  is used to explain the changes.
So do not add changelog again.
```
