### PR TITLE
bitbucket_access_key: Fix Python 2.7 compat

### DIFF
--- a/lib/ansible/modules/source_control/bitbucket/bitbucket_access_key.py
+++ b/lib/ansible/modules/source_control/bitbucket/bitbucket_access_key.py
@@ -166,7 +166,7 @@ def get_existing_deploy_key(module, bitbucket):
         if info['status'] != 200:
             module.fail_json(msg='Failed to retrieve the list of deploy keys: {0}'.format(info))
 
-        res = next(filter(lambda v: v['label'] == module.params['label'], content['values']), None)
+        res = next(iter(filter(lambda v: v['label'] == module.params['label'], content['values'])), None)
 
         if res is not None:
             return res


### PR DESCRIPTION
##### SUMMARY

Fixed Python 2.7 compatibility in `bitbucket_access_key` module

Fix: #58456

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/source_control/bitbucket/bitbucket_access_key.py
