### PR TITLE
Add purge_tags to s3_bucket to allow preservation of existing tags

### DIFF
--- a/changelogs/fragments/29366-allow-preservation-of-s3-bucket-tags.yml
+++ b/changelogs/fragments/29366-allow-preservation-of-s3-bucket-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add purge_tags parameter to s3_bucket to allow preservation of existing tags when updating tags.

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -68,6 +68,12 @@ options:
   tags:
     description:
       - tags dict to apply to bucket
+  purge_tags:
+    description:
+      - whether to remove tags that aren't present in the C(tags) parameter
+    type: bool
+    default: True
+    version_added: "2.9"
   versioning:
     description:
       - Whether versioning is enabled or disabled (note that once versioning is enabled, it can only be suspended)
@@ -152,6 +158,7 @@ def create_or_update_bucket(s3_client, module, location):
     name = module.params.get("name")
     requester_pays = module.params.get("requester_pays")
     tags = module.params.get("tags")
+    purge_tags = module.params.get("purge_tags")
     versioning = module.params.get("versioning")
     encryption = module.params.get("encryption")
     encryption_key_id = module.params.get("encryption_key_id")
@@ -278,6 +285,9 @@ def create_or_update_bucket(s3_client, module, location):
             tags = dict((to_text(k), to_text(v)) for k, v in tags.items())
             if current_tags_dict != tags:
                 if tags:
+                    if not purge_tags:
+                        current_tags_dict.update(tags)
+                        tags = current_tags_dict
                     try:
                         put_bucket_tagging(s3_client, name, tags)
                     except (BotoCoreError, ClientError) as e:
@@ -628,15 +638,16 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            force=dict(required=False, default='no', type='bool'),
-            policy=dict(required=False, default=None, type='json'),
-            name=dict(required=True, type='str'),
+            force=dict(default=False, type='bool'),
+            policy=dict(type='json'),
+            name=dict(required=True),
             requester_pays=dict(default=False, type='bool'),
-            s3_url=dict(aliases=['S3_URL'], type='str'),
-            state=dict(default='present', type='str', choices=['present', 'absent']),
-            tags=dict(required=False, default=None, type='dict'),
-            versioning=dict(default=None, type='bool'),
-            ceph=dict(default='no', type='bool'),
+            s3_url=dict(aliases=['S3_URL']),
+            state=dict(default='present', choices=['present', 'absent']),
+            tags=dict(type='dict'),
+            purge_tags=dict(type='bool', default=True),
+            versioning=dict(type='bool'),
+            ceph=dict(default=False, type='bool'),
             encryption=dict(choices=['none', 'AES256', 'aws:kms']),
             encryption_key_id=dict()
         )

--- a/test/integration/targets/s3_bucket/tasks/main.yml
+++ b/test/integration/targets/s3_bucket/tasks/main.yml
@@ -215,6 +215,53 @@
       pause:
         seconds: 10
 
+    - name: Update a tag for s3_bucket with purge_tags False
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-ansible-complex"
+        state: present
+        policy: "{{ lookup('template','policy.json') }}"
+        requester_pays: no
+        versioning: no
+        purge_tags: no
+        tags:
+          anewtag: next
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.tags.example == 'tag1-udpated'
+          - output.tags.anewtag == 'next'
+
+    # ============================================================
+    - name: Pause to help with s3 bucket eventual consistency
+      pause:
+        seconds: 10
+
+    - name: Pass empty tags dict for s3_bucket with purge_tags False
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-ansible-complex"
+        state: present
+        policy: "{{ lookup('template','policy.json') }}"
+        requester_pays: no
+        versioning: no
+        purge_tags: no
+        tags: {}
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
+          - output.tags.example == 'tag1-udpated'
+          - output.tags.anewtag == 'next'
+
+    # ============================================================
+    - name: Pause to help with s3 bucket eventual consistency
+      pause:
+        seconds: 10
+
     - name: Do not specify any tag to ensure previous tags are not removed
       s3_bucket:
         name: "{{ resource_prefix }}-testbucket-ansible-complex"

--- a/test/integration/targets/s3_bucket/tasks/main.yml
+++ b/test/integration/targets/s3_bucket/tasks/main.yml
@@ -6,10 +6,10 @@
     - name: set connection information for all tasks
       set_fact:
         aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
+          aws_access_key: "{{ aws_access_key | default('') }}"
+          aws_secret_key: "{{ aws_secret_key | default('') }}"
+          security_token: "{{ security_token | default('') }}"
+          region: "{{ aws_region | default('') }}"
       no_log: true
 
     # ============================================================
@@ -185,6 +185,30 @@
           - output.changed
           - output.tags.example == 'tag1-udpated'
           - "'another' not in output.tags"
+
+    # ============================================================
+    - name: Pause to help with s3 bucket eventual consistency
+      pause:
+        seconds: 10
+
+    - name: Add a tag for s3_bucket with purge_tags False
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-ansible-complex"
+        state: present
+        policy: "{{ lookup('template','policy.json') }}"
+        requester_pays: no
+        versioning: no
+        purge_tags: no
+        tags:
+          anewtag: here
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.tags.example == 'tag1-udpated'
+          - output.tags.anewtag == 'here'
 
     # ============================================================
     - name: Pause to help with s3 bucket eventual consistency


### PR DESCRIPTION
##### SUMMARY
Adding `purge_tags` with default `True` to maintain existing behaviour
allows users to set it to `False` to preserve existing tags

Fixes #29366


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
s3_bucket
