### PR TITLE
Fix exception in unixy callback v2_runner_retry

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -236,6 +236,6 @@ class CallbackModule(CallbackModule_default):
 
     def v2_runner_retry(self, result):
         msg = "  Retrying... (%d of %d)" % (result._result['attempts'], result._result['retries'])
-        if self._run_is_verbose(result, verbosity=2):
+        if self._run_is_verbose(result):
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)


### PR DESCRIPTION
This fixes the warning:

```
[WARNING]: Failure using method (v2_runner_retry) in callback plugin
(<ansible.plugins.callback.unixymdv.CallbackModule object at 0x7fb4fd4eeef0>): _run_is_verbose() got
an unexpected keyword argument 'verbosity'
```

##### SUMMARY
Fixes a little exception, probably on code that needed update

##### ISSUE TYPE
- Bugfix Pull Reques

##### COMPONENT NAME
unixy callback plugin

##### ADDITIONAL INFORMATION
```
- hosts: '*'
  tasks:
  - pause:
      prompt:
    until: false
```
