### PR TITLE
Fix broken slxos_config due to changed backup options

### DIFF
--- a/lib/ansible/plugins/action/slxos_config.py
+++ b/lib/ansible/plugins/action/slxos_config.py
@@ -22,8 +22,6 @@ __metaclass__ = type
 import re
 
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils.network.common.backup import write_backup, handle_template
 
 PRIVATE_KEYS_RE = re.compile('__.+__')
 


### PR DESCRIPTION
##### SUMMARY

PR https://github.com/ansible/ansible/pull/50301 overhauled network backup options. A change was missed in slxos_config, resulting in inability to use slxos_config.

This applies to both `devel` and 2.8.2. We'll probably need to backport this fix

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/slxos/slxos_config.py
lib/ansible/plugins/action/slxos_config.py
##### ADDITIONAL INFORMATION

PR #50301 removed lib/ansible/module_utils/network/common/backup.py. Most action plugins were updated to account for this, but slxos_config.py was missed.

This means that `slxos_config` is unusable in 2.8 and `devel`.

Simple playbook used for testing:

```yaml
---
- hosts: slx01
  gather_facts: no

  tasks:
    - name: NTP server 172.16.10.3
      slxos_config:
        lines: "ntp server 172.16.10.3 use-vrf mgmt-vrf"
        save_when: changed
        backup: yes
```

Example output using Ansible 2.8.2:
```shell
lhill @ Lindsays-MacBook-Pro $ ansible-playbook -i hosts slx_config_set_ntp.yaml -vvvv
ansible-playbook 2.8.2
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/venv/lib/python2.7/site-packages/ansible
  executable location = /Users/lhill/venv/bin/ansible-playbook
  python version = 2.7.10 (default, Feb 22 2019, 21:55:15) [GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
script declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
auto declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
Parsed /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: slx_config_set_ntp.yaml ******************************************************************************************************
Positional arguments: slx_config_set_ntp.yaml
become_method: sudo
inventory: (u'/Users/lhill/github/ansible-extreme/slxos/playbooks/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in slx_config_set_ntp.yaml

PLAY [slx01] ***************************************************************************************************************************
META: ran handlers
ERROR! Unexpected Exception, this is probably a bug: No module named backup
the full traceback was:

Traceback (most recent call last):
  File "/Users/lhill/venv/bin/ansible-playbook", line 110, in <module>
    exit_code = cli.run()
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/cli/playbook.py", line 123, in run
    results = pbex.run()
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 169, in run
    result = self._tqm.run(play=play)
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 249, in run
    play_return = strategy.run(iterator, play_context)
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/strategy/linear.py", line 245, in run
    action = action_loader.get(task.action, class_only=True)
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/loader.py", line 558, in get
    self._module_cache[path] = self._load_module_source(name, path)
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/loader.py", line 536, in _load_module_source
    module = imp.load_source(to_native(full_name), to_native(path), module_file)
  File "/Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/action/slxos_config.py", line 26, in <module>
    from ansible.module_utils.network.common.backup import write_backup, handle_template
ImportError: No module named backup
lhill @ Lindsays-MacBook-Pro $
```

