### PR TITLE
[stable-2.6] Skip tests with unsatisfied deps (#55853)

### DIFF
--- a/test/units/plugins/filter/test_network.py
+++ b/test/units/plugins/filter/test_network.py
@@ -23,7 +23,9 @@ import sys
 import pytest
 
 from ansible.compat.tests import unittest
-from ansible.plugins.filter.network import parse_xml, type5_pw, hash_salt, comp_type5
+from ansible.plugins.filter.network import (HAS_PASSLIB, parse_xml, type5_pw, hash_salt,
+                                            comp_type5)
+
 from ansible.errors import AnsibleFilterError
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'network')
@@ -83,6 +85,7 @@ class TestNetworkParseFilter(unittest.TestCase):
         self.assertEqual("parse_xml works on string input, but given input of : %s" % type(output), str(e.exception))
 
 
+@pytest.mark.skipif(not HAS_PASSLIB, reason="Current type5_pw filter needs passlib to function")
 class TestNetworkType5(unittest.TestCase):
 
     def test_defined_salt_success(self):
@@ -146,6 +149,7 @@ class TestHashSalt(unittest.TestCase):
         self.assertEqual("Could not parse salt out password correctly from $nTc1$Z28sUTcWfXlvVe2x.3XAa.", str(e.exception))
 
 
+@pytest.mark.skipif(not HAS_PASSLIB, reason="Current comp_type5 filter needs passlib to function")
 class TestCompareType5(unittest.TestCase):
 
     def test_compare_type5_boolean(self):
@@ -160,7 +164,7 @@ class TestCompareType5(unittest.TestCase):
         parsed = comp_type5(unencrypted_password, encrypted_password, True)
         self.assertEqual(parsed, '$1$nTc1$Z28sUTcWfXlvVe2x.3XAa.')
 
-    def test_compate_type5_fail(self):
+    def test_compare_type5_fail(self):
         unencrypted_password = 'invalid_password'
         encrypted_password = '$1$nTc1$Z28sUTcWfXlvVe2x.3XAa.'
         parsed = comp_type5(unencrypted_password, encrypted_password)

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -34,6 +34,7 @@ from units.mock.loader import DictDataLoader
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import mock_open, patch
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import builtins
 from ansible.plugins.loader import PluginLoader

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -20,8 +20,15 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import passlib
-from passlib.handlers import pbkdf2
+try:
+    import passlib
+    from passlib.handlers import pbkdf2
+except ImportError:
+    passlib = None
+    pbkdf2 = None
+
+import pytest
+
 from units.mock.loader import DictDataLoader
 
 from ansible.compat.tests import unittest
@@ -367,21 +374,18 @@ class TestWritePasswordFile(unittest.TestCase):
             m().write.assert_called_once_with(u'Testing Café\n'.encode('utf-8'))
 
 
-class TestLookupModule(unittest.TestCase):
+class BaseTestLookupModule(unittest.TestCase):
     def setUp(self):
         self.fake_loader = DictDataLoader({'/path/to/somewhere': 'sdfsdf'})
         self.password_lookup = password.LookupModule(loader=self.fake_loader)
         self.os_path_exists = password.os.path.exists
 
-        # Different releases of passlib default to a different number of rounds
-        self.sha256 = passlib.registry.get_crypt_handler('pbkdf2_sha256')
-        sha256_for_tests = pbkdf2.create_pbkdf2_hash("sha256", 32, 20000)
-        passlib.registry.register_crypt_handler(sha256_for_tests, force=True)
-
     def tearDown(self):
         password.os.path.exists = self.os_path_exists
         passlib.registry.register_crypt_handler(self.sha256, force=True)
 
+
+class TestLookupModuleWithoutPasslib(BaseTestLookupModule):
     @patch.object(PluginLoader, '_get_paths')
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_no_encrypt(self, mock_get_paths, mock_write_file):
@@ -393,6 +397,67 @@ class TestLookupModule(unittest.TestCase):
         for result in results:
             self.assertEquals(len(result), password.DEFAULT_LENGTH)
             self.assertIsInstance(result, text_type)
