### PR TITLE
consul_session: ensure scheme parameter is used

### DIFF
--- a/changelogs/fragments/58692-consul_session_dont_ignore_scheme_parameter.yml
+++ b/changelogs/fragments/58692-consul_session_dont_ignore_scheme_parameter.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "consul_session: don't ignore ``scheme`` parameter"

--- a/lib/ansible/modules/clustering/consul_session.py
+++ b/lib/ansible/modules/clustering/consul_session.py
@@ -232,7 +232,8 @@ def remove_session(module):
 
 def get_consul_api(module):
     return consul.Consul(host=module.params.get('host'),
-                         port=module.params.get('port'))
+                         port=module.params.get('port'),
+                         scheme=module.params.get('scheme'))
 
 
 def test_dependencies(module):

--- a/test/integration/targets/consul/tasks/consul_session.yml
+++ b/test/integration/targets/consul/tasks/consul_session.yml
@@ -70,6 +70,18 @@
     that:
       - result is failed
 
+- name: ensure unknown scheme fails
+  consul_session:
+    state: info
+    id: '{{ session_id }}'
+    scheme: non_existent
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result is failed
+
 - name: delete a session
   consul_session:
     state: absent


### PR DESCRIPTION
##### SUMMARY
consul_session: ensure `scheme` parameter is used

integration test provided

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_session

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
