### PR TITLE
openssl_privatekey: forgot to add secp256r1

### DIFF
--- a/changelogs/fragments/58605-openssl_privatekey-secp256r1.yml
+++ b/changelogs/fragments/58605-openssl_privatekey-secp256r1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_privatekey - ``secp256r1`` got accidentally forgotten in the curve list."

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -62,7 +62,7 @@ options:
     curve:
         description:
             - Note that not all curves are supported by all versions of C(cryptography).
-            - For maximal interoperability, C(secp384r1) or C(secp256k1) should be used.
+            - For maximal interoperability, C(secp384r1) or C(secp256r1) should be used.
             - We use the curve names as defined in the
               L(IANA registry for TLS,https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
         type: str
@@ -71,6 +71,7 @@ options:
             - secp521r1
             - secp224r1
             - secp192r1
+            - secp256r1
             - secp256k1
             - brainpoolP256r1
             - brainpoolP384r1
@@ -178,7 +179,7 @@ curve:
     description: Elliptic curve used to generate the TLS/SSL private key.
     returned: changed or success, and I(type) is C(ECC)
     type: str
-    sample: secp256k1
+    sample: secp256r1
 filename:
     description: Path to the generated TLS/SSL private key file.
     returned: changed or success
@@ -454,6 +455,7 @@ class PrivateKeyCryptography(PrivateKeyBase):
         self._add_curve('secp521r1', 'SECP521R1')
         self._add_curve('secp224r1', 'SECP224R1')
         self._add_curve('secp192r1', 'SECP192R1')
+        self._add_curve('secp256r1', 'SECP256R1')
         self._add_curve('secp256k1', 'SECP256K1')
         self._add_curve('brainpoolP256r1', 'BrainpoolP256R1', deprecated=True)
         self._add_curve('brainpoolP384r1', 'BrainpoolP384R1', deprecated=True)
@@ -613,8 +615,8 @@ def main():
                 'DSA', 'ECC', 'Ed25519', 'Ed448', 'RSA', 'X25519', 'X448'
             ]),
             curve=dict(type='str', choices=[
-                'secp384r1', 'secp521r1', 'secp224r1', 'secp192r1', 'secp256k1',
-                'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1',
+                'secp384r1', 'secp521r1', 'secp224r1', 'secp192r1', 'secp256r1',
+                'secp256k1', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1',
                 'sect571k1', 'sect409k1', 'sect283k1', 'sect233k1', 'sect163k1',
                 'sect571r1', 'sect409r1', 'sect283r1', 'sect233r1', 'sect163r2',
             ]),

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -67,6 +67,9 @@
     - curve: secp192r1
       openssl_name: prime192v1
       min_cryptography_version: "0.5"
+    - curve: secp256r1
+      openssl_name: secp256r1
+      min_cryptography_version: "0.5"
     - curve: secp256k1
       openssl_name: secp256k1
       min_cryptography_version: "0.9"


### PR DESCRIPTION
##### SUMMARY
When adding all elliptic curves, I forgot one of the most important ones (because it is one of the most interoperable ones): secp256r1.

I'm not sure whether this really counts as a bugfix, or is more a feature request. Since the original intend was to cover the most important curves, this one should have really be there. Mentioning secp256k1 instead of secp256r1 as most interoperable is definitely a bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey
