### PR TITLE
Correct machinectl become plugin function arguments

### DIFF
--- a/changelogs/fragments/58734-correct-machinectl-become-plugin.yaml
+++ b/changelogs/fragments/58734-correct-machinectl-become-plugin.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - machinectl become plugin - call proper get_option method
+  - machinectl become plugin - correct configuration option

--- a/changelogs/fragments/58734-correct-machinectl-become-plugin.yaml
+++ b/changelogs/fragments/58734-correct-machinectl-become-plugin.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - machinectl become plugin - call proper get_option method
-  - machinectl become plugin - correct configuration option
+  - machinectl become plugin - correct bugs which induced errors on plugin usage

--- a/lib/ansible/plugins/become/machinectl.py
+++ b/lib/ansible/plugins/become/machinectl.py
@@ -84,4 +84,4 @@ class BecomeModule(BecomeBase):
         become = self.get_option('become_exe') or self.name
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
-        return '%s shell -q %s %s@ -- %s' % (become, flags, user, cmd)
+        return '%s shell -q %s %s@ %s' % (become, flags, user, cmd)

--- a/lib/ansible/plugins/become/machinectl.py
+++ b/lib/ansible/plugins/become/machinectl.py
@@ -84,4 +84,4 @@ class BecomeModule(BecomeBase):
         become = self.get_option('become_exe') or self.name
         flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
-        return '%s shell -q %s %s@ %s' % (become, flags, user, cmd)
+        return '%s -q shell %s %s@ %s' % (become, flags, user, cmd)

--- a/lib/ansible/plugins/become/machinectl.py
+++ b/lib/ansible/plugins/become/machinectl.py
@@ -81,7 +81,7 @@ class BecomeModule(BecomeBase):
         if not cmd:
             return cmd
 
-        become = self._get_option('become_exe') or self.name
-        flags = self.get_option('flags') or ''
+        become = self.get_option('become_exe') or self.name
+        flags = self.get_option('become_flags') or ''
         user = self.get_option('become_user') or ''
         return '%s shell -q %s %s@ -- %s' % (become, flags, user, cmd)


### PR DESCRIPTION
##### SUMMARY

This pull request resolves a couple of bugs within the machinectl become plugin introduced when it was moved from the hardcoded setup to the modular setup with ansible 2.8.

- Changed a function call to `_get_option` to `get_option` to prevent an `AttributeError`.
- Changed an argument to `get_option` from `"flags"` to `"become_flags"` to prevent `ansible.errors.AnsibleError`.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
become