### PR TITLE
WIP combine filter: fine list handling (option a)

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -31,7 +31,7 @@ from ansible import context
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common._collections_compat import MutableMapping, MutableSequence
 from ansible.parsing.splitter import parse_kv
 
 
@@ -92,32 +92,90 @@ def combine_vars(a, b):
         return result
 
 
-def merge_hash(a, b):
+def merge_hash(x, y, recursive=True, list_merge='keep'):
     """
-    Recursively merges hash b into a so that keys from b take precedence over keys from a
+    Return a new dictionary result of the merges of y into x,
+    so that keys from y take precedence over keys from x.
+    (x and y aren't modified)
     """
+    if list_merge not in ('keep', 'append', 'prepend', 'append_np', 'prepend_np'):
+        raise AnsibleError("merge_hash: 'list_merge' argument can only be equal to 'keep', 'append', 'prepend', 'append_np' or 'prepend_np'")
 
-    _validate_mutable_mappings(a, b)
+    # verify x & y are dicts
+    _validate_mutable_mappings(x, y)
 
-    # if a is empty or equal to b, return b
-    if a == {} or a == b:
-        return b.copy()
+    # to speed things up: if x is empty or equal to y, return y
+    # (this `if` can be remove without impact on the function
+    #  except performance)
+    if x == {} or x == y:
+        return y.copy()
 
-    # if b is empty the below unfolds quickly
-    result = a.copy()
+    # in the following we will copy elements from y to x, but
+    # we don't want to modify x, so we create a copy of it
+    x = x.copy()
 
-    # next, iterate over b keys and values
-    for k, v in iteritems(b):
-        # if there's already such key in a
-        # and that key contains a MutableMapping
-        if k in result and isinstance(result[k], MutableMapping) and isinstance(v, MutableMapping):
-            # merge those dicts recursively
-            result[k] = merge_hash(result[k], v)
-        else:
-            # otherwise, just copy the value from b to a
-            result[k] = v
+    # to speed things up: use dict.update if possible
+    # (this `if` can be remove without impact on the function
+    #  except performance)
+    if not recursive and list_merge == 'keep':
+        x.update(y)
+        return x
 
-    return result
+    # insert each element of y in x, overriding the one in x
+    # (as y is of higher priority)
+    # we copy elements from y to x instead of x to y because
+    # there is a high probability x will be the "default" dict the user
+    # want to "patch" with y
+    # therefore x will have much more elements than y
+    for key, y_value in iteritems(y):
+        # if `key` isn't in x
+        # update x and move on to the next element of y
+        if key not in x:
+            x[key] = y_value
+            continue
+        # from this point we know `key` is in x
+
+        x_value = x[key]
+
+        # if both x's element and y's element are dicts
+        # recursively "combine" them or override x's with y's element
+        # depending on the `recursive` argument
+        # and move on to the next element of y
+        if isinstance(x_value, MutableMapping) and isinstance(y_value, MutableMapping):
+            if recursive:
+                x[key] = merge_hash(x_value, y_value, recursive, list_merge)
+            else:
+                x[key] = y_value
+            continue
+
+        # if both x's element and y's element are lists
+        # "merge" them depending on the `list_merge` argument
+        # and move on to the next element of y
+        if isinstance(x_value, MutableSequence) and isinstance(y_value, MutableSequence):
+            if list_merge == 'keep':
+                # keep y value as it as higher priority
+                x[key] = y_value
+            elif list_merge == 'append':
+                x[key] += y_value
+            elif list_merge == 'prepend':
+                # prepend x_value (low prio) to y_value (high prio)
+                x[key] += y_value
+            elif list_merge == 'append_np':
+                # append all elements from x_value (low prio) to y_value (high prio)
+                # except the one that where already there
+                # we don't remove elements from y_value nor x_value that were already in double
+                # (we assume that there is a reason if there where such double elements)
+                # _np stands for "non present"
+                x[key] = y_value + [z for z in x_value if z not in y_value]
+            else:  # prepend_np
+                # same as 'append_np' but x_value elements are prepend
+                x[key] = [z for z in x_value if z not in y_value] + y_value
+            continue
+
+        # else just override x's element with y's one
+        x[key] = y_value
+
+    return x
 
 
 def load_extra_vars(loader):


### PR DESCRIPTION
##### SUMMARY

see:

* #57623
* https://github.com/ansible/community/issues/474#issuecomment-500994513
* https://github.com/ansible/community/issues/474#issuecomment-501765541

Solution (a)

args:

* recursive: same as before
* list_merge:
  * keep: same as before
  * append, prepend: list are appended
  * append_np, prepend_np: only elements that isn't already present in left list are append (_np stands for "non present")

README: will come if this implementation is validated.

I didn't implement 'uniq' as I think 'append_np' and 'prepend_np' are more useful, and are equivalent to unique if list are already filtered from duplication.

non backward compatible: `[dict1, [dict2]] | combine` doesn't work anymore, because I thought it shouldn't. If you disagree, `flatten(terms, levels=1) → flatten(terms)` and it's fixed.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

component =lib/ansible/plugins/filter/core.py