+
+    @patch.object(PluginLoader, '_get_paths')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_password_already_created_no_encrypt(self, mock_get_paths, mock_write_file):
+        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+        password.os.path.exists = lambda x: True
+
+        with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
+            results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
+
+        for result in results:
+            self.assertEqual(result, u'hunter42')
+
+    @patch.object(PluginLoader, '_get_paths')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_only_a(self, mock_get_paths, mock_write_file):
+        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+
+        results = self.password_lookup.run([u'/path/to/somewhere chars=a'], None)
+        for result in results:
+            self.assertEquals(result, u'a' * password.DEFAULT_LENGTH)
+
+    def test_lock_been_held(self):
+        # pretend the lock file is here
+        password.os.path.exists = lambda x: True
+        try:
+            with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
+                # should timeout here
+                results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
+                self.fail("Lookup didn't timeout when lock already been held")
+        except AnsibleError:
+            pass
+
+    def test_lock_not_been_held(self):
+        # pretend now there is password file but no lock
+        password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
+        try:
+            with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
+                # should not timeout here
+                results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
+        except AnsibleError:
+            self.fail('Lookup timeouts when lock is free')
+
+        for result in results:
+            self.assertEqual(result, u'hunter42')
+
+
+@pytest.mark.skipif(passlib is None, reason='passlib must be installed to run these tests')
+class TestLookupModuleWithPasslib(BaseTestLookupModule):
+    def setUp(self):
+        super(TestLookupModuleWithPasslib, self).setUp()
+
+        # Different releases of passlib default to a different number of rounds
+        self.sha256 = passlib.registry.get_crypt_handler('pbkdf2_sha256')
+        sha256_for_tests = pbkdf2.create_pbkdf2_hash("sha256", 32, 20000)
+        passlib.registry.register_crypt_handler(sha256_for_tests, force=True)
+
+    def tearDown(self):
+        super(TestLookupModuleWithPasslib, self).tearDown()
+
+        passlib.registry.register_crypt_handler(self.sha256, force=True)
 
     @patch.object(PluginLoader, '_get_paths')
     @patch('ansible.plugins.lookup.password._write_password_file')
@@ -425,30 +490,9 @@ class TestLookupModule(unittest.TestCase):
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_password_already_created_encrypt(self, mock_get_paths, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True
+        password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
             results = self.password_lookup.run([u'/path/to/somewhere chars=anything encrypt=pbkdf2_sha256'], None)
         for result in results:
             self.assertEqual(result, u'$pbkdf2-sha256$20000$ODc2NTQzMjE$Uikde0cv0BKaRaAXMrUQB.zvG4GmnjClwjghwIRf2gU')
-
-    @patch.object(PluginLoader, '_get_paths')
-    @patch('ansible.plugins.lookup.password._write_password_file')
-    def test_password_already_created_no_encrypt(self, mock_get_paths, mock_write_file):
-        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-        password.os.path.exists = lambda x: True
-
-        with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
-            results = self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
-
-        for result in results:
-            self.assertEqual(result, u'hunter42')
-
-    @patch.object(PluginLoader, '_get_paths')
-    @patch('ansible.plugins.lookup.password._write_password_file')
-    def test_only_a(self, mock_get_paths, mock_write_file):
-        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
-
-        results = self.password_lookup.run([u'/path/to/somewhere chars=a'], None)
-        for result in results:
-            self.assertEquals(result, u'a' * password.DEFAULT_LENGTH)


### PR DESCRIPTION
* Skip gitlab tests if dependencies aren't met

* Skip certain unittests if passlib is not installed

* Fix tests with deps on paramiko to skip if paramiko is not installed

* Use pytest to skip for cloudstack

If either on Python-2.6 or the cs library is not installed we cannot run
this test so skip it.
(cherry picked from commit 8acf71f78fce89d70a58fc45ee528003c4785e6b)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>.
(cherry picked from commit 7d4e9b279e15286b51a8d50fbb80a84cdf1c865a)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
The backport is heavily modified to apply cleanly to the 2.6 unittests