### PR TITLE
Fix wrong unit in documentation example of ec2_metric_alarm

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
@@ -148,7 +148,7 @@ EXAMPLES = '''
       threshold: 1.0
       period: 60
       evaluation_periods: 2
-      unit: "Seconds"
+      unit: "Count"
       description: "This will recover an instance when it fails"
       dimensions: {"InstanceId":'i-XXX'}
       alarm_actions: ["arn:aws:automate:us-west-1:ec2:recover"]


### PR DESCRIPTION
##### SUMMARY
Fix invalid unit stated in documentation example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`ec2_metric_alarm.py`

##### ADDITIONAL INFORMATION

