### PR TITLE
Add new network modules to control/manage QUANTA switches

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_index.rst
+++ b/docs/docsite/rst/network/user_guide/platform_index.rst
@@ -23,6 +23,7 @@ Some Ansible Network platforms support multiple connection types, privilege esca
    platform_netvisor
    platform_nos
    platform_nxos
+   platform_qnos
    platform_routeros
    platform_slxos
    platform_voss
@@ -79,6 +80,8 @@ Settings by Platform
 | Nokia SR OS       | ``sros``                | ✓           |         |         | ✓        |
 +-------------------+-------------------------+-------------+---------+---------+----------+
 | Pluribus Netvisor | ``netvisor``            | ✓           |         |         |          |
++-------------------+-------------------------+-------------+---------+---------+----------+
+| Quanta QNOS       | ``qnos``                | ✓           |         |         |          |
 +-------------------+-------------------------+-------------+---------+---------+----------+
 | VyOS*             | ``vyos``                | ✓           |         |         | ✓        |
 +-------------------+-------------------------+-------------+---------+---------+----------+

--- a/docs/docsite/rst/network/user_guide/platform_qnos.rst
+++ b/docs/docsite/rst/network/user_guide/platform_qnos.rst
@@ -1,0 +1,74 @@
+.. _qnos_platform_options:
+
+***************************************
+QNOS Platform Options
+***************************************
+
+QNOS supports Enable Mode (Privilege Escalation). This page offers details on how to use Enable Mode on QNOS in Ansible.
+
+.. contents:: Topics
+
+Connections Available
+================================================================================
+
++---------------------------+-----------------------------------------------+
+|..                         | CLI                                           |
++===========================+===============================================+
+| **Protocol**              |  SSH                                          |
++---------------------------+-----------------------------------------------+
+| | **Credentials**         | | uses SSH keys / SSH-agent if present        |
+| |                         | | accepts ``-u myuser -k`` if using password  |
++---------------------------+-----------------------------------------------+
+| **Indirect Access**       | via a bastion (jump host)                     |
++---------------------------+-----------------------------------------------+
+| | **Connection Settings** | | ``ansible_connection: network_cli``         |
+| |                         | |                                             |
+| |                         | |                                             |
++---------------------------+-----------------------------------------------+
+| | **Enable Mode**         | | supported - use ``ansible_become: yes``     |
+| | (Privilege Escalation)  | | with ``ansible_become_method: enable``      |
+| |                         | | and ``ansible_become_password:``            |
++---------------------------+-----------------------------------------------+
+| **Returned Data Format**  | ``stdout[0].``                                |
++---------------------------+-----------------------------------------------+
+
+For legacy playbooks, QNOS still supports ``ansible_connection: local``. We recommend modernizing to use ``ansible_connection: network_cli`` as soon as possible.
+
+Using CLI in Ansible
+====================
+
+Example CLI ``group_vars/qnos.yml``
+-----------------------------------
+
+.. code-block:: yaml
+
+   ansible_connection: network_cli
+   ansible_network_os: qnos
+   ansible_user: myuser
+   ansible_password: !vault...
+
+
+- If you are using SSH keys (including an ssh-agent) you can remove the ``ansible_password`` configuration.
+- If you are accessing your host directly (not through a bastion/jump host) you can remove the ``ansible_ssh_common_args`` configuration.
+- If you are accessing your host through a bastion/jump host, you cannot include your SSH password in the ``ProxyCommand`` directive. To prevent secrets from leaking out (for example in ``ps`` output), SSH does not support providing passwords via environment variables.
+
+Example CLI Task
+----------------
+
+.. code-block:: yaml
+
+   - name: setup
+     cli_config:
+       config: 
+         hostname rdserver
+ 
+   - name: get hostname
+     cli_command:
+       command: show running-config | include hostname
+     register: result
+ 
+   - assert:
+       that:
+        - result.stdout.find('rdserver') != -1
+ 
+.. include:: shared_snippets/SSH_warning.txt

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1540,7 +1540,7 @@ MAX_FILE_SIZE_FOR_DIFF:
   type: int
 NETWORK_GROUP_MODULES:
   name: Network module families
-  default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf]
+  default: [eos, nxos, ios, iosxr, junos, enos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, bigip, ironware, onyx, netconf, qnos]
   description: 'TODO: write it'
   env:
   - name: NETWORK_GROUP_MODULES

--- a/lib/ansible/module_utils/network/qnos/qnos.py
+++ b/lib/ansible/module_utils/network/qnos/qnos.py
@@ -176,7 +176,7 @@ def run_reload(module, save=False):
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc))
     except UnicodeError:
-        module.fail_json(msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
+        module.fail_json(msg=u'Failed to decode output from %s: %s' % (command, to_text(out)))
 
     if (out.find("The system has unsaved changes.") >= 0):
         # not reload for previous command

--- a/lib/ansible/module_utils/network/qnos/qnos.py
+++ b/lib/ansible/module_utils/network/qnos/qnos.py
@@ -1,0 +1,386 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# (c) 2016 Red Hat Inc.
+#
+# Copyright (c) 2016 Dell Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import re
+import json
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.network.common.utils import to_list, ComplexList
+from ansible.module_utils.connection import Connection, ConnectionError
+
+from ansible.module_utils.network.common.config import NetworkConfig, ConfigLine, ignore_line
+
+_DEVICE_CONFIGS = {}
+
+qnos_provider_spec = {
+    'host': dict(),
+    'port': dict(type='int'),
+    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
+    'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
+    'timeout': dict(type='int')
+}
+qnos_argument_spec = {
+    'provider': dict(type='dict', options=qnos_provider_spec),
+}
+
+qnos_top_spec = {
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int')
+}
+qnos_argument_spec.update(qnos_top_spec)
+
+
+def get_provider_argspec():
+    return qnos_provider_spec
+
+
+def get_connection(module):
+    if hasattr(module, '_qnos_connection'):
+        return module._qnos_connection
+
+    capabilities = get_capabilities(module)
+    network_api = capabilities.get('network_api')
+    if network_api == 'cliconf':
+        module._qnos_connection = Connection(module._socket_path)
+    else:
+        module.fail_json(msg='Invalid connection type %s' % network_api)
+
+    return module._qnos_connection
+
+
+def get_capabilities(module):
+    if hasattr(module, '_qnos_capabilities'):
+        return module._qnos_capabilities
+    try:
+        capabilities = Connection(module._socket_path).get_capabilities()
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+    module._qnos_capabilities = json.loads(capabilities)
+    return module._qnos_capabilities
+
+
+def check_args(module, warnings):
+    pass
+
+
+def get_defaults_flag(module):
+    connection = get_connection(module)
+    try:
+        out = connection.get_defaults_flag()
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+    return to_text(out, errors='surrogate_then_replace').strip()
+
+
+def get_config(module, flags=None):
+    flags = to_list(flags)
+
+    flag_str = ' '.join(flags)
+
+    try:
+        return _DEVICE_CONFIGS[flag_str]
+    except KeyError:
+        connection = get_connection(module)
+        try:
+            out = connection.get_config(flags=flags)
+        except ConnectionError as exc:
+            module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+        cfg = to_text(out, errors='surrogate_then_replace').strip()
+        _DEVICE_CONFIGS[flag_str] = cfg
+        return cfg
+
+
+def run_commands(module, commands, check_rc=True):
+    responses = list()
+    connection = get_connection(module)
+
+    for cmd in to_list(commands):
+        if isinstance(cmd, dict):
+            command = cmd['command']
+            prompt = cmd['prompt']
+            answer = cmd['answer']
+        else:
+            command = cmd
+            prompt = None
+            answer = None
+
+        try:
+            out = connection.get(command, prompt, answer)
+            out = to_text(out, errors='surrogate_or_strict')
+        except ConnectionError as exc:
+            module.fail_json(msg=to_text(exc))
+        except UnicodeError:
+            module.fail_json(msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
+
+        responses.append(out)
+
+    return responses
+
+
+def send_data(module, data):
+    connection = Connection(module._socket_path)
+    if (connection):
+        try:
+            connection.send_data(data=data)
+        except ConnectionError as exc:
+            module.fail_json(msg=to_text(exc))
+
+
+def run_reload(module, save=False):
+    responses = list()
+    connection = get_connection(module)
+
+    command = 'reload'
+    prompt = '\\(y/n\\) ?$'
+    answer = 'n'
+
+    try:
+        out = connection.get(command, prompt, answer)
+        out = to_text(out, errors='surrogate_or_strict')
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc))
+    except UnicodeError:
+        module.fail_json(msg=u'Failed to decode output from %s: %s' % (cmd, to_text(out)))
+
+    if (out.find("The system has unsaved changes.") >= 0):
+        # not reload for previous command
+        send_data(module, 'n')
+        send_data(module, 'reload\n')
+        if save:
+            send_data(module, 'y')
+            out = """The system has unsaved changes.
+Would you like to save them now? (y/n) y
+
+Config file 'startup-config' created successfully .
+"""
+        else:
+            send_data(module, 'ny')
+            out += ' y'
+        responses.append(out)
+
+    else:
+        out = out[:-1]
+        out += 'y'
+        responses.append(out)
+        out = send_data(module, 'reload\n')
+        out = send_data(module, 'y')
+
+    return responses
+
+
+def load_config(module, commands):
+    connection = get_connection(module)
+
+    try:
+        resp = connection.edit_config(commands)
+        return resp.get('response')
+    except ConnectionError as exc:
+        module.fail_json(msg=to_text(exc))
+
+
+def normalize_interface(name):
+    """Return the normalized interface name
+    """
+    if not name:
+        return
+
+    def _get_number(name):
+        digits = ''
+        for char in name:
+            if char.isdigit() or char in '/.':
+                digits += char
+        return digits
+
+    if name.lower().startswith('co'):
+        if_type = 'control-plane'
+    elif name.lower().startswith('vl'):
+        if_type = 'Vlan'
+    elif name.lower().startswith('lo'):
+        if_type = 'loopback'
+    elif name.lower().startswith('po'):
+        if_type = 'port-channel'
+    elif name.lower().startswith('tu'):
+        if_type = 'tunnel'
+    elif name.lower().startswith('vx'):
+        if_type = 'vxlan'
+    else:
+        if_type = None
+
+    number_list = name.split(' ')
+    if len(number_list) == 2:
+        if_number = number_list[-1].strip()
+    else:
+        if_number = _get_number(name)
+
+    if if_type:
+        proper_interface = if_type + if_number
+    else:
+        proper_interface = name
+
+    return proper_interface
+
+
+def get_sublevel_config(running_config, module):
+    contents = list()
+    current_config_contents = list()
+    sublevel_config = QnosNetworkConfig(indent=0)
+    obj = running_config.get_object(module.params['parents'])
+    if obj:
+        contents = obj._children
+    for c in contents:
+        if isinstance(c, ConfigLine):
+            current_config_contents.append(c.raw)
+    sublevel_config.add(current_config_contents, module.params['parents'])
+    return sublevel_config
+
+
+def qnos_parse(lines, indent=None, comment_tokens=None):
+    sublevel_cmds = [
+        re.compile(r'^interface.*$'),
+        re.compile(r'line (console|ssh|vty).*$'),
+        re.compile(r'ip vrf.*$'),
+        re.compile(r'(ip|mac|arp) access-list.*$'),
+        re.compile(r'ipv6 router.*$'),
+        re.compile(r'data-center-bridging.*$'),
+        re.compile(r'router.*$'),
+        re.compile(r'route-map.*$'),
+        re.compile(r'policy-map.*$'),
+        re.compile(r'class-map.*$'),
+        re.compile(r'openflow.*$'),
+        re.compile(r'hybridmode (per-port|per-vlan).*$')]
+
+    vlanDbLine = re.compile(r'vlan database$')
+    vlanLstLine = re.compile(r'vlan \d+([,|-]\d+)?$')
+    childline = re.compile(r'^exit$')
+    config = list()
+    parent = list()
+    children = []
+    countexit = 0
+    inVlanDbMode = False
+    parent_match = False
+    for line in str(lines).split('\n'):
+        text = str(re.sub(r'([{};])', '', line)).strip()
+        cfg = ConfigLine(text)
+        cfg.raw = line
+        if not text or ignore_line(text, comment_tokens):
+            parent = list()
+            children = []
+            continue
+
+        else:
+            parent_match = False
+            if vlanDbLine.match(line):
+                inVlanDbMode = True
+                parent_match = True
+            elif not inVlanDbMode:
+                if vlanLstLine.match(line):
+                    parent_match = True
+            # handle sublevel parent
+            if not parent_match:
+                for pr in sublevel_cmds:
+                    if pr.match(line):
+                        parent_match = True
+                        break
+            if parent_match:
+                if len(parent) != 0:
+                    cfg._parents.extend(parent)
+                parent.append(cfg)
+                config.append(cfg)
+                if children:
+                    children.insert(len(parent) - 1, [])
+                    children[len(parent) - 2].append(cfg)
+
+            # handle exit
+            if childline.match(line):
+                inVlanDbMode = False
+                countexit += 1
+                if children:
+                    parent[len(children) - 1]._children.extend(children[len(children) - 1])
+                    if len(children) > 1:
+                        parent[len(children) - 2]._children.extend(parent[len(children) - 1]._children)
+                    cfg._parents.extend(parent)
+                    children.pop()
+                    parent.pop()
+                if not children:
+                    children = list()
+                    if parent:
+                        cfg._parents.extend(parent)
+                    parent = list()
+                config.append(cfg)
+            # handle sublevel children
+            elif parent_match is False and len(parent) > 0:
+                if not children:
+                    cfglist = [cfg]
+                    children.append(cfglist)
+                else:
+                    children[len(parent) - 1].append(cfg)
+                cfg._parents.extend(parent)
+                config.append(cfg)
+            # handle global commands
+            elif not parent:
+                config.append(cfg)
+    return config
+
+
+class QnosNetworkConfig(NetworkConfig):
+
+    def load(self, contents):
+        self._config_text = contents
+        self._items = qnos_parse(contents, self._indent)
+
+    def _diff_none(self, other, path=None):
+        diff = list()
+        return diff
+
+    def _diff_line(self, other, path=None):
+        diff = list()
+
+        for item in self.items:
+            if str(item) == "exit":
+                for diff_item in diff:
+                    if diff_item._parents:
+                        if item._parents == diff_item._parents:
+                            diff.append(item)
+                            break
+                    else:
+                        diff.append(item)
+                        break
+            elif item not in other:
+                diff.append(item)
+        return diff

