### PR TITLE
VMware: Fix vmware_guest cloning bug

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1862,7 +1862,9 @@ class PyVmomiHelper(PyVmomi):
                 continue
             elif vm_obj is None or self.params['template']:
                 # We are creating new VM or from Template
-                diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
+                # Only create virtual device if not backed by vmdk in original template
+                if diskspec.device.backing.fileName == '':
+                    diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
 
             # which datastore?
             if expected_disk_spec.get('datastore'):

--- a/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
@@ -1,0 +1,75 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Noe Gonzalez <noe.a.gonzalez@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: create new VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: clone_resize_disks_original
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    folder: "{{ f0 }}"
+    hardware:
+      num_cpus: 1
+      memory_mb: 128
+    guest_id: centos7_64Guest
+    disk:
+      - size_gb: 1
+        type: thin
+        autoselect_datastore: True
+    state: poweredoff
+
+- name: convert to VM template
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: clone_resize_disks_original
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    folder: "{{ f0 }}"
+    is_template: True
+
+- name: clone template and modify disks
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: clone_resize_disks_clone
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    folder: "{{ f0 }}"
+    disk:
+      - size_gb: 2
+        type: thin
+        autoselect_datastore: True
+      - size_gb: 3
+        type: thin
+        autoselect_datastore: True
+    template: clone_resize_disks_original
+    state: poweredoff
+  register: l_clone_template_modify_disks
+
+- assert:
+    that:
+      - l_clone_template_modify_disks.changed | bool
+
+- name: delete VM clone & original template
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ item }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    folder: "{{ f0 }}"
+    state: absent
+  with_items:
+    - clone_resize_disks_original
+    - clone_resize_disks_clone

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -38,10 +38,10 @@
         force: yes
         state: absent
       with_items:
-        - clone_resize_disks_original
-        - clone_resize_disks_clone
         - CDROM-Test
         - CDROM-Test-38679
+        - clone_resize_disks_clone
+        - clone_resize_disks_original
         - newvm_2
         - newvm_3
         - newvmnw_4

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -15,6 +15,7 @@
     - include: poweroff_d1_c1_f0.yml
     - include: poweroff_d1_c1_f1.yml
     - include: check_mode.yml
+    - include: clone_resize_disks.yml
     - include: clone_d1_c1_f0.yml
     - include: create_d1_c1_f0.yml
     - include: cdrom_d1_c1_f0.yml
@@ -37,6 +38,8 @@
         force: yes
         state: absent
       with_items:
+        - clone_resize_disks_original
+        - clone_resize_disks_clone
         - CDROM-Test
         - CDROM-Test-38679
         - newvm_2


### PR DESCRIPTION
##### SUMMARY
Fixes #58721, #56861, #55551

VM cloning in 2.8 tries to create new disks even if they already exist in the original template.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION

This PR adds a conditional check that only creates new virtual devices if they aren't based off an existing disk.