### PR TITLE
handle iam_managed_policy failures other than version count exceeded

### DIFF
--- a/changelogs/fragments/58612-iam-managed-policy-errors.yml
+++ b/changelogs/fragments/58612-iam-managed-policy-errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iam_managed_policy - improve error reporting for policy update problems

--- a/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
@@ -195,8 +195,8 @@ def get_or_create_policy_version(module, iam, policy, policy_document):
             try:
                 version = iam.create_policy_version(PolicyArn=policy['Arn'], PolicyDocument=policy_document)['PolicyVersion']
                 return version, True
-            except botocore.exceptions.ClientError as e:
-                pass
+            except botocore.exceptions.ClientError as second_e:
+                e = second_e
         # Handle both when the exception isn't LimitExceeded or
         # the second attempt still failed
         module.fail_json(msg="Couldn't create policy version: %s" % str(e),


### PR DESCRIPTION
##### SUMMARY

If a managed policy addition fails for a reason other than version
count exceeded, that failure should be handled correctly otherwise
the error message is not at all clear.

This is the case e.g. for a policy that is too big

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iam_managed_policy

