### PR TITLE
Unit tests for bytes_to_human

### DIFF
--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -123,7 +123,7 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
     assert bytes_to_human(input_data, isbits=True, unit=unit) == expected
 
 
-@pytest.mark.parametrize('input_data', [0j, '1B', [1], {1}, ])
+@pytest.mark.parametrize('input_data', [0j, '1B', [1], {1: 1}, ])
 def test_bytes_to_human_unexpected_size(input_data):
     """Test of bytes_to_human function, unexpected numbers are passed."""
     with pytest.raises(TypeError):

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -109,5 +109,6 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
 @pytest.mark.parametrize('input_data', [0j, u'1B', [1], {1: 1}, None, b'1B'])
 def test_bytes_to_human_illegal_size(input_data):
     """Test of bytes_to_human function, illegal objects are passed as a size."""
-    with pytest.raises(TypeError, match=r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) for /)'):
+    e_regexp = r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) for /)|(unorderable types)'
+    with pytest.raises(TypeError, match=e_regexp):
         bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -109,7 +109,8 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
 @pytest.mark.parametrize('input_data', [0j, u'1B', [1], {1: 1}, None, b'1B'])
 def test_bytes_to_human_illegal_size(input_data):
     """Test of bytes_to_human function, illegal objects are passed as a size."""
-    e_regexp = r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) '\
-               'for /)|(unorderable types)|(not supported between instances of)'
+    e_regexp = (r'(no ordering relation is defined for complex numbers)|'
+                r'(unsupported operand type\(s\) for /)|(unorderable types)|'
+                r'(not supported between instances of)')
     with pytest.raises(TypeError, match=e_regexp):
         bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019, Andrew Klychkov @Andersson007 <aaklychkov@mail.ru>
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.common.text.formatters import bytes_to_human
+
+
+# def bytes_to_human(size, isbits=False, unit=None):
+#    base = 'Bytes'
+#    if isbits:
+#        base = 'bits'
+#    suffix = ''
+#
+#    for suffix, limit in sorted(iteritems(SIZE_RANGES), key=lambda item: -item[1]):
+#        if (unit is None and size >= limit) or unit is not None and unit.upper() == suffix[0]:
+#            break
+#
+#    if limit != 1:
+#        suffix += base[0]
+#    else:
+#        suffix = base
+#
+#    return '%.2f %s' % (size / limit, suffix)
+
+@pytest.mark.parametrize(
+    'input_data,expected',
+    [
+        (0, u'0.00 Bytes'),
+        (0.5, u'0.50 Bytes'),
+        (0.54, u'0.54 Bytes'),
+        (1024, u'1.00 KB'),
+        (1025, u'1.00 KB'),
+        (1536, u'1.50 KB'),
+        (1790, u'1.75 KB'),
+        (1048576, u'1.00 MB'),
+        (1073741824, u'1.00 GB'),
+        (1099511627776, u'1.00 TB'),
+        (1125899906842624, u'1.00 PB'),
+        (1152921504606846976, u'1.00 EB'),
+        (1180591620717411303424, u'1.00 ZB'),
+        (1208925819614629174706176, u'1.00 YB'),
+    ]
+)
+def test_bytes_to_human(input_data, expected):
+    """Test of bytes_to_human function, only proper numbers are passed."""
+    assert bytes_to_human(input_data) == expected
+
+
+@pytest.mark.parametrize(
+    'input_data,expected',
+    [
+        (0, u'0.00 bits'),
+        (0.5, u'0.50 bits'),
+        (0.54, u'0.54 bits'),
+        (1024, u'1.00 Kb'),
+        (1025, u'1.00 Kb'),
+        (1536, u'1.50 Kb'),
+        (1790, u'1.75 Kb'),
+        (1048576, u'1.00 Mb'),
+        (1073741824, u'1.00 Gb'),
+        (1099511627776, u'1.00 Tb'),
+        (1125899906842624, u'1.00 Pb'),
+        (1152921504606846976, u'1.00 Eb'),
+        (1180591620717411303424, u'1.00 Zb'),
+        (1208925819614629174706176, u'1.00 Yb'),
+    ]
+)
+def test_bytes_to_human_isbits(input_data, expected):
+    """Test of bytes_to_human function with isbits=True proper results."""
+    assert bytes_to_human(input_data, isbits=True) == expected
+
+
+@pytest.mark.parametrize(
+    'input_data,unit,expected',
+    [
+        (0, u'B', u'0.00 Bytes'),
+        (0.5, u'B', u'0.50 Bytes'),
+        (0.54, u'B', u'0.54 Bytes'),
+        (1024, u'K', u'1.00 KB'),
+        (1536, u'K', u'1.50 KB'),
+        (1790, u'K', u'1.75 KB'),
+        (1048576, u'M', u'1.00 MB'),
+        (1099511627776, u'T', u'1.00 TB'),
+        (1152921504606846976, u'E', u'1.00 EB'),
+        (1180591620717411303424, u'Z', u'1.00 ZB'),
+        (1208925819614629174706176, u'Y', u'1.00 YB'),
+        (1025, u'KB', u'1025.00 Bytes'),
+        (1073741824, u'Gb', u'1073741824.00 Bytes'),
+        (1125899906842624, u'Pb', u'1125899906842624.00 Bytes'),
+    ]
+)
+def test_bytes_to_human_unit(input_data, unit, expected):
+    """Test unit argument of bytes_to_human function proper results."""
+    assert bytes_to_human(input_data, unit=unit) == expected
+
+
+@pytest.mark.parametrize(
+    'input_data,unit,expected',
+    [
+        (0, u'B', u'0.00 bits'),
+        (0.5, u'B', u'0.50 bits'),
+        (0.54, u'B', u'0.54 bits'),
+        (1024, u'K', u'1.00 Kb'),
+        (1536, u'K', u'1.50 Kb'),
+        (1790, u'K', u'1.75 Kb'),
+        (1048576, u'M', u'1.00 Mb'),
+        (1099511627776, u'T', u'1.00 Tb'),
+        (1152921504606846976, u'E', u'1.00 Eb'),
+        (1180591620717411303424, u'Z', u'1.00 Zb'),
+        (1208925819614629174706176, u'Y', u'1.00 Yb'),
+        (1025, u'KB', u'1025.00 bits'),
+        (1073741824, u'Gb', u'1073741824.00 bits'),
+        (1125899906842624, u'Pb', u'1125899906842624.00 bits'),
+    ]
+)
+def test_bytes_to_human_unit_isbits(input_data, unit, expected):
+    """Test unit argument of bytes_to_human function with isbits=True proper results."""
+    assert bytes_to_human(input_data, isbits=True, unit=unit) == expected
+
+
+@pytest.mark.parametrize('input_data', [0j, '1B', [1], {1}, ])
+def test_bytes_to_human_unexpected_size(input_data):
+    """Test of bytes_to_human function, unexpected numbers are passed."""
+    with pytest.raises(TypeError):
+        bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -10,23 +10,6 @@ import pytest
 from ansible.module_utils.common.text.formatters import bytes_to_human
 
 
