### PR TITLE
Added NetApp ONTAP Adaptive QoS Policy Module

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
@@ -17,7 +17,7 @@ short_description: NetApp ONTAP Adaptive Quality of Service policy group.
 extends_documentation_fragment:
   - netapp.na_ontap
 version_added: '2.9'
-author: NetApp Professional Services - (@joshedmonds) <edmonds@netapp.com>
+author: NetApp Ansible Team (@joshedmonds) <ng-ansibleteam@netapp.com>
 
 description:
   - Create, destroy, modify, or rename an Adaptive QoS policy group on NetApp ONTAP. Module is based on the standard QoS policy group module.

--- a/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
@@ -1,0 +1,326 @@
+#!/usr/bin/python
+
+# (c) 2018-2019, NetApp, Inc
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = '''
+module: na_ontap_qos_adaptive_policy_group
+short_description: NetApp ONTAP Adaptive Quality of Service policy group.
+extends_documentation_fragment:
+  - netapp.na_ontap
+version_added: '2.9'
+author: NetApp Professional Services - Joshua Edmonds <edmonds@netapp.com>
+
+description:
+  - Create, destroy, modify, or rename an Adaptive QoS policy group on NetApp ONTAP. Module is based on the standard QoS policy group module.
+
+options:
+  state:
+    choices: ['present', 'absent']
+    description:
+      - Whether the specified policy group should exist or not.
+    default: 'present'
+
+  name:
+    description:
+    - The name of the policy group to manage.
+
+  vserver:
+    description:
+    - Name of the vserver to use.
+
+  from_name:
+    description:
+    - Name of the existing policy group to be renamed to name.
+
+  absolute_min_iops:
+    description:
+    - Absolute minimum IOPS defined by this policy.
+
+  expected_iops:
+    description:
+    - Minimum expected IOPS defined by this policy.
+
+  peak_iops:
+    description:
+    - Maximum possible IOPS per allocated or used TB|GB.
+
+  peak_iops_allocation:
+    description:
+    - Whether peak_iops is specified by allocated or used space.
+
+  force:
+    type: bool
+    default: False
+    description:
+    - Setting to 'true' forces the deletion of the workloads associated with the policy group along with the policy group.
+'''
+
+EXAMPLES = """
+    - name: create adaptive qos policy group
+      na_ontap_qos_adaptive_policy_group:
+        state: present
+        name: aq_policy_1
+        vserver: policy_vserver
+        absolute_min_iops: 70IOPS
+        expected_iops: 100IOPS/TB
+        peak_iops: 250IOPS/TB
+        peak_iops_allocation: allocated_space
+        hostname: 10.193.78.30
+        username: admin
+        password: netapp1!
+
+    - name: modify adaptive qos policy group expected iops
+      na_ontap_qos_adaptive_policy_group:
+        state: present
+        name: aq_policy_1
+        vserver: policy_vserver
+        absolute_min_iops: 70IOPS
+        expected_iops: 125IOPS/TB
+        peak_iops: 250IOPS/TB
+        peak_iops_allocation: allocated_space
+        hostname: 10.193.78.30
+        username: admin
+        password: netapp1!
+
+    - name: modify adaptive qos policy group peak iops allocation
+      na_ontap_qos_adaptive_policy_group:
+        state: present
+        name: aq_policy_1
+        vserver: policy_vserver
+        absolute_min_iops: 70IOPS
+        expected_iops: 125IOPS/TB
+        peak_iops: 250IOPS/TB
+        peak_iops_allocation: used_space
+        hostname: 10.193.78.30
+        username: admin
+        password: netapp1!
+
+    - name: delete qos policy group
+      na_ontap_qos_adaptive_policy_group:
+        state: absent
+        name: aq_policy_1
+        vserver: policy_vserver
+        hostname: 10.193.78.30
+        username: admin
+        password: netapp1!
+
+"""
+
+RETURN = """
+"""
+
+import traceback
+
+import ansible.module_utils.netapp as netapp_utils
+from ansible.module_utils.netapp_module import NetAppModule
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
+
+
+class NetAppOntapAdaptiveQosPolicyGroup(object):
+    """
+    Create, delete, modify and rename a policy group.
+    """
+    def __init__(self):
+        """
+        Initialize the Ontap qos policy group class.
+        """
+        self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
+        self.argument_spec.update(dict(
+            state=dict(required=False, type='str', choices=['present', 'absent'], default='present'),
+            name=dict(required=True, type='str'),
+            from_name=dict(required=False, type='str'),
+            vserver=dict(required=True, type='str'),
+            absolute_min_iops=dict(required=False, type='str'),
+            expected_iops=dict(required=False, type='str'),
+            peak_iops=dict(required=False, type='str'),
+            peak_iops_allocation=dict(choices=['allocated_space', 'used_space'], default='used_space'),
+            force=dict(required=False, type='bool', default=False)
+        ))
+
+        self.module = AnsibleModule(
+            argument_spec=self.argument_spec,
+            supports_check_mode=True
+        )
+        self.na_helper = NetAppModule()
+        self.parameters = self.na_helper.set_parameters(self.module.params)
+
+        if HAS_NETAPP_LIB is False:
+            self.module.fail_json(
+                msg="the python NetApp-Lib module is required")
+        else:
+            self.server = netapp_utils.setup_na_ontap_zapi(
+                module=self.module)
+
+    def get_policy_group(self, policy_group_name=None):
+        """
+        Return details of a policy group.
+        :param policy_group_name: policy group name
+        :return: policy group details.
+        :rtype: dict.
+        """
+        if policy_group_name is None:
+            policy_group_name = self.parameters['name']
+        policy_group_get_iter = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-get-iter')
+        policy_group_info = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-info')
+        policy_group_info.add_new_child('policy-group', policy_group_name)
+        query = netapp_utils.zapi.NaElement('query')
+        query.add_child_elem(policy_group_info)
+        policy_group_get_iter.add_child_elem(query)
+        result = self.server.invoke_successfully(policy_group_get_iter, True)
+        policy_group_detail = None
+
+        if result.get_child_by_name('num-records') and int(result.get_child_content('num-records')) == 1:
+            policy_info = result.get_child_by_name('attributes-list').get_child_by_name('qos-adaptive-policy-group-info')
+
+            policy_group_detail = {
+                'name': policy_info.get_child_content('policy-group'),
+                'vserver': policy_info.get_child_content('vserver'),
+                'absolute_min_iops': policy_info.get_child_content('absolute-min-iops'),
+                'expected_iops': policy_info.get_child_content('expected-iops'),
+                'peak_iops': policy_info.get_child_content('peak-iops'),
+                'peak_iops_allocation': policy_info.get_child_content('peak-iops-allocation')
+            }
+        return policy_group_detail
+
+    def create_policy_group(self):
+        """
+        create a policy group name.
+        """
+        policy_group = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-create')
+        policy_group.add_new_child('policy-group', self.parameters['name'])
+        policy_group.add_new_child('vserver', self.parameters['vserver'])
+        if self.parameters.get('absolute_min_iops'):
+            policy_group.add_new_child('absolute-min-iops', self.parameters['absolute_min_iops'])
+        if self.parameters.get('expected_iops'):
+            policy_group.add_new_child('expected-iops', self.parameters['expected_iops'])
+        if self.parameters.get('peak_iops'):
+            policy_group.add_new_child('peak-iops', self.parameters['peak_iops'])
+        if self.parameters.get('peak_iops_allocation'):
+            policy_group.add_new_child('peak-iops-allocation', self.parameters['peak_iops_allocation'])
+        try:
+            self.server.invoke_successfully(policy_group, True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error creating adaptive qos policy group %s: %s' %
+                                  (self.parameters['name'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def delete_policy_group(self, policy_group=None):
+        """
+        delete an existing policy group.
+        :param policy_group: policy group name.
+        """
+        if policy_group is None:
+            policy_group = self.parameters['name']
+        policy_group_obj = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-delete')
+        policy_group_obj.add_new_child('policy-group', policy_group)
+        if self.parameters.get('force'):
+            policy_group_obj.add_new_child('force', str(self.parameters['force']))
+        try:
+            self.server.invoke_successfully(policy_group_obj, True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error deleting adaptive qos policy group %s: %s' %
+                                  (policy_group, to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def modify_policy_group(self):
+        """
+        Modify policy group.
+        """
+        policy_group_obj = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-modify')
+        policy_group_obj.add_new_child('policy-group', self.parameters['name'])
+        if self.parameters.get('absolute_min_iops'):
+            policy_group_obj.add_new_child('absolute-min-iops', self.parameters['absolute_min_iops'])
+        if self.parameters.get('expected_iops'):
+            policy_group_obj.add_new_child('expected-iops', self.parameters['expected_iops'])
+        if self.parameters.get('peak_iops'):
+            policy_group_obj.add_new_child('peak-iops', self.parameters['peak_iops'])
+        if self.parameters.get('peak_iops_allocation'):
+            policy_group_obj.add_new_child('peak-iops-allocation', self.parameters['peak_iops_allocation'])
+        try:
+            self.server.invoke_successfully(policy_group_obj, True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error modifying adaptive qos policy group %s: %s' %
+                                      (self.parameters['name'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def rename_policy_group(self):
+        """
+        Rename policy group name.
+        """
+        rename_obj = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-rename')
+        rename_obj.add_new_child('new-name', self.parameters['name'])
+        rename_obj.add_new_child('policy-group-name', self.parameters['from_name'])
+        try:
+            self.server.invoke_successfully(rename_obj, True)
+        except netapp_utils.zapi.NaApiError as error:
+            self.module.fail_json(msg='Error renaming adaptive qos policy group %s: %s' %
+                                      (self.parameters['from_name'], to_native(error)),
+                                  exception=traceback.format_exc())
+
+    def modify_helper(self, modify):
+        """
+        helper method to modify policy group.
+        :param modify: modified attributes.
+        """
+        for attribute in modify.keys():
+            if attribute in ['absolute_min_iops', 'expected_iops', 'peak_iops', 'peak_iops_allocation']:
+                self.modify_policy_group()
+
+    def apply(self):
+        """
+        Run module based on playbook
+        """
+        self.asup_log_for_cserver("na_ontap_qos_policy_group")
+        current = self.get_policy_group()
+        rename, cd_action = None, None
+        if self.parameters.get('from_name'):
+            rename = self.na_helper.is_rename_action(self.get_policy_group(self.parameters['from_name']), current)
+        else:
+            cd_action = self.na_helper.get_cd_action(current, self.parameters)
+        modify = self.na_helper.get_modified_attributes(current, self.parameters)
+        if self.na_helper.changed:
+            if self.module.check_mode:
+                pass
+            else:
+                if rename:
+                    self.rename_policy_group()
+                if cd_action == 'create':
+                    self.create_policy_group()
+                elif cd_action == 'delete':
+                    self.delete_policy_group()
+                elif modify:
+                    self.modify_helper(modify)
+        self.module.exit_json(changed=self.na_helper.changed)
+
+    def asup_log_for_cserver(self, event_name):
+        """
+        Fetch admin vserver for the given cluster
+        Create and Autosupport log event with the given module name
+        :param event_name: Name of the event log
+        :return: None
+        """
+        results = netapp_utils.get_cserver(self.server)
+        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
+        netapp_utils.ems_log_event(event_name, cserver)
+
+
+def main():
+    '''Apply vserver operations from playbook'''
+    qos_policy_group = NetAppOntapAdaptiveQosPolicyGroup()
+    qos_policy_group.apply()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
@@ -324,6 +324,7 @@ class NetAppOntapAdaptiveQosPolicyGroup(object):
         server = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=self.parameters['vserver'])
         netapp_utils.ems_log_event(event_name, server)
 
+
 def main():
     '''Apply vserver operations from playbook'''
     qos_policy_group = NetAppOntapAdaptiveQosPolicyGroup()

--- a/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
@@ -34,11 +34,13 @@ options:
     description:
     - The name of the policy group to manage.
     type: str
+    required: true
 
   vserver:
     description:
     - Name of the vserver to use.
     type: str
+    required: true
 
   from_name:
     description:
@@ -185,6 +187,7 @@ class NetAppOntapAdaptiveQosPolicyGroup(object):
         policy_group_get_iter = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-get-iter')
         policy_group_info = netapp_utils.zapi.NaElement('qos-adaptive-policy-group-info')
         policy_group_info.add_new_child('policy-group', policy_group_name)
+        policy_group_info.add_new_child('vserver', self.parameters['vserver'])
         query = netapp_utils.zapi.NaElement('query')
         query.add_child_elem(policy_group_info)
         policy_group_get_iter.add_child_elem(query)
@@ -292,7 +295,7 @@ class NetAppOntapAdaptiveQosPolicyGroup(object):
         """
         Run module based on playbook
         """
-        self.asup_log_for_cserver("na_ontap_qos_policy_group")
+        self.autosupport_log("na_ontap_qos_policy_group")
         current = self.get_policy_group()
         rename, cd_action = None, None
         if self.parameters.get('from_name'):
@@ -314,17 +317,12 @@ class NetAppOntapAdaptiveQosPolicyGroup(object):
                     self.modify_helper(modify)
         self.module.exit_json(changed=self.na_helper.changed)
 
-    def asup_log_for_cserver(self, event_name):
+    def autosupport_log(self, event_name):
         """
-        Fetch admin vserver for the given cluster
-        Create and Autosupport log event with the given module name
-        :param event_name: Name of the event log
-        :return: None
+        Create a log event against the provided vserver
         """
-        results = netapp_utils.get_cserver(self.server)
-        cserver = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=results)
-        netapp_utils.ems_log_event(event_name, cserver)
-
+        server = netapp_utils.setup_na_ontap_zapi(module=self.module, vserver=self.parameters['vserver'])
+        netapp_utils.ems_log_event(event_name, server)
 
 def main():
     '''Apply vserver operations from playbook'''

--- a/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_qos_adaptive_policy_group.py
@@ -17,7 +17,7 @@ short_description: NetApp ONTAP Adaptive Quality of Service policy group.
 extends_documentation_fragment:
   - netapp.na_ontap
 version_added: '2.9'
-author: NetApp Professional Services - Joshua Edmonds <edmonds@netapp.com>
+author: NetApp Professional Services - (@joshedmonds) <edmonds@netapp.com>
 
 description:
   - Create, destroy, modify, or rename an Adaptive QoS policy group on NetApp ONTAP. Module is based on the standard QoS policy group module.
@@ -28,34 +28,44 @@ options:
     description:
       - Whether the specified policy group should exist or not.
     default: 'present'
+    type: str
 
   name:
     description:
     - The name of the policy group to manage.
+    type: str
 
   vserver:
     description:
     - Name of the vserver to use.
+    type: str
 
   from_name:
     description:
     - Name of the existing policy group to be renamed to name.
+    type: str
 
   absolute_min_iops:
     description:
     - Absolute minimum IOPS defined by this policy.
+    type: str
 
   expected_iops:
     description:
     - Minimum expected IOPS defined by this policy.
+    type: str
 
   peak_iops:
     description:
     - Maximum possible IOPS per allocated or used TB|GB.
+    type: str
 
   peak_iops_allocation:
+    choices: ['allocated_space', 'used_space']
     description:
-    - Whether peak_iops is specified by allocated or used space.
+      - Whether peak_iops is specified by allocated or used space.
+    default: 'used_space'
+    type: str
 
   force:
     type: bool

--- a/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
@@ -3,7 +3,8 @@
 
 ''' unit test template for ONTAP Ansible module '''
 
-from __future__ import print_function
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 import json
 import pytest
 

--- a/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
@@ -132,7 +132,6 @@ class TestMyModule(unittest.TestCase):
         :return: na_ontap_volume object
         """
         policy_obj = qos_policy_group_module()
-        #policy_obj.asup_log_for_cserver = Mock(return_value=None)
         policy_obj.autosupport_log = Mock(return_value=None)
         policy_obj.cluster = Mock()
         policy_obj.cluster.invoke_successfully = Mock()

--- a/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
@@ -132,7 +132,8 @@ class TestMyModule(unittest.TestCase):
         :return: na_ontap_volume object
         """
         policy_obj = qos_policy_group_module()
-        policy_obj.asup_log_for_cserver = Mock(return_value=None)
+        #policy_obj.asup_log_for_cserver = Mock(return_value=None)
+        policy_obj.autosupport_log = Mock(return_value=None)
         policy_obj.cluster = Mock()
         policy_obj.cluster.invoke_successfully = Mock()
         if kind is None:

--- a/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
+++ b/test/units/modules/storage/netapp/test_na_ontap_qos_adaptive_policy_group.py
@@ -1,0 +1,346 @@
+# (c) 2018, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+''' unit test template for ONTAP Ansible module '''
+
+from __future__ import print_function
+import json
+import pytest
+
+from units.compat import unittest
+from units.compat.mock import patch, Mock
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+import ansible.module_utils.netapp as netapp_utils
+
+from ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group \
+    import NetAppOntapAdaptiveQosPolicyGroup as qos_policy_group_module  # module under test
+
+if not netapp_utils.has_netapp_lib():
+    pytestmark = pytest.mark.skip('skipping as missing required netapp_lib')
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation"""
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)  # pylint: disable=protected-access
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the test case"""
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the test case"""
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an exception"""
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over fail_json; package return data into an exception"""
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class MockONTAPConnection(object):
+    ''' mock server connection to ONTAP host '''
+
+    def __init__(self, kind=None, data=None):
+        ''' save arguments '''
+        self.kind = kind
+        self.params = data
+        self.xml_in = None
+        self.xml_out = None
+
+    def invoke_successfully(self, xml, enable_tunneling):  # pylint: disable=unused-argument
+        ''' mock invoke_successfully returning xml data '''
+        self.xml_in = xml
+        if self.kind == 'policy':
+            xml = self.build_policy_group_info(self.params)
+        if self.kind == 'error':
+            error = netapp_utils.zapi.NaApiError('test', 'error')
+            raise error
+        self.xml_out = xml
+        return xml
+
+    @staticmethod
+    def build_policy_group_info(vol_details):
+        ''' build xml data for volume-attributes '''
+        xml = netapp_utils.zapi.NaElement('xml')
+        attributes = {
+            'num-records': 1,
+            'attributes-list': {
+                'qos-adaptive-policy-group-info': {
+                    'absolute-min-iops': '50IOPS',
+                    'expected-iops': '150IOPS/TB',
+                    'peak-iops': '220IOPS/TB',
+                    'peak-iops-allocation': 'used_space',
+                    'num-workloads': 0,
+                    'pgid': 6941,
+                    'policy-group': vol_details['name'],
+                    'vserver': vol_details['vserver']
+                }
+            }
+        }
+        xml.translate_struct(attributes)
+        return xml
+
+
+class TestMyModule(unittest.TestCase):
+    ''' a group of related Unit Tests '''
+
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.mock_policy_group = {
+            'name': 'policy_1',
+            'vserver': 'policy_vserver',
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space'
+        }
+
+    def mock_args(self):
+        return {
+            'name': self.mock_policy_group['name'],
+            'vserver': self.mock_policy_group['vserver'],
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'hostname': 'test',
+            'username': 'test_user',
+            'password': 'test_pass!',
+            'https': 'False'
+        }
+
+    def get_policy_group_mock_object(self, kind=None):
+        """
+        Helper method to return an na_ontap_volume object
+        :param kind: passes this param to MockONTAPConnection()
+        :return: na_ontap_volume object
+        """
+        policy_obj = qos_policy_group_module()
+        policy_obj.asup_log_for_cserver = Mock(return_value=None)
+        policy_obj.cluster = Mock()
+        policy_obj.cluster.invoke_successfully = Mock()
+        if kind is None:
+            policy_obj.server = MockONTAPConnection()
+        else:
+            policy_obj.server = MockONTAPConnection(kind=kind, data=self.mock_policy_group)
+        return policy_obj
+
+    def test_module_fail_when_required_args_missing(self):
+        ''' required arguments are reported as errors '''
+        with pytest.raises(AnsibleFailJson) as exc:
+            set_module_args({})
+            qos_policy_group_module()
+        print('Info: %s' % exc.value.args[0]['msg'])
+
+    def test_get_nonexistent_policy(self):
+        ''' Test if get_policy_group returns None for non-existent policy_group '''
+        set_module_args(self.mock_args())
+        result = self.get_policy_group_mock_object().get_policy_group()
+        assert result is None
+
+    def test_get_existing_policy_group(self):
+        ''' Test if get_policy_group returns details for existing policy_group '''
+        set_module_args(self.mock_args())
+        result = self.get_policy_group_mock_object('policy').get_policy_group()
+        assert result['name'] == self.mock_policy_group['name']
+        assert result['vserver'] == self.mock_policy_group['vserver']
+
+    def test_create_error_missing_param(self):
+        ''' Test if create throws an error if name is not specified'''
+        data = self.mock_args()
+        del data['name']
+        set_module_args(data)
+        with pytest.raises(AnsibleFailJson) as exc:
+            self.get_policy_group_mock_object('policy').create_policy_group()
+        msg = 'missing required arguments: name'
+        assert exc.value.args[0]['msg'] == msg
+
+    def test_successful_create(self):
+        ''' Test successful create '''
+        data = self.mock_args()
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object().apply()
+        assert exc.value.args[0]['changed']
+
+    def test_create_idempotency(self):
+        ''' Test create idempotency '''
+        set_module_args(self.mock_args())
+        obj = self.get_policy_group_mock_object('policy')
+        with pytest.raises(AnsibleExitJson) as exc:
+            obj.apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_create_error(self, get_policy_group):
+        ''' Test create error '''
+        set_module_args(self.mock_args())
+        get_policy_group.side_effect = [
+            None
+        ]
+        with pytest.raises(AnsibleFailJson) as exc:
+            self.get_policy_group_mock_object('error').apply()
+        assert exc.value.args[0]['msg'] == 'Error creating adaptive qos policy group policy_1: NetApp API failed. Reason - test:error'
+
+    def test_successful_delete(self):
+        ''' Test delete existing volume '''
+        data = self.mock_args()
+        data['state'] = 'absent'
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object('policy').apply()
+        assert exc.value.args[0]['changed']
+
+    def test_delete_idempotency(self):
+        ''' Test delete idempotency '''
+        data = self.mock_args()
+        data['state'] = 'absent'
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object().apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_delete_error(self, get_policy_group):
+        ''' Test create idempotency'''
+        data = self.mock_args()
+        data['state'] = 'absent'
+        set_module_args(data)
+        current = {
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'name': 'policy_1',
+            'vserver': 'policy_vserver'
+        }
+        get_policy_group.side_effect = [
+            current
+        ]
+        with pytest.raises(AnsibleFailJson) as exc:
+            self.get_policy_group_mock_object('error').apply()
+        assert exc.value.args[0]['msg'] == 'Error deleting adaptive qos policy group policy_1: NetApp API failed. Reason - test:error'
+
+    def test_successful_modify_expected_iops(self):
+        ''' Test successful modify expected iops '''
+        data = self.mock_args()
+        data['expected_iops'] = '175IOPS'
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object('policy').apply()
+        assert exc.value.args[0]['changed']
+
+    def test_modify_expected_iops_idempotency(self):
+        ''' Test modify idempotency '''
+        data = self.mock_args()
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object('policy').apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_modify_error(self, get_policy_group):
+        ''' Test create idempotency '''
+        data = self.mock_args()
+        data['expected_iops'] = '175IOPS'
+        set_module_args(data)
+        current = {
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'name': 'policy_1',
+            'vserver': 'policy_vserver'
+        }
+        get_policy_group.side_effect = [
+            current
+        ]
+        with pytest.raises(AnsibleFailJson) as exc:
+            self.get_policy_group_mock_object('error').apply()
+        assert exc.value.args[0]['msg'] == 'Error modifying adaptive qos policy group policy_1: NetApp API failed. Reason - test:error'
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_rename(self, get_policy_group):
+        ''' Test rename idempotency '''
+        data = self.mock_args()
+        data['name'] = 'policy_2'
+        data['from_name'] = 'policy_1'
+        set_module_args(data)
+        current = {
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'name': 'policy_1',
+            'vserver': 'policy_vserver'
+        }
+        get_policy_group.side_effect = [
+            None,
+            current
+        ]
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object('policy').apply()
+        assert exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_rename_idempotency(self, get_policy_group):
+        ''' Test rename idempotency '''
+        data = self.mock_args()
+        data['name'] = 'policy_1'
+        data['from_name'] = 'policy_1'
+        current = {
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'name': 'policy_1',
+            'vserver': 'policy_vserver'
+        }
+        get_policy_group.side_effect = [
+            current,
+            current
+        ]
+        set_module_args(data)
+        with pytest.raises(AnsibleExitJson) as exc:
+            self.get_policy_group_mock_object('policy').apply()
+        assert not exc.value.args[0]['changed']
+
+    @patch('ansible.modules.storage.netapp.na_ontap_qos_adaptive_policy_group.NetAppOntapAdaptiveQosPolicyGroup.get_policy_group')
+    def test_rename_error(self, get_policy_group):
+        ''' Test create idempotency '''
+        data = self.mock_args()
+        data['from_name'] = 'policy_1'
+        data['name'] = 'policy_2'
+        set_module_args(data)
+        current = {
+            'absolute_min_iops': '50IOPS',
+            'expected_iops': '150IOPS/TB',
+            'peak_iops': '220IOPS/TB',
+            'peak_iops_allocation': 'used_space',
+            'is_shared': 'true',
+            'name': 'policy_1',
+            'vserver': 'policy_vserver'
+        }
+        get_policy_group.side_effect = [
+            None,
+            current
+        ]
+        with pytest.raises(AnsibleFailJson) as exc:
+            self.get_policy_group_mock_object('error').apply()
+        assert exc.value.args[0]['msg'] == 'Error renaming adaptive qos policy group policy_1: NetApp API failed. Reason - test:error'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
na_ontap_qos_adaptive_policy_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example playbook to create, modify and rename an Adaptive QoS Policy Group
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- hosts: localhost

  vars:
   login: &login
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
     https: true
     validate_certs: false

 name: basic provisioning testing
 tasks:
   - name: create qos policy group
     na_ontap_qos_adaptive_policy_group:
       state: present
       name: aqos_new
       vserver: je_ansible
       absolute_min_iops: 50IOPS
       expected_iops: 150IOPS/TB
       peak_iops: 220IOPS/TB
       peak_iops_allocation: allocated_space
       <<: *login
    - name: modify qos policy group
      na_ontap_qos_adaptive_policy_group:
        state: present
        name: adaptive_qos_pol1
        vserver: je_ansible
        absolute_min_iops: 75IOPS
        expected_iops: 200IOPS/TB
        peak_iops: 300IOPS/TB
        peak_iops_allocation: allocated_space
        <<: *login
    - name: rename qos policy group
      na_ontap_qos_adaptive_policy_group:
        state: present
        name: adaptive_qos_pol1_renamed
        from_name: adaptive_qos_pol1
        vserver: je_ansible
        absolute_min_iops: 75IOPS
        expected_iops: 200IOPS/TB
        peak_iops: 300IOPS/TB
        peak_iops_allocation: allocated_space
        <<: *login



```
Playbook output (create):
```python
TASK [create qos policy group] 
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "absolute_min_iops": "50IOPS",
            "expected_iops": "150IOPS/TB",
            "force": false,
            "from_name": null,
            "hostname": "cluster1",
            "http_port": null,
            "https": true,
            "name": "adaptive_qos_pol1",
            "ontapi": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "peak_iops": "220IOPS/TB",
            "peak_iops_allocation": "allocated_space",
            "state": "present",
            "username": "admin",
            "validate_certs": false,
            "vserver": "je_ansible"
        }
    }
}
```
ONTAP output (create):
```
::> qos adaptive-policy-group show -policy-group adaptive_qos_pol1

                 Name: adaptive_qos_pol1
              Vserver: je_ansible
                 Uuid: b3b2f429-9e1e-11e9-a00e-00a0b8eb802b
                   ID: 4174
        Expected IOPS: 150IOPS/TB
            Peak IOPS: 220IOPS/TB
Absolute Minimum IOPS: 50IOPS
 Peak IOPS Allocation: allocated-space
  Number of Workloads: 0
```

Playbook output (modify):
```python
TASK [modify qos policy group]
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "absolute_min_iops": "75IOPS",
            "expected_iops": "200IOPS/TB",
            "force": false,
            "from_name": null,
            "hostname": "cluster1",
            "http_port": null,
            "https": true,
            "name": "adaptive_qos_pol1",
            "ontapi": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "peak_iops": "300IOPS/TB",
            "peak_iops_allocation": "allocated_space",
            "state": "present",
            "username": "admin",
            "validate_certs": false,
            "vserver": "je_ansible"
        }
    }
}
```
ONTAP output (modify):
```
::> qos adaptive-policy-group show -policy-group adaptive_qos_pol1

                 Name: adaptive_qos_pol1
              Vserver: je_ansible
                 Uuid: b3b2f429-9e1e-11e9-a00e-00a0b8eb802b
                   ID: 4174
        Expected IOPS: 200IOPS/TB
            Peak IOPS: 300IOPS/TB
Absolute Minimum IOPS: 75IOPS
 Peak IOPS Allocation: allocated-space
  Number of Workloads: 0
```
Playbook output (rename):
```python
TASK [rename qos policy group]
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "absolute_min_iops": "75IOPS",
            "expected_iops": "200IOPS/TB",
            "force": false,
            "from_name": "adaptive_qos_pol1",
            "hostname": "nse-ots-per01.ausngs.netapp.au",
            "http_port": null,
            "https": true,
            "name": "adaptive_qos_pol1_renamed",
            "ontapi": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "peak_iops": "300IOPS/TB",
            "peak_iops_allocation": "allocated_space",
            "state": "present",
            "username": "admin",
            "validate_certs": false,
            "vserver": "je_ansible"
        }
    }
}
```
ONTAP output (rename):
```
::> qos adaptive-policy-group show -policy-group adaptive_qos_pol1_renamed

                 Name: adaptive_qos_pol1_renamed
              Vserver: je_ansible
                 Uuid: b3b2f429-9e1e-11e9-a00e-00a0b8eb802b
                   ID: 4174
        Expected IOPS: 200IOPS/TB
            Peak IOPS: 300IOPS/TB
Absolute Minimum IOPS: 75IOPS
 Peak IOPS Allocation: allocated-space
  Number of Workloads: 0
```
Playbook output (delete):
```python
TASK [delete qos policy group]
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "absolute_min_iops": null,
            "expected_iops": null,
            "force": false,
            "from_name": null,
            "hostname": "cluster1",
            "http_port": null,
            "https": true,
            "name": "adaptive_qos_pol1",
            "ontapi": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "peak_iops": null,
            "peak_iops_allocation": "used_space",
            "state": "absent",
            "username": "admin",
            "validate_certs": false,
            "vserver": "je_ansible"
        }
    }
}
```
ONTAP output (delete):
```
::> qos adaptive-policy-group show -policy-group adaptive_qos_pol1
There are no entries matching your query.
```