### PR TITLE
Updating known_hosts module Docs

### DIFF
--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -27,6 +27,7 @@ options:
     aliases: [ 'host' ]
     description:
       - The host to add or remove (must match a host specified in key). It will be converted to lowercase so that ssh-keygen can find it.
+      - Must match with <hostname> or <ip> present in key attribute.
     required: true
   key:
     description:
@@ -36,6 +37,8 @@ options:
         Specifically, the key should not match the format that is found in an SSH pubkey file, but should rather have the hostname prepended to a
         line that includes the pubkey, the same way that it would appear in the known_hosts file. The value prepended to the line must also match
         the value of the name parameter.
+
+        Should be of format `<hostname[,IP]> ssh-rsa <pubkey>`
   path:
     description:
       - The known_hosts file to edit
@@ -61,6 +64,13 @@ EXAMPLES = '''
     path: /etc/ssh/ssh_known_hosts
     name: foo.com.invalid
     key: "{{ lookup('file', 'pubkeys/foo.com.invalid') }}"
+
+- name: Another way to call known_hosts
+  known_hosts:
+    hostname: host1.example.com   # or 10.9.8.77
+    key: host1.example.com,10.9.8.77 ssh-rsa ASDeararAIUHI324324  # some key gibberish
+    path: /etc/ssh/ssh_known_hosts
+    state: present
 '''
 
 # Makes sure public host keys are present or absent in the given known_hosts


### PR DESCRIPTION
##### SUMMARY
When I came across this module for the first time I ran into errors as I could not understand from the docs that I need to mention hostname in key attribute and also use same in `name`/`host` attribute. Hence adding some clarity around the same.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr


##### ISSUE TYPE
The issue was because of lack of clarity in the documentation I ran into following error `Host parameter does not match hashed host field in supplied key`

- Docs Pull Request

##### COMPONENT NAME
known_hosts

##### ADDITIONAL INFORMATION
Run following:
```
known_hosts:
  key: host1.example.com ssh-rsa some-key-gibberish
  name: host1
```

Before it will fail as follows: 
```
 "msg": "Host parameter does not match hashed host field in supplied key"
```

But after I got the clarity around how to use the module more appropriately, I was able to run the module with parameters like below:
```
known_hosts:
  key: host1.example.com ssh-rsa some-key-gibberish
  name: host1.example.com

```

Added an example as well.