### PR TITLE
timezone - Add AIX support using `chtz`

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -859,7 +859,7 @@ class AIXTimezone(Timezone):
             #  change.
             TZ = self.__get_timezone()
             if TZ != value:
-                msg = 'TZ value does not match post-change (Actual: %s, Expected: %s).' % (match.group(0), value)
+                msg = 'TZ value does not match post-change (Actual: %s, Expected: %s).' % (TZ, value)
                 self.module.fail_json(msg=msg)
 
         else:

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -135,7 +135,7 @@ class Timezone(object):
             if AIXoslevel >= 61:
                 return super(Timezone, AIXTimezone).__new__(AIXTimezone)
             else:
-                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel )
+                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel)
         else:
             # Not supported yet
             return super(Timezone, Timezone).__new__(Timezone)
@@ -785,7 +785,7 @@ class AIXTimezone(Timezone):
     inspects C(/etc/environment) to determine the current timezone.
 
     While AIX time zones can be set using two formats (POSIX and
-    Olson) the prefered method is Olson.  
+    Olson) the prefered method is Olson.
     See the following article for more information:
     https://developer.ibm.com/articles/au-aix-posix/
 
@@ -821,8 +821,8 @@ class AIXTimezone(Timezone):
         """
         if key == 'name':
             # chtz seems to always return 0 on AIX 7.2, even for invalid timezone values.
-            # It will only return non-zero if the chtz command itself fails, it does not check for 
-            #  valid timezones. We need to perform a basic check to confirm that the timezone 
+            # It will only return non-zero if the chtz command itself fails, it does not check for
+            #  valid timezones. We need to perform a basic check to confirm that the timezone
             #  definition exists in /usr/share/lib/zoneinfo
             # This does mean that we can only support Olson for now. The below commented out regex
             #  detects Olson date formats, so in the future we could detect Posix or Olson and
@@ -848,8 +848,8 @@ class AIXTimezone(Timezone):
 
             if rc != 0:
                 self.module.fail_json(msg=stderr)
-            
-            # The best condition check we can do is to check the environment file after making the 
+
+            # The best condition check we can do is to check the environment file after making the
             #  change.
             try:
                 p = re.compile('^TZ=(.*)$')

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -795,9 +795,7 @@ class AIXTimezone(Timezone):
 
     def __init__(self, module):
         super(AIXTimezone, self).__init__(module)
-        self.settimezone = self.module.get_bin_path('chtz', required=False)
-        if not self.settimezone:
-            module.fail_json(msg='chtz not found.')
+        self.settimezone = self.module.get_bin_path('chtz', required=True)
 
     def get(self, key, phase):
         """Lookup the current timezone name in `/etc/environment`. If anything else

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -21,9 +21,11 @@ description:
   - Several different tools are used depending on the OS/Distribution involved.
     For Linux it can use C(timedatectl) or edit C(/etc/sysconfig/clock) or C(/etc/timezone) and C(hwclock).
     On SmartOS, C(sm-set-timezone), for macOS, C(systemsetup), for BSD, C(/etc/localtime) is modified.
+    On AIX, C(chtz) is used.
   - As of Ansible 2.3 support was added for SmartOS and BSDs.
   - As of Ansible 2.4 support was added for macOS.
-  - Windows, AIX and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
+  - As of Ansible 2.9 support was added for AIX 6.1+
+  - Windows and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
 version_added: "2.2"
 options:
   name:
@@ -45,6 +47,8 @@ options:
     choices: [ local, UTC ]
 notes:
   - On SmartOS the C(sm-set-timezone) utility (part of the smtools package) is required to set the zone timezone
+  - On AIX only Olson/tz database timezones are useable (POSIX is not supported).
+    - An OS reboot is also required on AIX for the new timezone setting to take effect.
 author:
   - Shinichi TAMURA (@tmshn)
   - Jasper Lievisse Adriaanse (@jasperla)
@@ -126,6 +130,12 @@ class Timezone(object):
             return super(Timezone, DarwinTimezone).__new__(DarwinTimezone)
         elif re.match('^(Free|Net|Open)BSD', platform.platform()):
             return super(Timezone, BSDTimezone).__new__(BSDTimezone)
+        elif platform.system() == 'AIX':
+            AIXoslevel = int(platform.version() + platform.release())
+            if AIXoslevel >= 61:
+                return super(Timezone, AIXTimezone).__new__(AIXTimezone)
+            else:
+                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel )
         else:
             # Not supported yet
             return super(Timezone, Timezone).__new__(Timezone)
@@ -764,6 +774,95 @@ class BSDTimezone(Timezone):
             except Exception:
                 os.remove(new_localtime)
                 self.module.fail_json(msg='Could not update /etc/localtime')
