### PR TITLE
[2.8] VMware: looking up maxMksConnections in incorrect location

### DIFF
--- a/changelogs/fragments/58060-vmware_guest-make_max_connections_work.yml
+++ b/changelogs/fragments/58060-vmware_guest-make_max_connections_work.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Make max_connections parameter work again in vmware_guest module (https://github.com/ansible/ansible/pull/58061).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1093,7 +1093,7 @@ class PyVmomiHelper(PyVmomi):
             if 'max_connections' in self.params['hardware']:
                 # maxMksConnections == max_connections
                 self.configspec.maxMksConnections = int(self.params['hardware']['max_connections'])
-                if vm_obj is None or self.configspec.maxMksConnections != vm_obj.config.hardware.maxMksConnections:
+                if vm_obj is None or self.configspec.maxMksConnections != vm_obj.config.maxMksConnections:
                     self.change_detected = True
 
             if 'nested_virt' in self.params['hardware']:

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -28,3 +28,4 @@
 - include: linked_clone_d1_c1_f0.yml
 - include: boot_firmware_d1_c1_f0.yml
 - include: clone_with_convert.yml
+#- include: max_connections.yml

--- a/test/integration/targets/vmware_guest/tasks/max_connections.yml
+++ b/test/integration/targets/vmware_guest/tasks/max_connections.yml
@@ -1,0 +1,70 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=2&pool=2&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- &add_mk_conn
+  name: Create new VMs again with max_connections as 4
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_mk_conn_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+      max_connections: 4
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: mk_conn_result_0001
+
+- debug: var=mk_conn_result_0001
+
+- name: Assert that changes were made
+  assert:
+    that:
+      - "mk_conn_result_0001.results|map(attribute='changed')|unique|list == [true]"
+
+- <<: *add_mk_conn
+  name: Again create new VMs again with max_connections as 4
+  register: mk_conn_result_0002
+
+- debug: var=mk_conn_result_0002
+
+- name: Assert that changes were not made
+  assert:
+    that:
+      - "mk_conn_result_0002.results|map(attribute='changed')|unique|list == [false]"


### PR DESCRIPTION
##### SUMMARY
maxMksConnections is contained in vim.vm.ConfigInfo not vim.vm.VirtualHardware

Fixes: #58060

Signed-off-by: lijok <28689084+lijok@users.noreply.github.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 63bdd0d6cdb122b6feb646f1d9721357df9bb3ca)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/58060-vmware_guest-make_max_connections_work.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml
test/integration/targets/vmware_guest/tasks/max_connections.yml
