### PR TITLE
Changed command for next-hop-self to next-hop-self instead of activate

### DIFF
--- a/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
+++ b/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
@@ -163,7 +163,7 @@ class AFNeighbors(CliProvider):
             return cmd
 
     def _render_next_hop_self(self, item, config=None):
-        cmd = 'neighbor %s activate' % item['neighbor']
+        cmd = 'neighbor %s next-hop-self' % item['neighbor']
         if item['next_hop_self'] is False:
             if not config or cmd in config:
                 cmd = 'no %s' % cmd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modified `lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py` line 166 to be `neighbor %s next-hop-self` instead of `neighbor %s activate` for proper command processing
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #58788 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_bgp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When testing out the ios_bgp command I found that it was not sending `next-hop-self` to the routers. I dug in and found where this was set and it was a copy/paste from activate that missed changing the command. Very plausible to be done.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [r4] => {
    "msg": {
        "changed": true,
        "commands": [
            "no router bgp 65500",
            "router bgp 65500",
            "bgp router-id 10.0.0.4",
            "bgp log-neighbor-changes",
            "neighbor 192.0.2.5 remote-as 65510",
            "neighbor 192.0.2.5 timers 15 45 5",
            "neighbor 192.0.2.5 description R2 Uplink",
            "neighbor 198.51.100.1 remote-as 65500",
            "neighbor 198.51.100.1 timers 15 45 5",
            "neighbor 198.51.100.1 description R3 conenction",
            "network 0.0.0.0",
            "address-family ipv4",
            "redistribute eigrp 20 metric 10",
            "neighbor 198.51.100.1 activate",
            "neighbor 198.51.100.1 next-hop-self",
            "exit-address-family",
            "exit"
        ],
        "failed": false
    }
}
```
