### PR TITLE
Fix reported issues failing-ok and pp_size in module aix_lvg 

### DIFF
--- a/lib/ansible/modules/system/aix_lvg.py
+++ b/lib/ansible/modules/system/aix_lvg.py
@@ -341,7 +341,11 @@ def main():
     if pp_size is None:
         pp_size = ''
     else:
+        if pp_size > 0 and (pp_size & (pp_size - 1)) == 0:
         pp_size = "-s %s" % pp_size
+        else:
+            msg = "pp_size must be >0 and a multiple of 2 (supplied: '%s')." % pp_size
+            module.fail_json(msg=msg)
 
     vg_validation = _validate_vg(module, vg)
 

--- a/lib/ansible/modules/system/aix_lvg.py
+++ b/lib/ansible/modules/system/aix_lvg.py
@@ -341,10 +341,10 @@ def main():
     if pp_size is None:
         pp_size = ''
     else:
-        if pp_size > 0 and (pp_size & (pp_size - 1)) == 0:
+        if 1 <= pp_size <= 1024 and (pp_size & (pp_size - 1)) == 0:
         pp_size = "-s %s" % pp_size
         else:
-            msg = "pp_size must be >0 and a multiple of 2 (supplied: '%s')." % pp_size
+            msg = "pp_size must be >= 1 and <= 1024, and a multiple of 2 (supplied: '%s')." % pp_size
             module.fail_json(msg=msg)
 
     vg_validation = _validate_vg(module, vg)

--- a/lib/ansible/modules/system/aix_lvg.py
+++ b/lib/ansible/modules/system/aix_lvg.py
@@ -219,11 +219,12 @@ def create_extend_vg(module, vg, pvs, pp_size, vg_type, force, vg_validation):
 
         if not module.check_mode:
             mkvg_cmd = module.get_bin_path('mkvg', True)
-            rc, output, err = module.run_command("%s %s %s %s -y %s %s" % (mkvg_cmd, vg_opt[vg_type], pp_size, force_opt[force], vg, ' '.join(pvs)))
+            cmd = "%s %s %s %s -y %s %s" % (mkvg_cmd, vg_opt[vg_type], pp_size, force_opt[force], vg, ' '.join(pvs))
+            rc, output, err = module.run_command(cmd)
             if rc != 0:
                 changed = False
-                msg = "Creating volume group '%s' failed." % vg
-                return changed, msg
+                msg = "Failed to create volume group '%s' using command '%s'. Error message: %s" % (vg, cmd, err)
+                module.fail_json(msg=msg)
 
         msg = "Volume group '%s' created." % vg
         return changed, msg

--- a/lib/ansible/modules/system/aix_lvg.py
+++ b/lib/ansible/modules/system/aix_lvg.py
@@ -342,7 +342,7 @@ def main():
         pp_size = ''
     else:
         if 1 <= pp_size <= 1024 and (pp_size & (pp_size - 1)) == 0:
-        pp_size = "-s %s" % pp_size
+            pp_size = "-s %s" % pp_size
         else:
             msg = "pp_size must be >= 1 and <= 1024, and a multiple of 2 (supplied: '%s')." % pp_size
             module.fail_json(msg=msg)

--- a/lib/ansible/modules/system/aix_lvg.py
+++ b/lib/ansible/modules/system/aix_lvg.py
@@ -344,7 +344,7 @@ def main():
         if 1 <= pp_size <= 1024 and (pp_size & (pp_size - 1)) == 0:
             pp_size = "-s %s" % pp_size
         else:
-            msg = "pp_size must be >= 1 and <= 1024, and a multiple of 2 (supplied: '%s')." % pp_size
+            msg = "pp_size must be >= 1 and <= 1024, and a power of 2 (supplied: '%s')." % pp_size
             module.fail_json(msg=msg)
 
     vg_validation = _validate_vg(module, vg)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes two issues described in #58522:

1. If VG fails to create, exist with fail_json instead of returning OK.
2. Added checks to main() to confirm that supplied pp_size is a valid value before continuing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aix_lvg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See #58522 for full issue details.

**Test output:**

With test task:
```text
---
- name: "Test AIX LVM Stuff"
  hosts: all
  become: yes
  tasks:
  - name: manage_aix_lvm | creating new AIX volume group(s)
      force: true
      pp_size: "{{ item }}"
      pvs: "hdisk4"
      vg: "vg_exp1"
      state: present
    become: true
    with_items:
        - "-32"
        - 0
        - 129
        - "INVALID"
        - 128
```

Before:- False OK's returned from invalid data and failed creations
```text
ok: [TEST] => (item=-32)
ok: [TEST] => (item=0)
ok: [TEST] => (item=129)
failed: [TEST] (item=INVALID) => {"ansible_loop_var": "item", "changed": false, "item": "INVALID", "msg": "argument pp_size is of type <type 'str'> and we were unable to convert to int: <type 'str'> cannot be converted to an int"}
ok: [TEST] => (item=256)


ok: [TEST] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "force": true,
            "pp_size": 2048,
            "pvs": [
                "hdisk4"
            ],
            "state": "present",
            "vg": "vg_exp1",
            "vg_type": "normal"
        }
    },
    "msg": "Creating volume group 'vg_exp1' failed.",
    "state": "present"
}


```

After:
```text
failed: [TEST] (item=-32) => {"ansible_loop_var": "item", "changed": false, "item": "-32", "msg": "pp_size must be >0 and a multiple of 2 (supplied: '-32')."}
failed: [TEST] (item=0) => {"ansible_loop_var": "item", "changed": false, "item": 0, "msg": "pp_size must be >0 and a multiple of 2 (supplied: '0')."}
failed: [TEST] (item=129) => {"ansible_loop_var": "item", "changed": false, "item": 129, "msg": "pp_size must be >0 and a multiple of 2 (supplied: '129')."}
failed: [TEST] (item=INVALID) => {"ansible_loop_var": "item", "changed": false, "item": "INVALID", "msg": "argument pp_size is of type <type 'str'> and we were unable to convert to int: <type 'str'> cannot be converted to an int"}
changed: [TEST] => (item=128)



fatal: [TEST]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "force": true,
            "pp_size": 2048,
            "pvs": [
                "hdisk4"
            ],
            "state": "present",
            "vg": "vg_expx1",
            "vg_type": "normal"
        }
    },
    "msg": "Failed to create volume group 'vg_expx1' using command '/usr/sbin/mkvg  -s 2048 -f -y vg_expx1 hdisk4'. Error message: 0516-1197 /usr/sbin/mkvg: The -s parameter for Size must be a power\n\tof 2 between 1 and 1024.\n0516-862 /usr/sbin/mkvg: Unable to create volume group.\n"
}


```