Output after making changes in this PR
```
lhill @ Lindsays-MacBook-Pro $ ansible-playbook -i hosts slx_config_set_ntp.yaml -vvvv
ansible-playbook 2.8.2
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/lhill/venv/lib/python2.7/site-packages/ansible
  executable location = /Users/lhill/venv/bin/ansible-playbook
  python version = 2.7.10 (default, Feb 22 2019, 21:55:15) [GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)]
No config file found; using defaults
setting up inventory plugins
host_list declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
script declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
auto declined parsing /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts as it did not pass it's verify_file() method
Parsed /Users/lhill/github/ansible-extreme/slxos/playbooks/hosts inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /Users/lhill/venv/lib/python2.7/site-packages/ansible/plugins/callback/default.pyc

PLAYBOOK: slx_config_set_ntp.yaml ******************************************************************************************************
Positional arguments: slx_config_set_ntp.yaml
become_method: sudo
inventory: (u'/Users/lhill/github/ansible-extreme/slxos/playbooks/hosts',)
forks: 5
tags: (u'all',)
verbosity: 4
connection: smart
timeout: 10
1 plays in slx_config_set_ntp.yaml

PLAY [slx01] ***************************************************************************************************************************
META: ran handlers

TASK [NTP server 172.16.10.3] **********************************************************************************************************
task path: /Users/lhill/github/ansible-extreme/slxos/playbooks/slx_config_set_ntp.yaml:6
<slx01> attempting to start connection
<slx01> using connection plugin network_cli
<slx01> local domain socket does not exist, starting it
<slx01> control socket path is /Users/lhill/.ansible/pc/0dbd5c273e
<slx01> <slx01> ESTABLISH PARAMIKO SSH CONNECTION FOR USER: admin on PORT 22 TO slx01
<slx01> connection to remote device started successfully
<slx01> local domain socket listeners started successfully
<slx01> loaded cliconf plugin for network_os slxos
<slx01> ssh connection done, setting terminal
<slx01> loaded terminal plugin for network_os slxos
<slx01> Response received, triggered 'persistent_buffer_read_timeout' timer of 0.1 seconds
<slx01> firing event: on_open_shell()
<slx01> Response received, triggered 'persistent_buffer_read_timeout' timer of 0.1 seconds
<slx01> ssh connection has completed successfully
<slx01>
<slx01> local domain socket path is /Users/lhill/.ansible/pc/0dbd5c273e
<slx01> ESTABLISH LOCAL CONNECTION FOR USER: lhill
<slx01> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628 `" && echo ansible-tmp-1562540345.47-108247373026628="` echo /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628 `" ) && sleep 0'
<slx01> Attempting python interpreter discovery
<slx01> EXEC /bin/sh -c 'echo PLATFORM; uname; echo FOUND; command -v '"'"'/usr/bin/python'"'"'; command -v '"'"'python3.7'"'"'; command -v '"'"'python3.6'"'"'; command -v '"'"'python3.5'"'"'; command -v '"'"'python2.7'"'"'; command -v '"'"'python2.6'"'"'; command -v '"'"'/usr/libexec/platform-python'"'"'; command -v '"'"'/usr/bin/python3'"'"'; command -v '"'"'python'"'"'; echo ENDFOUND && sleep 0'
<slx01> Python interpreter discovery fallback (unsupported platform for extended discovery: darwin)
Using module file /Users/lhill/venv/lib/python2.7/site-packages/ansible/modules/network/slxos/slxos_config.py
<slx01> PUT /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/tmpi6pLG8 TO /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628/AnsiballZ_slxos_config.py
<slx01> EXEC /bin/sh -c 'chmod u+x /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628/ /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628/AnsiballZ_slxos_config.py && sleep 0'
<slx01> EXEC /bin/sh -c '/usr/bin/python /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628/AnsiballZ_slxos_config.py && sleep 0'
<slx01> EXEC /bin/sh -c 'rm -f -r /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540345.47-108247373026628/ > /dev/null 2>&1 && sleep 0'
<slx01> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596 `" && echo ansible-tmp-1562540358.36-37340971994596="` echo /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596 `" ) && sleep 0'
Using module file /Users/lhill/venv/lib/python2.7/site-packages/ansible/modules/files/stat.py
<slx01> PUT /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/tmp3nnlWE TO /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_stat.py
<slx01> EXEC /bin/sh -c 'chmod u+x /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/ /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_stat.py && sleep 0'
<slx01> EXEC /bin/sh -c '/usr/bin/python /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_stat.py && sleep 0'
<slx01> PUT /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/tmpzK8sa3 TO /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/source
<slx01> EXEC /bin/sh -c 'chmod u+x /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/ /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/source && sleep 0'
Using module file /Users/lhill/venv/lib/python2.7/site-packages/ansible/modules/files/copy.py
<slx01> PUT /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/tmpmTwfLo TO /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_copy.py
<slx01> EXEC /bin/sh -c 'chmod u+x /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/ /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_copy.py && sleep 0'
<slx01> EXEC /bin/sh -c '/usr/bin/python /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/AnsiballZ_copy.py && sleep 0'
<slx01> EXEC /bin/sh -c 'rm -f -r /Users/lhill/.ansible/tmp/ansible-local-19295wupicU/ansible-tmp-1562540358.36-37340971994596/ > /dev/null 2>&1 && sleep 0'
 [WARNING]: Platform darwin on host slx01 is using the discovered Python interpreter at /usr/bin/python, but future installation of
another Python interpreter could change this. See https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html
for more information.

changed: [slx01] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "backup_path": "/Users/lhill/github/ansible-extreme/slxos/playbooks/backup/slx01_config.2019-07-07@15:59:18",
    "changed": true,
    "commands": [
        "ntp server 172.16.10.3 use-vrf mgmt-vrf"
    ],
    "date": "2019-07-07",
    "filename": "slx01_config.2019-07-07@15:59:18",
    "invocation": {
        "module_args": {
            "after": null,
            "backup": true,
            "backup_options": null,
            "before": null,
            "defaults": false,
            "diff_against": null,
            "diff_ignore_lines": null,
            "intended_config": null,
            "lines": [
                "ntp server 172.16.10.3 use-vrf mgmt-vrf"
            ],
            "match": "line",
            "multiline_delimiter": "@",
            "parents": null,
            "replace": "line",
            "running_config": null,
            "save_when": "changed",
            "src": null
        }
    },
    "shortname": "/Users/lhill/github/ansible-extreme/slxos/playbooks/backup/slx01_config",
    "time": "15:59:18",
    "updates": [
        "ntp server 172.16.10.3 use-vrf mgmt-vrf"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP *****************************************************************************************************************************
slx01                      : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
lhill @ Lindsays-MacBook-Pro $ 
```