### PR TITLE
consul_session: ensure empty result is handled

### DIFF
--- a/changelogs/fragments/58694-consul_session_ensure_empty_result_is_handled.yml
+++ b/changelogs/fragments/58694-consul_session_ensure_empty_result_is_handled.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - consul_session - ``sessions`` returned value is a list even though no sessions were found

--- a/lib/ansible/modules/clustering/consul_session.py
+++ b/lib/ansible/modules/clustering/consul_session.py
@@ -162,7 +162,7 @@ def lookup_sessions(module):
         if state == 'list':
             sessions_list = consul_client.session.list(dc=datacenter)
             # Ditch the index, this can be grabbed from the results
-            if sessions_list and sessions_list[1]:
+            if sessions_list and len(sessions_list) >= 2:
                 sessions_list = sessions_list[1]
             module.exit_json(changed=True,
                              sessions=sessions_list)

--- a/test/integration/targets/consul/tasks/consul_session.yml
+++ b/test/integration/targets/consul/tasks/consul_session.yml
@@ -101,4 +101,5 @@
 - name: ensure session was deleted
   assert:
     that:
-      - not ((search_deleted['results']|map('changed')|list) is any)
+      - search_deleted is success
+      - search_deleted is not changed

--- a/test/integration/targets/consul/tasks/consul_session.yml
+++ b/test/integration/targets/consul/tasks/consul_session.yml
@@ -79,3 +79,26 @@
 - assert:
     that:
       - result is changed
+
+- name: list sessions after deletion
+  consul_session:
+    state: list
+  register: result
+
+- assert:
+    that:
+      - result is changed
+      # selectattr and equalto not available on Jinja 2.2 provided by CentOS 6
+      # hence the two following tasks (command/assert) are used
+      # - (result['sessions'] | selectattr('ID', 'equalto', session_id) | list | length) == 0
+
+- name: search deleted session
+  command: echo 'session found'
+  loop: "{{ result['sessions'] }}"
+  when: "item.get('ID') == session_id and item.get('Name') == 'testsession'"
+  register: search_deleted
+
+- name: ensure session was deleted
+  assert:
+    that:
+      - not ((search_deleted['results']|map('changed')|list) is any)


### PR DESCRIPTION
##### SUMMARY
`consul_session`: ensure empty result is handled, ditch the index even if there is no session.

Integration test provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
consul_session

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```