+        else:
+            self.module.fail_json(msg='%s is not a supported option on target platform' % key)
+
+
+class AIXTimezone(Timezone):
+    """This is a Timezone manipulation class for AIX instances.
+
+    It uses the C(chtz) utility to set the timezone, and
+    inspects C(/etc/environment) to determine the current timezone.
+
+    While AIX time zones can be set using two formats (POSIX and
+    Olson) the prefered method is Olson.  
+    See the following article for more information:
+    https://developer.ibm.com/articles/au-aix-posix/
+
+    NB: AIX needs to be rebooted in order for the change to be
+    activated.
+    """
+
+    def __init__(self, module):
+        super(AIXTimezone, self).__init__(module)
+        self.settimezone = self.module.get_bin_path('chtz', required=False)
+        if not self.settimezone:
+            module.fail_json(msg='chtz not found.')
+
+    def get(self, key, phase):
+        """Lookup the current timezone name in `/etc/environment`. If anything else
+        is requested, or if the TZ field is not set we fail.
+        """
+        if key == 'name':
+            try:
+                f = open('/etc/environment', 'r')
+                for line in f:
+                    m = re.match('^TZ=(.*)$', line.strip())
+                    if m:
+                        return m.groups()[0]
+            except Exception:
+                self.module.fail_json(msg='Failed to read /etc/environment')
+        else:
+            self.module.fail_json(msg='%s is not a supported option on target platform' % key)
+
+    def set(self, key, value):
+        """Set the requested timezone through chtz, an invalid timezone name
+        will be rejected and we have no further input validation to perform.
+        """
+        if key == 'name':
+            # chtz seems to always return 0 on AIX 7.2, even for invalid timezone values.
+            # It will only return non-zero if the chtz command itself fails, it does not check for 
+            #  valid timezones. We need to perform a basic check to confirm that the timezone 
+            #  definition exists in /usr/share/lib/zoneinfo
+            # This does mean that we can only support Olson for now. The below commented out regex
+            #  detects Olson date formats, so in the future we could detect Posix or Olson and
+            #  act accordingly.
+
+            # regex_olson = re.compile('^([a-z0-9_\-\+]+\/?)+$', re.IGNORECASE)
+            # if not regex_olson.match(value):
+            #     msg = 'Supplied timezone (%s) does not appear to a be valid Olson string' % value
+            #     self.module.fail_json(msg=msg)
+
+            # First determine if the requested timezone is valid by looking in the zoneinfo
+            #  directory.
+            zonefile = '/usr/share/lib/zoneinfo/' + value
+            try:
+                if not os.path.isfile(zonefile):
+                    self.module.fail_json(msg='%s is not a recognized timezone.' % value)
+            except Exception:
+                self.module.fail_json(msg='Failed to check %s.' % zonefile)
+
+            # Now set the TZ using chtz
+            cmd = 'chtz %s' % value
+            (rc, stdout, stderr) = self.module.run_command(cmd)
+
+            if rc != 0:
+                self.module.fail_json(msg=stderr)
+            
+            # The best condition check we can do is to check the environment file after making the 
+            #  change.
+            try:
+                p = re.compile('^TZ=(.*)$')
+                f = open('/etc/environment', 'r')
+                for line in f:
+                    line = line.strip()
+                    if p.match(line):
+                        check = line.split('=')[1]
+                        if check != value:
+                            msg = 'Post-change check does not match supplied value (%s - %s)' % (check, value)
+                            self.module.fail_json(msg=msg)
+            except Exception:
+                self.module.fail_json(msg='Failed to check status of change; issue reading /etc/environment')
         else:
             self.module.fail_json(msg='%s is not a supported option on target platform' % key)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding AIX support to module timezone.

This code does not support posix format, Olson/tz database only (similar to all other implementations).  Tested on AIX 7.1 and 7.2, but should work on all AIX 6.1+ instances.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
timezone

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
There's a small block of commented out code that checks to see if the supplied format is Olson/tzdatabase.  This could be used for future additional Posix support, but I do not believe that it would ever be necessary.  Just in case someone ever requests it.

Contrary to IBM's man page, `chtz` pretty much never returns non-zero *except* when it is unable to update the /etc/environment file.  Totally invalid timezones such as `aaaBadTimeZoneaaa` can be supplied and AIX will happy set `TZ=aaaBadTimeZoneaaa` in the environment file.

To avoid this we confirm that the supplied Olson/tz database `name` is found in `/usr/share/lib/zoneinfo/'name'` before making the change.  If the target file does not exist we exit with failure

If the timezone file does exist, we update /etc/environment using `chtz name`, and then post-check `/etc/environment` to ensure that `TZ=name` exists

##### Examples / Testing

For the given example of `Asia/Tokyo`:
On the target AIX host, the file exists:
```text
root@AIXSERVER:/ # oslevel -s
7200-01-00-0000
root@AIXSERVER:/ # ls -l /usr/share/lib/zoneinfo/Asia/Tokyo
-rw-r--r--    1 bin      bin             355 Feb  2 2017  /usr/share/lib/zoneinfo/Asia/Tokyo
root@AIXSERVER:/ # file /usr/share/lib/zoneinfo/Asia/Tokyo
/usr/share/lib/zoneinfo/Asia/Tokyo: data or International Language text
root@AIXSERVER:/ # grep '^TZ' /etc/environment
TZ=US/Central
```

And testing:

###### Running on a server with a new, valid, timezone
```
# ansible -vvv AIXSERVER -i /etc/ansible/test.ini -m timezone -a "name=Asia/Tokyo"
--cut--
AIXSERVER | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "diff": {
        "after": {
            "name": "Asia/Tokyo"
        },
        "before": {
            "name": "US/Central"
        }
    },
    "invocation": {
        "module_args": {
            "hwclock": null,
            "name": "Asia/Tokyo"
        }
    }
}
```

###### Running on a server with a the existing timezone
```
# ansible -vvv AIXSERVER -i /etc/ansible/test.ini -m timezone -a "name=Asia/Tokyo"
--cut--
AIXSERVER | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "diff": {
        "after": {
            "name": "Asia/Tokyo"
        },
        "before": {
            "name": "Asia/Tokyo"
        }
    },
    "invocation": {
        "module_args": {
            "hwclock": null,
            "name": "Asia/Tokyo"
        }
    }
}
```

###### Running with an invalid timezone
```
# ansible -vvv AIXSERVER -i /etc/ansible/test.ini -m timezone -a "name=Moon/Lunar-Base"
AIXSERVER | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "hwclock": null,
            "name": "Moon/Lunar-Base"
        }
    },
    "msg": "Moon/Lunar-Base is not a recognized timezone"
```
