### PR TITLE
Added update functionality for ONTAP Snapshot Policy

### DIFF
--- a/lib/ansible/module_utils/netapp_module.py
+++ b/lib/ansible/module_utils/netapp_module.py
@@ -168,7 +168,7 @@ class NetAppModule(object):
         '''
         pass
 
-    def get_modified_attributes(self, current, desired, get_list_diff=False):
+    def get_modified_attributes(self, current, desired, get_list_diff=False, sort_list=True):
         ''' takes two dicts of attributes and return a dict of attributes that are
             not in the current state
             It is expected that all attributes of interest are listed in current and
@@ -194,7 +194,7 @@ class NetAppModule(object):
         # collect changed attributes
         for key, value in current.items():
             if key in desired and desired[key] is not None:
-                if type(value) is list:
+                if type(value) is list and sort_list:
                     value.sort()
                     desired[key].sort()
                 if cmp(value, desired[key]) != 0:

--- a/lib/ansible/modules/storage/netapp/na_ontap_snapshot_policy.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapshot_policy.py
@@ -53,7 +53,7 @@ options:
     - SnapMirror label assigned to each schedule inside the policy.
     type: list
     required: false
-   vserver:
+  vserver:
     description:
     - The name of the vserver to use.
     required: false
@@ -189,7 +189,7 @@ class NetAppOntapSnapshotPolicy(object):
                         current['count'].append(int(schedule.get_child_content('count')))
                         current['prefix'].append(schedule.get_child_content('prefix'))
                         snapmirror_label = schedule.get_child_content('snapmirror-label')
-                        if snapmirror_label == None or snapmirror_label == '-':
+                        if snapmirror_label is None or snapmirror_label == '-':
                             snapmirror_label = ''
                         current['snapmirror_label'].append(snapmirror_label)
                 return current
@@ -207,14 +207,14 @@ class NetAppOntapSnapshotPolicy(object):
                 len(self.parameters['count']) < 1 or len(self.parameters['schedule']) < 1 or \
                 len(self.parameters['count']) != len(self.parameters['schedule']):
             self.module.fail_json(msg="Error: A Snapshot policy must have at least 1 "
-                "schedule and can have up to a maximum of 5 schedules, with a count "
-                "representing the maximum number of Snapshot copies for each schedule")
+                                      "schedule and can have up to a maximum of 5 schedules, with a count "
+                                      "representing the maximum number of Snapshot copies for each schedule")
 
         if 'snapmirror_label' in self.parameters:
             if len(self.parameters['snapmirror_label']) != len(self.parameters['schedule']):
                 self.module.fail_json(msg="Error: Each Snapshot Policy schedule must have an "
-                    "accompanying SnapMirror Label")
-                
+                                          "accompanying SnapMirror Label")
+
     def modify_snapshot_policy(self, current):
         """
         Modifies an existing snapshot policy
@@ -248,7 +248,7 @@ class NetAppOntapSnapshotPolicy(object):
         if 'snapmirror_label' in self.parameters:
             snapmirror_labels = self.parameters['snapmirror_label']
         else:
-            snapmirror_labels = ['']*len(self.parameters['schedule'])
+            snapmirror_labels = [''] * len(self.parameters['schedule'])
 
         # Modify existing or add new schedules
         for schedule, count, snapmirror_label in zip(self.parameters['schedule'], self.parameters['count'], snapmirror_labels):
@@ -273,7 +273,7 @@ class NetAppOntapSnapshotPolicy(object):
             schedule.strip()
             if schedule not in [item.strip() for item in self.parameters['schedule']]:
                 options = {'policy': current['name'],
-                            'schedule': schedule}
+                           'schedule': schedule}
                 self.modify_snapshot_policy_schedule(options, 'snapshot-policy-remove-schedule')
 
     def modify_snapshot_policy_schedule(self, options, zapi):
@@ -302,7 +302,7 @@ class NetAppOntapSnapshotPolicy(object):
         if 'snapmirror_label' in self.parameters:
             snapmirror_labels = self.parameters['snapmirror_label']
         else:
-            snapmirror_labels = ['']*len(self.parameters['schedule'])
+            snapmirror_labels = [''] * len(self.parameters['schedule'])
 
         # zapi attribute for first schedule is schedule1, second is schedule2 and so on
         positions = [str(i) for i in range(1, len(self.parameters['schedule']) + 1)]

--- a/lib/ansible/modules/storage/netapp/na_ontap_snapshot_policy.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapshot_policy.py
@@ -53,10 +53,12 @@ options:
     - SnapMirror label assigned to each schedule inside the policy.
     type: list
     required: false
+    version_added: '2.9'
   vserver:
     description:
     - The name of the vserver to use.
     required: false
+    version_added: '2.9'
 '''
 EXAMPLES = """
     - name: Create Snapshot policy

