### PR TITLE
Adding vserver/SVM NFS info to na_ontap_gather_facts

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_gather_facts.py
@@ -37,7 +37,7 @@ options:
                 "nvme_namespace_info", "nvme_subsystem_info", "ontap_version",
                 "qos_adaptive_policy_info", "qos_policy_info", "security_key_manager_key_info",
                 "security_login_account_info", "storage_failover_info", "volume_info",
-                "vserver_info", "vserver_login_banner_info", "vserver_motd_info"
+                "vserver_info", "vserver_login_banner_info", "vserver_motd_info", "vserver_nfs_info"
                 Can specify a list of values to include a larger subset.  Values can also be used
                 with an initial C(M(!)) to specify that a specific subset should
                 not be collected.
@@ -103,6 +103,7 @@ ontap_facts:
             "vserver_login_banner_info": {...},
             "vserver_motd_info": {...},
             "vserver_info": {...},
+            "vserver_nfs_info": {...},
             "ontap_version": {...},
             "igroup_info": {...},
             "qos_policy_info": {...},
@@ -258,6 +259,16 @@ class NetAppONTAPGatherFacts(object):
                     'call': 'vserver-get-iter',
                     'attribute': 'vserver-info',
                     'field': 'vserver-name',
+                    'query': {'max-records': '1024'},
+                },
+                'min_version': '0',
+            },
+            'vserver_nfs_info': {
+                'method': self.get_generic_get_iter,
+                'kwargs': {
+                    'call': 'nfs-service-get-iter',
+                    'attribute': 'nfs-info',
+                    'field': 'vserver',
                     'query': {'max-records': '1024'},
                 },
                 'min_version': '0',


### PR DESCRIPTION
##### SUMMARY
Adding NFS service information to module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
na_ontap_gather_facts

##### ADDITIONAL INFORMATION
Calling `nfs-service-get-iter` to get information about NFS configuration.
Let me know if `vserver_nfs_info` is a good name. We can change it to 'nfs-service' for example. However, I feel that it belong under vserver. 

