### PR TITLE
- Fixed error handling on aws_kms

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -595,7 +595,7 @@ def update_key(connection, module, key):
                 connection.create_alias(KeyId=key_id, AliasName=alias)
                 changed = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(msg="Failed create key alias")
+                module.fail_json_aws(e, msg="Failed create key alias")
 
     if key['key_state'] == 'PendingDeletion':
         try:


### PR DESCRIPTION
##### SUMMARY
While alias creation failes, this PR fixes the requirement of passing 2 arguments for the `fail_json_aws` method.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_kms

##### ADDITIONAL INFORMATION
Trying to use the `aws_kms` module to update alias on existing key:
- Creating alias fails.
- Module fails, but fails also to call the `fail_json_aws` method.

```
Traceback (most recent call last):
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1562189778.92-156004025381630/AnsiballZ_aws_kms.py", line 114, in <module>
    _ansiballz_main()
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1562189778.92-156004025381630/AnsiballZ_aws_kms.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1562189778.92-156004025381630/AnsiballZ_aws_kms.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_aws_kms_payload_g2M7R4/__main__.py", line 915, in <module>
  File "/tmp/ansible_aws_kms_payload_g2M7R4/__main__.py", line 901, in main
  File "/tmp/ansible_aws_kms_payload_g2M7R4/__main__.py", line 598, in update_key
TypeError: fail_json_aws() takes at least 2 arguments (2 given)
```