-# def bytes_to_human(size, isbits=False, unit=None):
-#    base = 'Bytes'
-#    if isbits:
-#        base = 'bits'
-#    suffix = ''
-#
-#    for suffix, limit in sorted(iteritems(SIZE_RANGES), key=lambda item: -item[1]):
-#        if (unit is None and size >= limit) or unit is not None and unit.upper() == suffix[0]:
-#            break
-#
-#    if limit != 1:
-#        suffix += base[0]
-#    else:
-#        suffix = base
-#
-#    return '%.2f %s' % (size / limit, suffix)
-
 @pytest.mark.parametrize(
     'input_data,expected',
     [

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -109,6 +109,7 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
 @pytest.mark.parametrize('input_data', [0j, u'1B', [1], {1: 1}, None, b'1B'])
 def test_bytes_to_human_illegal_size(input_data):
     """Test of bytes_to_human function, illegal objects are passed as a size."""
-    e_regexp = r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) for /)|(unorderable types)'
+    e_regexp = r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) '\
+               'for /)|(unorderable types)|(not supported between instances of)'
     with pytest.raises(TypeError, match=e_regexp):
         bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -109,5 +109,5 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
 @pytest.mark.parametrize('input_data', [0j, u'1B', [1], {1: 1}, None, b'1B'])
 def test_bytes_to_human_illegal_size(input_data):
     """Test of bytes_to_human function, illegal objects are passed as a size."""
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match=r'(no ordering relation is defined for complex numbers)|(unsupported operand type\(s\) for /)'):
         bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -123,8 +123,8 @@ def test_bytes_to_human_unit_isbits(input_data, unit, expected):
     assert bytes_to_human(input_data, isbits=True, unit=unit) == expected
 
 
-@pytest.mark.parametrize('input_data', [0j, '1B', [1], {1: 1}, ])
-def test_bytes_to_human_unexpected_size(input_data):
-    """Test of bytes_to_human function, unexpected numbers are passed."""
+@pytest.mark.parametrize('input_data', [0j, u'1B', [1], {1: 1}, None, b'1B'])
+def test_bytes_to_human_illegal_size(input_data):
+    """Test of bytes_to_human function, illegal objects are passed as a size."""
     with pytest.raises(TypeError):
         bytes_to_human(input_data)

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019, Andrew Klychkov @Andersson007 <aaklychkov@mail.ru>
-# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type


### PR DESCRIPTION
##### SUMMARY
Unit tests for bytes_to_human from lib/ansible/module_utils/common/text/formatters.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### NEEDS TO DISCUSS
Look at the input and output from line 92-94 and 116 to 118 (the same is true for test function test_bytes_to_human_unit):
```
102 @pytest.mark.parametrize(
103     'input_data,unit,expected',
104     [
105         (0, u'B', u'0.00 bits'),
106         (0.5, u'B', u'0.50 bits'),
107         (0.54, u'B', u'0.54 bits'),
108         (1024, u'K', u'1.00 Kb'),
109         (1536, u'K', u'1.50 Kb'),
110         (1790, u'K', u'1.75 Kb'),
111         (1048576, u'M', u'1.00 Mb'),
112         (1099511627776, u'T', u'1.00 Tb'),
113         (1152921504606846976, u'E', u'1.00 Eb'),
114         (1180591620717411303424, u'Z', u'1.00 Zb'),
115         (1208925819614629174706176, u'Y', u'1.00 Yb'),
116         (1025, u'KB', u'1025.00 bits'),
117         (1073741824, u'Gb', u'1073741824.00 bits'),
118         (1125899906842624, u'Pb', u'1125899906842624.00 bits'),
119     ]
120 )
121 def test_bytes_to_human_unit_isbits(input_data, unit, expected):
122     """Test unit argument of bytes_to_human function with isbits=True proper results."""
123     assert bytes_to_human(input_data, isbits=True, unit=unit) == expected
```
Function bytes_to_human doesn't contain any docstrings.

I did grep in the source tree, the arguments isbits and unit are not used anywere.

**I suggest that:**
1. we need change the logic, for example, we could check unit length and raise an exception or something else.
2. regarding the decision about the previous point, needs to add the proper docstrings.
3. I would try to implement the previous two points after discussion in this PR.
