### PR TITLE
azure_rm_gallery: add unstable to aliases

### DIFF
--- a/test/integration/targets/azure_rm_gallery/aliases
+++ b/test/integration/targets/azure_rm_gallery/aliases
@@ -3,3 +3,4 @@ shippable/azure/group4
 destructive
 azure_rm_galleryimage
 azure_rm_galleryimageversion
+unstable


### PR DESCRIPTION
##### SUMMARY
azure_rm_gallery: add unstable to aliases

because tests fail for unrelated PRs with:
```
10:20 <testhost> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1562154933.93-98980176504656/ > /dev/null 2>&1 && sleep 0'
10:20 The full traceback is:
10:20 WARNING: The below traceback may *not* be related to the actual failure.
10:20   File "/tmp/ansible_azure_rm_galleryimageversion_payload_DCkqlY/__main__.py", line 397, in create_update_resource
10:20     30)
10:20   File "/tmp/ansible_azure_rm_galleryimageversion_payload_DCkqlY/ansible_azure_rm_galleryimageversion_payload.zip/ansible/module_utils/azure_rm_common_rest.py", line 80, in query
10:20     raise exp
10:20 
10:20 fatal: [testhost]: FAILED! => {
10:20     "changed": false, 
10:20     "invocation": {
10:20         "module_args": {
10:20             "ad_user": null, 
10:20             "adfs_authority_url": null, 
10:20             "api_profile": "latest", 
10:20             "append_tags": true, 
10:20             "auth_source": null, 
10:20             "cert_validation_mode": null, 
10:20             "client_id": null, 
10:20             "cloud_environment": "AzureCloud", 
10:20             "gallery_image_name": "myImage", 
10:20             "gallery_name": "myGalleryebce060794", 
10:20             "location": "West US", 
10:20             "name": "10.1.3", 
10:20             "password": null, 
10:20             "profile": null, 
10:20             "publishing_profile": {
10:20                 "endOfLifeDate": "2021-10-01t00:00:00+00:00", 
10:20                 "excludeFromLatest": true, 
10:20                 "replicaCount": 3, 
10:20                 "source": {
10:20                     "managedImage": {
10:20                         "id": "/subscriptions/6d22db98-3e5f-4ab9-bdf9-2f911a2775f7/resourceGroups/ansible-core-ci-prod-991ee744-e8ec-4af3-888b-6f86a91dedfc-1/providers/Microsoft.Compute/images/testimagea"
10:20                     }
10:20                 }, 
10:20                 "storageAccountType": "Standard_LRS", 
10:20                 "targetRegions": [
10:20                     {
10:20                         "name": "West US", 
10:20                         "regionalReplicaCount": 1
10:20                     }, 
10:20                     {
10:20                         "name": "East US", 
10:20                         "regionalReplicaCount": 2, 
10:20                         "storageAccountType": "Standard_ZRS"
10:20                     }
10:20                 ]
10:20             }, 
10:20             "resource_group": "ansible-core-ci-prod-991ee744-e8ec-4af3-888b-6f86a91dedfc-1", 
10:20             "secret": null, 
10:20             "state": "present", 
10:20             "subscription_id": null, 
10:20             "tags": null, 
10:20             "tenant": null
10:20         }
10:20     }, 
10:20     "msg": "Error creating the GalleryImageVersion instance: Azure Error: InvalidParameter\nMessage: Parameter 'galleryImageVersion.properties.storageProfile' is not allowed.\nTarget: galleryImageVersion.properties.storageProfile"
10:20 }
10:20 
10:20 PLAY RECAP *********************************************************************
10:20 testhost                   : ok=29   changed=8    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
10:20 
10:21 Command exited with status 2 after 276.723038912 seconds.
10:21 NOTICE: If azure_rm_gallery failed due to permissions, the test policy may need to be updated. For help, consult @mattclay or @gundalow on GitHub or #ansible-devel on IRC.
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request