### PR TITLE
Load Ansible module_utils for ps_argspec validator

### DIFF
--- a/test/sanity/validate-modules/ps_argspec.ps1
+++ b/test/sanity/validate-modules/ps_argspec.ps1
@@ -49,6 +49,33 @@ Add-Type -TypeDefinition $dummy_ansible_basic
 $module_code = Get-Content -LiteralPath $module_path -Raw
 
 $powershell = [PowerShell]::Create()
+$powershell.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", "Stop")
+
+# Load the PowerShell module utils as the module may be using them to refer to shared module options
+$required_modules = [ScriptBlock]::Create($module_code).Ast.ScriptRequirements.RequiredModules
+foreach ($required_module in $required_modules) {
+    if (-not $required_module.Name.StartsWith('Ansible.ModuleUtils.')) {
+        continue
+    }
+
+    # FUTURE: Lookup utils in the role or collection's module_utils dir.
+    $module_util_path = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($module_path, '..', '..', '..',
+        'module_utils', 'powershell', "$($required_module.Name).psm1"))
+    if (-not (Test-Path -LiteralPath $module_util_path -PathType Leaf)) {
+        # Failed to find path, just silently ignore for now and hope for the best
+        continue
+    }
+
+    $module_util_sb = [ScriptBlock]::Create((Get-Content -LiteralPath $module_util_path -Raw))
+    $powershell.AddCommand('New-Module').AddParameters(@{
+        Name = $required_module.Name
+        ScriptBlock = $module_util_sb
+    }) > $null
+    $powershell.AddCommand('Import-Module').AddParameter('WarningAction', 'SilentlyContinue') > $null
+    $powershell.AddCommand('Out-Null').AddStatement() > $null
+
+}
+
 $powershell.AddScript($module_code) > $null
 $powershell.Invoke() > $null
 

--- a/test/sanity/validate-modules/ps_argspec.ps1
+++ b/test/sanity/validate-modules/ps_argspec.ps1
@@ -52,6 +52,7 @@ $powershell = [PowerShell]::Create()
 $powershell.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", "Stop")
 
 # Load the PowerShell module utils as the module may be using them to refer to shared module options
+# FUTURE: Lookup utils in the role or collection's module_utils dir based on #AnsibleRequires
 $script_requirements = [ScriptBlock]::Create($module_code).Ast.ScriptRequirements
 $required_modules = @()
 if ($null -ne $script_requirements) {
@@ -62,7 +63,6 @@ foreach ($required_module in $required_modules) {
         continue
     }
 
-    # FUTURE: Lookup utils in the role or collection's module_utils dir.
     $module_util_path = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($module_path, '..', '..', '..',
         'module_utils', 'powershell', "$($required_module.Name).psm1"))
     if (-not (Test-Path -LiteralPath $module_util_path -PathType Leaf)) {

--- a/test/sanity/validate-modules/ps_argspec.ps1
+++ b/test/sanity/validate-modules/ps_argspec.ps1
@@ -52,7 +52,11 @@ $powershell = [PowerShell]::Create()
 $powershell.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", "Stop")
 
 # Load the PowerShell module utils as the module may be using them to refer to shared module options
-$required_modules = [ScriptBlock]::Create($module_code).Ast.ScriptRequirements.RequiredModules
+$script_requirements = [ScriptBlock]::Create($module_code).Ast.ScriptRequirements
+$required_modules = @()
+if ($null -ne $script_requirements) {
+    $required_modules = $script_requirements.RequiredModules
+}
 foreach ($required_module in $required_modules) {
     if (-not $required_module.Name.StartsWith('Ansible.ModuleUtils.')) {
         continue


### PR DESCRIPTION
##### SUMMARY
As part of https://github.com/ansible/ansible/pull/54759, we will want to pull argument specs from common module_util code. This PR updates the PowerShell argument spec validator to load the PowerShell module_utils before it is run. C# module_utils are still excluded due to issues compiling C# utils that may only work on Windows.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/validate-modules