### PR TITLE
Fix unicode error in changelog generation

### DIFF
--- a/packaging/release/changelogs/changelog.py
+++ b/packaging/release/changelogs/changelog.py
@@ -26,6 +26,7 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_bytes
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 CHANGELOG_DIR = os.path.join(BASE_DIR, 'changelogs')
@@ -285,8 +286,8 @@ def generate_changelog(changes, plugins, fragments):
     generator = ChangelogGenerator(config, changes, plugins, fragments)
     rst = generator.generate()
 
-    with open(changelog_path, 'w') as changelog_fd:
-        changelog_fd.write(rst)
+    with open(changelog_path, 'wb') as changelog_fd:
+        changelog_fd.write(to_bytes(rst))
 
 
 class ChangelogFragmentLinter(object):


### PR DESCRIPTION
##### SUMMARY

```
[pts/8@peru /srv/ansible/release-2.8/packaging/release]$ make release version=2.8.2        *[stable-2.8]  (09:43:02)
sed -i.bak "s/^__version__ = .*$/__version__ = '2.8.2'/" ../../lib/ansible/release.py
rm ../../lib/ansible/release.py.bak
changelogs/changelog.py release -vv && changelogs/changelog.py generate -vv
INFO version 2.8.2 does not match plugin cache version 2.8.1
INFO refreshing plugin cache
INFO release version 2.8.2 is a release version
INFO skipping fragment v2.8.0rc3_summary.yaml in version 2.8.0rc3 due to newer fragment v2.8.0_summary.yaml in version 2.8.0
INFO skipping fragment v2.8.0rc2_summary.yaml in version 2.8.0rc2 due to newer fragment v2.8.0_summary.yaml in version 2.8.0
INFO skipping fragment v2.8.0rc1_summary.yaml in version 2.8.0rc1 due to newer fragment v2.8.0_summary.yaml in version 2.8.0
INFO skipping fragment v2.8.0b1_summary.yaml in version 2.8.0b1 due to newer fragment v2.8.0_summary.yaml in version 2.8.0
INFO skipping fragment v2.8.0a1_summary.yaml in version 2.8.0a1 due to newer fragment v2.8.0_summary.yaml in version 2.8.0
Traceback (most recent call last):
  File "changelogs/changelog.py", line 833, in <module>
    main()
  File "changelogs/changelog.py", line 101, in main
    args.func(args)
  File "changelogs/changelog.py", line 134, in command_release
    generate_changelog(changes, plugins, fragments)
  File "changelogs/changelog.py", line 289, in generate_changelog
    changelog_fd.write(rst)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 19671: ordinal not in range(128)
make: *** [Makefile:34: changelog] Error 1
```

Python is trying to transform from a text string into a byte string and failing.  Likely triggered by a non-ascii character in a changelog fragment.


##### ISSUE TYPE
- Bugfix Pull Request
