### PR TITLE
backport/2.8/57907    update ce_interface to fix bugs (#57907)

### DIFF
--- a/changelogs/fragments/57907-update-ce_interface-to-fix-bugs.yml
+++ b/changelogs/fragments/57907-update-ce_interface-to-fix-bugs.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ce_interface - It is not a good way to find data from a xml tree by regular. lin379 line405.
+  - ce_interface - line 750,779 Some attributes of interfaces are missing, 'ifAdminStatus', 'ifDescr', 'isL2SwitchPort'.So add them when get interface status.

--- a/lib/ansible/modules/network/cloudengine/ce_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_interface.py
@@ -149,6 +149,7 @@ changed:
 
 
 import re
+from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
 
@@ -193,7 +194,7 @@ CE_NC_GET_INTF = """
 CE_NC_XML_CREATE_INTF = """
 <ifm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
 <interfaces>
-  <interface operation="create">
+  <interface operation="merge">
     <ifName>%s</ifName>
     <ifDescr>%s</ifDescr>
   </interface>
@@ -204,7 +205,7 @@ CE_NC_XML_CREATE_INTF = """
 CE_NC_XML_CREATE_INTF_L2SUB = """
 <ifm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
 <interfaces>
-  <interface operation="create">
+  <interface operation="merge">
     <ifName>%s</ifName>
     <ifDescr>%s</ifDescr>
     <l2SubIfFlag>true</l2SubIfFlag>
@@ -376,21 +377,22 @@ class Interface(object):
         if "<data/>" in recv_xml:
             return intfs_info
 
-        intf = re.findall(
-            r'.*<ifName>(.*)</ifName>.*\s*<ifPhyType>(.*)</ifPhyType>.*\s*'
-            r'<ifNumber>(.*)</ifNumber>.*\s*<ifDescr>(.*)</ifDescr>.*\s*'
-            r'<isL2SwitchPort>(.*)</isL2SwitchPort>.*\s*<ifAdminStatus>'
-            r'(.*)</ifAdminStatus>.*\s*<ifMtu>(.*)</ifMtu>.*', recv_xml)
+        xml_str = recv_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
-        for tmp in intf:
-            if tmp[1]:
-                if not intfs_info.get(tmp[1].lower()):
-                    # new interface type list
-                    intfs_info[tmp[1].lower()] = list()
-                intfs_info[tmp[1].lower()].append(dict(ifName=tmp[0], ifPhyType=tmp[1], ifNumber=tmp[2],
-                                                       ifDescr=tmp[3], isL2SwitchPort=tmp[4],
-                                                       ifAdminStatus=tmp[5], ifMtu=tmp[6]))
-
+        root = ElementTree.fromstring(xml_str)
+        intfs = root.findall("ifm/interfaces/")
+        if intfs:
+            for intf in intfs:
+                intf_type = intf.find("ifPhyType").text.lower()
+                if intf_type:
+                    if not intfs_info.get(intf_type):
+                        intfs_info[intf_type] = list()
+                    intf_info = dict()
+                    for tmp in intf:
+                        intf_info[tmp.tag] = tmp.text
+                    intfs_info[intf_type].append(intf_info)
         return intfs_info
 
     def get_interface_dict(self, ifname):
@@ -402,22 +404,15 @@ class Interface(object):
 
         if "<data/>" in recv_xml:
             return intf_info
+        xml_str = recv_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
 
-        intf = re.findall(
-            r'.*<ifName>(.*)</ifName>.*\s*'
-            r'<ifPhyType>(.*)</ifPhyType>.*\s*'
-            r'<ifNumber>(.*)</ifNumber>.*\s*'
-            r'<ifDescr>(.*)</ifDescr>.*\s*'
-            r'<isL2SwitchPort>(.*)</isL2SwitchPort>.*\s*'
-            r'<ifAdminStatus>(.*)</ifAdminStatus>.*\s*'
-            r'<ifMtu>(.*)</ifMtu>.*', recv_xml)
-
-        if intf:
-            intf_info = dict(ifName=intf[0][0], ifPhyType=intf[0][1],
-                             ifNumber=intf[0][2], ifDescr=intf[0][3],
-                             isL2SwitchPort=intf[0][4],
-                             ifAdminStatus=intf[0][5], ifMtu=intf[0][6])
-
+        root = ElementTree.fromstring(xml_str)
+        intfs = root.findall("ifm/interfaces/interface/")
+        if intfs:
+            for intf in intfs:
+                intf_info[intf.tag] = intf.text
         return intf_info
 
     def create_interface(self, ifname, description, admin_state, mode, l2sub):
@@ -752,10 +747,23 @@ class Interface(object):
                 else:
                     self.existing["mode"] = "layer3"
 
+        if self.intfs_info:
+            intfs = self.intfs_info.get(self.intf_type.lower())
+            for intf in intfs:
+                intf_para = dict()
+                if intf["ifAdminStatus"]:
+                    intf_para["admin_state"] = intf["ifAdminStatus"]
+                intf_para["description"] = intf["ifDescr"]
+
+                if intf["isL2SwitchPort"] == "true":
+                    intf_para["mode"] = "layer2"
+                else:
+                    intf_para["mode"] = "layer3"
+                self.existing[intf["ifName"]] = intf_para
+
     def get_end_state(self):
         """get_end_state"""
-
-        if self.intf_info:
+        if self.interface:
             end_info = self.get_interface_dict(self.interface)
             if end_info:
                 self.end_state["interface"] = end_info["ifName"]
@@ -767,6 +775,21 @@ class Interface(object):
                         self.end_state["mode"] = "layer2"
                     else:
                         self.end_state["mode"] = "layer3"
+
+        if self.interface_type:
+            end_info = self.get_interfaces_dict()
+            intfs = end_info.get(self.intf_type.lower())
+            for intf in intfs:
+                intf_para = dict()
+                if intf["ifAdminStatus"]:
+                    intf_para["admin_state"] = intf["ifAdminStatus"]
+                intf_para["description"] = intf["ifDescr"]
+
+                if intf["isL2SwitchPort"] == "true":
+                    intf_para["mode"] = "layer2"
+                else:
+                    intf_para["mode"] = "layer3"
+                self.end_state[intf["ifName"]] = intf_para
 
     def work(self):
         """worker"""


### PR DESCRIPTION
* update ce_interface

* update ce_interface

* add a changelog fragment.

(cherry picked from commit e02353026d1497a527c3db1535753aa9c2411042)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a changelog fragment that  is used to explain the changes.
So do not add changelog again.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_interface.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. It is not a good way to find data from a xml tree by regular.  lin379 line405.
2.  line 750,764
Some attributes of interfaces  are missing, 'ifAdminStatus', 'ifDescr', 'isL2SwitchPort'.
So add them when get interface  status.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
#####Test playbook
"""
---

- name: test ce_config
  gather_facts: no
  hosts: switch4

  tasks:
 

  - name: "Test the correct interface"
    ce_interface:     
      interface: 100GE1/0/48
      admin_state: up
      description: Configured by ansible.
    ignore_errors: false"""




#####Test:  befor fix
"""
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1561707413.770977-165250362343882/AnsiballZ_ce_interface.py", line 125, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1561707413.770977-165250362343882/AnsiballZ_ce_interface.py", line 117, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1561707413.770977-165250362343882/AnsiballZ_ce_interface.py", line 51, in invoke_module
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 662, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/tmp/ansible_ce_interface_payload_msuun_nn/__main__.py", line 871, in <module>
  File "/tmp/ansible_ce_interface_payload_msuun_nn/__main__.py", line 867, in main
  File "/tmp/ansible_ce_interface_payload_msuun_nn/__main__.py", line 787, in work
  File "/tmp/ansible_ce_interface_payload_msuun_nn/__main__.py", line 455, in create_interface
  File "/tmp/ansible_ce_interface_payload_msuun_nn/ansible_ce_interface_payload.zip/ansible/module_utils/network/cloudengine/ce.py", line 339, in set_nc_config
  File "/tmp/ansible_ce_interface_payload_msuun_nn/ansible_ce_interface_payload.zip/ansible/module_utils/network/common/netconf.py", line 76, in __rpc__
  File "/tmp/ansible_ce_interface_payload_msuun_nn/ansible_ce_interface_payload.zip/ansible/module_utils/network/common/netconf.py", line 105, in parse_rpc_error
ansible.module_utils.connection.ConnectionError: <?xml version="1.0" encoding="UTF-8"?><rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
    <error-type>application</error-type>
    <error-tag>data-exists</error-tag>
    <error-severity>error</error-severity>
    <error-app-tag>8432</error-app-tag>
    <error-message>The interface 100GE1/0/48 already exists.&#13;
</error-message>
    <error-info>
      <ifm xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
        <interfaces>
          <interface>
            <ifName>100GE1/0/48</ifName>
            <ifDescr>Configured by ansible.</ifDescr>
          </interface>
        </interfaces>
      </ifm>
      <error-paras>
        <error-para>100GE1/0/48</error-para>
      </error-paras>
    </error-info>
  </rpc-error>"""

##### Test  after fix
"""
changed: [10.10.30.18] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "admin_state": "up",
        "description": "Configured by ansible.",
        "interface": "100GE1/0/48",
        "mode": "layer2"
    },
    "existing": {
        "admin_state": "up",
        "description": null,
        "interface": "100GE1/0/48",
        "mode": "layer2"
    },
    "invocation": {
        "module_args": {
            "admin_state": "up",
            "description": "Configured by ansible.",
            "host": "10.10.30.18",
            "interface": "100GE1/0/48",
            "interface_type": null,
            "l2sub": false,
            "mode": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10066,
            "provider": {
                "host": "10.10.30.18",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10066,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "proposed": {
        "admin_state": "up",
        "description": "Configured by ansible.",
        "interface": "100GE1/0/48",
        "l2sub": false,
        "state": "present"
    },
    "updates": [
        "interface 100GE1/0/48",
        "description Configured by ansible."
    ]
}
"""