--- a/lib/ansible/modules/network/qnos/qnos_command.py
+++ b/lib/ansible/modules/network/qnos/qnos_command.py
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: qnos_command
+version_added: "2.9"
+author: "Peter Sprygada (@privateip)"
+short_description: Run commands on remote devices running Quanta
+description:
+  - Sends arbitrary commands to an qnos node and returns the results
+    read from the device. This module includes an
+    argument that will cause the module to wait for a specific condition
+    before returning or timing out if the condition is not met.
+  - This module does not support running commands in configuration mode.
+    Please use M(qnos_config) to configure Quanta Switches.
+extends_documentation_fragment: qnos
+notes:
+  - Tested against Quanta Switch
+options:
+  commands:
+    description:
+      - List of commands to send to the remote qnos device over the
+        configured provider. The resulting output from the command
+        is returned. If the I(wait_for) argument is provided, the
+        module is not returned until the condition is satisfied or
+        the number of retries has expired. If a command sent to the
+        device requires answering a prompt, it is possible to pass
+        a dict containing I(command), I(answer) and I(prompt).
+        Common answers are 'y' or "\\r" (carriage return, must be
+        double quotes). See examples.
+    type: list
+    required: true
+  wait_for:
+    description:
+      - List of conditions to evaluate against the output of the
+        command. The task will wait for each condition to be true
+        before moving forward. If the conditional is not true
+        within the configured number of retries, the task fails.
+        See examples.
+    type: list
+    aliases: ['waitfor']
+  match:
+    description:
+      - The I(match) argument is used in conjunction with the
+        I(wait_for) argument to specify the match policy.  Valid
+        values are C(all) or C(any).  If the value is set to C(all)
+        then all conditionals in the wait_for must be satisfied.  If
+        the value is set to C(any) then only one of the values must be
+        satisfied.
+    type: str
+    default: all
+    choices: ['any', 'all']
+  retries:
+    description:
+      - Specifies the number of retries a command should by tried
+        before it is considered failed. The command is run on the
+        target device every retry and evaluated against the
+        I(wait_for) conditions.
+    type: int
+    default: 10
+  interval:
+    description:
+      - Configures the interval in seconds to wait between retries
+        of the command. If the command does not pass the specified
+        conditions, the interval indicates how long to wait before
+        trying the command again.
+    type: int
+    default: 1
+"""
+
+EXAMPLES = r"""
+tasks:
+  - name: run show version on remote devices
+    qnos_command:
+      commands: show version
+
+  - name: run show version and check to see if output contains Quanta
+    qnos_command:
+      commands: show version
+      wait_for: result[0] contains QUANTA
+
+  - name: run multiple commands on remote nodes
+    qnos_command:
+      commands:
+        - show version
+        - show interfaces
+
+  - name: run multiple commands and evaluate the output
+    qnos_command:
+      commands:
+        - show version
+        - show interface status
+      wait_for:
+        - result[0] contains QUANTA
+        - result[1] contains lb0
+  - name: run commands that require answering a prompt
+    qnos_command:
+      commands:
+        - command: 'clear counters 0/1'
+          prompt: 'Are you sure you want to clear the port stats?'
+          answer: 'y'
+"""
+
+RETURN = """
+stdout:
+  description: The set of responses from the commands
+  returned: always apart from low level errors (such as action plugin)
+  type: list
+  sample: ['...', '...']
+stdout_lines:
+  description: The value of stdout split into a list
+  returned: always apart from low level errors (such as action plugin)
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+failed_conditions:
+  description: The list of conditionals that have failed
+  returned: failed
+  type: list
+  sample: ['...', '...']
+"""
+import re
+import time
+
+from ansible.module_utils.network.qnos.qnos import run_commands
+from ansible.module_utils.network.qnos.qnos import qnos_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.utils import ComplexList
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.six import string_types
+
+
+def to_lines(stdout):
+    for item in stdout:
+        if isinstance(item, string_types):
+            item = str(item).split('\n')
+        yield item
+
+
+def parse_commands(module, warnings):
+    command = ComplexList(dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+    commands = command(module.params['commands'])
+    for item in list(commands):
+        configure_type = re.match(r'conf(?:\w*)(?:\s+(\w+))?', item['command'])
+        if module.check_mode:
+            if configure_type and configure_type.group(1) not in ('confirm', 'replace', 'revert', 'network'):
+                module.fail_json(
+                    msg='qnos_command does not support running config mode '
+                        'commands.  Please use qnos_config instead'
+                )
+            if not item['command'].startswith('show'):
+                warnings.append(
+                    'only show commands are supported when using check mode, not '
+                    'executing `%s`' % item['command']
+                )
+                commands.remove(item)
+    return commands
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        commands=dict(type='list', required=True),
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
+        retries=dict(default=10, type='int'),
+        interval=dict(default=1, type='int')
+    )
+
+    argument_spec.update(qnos_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
+    result['warnings'] = warnings
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not been satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result.update({
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/qnos/qnos_config.py
+++ b/lib/ansible/modules/network/qnos/qnos_config.py
@@ -1,0 +1,539 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: qnos_config
+version_added: "2.9"
+author: "Peter Sprygada (@privateip)"
+short_description: Manage Quanta Switch configuration sections
+description:
+  - Quanta switch configurations use a simple block file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with Quanta switch configuration sections in
+    a deterministic way.
+extends_documentation_fragment: qnos
+notes:
+  - Tested against Quanta Switch (QNOS)
+  - Abbreviated commands are NOT idempotent, see
+    L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    type: list
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section or hierarchy
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    type: list
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines), I(parents).
+    type: path
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    type: list
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    type: list
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    type: str
+    choices: ['line', 'strict', 'exact', 'none']
+    default: line
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device. If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    type: str
+    default: line
+    choices: ['line', 'block']
+  multiline_delimiter:
+    description:
+      - This argument is used when pushing a multiline configuration
+        element to the Quanta Switches.  It specifies the character to use
+        as the delimiting character.  This only applies to the
+        configuration action.
+    type: str
+    default: "@"
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made. If the C(backup_options) value is not given,
+        the backup file is written to the C(backup) folder in the playbook
+        root directory or role root directory, if playbook is part of an
+        ansible role. If the directory does not exist, it is created.
+    type: bool
+    default: 'no'
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    type: str
+    aliases: ['config']
+  defaults:
+    description:
+      - This argument specifies whether or not to collect all defaults
+        when getting the remote device running config.  When enabled,
+        the module will get the current config by issuing the command
+        C(show running-config all).
+    type: bool
+    default: 'no'
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that before.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup-config if it has changed since
+        the last save to startup-config.  If the argument is set to
+        I(never), the running-config will never be copied to the
+        startup-config.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup-config if the task has made a change.
+    type: str
+    default: never
+    choices: ['always', 'never', 'modified', 'changed']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configure as I(startup), the module will return
+        the diff of the running-config against the startup-config.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    type: str
+    choices: ['running', 'startup', 'intended']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff.  This is used for lines in the configuration
+        that are automatically updated by the system.  This argument takes
+        a list of regular expressions or exact line matches.
+    type: list
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against. This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against.  When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+    type: str
+  backup_options:
+    description:
+      - This is a dict object containing configurable options related to backup file path.
+        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
+        to I(no) this option will be silently ignored.
+    suboptions:
+      filename:
+        description:
+          - The filename to be used to store the backup configuration. If the the filename
+            is not given it will be generated based on the hostname, current time and date
+            in format defined by <hostname>_config.<current-date>@<current-time>
+      dir_path:
+        description:
+          - This option provides the path ending with directory name in which the backup
+            configuration file will be stored. If the directory does not exist it will be first
+            created and the filename is either the value of C(filename) or default filename
+            as described in C(filename) options description. If the path value is not given
+            in that case a I(backup) directory will be created in the current working directory
+            and backup configuration will be copied in C(filename) within I(backup) directory.
+        type: path
+    type: dict
+"""
+
+EXAMPLES = """
+- name: configure top level configuration
+  qnos_config:
+    lines: hostname {{ inventory_hostname }}
+
+- name: configure interface settings
+  qnos_config:
+    lines:
+      - description test1
+      - ip address 172.31.1.1 255.255.255.0
+    parents: interface 0/1
+
+
+- name: load new acl into device
+  qnos_config:
+    lines:
+      - 10 permit ip host 192.0.2.1 any log
+      - 20 permit ip host 192.0.2.2 any log
+      - 30 permit ip host 192.0.2.3 any log
+      - 40 permit ip host 192.0.2.4 any log
+      - 50 permit ip host 192.0.2.5 any log
+    parents: ip access-list test
+    before: no ip access-list test
+    match: exact
+
+- name: check the running-config against master config
+  qnos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
+
+- name: check the startup-config against the running-config
+  qnos_config:
+    diff_against: startup
+    diff_ignore_lines:
+      - service prohibit access telnet
+
+- name: save running to startup when modified
+  qnos_config:
+    save_when: modified
+
+- name: for idempotency, use full-form commands
+  qnos_config:
+    lines:
+      - shutdown
+    parents: interface 0/1
+
+
+- name: render a Jinja2 template onto an Quanta Switch
+  qnos_config:
+    backup: yes
+    src: qnos_template.j2
+
+- name: configurable backup path
+  qnos_config:
+    src: qnos_template.j2
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: /home/user
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['hostname foo', 'router ospf', 'router-id 192.0.2.1']
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['hostname foo', 'router ospf', 'router-id 192.0.2.1']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: str
+  sample: /playbooks/ansible/backup/qnos_config.2019-06-13@11:28:34
+filename:
+  description: The name of the backup file
+  returned: when backup is yes and filename is not specified in backup options
+  type: str
+  sample: qnos_config.2019-06-13@11:28:34
+shortname:
+  description: The full path to the backup file excluding the timestamp
+  returned: when backup is yes and filename is not specified in backup options
+  type: str
+  sample: /playbooks/ansible/backup/qnos_config
+date:
+  description: The date extracted from the backup file name
+  returned: when backup is yes
+  type: str
+  sample: "2019-06-13"
+time:
+  description: The time extracted from the backup file name
+  returned: when backup is yes
+  type: str
+  sample: "11:28:34"
+"""
+import json
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import ConnectionError
+from ansible.module_utils.network.qnos.qnos import get_sublevel_config, QnosNetworkConfig
+from ansible.module_utils.network.qnos.qnos import run_commands, get_config
+from ansible.module_utils.network.qnos.qnos import get_defaults_flag, get_connection
+from ansible.module_utils.network.qnos.qnos import qnos_argument_spec
+from ansible.module_utils.network.qnos.qnos import check_args as qnos_check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.config import NetworkConfig, dumps
+
+
+def check_args(module, warnings):
+    qnos_check_args(module, warnings)
+    if module.params['multiline_delimiter']:
+        if len(module.params['multiline_delimiter']) != 1:
+            module.fail_json(msg='multiline_delimiter value can only be a '
+                                 'single character')
+
+
+def edit_config_or_macro(connection, commands):
+    # only catch the macro configuration command,
+    # not negated 'no' variation.
+    if commands[0].startswith("macro name"):
+        connection.edit_macro(candidate=commands)
+    else:
+        connection.edit_config(candidate=commands)
+
+
+def get_candidate_config(module):
+    candidate = ''
+    if module.params['src']:
+        candidate = module.params['src']
+
+    elif module.params['lines']:
+        candidate_obj = QnosNetworkConfig(indent=0)
+        parents = module.params['parents'] or list()
+        candidate_obj.add(module.params['lines'], parents=parents)
+        candidate = dumps(candidate_obj, 'raw')
+
+    return candidate
+
+
+def get_running_config(module, current_config=None, flags=None):
+    running = module.params['running_config']
+    if not running:
+        if not module.params['defaults'] and current_config:
+            running = current_config
+        else:
+            running = get_config(module, flags=flags)
+
+    return running
+
+
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        run_commands(module, 'copy running-config startup-config\r')
+    else:
+        module.warn('Skipping command `copy running-config startup-config` '
+                    'due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    backup_spec = dict(
+        filename=dict(),
+        dir_path=dict(type='path')
+    )
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        multiline_delimiter=dict(default='@'),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        defaults=dict(type='bool', default=False),
+        backup=dict(type='bool', default=False),
+        backup_options=dict(type='dict', options=backup_spec),
+        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
+
+        diff_against=dict(choices=['startup', 'intended', 'running']),
+        diff_ignore_lines=dict(type='list'),
+    )
+
+    argument_spec.update(qnos_argument_spec)
+
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    result['warnings'] = warnings
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+    config = None
+    contents = None
+    flags = get_defaults_flag(module) if module.params['defaults'] else []
+    connection = get_connection(module)
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module, flags=flags)
+        config = QnosNetworkConfig(indent=0, contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['lines'], module.params['src'])):
+        match = module.params['match']
+        replace = module.params['replace']
+        path = module.params['parents']
+
+        candidate = get_candidate_config(module)
+        running = get_running_config(module, contents, flags=flags)
+        try:
+            response = connection.get_diff(candidate=candidate, running=running, diff_match=match, diff_ignore_lines=diff_ignore_lines, path=path,
+                                           diff_replace=replace)
+        except ConnectionError as exc:
+            module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+
+        config_diff = response['config_diff']
+
+        if config_diff:
+            commands = config_diff.split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            # send the configuration commands to the device and merge
+            # them with the current running config
+            if not module.check_mode:
+                if commands:
+                    edit_config_or_macro(connection, commands)
+
+            result['changed'] = True
+
+    running_config = module.params['running_config']
+    startup_config = None
+
+    if module.params['save_when'] == 'always':
+        save_config(module, result)
+    elif module.params['save_when'] == 'modified':
+        output = run_commands(module, ['show running-config', 'show startup-config'])
+
+        running_config = QnosNetworkConfig(indent=0, contents=output[0], ignore_lines=diff_ignore_lines)
+        startup_config = QnosNetworkConfig(indent=0, contents=output[1], ignore_lines=diff_ignore_lines)
+
+        if running_config.sha1 != startup_config.sha1:
+            save_config(module, result)
+    elif module.params['save_when'] == 'changed' and result['changed']:
+        save_config(module, result)
+
+    if module._diff:
+        if not running_config:
+            output = run_commands(module, 'show running-config')
+            contents = output[0]
+        else:
+            contents = running_config
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = QnosNetworkConfig(indent=0, contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'startup':
+            if not startup_config:
+                output = run_commands(module, 'show startup-config')
+                contents = output[0]
+            else:
+                contents = startup_config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = QnosNetworkConfig(indent=0, contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                if module.params['diff_against'] == 'intended':
+                    before = running_config
+                    after = base_config
+                elif module.params['diff_against'] in ('startup', 'running'):
+                    before = base_config
+                    after = running_config
+
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(before), 'after': str(after)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/qnos/qnos_facts.py
+++ b/lib/ansible/modules/network/qnos/qnos_facts.py
@@ -47,7 +47,7 @@ options:
         values to include a larger subset.  Values can also be used
         with an initial C(M(!)) to specify that a specific subset should
         not be collected.
-    type: str
+    type: list
     required: false
     default: '!config'
 """
@@ -135,7 +135,7 @@ ansible_net_powers:
 ansible_net_config:
   description: The current active config from the device
   returned: when config is configured
-  type: string
+  type: str
 
 # interfaces
 ansible_net_all_ipv4_addresses:

--- a/lib/ansible/modules/network/qnos/qnos_facts.py
+++ b/lib/ansible/modules/network/qnos/qnos_facts.py
@@ -47,7 +47,7 @@ options:
         values to include a larger subset.  Values can also be used
         with an initial C(M(!)) to specify that a specific subset should
         not be collected.
-    type: list
+    type: str
     required: false
     default: '!config'
 """
@@ -593,7 +593,6 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
-global warnings
 warnings = list()
 
 

--- a/lib/ansible/modules/network/qnos/qnos_facts.py
+++ b/lib/ansible/modules/network/qnos/qnos_facts.py
@@ -1,0 +1,667 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: qnos_facts
+version_added: "2.9"
+author: "Mark Yang (@QCT)"
+short_description: Collect facts from remote devices running Quanta Switches
+description:
+  - Collects a base set of device facts from a remote device that
+    is running QNOS.  This module prepends all of the
+    base network fact keys with C(ansible_net_<fact>).  The facts
+    module will always collect a base set of facts from the device
+    and can enable or disable collection of additional facts.
+extends_documentation_fragment: qnos
+notes:
+  - Tested against QNOS
+options:
+  gather_subset:
+    description:
+      - When supplied, this argument will restrict the facts collected
+        to a given subset.  Possible values for this argument include
+        all, hardware, config, and interfaces.  Can specify a list of
+        values to include a larger subset.  Values can also be used
+        with an initial C(M(!)) to specify that a specific subset should
+        not be collected.
+    type: list
+    required: false
+    default: '!config'
+"""
+
+EXAMPLES = """
+# Collect all facts from the device
+- qnos_facts:
+    gather_subset: all
+
+# Collect only the config and default facts
+- qnos_facts:
+    gather_subset:
+      - config
+
+# Do not collect hardware facts
+- qnos_facts:
+    gather_subset:
+      - "!hardware"
+"""
+
+RETURN = """
+ansible_net_gather_subset:
+  description: The list of fact subsets collected from the device
+  returned: always
+  type: list
+
+# default
+ansible_net_burned_in_mac:
+  description: The burned in mac of the remote device
+  returned: always
+  type: str
+ansible_net_hostname:
+  description: The configured hostname of the device
+  returned: always
+  type: str
+ansible_net_license:
+  description: The license status of the remote device
+  returned: always
+  type: str
+ansible_net_model:
+  description: The model name returned from the device
+  returned: always
+  type: str
+ansible_net_part_no:
+  description: The part no of the remote device
+  returned: always
+  type: str
+ansible_net_serialnum:
+  description: The serial number of the remote device
+  returned: always
+  type: str
+ansible_net_storage:
+  description: The storage type of the remote device
+  returned: always
+  type: str
+ansible_net_version:
+  description: The operating system version running on the remote device
+  returned: always
+  type: str
+
+
+# hardware
+ansible_net_memfree_mb:
+  description: The available free memory on the remote device in Mb
+  returned: when hardware is configured
+  type: int
+ansible_net_memtotal_mb:
+  description: The total memory on the remote device in Mb
+  returned: when hardware is configured
+  type: int
+ansible_net_network_chip:
+  description: The network processing chip the remote device
+  returned: when hardware is configured
+  type: str
+ansible_net_fans:
+  description: The information of fans on the remote device
+  returned: when hardware is configured
+  type: dict
+ansible_net_powers:
+  description: The information of powers on the remote device in Mb
+  returned: when hardware is configured
+  type: dict
+
+# config
+ansible_net_config:
+  description: The current active config from the device
+  returned: when config is configured
+  type: string
+
+# interfaces
+ansible_net_all_ipv4_addresses:
+  description: All IPv4 addresses configured on the device
+  returned: when interfaces is configured
+  type: list
+ansible_net_all_ipv6_addresses:
+  description: All IPv6 addresses configured on the device
+  returned: when interfaces is configured
+  type: list
+ansible_net_interfaces:
+  description: A hash of all interfaces running on the system
+  returned: when interfaces is configured
+  type: dict
+ansible_net_neighbors:
+  description: The list of LLDP neighbors from the remote device
+  returned: when interfaces is configured
+  type: dict
+"""
+import re
+
+from ansible.module_utils.network.qnos.qnos import run_commands
+from ansible.module_utils.network.qnos.qnos import qnos_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
+
+
+class FactsBase(object):
+
+    COMMANDS = list()
+
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(self.module, commands=self.COMMANDS, check_rc=False)
+
+    def run(self, cmd):
+        return run_commands(self.module, commands=cmd, check_rc=False)
+
+
+class Default(FactsBase):
+
+    COMMANDS = ['show version', 'show hosts']
+
+    def populate(self):
+        super(Default, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts['version'] = self.parse_version(data)
+            self.facts['serialnum'] = self.parse_serialnum(data)
+            self.facts['model'] = self.parse_model(data)
+            self.facts['part_no'] = self.parse_partno(data)
+            self.facts['burned_in_mac'] = self.parse_burned_in_mac(data)
+            self.facts['license'] = self.parse_license(data)
+            self.facts['storage'] = self.parse_storage(data)
+
+        data = self.responses[1]
+        if data:
+            self.facts['hostname'] = self.parse_hostname(data)
+
+    def parse_version(self, data):
+        match = re.search(r'Software Version[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_hostname(self, data):
+        match = re.search(r'Host name[\.]+ \s*(.+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_model(self, data):
+        match = re.search(r'Machine Model[\.]+ \s*(.+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_partno(self, data):
+        match = re.search(r'Part Number[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_serialnum(self, data):
+        match = re.search(r'Serial Number[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_burned_in_mac(self, data):
+        match = re.search(r'Burned In MAC Address[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_license(self, data):
+        match = re.search(r'License Key Status[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_storage(self, data):
+        match = re.search(r'Software Storage[\.]+ \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+
+class Hardware(FactsBase):
+
+    COMMANDS = [
+        'show process cpu',
+        'show hardware',
+        'show environment'
+    ]
+
+    def populate(self):
+        super(Hardware, self).populate()
+        data = self.responses[0]
+        if data:
+            memalloc = self.parse_memallocate_mb(data)
+            memfree = self.parse_memfree_mb(data)
+            self.facts['memtotal_mb'] = (int(memalloc) + int(memfree)) / 1024
+            self.facts['memfree_mb'] = int(memfree) / 1024
+
+        data = self.responses[1]
+        if data:
+            network_chip = self.parse_network_processiong_device(data)
+            self.facts['network_chip'] = network_chip
+            data_env = self.responses[2]
+            self.facts['fans'] = self.populate_fans(data, data_env)
+            self.facts['powers'] = self.populate_powers(data, data_env)
+
+    def parse_memfree_mb(self, data):
+        match = re.search(r'free      \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_memallocate_mb(self, data):
+        match = re.search(r'alloc     \s*(.+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_network_processiong_device(self, data):
+        match = re.search(r'Network Processing Device[\.]+ (.+)', data)
+        if match:
+            return match.group(1)
+
+    def populate_fans(self, data, data_env):
+        fans = dict()
+        match = re.findall(r'FAN (\d) Status', data)
+        for entry in match:
+            status = '-'
+            direction = '-'
+            match = re.search(r'FAN {0} Status[\.]+ (.+)'.format(entry), data)
+            if match:
+                status = match.group(1)
+
+            match = re.search(r'FAN {0} Airflow Direction[\.]+ (.+)'.format(entry), data)
+            if match:
+                direction = match.group(1)
+
+            fans[entry] = dict(status=status, direction=direction)
+        return fans
+
+    def populate_powers(self, data, data_env):
+        powers = dict()
+        match = re.findall(r'Switch Power\+ (\d)\.', data)
+        for entry in match:
+            status = '-'
+            type = 'NA'
+            model = 'NA'
+            serial = 'NA'
+            revision = 'NA'
+            firmware = 'NA'
+            direction = 'NA'
+            match = re.search(r'(Switch Power\+ {0}[\S ]+?[\r\n][\r\n])'.format(entry), data)
+            if match:
+                power_info = match.group(1)
+                if power_info:
+                    match = re.search(r'Switch Power\+ {0}[\.]+ (.+)'.format(entry), power_info)
+                    if match:
+                        status = match.group(1)
+
+                    match = re.search(r'Type[\.]+ (.+)', power_info)
+                    if match:
+                        type = match.group(1)
+
+                    match = re.search(r'Model[\.]+ (.+)', power_info)
+                    if match:
+                        model = match.group(1)
+
+                    match = re.search(r'Serial Number[\.]+ (.+)', power_info)
+                    if match:
+                        serial = match.group(1)
+
+                    match = re.search(r'Revision Number[\.]+ (.+)', power_info)
+                    if match:
+                        revision = match.group(1)
+
+                    match = re.search(r'FW Version[\.]+ (.+)', power_info)
+                    if match:
+                        firmware = match.group(1)
+
+                    match = re.search(r'Airflow Direction[\.]+ (.+)', power_info)
+                    if match:
+                        direction = match.group(1)
+
+            powers[entry] = dict(status=status, type=type, model=model, revision=revision, firmware=firmware, direction=direction)
+        return powers
+
+
+class Config(FactsBase):
+
+    COMMANDS = ['show running-config']
+
+    def populate(self):
+        super(Config, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts['config'] = data
+
+
+class Interfaces(FactsBase):
+
+    COMMANDS = [
+        'show interface status | begin 0/1',
+        'show lldp remote-device | begin 0/1'
+    ]
+
+    def populate(self):
+        super(Interfaces, self).populate()
+
+        self.facts['all_ipv4_addresses'] = list()
+        self.facts['all_ipv6_addresses'] = list()
+
+        data = self.responses[0]
+        if data:
+            interfaces = self.parse_interfaces(data)
+            self.facts['interfaces'] = self.populate_interfaces(interfaces)
+
+        data = self.responses[1]
+        if data:
+            self.facts['neighbors'] = self.parse_neighbors(data)
+
+    def populate_interfaces(self, interfaces):
+        facts = dict()
+        for key, value in iteritems(interfaces):
+            interface_type = ''
+            match = re.match(r'^(vlan \d+)|^(tunnel \d+)|^(ch\d+)|^(lb\d+)|^(\d+/\d+)', value)
+            if match:
+                if match.group(1):
+                    interface_type = 'vlan'
+                elif match.group(2):
+                    interface_type = 'tunnel'
+                elif match.group(3):
+                    interface_type = 'port-channel'
+                elif match.group(4):
+                    interface_type = 'loopback'
+                else:
+                    interface_type = 'port'
+
+            if interface_type not in facts:
+                facts[interface_type] = list()
+
+            intf = dict()
+            intf_info = dict()
+            intf_info = self.populate_interface_info(key, interface_type)
+            intf[key] = intf_info
+            facts[interface_type].append(intf)
+        return facts
+
+    def populate_interface_info(self, data, interface_type):
+        intf_info = dict()
+        commands = list()
+        if interface_type == 'port':
+            commands.append('show interface status {0}'.format(data))
+            commands.append('show ip interface port {0}'.format(data))
+            commands.append('show ipv6 interface port {0}'.format(data))
+        elif interface_type == 'vlan':
+            commands.append('show interface status {0}'.format(data))
+            commands.append('show ip interface {0}'.format(data))
+            commands.append('show ipv6 interface {0}'.format(data))
+        elif interface_type == 'loopback':
+            id = data.split('lb')[1]
+            commands.append('show interface status loopback {0}'.format(id))
+            commands.append('show ip interface loopback {0}'.format(id))
+            commands.append('show ipv6 interface loopback {0}'.format(id))
+        elif interface_type == 'port-channel':
+            id = data.split('ch')[1]
+            commands.append('show interface status port-channel {0}'.format(id))
+        else:
+            commands.append('show interface status {0}'.format(data))
+
+        value = run_commands(self.module, commands, check_rc=False)
+        intf_info['description'] = self.parse_description(value[0])
+        intf_info['adminmode'] = self.parse_adminmode(value[0])
+        intf_info['macaddress'] = self.parse_macaddress(value[0])
+        intf_info['capability'] = self.parse_capability(value[0])
+        intf_info['physicalmode'] = self.parse_physicalmode(value[0])
+        intf_info['physicalstatus'] = self.parse_physicalstatus(value[0])
+        intf_info['lacpmode'] = self.parse_lacpmode(value[0])
+        intf_info['linkstatus'] = self.parse_linkstatus(value[0])
+        intf_info['mediatype'] = self.parse_mediatype(value[0])
+
+        if len(value) > 2:
+            ipv4 = self.parse_ipv4(value[1])
+            intf_info['ipv4'] = self.parse_ipv4(value[1])
+            if ipv4:
+                self.add_ip_address(ipv4, 'ipv4')
+
+            intf_info['mtu'] = self.parse_mtu(value[1])
+            intf_info['bandwidth'] = self.parse_bandwidth(value[1])
+            intf_info['linkspeed'] = self.parse_linkspeed(value[1])
+
+            intf_info['ipv6'] = self.parse_ipv6(value[2])
+
+        return intf_info
+
+    def add_ip_address(self, address, family):
+        if family == 'ipv4':
+            for key, value in iteritems(address):
+                if key == 'primary':
+                    self.facts['all_ipv4_addresses'].append(value['address'])
+                if key == 'secondary':
+                    for entry in value:
+                        self.facts['all_ipv4_addresses'].append(entry['address'])
+        else:
+            self.facts['all_ipv6_addresses'].append(address)
+
+    def parse_neighbors(self, neighbors):
+        facts = dict()
+        lldpObjRegex = re.compile(r'^(\d+/\d+) +(\d+)+ +([0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}:[0-9A-F]{2}) +(\d+/\d+) *(.+)?$')
+        for entry in neighbors.split('\n'):
+            if entry != '':
+                lldp_value = lldpObjRegex.match(entry)
+                if lldp_value:
+                    intf = lldp_value.group(1)
+                    if intf not in facts:
+                        facts[intf] = list()
+                    fact = dict()
+                    fact['chassis_id'] = lldp_value.group(3)
+                    fact['port'] = lldp_value.group(4)
+                    fact['host'] = lldp_value.group(5)
+                    facts[intf].append(fact)
+        return facts
+
+    def parse_interfaces(self, data):
+        parsed = dict()
+        key = ''
+        for line in data.split('\n'):
+            if len(line) == 0:
+                continue
+            elif line[0] == ' ':
+                parsed[key] += '\n%s' % line
+            else:
+                match = re.match(r'^(vlan \d+|tunnel \d+|ch\d+|lb\d+|\d+/\d+)', line)
+                if match:
+                    key = match.group(1)
+                    parsed[key] = line
+
+        return parsed
+
+    def parse_description(self, data):
+        match = re.search(r'Description[\.]+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_macaddress(self, data):
+        match = re.search(r'MAC address[\.]+ (\S+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_ipv4(self, data):
+        parsed = dict()
+        match = re.search(r'Primary IP address[\.]+ (\S+)', data)
+        if match:
+            addr, mask = match.group(1).split('/')
+            parsed['primary'] = dict(address=addr, mask=mask)
+        match = re.search(r'Secondary IP Address\(es\)[\.]+ (\S+)', data, re.M)
+        if match:
+            secondary = list()
+            addr, mask = match.group(1).split('/')
+            secondary.append(dict(address=addr, mask=mask))
+            match = re.findall(r'[\r\n]\.+ (\S+)', data)
+            for entry in match:
+                addr, mask = entry.split('/')
+                secondary.append(dict(address=addr, mask=mask))
+            parsed['secondary'] = secondary
+        return parsed
+
+    def parse_ipv6(self, data):
+        parsed = list()
+        match = re.findall(r' (\S+)? \[TENT\]', data)
+        for entry in match:
+            prefix, prefix_length = entry.split('/')
+            parsed.append(dict(prefix=prefix, prefix_length=prefix_length))
+            self.add_ip_address(prefix, 'ipv6')
+        return parsed
+
+    def parse_mtu(self, data):
+        match = re.search(r'IP MTU\.+ (\S+)', data)
+        if match:
+            return int(match.group(1))
+
+    def parse_bandwidth(self, data):
+        match = re.search(r'Bandwidth\.+ (\S+)', data)
+        if match:
+            return int(match.group(1))
+
+    def parse_linkspeed(self, data):
+        match = re.search(r'Link Speed Data Rate\.+ (\S+? \S+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_mediatype(self, data):
+        match = re.search(r'Cable Type\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_linkstatus(self, data):
+        match = re.search(r'Link Status\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_adminmode(self, data):
+        match = re.search(r'Admin Mode\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lacpmode(self, data):
+        match = re.search(r'LACP Mode\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_capability(self, data):
+        match = re.search(r'Capability Information\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_physicalmode(self, data):
+        match = re.search(r'Physical Mode\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_physicalstatus(self, data):
+        match = re.search(r'Physical Status\.+ (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+
+FACT_SUBSETS = dict(
+    default=Default,
+    hardware=Hardware,
+    interfaces=Interfaces,
+    config=Config,
+)
+
+VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
+
+global warnings
+warnings = list()
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        gather_subset=dict(default=['!config'], type='list')
+    )
+
+    argument_spec.update(qnos_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    gather_subset = module.params['gather_subset']
+
+    runable_subsets = set()
+    exclude_subsets = set()
+
+    for subset in gather_subset:
+        if subset == 'all':
+            runable_subsets.update(VALID_SUBSETS)
+            continue
+
+        if subset.startswith('!'):
+            subset = subset[1:]
+            if subset == 'all':
+                exclude_subsets.update(VALID_SUBSETS)
+                continue
+            exclude = True
+        else:
+            exclude = False
+
+        if subset not in VALID_SUBSETS:
+            module.fail_json(msg='Bad subset')
+
+        if exclude:
+            exclude_subsets.add(subset)
+        else:
+            runable_subsets.add(subset)
+
+    if not runable_subsets:
+        runable_subsets.update(VALID_SUBSETS)
+
+    runable_subsets.difference_update(exclude_subsets)
+    runable_subsets.add('default')
+
+    facts = dict()
+    facts['gather_subset'] = list(runable_subsets)
+
+    instances = list()
+    for key in runable_subsets:
+        instances.append(FACT_SUBSETS[key](module))
+
+    for inst in instances:
+        inst.populate()
+        facts.update(inst.facts)
+
+    ansible_facts = dict()
+    for key, value in iteritems(facts):
+        key = 'ansible_net_%s' % key
+        ansible_facts[key] = value
+
+    check_args(module, warnings)
+
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/qnos/qnos_reboot.py
+++ b/lib/ansible/modules/network/qnos/qnos_reboot.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+DOCUMENTATION = """
+---
+module: qnos_reboot
+version_added: "2.9"
+author: "Mark Yang (@QCT)"
+short_description: Reboot a Quanta QNOS network device.
+description:
+  - Reboot a Quanta QNOS network device.
+extends_documentation_fragment: qnos
+options:
+  confirm:
+    description:
+      - Safeguard boolean. Set to true if you're sure you want to reboot.
+    type: bool
+    required: true
+  save:
+    description:
+      - Safeguard boolean. Set to yes if you're sure to save the running-
+        config to the startup-config at rebooting.
+    type: bool
+    required: true
+"""
+
+EXAMPLES = """
+- name: reboot the device
+  qnos_reboot:
+    confirm: yes
+    save: no
+"""
+
+RETURN = """
+rebooted:
+    description: Whether the device was instructed to reboot.
+    returned: success
+    type: bool
+    sample: true
+"""
+import re
+import time
+
+from ansible.module_utils.network.qnos.qnos import run_reload
+from ansible.module_utils.network.qnos.qnos import qnos_argument_spec
+from ansible.module_utils.network.qnos.qnos import check_args as qnos_check_args
+from ansible.module_utils.network.qnos.qnos import send_data
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.common.utils import ComplexList
+from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.connection import exec_command
+from ansible.module_utils.six import string_types
+
+
+def check_args(module, warnings):
+
+    qnos_check_args(module, warnings)
+    confirm = module.params['confirm']
+    if not confirm:
+        module.fail_json(msg='confirm must be set to yes for this '
+                             'module to work.')
+
+    save = module.params['save']
+    if save == '':
+        module.fail_json(msg='save must be explicitly set to yes or no for this '
+                             'module to work.')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    commands = list()
+    responses = list()
+    argument_spec = dict(
+        confirm=dict(required=True, type='bool'),
+        save=dict(required=True, type='bool')
+    )
+
+    argument_spec.update(qnos_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    warnings = list()
+    check_args(module, warnings)
+
+    result = {'changed': False, 'warnings': warnings}
+
+    changed = False
+    rebooted = False
+    save = module.params['save']
+
+    responses = run_reload(module, save=save)
+
+    result['response'] = responses
+    changed = save
+    rebooted = True
+
+    result['changed'] = changed
+    result['rebooted'] = rebooted
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/qnos/qnos_system.py
+++ b/lib/ansible/modules/network/qnos/qnos_system.py
@@ -1,0 +1,370 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: qnos_system
+version_added: "2.9"
+author: "Peter Sprygada (@privateip)"
+short_description: Manage the system attributes on Quanta Switch
+description:
+  - This module provides declarative management of node system attributes
+    on Quanta Switch.  It provides an option to configure host system
+    parameters or remove those parameters from the device active
+    configuration.
+extends_documentation_fragment: qnos
+notes:
+  - Tested against QNOS Switch
+options:
+  hostname:
+    description:
+      - Configure the device hostname parameter. This option takes an ASCII string value.
+    type: str
+  domain_name:
+    description:
+      - Configure the IP domain name
+        on the remote device to the provided value. Value
+        should be in the dotted name form and will be
+        appended to the C(hostname) to create a fully-qualified
+        domain name.
+    type: list
+  domain_search:
+    description:
+      - Provides the list of domain suffixes to
+        append to the hostname for the purpose of doing name resolution.
+        This argument accepts a list of names and will be reconciled
+        with the current active configuration on the running node.
+    type: list
+  lookup_enabled:
+    description:
+      - Administrative control
+        for enabling or disabling DNS lookups.  When this argument is
+        set to True, lookups are performed and when it is set to False,
+        lookups are not performed.
+    type: bool
+  name_servers:
+    description:
+      - List of DNS name servers by IP address to use to perform name resolution
+        lookups.  This argument accepts either a list of DNS servers See
+        examples.
+    type: list
+  state:
+    description:
+      - State of the configuration
+        values in the device's current active configuration.  When set
+        to I(present), the values should be configured in the device active
+        configuration and when set to I(absent) the values should not be
+        in the device active configuration
+    type: str
+    default: present
+    choices: ['present', 'absent']
+"""
+
+EXAMPLES = """
+- name: configure hostname and domain name
+  qnos_system:
+    hostname: qnos01
+    domain_name: test.example.com
+    domain_search:
+      - ansible.com
+      - redhat.com
+
+- name: remove configuration
+  qnos_system:
+    name_servers:
+      - 192.0.2.1
+      - 192.0.2.2
+      - 192.0.2.3
+    state: absent
+
+- name: configure name servers
+  qnos_system:
+    name_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device
+  returned: always
+  type: list
+  sample:
+    - hostname qnos01
+    - ip domain-name test.example.com
+"""
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.qnos.qnos import get_config, load_config
+from ansible.module_utils.network.qnos.qnos import qnos_argument_spec, check_args
+from ansible.module_utils.network.common.utils import ComplexList
+
+
+_CONFIGURED_VRFS = None
+
+
+def has_vrf(module, vrf):
+    global _CONFIGURED_VRFS
+    if _CONFIGURED_VRFS is not None:
+        return vrf in _CONFIGURED_VRFS
+    config = get_config(module)
+    _CONFIGURED_VRFS = re.findall(r'vrf definition (\S+)', config)
+    return vrf in _CONFIGURED_VRFS
+
+
+def requires_vrf(module, vrf):
+    if not has_vrf(module, vrf):
+        module.fail_json(msg='vrf %s is not configured' % vrf)
+
+
+def diff_list(want, have):
+    adds = [w for w in want if w not in have]
+    removes = [h for h in have if h not in want]
+    return (adds, removes)
+
+
+def map_obj_to_commands(want, have, module):
+    commands = list()
+    state = module.params['state']
+
+    def needs_update(x):
+        return want.get(x) is not None and (want.get(x) != have.get(x))
+
+    if state == 'absent':
+        if have['hostname'] != 'Switch':
+            commands.append('no hostname')
+
+        if have['lookup_enabled'] is False:
+            commands.append('ip domain-lookup')
+
+        vrfs = set()
+        for item in have['domain_name']:
+            if item['vrf'] and item['vrf'] not in vrfs:
+                vrfs.add(item['vrf'])
+                commands.append('no ip domain-name vrf %s' % item['vrf'])
+            elif None not in vrfs:
+                vrfs.add(None)
+                commands.append('no ip domain-name')
+
+        vrfs = set()
+        for item in have['domain_search']:
+            if item['vrf'] and item['vrf'] not in vrfs:
+                vrfs.add(item['vrf'])
+                commands.append('no ip domain-list vrf %s' % item['vrf'])
+            elif None not in vrfs:
+                vrfs.add(None)
+                commands.append('no ip domain-list')
+
+        vrfs = set()
+        for item in have['name_servers']:
+            if item['vrf'] and item['vrf'] not in vrfs:
+                vrfs.add(item['vrf'])
+                commands.append('no ip name-server vrf %s' % item['vrf'])
+            elif None not in vrfs:
+                vrfs.add(None)
+                commands.append('no ip name-server')
+
+    elif state == 'present':
+        if needs_update('hostname'):
+            commands.append('hostname %s' % want['hostname'])
+
+        if needs_update('lookup_enabled'):
+            cmd = 'ip domain-lookup'
+            if want['lookup_enabled'] is False:
+                cmd = 'no %s' % cmd
+            commands.append(cmd)
+
+        if want['domain_name']:
+            adds, removes = diff_list(want['domain_name'], have['domain_name'])
+            for item in removes:
+                if item['vrf']:
+                    commands.append('no ip domain-name vrf %s %s' % (item['vrf'], item['name']))
+                else:
+                    commands.append('no ip domain-name %s' % item['name'])
+            for item in adds:
+                if item['vrf']:
+                    requires_vrf(module, item['vrf'])
+                    commands.append('ip domain-name vrf %s %s' % (item['vrf'], item['name']))
+                else:
+                    commands.append('ip domain-name %s' % item['name'])
+
+        if want['domain_search']:
+            adds, removes = diff_list(want['domain_search'], have['domain_search'])
+            for item in removes:
+                if item['vrf']:
+                    commands.append('no ip domain-list vrf %s %s' % (item['vrf'], item['name']))
+                else:
+                    commands.append('no ip domain-list %s' % item['name'])
+            for item in adds:
+                if item['vrf']:
+                    requires_vrf(module, item['vrf'])
+                    commands.append('ip domain-list vrf %s %s' % (item['vrf'], item['name']))
+                else:
+                    commands.append('ip domain-list %s' % item['name'])
+
+        if want['name_servers']:
+            adds, removes = diff_list(want['name_servers'], have['name_servers'])
+            for item in removes:
+                if item['vrf']:
+                    commands.append('no ip name-server vrf %s %s' % (item['vrf'], item['server']))
+                else:
+                    commands.append('no ip name-server %s' % item['server'])
+            for item in adds:
+                if item['vrf']:
+                    requires_vrf(module, item['vrf'])
+                    commands.append('ip name-server vrf %s %s' % (item['vrf'], item['server']))
+                else:
+                    commands.append('ip name-server %s' % item['server'])
+
+    return commands
+
+
+def parse_hostname(config):
+    match = re.search(r'^hostname \s?"(.+)"', config, re.M)
+    # match = re.search(r'^hostname (\S+)', config, re.M)
+    if match is not None:
+        return match.group(1)
+    else:
+        return None
+
+
+def parse_domain_name(config):
+    match = re.findall(r'^ip domain-name (?:vrf (\S+) )*"(.+)"', config, re.M)
+    matches = list()
+    for vrf, name in match:
+        if not vrf:
+            vrf = None
+        matches.append({'name': name, 'vrf': vrf})
+    return matches
+
+
+def parse_domain_search(config):
+    match = re.findall(r'^ip domain-list (?:vrf (\S+) )*"(.+)"', config, re.M)
+    matches = list()
+    for vrf, name in match:
+        if not vrf:
+            vrf = None
+        matches.append({'name': name, 'vrf': vrf})
+    return matches
+
+
+def parse_name_servers(config):
+    match = re.findall(r'^ip name-server (?:vrf (\S+) )*(.*)', config, re.M)
+    matches = list()
+    for vrf, servers in match:
+        if not vrf:
+            vrf = None
+        for server in servers.split():
+            matches.append({'server': server, 'vrf': vrf})
+    return matches
+
+
+def map_config_to_obj(module):
+    config = get_config(module)
+    return {
+        'hostname': parse_hostname(config),
+        'domain_name': parse_domain_name(config),
+        'domain_search': parse_domain_search(config),
+        'lookup_enabled': 'no ip domain-lookup' not in config,
+        'name_servers': parse_name_servers(config)
+    }
+
+
+def map_params_to_obj(module):
+    obj = {
+        'hostname': module.params['hostname'],
+        'lookup_enabled': module.params['lookup_enabled'],
+    }
+
+    domain_name = ComplexList(dict(
+        name=dict(key=True),
+        vrf=dict()
+    ), module)
+
+    domain_search = ComplexList(dict(
+        name=dict(key=True),
+        vrf=dict()
+    ), module)
+
+    name_servers = ComplexList(dict(
+        server=dict(key=True),
+        vrf=dict()
+    ), module)
+
+    for arg, cast in [('domain_name', domain_name),
+                      ('domain_search', domain_search),
+                      ('name_servers', name_servers)]:
+
+        if module.params[arg]:
+            obj[arg] = cast(module.params[arg])
+        else:
+            obj[arg] = None
+
+    return obj
+
+
+def main():
+    """ Main entry point for Ansible module execution
+    """
+    argument_spec = dict(
+        hostname=dict(),
+
+        domain_name=dict(type='list'),
+        domain_search=dict(type='list'),
+        name_servers=dict(type='list'),
+
+        lookup_enabled=dict(type='bool'),
+
+        state=dict(choices=['present', 'absent'], default='present')
+    )
+
+    argument_spec.update(qnos_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    warnings = list()
+    check_args(module, warnings)
+    result['warnings'] = warnings
+
+    want = map_params_to_obj(module)
+    have = map_config_to_obj(module)
+
+    commands = map_obj_to_commands(want, have, module)
+    result['commands'] = commands
+
+    if commands:
+        if not module.check_mode:
+            load_config(module, commands)
+        result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/plugins/action/qnos.py
+++ b/lib/ansible/plugins/action/qnos.py
@@ -1,0 +1,96 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import sys
+import copy
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.plugins.action.network import ActionModule as ActionNetworkModule
+from ansible.module_utils.network.common.utils import load_provider
+from ansible.module_utils.network.qnos.qnos import qnos_provider_spec
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class ActionModule(ActionNetworkModule):
+
+    def run(self, tmp=None, task_vars=None):
+        del tmp  # tmp no longer has any effect
+
+        self._config_module = True if self._task.action == 'qnos_config' else False
+        socket_path = None
+
+        if self._play_context.connection == 'network_cli':
+            provider = self._task.args.get('provider', {})
+            if any(provider.values()):
+                display.warning('provider is unnecessary when using network_cli and will be ignored')
+                del self._task.args['provider']
+        elif self._play_context.connection == 'local':
+            provider = load_provider(qnos_provider_spec, self._task.args)
+            pc = copy.deepcopy(self._play_context)
+            pc.connection = 'network_cli'
+            pc.network_os = 'qnos'
+            pc.remote_addr = provider['host'] or self._play_context.remote_addr
+            pc.port = int(provider['port'] or self._play_context.port or 22)
+            pc.remote_user = provider['username'] or self._play_context.connection_user
+            pc.password = provider['password'] or self._play_context.password
+            pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+            pc.become = provider['authorize'] or False
+            if pc.become:
+                pc.become_method = 'enable'
+            pc.become_pass = provider['auth_pass']
+
+            display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+            command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
+            connection.set_options(direct={'persistent_command_timeout': command_timeout})
+
+            socket_path = connection.run()
+            display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+            if not socket_path:
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+            task_vars['ansible_socket'] = socket_path
+        else:
+            return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
+
+        # make sure we are in the right cli context which should be
+        # enable mode and not config module
+        if socket_path is None:
+            socket_path = self._connection.socket_path
+
+        conn = Connection(socket_path)
+        try:
+            out = conn.get_prompt()
+            if re.search(r'Config.*\)#', to_text(out, errors='surrogate_then_replace').strip()):
+                display.vvvv('wrong context, sending end to device', self._play_context.remote_addr)
+                conn.send_command('end')
+        except ConnectionError as exc:
+            return {'failed': True, 'msg': to_text(exc)}
+
+        result = super(ActionModule, self).run(task_vars=task_vars)
+        return result

--- a/lib/ansible/plugins/cliconf/qnos.py
+++ b/lib/ansible/plugins/cliconf/qnos.py
@@ -1,0 +1,295 @@
+#
+# (c) 2017 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+author: Ansible Networking Team
+cliconf: qnos
+short_description: Use qnos cliconf to run command on Quanta Switches
+description:
+  - This qnos plugin provides low level abstraction apis for
+    sending and receiving CLI commands from Quanta Switches.
+version_added: "2.9"
+"""
+
+import re
+import time
+import json
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text
+from ansible.module_utils.common._collections_compat import Mapping
+from ansible.module_utils.network.common.config import dumps
+from ansible.module_utils.network.common.utils import to_list
+from ansible.module_utils.network.qnos.qnos import QnosNetworkConfig
+from ansible.plugins.cliconf import CliconfBase, enable_mode
+
+
+class Cliconf(CliconfBase):
+
+    @enable_mode
+    def get_config(self, source='running', flags=None, format=None):
+        if source not in ('running', 'startup'):
+            raise ValueError("fetching configuration from %s is not supported" % source)
+
+        if format:
+            raise ValueError("'format' value %s is not supported for get_config" % format)
+
+        if not flags:
+            flags = []
+        if source == 'running':
+            cmd = 'show running-config '
+        else:
+            cmd = 'show startup-config '
+
+        cmd += ' '.join(to_list(flags))
+        cmd = cmd.strip()
+
+        return self.send_command(cmd)
+
+    def get_diff(self, candidate=None, running=None, diff_match='line', diff_ignore_lines=None, path=None, diff_replace='line'):
+        """
+        Generate diff between candidate and running configuration. If the
+        remote host supports onbox diff capabilities ie. supports_onbox_diff in that case
+        candidate and running configurations are not required to be passed as argument.
+        In case if onbox diff capability is not supported candidate argument is mandatory
+        and running argument is optional.
+        :param candidate: The configuration which is expected to be present on remote host.
+        :param running: The base configuration which is used to generate diff.
+        :param diff_match: Instructs how to match the candidate configuration with current device configuration
+                      Valid values are 'line', 'strict', 'exact', 'none'.
+                      'line' - commands are matched line by line
+                      'strict' - command lines are matched with respect to position
+                      'exact' - command lines must be an equal match
+                      'none' - will not compare the candidate configuration with the running configuration
+        :param diff_ignore_lines: Use this argument to specify one or more lines that should be
+                                  ignored during the diff.  This is used for lines in the configuration
+                                  that are automatically updated by the system.  This argument takes
+                                  a list of regular expressions or exact line matches.
+        :param path: The ordered set of parents that uniquely identify the section or hierarchy
+                     the commands should be checked against.  If the parents argument
+                     is omitted, the commands are checked against the set of top
+                    level or global commands.
+        :param diff_replace: Instructs on the way to perform the configuration on the device.
+                        If the replace argument is set to I(line) then the modified lines are
+                        pushed to the device in configuration mode.  If the replace argument is
+                        set to I(block) then the entire command block is pushed to the device in
+                        configuration mode if any line is not correct.
+        :return: Configuration diff in  json format.
+               {
+                   'config_diff': ''
+               }
+
+        """
+        diff = {}
+        device_operations = self.get_device_operations()
+        option_values = self.get_option_values()
+
+        if candidate is None and device_operations['supports_generate_diff']:
+            raise ValueError("candidate configuration is required to generate diff")
+
+        if diff_match not in option_values['diff_match']:
+            raise ValueError("'match' value %s in invalid, valid values are %s" % (diff_match, ', '.join(option_values['diff_match'])))
+
+        if diff_replace not in option_values['diff_replace']:
+            raise ValueError("'replace' value %s in invalid, valid values are %s" % (diff_replace, ', '.join(option_values['diff_replace'])))
+
+        # prepare candidate configuration
+        candidate_obj = QnosNetworkConfig(indent=0)
+        candidate_obj.load(candidate)
+
+        if running and diff_match != 'none':
+            # running configuration
+            running_obj = QnosNetworkConfig(indent=0, contents=running, ignore_lines=diff_ignore_lines)
+            configdiffobjs = candidate_obj.difference(running_obj, path=path, match=diff_match, replace=diff_replace)
+
+        else:
+            configdiffobjs = candidate_obj.items
+
+        diff['config_diff'] = dumps(configdiffobjs, 'commands') if configdiffobjs else ''
+
+        return diff
+
+    @enable_mode
+    def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
+        resp = {}
+        operations = self.get_device_operations()
+        self.check_edit_config_capability(operations, candidate, commit, replace, comment)
+
+        results = []
+        requests = []
+        if commit:
+            if not self._connection.get_prompt().endswith(b'(Config)#'):
+                self.send_command('configure')
+            for line in to_list(candidate):
+                if not isinstance(line, Mapping):
+                    line = {'command': line}
+
+                cmd = line['command']
+                if cmd != 'end' and cmd[0] != '!':
+                    results.append(self.send_command(**line))
+                    requests.append(cmd)
+
+            self.send_command('end')
+        else:
+            raise ValueError('check mode is not supported')
+
+        resp['request'] = requests
+        resp['response'] = results
+        return resp
+
+    def edit_macro(self, candidate=None, commit=True, replace=None, comment=None):
+        resp = {}
+        operations = self.get_device_operations()
+        self.check_edit_config_capabiltiy(operations, candidate, commit, replace, comment)
+
+        results = []
+        requests = []
+        if commit:
+            commands = ''
+            for line in candidate:
+                if line != 'None':
+                    commands += (' ' + line + '\n')
+                self.send_command('config', sendonly=True)
+                obj = {'command': commands, 'sendonly': True}
+                results.append(self.send_command(**obj))
+                requests.append(commands)
+
+            self.send_command('end', sendonly=True)
+            time.sleep(0.1)
+            results.append(self.send_command('\n'))
+            requests.append('\n')
+
+        resp['request'] = requests
+        resp['response'] = results
+        return resp
+
+    def get(self, command=None, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
+        if not command:
+            raise ValueError('must provide value of command to execute')
+        if output:
+            raise ValueError("'output' value %s is not supported for get" % output)
+
+        return self.send_command(command=command, prompt=prompt, answer=answer, sendonly=sendonly, newline=newline, check_all=check_all)
+
+    def get_device_info(self):
+        device_info = {}
+
+        device_info['network_os'] = 'qnos'
+        if self._connection.get_prompt().endswith(b'>'):
+            reply = self.get(command='enable')
+        reply = self.get(command='show version')
+        data = to_text(reply, errors='surrogate_or_strict').strip()
+
+        match = re.search(r'^Software Version\.+ (.+)', data, re.M)
+        if match:
+            device_info['network_os_version'] = match.group(1)
+
+        match = re.search(r'^Machine Model\.+ (.+)', data, re.M)
+        if match:
+            device_info['network_os_model'] = match.group(1)
+
+        reply = self.get(command='show hosts')
+        data = to_text(reply, errors='surrogate_or_strict').strip()
+        match = re.search(r'^Host name\.+ (.+)', data, re.M)
+        if match:
+            device_info['network_os_hostname'] = match.group(1)
+
+        return device_info
+
+    def get_device_operations(self):
+        return {
+            'supports_diff_replace': True,
+            'supports_commit': False,
+            'supports_rollback': False,
+            'supports_defaults': True,
+            'supports_onbox_diff': False,
+            'supports_commit_comment': False,
+            'supports_multiline_delimiter': False,
+            'supports_diff_match': True,
+            'supports_diff_ignore_lines': True,
+            'supports_generate_diff': True,
+            'supports_replace': False
+        }
+
+    def get_option_values(self):
+        return {
+            'format': ['text'],
+            'diff_match': ['line', 'strict', 'exact', 'none'],
+            'diff_replace': ['line', 'block'],
+            'output': []
+        }
+
+    def get_capabilities(self):
+        result = super(Cliconf, self).get_capabilities()
+        result['rpc'] += ['get_diff', 'run_commands', 'get_defaults_flag']
+        result['device_operations'] = self.get_device_operations()
+        result.update(self.get_option_values())
+        return json.dumps(result)
+
+    def run_commands(self, commands=None, check_rc=True):
+        if commands is None:
+            raise ValueError("'commands' value is required")
+
+        responses = list()
+        for cmd in to_list(commands):
+            if not isinstance(cmd, Mapping):
+                cmd = {'command': cmd}
+
+            output = cmd.pop('output', None)
+            if output:
+                raise ValueError("'output' value %s is not supported for run_commands" % output)
+
+            try:
+                out = self.send_command(**cmd)
+            except AnsibleConnectionFailure as e:
+                if check_rc:
+                    raise
+                out = getattr(e, 'err', to_text(e))
+
+            responses.append(out)
+
+        return responses
+
+    # This function is used to send key (or key string) and NOT wait response
+    def send_data(self, data=None):
+        if data is None:
+            return
+        out = self.send_command(data, sendonly=True)
+
+    def get_defaults_flag(self):
+        """
+        The method identifies the filter that should be used to fetch running-configuration
+        with defaults.
+        :return: valid default filter
+        """
+        out = self.get('show running-config ?')
+        out = to_text(out, errors='surrogate_then_replace')
+
+        commands = set()
+        for line in out.splitlines():
+            if line.strip():
+                commands.add(line.strip().split()[0])
+
+        if 'all' in commands:
+            return 'all'
+        else:
+            return 'full'

--- a/lib/ansible/plugins/doc_fragments/qnos.py
+++ b/lib/ansible/plugins/doc_fragments/qnos.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Peter Sprygada <psprygada@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = r'''
+options:
+  authorize:
+    description:
+      - B(Deprecated)
+      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes)."
+      - For more information please see the L(QNOS Platform Options guide, ../network/user_guide/platform_qnos.html).
+      - HORIZONTALLINE
+      - Instructs the module to enter privileged mode on the remote device
+        before sending any commands.  If not specified, the device will
+        attempt to execute all commands in non-privileged mode. If the value
+        is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    type: bool
+    default: no
+  auth_pass:
+    description:
+      - B(Deprecated)
+      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes) with C(become_pass)."
+      - For more information please see the L(QNOS Platform Options guide, ../network/user_guide/platform_qnos.html).
+      - HORIZONTALLINE
+      - Specifies the password to use if required to enter privileged mode
+        on the remote device.  If I(authorize) is false, then this argument
+        does nothing. If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+    type: str
+  provider:
+    description:
+      - B(Deprecated)
+      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli)."
+      - For more information please see the L(QNOS Platform Options guide, ../network/user_guide/platform_qnos.html).
+      - HORIZONTALLINE
+      - A dict object containing connection details.
+    type: dict
+    suboptions:
+      host:
+        description:
+          - Specifies the DNS host name or address for connecting to the remote
+            device over the specified transport.  The value of host is used as
+            the destination address for the transport.
+        type: str
+        required: true
+      port:
+        description:
+          - Specifies the port to use when building the connection to the remote device.
+        type: int
+        default: 22
+      username:
+        description:
+          - Configures the username to use to authenticate the connection to
+            the remote device.  This value is used to authenticate
+            the SSH session. If the value is not specified in the task, the
+            value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
+        type: str
+      password:
+        description:
+          - Specifies the password to use to authenticate the connection to
+            the remote device.   This value is used to authenticate
+            the SSH session. If the value is not specified in the task, the
+            value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+        type: str
+      timeout:
+        description:
+          - Specifies the timeout in seconds for communicating with the network device
+            for either connecting or sending commands.  If the timeout is
+            exceeded before the operation is completed, the module will error.
+        type: int
+        default: 10
+      ssh_keyfile:
+        description:
+          - Specifies the SSH key to use to authenticate the connection to
+            the remote device.   This value is the path to the
+            key used to authenticate the SSH session. If the value is not specified
+            in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
+            will be used instead.
+        type: path
+      authorize:
+        description:
+          - Instructs the module to enter privileged mode on the remote device
+            before sending any commands.  If not specified, the device will
+            attempt to execute all commands in non-privileged mode. If the value
+            is not specified in the task, the value of environment variable
+            C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+        type: bool
+        default: no
+      auth_pass:
+        description:
+          - Specifies the password to use if required to enter privileged mode
+            on the remote device.  If I(authorize) is false, then this argument
+            does nothing. If the value is not specified in the task, the value of
+            environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+        type: str
+notes:
+  - For more information on using Ansible to manage network devices see the :ref:`Ansible Network Guide <network_guide>`
+'''

--- a/lib/ansible/plugins/terminal/qnos.py
+++ b/lib/ansible/plugins/terminal/qnos.py
@@ -1,0 +1,96 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import re
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text, to_bytes
+from ansible.plugins.terminal import TerminalBase
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
+        re.compile(br"[\r\n]?(?:\([^\)]+\) ){,3}(?:>|#)$"),
+        re.compile(br"[\r\n]?Password:$")
+        # re.compile(br"\(y/n\) ?$")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(br"% ?Error"),
+        # re.compile(br"^% \w+", re.M),
+        re.compile(br"% ?Bad secret"),
+        re.compile(br"[\r\n%] Bad passwords"),
+        re.compile(br"invalid input", re.I),
+        re.compile(br"(?:incomplete|ambiguous) command", re.I),
+        re.compile(br"connection timed out", re.I),
+        re.compile(br"[^\r\n]+ not found"),
+        re.compile(br"'[^']' +returned error code: ?\d+"),
+        re.compile(br"Bad mask", re.I),
+        re.compile(br"% ?(\S+) ?overlaps with ?(\S+)", re.I),
+        re.compile(br"[%\S] ?Error: ?[\s]+", re.I),
+        re.compile(br"[%\S] ?Informational: ?[\s]+", re.I),
+        re.compile(br"Command authorization failed")
+    ]
+
+    def on_open_shell(self):
+        try:
+            for cmd in (['terminal length 25', 'no pager']):
+                self._exec_cli_command(cmd)
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+    def on_become(self, passwd=None):
+        if self._get_prompt().endswith(b'#'):
+            return
+
+        cmd = {u'command': u'enable'}
+        if passwd:
+            # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
+            # an r string and use to_text to ensure it's text on both py2 and py3.
+            cmd[u'prompt'] = to_text(r"[\r\n](?:Local_)?[Pp]assword: ?$", errors='surrogate_or_strict')
+            cmd[u'answer'] = passwd
+            cmd[u'prompt_retry_check'] = True
+        try:
+            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+            prompt = self._get_prompt()
+            if prompt is None or not prompt.endswith(b'#'):
+                raise AnsibleConnectionFailure('failed to elevate privilege to enable mode still at prompt [%s]' % prompt)
+        except AnsibleConnectionFailure as e:
+            prompt = self._get_prompt()
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode, at prompt [%s] with error: %s' % (prompt, e.message))
+
+    def on_unbecome(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+        if b'(Config' in prompt:
+            self._exec_cli_command(b'end')
+            self._exec_cli_command(b'exit')
+
+        elif prompt.endswith(b'#'):
+            self._exec_cli_command(b'exit')

--- a/test/integration/target-prefixes.network
+++ b/test/integration/target-prefixes.network
@@ -27,6 +27,7 @@ onyx
 openvswitch
 ops
 pn
+qnos
 slxos
 sros
 vyos

--- a/test/integration/targets/prepare_qnos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_qnos_tests/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Ensure we have loopback 0 for testing
+  qnos_config:
+    src: config.j2
+  connection: network_cli
+
+# Some AWS hostnames can be longer than those allowed by the system we are testing
+# Truncate the hostname
+# http://jinja.pocoo.org/docs/2.9/templates/#truncate
+- set_fact:
+    shorter_hostname: '{{ inventory_hostname_short| truncate(10, True, "") }}'
+
+- name: "Discover Quantata Switch version"
+  qnos_command:
+    commands: ['show version']
+  connection: network_cli
+  register: result
+
+- set_fact: switch_type=""
+
+- set_fact: switch_type="DataCenter"
+  when: "'Data Center' in result.stdout[0]"
+
+- block:
+    - name: Set test interface 1 to 0/1 as we are on Quanta Switch QNOS
+      set_fact: test_interface=0/1
+    - name: Set test interface 2 to 0/2 as we are on Quanta Switch QNOS 
+      set_fact: test_interface2=0/2
+  when: "'QUANTA' in result.stdout[0]"
+
+- block:
+    - name: Set test interface 2 to 0/1 as we are on Quanta Switch QNOS
+      set_fact: test_interface2=0/2
+    - name: Disable autonegotiation on 0/2
+      qnos_config:
+        lines:
+          - no negotiate 
+        parents: int {{ test_interface2 }}
+        authorize: yes
+
+    - name: Set test interface 3 to 0/3 as we are on Quanta Switch QNOS
+      set_fact: test_interface3=0/3
+    - name: Disable autonegotiation on 0/3
+      qnos_config:
+        lines:
+          - no negotiate 
+        parents: int {{ test_interface3 }}
+        authorize: yes
+  when: "'QUANTA' in result.stdout[0]"

--- a/test/integration/targets/prepare_qnos_tests/templates/config.j2
+++ b/test/integration/targets/prepare_qnos_tests/templates/config.j2
@@ -1,0 +1,4 @@
+interface loopback 0
+description 'test for ansible'
+shutdown
+

--- a/test/integration/targets/qnos_command/aliases
+++ b/test/integration/targets/qnos_command/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/qnos_command/defaults/main.yaml
+++ b/test/integration/targets/qnos_command/defaults/main.yaml
@@ -1,0 +1,7 @@
+---
+testcase: "*"
+test_items: []
+cli:
+  username: "{{ ansible_ssh_user }}"
+  password: "{{ ansible_ssh_pass }}" 
+  

--- a/test/integration/targets/qnos_command/meta/main.yml
+++ b/test/integration/targets/qnos_command/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_qnos_tests

--- a/test/integration/targets/qnos_command/tasks/cli.yaml
+++ b/test/integration/targets/qnos_command/tasks/cli.yaml
@@ -1,0 +1,23 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_command/tasks/main.yaml
+++ b/test/integration/targets/qnos_command/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/qnos_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/bad_operator.yaml
@@ -1,0 +1,20 @@
+---
+- debug: msg="START cli/bad_operator.yaml on connection={{ ansible_connection }}"
+
+- name: test bad operator
+  qnos_command:
+    commands:
+      - show version
+      - show interfaces 0/0
+    provider: "{{ cli }}"
+    wait_for:
+      - "result[0] contains 'Description: Foo'"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "result.msg is defined"
+
+- debug: msg="END cli/bad_operator.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_command/tests/cli/cli_command.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/cli_command.yaml
@@ -1,0 +1,37 @@
+---
+- debug:
+    msg: "START cli/cli_command.yaml on connection={{ ansible_connection }}"
+
+- block:
+  - name: get output for single command
+    cli_command:
+      command: show version
+    register: result
+  
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.stdout is defined"
+  
+  - name: send invalid command
+    cli_command:
+      command: 'show foo'
+    register: result
+    ignore_errors: yes
+  
+  - assert:
+      that:
+        - "result.failed == true"
+        - "result.msg is defined"
+  
+  - name: send invalid command
+    cli_command:
+      command: 'clear counters 0/1'
+      prompt:
+          - "Are you sure you want to clear the port stats?"
+      answer: y
+    register: result
+    ignore_errors: yes
+  when: "ansible_connection == 'network_cli'"
+
+- debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_command/tests/cli/contains.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/contains.yaml
@@ -1,0 +1,20 @@
+---
+- debug: msg="START cli/contains.yaml on connection={{ ansible_connection }}"
+
+- name: test contains operator
+  qnos_command:
+    commands:
+      - show version
+      - show interface status loopback 0
+    provider: "{{ cli }}"
+    wait_for:
+      - "result[0] contains QUANTA"
+      - "result[1] contains lb0"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+
+- debug: msg="END cli/contains.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/invalid.yaml
@@ -1,0 +1,28 @@
+---
+- debug: msg="START cli/invalid.yaml on connection={{ ansible_connection }}"
+
+- name: run invalid command
+  qnos_command:
+    commands: show foo
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed"
+
+- name: run commands that include invalid command
+  qnos_command:
+    commands:
+      - show version
+      - show foo
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed"
+
+- debug: msg="END cli/invalid.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_command/tests/cli/output.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/output.yaml
@@ -1,0 +1,30 @@
+---
+- debug: msg="START cli/output.yaml on connection={{ ansible_connection }}"
+
+- name: get output for single command
+  qnos_command:
+    commands:
+      - show version
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+
+- name: get output for multiple commands
+  qnos_command:
+    commands:
+      - show version
+      - show interface status
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+      - "result.stdout | length == 2"
+
+- debug: msg="END cli/output.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/qnos_command/tests/cli/timeout.yaml
@@ -1,0 +1,19 @@
+---
+- debug: msg="START cli/timeout.yaml on connection={{ ansible_connection }}"
+
+- name: test bad condition
+  qnos_command:
+    commands:
+      - show version
+    provider: "{{ cli }}"
+    wait_for:
+      - "result[0] contains bad_value_string"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "result.msg is defined"
+
+- debug: msg="END cli/timeout.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/aliases
+++ b/test/integration/targets/qnos_config/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/qnos_config/defaults/main.yaml
+++ b/test/integration/targets/qnos_config/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/qnos_config/meta/main.yml
+++ b/test/integration/targets/qnos_config/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_qnos_tests

--- a/test/integration/targets/qnos_config/tasks/cli.yaml
+++ b/test/integration/targets/qnos_config/tasks/cli.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_config/tasks/cli_config.yaml
+++ b/test/integration/targets/qnos_config/tasks/cli_config.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect all cli_config test cases
+  find:
+    paths: "{{ role_path }}/tests/cli_config"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=network_cli)
+  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_config/tasks/main.yaml
+++ b/test/integration/targets/qnos_config/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- { include: cli.yaml, tags: ['cli'] }
+- { include: cli_config.yaml, tags: ['cli_config'] }

--- a/test/integration/targets/qnos_config/templates/basic/base_running_config
+++ b/test/integration/targets/qnos_config/templates/basic/base_running_config
@@ -1,0 +1,5 @@
+service prohibit access telnet
+service prohibit access snmp
+!
+hostname "an-qnos-01.ansible.com"
+!

--- a/test/integration/targets/qnos_config/templates/basic/config.j2
+++ b/test/integration/targets/qnos_config/templates/basic/config.j2
@@ -1,0 +1,3 @@
+interface loopback 0
+description 'this is a test'
+shutdown

--- a/test/integration/targets/qnos_config/templates/basic/configexact1.j2
+++ b/test/integration/targets/qnos_config/templates/basic/configexact1.j2
@@ -1,0 +1,6 @@
+no ip access-list test
+ip access-list test
+permit ip host 192.0.2.1 any log
+permit ip host 192.0.2.2 any log
+permit ip host 192.0.2.3 any log
+permit ip host 192.0.2.4 any log

--- a/test/integration/targets/qnos_config/templates/basic/configexact2.j2
+++ b/test/integration/targets/qnos_config/templates/basic/configexact2.j2
@@ -1,0 +1,5 @@
+ip access-list test
+1 permit ip host 192.0.2.1 any log
+2 permit ip host 192.0.2.2 any log
+3 permit ip host 192.0.2.3 any log
+4 permit ip host 192.0.2.4 any log

--- a/test/integration/targets/qnos_config/templates/basic/intended_running_config
+++ b/test/integration/targets/qnos_config/templates/basic/intended_running_config
@@ -1,0 +1,5 @@
+service prohibit access telnet
+service prohibit access snmp
+!
+hostname "an-qnos-02.ansible.com"
+!

--- a/test/integration/targets/qnos_config/templates/basic/setupblock.j2
+++ b/test/integration/targets/qnos_config/templates/basic/setupblock.j2
@@ -1,0 +1,5 @@
+no ip access-list test
+ip access-list test
+permit ip host 192.0.2.1 any log
+permit ip host 192.0.2.2 any log
+permit ip host 192.0.2.3 any log

--- a/test/integration/targets/qnos_config/templates/basic/setupexact.j2
+++ b/test/integration/targets/qnos_config/templates/basic/setupexact.j2
@@ -1,0 +1,7 @@
+no ip access-list test
+ip access-list test
+ permit ip host 192.0.2.1 any log
+ permit ip host 192.0.2.2 any log
+ permit ip host 192.0.2.3 any log
+ permit ip host 192.0.2.4 any log
+ permit ip host 192.0.2.5 any log

--- a/test/integration/targets/qnos_config/templates/defaults/config.j2
+++ b/test/integration/targets/qnos_config/templates/defaults/config.j2
@@ -1,0 +1,3 @@
+interface loopback 0
+description 'this is a test'
+no shutdown

--- a/test/integration/targets/qnos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/backup.yaml
@@ -1,0 +1,125 @@
+---
+- debug: msg="START cli/backup.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface loopback 0
+    match: none
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_files
+  connection: local
+
+- name: delete backup files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{backup_files.files|default([])}}"
+
+- name: configure device with config
+  qnos_config:
+    src: basic/config.j2
+    backup: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+# FIXME Bug https://github.com/ansible/ansible/issues/19382
+#      - "result.updates is not defined"
+
+- name: collect any backup files
+  find:
+    paths: "{{ role_path }}/backup"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_files
+  connection: local
+
+- assert:
+    that:
+      - "backup_files.files is defined"
+
+- name: delete configurable backup file path
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ role_path }}/backup_test_dir/"
+    - "{{ role_path }}/backup/backup.cfg"
+
+- name: take configuration backup in custom filename and directory path
+  qnos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-1 exist
+  stat:
+    path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.stat.exists == True"
+
+- name: take configuration backup in custom filename
+  qnos_config:
+    backup: yes
+    backup_options:
+      filename: backup.cfg
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-2 exist
+  stat:
+    path: "{{ role_path }}/backup/backup.cfg"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.stat.exists == True"
+
+- name: take configuration backup in custom path and default filename
+  qnos_config:
+    backup: yes
+    backup_options:
+      dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+  become: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check if the backup file-3 exist
+  find:
+    paths: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
+    pattern: "{{ inventory_hostname_short }}_config*"
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - "backup_file.files is defined"
+
+- debug: msg="END cli/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/defaults.yaml
@@ -1,0 +1,58 @@
+---
+- debug: msg="START cli/defaults.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    commands:
+      - no description
+      - shutdown
+    parents:
+      - interface loopback 0
+    match: none
+
+- name: configure device with defaults included
+  qnos_config:
+    src: defaults/config.j2
+    defaults: yes
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == true"
+# FIXME Bug https://github.com/ansible/ansible/issues/19382
+#    - "result.updates is not defined"
+
+- name: check device with defaults included
+  qnos_config:
+    src: defaults/config.j2
+    defaults: yes
+  register: result
+
+- debug: var=result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.updates is not defined"
+
+- name: Check device is in proper prompt after error
+  qnos_config:
+    lines:
+        - mac-addr-table aging-time 500
+  ignore_errors: yes
+
+- name: show interfaces brief to ensure deivce goes to valid prompt
+  qnos_command:
+    commands:
+      - show interface status
+      - exit
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+
+- debug: msg="END cli/defaults.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli/diff.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/diff.yaml
@@ -1,0 +1,46 @@
+---
+- debug: msg="START cli/diff.yaml on connection={{ ansible_connection }}"
+
+- name: Ensure hostname is preset
+  qnos_system:
+    hostname: "{{ shorter_hostname }}"
+
+- name: qnos_config diff against running configuration
+  qnos_config:
+    commands:
+      - hostname an-qnos-03.ansible.com
+    diff_against: running
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname \"an-qnos-03.ansible.com\"' in result['diff']['after']"
+      - "'hostname \"{{ shorter_hostname }}\"' in result['diff']['before']"
+
+- name: qnos_config diff against retrieved config
+  qnos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname \"an-qnos-02.ansible.com\"' in result['diff']['after']"
+      - "'hostname \"an-qnos-03.ansible.com\"' in result['diff']['before']"
+
+- name: qnos_config diff against provided running_config
+  qnos_config:
+    diff_against: intended
+    intended_config: "{{ lookup('file', '{{ role_path }}/templates/basic/intended_running_config') }}"
+    running_config: "{{ lookup('file', '{{ role_path }}/templates/basic/base_running_config') }}"
+  diff: true
+  register: result
+
+- assert:
+    that:
+      - "'hostname \"an-qnos-02.ansible.com\"' in result['diff']['after']"
+      - "'hostname \"an-qnos-01.ansible.com\"' in result['diff']['before']"
+
+- debug: msg="END cli/diff.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli/save.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/save.yaml
@@ -1,0 +1,49 @@
+---
+- debug: msg="START cli/save.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface loopback 0
+    match: none
+    save_when: modified
+
+- name: save should always run
+  qnos_config:
+    save_when: always
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: delete config (setup)
+  qnos_config:
+    replace: line
+    lines:
+      - ip load-sharing 1 inner
+    save_when: modified
+  register: result
+
+- name: save should run when changed
+  qnos_config:
+    replace: line
+    lines:
+      - no ip load-sharing
+    save_when: modified
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: teardown
+  qnos_config:
+    lines:
+      - no ip load-sharing
+  register: result
+
+- debug: msg="END cli/save.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/src_basic.yaml
@@ -1,0 +1,103 @@
+---
+- debug: msg="START cli/src_basic.yaml on connection={{ ansible_connection }}"
+
+#- name: vlan database configuration
+#  qnos_config:
+#    commands:
+#      - vlan 22,25-28,4093
+#    parents:
+#      - vlan database
+#    match: none
+#
+#- name: vlan mode configuration
+#  qnos_config:
+#    commands:
+#      - private-vlan isolated 
+#    parents:
+#      - vlan 25-28
+#    match: none
+#
+#- name: show vlan
+#  qnos_command:
+#    commands: 
+#    - show vlan
+#  register: result
+#
+#- debug: msg=result
+#
+#- name: vlan configuration
+#  qnos_config:
+#    commands:
+#      - no vlan 22,25-28,4093
+#    parents:
+#      - vlan database
+#    match: none
+
+
+- name: setup
+  qnos_config:
+    commands:
+      - no description
+      - no shutdown
+    parents:
+      - interface loopback 0
+    match: none
+
+- name: configure device with config
+  qnos_config:
+    src: basic/config.j2
+  register: result
+
+- name: debug, remove me
+  debug:
+    msg: "{{ result }}"
+- assert:
+    that:
+      - "result.changed == true"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+# FIXME Bug https://github.com/ansible/ansible/issues/19382
+#      - "result.updates is not defined"
+
+- name: check device with config
+  qnos_config:
+    src: basic/config.j2
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+# https://github.com/ansible/ansible-modules-core/issues/4807
+# FIXME Bug https://github.com/ansible/ansible/issues/19382
+#      - "result.updates is not defined"
+
+- name: check for empty diff
+  qnos_config:
+    running_config: |
+      service prohibit access snmp
+      service prohibit access telnet
+    lines:
+      - service prohibit access snmp
+      - service prohibit access telnet
+  check_mode: True
+  register: result
+- assert:
+    that:
+      - "result.updates is undefined"
+
+- name: check for diff with ignore lines for running config
+  qnos_config:
+    running_config: |
+      service prohibit access snmp
+      service prohibit access telnet
+    lines:
+      - service prohibit access snmp
+      - service prohibit access telnet
+    diff_ignore_lines: service prohibit access telnet
+  check_mode: True
+  register: result
+
+- assert:
+    that:
+      - "'service prohibit access telnet' in result.updates"
+
+- debug: msg="END cli/src_basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/qnos_config/tests/cli/sublevel_strict.yaml
@@ -1,0 +1,61 @@
+---
+- debug: msg="START cli/sublevel_strict.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    lines:
+      - permit ip host 192.0.2.1 any log
+      - permit ip host 192.0.2.2 any log
+      - permit ip host 192.0.2.3 any log
+      - permit ip host 192.0.2.4 any log
+      - permit ip host 192.0.2.5 any log
+    parents: ip access-list test
+    before: no ip access-list test
+    match: none
+
+- name: configure sub level command using strict match
+  qnos_config:
+    lines:
+      - 1 permit ip host 192.0.2.1 any log
+      - 2 permit ip host 192.0.2.2 any log
+      - 3 permit ip host 192.0.2.3 any log
+      - 4 permit ip host 192.0.2.4 any log
+    parents: ip access-list test
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: check sub level command using strict match
+  qnos_config:
+    lines:
+      - 1 permit ip host 192.0.2.1 any log
+      - no rule 2
+      - no rule 3
+      - 2 permit ip host 192.0.2.3 any log
+      - 3 permit ip host 192.0.2.2 any log      
+    parents: ip access-list test
+    after: exit
+    match: strict
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+
+      - "'ip access-list test' in result.updates"
+      - "'1 permit ip host 192.0.2.1 any log' not in result.updates"
+      - "'3 permit ip host 192.0.2.2 any log' in result.updates"
+      - "'2 permit ip host 192.0.2.3 any log' in result.updates"
+      - "'4 permit ip host 192.0.2.4 any log' not in result.updates"
+      - "'5 permit ip host 192.0.2.5 any log' not in result.updates"
+
+- name: teardown
+  qnos_config:
+    lines: no ip access-list test
+    match: none
+
+- debug: msg="END cli/sublevel_strict.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli_config/cli_basic.yaml
+++ b/test/integration/targets/qnos_config/tests/cli_config/cli_basic.yaml
@@ -1,0 +1,62 @@
+---
+- debug: msg="START cli_config/cli_basic.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  cli_config: &rm
+    config: |
+      interface loopback 0
+      no description
+      shutdown
+    diff_match: none
+
+#- name: test interface range
+#  cli_config:
+#    config: |
+#      interface range 0/1-0/10
+#      shutdown
+#    diff_match: none
+#
+- name: test interface range
+  cli_config:
+    config: |
+      vlan database
+      vlan 2-7
+      exit
+      interface range vlan 2-7
+      description testhaha
+    diff_match: none
+
+- name: configure device with config
+  cli_config: &conf
+    config: "{{ lookup('template', 'basic/config.j2') }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Idempotence
+  cli_config: *conf
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: remove config
+  cli_config: *rm
+
+- name: configure device with config
+  cli_config:
+    config: "{{ lookup('template', 'basic/config.j2') }}"
+    #defaults: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: teardown
+  cli_config: *rm
+
+- debug: msg="END cli_config/cli_basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_config/tests/cli_config/cli_exact_match.yaml
+++ b/test/integration/targets/qnos_config/tests/cli_config/cli_exact_match.yaml
@@ -1,0 +1,33 @@
+---
+- debug: msg="START cli_config/cli_exact_match.yaml on connection={{ ansible_connection }}"
+
+- name: setup - remove configuration
+  cli_config:
+    config: "{{ lookup('template', 'basic/setupexact.j2') }}"
+    diff_match: none
+
+- name: configure using exact match
+  cli_config:
+    config: "{{ lookup('template', 'basic/configexact1.j2') }}"
+    diff_match: exact
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: check using exact match
+  cli_config:
+    config: "{{ lookup('template', 'basic/configexact2.j2') }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  cli_config:
+    config: no ip access-list test
+    diff_match: none
+
+- debug: msg="END cli_config/cli_exact_match.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_facts/aliases
+++ b/test/integration/targets/qnos_facts/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/qnos_facts/defaults/main.yaml
+++ b/test/integration/targets/qnos_facts/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+testcase: "*"
+test_items: []
+cli:
+  username: "{{ ansible_ssh_user }}"
+  password: "{{ ansible_ssh_pass }}"

--- a/test/integration/targets/qnos_facts/meta/main.yml
+++ b/test/integration/targets/qnos_facts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_qnos_tests

--- a/test/integration/targets/qnos_facts/tasks/cli.yaml
+++ b/test/integration/targets/qnos_facts/tasks/cli.yaml
@@ -1,0 +1,22 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_facts/tasks/main.yaml
+++ b/test/integration/targets/qnos_facts/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/qnos_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/qnos_facts/tests/cli/all_facts.yaml
@@ -1,0 +1,32 @@
+---
+- debug: msg="START cli/all_facts.yaml on connection={{ ansible_connection }}"
+
+
+- name: test getting all facts
+  qnos_facts:
+    gather_subset:
+      - all
+    provider: "{{ cli }}"
+  register: result
+
+
+
+- assert:
+    that:
+      # _facts modules should never report a change
+      - "result.changed == false"
+
+      # Correct subsets are present
+      - "'config' in result.ansible_facts.ansible_net_gather_subset"
+      - "'hardware' in result.ansible_facts.ansible_net_gather_subset"
+      - "'default' in result.ansible_facts.ansible_net_gather_subset"
+      - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
+
+      # Items from those subsets are present
+      - "result.ansible_facts.ansible_net_fans is defined"
+      # Check that these facts not only are present, but are valid (positive integers)
+      - "result.ansible_facts.ansible_net_memfree_mb > 1"
+      - "result.ansible_facts.ansible_net_memtotal_mb > 1"
+
+
+- debug: msg="END cli/all_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/qnos_facts/tests/cli/default_facts.yaml
@@ -1,0 +1,35 @@
+---
+- debug: msg="START cli/default_facts.yaml on connection={{ ansible_connection }}"
+
+
+- name: test getting default facts
+  qnos_facts:
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      # _facts modules should never report a change
+      - "result.changed == false"
+
+      # Correct subsets are present
+      - "'hardware' in result.ansible_facts.ansible_net_gather_subset"
+      - "'default' in result.ansible_facts.ansible_net_gather_subset"
+      - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
+      #- "result.ansible_facts.ansible_net_filesystems is defined"
+      # ... and not present
+      - "'config' not in result.ansible_facts.ansible_net_gather_subset"
+
+      # Items from those subsets are present
+      #- "result.ansible_facts.ansible_net_filesystems is defined" #hw
+      #- "result.ansible_facts.ansible_net_memtotal_mb > 10" #hw
+      - "result.ansible_facts.ansible_net_interfaces | length > 1" # more than one interface returned
+
+      # ... and not present
+      - "result.ansible_facts.ansible_net_config is not defined" # config
+
+#- assert:
+#    that: "{{ item.value.spacetotal_kb }} > {{ item.value.spacefree_kb }}"
+#  loop: "{{ lookup('dict', result.ansible_facts.ansible_net_filesystems_info, wantlist=True) }}"
+
+- debug: msg="END cli/default.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_facts/tests/cli/invalid_subset.yaml
+++ b/test/integration/targets/qnos_facts/tests/cli/invalid_subset.yaml
@@ -1,0 +1,48 @@
+---
+- debug: msg="START cli/invalid_subset.yaml on connection={{ ansible_connection }}"
+
+
+- name: test invalid subset (foobar)
+  qnos_facts:
+    gather_subset:
+      - "foobar"
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: true
+
+
+- assert:
+    that:
+      # Failures shouldn't return changes
+      - "result.changed == false"
+      # It's a failure
+      - "result.failed == true"
+      # Sensible Failure message
+      - "result.msg == 'Bad subset'"
+
+###############
+# FIXME Future
+# We may in the future want to add a test for
+
+- name: test subset specified multiple times
+  qnos_facts:
+    gather_subset:
+      - "!hardware"
+      - "hardware"
+    provider: "{{ cli }}"
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      # Failures shouldn't return changes
+      - "result.changed == false"
+      # It's a failure
+      - "result.failed == true"
+      # Sensible Failure message
+      - "result.msg == 'Bad subset'"
+  ignore_errors: true
+
+
+
+- debug: msg="END cli/invalid_subset.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/qnos_facts/tests/cli/not_hardware.yaml
@@ -1,0 +1,31 @@
+---
+- debug: msg="START cli/not_hardware_facts.yaml on connection={{ ansible_connection }}"
+
+
+- name: test not hardware
+  qnos_facts:
+    gather_subset:
+      - "!hardware"
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      # _facts modules should never report a change
+      - "result.changed == false"
+
+      # Correct subsets are present
+      - "'config' in result.ansible_facts.ansible_net_gather_subset"
+
+      - "'default' in result.ansible_facts.ansible_net_gather_subset"
+      - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
+      # ... and not present
+      - "'hardware' not in result.ansible_facts.ansible_net_gather_subset"
+
+      # Items from those subsets are present
+      - "result.ansible_facts.ansible_net_interfaces | length > 1" # more than one interface returned
+      # ... and not present
+      - "result.ansible_facts.ansible_net_memtotal_mb is not defined"
+      - "result.ansible_facts.ansible_net_network_chip is not defined"
+
+- debug: msg="END cli/not_hardware_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_reboot/aliases
+++ b/test/integration/targets/qnos_reboot/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/qnos_reboot/defaults/main.yaml
+++ b/test/integration/targets/qnos_reboot/defaults/main.yaml
@@ -1,0 +1,7 @@
+
+---
+testcase: "*"
+test_items: []
+cli:
+  username: "{{ ansible_ssh_user }}"
+  password: "{{ ansible_ssh_pass }}"

--- a/test/integration/targets/qnos_reboot/defaults/main.yaml
+++ b/test/integration/targets/qnos_reboot/defaults/main.yaml
@@ -1,4 +1,3 @@
-
 ---
 testcase: "*"
 test_items: []

--- a/test/integration/targets/qnos_reboot/meta/main.yml
+++ b/test/integration/targets/qnos_reboot/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_qnos_tests

--- a/test/integration/targets/qnos_reboot/tasks/cli.yaml
+++ b/test/integration/targets/qnos_reboot/tasks/cli.yaml
@@ -1,0 +1,22 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_reboot/tasks/main.yaml
+++ b/test/integration/targets/qnos_reboot/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/qnos_reboot/tests/cli/reboot.yaml
+++ b/test/integration/targets/qnos_reboot/tests/cli/reboot.yaml
@@ -1,0 +1,28 @@
+---
+- debug: msg="START cli/reboot.yaml on connection={{ ansible_connection }} "
+
+- name: reboot not save
+  qnos_reboot:
+    confirm: yes
+    save: no
+    provider: "{{ cli }}"
+  become: True
+  become_method: enable
+
+#- pause: seconds=120
+
+- name: Wait for switch to come back
+  become: false
+  local_action: wait_for
+  #connection: local
+  args:
+    host: "{{ ansible_host }}"
+    port: "{{ ansible_ssh_port }}"
+    state: started
+    #search_regex: "Using username"
+    search_regex: "OpenSSH"
+    delay: 10
+    timeout: 180
+  changed_when: false
+
+- debug: msg="END cli/reboot.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_system/defaults/main.yaml
+++ b/test/integration/targets/qnos_system/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+testcase: "*"
+cli:
+  username: "{{ ansible_ssh_user }}"
+  password: "{{ ansible_ssh_pass }}"

--- a/test/integration/targets/qnos_system/meta/main.yml
+++ b/test/integration/targets/qnos_system/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_qnos_tests

--- a/test/integration/targets/qnos_system/tasks/cli.yaml
+++ b/test/integration/targets/qnos_system/tasks/cli.yaml
@@ -1,0 +1,22 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test cases (connection=network_cli)
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_first_found: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/qnos_system/tasks/main.yaml
+++ b/test/integration/targets/qnos_system/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/qnos_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/qnos_system/tests/cli/set_domain_list.yaml
@@ -1,0 +1,122 @@
+---
+- debug: msg="START cli/set_domain_search.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    lines:
+      - no ip domain-list ansible.com
+      - no ip domain-list redhat.com
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure domain_search
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'ip domain-list ansible.com' in result.commands"
+      - "'ip domain-list redhat.com' in result.commands"
+
+- name: verify domain_search
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == false
+
+- name: remove one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'no ip domain-list redhat.com' in result.commands"
+
+- name: verify remove one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == false
+
+- name: add one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'ip domain-list redhat.com' in result.commands"
+
+- name: verify add one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - redhat.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == false
+
+- name: add and remove one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - eng.ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'no ip domain-list redhat.com' in result.commands"
+      - "'ip domain-list eng.ansible.com' in result.commands"
+      - result.commands|length == 2
+
+- name: verify add and remove one entry
+  qnos_system:
+    domain_search:
+      - ansible.com
+      - eng.ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == false
+
+- name: teardown
+  qnos_config:
+    lines:
+      - no ip domain-list ansible.com
+      - no ip domain-list redhat.com
+      - no ip domain-list eng.ansible.com
+    match: none
+    provider: "{{ cli }}"
+
+- debug: msg="END cli/set_domain_search.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/qnos_system/tests/cli/set_domain_name.yaml
@@ -1,0 +1,36 @@
+---
+- debug: msg="START cli/set_domain_name.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    lines: no ip domain-name
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure domain_name
+  qnos_system:
+    domain_name: eng.ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: verify domain_name
+  qnos_system:
+    domain_name: eng.ansible.com
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  qnos_config:
+    lines: no ip domain-name
+    match: none
+    provider: "{{ cli }}"
+
+- debug: msg="END cli/set_domain_name.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_system/tests/cli/set_hostname.yaml
+++ b/test/integration/targets/qnos_system/tests/cli/set_hostname.yaml
@@ -1,0 +1,36 @@
+---
+- debug: msg="START cli/set_hostname.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    lines: hostname switch
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure hostname
+  qnos_system:
+    hostname: foo
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: verify hostname
+  qnos_system:
+    hostname: foo
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: teardown
+  qnos_config:
+    lines: "hostname {{ inventory_hostname }}"
+    match: none
+    provider: "{{ cli }}"
+
+- debug: msg="END cli/set_hostname.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/qnos_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/qnos_system/tests/cli/set_name_servers.yaml
@@ -1,0 +1,62 @@
+---
+- debug: msg="START cli/set_name_servers.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  qnos_config:
+    lines:
+      - no ip name-server
+    match: none
+    provider: "{{ cli }}"
+
+- name: configure name_servers
+  qnos_system:
+    name_servers:
+      - 192.0.2.1
+      - 192.0.2.2
+      - 192.0.2.3
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - result.commands|length == 3
+      - "'ip name-server 192.0.2.1' in result.commands"
+      - "'ip name-server 192.0.2.2' in result.commands"
+      - "'ip name-server 192.0.2.3' in result.commands"
+
+- name: verify name_servers
+  qnos_system:
+    name_servers:
+      - 192.0.2.1
+      - 192.0.2.2
+      - 192.0.2.3
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == false
+
+- name: remove one
+  qnos_system:
+    name_servers:
+      - 192.0.2.1
+      - 192.0.2.2
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - result.commands|length == 1
+      - "'no ip name-server 192.0.2.3' in result.commands"
+
+- name: teardown
+  qnos_config:
+    lines:
+      - no ip name-server
+    match: none
+    provider: "{{ cli }}"
+
+- debug: msg="END cli/set_name_servers.yaml on connection={{ ansible_connection }}"

--- a/test/sanity/code-smell/action-plugin-docs.py
+++ b/test/sanity/code-smell/action-plugin-docs.py
@@ -37,6 +37,7 @@ def main():
         'junos',
         'netconf',
         'nxos',
+        'qnos',
         'sros',
         'vyos',
     ])


### PR DESCRIPTION
##### SUMMARY
Add new network modules to control/manage QUANTA switches.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/qnos/qnos_command
lib/ansible/modules/network/qnos/qnos_config
lib/ansible/modules/network/qnos/qnos_facts
lib/ansible/modules/network/qnos/qnos_reboot
lib/ansible/modules/network/qnos/qnos_system
lib/ansible/plugins/action/qnos.py
lib/ansible/plugins/cliconf/qnos.py
lib/ansible/plugins/terminal/qnos.py

test/integration/targets/prepare_qnos_tests/
test/integration/targets/qnos_command/
test/integration/targets/qnos_config/
test/integration/targets/qnos_facts/
test/integration/targets/qnos_system/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Sample inventory:
```
ansible_network_os=qnos
ansible_connection=network_cli

```