### PR TITLE
Pass allow_unauthenticated when installing a deb directly - allowing unauthenticated dependencies

### DIFF
--- a/changelogs/fragments/58771-allow-unauthenticated-deb.yaml
+++ b/changelogs/fragments/58771-allow-unauthenticated-deb.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - fixed issue where allow_unauthenticated did not apply to dependencies when installing a deb directly

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -750,6 +750,7 @@ def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated
     if deps_to_install:
         (success, retvals) = install(m=m, pkgspec=deps_to_install, cache=cache,
                                      install_recommends=install_recommends,
+                                     allow_unauthenticated=allow_unauthenticated,
                                      dpkg_options=expand_dpkg_options(dpkg_options))
         if not success:
             m.fail_json(**retvals)


### PR DESCRIPTION
##### SUMMARY
There is a bug when installing a deb with dependencies in an unauthenticated repo. Normally we can just add `allow_unauthenticated` to the apt stanza but in the case of a deb file, the `allow_unauthenticated` setting is ignored. This change passes the value down to the install function so that the setting is no longer ignored.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
Try it out like so:
```
- name: Add poorly configured repository
  apt_repository:
    repo: "deb http://apt_repo/missing_gpg_signed_Packages"
    state: present

- name: deb with unauthenticated dependencies
  apt:
    deb: ./mypackage.deb
    allow_unauthenticated: yes
```
