### PR TITLE
Handle mode-setting of symlink to RO filesystem

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1114,7 +1114,7 @@ class AnsibleModule(object):
                         if underlying_stat.st_mode != new_underlying_stat.st_mode:
                             os.chmod(b_path, stat.S_IMODE(underlying_stat.st_mode))
             except OSError as e:
-                if os.path.islink(b_path) and e.errno == errno.EPERM:  # Can't set mode on symbolic links
+                if os.path.islink(b_path) and e.errno in (errno.EPERM, errno.EROFS):  # Can't set mode on symbolic links
                     pass
                 elif e.errno in (errno.ENOENT, errno.ELOOP):  # Can't set mode on broken symbolic links
                     pass


### PR DESCRIPTION
When `os.chmod()` is attempted on a symlink, and it fails due to the symlink pointing to a read-only filesystem, ignore the `OSError`.

##### SUMMARY

Fixes #58562

##### COMPONENT
`lib/ansible/module_utils/basic.py`

##### ISSUE TYPE

- Bugfix Pull Request
