### PR TITLE
[2.8] openssl_privatekey: forgot to add secp256r1

### DIFF
--- a/changelogs/fragments/58605-openssl_privatekey-secp256r1.yml
+++ b/changelogs/fragments/58605-openssl_privatekey-secp256r1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_privatekey - ``secp256r1`` got accidentally forgotten in the curve list."

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -62,7 +62,7 @@ options:
     curve:
         description:
             - Note that not all curves are supported by all versions of C(cryptography).
-            - For maximal interoperability, C(secp384r1) or C(secp256k1) should be used.
+            - For maximal interoperability, C(secp384r1) or C(secp256r1) should be used.
             - We use the curve names as defined in the
               L(IANA registry for TLS,https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8).
         type: str
@@ -71,6 +71,7 @@ options:
             - secp521r1
             - secp224r1
             - secp192r1
+            - secp256r1
             - secp256k1
             - brainpoolP256r1
             - brainpoolP384r1
@@ -178,7 +179,7 @@ curve:
     description: Elliptic curve used to generate the TLS/SSL private key.
     returned: changed or success, and I(type) is C(ECC)
     type: str
-    sample: secp256k1
+    sample: secp256r1
 filename:
     description: Path to the generated TLS/SSL private key file.
     returned: changed or success
@@ -454,6 +455,7 @@ class PrivateKeyCryptography(PrivateKeyBase):
         self._add_curve('secp521r1', 'SECP521R1')
         self._add_curve('secp224r1', 'SECP224R1')
         self._add_curve('secp192r1', 'SECP192R1')
+        self._add_curve('secp256r1', 'SECP256R1')
         self._add_curve('secp256k1', 'SECP256K1')
         self._add_curve('brainpoolP256r1', 'BrainpoolP256R1', deprecated=True)
         self._add_curve('brainpoolP384r1', 'BrainpoolP384R1', deprecated=True)
@@ -613,8 +615,8 @@ def main():
                 'DSA', 'ECC', 'Ed25519', 'Ed448', 'RSA', 'X25519', 'X448'
             ]),
             curve=dict(type='str', choices=[
-                'secp384r1', 'secp521r1', 'secp224r1', 'secp192r1', 'secp256k1',
-                'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1',
+                'secp384r1', 'secp521r1', 'secp224r1', 'secp192r1', 'secp256r1',
+                'secp256k1', 'brainpoolP256r1', 'brainpoolP384r1', 'brainpoolP512r1',
                 'sect571k1', 'sect409k1', 'sect283k1', 'sect233k1', 'sect163k1',
                 'sect571r1', 'sect409r1', 'sect283r1', 'sect233r1', 'sect163r2',
             ]),

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -67,6 +67,9 @@
     - curve: secp192r1
       openssl_name: prime192v1
       min_cryptography_version: "0.5"
+    - curve: secp256r1
+      openssl_name: secp256r1
+      min_cryptography_version: "0.5"
     - curve: secp256k1
       openssl_name: secp256k1
       min_cryptography_version: "0.9"


### PR DESCRIPTION
##### SUMMARY
Backport of #58605 to stable-2.8.

I'm not sure whether this really counts as a bugfix, or is more a feature request, since this adds a new curve. Since the original intend of elliptic curve support was to cover the most important curves, this one should have really been there in the first place. Mentioning secp256k1 instead of secp256r1 as most interoperable is definitely a bug: secp256r1 and secp384r1 are the only elliptic curves supported by almost all browsers (excluding too old ones), while secp256k1 usually isn't supported. (For example, both [Chrome 49](https://www.ssllabs.com/ssltest/viewClient.html?name=Chrome&version=49&platform=XP%20SP3&key=136) and [IE11](https://www.ssllabs.com/ssltest/viewClient.html?name=IE&version=11&platform=Win%207&key=143) only support these two curves, while [Firefox 47](https://www.ssllabs.com/ssltest/viewClient.html?name=Firefox&version=47&platform=Win%207&key=132) and [Safari 7](https://www.ssllabs.com/ssltest/viewClient.html?name=Safari&version=7&platform=iOS%207.1&key=63) additionally support secp521r1; search for "named groups" in the links for details. [Safari 10](https://www.ssllabs.com/ssltest/viewClient.html?name=Safari&version=10&platform=OS%20X%2010.12&key=138) still supports no other groups, so even with more modern browsers one still is stuck with these two curves.)

So I'd argue for this to be a bugfix. In the PR, @MarkusTeufelberger [also agreed to this](https://github.com/ansible/ansible/pull/58605#issuecomment-507412123).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey
