### PR TITLE
Call remove-brick only if no. of bricks > 0 (#56781)

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -548,7 +548,8 @@ def main():
                     if brick not in bricks_in_volume:
                         new_bricks.append(brick)
 
-            if not new_bricks and len(all_bricks) < len(bricks_in_volume):
+            if not new_bricks and len(all_bricks) > 0 and \
+               len(all_bricks) < len(bricks_in_volume):
                 for brick in bricks_in_volume:
                     if brick not in all_bricks:
                         removed_bricks.append(brick)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add an extra condition to call remove-brick operation. Now we check if the
number of bricks is greater than 0.

Earlier remove-brick was called if len(all_bricks) < len(bricks_in_volume) and
if all_bricks was 0, remove-brick was called anyway. We avoid this erroneous
behavior.

Fixes #56781
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gluster_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the Fix:
```paste below
TASK [Set volume options for SSL] *****************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: None
fatal: [10.70.43.171]: FAILED! => {"changed": false, "msg": "error running gluster (/usr/sbin/gluster --mode=script volume remove-brick volset 10.70.43.171:/data/r1 10.70.43.171:/data/r2 10.70.43.171:/data/r3 10.70.43.171:/data/r4 start) command (rc=1): volume remove-brick start: failed: Deleting all the bricks of the volume is not allowed\n"}

```

After the Fix:
```
TASK [Set volume options for SSL] *****************************************************************************
changed: [10.70.43.171]

PLAY RECAP ****************************************************************************************************
10.70.43.171               : ok=1    changed=1    unreachable=0    failed=0   

```
