### PR TITLE
[backport][2.6] Add a banner message to warn when not on latest documentation (#58526)

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -1,0 +1,24 @@
+<!--- Based on sphinx versionwarning extension. Extension currently only works on READTHEDOCS -->
+{# Creates a banner at the top of the page for any version not latest. #}
+  <script>
+    current_url = window.location.href;
+    if ((current_url.search("latest") > -1) || (current_url.search("/{{ latest_version }}/") > -1)) {
+     // no banner for latest release
+    } else if (current_url.search("devel") > -1) {
+      document.write('<div id="banner_id" class="admonition caution">');
+      para = document.createElement('p');
+      banner_text=document.createTextNode("You are reading the *devel* version of the Ansible documentation - this version is not guaranteed stable. Use the version selection to the left if you want the latest stable released version.");
+      para.appendChild(banner_text);
+      element = document.getElementById('banner_id');
+      element.appendChild(para);
+      document.write('</div>');
+    } else {
+      document.write('<div id="banner_id" class="admonition caution">');
+      para = document.createElement('p');
+      banner_text=document.createTextNode("You are reading an older version of the Ansible documentation. Use the version selection to the left if you want the latest stable released version.");
+      para.appendChild(banner_text);
+      element = document.getElementById('banner_id');
+      element.appendChild(para);
+      document.write('</div>');
+    }
+  </script>

--- a/docs/docsite/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/layout.html
@@ -232,6 +232,8 @@
         </div> -->
 
           {% include "breadcrumbs.html" %}
+          
+          {% include "ansible_banner.html" %}
           <div id="page-content">
           {% block body %}{% endblock %}
           </div>

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -138,7 +138,11 @@ html_context = {
     'github_user': 'ansible',
     'github_repo': 'ansible',
     'github_version': 'devel/docs/docsite/rst/',
-    'github_module_version': 'devel/lib/ansible/modules/'
+    'github_module_version': 'devel/lib/ansible/modules/',
+    'current_version': version,
+    'latest_version': '2.8',
+    # list specifically out of order to make latest work
+    'available_versions': ('latest', '2.7', '2.6', 'devel')
 }
 
 # The style sheet to use for HTML and HTML Help pages. A file of that name
@@ -244,9 +248,3 @@ autoclass_content = 'both'
 intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../python2-2.7.13.inv')),
                        'python3': ('https://docs.python.org/3/', (None, '../python3-3.6.2.inv')),
                        'jinja2': ('http://jinja.pocoo.org/docs/', (None, '../jinja2-2.9.7.inv'))}
-
-# list specifically out of order to make latest work
-html_context = {
-    'current_version': version,
-    'available_versions': ('latest', '2.7', '2.6', 'devel')
-}


### PR DESCRIPTION
* add banner to versions that are not latest

(cherry picked from commit 35b6345bdcdc47126b05617736c67892f27db784)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
