### PR TITLE
Added missing param to lambda module to pass it through to boto

### DIFF
--- a/changelogs/fragments/58822-aws-lamda-tracing-config.yaml
+++ b/changelogs/fragments/58822-aws-lamda-tracing-config.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lambda - add a tracing_mode parameter to set the TracingConfig for AWS X-Ray. Also allow updating Lambda runtime.

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -181,7 +181,7 @@ configuration:
     type: dict
     sample:
       {
-        'code_sha256': 'SHA256 hash',
+        'code_sha256': 'zOAGfF5JLFuzZoSNirUtOrQp+S341IOA3BcoXXoaIaU=',
         'code_size': 123,
         'description': 'My function',
         'environment': {
@@ -194,6 +194,7 @@ configuration:
         'handler': 'index.handler',
         'last_modified': '2017-08-01T00:00:00.000+0000',
         'memory_size': 128,
+        'revision_id': 'a2x9886d-d48a-4a0c-ab64-82abc005x80c',
         'role': 'arn:aws:iam::123456789012:role/lambda_basic_execution',
         'runtime': 'nodejs6.10',
         'tracing_config': { 'mode': 'Active' },
@@ -201,7 +202,8 @@ configuration:
         'version': '1',
         'vpc_config': {
           'security_group_ids': [],
-          'subnet_ids': []
+          'subnet_ids': [],
+          'vpc_id': '123'
         }
       }
 '''

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -100,7 +100,7 @@ options:
     description:
       - Set mode to 'Active' to sample and trace incoming requests with AWS X-Ray. Turned off (set to 'PassThrough') by default.
     choices: ['Active', 'PassThrough']
-    version_added: "2.9"
+    version_added: "2.10"
 
   tags:
     description:

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -196,6 +196,7 @@ configuration:
         'memory_size': 128,
         'role': 'arn:aws:iam::123456789012:role/lambda_basic_execution',
         'runtime': 'nodejs6.10',
+        'tracing_config': { 'mode': 'Active' },
         'timeout': 3,
         'version': '1',
         'vpc_config': {

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -440,7 +440,7 @@ def main():
             else:
                 if dead_letter_arn != "":
                     func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
-        if tracing_mode:
+        if tracing_mode and (current_config.get('TracingConfig', {}).get('Mode', 'PassThrough') != tracing_mode):
             func_kwargs.update({'TracingConfig': {'Mode': tracing_mode}})
 
         # If VPC configuration is desired

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -425,6 +425,8 @@ def main():
             func_kwargs.update({'Timeout': timeout})
         if memory_size and current_config['MemorySize'] != memory_size:
             func_kwargs.update({'MemorySize': memory_size})
+        if runtime and current_config['Runtime'] != runtime:
+            func_kwargs.update({'Runtime': runtime})
         if (environment_variables is not None) and (current_config.get(
                 'Environment', {}).get('Variables', {}) != environment_variables):
             func_kwargs.update({'Environment': {'Variables': environment_variables}})
@@ -437,10 +439,6 @@ def main():
                     func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
         if tracing_mode:
             func_kwargs.update({'TracingConfig': {'Mode': tracing_mode}})
-
-        # Check for unsupported mutation
-        if current_config['Runtime'] != runtime:
-            module.fail_json(msg='Cannot change runtime. Please recreate the function')
 
         # If VPC configuration is desired
         if vpc_subnet_ids or vpc_security_group_ids:

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -96,6 +96,12 @@ options:
     description:
       - The parent object that contains the target Amazon Resource Name (ARN) of an Amazon SQS queue or Amazon SNS topic.
     version_added: "2.3"
+  tracing_mode:
+    description:
+      - Set mode to 'Active' to sample and trace incoming requests with AWS X-Ray. Turned off (set to 'PassThrough') by default.
+    choices: ['Active', 'PassThrough']
+    version_added: "2.9"
+
   tags:
     description:
       - tag dict to apply to the function (requires botocore 1.5.40 or above).
@@ -336,6 +342,7 @@ def main():
         vpc_security_group_ids=dict(type='list'),
         environment_variables=dict(type='dict'),
         dead_letter_arn=dict(),
+        tracing_mode=dict(choices=['Active', 'PassThrough']),
         tags=dict(type='dict'),
     )
 
@@ -370,6 +377,7 @@ def main():
     vpc_security_group_ids = module.params.get('vpc_security_group_ids')
     environment_variables = module.params.get('environment_variables')
     dead_letter_arn = module.params.get('dead_letter_arn')
+    tracing_mode = module.params.get('tracing_mode')
     tags = module.params.get('tags')
 
     check_mode = module.check_mode
@@ -427,6 +435,8 @@ def main():
             else:
                 if dead_letter_arn != "":
                     func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
+        if tracing_mode:
+            func_kwargs.update({'TracingConfig': {'Mode': tracing_mode}})
 
         # Check for unsupported mutation
         if current_config['Runtime'] != runtime:
@@ -554,6 +564,9 @@ def main():
 
         if dead_letter_arn:
             func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
+
+        if tracing_mode:
+            func_kwargs.update({'TracingConfig': {'Mode': tracing_mode}})
 
         # If VPC configuration is given
         if vpc_subnet_ids or vpc_security_group_ids:

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -20,7 +20,7 @@
     # ============================================================
     - name: test with no parameters except state absent
       lambda:
-        state=absent
+        state: absent
       register: result
       ignore_errors: true
 
@@ -33,8 +33,8 @@
     # ============================================================
     - name: test with no role or handler
       lambda:
-        name=ansible-testing-fake-should-not-be-created
-        runtime="python2.7"
+        name: ansible-testing-fake-should-not-be-created
+        runtime: "python2.7"
       register: result
       ignore_errors: true
 
@@ -47,10 +47,10 @@
     # ============================================================
     - name: test with all module required variables but no region
       lambda:
-        name=ansible-testing-fake-should-not-be-created
-        runtime="python2.7"
-        handler="no-handler"
-        role=arn:fake-role-doesnt-exist
+        name: ansible-testing-fake-should-not-be-created
+        runtime: "python2.7"
+        handler: "no-handler"
+        role: "arn:fake-role-doesnt-exist"
       register: result
       ignore_errors: true
 
@@ -139,6 +139,8 @@
         name: "{{lambda_function_name}}"
         runtime: "nodejs10.x"
         tracing_mode: 'Active'
+        handler: "mini_lambda.handler"
+        role: "ansible_lambda_role"
         ec2_region: '{{ec2_region}}'
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
@@ -157,6 +159,8 @@
         name: "{{lambda_function_name}}"
         runtime: "python2.7"
         tracing_mode: 'PassThrough'
+        handler: "mini_lambda.handler"
+        role: "ansible_lambda_role"
         ec2_region: '{{ec2_region}}'
         ec2_access_key: '{{ec2_access_key}}'
         ec2_secret_key: '{{ec2_secret_key}}'
@@ -282,12 +286,12 @@
     # ============================================================
     - name: test state=absent (expect changed=False)
       lambda:
-        name="{{lambda_function_name}}"
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=absent
+        name: "{{lambda_function_name}}"
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: absent
       register: result
 
     - name: assert state=absent
@@ -458,19 +462,11 @@
 
   always:
 
-    # ============================================================
-    - name: test state=absent (expect changed=False)
+    - name: ensure function is absent at end of test
       lambda:
-        name="{{lambda_function_name}}"
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        state=absent
-      register: result
-
-    - name: assert state=absent
-      assert:
-        that:
-           - 'result is not failed'
-           - 'result.changed == False'
+        name: "{{lambda_function_name}}"
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: absent

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -76,7 +76,6 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
-        tracing_mode:
       register: result
       ignore_errors: true
 
@@ -180,7 +179,6 @@
         vpc_security_group_ids: sg-FA6E
         environment_variables:
         dead_letter_arn:
-        tracing_mode:
       register: result
       ignore_errors: true
 
@@ -213,7 +211,6 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
-        tracing_mode:
       register: result
 
     - name: assert lambda remains as before
@@ -221,8 +218,6 @@
         that:
            - 'result is not failed'
            - 'result.changed == False'
-
-
 
     # ============================================================
     - name: test putting an environment variable changes lambda

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -76,6 +76,7 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
+        tracing_mode:
       register: result
       ignore_errors: true
 
@@ -101,15 +102,15 @@
 
     - name: test state=present - upload the lambda
       lambda:
-        name="{{lambda_function_name}}"
-        runtime="python2.7"
-        handler="mini_lambda.handler"
-        role="ansible_lambda_role"
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        zip_file="{{zip_res.dest}}"
+        name: "{{lambda_function_name}}"
+        runtime: "python2.7"
+        handler: "mini_lambda.handler"
+        role: "ansible_lambda_role"
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        zip_file: "{{zip_res.dest}}"
       register: result
 
     - name: assert lambda upload succeeded
@@ -134,6 +135,34 @@
            - 'result is not failed'
            - 'result.result.output.message == "hello Mr Ansible Tests"'
 
+    - name: test lambda config updates
+      lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "nodejs10.x"
+        tracing_mode: 'Active'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: update_result
+
+    - name: assert that update succeeded
+      assert:
+        that:
+          - update_result is not failed
+          - update_result is updated
+          - update_result.configuration.runtime == 'nodejs10.x'
+
+    - name: reset config updates for the following tests
+      lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "python2.7"
+        tracing_mode: 'PassThrough'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+
     # ============================================================
     - name: test state=present with security group but no vpc
       lambda:
@@ -151,6 +180,7 @@
         vpc_security_group_ids: sg-FA6E
         environment_variables:
         dead_letter_arn:
+        tracing_mode:
       register: result
       ignore_errors: true
 
@@ -183,6 +213,7 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
+        tracing_mode:
       register: result
 
     - name: assert lambda remains as before

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
-#
-#  Author: Michael De La Rue
-#  based on ec2_key.yml + lambda.py
+# tasks file for aws_lambda test
+
+- name: set up aws connection info
+  set_fact:
+    aws_connection_info: &aws_connection_info
+      ec2_region: '{{ec2_region}}'
+      ec2_access_key: '{{ec2_access_key}}'
+      ec2_secret_key: '{{ec2_secret_key}}'
+      security_token: '{{security_token}}'
+  no_log: yes
 
 - block:
 
@@ -105,11 +112,8 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda upload succeeded
@@ -122,10 +126,7 @@
         name: "{{lambda_function_name}}"
         payload:
           name: "Mr Ansible Tests"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -141,10 +142,7 @@
         tracing_mode: 'Active'
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: update_result
 
     - name: assert that update succeeded
@@ -161,10 +159,7 @@
         tracing_mode: 'PassThrough'
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
 
     # ============================================================
     - name: test state=present with security group but no vpc
@@ -172,10 +167,6 @@
         name: "{{lambda_function_name}}"
         runtime: "python2.7"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
         handler:
         description:
@@ -183,6 +174,7 @@
         vpc_security_group_ids: sg-FA6E
         environment_variables:
         dead_letter_arn:
+        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -200,10 +192,6 @@
         name: "{{lambda_function_name}}"
         runtime: "python2.7"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
         handler: "mini_lambda.handler"
 # These are not allowed because of mutually exclusive.
@@ -215,6 +203,7 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda remains as before
@@ -230,13 +219,10 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
         environment_variables:
             EXTRA_MESSAGE: "I think you are great!!"
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda upload succeeded
@@ -250,10 +236,8 @@
         name: "{{lambda_function_name}}"
         payload:
           name: "Mr Ansible Tests"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
         security_token: '{{security_token}}'
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -287,10 +271,7 @@
     - name: test state=absent (expect changed=False)
       lambda:
         name: "{{lambda_function_name}}"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
         state: absent
       register: result
 
@@ -309,11 +290,8 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_1
 
@@ -323,11 +301,8 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_2
 
@@ -337,11 +312,8 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_3
 
@@ -351,11 +323,8 @@
         runtime: "python2.7"
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -386,11 +355,8 @@
       lambda:
         name: "{{lambda_function_name}}_1"
         state: absent
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_1
 
@@ -398,11 +364,8 @@
       lambda:
         name: "{{lambda_function_name}}_2"
         state: absent
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_2
 
@@ -410,11 +373,8 @@
       lambda:
         name: "{{lambda_function_name}}_3"
         state: absent
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       async: 1000
       register: async_3
 
@@ -422,11 +382,8 @@
       lambda:
         name: "{{lambda_function_name}}_4"
         state: absent
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         zip_file: "{{zip_res.dest}}"
+        <<: *aws_connection_info
       register: result
 
     - name: assert lambda creation has succeeded
@@ -452,21 +409,12 @@
       until: job_result is finished
       retries: 30
 
-
-    # ============================================================
-    # upload via s3 bucket - multi function
-
-    # ============================================================
-    # update already existing function
-
-
+  # ============================================================
   always:
 
     - name: ensure function is absent at end of test
       lambda:
         name: "{{lambda_function_name}}"
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
+        <<: *aws_connection_info
         state: absent
+      ignore_errors: true

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -152,6 +152,23 @@
           - update_result.configuration.runtime == 'nodejs10.x'
           - update_result.configuration.tracing_config.mode == 'Active'
 
+  - name: test no changes are made with the same parameters
+      lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "nodejs10.x"
+        tracing_mode: 'Active'
+        handler: "mini_lambda.handler"
+        role: "ansible_lambda_role"
+      register: update_result
+
+    - name: assert that update succeeded
+      assert:
+        that:
+          - update_result is not failed
+          - update_result.changed == False
+          - update_result.configuration.runtime == 'nodejs10.x'
+          - update_result.configuration.tracing_config.mode == 'Active'
+
     - name: reset config updates for the following tests
       lambda:
         name: "{{lambda_function_name}}"

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -152,7 +152,7 @@
           - update_result.configuration.runtime == 'nodejs10.x'
           - update_result.configuration.tracing_config.mode == 'Active'
 
-  - name: test no changes are made with the same parameters
+    - name: test no changes are made with the same parameters
       lambda:
         name: "{{lambda_function_name}}"
         runtime: "nodejs10.x"

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -139,7 +139,8 @@
       lambda:
         name: "{{lambda_function_name}}"
         runtime: "nodejs10.x"
-        tracing_mode: 'Active'
+# Can only be uncommented once the ansible_lambda_role has permission to call PutTraceSegments on XRAY
+#        tracing_mode: 'Active'
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         <<: *aws_connection_info
@@ -149,7 +150,7 @@
       assert:
         that:
           - update_result is not failed
-          - update_result is updated
+          - update_result.changed == True
           - update_result.configuration.runtime == 'nodejs10.x'
 
     - name: reset config updates for the following tests

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -1,16 +1,15 @@
 ---
 # tasks file for aws_lambda test
 
-- name: set up aws connection info
-  set_fact:
-    aws_connection_info: &aws_connection_info
-      ec2_region: '{{ec2_region}}'
-      ec2_access_key: '{{ec2_access_key}}'
-      ec2_secret_key: '{{ec2_secret_key}}'
-      security_token: '{{security_token}}'
-  no_log: yes
+- name: set connection information for AWS modules and run tests
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
-- block:
+  block:
 
     # ============================================================
     - name: test with no parameters
@@ -58,6 +57,7 @@
         runtime: "python2.7"
         handler: "no-handler"
         role: "arn:fake-role-doesnt-exist"
+        region:
       register: result
       ignore_errors: true
 
@@ -83,6 +83,7 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
+        region:
       register: result
       ignore_errors: true
 
@@ -113,20 +114,19 @@
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda upload succeeded
       assert:
         that:
-           - 'result is not failed'
+          - result is not failed
+          - result.configuration.tracing_config.mode == "PassThrough"
 
     - name: test lambda works
       execute_lambda:
         name: "{{lambda_function_name}}"
         payload:
           name: "Mr Ansible Tests"
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -139,11 +139,9 @@
       lambda:
         name: "{{lambda_function_name}}"
         runtime: "nodejs10.x"
-# Can only be uncommented once the ansible_lambda_role has permission to call PutTraceSegments on XRAY
-#        tracing_mode: 'Active'
+        tracing_mode: 'Active'
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        <<: *aws_connection_info
       register: update_result
 
     - name: assert that update succeeded
@@ -152,6 +150,7 @@
           - update_result is not failed
           - update_result.changed == True
           - update_result.configuration.runtime == 'nodejs10.x'
+          - update_result.configuration.tracing_config.mode == 'Active'
 
     - name: reset config updates for the following tests
       lambda:
@@ -160,7 +159,15 @@
         tracing_mode: 'PassThrough'
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
-        <<: *aws_connection_info
+      register: result
+
+    - name: assert that reset succeeded
+      assert:
+        that:
+          - result is not failed
+          - result.changed == True
+          - result.configuration.runtime == 'python2.7'
+          - result.configuration.tracing_config.mode == 'PassThrough'
 
     # ============================================================
     - name: test state=present with security group but no vpc
@@ -175,7 +182,6 @@
         vpc_security_group_ids: sg-FA6E
         environment_variables:
         dead_letter_arn:
-        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -204,7 +210,6 @@
         vpc_security_group_ids:
         environment_variables:
         dead_letter_arn:
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda remains as before
@@ -223,7 +228,6 @@
         zip_file: "{{zip_res.dest}}"
         environment_variables:
             EXTRA_MESSAGE: "I think you are great!!"
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda upload succeeded
@@ -238,7 +242,6 @@
         payload:
           name: "Mr Ansible Tests"
         security_token: '{{security_token}}'
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -272,7 +275,6 @@
     - name: test state=absent (expect changed=False)
       lambda:
         name: "{{lambda_function_name}}"
-        <<: *aws_connection_info
         state: absent
       register: result
 
@@ -292,7 +294,6 @@
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_1
 
@@ -303,7 +304,6 @@
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_2
 
@@ -314,7 +314,6 @@
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_3
 
@@ -325,7 +324,6 @@
         handler: "mini_lambda.handler"
         role: "ansible_lambda_role"
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda manages to respond as expected
@@ -357,7 +355,6 @@
         name: "{{lambda_function_name}}_1"
         state: absent
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_1
 
@@ -366,7 +363,6 @@
         name: "{{lambda_function_name}}_2"
         state: absent
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_2
 
@@ -375,7 +371,6 @@
         name: "{{lambda_function_name}}_3"
         state: absent
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       async: 1000
       register: async_3
 
@@ -384,7 +379,6 @@
         name: "{{lambda_function_name}}_4"
         state: absent
         zip_file: "{{zip_res.dest}}"
-        <<: *aws_connection_info
       register: result
 
     - name: assert lambda creation has succeeded
@@ -416,6 +410,5 @@
     - name: ensure function is absent at end of test
       lambda:
         name: "{{lambda_function_name}}"
-        <<: *aws_connection_info
         state: absent
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Added missing `tracing_mode` param that passes value through to `TracingConfig` in boto, which was somehow not implemented in this module so far.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
lambda module

##### ADDITIONAL INFORMATION
Module now allows setting all parameters the boto method/AWS API allows.
