### PR TITLE
Fix idempotency in the rabbitmq_user module

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -174,7 +174,7 @@ class RabbitMqUser(object):
 
     def _get_permissions(self):
         """Get permissions of the user from RabbitMQ."""
-        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
+        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username, '--no-table-headers'], True) if perm.strip()]
 
         perms_list = list()
         for perm in perms_out:


### PR DESCRIPTION
Issue: Error when adding user that already exists and permissions dict is passed.

![Screenshot from 2019-07-04 23-38-08](https://user-images.githubusercontent.com/8451484/60694543-d4065f00-9eb4-11e9-85d2-c63d0930bfc1.png)

##### SUMMARY
The function _get_permissions is executing list_user_permissions without --no-table-headers.
The return has header included and it is being interpreted as one permission.

Solution:
include --no-table-headers argument

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

