### PR TITLE
Fix nagios module to recognize if file exists and is fifo pipe

### DIFF
--- a/changelogs/fragments/58569-nagios-fifo-fix.yaml
+++ b/changelogs/fragments/58569-nagios-fifo-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nagios module - Fix nagios module to recognize if ``cmdfile`` exists and is fifo pipe.

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -196,6 +196,7 @@ EXAMPLES = '''
 import types
 import time
 import os.path
+import stat
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -389,6 +390,12 @@ class Nagios(object):
         Write the given command to the Nagios command file
         """
 
+        if not os.path.exists(self.cmdfile):
+            self.module.fail_json(msg='nagios command file does not exist',
+                                  cmdfile=self.cmdfile)
+        if not stat.S_ISFIFO(os.stat(self.cmdfile).st_mode):
+            self.module.fail_json(msg='nagios command file is not a fifo file',
+                                  cmdfile=self.cmdfile)
         try:
             fp = open(self.cmdfile, 'w')
             fp.write(cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible nagios module does not check if cmdfile is actually a fifo file. If the file does not exist (for example nagios is not started, it will create a normal file. If the file exists nagios won't start.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/monitoring/nagios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
[klaas@notebook ~]$ file /home/klaas/test.file
/home/klaas/test.file: cannot open `/home/klaas/test.file' (No such file or directory)
[klaas@notebook ~]$ ansible -i "localhost," --connection local -m nagios -a "action=downtime cmdfile=/home/klaas/test.file command=host comment=test host=test.tld services=host " all
[DEPRECATION WARNING]: Distribution fedora 30 on host localhost should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility 
with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 
2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
localhost | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "nagios_commands": [
        "[1561907405] SCHEDULE_HOST_DOWNTIME;test.tld;1561907405;1561909205;1;0;1800;Ansible;test"
    ]
}
[klaas@notebook ~]$ file /home/klaas/test.file
/home/klaas/test.file: JSON data
```
After change (file doesn't exist):
```
[klaas@notebook ~]$ rm test.file 
[klaas@notebook ~]$ ansible -i "localhost," --connection local -m nagios -a "action=downtime cmdfile=/home/klaas/test.file command=host comment=test host=test.tld services=host" all
[DEPRECATION WARNING]: Distribution fedora 30 on host localhost should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility 
with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 
2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "cmdfile": "/home/klaas/test.file",
    "msg": "nagios command file does not exist"
}
```

After change file not fifo:
```
[klaas@notebook ~]$ touch test.file
[klaas@notebook ~]$ ansible -i "localhost," --connection local -m nagios -a "action=downtime cmdfile=/home/klaas/test.file command=host comment=test host=test.tld services=host" all
[DEPRECATION WARNING]: Distribution fedora 30 on host localhost should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility 
with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 
2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "cmdfile": "/home/klaas/test.file",
    "msg": "nagios command file is not a fifo file"
}
```

After change file is fifo: (you'll need to cat test.file from another shell)
```
[klaas@notebook ~]$ mkfifo test.file
[klaas@notebook ~]$ ansible -i "localhost," --connection local -m nagios -a "action=downtime cmdfile=/home/klaas/test.file command=host comment=test host=test.tld services=host" all
[DEPRECATION WARNING]: Distribution fedora 30 on host localhost should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility 
with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. See 
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html for more information. This feature will be removed in version 
2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
localhost | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "nagios_commands": [
        "[1561909146] SCHEDULE_HOST_DOWNTIME;test.tld;1561909146;1561910946;1;0;1800;Ansible;test"
    ]
}
```
