### PR TITLE
feat: support postgres 11 in azure_rm_postgresqlserver

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_postgresqlserver.py
@@ -63,6 +63,7 @@ options:
             - '9.5'
             - '9.6'
             - '10'
+            - '11'
     enforce_ssl:
         description:
             - Enable SSL enforcement.
@@ -119,7 +120,7 @@ id:
     sample: /subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/myResourceGroup/providers/Microsoft.DBforPostgreSQL/servers/mysqlsrv1b6dd89593
 version:
     description:
-        - Server version. Possible values include C(9.5), C(9.6), C(10).
+        - Server version. Possible values include C(9.5), C(9.6), C(10), C(11).
     returned: always
     type: str
     sample: 9.6
@@ -178,7 +179,7 @@ class AzureRMPostgreSqlServers(AzureRMModuleBase):
             ),
             version=dict(
                 type='str',
-                choices=['9.5', '9.6', '10']
+                choices=['9.5', '9.6', '10', '11']
             ),
             enforce_ssl=dict(
                 type='bool',


### PR DESCRIPTION
##### SUMMARY

Add support to Azure Postgres 10.x (see [azure official docs](https://docs.microsoft.com/lv-lv/azure//postgresql/concepts-supported-versions)).

##### ISSUE TYPE

* Feature Pull Request

##### COMPONENT NAME
azure_rm_postgresqlserver

##### ADDITIONAL INFORMATION
```
ansible 2.7.0
  config file = None
  configured module search path = [u'/Users/xyz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.15 (default, Jul 23 2018, 21:31:33) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```

See azure portal screenshot

![image](https://user-images.githubusercontent.com/26145086/60666100-85ca6f00-9e66-11e9-946b-5dfd38e68eaa.png)
