### PR TITLE
ini_file: Add a parameter to append options

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -55,6 +55,7 @@ options:
         required (e.g. for systemd config files).
     type: bool
     default: no
+    version_added: "2.9"
   value:
     description:
       - The string value to be associated with an I(option).


### PR DESCRIPTION
Currently it is not possible to have duplicate keys as e.g. required
to write VLANs to systemd-networkd network files. This commit adds
a parameter append_option which defaults to 'no' and thus does not
change the module behaviour. If set to yes, no existing options are
changed but options are appended instead.