### PR TITLE
win_updates: Add flag to only download updates without installing them

### DIFF
--- a/lib/ansible/modules/windows/win_updates.ps1
+++ b/lib/ansible/modules/windows/win_updates.ps1
@@ -297,8 +297,8 @@ $update_script_block = {
         }
 
         # Early exit for download-only
-        if ($state -eq "Downloaded $($updates_to_install.Count) updates") {
-            Write-DebugLog -msg "Downloaded updates..."
+        if ($state -eq "downloaded") {
+            Write-DebugLog -msg "Downloaded $($updates_to_install.Count) updates..."
             $result.failed = $false
             $result.msg = "Downloaded $($updates_to_install.Count) updates"
             return $result

--- a/lib/ansible/modules/windows/win_updates.ps1
+++ b/lib/ansible/modules/windows/win_updates.ps1
@@ -13,7 +13,7 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 
 $category_names = Get-AnsibleParam -obj $params -name "category_names" -type "list" -default @("CriticalUpdates", "SecurityUpdates", "UpdateRollups")
 $log_path = Get-AnsibleParam -obj $params -name "log_path" -type "path"
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "installed" -validateset "installed", "searched"
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "installed" -validateset "installed", "searched", "downloaded"
 $blacklist = Get-AnsibleParam -obj $params -name "blacklist" -type "list"
 $whitelist = Get-AnsibleParam -obj $params -name "whitelist" -type "list"
 $server_selection = Get-AnsibleParam -obj $params -name "server_selection" -type "string" -default "default" -validateset "default", "managed_server", "windows_update"
@@ -294,6 +294,14 @@ $update_script_block = {
 
             $result.changed = $true
             $update_index++
+        }
+
+        # Early exit for download-only
+        if ($state -eq "Downloaded $($updates_to_install.Count) updates") {
+            Write-DebugLog -msg "Downloaded updates..."
+            $result.failed = $false
+            $result.msg = "Downloaded $($updates_to_install.Count) updates"
+            return $result
         }
 
         Write-DebugLog -msg "Installing updates..."

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -187,10 +187,10 @@ EXAMPLES = r'''
   win_updates:
     reboot: yes
     reboot_timeout: 3600
-    
+
 # Search and download Windows updates
 - name: Search and download Windows updates without installing them
-  win_updates: 
+  win_updates:
     state: downloaded
 '''
 

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -78,10 +78,10 @@ options:
         version_added: '2.8'
     state:
         description:
-        - Controls whether found updates are returned as a list or actually installed.
+        - Controls whether found updates are downloaded or installed or listed
         - This module also supports Ansible check mode, which has the same effect as setting state=searched
         type: str
-        choices: [ installed, searched ]
+        choices: [ installed, searched, downloaded ]
         default: installed
     log_path:
         description:
@@ -187,6 +187,11 @@ EXAMPLES = r'''
   win_updates:
     reboot: yes
     reboot_timeout: 3600
+    
+# Search and download Windows updates
+- name: Search and download Windows updates without installing them
+  win_updates: 
+    state: downloaded
 '''
 
 RETURN = r'''
@@ -253,7 +258,7 @@ found_update_count:
     type: int
     sample: 3
 installed_update_count:
-    description: The number of updates successfully installed.
+    description: The number of updates successfully installed or downloaded.
     returned: success
     type: int
     sample: 2

--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -141,9 +141,9 @@ class ActionModule(ActionBase):
         use_task = boolean(self._task.args.get('use_scheduled_task', False),
                            strict=False)
 
-        if state not in ['installed', 'searched']:
+        if state not in ['installed', 'searched', 'downloaded']:
             result['failed'] = True
-            result['msg'] = "state must be either installed or searched"
+            result['msg'] = "state must be either installed, searched or downloaded"
             return result
 
         try:

--- a/test/integration/targets/win_updates/tasks/tests.yml
+++ b/test/integration/targets/win_updates/tasks/tests.yml
@@ -3,7 +3,7 @@
   win_updates:
     state: invalid
   register: invalid_state
-  failed_when: invalid_state.msg != 'state must be either installed or searched'
+  failed_when: invalid_state.msg != 'state must be either installed, searched or downloaded'
 
 - name: ensure log file not present before tests
   win_file:

--- a/test/units/plugins/action/test_win_updates.py
+++ b/test/units/plugins/action/test_win_updates.py
@@ -19,7 +19,7 @@ class TestWinUpdatesActionPlugin(object):
         (
             {"state": "invalid"},
             False,
-            "state must be either installed or searched"
+            "state must be either installed, searched or downloaded"
         ),
         (
             {"reboot": "nonsense"},


### PR DESCRIPTION
##### SUMMARY
Download win_updates only.  
For some use cases (low bandwidth, etc), it can be desirable to create a play which only (searches and) downloads the Windows updates. Where a later play only installs them. This saves time for our precious and relatively small maintenance windows. 

Like the 'state: searched' feature, this is mainly a premature exit, since the module currently searches, downloads, installs and reboots.  
Caveat: changed is True whenever there are updates available, which are at this point already downloaded. Running the module twice, will return changed=True, even when no new updates have physically been downloaded.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
modules/win_updates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
