### PR TITLE
dnf - fix error formatting of module name in error message

### DIFF
--- a/changelogs/fragments/dnf-fix-module-name-in-error-message.yml
+++ b/changelogs/fragments/dnf-fix-module-name-in-error-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - fix formatting of module name in error message (https://github.com/ansible/ansible/pull/58647)

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -946,7 +946,7 @@ class DnfModule(YumDnf):
                             self.module_base.install([module])
                             self.module_base.enable([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(' '.join(module, to_native(e)))
+                            failure_response['failures'].append(' '.join((module, to_native(e))))
 
                 # Install groups.
                 for group in groups:
@@ -1009,7 +1009,7 @@ class DnfModule(YumDnf):
                                 response['results'].append("Module {0} upgraded.".format(module))
                             self.module_base.upgrade([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(' '.join(module, to_native(e)))
+                            failure_response['failures'].append(' '.join((module, to_native(e))))
 
                 for group in groups:
                     try:
@@ -1073,7 +1073,7 @@ class DnfModule(YumDnf):
                             self.module_base.disable([module])
                             self.module_base.reset([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(' '.join(module, to_native(e)))
+                            failure_response['failures'].append(' '.join((module, to_native(e))))
 
                 for group in groups:
                     try:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -949,7 +949,7 @@ class DnfModule(YumDnf):
                             failure_response['failures'].append(
                                 " ".join(
                                     (
-                                        ' '.join(module),
+                                        module,
                                         to_native(e)
                                     )
                                 )

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -946,14 +946,7 @@ class DnfModule(YumDnf):
                             self.module_base.install([module])
                             self.module_base.enable([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(
-                                " ".join(
-                                    (
-                                        module,
-                                        to_native(e)
-                                    )
-                                )
-                            )
+                            failure_response['failures'].append(' '.join(module, to_native(e)))
 
                 # Install groups.
                 for group in groups:
@@ -1016,14 +1009,7 @@ class DnfModule(YumDnf):
                                 response['results'].append("Module {0} upgraded.".format(module))
                             self.module_base.upgrade([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(
-                                " ".join(
-                                    (
-                                        ' '.join(module),
-                                        to_native(e)
-                                    )
-                                )
-                            )
+                            failure_response['failures'].append(' '.join(module, to_native(e)))
 
                 for group in groups:
                     try:
@@ -1087,14 +1073,7 @@ class DnfModule(YumDnf):
                             self.module_base.disable([module])
                             self.module_base.reset([module])
                         except dnf.exceptions.MarkingErrors as e:
-                            failure_response['failures'].append(
-                                " ".join(
-                                    (
-                                        ' '.join(module),
-                                        to_native(e)
-                                    )
-                                )
-                            )
+                            failure_response['failures'].append(' '.join(module, to_native(e)))
 
                 for group in groups:
                     try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a failure occurs, the name of the module is incorrectly being joined with spaces:

```
"failures": ["s w i g : 3 . 0 / d e f a u l t Problems in request:\nmissing groups or modules: swig:3.0/default"]
```

This PR fixes that and it displays like this:
```
"failures": ["swig:3.0/default Problems in request:\nmissing groups or modules: swig:3.0/default"]
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/packaging/os/dnf.py`
