### PR TITLE
Load Ansible module_utils for ps_argspec validator (#58571) - 2.8

### DIFF
--- a/test/sanity/validate-modules/ps_argspec.ps1
+++ b/test/sanity/validate-modules/ps_argspec.ps1
@@ -49,6 +49,37 @@ Add-Type -TypeDefinition $dummy_ansible_basic
 $module_code = Get-Content -LiteralPath $module_path -Raw
 
 $powershell = [PowerShell]::Create()
+$powershell.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", "Stop")
+
+# Load the PowerShell module utils as the module may be using them to refer to shared module options
+# FUTURE: Lookup utils in the role or collection's module_utils dir based on #AnsibleRequires
+$script_requirements = [ScriptBlock]::Create($module_code).Ast.ScriptRequirements
+$required_modules = @()
+if ($null -ne $script_requirements) {
+    $required_modules = $script_requirements.RequiredModules
+}
+foreach ($required_module in $required_modules) {
+    if (-not $required_module.Name.StartsWith('Ansible.ModuleUtils.')) {
+        continue
+    }
+
+    $module_util_path = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($module_path, '..', '..', '..',
+        'module_utils', 'powershell', "$($required_module.Name).psm1"))
+    if (-not (Test-Path -LiteralPath $module_util_path -PathType Leaf)) {
+        # Failed to find path, just silently ignore for now and hope for the best
+        continue
+    }
+
+    $module_util_sb = [ScriptBlock]::Create((Get-Content -LiteralPath $module_util_path -Raw))
+    $powershell.AddCommand('New-Module').AddParameters(@{
+        Name = $required_module.Name
+        ScriptBlock = $module_util_sb
+    }) > $null
+    $powershell.AddCommand('Import-Module').AddParameter('WarningAction', 'SilentlyContinue') > $null
+    $powershell.AddCommand('Out-Null').AddStatement() > $null
+
+}
+
 $powershell.AddScript($module_code) > $null
 $powershell.Invoke() > $null
 


### PR DESCRIPTION
(cherry picked from commit c3978fed4be856a4f3540a7dcdaf35a07fd5570b)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/58571.

While this is technically a feature it's not a user facing issue and is being backported so the ansible-test code base is aligned between versions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate-mdoules