### PR TITLE
ec2_snapshot: Update snapshot time format time

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_snapshot.py
@@ -126,7 +126,7 @@ from ansible.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
 
 # Find the most recent snapshot
 def _get_snapshot_starttime(snap):
-    return datetime.datetime.strptime(snap.start_time, '%Y-%m-%dT%H:%M:%S.000Z')
+    return datetime.datetime.strptime(snap.start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 def _get_most_recent_snapshot(snapshots, max_snapshot_age_secs=None, now=None):
@@ -147,7 +147,7 @@ def _get_most_recent_snapshot(snapshots, max_snapshot_age_secs=None, now=None):
     youngest_snapshot = max(snapshots, key=_get_snapshot_starttime)
 
     # See if the snapshot is younger that the given max age
-    snapshot_start = datetime.datetime.strptime(youngest_snapshot.start_time, '%Y-%m-%dT%H:%M:%S.000Z')
+    snapshot_start = datetime.datetime.strptime(youngest_snapshot.start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
     snapshot_age = now - snapshot_start
 
     if max_snapshot_age_secs is not None:


### PR DESCRIPTION
ansible ec2_snapshot ValueError: time data '2019-05-27T12:08:49.929Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'

##### SUMMARY
Fix error
ansible ec2_snapshot ValueError: time data '2019-05-27T12:08:49.929Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'

##### ISSUE TYPE
- Bugfix Pull Request

https://github.com/ansible/ansible/issues/57026