### PR TITLE
Added dnssrv lookup module.

### DIFF
--- a/changelogs/fragments/58806-dnssrv_lkp_plugin.yml
+++ b/changelogs/fragments/58806-dnssrv_lkp_plugin.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - dnssrv lookup plugin - Search and parse SRV DNS records

--- a/lib/ansible/plugins/lookup/dnssrv.py
+++ b/lib/ansible/plugins/lookup/dnssrv.py
@@ -33,10 +33,10 @@ EXAMPLES = """
   debug: msg="{{ lookup('dnssrv', '_test._tcp.example.com') }}"
 
 - name: show lowest priority, highest weight target
-  debug: msg="{{ lookup('dnssrv', '_test._tcp.example.com').0.0 }}"
+  debug: msg="{{ lookup('dnssrv', '_test._tcp.example.com').0.0.target }}"
 
 - name: iterate over lowest priority entries
-  debug: msg="Target {{ item.1 }} should be used {{ item.0 }}% of the time."
+  debug: msg="Target {{ item.target }} should be used {{ item.weight }}% of the time."
   loop: "{{ lookup('dnssrv', '_test._tcp.example.com').0 }}"
 """
 

--- a/lib/ansible/plugins/lookup/dnssrv.py
+++ b/lib/ansible/plugins/lookup/dnssrv.py
@@ -1,0 +1,121 @@
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: dnssrv
+    author: Ryan Kraus (@rmkraus) <rmkraus(at)gmail.com>
+    version_added: "2.9"
+    short_description: query a domain(s)'s DNS srv fields
+    requirements:
+      - dns/dns.resolver (python library)
+    description:
+      - "Uses a python library to return the sorted DNS SRV records for a domain."
+      - "Records are returned as a list of lists of dictionaries.
+         Entries in the top level are lists grouped by priority (lowest first).
+         Entries in the next level are dictionaries sorted by weight (highest first).
+         The dictionaries have two keys, weight (normalized to be a percentage) and target."
+      - "The target values returned will be cleaned to remove any trailing dots
+         and have the port appended with a semicolon seperation. Ex: test.example.com:8080"
+    options:
+      _terms:
+        description: domain to query SRV records from
+        required: True
+        type: string
+    notes:
+      - Per RFC 2782, lowest priority entries MUST be attempted first.
+        Higher weights SHOULD be used more often proportionally to their relative weight.
+"""
+
+EXAMPLES = """
+- name: show all srv entries
+  debug: msg="{{ lookup('dnssrv', '_test._tcp.example.com') }}"
+
+- name: show lowest priority, highest weight target
+  debug: msg="{{ lookup('dnssrv', '_test._tcp.example.com').0.0 }}"
+
+- name: iterate over lowest priority entries
+  debug: msg="Target {{ item.1 }} should be used {{ item.0 }}% of the time."
+  loop: "{{ lookup('dnssrv', '_test._tcp.example.com').0 }}"
+"""
+
+RETURN = """
+  _list:
+    description:
+      - "List of lists of dicts. Sorted and grouped by priority then weight."
+      - "Dicts have keys: weight and target."
+    type: list
+"""
+
+HAVE_DNS = False
+try:
+    import dns.resolver
+    from dns.exception import DNSException
+    HAVE_DNS = True
+except ImportError:
+    pass
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.plugins.lookup import LookupBase
+
+from collections import defaultdict
+
+
+def _normalize_weights(records):
+    '''Normalize all the weights in a record set to be percentages and sort.'''
+    wt_sum = float(sum([rec['weight'] for rec in records]))
+    _ = [rec.update({'weight': rec['weight']/wt_sum * 100}) for rec in records]
+    records.sort(key=lambda record: 1 - record['weight'])
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+
+        if HAVE_DNS is False:
+            raise AnsibleError("Can't LOOKUP(dnssrv): module dns.resolver is not installed")
+
+        # parse inputs
+        try:
+            term = terms.pop(0)
+        except IndexError:
+            raise AnsibleError("dnssrv lookup plugin requires an input")
+        domain = term.split()[0]
+
+        # perform query
+        try:
+            answers = dns.resolver.query(domain, 'SRV')
+        except dns.resolver.Timeout:
+            return [[]]
+        except dns.resolver.NoAnswer:
+            return [[]]
+        except DNSException as e:
+            raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
+
+        # extract all dns answers, group by priority
+        raw = defaultdict(list)
+        for rdata in answers:
+            # Per RFC 2782, targets will be an absolute FQDN. This means
+            # they end with a final dot. Most Python libraries break spec
+            # and do not tolerate this trailing dot. This will strip it off.
+            target = '.'.join(rdata.target.to_text().split('.')[:-1])
+            port = '{0}'.format(rdata.port)
+            weight = rdata.weight
+            priority = rdata.priority
+
+            raw[priority].append(
+                {'priority': rdata.priority,
+                 'weight': weight,
+                 'target': ':'.join([target, port])
+                 })
+
+        # sort by priority, normalize/sort by weight
+        pris = sorted(raw)
+        all = []
+        for pri in pris:
+            all.append(raw[pri])
+            _normalize_weights(all[-1])
+
+        return all

--- a/lib/ansible/plugins/lookup/dnssrv.py
+++ b/lib/ansible/plugins/lookup/dnssrv.py
@@ -66,7 +66,7 @@ from collections import defaultdict
 def _normalize_weights(records):
     '''Normalize all the weights in a record set to be percentages and sort.'''
     wt_sum = float(sum([rec['weight'] for rec in records]))
-    _ = [rec.update({'weight': rec['weight']/wt_sum * 100}) for rec in records]
+    [rec.update({'weight': rec['weight'] / wt_sum * 100}) for rec in records]
     records.sort(key=lambda record: 1 - record['weight'])
 
 

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -46,3 +46,6 @@ httmock
 
 # requirment for kubevirt modules
 openshift ; python_version >= '2.7'
+
+# requirements for dns lookup plugins
+dnspython

--- a/test/units/plugins/lookup/test_dnssrv.py
+++ b/test/units/plugins/lookup/test_dnssrv.py
@@ -1,5 +1,3 @@
-# (c)2016 Andrew Zenk <azenk@umn.edu>
-#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -36,11 +34,11 @@ MOCK_RECORDS = [
     rdata.from_text(IN, SRV, '20 40 8443 demo-4.example.com.')
 ]
 MOCK_ANSWER = [
-    [{'priority': 10, 'weight': 3 / 6. * 100, 'target': 'demo-3.example.com:8443'},
-     {'priority': 10, 'weight': 2 / 6. * 100, 'target': 'demo-2.example.com:8443'},
-     {'priority': 10, 'weight': 1 / 6. * 100, 'target': 'demo-0.example.com:8443'}],
-    [{'priority': 20, 'weight': 4 / 5. * 100, 'target': 'demo-4.example.com:8443'},
-     {'priority': 20, 'weight': 1 / 5. * 100, 'target': 'demo-1.example.com:8443'}]
+    [{'priority': 10, 'weight': 3 / 6 * 100, 'target': 'demo-3.example.com:8443'},
+     {'priority': 10, 'weight': 2 / 6 * 100, 'target': 'demo-2.example.com:8443'},
+     {'priority': 10, 'weight': 1 / 6 * 100, 'target': 'demo-0.example.com:8443'}],
+    [{'priority': 20, 'weight': 4 / 5 * 100, 'target': 'demo-4.example.com:8443'},
+     {'priority': 20, 'weight': 1 / 5 * 100, 'target': 'demo-1.example.com:8443'}]
 ]
 
 

--- a/test/units/plugins/lookup/test_dnssrv.py
+++ b/test/units/plugins/lookup/test_dnssrv.py
@@ -1,0 +1,71 @@
+# (c)2016 Andrew Zenk <azenk@umn.edu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+
+from dns import rdatatype, rdataclass, rdata
+from dns.rdatatype import SRV
+from dns.rdataclass import IN
+
+from ansible.plugins.lookup.dnssrv import LookupModule
+
+
+MOCK_RECORDS = [
+    rdata.from_text(IN, SRV, '10 10 8443 demo-0.example.com.'),
+    rdata.from_text(IN, SRV, '20 10 8443 demo-1.example.com.'),
+    rdata.from_text(IN, SRV, '10 20 8443 demo-2.example.com.'),
+    rdata.from_text(IN, SRV, '10 30 8443 demo-3.example.com.'),
+    rdata.from_text(IN, SRV, '20 40 8443 demo-4.example.com.')
+]
+MOCK_ANSWER = [
+    [{'priority': 10, 'weight': 3/6.*100, 'target': 'demo-3.example.com:8443'},
+     {'priority': 10, 'weight': 2/6.*100, 'target': 'demo-2.example.com:8443'},
+     {'priority': 10, 'weight': 1/6.*100, 'target': 'demo-0.example.com:8443'}],
+    [{'priority': 20, 'weight': 4/5.*100, 'target': 'demo-4.example.com:8443'},
+     {'priority': 20, 'weight': 1/5.*100, 'target': 'demo-1.example.com:8443'}]
+]
+
+
+class MockLookupModule(LookupModule):
+
+    @staticmethod
+    def _do_dns_query(domain):
+        if domain == '_test._tcp.example.com':
+            return MOCK_RECORDS
+        if domain == '_inop._tcp.example.com':
+            return []
+
+
+class TestDnsSrvPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self._dnssrv = MockLookupModule()
+
+    def tearDown(self):
+        pass
+
+    def test_dnssrv_good_lkp(self):
+        result = self._dnssrv.run(terms=['_test._tcp.example.com'])
+        self.assertEqual(result, MOCK_ANSWER)
+
+    def test_dnssrv_bad_lkp(self):
+        result = self._dnssrv.run(terms=['_inop._tcp.example.com'])
+        self.assertFalse(result)

--- a/test/units/plugins/lookup/test_dnssrv.py
+++ b/test/units/plugins/lookup/test_dnssrv.py
@@ -36,11 +36,11 @@ MOCK_RECORDS = [
     rdata.from_text(IN, SRV, '20 40 8443 demo-4.example.com.')
 ]
 MOCK_ANSWER = [
-    [{'priority': 10, 'weight': 3/6.*100, 'target': 'demo-3.example.com:8443'},
-     {'priority': 10, 'weight': 2/6.*100, 'target': 'demo-2.example.com:8443'},
-     {'priority': 10, 'weight': 1/6.*100, 'target': 'demo-0.example.com:8443'}],
-    [{'priority': 20, 'weight': 4/5.*100, 'target': 'demo-4.example.com:8443'},
-     {'priority': 20, 'weight': 1/5.*100, 'target': 'demo-1.example.com:8443'}]
+    [{'priority': 10, 'weight': 3 / 6. * 100, 'target': 'demo-3.example.com:8443'},
+     {'priority': 10, 'weight': 2 / 6. * 100, 'target': 'demo-2.example.com:8443'},
+     {'priority': 10, 'weight': 1 / 6. * 100, 'target': 'demo-0.example.com:8443'}],
+    [{'priority': 20, 'weight': 4 / 5. * 100, 'target': 'demo-4.example.com:8443'},
+     {'priority': 20, 'weight': 1 / 5. * 100, 'target': 'demo-1.example.com:8443'}]
 ]
 
 


### PR DESCRIPTION
##### SUMMARY
This adds a new lookup module, dnssrv. It was modeled after the dnstxt lookup module, but for SRV records. It parses the results and returns them grouped and sorted per the RFC 2782 spec.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
plugin/lookup/dnssrv

##### ADDITIONAL INFORMATION
Formerly, this same action could be mostly replicated using the dig lkp module. That code would look like this:
```yaml
record: '{{ ["target", "port"] | map("extract", lookup("dig", "_test._tcp.example.com/SRV", "flat=0", wantlist=True).0) | map("regex_replace", "\.$", "") | join(":") }}'
```

With the dnssrv lookup module, it now looks like this:
```yaml
record: '{{ lookup("dnssrv", "_test._tcp.example.com").0.0.target }}'
```

This lookup plugin also extends what is reasonably possible with the dig plugin as everything is sorted and provides the provided weighting information from the DNS records. 
