### PR TITLE
consul_session: ensure certificate is checked when HTTPS is used

### DIFF
--- a/changelogs/fragments/58693-consul_session-validate_certs.yml
+++ b/changelogs/fragments/58693-consul_session-validate_certs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "consul_session - don't ignore ``validate_certs`` parameter"

--- a/lib/ansible/modules/clustering/consul_session.py
+++ b/lib/ansible/modules/clustering/consul_session.py
@@ -233,7 +233,8 @@ def remove_session(module):
 def get_consul_api(module):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
-                         scheme=module.params.get('scheme'))
+                         scheme=module.params.get('scheme'),
+                         verify=module.params.get('validate_certs'))
 
 
 def test_dependencies(module):

--- a/test/integration/targets/consul/tasks/consul_session.yml
+++ b/test/integration/targets/consul/tasks/consul_session.yml
@@ -82,6 +82,51 @@
     that:
       - result is failed
 
+- when: pyopenssl_version.stdout is version('0.15', '>=')
+  block:
+    - name: ensure SSL certificate is checked
+      consul_session:
+        state: info
+        id: '{{ session_id }}'
+        port: 8501
+        scheme: https
+      register: result
+      ignore_errors: True
+
+    - name: previous task should fail since certificate is not known
+      assert:
+        that:
+          - result is failed
+          - "'certificate verify failed' in result.msg"
+
+    - name: ensure SSL certificate isn't checked when validate_certs is disabled
+      consul_session:
+        state: info
+        id: '{{ session_id }}'
+        port: 8501
+        scheme: https
+        validate_certs: False
+      register: result
+
+    - name: previous task should succeed since certificate isn't checked
+      assert:
+        that:
+          - result is changed
+
+    - name: ensure a secure connection is possible
+      consul_session:
+        state: info
+        id: '{{ session_id }}'
+        port: 8501
+        scheme: https
+      environment:
+        REQUESTS_CA_BUNDLE: '{{ remote_dir }}/cert.pem'
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
 - name: delete a session
   consul_session:
     state: absent
@@ -113,5 +158,5 @@
 - name: ensure session was deleted
   assert:
     that:
-      - search_deleted is success
-      - search_deleted is not changed
+      - search_deleted is skipped  # each iteration is skipped
+      - search_deleted is not changed  # and then unchanged

--- a/test/integration/targets/consul/tasks/main.yml
+++ b/test/integration/targets/consul/tasks/main.yml
@@ -71,15 +71,15 @@
       register: result
       until: result is success
 
-    - block:
+    - vars:
+        remote_dir: '{{ echo_output_dir.stdout }}'
+      block:
         # output_dir is hardcoded/created in test/runner/lib/executor.py and
         # contains '~': expand remote path
         - command: 'echo {{ output_dir }}'
           register: echo_output_dir
 
         - name: 'Create configuration file'
-          vars:
-            remote_dir: '{{ echo_output_dir.stdout }}'
           template:
             src: consul_config.hcl.j2
             dest: '{{ output_dir }}/consul_config.hcl'


### PR DESCRIPTION
##### SUMMARY
`consul_session`: ensure that:
* cert is checked when HTTPS is used
* cert isn't checked when `validate_certs` is disabled

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_session

##### ADDITIONAL INFORMATION
Depends on #58692. Currently fails with:
```
Could not retrieve session info 400 Client sent an HTTP request to an HTTPS server
```