--- a/test/units/modules/storage/netapp/test_na_ontap_snapshot_policy.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_snapshot_policy.py
@@ -63,6 +63,16 @@ class MockONTAPConnection(object):
         self.xml_in = xml
         if self.type == 'policy':
             xml = self.build_snapshot_policy_info()
+        elif self.type == 'snapshot_policy_info_policy_disabled':
+            xml = self.build_snapshot_policy_info_policy_disabled()
+        elif self.type == 'snapshot_policy_info_comment_modified':
+            xml = self.build_snapshot_policy_info_comment_modified()
+        elif self.type == 'snapshot_policy_info_schedules_added':
+            xml = self.build_snapshot_policy_info_schedules_added()
+        elif self.type == 'snapshot_policy_info_schedules_deleted':
+            xml = self.build_snapshot_policy_info_schedules_deleted()
+        elif self.type == 'snapshot_policy_info_modified_schedule_counts':
+            xml = self.build_snapshot_policy_info_modified_schedule_counts()
         elif self.type == 'policy_fail':
             raise netapp_utils.zapi.NaApiError(code='TEST', message="This exception is from the unit test")
         self.xml_out = xml
@@ -77,7 +87,180 @@ class MockONTAPConnection(object):
         ''' build xml data for snapshot-policy-info '''
         xml = netapp_utils.zapi.NaElement('xml')
         data = {'num-records': 1,
-                'attributes-list': {'snapshot-policy-info': {'policy': 'ansible'}}}
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'new comment',
+                        'enabled': 'true',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules' : {
+                            'snapshot-schedule-info' : {
+                                'count': 100,
+                                'prefix': 'hourly',
+                                'schedule': 'hourly',
+                                'snapmirror-label': ''
+                            }
+                        },
+                        'vserver-name': 'hostname'
+                    }
+                }}
+        xml.translate_struct(data)
+        return xml
+
+    @staticmethod
+    def build_snapshot_policy_info_comment_modified():
+        ''' build xml data for snapshot-policy-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        data = {'num-records': 1,
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'modified comment',
+                        'enabled': 'true',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules' : {
+                            'snapshot-schedule-info' : {
+                                'count': 100,
+                                'prefix': 'hourly',
+                                'schedule': 'hourly',
+                                'snapmirror-label': ''
+                            }
+                        },
+                        'vserver-name': 'hostname'
+                    }
+                }}
+        xml.translate_struct(data)
+        return xml
+
+    @staticmethod
+    def build_snapshot_policy_info_policy_disabled():
+        ''' build xml data for snapshot-policy-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        data = {'num-records': 1,
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'new comment',
+                        'enabled': 'false',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules' : {
+                            'snapshot-schedule-info' : {
+                                'count': 100,
+                                'prefix': 'hourly',
+                                'schedule': 'hourly',
+                                'snapmirror-label': ''
+                            }
+                        },
+                        'vserver-name': 'hostname'
+                    }
+                }}
+        xml.translate_struct(data)
+        return xml
+
+    @staticmethod
+    def build_snapshot_policy_info_schedules_added():
+        ''' build xml data for snapshot-policy-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        data = {'num-records': 1,
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'new comment',
+                        'enabled': 'true',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules': [
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 100,
+                                    'prefix': 'hourly',
+                                    'schedule': 'hourly',
+                                    'snapmirror-label': ''
+                                }
+                            },
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 5,
+                                    'prefix': 'daily',
+                                    'schedule': 'daily',
+                                    'snapmirror-label': 'daily'
+                                }
+                            },
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 10,
+                                    'prefix': 'weekly',
+                                    'schedule': 'weekly',
+                                    'snapmirror-label': ''
+                                }
+                            }
+                        ],
+                        'vserver-name': 'hostname'
+                    }
+                }}
+        xml.translate_struct(data)
+        return xml
+
+    @staticmethod
+    def build_snapshot_policy_info_schedules_deleted():
+        ''' build xml data for snapshot-policy-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        data = {'num-records': 1,
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'new comment',
+                        'enabled': 'true',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules': [
+                            {
+                                'snapshot-schedule-info': {
+                                    'schedule': 'daily',
+                                    'count': 5,
+                                    'prefix': 'daily',
+                                    'snapmirror-label': 'daily'
+                                }
+                            }
+                        ],
+                        'vserver-name': 'hostname'
+                    }
+                }}
+        xml.translate_struct(data)
+        return xml
+
+    @staticmethod
+    def build_snapshot_policy_info_modified_schedule_counts():
+        ''' build xml data for snapshot-policy-info '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        data = {'num-records': 1,
+                'attributes-list': {
+                    'snapshot-policy-info': {
+                        'comment': 'new comment',
+                        'enabled': 'true',
+                        'policy': 'ansible',
+                        'snapshot-policy-schedules': [
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 10,
+                                    'prefix': 'hourly',
+                                    'schedule': 'hourly',
+                                    'snapmirror-label': ''
+                                }
+                            },
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 50,
+                                    'prefix': 'daily',
+                                    'schedule': 'daily',
+                                    'snapmirror-label': 'daily'
+                                }
+                            },
+                            {
+                                'snapshot-schedule-info': {
+                                    'count': 100,
+                                    'prefix': 'weekly',
+                                    'schedule': 'weekly',
+                                    'snapmirror-label': ''
+                                }
+                            }
+                        ],
+                        'vserver-name': 'hostname'
+                    }
+                }}
         xml.translate_struct(data)
         return xml
 
@@ -124,6 +307,19 @@ class TestMyModule(unittest.TestCase):
             'comment': comment
         })
 
+    def set_default_current(self):
+        default_args = self.set_default_args()
+        return dict({
+            'name': default_args['name'],
+            'enabled': default_args['enabled'],
+            'count': [default_args['count']],
+            'schedule': [default_args['schedule']],
+            'snapmirror_label': [''],
+            'prefix': [default_args['schedule']],
+            'comment': default_args['comment'],
+            'vserver': default_args['hostname']
+        })
+
     def test_module_fail_when_required_args_missing(self):
         ''' required arguments are reported as errors '''
         with pytest.raises(AnsibleFailJson) as exc:
@@ -166,6 +362,155 @@ class TestMyModule(unittest.TestCase):
             my_obj.apply()
         assert not exc.value.args[0]['changed']
 
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_modify_comment(self, modify_snapshot):
+        ''' modifying snapshot policy comment and testing idempotency '''
+        data = self.set_default_args()
+        data['comment'] = 'modified comment'
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_comment_modified')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_disable_policy(self, modify_snapshot):
+        ''' disabling snapshot policy and testing idempotency '''
+        data = self.set_default_args()
+        data['enabled'] = False
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_policy_disabled')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_enable_policy(self, modify_snapshot):
+        ''' enabling snapshot policy and testing idempotency '''
+        data = self.set_default_args()
+        data['enabled'] = True
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_policy_disabled')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        current['enabled'] = False
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_modify_schedules_add(self, modify_snapshot):
+        ''' adding snapshot policy schedules and testing idempotency '''
+        data = self.set_default_args()
+        data['schedule'] = ['hourly', 'daily', 'weekly']
+        data['count'] = [100, 5, 10]
+        data['snapmirror_label'] = ['', 'daily', '']
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_schedules_added')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_modify_schedules_delete(self, modify_snapshot):
+        ''' deleting snapshot policy schedules and testing idempotency '''
+        data = self.set_default_args()
+        data['schedule'] = ['daily']
+        data['count'] = [5]
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_schedules_deleted')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.modify_snapshot_policy')
+    def test_successful_modify_schedules(self, modify_snapshot):
+        ''' modifying snapshot policy schedule counts and testing idempotency '''
+        data = self.set_default_args()
+        data['schedule'] = ['hourly', 'daily', 'weekly']
+        data['count'] = [10, 50, 100]
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert exc.value.args[0]['changed']
+        current = self.set_default_current()
+        modify_snapshot.assert_called_with(current)
+        # to reset na_helper from remembering the previous 'changed' value
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = MockONTAPConnection('snapshot_policy_info_modified_schedule_counts')
+        with pytest.raises(AnsibleExitJson) as exc:
+            my_obj.apply()
+        assert not exc.value.args[0]['changed']
+
     @patch('ansible.modules.storage.netapp.na_ontap_snapshot_policy.NetAppOntapSnapshotPolicy.delete_snapshot_policy')
     def test_successful_delete(self, delete_snapshot):
         ''' deleting snapshot policy and testing idempotency '''
@@ -203,6 +548,23 @@ class TestMyModule(unittest.TestCase):
         create_xml = my_obj.server.xml_in
         assert data['count'][2] == int(create_xml['count3'])
         assert data['schedule'][4] == create_xml['schedule5']
+
+    def test_valid_schedule_count_with_snapmirror_labels(self):
+        ''' validate when schedule has same number of elements with snapmirror labels '''
+        data = self.set_default_args()
+        data['schedule'] = ['hourly', 'daily', 'weekly', 'monthly', '5min']
+        data['count'] = [1, 2, 3, 4, 5]
+        data['snapmirror_label'] = ['hourly', 'daily', 'weekly', 'monthly', '5min']
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = self.server
+        my_obj.create_snapshot_policy()
+        create_xml = my_obj.server.xml_in
+        assert data['count'][2] == int(create_xml['count3'])
+        assert data['schedule'][4] == create_xml['schedule5']
+        assert data['snapmirror_label'][3] == create_xml['snapmirror-label4']
 
     def test_invalid_params(self):
         ''' validate error when schedule does not have same number of elements '''
@@ -270,6 +632,22 @@ class TestMyModule(unittest.TestCase):
         msg = 'Error: A Snapshot policy must have at least 1 ' \
               'schedule and can have up to a maximum of 5 schedules, with a count ' \
               'representing the maximum number of Snapshot copies for each schedule'
+        assert exc.value.args[0]['msg'] == msg
+
+    def test_invalid_schedule_count_with_snapmirror_labels(self):
+        ''' validate error when schedule with snapmirror labels does not have same number of elements '''
+        data = self.set_default_args()
+        data['schedule'] = ['s1', 's2', 's3']
+        data['count'] = [1, 2, 3]
+        data['snapmirror_label'] = ['sm1', 'sm2']
+        set_module_args(data)
+        my_obj = my_module()
+        my_obj.asup_log_for_cserver = Mock(return_value=None)
+        if not self.onbox:
+            my_obj.server = self.server
+        with pytest.raises(AnsibleFailJson) as exc:
+            my_obj.create_snapshot_policy()
+        msg = 'Error: Each Snapshot Policy schedule must have an accompanying SnapMirror Label'
         assert exc.value.args[0]['msg'] == msg
 
     def test_if_all_methods_catch_exception(self):

--- a/test/units/modules/storage/netapp/test_na_ontap_snapshot_policy.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_snapshot_policy.py
@@ -92,8 +92,8 @@ class MockONTAPConnection(object):
                         'comment': 'new comment',
                         'enabled': 'true',
                         'policy': 'ansible',
-                        'snapshot-policy-schedules' : {
-                            'snapshot-schedule-info' : {
+                        'snapshot-policy-schedules': {
+                            'snapshot-schedule-info': {
                                 'count': 100,
                                 'prefix': 'hourly',
                                 'schedule': 'hourly',
@@ -116,8 +116,8 @@ class MockONTAPConnection(object):
                         'comment': 'modified comment',
                         'enabled': 'true',
                         'policy': 'ansible',
-                        'snapshot-policy-schedules' : {
-                            'snapshot-schedule-info' : {
+                        'snapshot-policy-schedules': {
+                            'snapshot-schedule-info': {
                                 'count': 100,
                                 'prefix': 'hourly',
                                 'schedule': 'hourly',
@@ -140,8 +140,8 @@ class MockONTAPConnection(object):
                         'comment': 'new comment',
                         'enabled': 'false',
                         'policy': 'ansible',
-                        'snapshot-policy-schedules' : {
-                            'snapshot-schedule-info' : {
+                        'snapshot-policy-schedules': {
+                            'snapshot-schedule-info': {
                                 'count': 100,
                                 'prefix': 'hourly',
                                 'schedule': 'hourly',


### PR DESCRIPTION
<!--- Verify first that your feature was not already discussed on GitHub -->
<!--- Complete *all* sections as described, this form is processed automatically -->

##### SUMMARY
Added update functionality for Snapshot Policy

- Add, modify, delete Snapshot Policy schedules
- Added optional SnapMirror labels for schedules
- Update schedule counts and optional SnapMirror labels
- Update comment
- Enable/disable Snapshot Policy
- Specify optional vserver that owns Snapshot Policy

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- na_ontap_snapshot_policy
##### ANSIBLE VERSION
```
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/jasonl4/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /bin/ansible
  python version = 3.6.8 (default, Apr 25 2019, 21:02:35) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
```

##### CONFIGURATION
```

```

##### OS / ENVIRONMENT
```
CentOS Linux release 7.5.1804 (Core)
NetApp Release 9.4P1: Fri Jul 20 23:17:19 UTC 2018 (ONTAP Select)
```
##### ADDITIONAL INFORMATION
<!--- Describe how the feature would be used, why it is needed and what it would solve -->

<!--- Paste example playbooks or commands between quotes below -->
Example playbook exhibiting additional functionality.
```yaml
---
- hosts: localhost
  gather_facts: false
  vars_files:
    - globals.yml
  vars:
    login: &login
      hostname: "{{ netapp_hostname }}"
      username: "{{ netapp_username }}"
      password: "{{ netapp_password }}"
      ontapi: 32
      https: true
      validate_certs: false
  tasks:

  - name: Delete snapshot policy owned by cluster-admin and check idempotency
    na_ontap_snapshot_policy:
      state: absent
      name: ansible
      <<: *login
    loop: [1,2]

  - name: Delete snapshot policy in vserver and check idempotency
    na_ontap_snapshot_policy:
      state: absent
      name: ansible1
      vserver: svm1
      <<: *login
    loop: [1,2]

  - name: Create snapshot policy with 1 schedule and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: hourly
      count: 100
      <<: *login
    loop: [1,2]

  - name: Add 4 schedules to snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['hourly', 'daily', 'weekly', 'monthly', '5min']
      count: [100, 2, 3, 4, 5]
      <<: *login
    loop: [1,2]

  - name: Modify all schedule counts in snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['hourly', 'daily', 'weekly', 'monthly', '5min']
      count: [10, 20, 30, 40, 50]
      <<: *login
    loop: [1,2]

  - name: Delete 3 of 5 schedules from snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['daily', 'weekly']
      count: [20, 30]
      <<: *login
    loop: [1,2]

  - name: Pass remaining 2 schedules in different order to snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['weekly', 'daily']
      count: [30, 20]
      <<: *login

  - name: Add SnapMirror labels to 5 schedules in snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['hourly', 'daily', 'weekly', 'monthly', '5min']
      count: [10, 20, 30, 40, 50]
      snapmirror_label: ['hourly_label', 'daily_label', 'weekly_label', 'monthly_label', '5min_label']
      <<: *login
    loop: [1,2]

  - name: Remove SnapMirror labels from 3 of 5 schedules in snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['hourly', 'daily', 'weekly', 'monthly', '5min']
      count: [10, 20, 30, 40, 50]
      snapmirror_label: ['hourly_label', '', '', '', '5min_label']
      <<: *login
    loop: [1,2]

  - name: Disable snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: false
      schedule: ['daily', 'weekly']
      count: [20, 30]
      <<: *login
    loop: [1,2]

  - name: Re-enable snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['daily', 'weekly']
      count: [20, 30]
      <<: *login
    loop: [1,2]

  - name: Add comment to snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['daily', 'weekly']
      count: [20, 30]
      comment: 'New comment'
      <<: *login
    loop: [1,2]

  - name: Modify comment of snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible
      enabled: true
      schedule: ['daily', 'weekly']
      count: [20, 30]
      comment: 'Modified comment'
      <<: *login
    loop: [1,2]

  - name: Create vserver owned snapshot policy and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible1
      vserver: svm1
      enabled: true
      schedule: ['hourly', 'daily', 'weekly']
      count: [100, 20, 30]
      snapmirror_label: ['', 'daily_label', '']
      comment: "Snapshot policy owned by SVM"
      <<: *login
    loop: [1,2]

  - name: Modify vserver owned snapshot policy schedules and check idempotency
    na_ontap_snapshot_policy:
      state: present
      name: ansible1
      vserver: svm1
      enabled: true
      schedule: ['hourly', 'daily', 'weekly']
      count: [1, 2, 30]
      snapmirror_label: ['hourly_label', 'daily_label', '']
      comment: ""
      <<: *login
    loop: [1,2]
```

Example playbook output.

```
$ ansible-playbook example.yml
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit
localhost does not match 'all'


PLAY [localhost] **********************************************************************************

TASK [Delete snapshot policy owned by cluster-admin and check idempotency] ************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Delete snapshot policy in vserver and check idempotency] ************************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Create snapshot policy with 1 schedule and check idempotency] *******************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Add 4 schedules to snapshot policy and check idempotency] ***********************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Modify all schedule counts in snapshot policy and check idempotency] ************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Delete 3 of 5 schedules from snapshot policy and check idempotency] *************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Pass remaining 2 schedules in different order to snapshot policy and check idempotency] *****
ok: [localhost]

TASK [Add SnapMirror labels to 5 schedules in snapshot policy and check idempotency] **************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Remove SnapMirror labels from 3 of 5 schedules in snapshot policy and check idempotency] ****
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Disable snapshot policy and check idempotency] **********************************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Re-enable snapshot policy and check idempotency] ********************************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Add comment to snapshot policy and check idempotency] ***************************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Modify comment of snapshot policy and check idempotency] ************************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Create vserver owned snapshot policy and check idempotency] *********************************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

TASK [Modify vserver owned snapshot policy schedules and check idempotency] ***********************
changed: [localhost] => (item=1)
ok: [localhost] => (item=2)

PLAY RECAP ****************************************************************************************
localhost                  : ok=15   changed=14   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

<!--- HINT: You can also paste gist.github.com links for larger files -->

**Note:** I reluctantly added `sort_list=True` parameter to `get_modified_attributes(self, current, desired, get_list_diff=False, sort_list=True)` in `lib/ansible/module_utils/netapp_module.py` because when the Snapshot Policy `schedule`, `count` and `snapmirror_label` lists were being sorted, it caused the intended ordering to mess up.
 
Example `self.parameters` before call to `get_modified_attributes()`.
```python
schedule = ['hourly', 'daily', 'weekly']
count = [100, 50, 10]
```
after call to `get_modified_attributes()`, resulting in incorrect order.
```python
schedule = ['daily', 'hourly', 'weekly']
count = [10, 50, 100]
```

Now, in `na_ontap_snapshot_policy.py`, the call to `self.na_helper.get_modified_attributes(current, self.parameters, sort_list=False)` skips the sorting of lists, thus the intended order remains intact. Happy to discuss other ways to solve this issue.
