### PR TITLE
Fix broken slxos_config due to changed backup options (#58804)

### DIFF
--- a/changelogs/fragments/slxos_config_fix.yaml
+++ b/changelogs/fragments/slxos_config_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix broken slxos_config due to changed backup options (https://github.com/ansible/ansible/pull/58804).

--- a/lib/ansible/plugins/action/slxos_config.py
+++ b/lib/ansible/plugins/action/slxos_config.py
@@ -22,8 +22,6 @@ __metaclass__ = type
 import re
 
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils.network.common.backup import write_backup, handle_template
 
 PRIVATE_KEYS_RE = re.compile('__.+__')
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR #50301 overhauled network backup options. A change was missed in slxos_config, resulting in inability to use slxos_config.
(cherry picked from commit 5b2d1cc24d9482e8777b324e824aaa2e43b6e538)
Megred to devel https://github.com/ansible/ansible/pull/58804
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
slox_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
