### PR TITLE
Backport/2.8/55218

### DIFF
--- a/changelogs/fragments/ios_command_edit_macro_dont_handle_no_macro.yaml
+++ b/changelogs/fragments/ios_command_edit_macro_dont_handle_no_macro.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ios_config - fixed issue where the "no macro" command was erroneously handled by edit_macro(). https://github.com/ansible/ansible/issues/55212

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -356,7 +356,9 @@ def check_args(module, warnings):
 
 
 def edit_config_or_macro(connection, commands):
-    if "macro name" in commands[0]:
+    # only catch the macro configuration command,
+    # not negated 'no' variation.
+    if commands[0].startswith("macro name"):
         connection.edit_macro(candidate=commands)
     else:
         connection.edit_config(candidate=commands)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deleting a Cisco IOS macro fails because the "no macro" command was erroneously handled by edit_macro()
Fixes #55212

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ios_config

##### ADDITIONAL INFORMATION
STEPS TO REPRODUCE
Try to send a 'no macro name <my_macro_name>' line with ios_config

```yaml
ios_config:
  lines: "no macro name {{ macro_name }}"

```
EXPECTED RESULTS
Macro deleted/undefined on device.

ACTUAL RESULTS
ios_config fails.
