### PR TITLE
Minor typo in sros_config docstrings

### DIFF
--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -96,7 +96,7 @@ options:
     description:
       - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
-        changes are made. f the C(backup_options) value is not given,
+        changes are made. If the C(backup_options) value is not given,
         the backup file is written to the C(backup) folder in the playbook
         root directory. If the directory does not exist, it is created.
     type: bool


### PR DESCRIPTION
##### SUMMARY
Very minor typo in sros_config `backup` docs


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Typo, `s/f the/If the/`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sros_config
##### ADDITIONAL INFORMATION
