### PR TITLE
Fix traceback when using gluster_volume

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -548,7 +548,7 @@ def main():
                     if brick not in bricks_in_volume:
                         new_bricks.append(brick)
 
-            if not new_bricks and len(all_bricks) < bricks_in_volume:
+            if not new_bricks and len(all_bricks) < len(bricks_in_volume):
                 for brick in bricks_in_volume:
                     if brick not in all_bricks:
                         removed_bricks.append(brick)


### PR DESCRIPTION
##### SUMMARY

Fix traceback when using the module

Since bricks_in_volume is a list, it can't be compared to a int.

    Traceback (most recent call last):
      File \"/root/.ansible/tmp/ansible-tmp-1561989216.06-31322871319024/AnsiballZ_gluster_volume.py\", line 114, in <module>
        _ansiballz_main()
      File \"/root/.ansible/tmp/ansible-tmp-1561989216.06-31322871319024/AnsiballZ_gluster_volume.py\", line 106, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File \"/root/.ansible/tmp/ansible-tmp-1561989216.06-31322871319024/AnsiballZ_gluster_volume.py\", line 49, in invoke_module
        imp.load_module('__main__', mod, module, MOD_DESC)
      File \"/usr/lib64/python3.7/imp.py\", line 234, in load_module
        return load_source(name, filename, file)
      File \"/usr/lib64/python3.7/imp.py\", line 169, in load_source
        module = _exec(spec, sys.modules[name])
      File \"<frozen importlib._bootstrap>\", line 630, in _exec
      File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module
      File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed
      File \"/tmp/ansible_gluster_volume_payload_d5mfag24/__main__.py\", line 610, in <module>
      File \"/tmp/ansible_gluster_volume_payload_d5mfag24/__main__.py\", line 551, in main
    TypeError: '<' not supported between instances of 'int' and 'list'

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gluster_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See https://github.com/gluster/gluster.org_ansible_configuration/blob/master/roles/cert_syncer/tasks/main.yml#L21 for the code that was used to trigger that.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
