### PR TITLE
Fix reported AIX filesystem module incorrect fail_json() usage

### DIFF
--- a/lib/ansible/modules/system/aix_filesystem.py
+++ b/lib/ansible/modules/system/aix_filesystem.py
@@ -5,9 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ismount import ismount
-import re
 
 __metaclass__ = type
 
@@ -179,6 +176,10 @@ msg:
   type: str
 '''
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ismount import ismount
+import re
+
 
 def _fs_exists(module, filesystem):
     """
@@ -269,7 +270,7 @@ def resize_fs(module, filesystem, size):
                 changed = False
                 return changed, err
             else:
-                module.fail_json("Failed to run chfs. Error message: %s" % err)
+                module.fail_json(msg="Failed to run chfs. Error message: %s" % err)
 
         else:
             if re.findall('The filesystem size is already', chfs_out):
@@ -364,7 +365,7 @@ def create_fs(
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
             cmd = "%s -v %s -m %s %s %s %s %s %s -p %s %s -a %s" % (
-                    crfs_cmd, fs_type, filesystem, vg, device, mount_group, auto_mount, account_subsystem, permissions, size, attributes)
+                crfs_cmd, fs_type, filesystem, vg, device, mount_group, auto_mount, account_subsystem, permissions, size, attributes)
             rc, crfs_out, err = module.run_command(cmd)
 
             if rc == 10:

--- a/lib/ansible/modules/system/aix_filesystem.py
+++ b/lib/ansible/modules/system/aix_filesystem.py
@@ -5,6 +5,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ismount import ismount
+import re
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
@@ -175,10 +179,6 @@ msg:
   type: str
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ismount import ismount
-import re
-
 
 def _fs_exists(module, filesystem):
     """
@@ -195,7 +195,7 @@ def _fs_exists(module, filesystem):
             return False
 
         else:
-            module.fail_json(msg="Failed to run lsfs.", rc=rc, err=err)
+            module.fail_json(msg="Failed to run lsfs. Error message: %s" % err)
 
     else:
 
@@ -215,7 +215,7 @@ def _check_nfs_device(module, nfs_host, device):
     rc, showmount_out, err = module.run_command(
         "%s -a %s" % (showmount_cmd, nfs_host))
     if rc != 0:
-        module.fail_json(msg="Failed to run showmount.", rc=rc, err=err)
+        module.fail_json(msg="Failed to run showmount. Error message: %s" % err)
     else:
         showmount_data = showmount_out.splitlines()
         for line in showmount_data:
@@ -263,17 +263,13 @@ def resize_fs(module, filesystem, size):
 
         if rc == 28:
             changed = False
-
             return changed, chfs_out
-
         elif rc != 0:
             if re.findall('Maximum allocation for logical', err):
                 changed = False
-
                 return changed, err
-
             else:
-                module.fail_json("Failed to run chfs.", rc=rc, err=err)
+                module.fail_json("Failed to run chfs. Error message: %s" % err)
 
         else:
             if re.findall('The filesystem size is already', chfs_out):
@@ -351,7 +347,7 @@ def create_fs(
             rc, mknfsmnt_out, err = module.run_command('%s -f "%s" %s -h "%s" -t "%s" "%s" -w "bg"' % (
                 mknfsmnt_cmd, filesystem, device, nfs_server, permissions, auto_mount))
             if rc != 0:
-                module.fail_json(msg="Failed to run mknfsmnt.", rc=rc, err=err)
+                module.fail_json(msg="Failed to run mknfsmnt. Error message: %s" % err)
             else:
                 changed = True
                 msg = "NFS file system %s created." % filesystem
@@ -367,9 +363,9 @@ def create_fs(
         # Creates a LVM file system.
         crfs_cmd = module.get_bin_path('crfs', True)
         if not module.check_mode:
-            rc, crfs_out, err = module.run_command(
-                "%s -v %s -m %s %s %s %s %s %s -p %s %s -a %s" % (
-                    crfs_cmd, fs_type, filesystem, vg, device, mount_group, auto_mount, account_subsystem, permissions, size, attributes))
+            cmd = "%s -v %s -m %s %s %s %s %s %s -p %s %s -a %s" % (
+                    crfs_cmd, fs_type, filesystem, vg, device, mount_group, auto_mount, account_subsystem, permissions, size, attributes)
+            rc, crfs_out, err = module.run_command(cmd)
 
             if rc == 10:
                 module.exit_json(
@@ -377,7 +373,7 @@ def create_fs(
                         "volume group needs to be empty. %s" % err)
 
             elif rc != 0:
-                module.fail_json(msg="Failed to run crfs.", rc=rc, err=err)
+                module.fail_json(msg="Failed to run %s. Error message: %s" % (cmd, err))
 
             else:
                 changed = True
@@ -402,9 +398,10 @@ def remove_fs(module, filesystem, rm_mount_point):
 
     rmfs_cmd = module.get_bin_path('rmfs', True)
     if not module.check_mode:
-        rc, rmfs_out, err = module.run_command("%s -r %s %s" % (rmfs_cmd, rm_mount_point, filesystem))
+        cmd = "%s -r %s %s" % (rmfs_cmd, rm_mount_point, filesystem)
+        rc, rmfs_out, err = module.run_command(cmd)
         if rc != 0:
-            module.fail_json(msg="Failed to run rmfs.", rc=rc, err=err)
+            module.fail_json(msg="Failed to run %s. Error message: %s" % (cmd, err))
         else:
             changed = True
             msg = rmfs_out
@@ -427,7 +424,7 @@ def mount_fs(module, filesystem):
         rc, mount_out, err = module.run_command(
             "%s %s" % (mount_cmd, filesystem))
         if rc != 0:
-            module.fail_json("Failed to run mount.", rc=rc, err=err)
+            module.fail_json(msg="Failed to run mount. Error message: %s" % err)
         else:
             changed = True
             msg = "File system %s mounted." % filesystem
@@ -447,7 +444,7 @@ def unmount_fs(module, filesystem):
     if not module.check_mode:
         rc, unmount_out, err = module.run_command("%s %s" % (unmount_cmd, filesystem))
         if rc != 0:
-            module.fail_json("Failed to run unmount.", rc=rc, err=err)
+            module.fail_json(msg="Failed to run unmount. Error message: %s" % err)
         else:
             changed = True
             msg = "File system %s unmounted." % filesystem
@@ -518,9 +515,7 @@ def main():
             if nfs_server is not None:
                 if device is None:
                     result['msg'] = 'Parameter "device" is required when "nfs_server" is defined.'
-
                     module.fail_json(**result)
-
                 else:
                     # Create a fs from NFS export.
                     if _check_nfs_device(module, nfs_server, device):
@@ -529,9 +524,8 @@ def main():
 
             if device is None:
                 if vg is None:
-
+                    result['msg'] = 'Required parameter "device" and/or "vg" is missing for filesystem creation.'
                     module.fail_json(**result)
-
                 else:
                     # Create a fs from
                     result['changed'], result['msg'] = create_fs(


### PR DESCRIPTION
##### SUMMARY

Fix reported AIX filesystem module incorrect fail_json() usage and extend reporting on an error.

Fixes #58609

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_filesystem

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible aix7 -m aix_filesystem -a "filesystem=/mnt/exp1 state=mounted"  
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: fail_json() takes exactly 1 argument (4 given)
aix7 | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "module_stderr": "Shared connection to aix7 closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/.ansible/tmp/ansible-tmp-1562092525.37-233239812793604/AnsiballZ_aix_filesystem.py\", line 125, in <module>\r\n    _ansiballz_main()\r\n  File \"/.ansible/tmp/ansible-tmp-1562092525.37-233239812793604/AnsiballZ_aix_filesystem.py\", line 117, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/.ansible/tmp/ansible-tmp-1562092525.37-233239812793604/AnsiballZ_aix_filesystem.py\", line 54, in invoke_module\r\n    imp.load_module('__main__', mod, module, MOD_DESC)\r\n  File \"/tmp/ansible_aix_filesystem_payload_bQ1ysS/__main__.py\", line 579, in <module>\r\n  File \"/tmp/ansible_aix_filesystem_payload_bQ1ysS/__main__.py\", line 561, in main\r\n  File \"/tmp/ansible_aix_filesystem_payload_bQ1ysS/__main__.py\", line 430, in mount_fs\r\nTypeError: fail_json() takes exactly 1 argument (4 given)\r\n", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
```
after:
```
$ ansible aix7 -m aix_filesystem -a "filesystem=/mnt/exp1 state=mounted"
aix7 | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "msg": "Failed to run mount. Error message: mount: 0506-334 /mnt/exp1 is not a known file system.\n"
}


$ ansible aix7 -m aix_filesystem -a "filesystem=/mnt/exp1 state=present"
aix7 | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": false, 
    "msg": "Required parameter \"device\" and/or \"vg\" is missing for filesystem creation."
}
```
