### PR TITLE
vmware_inventory: Python 2 and 3 compat fix

### DIFF
--- a/changelogs/fragments/vmware_inventory_py23_fix.yml
+++ b/changelogs/fragments/vmware_inventory_py23_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use to_native instead of encode / decode in order to handle Python 2 and 3 syntax in vmware_inventory.py.

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -42,6 +42,7 @@ from jinja2 import Environment
 
 from ansible.module_utils.six import integer_types, PY3
 from ansible.module_utils.six.moves import configparser
+from ansible.module_utils._text import to_native
 
 try:
     import argparse
@@ -150,11 +151,7 @@ class VMWareInventory(object):
 
     def debugl(self, text):
         if self.args.debug:
-            try:
-                text = str(text)
-            except UnicodeEncodeError:
-                text = text.encode('utf-8')
-            print('%s %s' % (datetime.datetime.now(), text))
+            print('%s %s' % (datetime.datetime.now(), to_native(text)))
 
     def show(self):
         # Data to print
@@ -693,7 +690,7 @@ class VMWareInventory(object):
             if vobj.isalnum():
                 rdata = vobj
             else:
-                rdata = vobj.encode('utf-8').decode('utf-8')
+                rdata = to_native(vobj)
         elif issubclass(type(vobj), bool) or isinstance(vobj, bool):
             rdata = vobj
         elif issubclass(type(vobj), integer_types) or isinstance(vobj, integer_types):


### PR DESCRIPTION
##### SUMMARY
* Use `to_native` instead of encode/decode 

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/vmware_inventory.py
