### PR TITLE
ip_netns - some fixes and code rework

### DIFF
--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -47,11 +47,11 @@ options:
 EXAMPLES = '''
 # Create a namespace named mario
 - name: Create a namespace named mario
-  namespace:
+  ip_netns:
     name: mario
     state: present
 - name: Delete a namespace named luigi
-  namespace:
+  ip_netns:
     name: luigi
     state: absent
 '''

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -84,10 +84,10 @@ class Namespace(object):
         if rc != 0:
             self.module.fail_json(msg=to_text(err))
 
-        out = json.load(out)
+        out = json.loads(out)
 
         for netns in out:
-            if self.name == netns.name:
+            if self.name == netns["name"]:
                 return True
 
         return False

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -60,6 +60,7 @@ RETURN = '''
 # Default return values
 '''
 
+import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
 
@@ -74,14 +75,22 @@ class Namespace(object):
 
     def _netns(self, command):
         '''Run ip nents command'''
-        return self.module.run_command(['ip', 'netns'] + command)
+        return self.module.run_command(['ip', '-json', 'netns'] + command)
 
     def exists(self):
         '''Check if the namespace already exists'''
         rc, out, err = self._netns(['list'])
+
         if rc != 0:
             self.module.fail_json(msg=to_text(err))
-        return self.name in out
+
+        out = json.load(out)
+
+        for netns in out:
+            if self.name == netns.name:
+                return True
+
+        return False
 
     def add(self):
         '''Create network namespace'''

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -84,9 +84,11 @@ class Namespace(object):
         if rc != 0:
             self.module.fail_json(msg=to_text(err))
 
-        out = json.loads(out)
+        netns_list = []
+        if out != "":
+            netns_list = json.loads(out)
 
-        for netns in out:
+        for netns in netns_list:
             if self.name == netns["name"]:
                 return True
 

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -33,7 +33,7 @@ description:
     - Create or delete network namespaces using the ip command.
 options:
     name:
-        required: false
+        required: yes
         description:
             - Name of the namespace
     state:
@@ -135,7 +135,7 @@ def main():
     """Entry point."""
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(default=None),
+            name=dict(required=True),
             state=dict(default='present', choices=['present', 'absent']),
         ),
         supports_check_mode=True,

--- a/lib/ansible/modules/net_tools/ip_netns.py
+++ b/lib/ansible/modules/net_tools/ip_netns.py
@@ -100,12 +100,9 @@ class Namespace(object):
         '''Run check mode'''
         changed = False
 
-        if self.state == 'present' and self.exists():
+        if self.state == 'present' and not self.exists():
             changed = True
-
         elif self.state == 'absent' and self.exists():
-            changed = True
-        elif self.state == 'present' and not self.exists():
             changed = True
 
         self.module.exit_json(changed=changed)


### PR DESCRIPTION
##### SUMMARY
Fixes some Bugs in ip_netns:
- Check-mode not working correctly (netns exists but check-mode reporting `changed=True`)
- No new netns added if name ist part of the name of an existing netns.
- Require `name`, because `ip netns [add|del]` raises the following error: `No netns name specified`

And some code rework.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
ip_netns

##### ADDITIONAL INFORMATION
Reproduce check-mode issue:
- Create Playbook
- Run Playbook (netns will be added, `changed=True`)
- Run in check-mode (netns already exists but `changed=True`)
- Run again in normal mode (everything is fine, `changed=False`)

Reproduce netns name issue:
- Create netns `red-test`
- Try to create netns `red` or `test` (netns won't be added, `changed=False`)