### PR TITLE
Directly use the list of packages for yum module in examples

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -15,11 +15,11 @@ Blocks allow for logical grouping of tasks and in play error handling. Most of w
       block:
       - name: install httpd and memcached
         yum:
-          name: "{{ item }}"
-          state: present
-        loop:
+          name:
           - httpd
           - memcached
+          state: present
+
       - name: apply the foo config template
         template:
           src: templates/src.j2

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -16,11 +16,10 @@ that tags two tasks with different tags::
 
     tasks:
     - yum:
-        name: "{{ item }}"
+        name:
+        - httpd
+        - memcached
         state: present
-      loop:
-      - httpd
-      - memcached
       tags:
       - packages
 


### PR DESCRIPTION
##### SUMMARY
The updated examples used the loop to substitute names of packages. Currently preferred way is directly providing the list of packages to the `name` parameter of the yum module.

##### ISSUE TYPE
- Docs Pull Request
