### PR TITLE
Improve dnf test formatting and fix RHEL 8 module name

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -6,6 +6,8 @@
   shell: rpm -q python2-dnf
   register: rpm_result
   ignore_errors: true
+  args:
+    warn: no
 
 # Don't uninstall python2-dnf with the `dnf` module in case it needs to load
 # some dnf python files after the package is uninstalled.

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -19,23 +19,24 @@
 # Note: We install the yum package onto Fedora so that this will work on dnf systems
 # We want to test that for people who don't want to upgrade their systems.
 
-- include: 'dnf.yml'
-  when:
-    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23) or (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8)
+- include_tasks: dnf.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
 
-- include: 'repo.yml'
-  when:
-    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23) or (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8)
+- include_tasks: repo.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
 
-- include: 'dnfinstallroot.yml'
-  when:
-    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23) or (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8)
+- include_tasks: dnfinstallroot.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
-- include: 'dnfreleasever.yml'
+- include_tasks: dnfreleasever.yml
   when:
-    - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 23
+    - ansible_distribution == 'Fedora'
+    - ansible_distribution_major_version is version('23', '>=')
 
-- import_tasks: 'modularity.yml'
-  when:
-    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 29) or (ansible_distribution == 'RedHat' and ansible_distribution_major_version|int >= 8)
+- include_tasks: modularity.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
+        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))

--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -1,13 +1,6 @@
 # FUTURE - look at including AppStream support in our local repo
-- name: set package for RHEL
-  set_fact:
-    astream_name: '@swig:3.0/default'
-  when: ansible_distribution == 'RedHat'
-
-- name: set package for Fedora
-  set_fact:
-    astream_name: '@ripgrep:master/default'
-  when: ansible_distribution == 'Fedora'
+- name: Include distribution specific variables
+  include_vars: "{{ ansible_facts.distribution }}.yml"
 
 - name: install "{{ astream_name }}" module
   dnf:

--- a/test/integration/targets/dnf/vars/Fedora.yml
+++ b/test/integration/targets/dnf/vars/Fedora.yml
@@ -1,0 +1,1 @@
+astream_name: '@ripgrep:master/default'

--- a/test/integration/targets/dnf/vars/RedHat.yml
+++ b/test/integration/targets/dnf/vars/RedHat.yml
@@ -1,0 +1,1 @@
+astream_name: '@php:7.1/minimal'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- use single `include_vars` task rather than multiple `set_fact` tasks
- use multi-line YAML to break up long conditionals
- use `version()` test rather than direct comparisons
- use different appstream package on RHEL since '@swig:3.0/default' is not working in the GA

I am not sure why, but it seems using `/default` in the RHEL 8 GA is broken. According to [this document](url), `/default` should be omitted:
> Omit /profile to use the default profile. If no profile is set as default, this step fails without a specified profile and you must specify it.

Maybe it's just a problem with `swig` but I got similar errors using `/default` on other modules. I believe I found a module that works reliably with RHEL 8 GA.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/dnf/`
