### PR TITLE
[stable-2.6] Fix unicode error in changelog generation

### DIFF
--- a/packaging/release/changelogs/changelog.py
+++ b/packaging/release/changelogs/changelog.py
@@ -25,6 +25,7 @@ except ImportError:
     argcomplete = None
 
 from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_bytes
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 CHANGELOG_DIR = os.path.join(BASE_DIR, 'changelogs')
@@ -280,8 +281,8 @@ def generate_changelog(changes, plugins, fragments):
     generator = ChangelogGenerator(config, changes, plugins, fragments)
     rst = generator.generate()
 
-    with open(changelog_path, 'w') as changelog_fd:
-        changelog_fd.write(rst)
+    with open(changelog_path, 'wb') as changelog_fd:
+        changelog_fd.write(to_bytes(rst))
 
 
 class ChangelogFragmentLinter(object):


### PR DESCRIPTION
(cherry picked from commit fed90ef)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### SUMMARY
Backport unicode fix to changelog generation.

##### ISSUE TYPE
- Bugfix Pull Request

