### PR TITLE
proxmox_kvm: fixes parameters for linked clones.

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -735,6 +735,8 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             if module.params[param] is not None:
                 clone_params[param] = module.params[param]
         clone_params.update(dict([k, int(v)] for k, v in clone_params.items() if isinstance(v, bool)))
+        if clone_params['full'] == 0:  # linked clones don't need format:
+            del clone_params['format']
         taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
     else:
         taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`proxmox_kvm` has a default value for `format` - but `format` is an invalid parameter for the case that `full` is false. This removes the `format` parameter in this case.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before when setting `full=0` this error would occur:
```
fatal: [nuc1]: FAILED! => {"changed": false, "msg": "Unable to clone vm testguy from vmid 9000=500 Internal Server Error: {\"data\":null}"}
```

This is because the `format` parameter is being sent.  Format is only valid for a full clone, but since we request a linked clone (`full=0`) we do not need to specify `format`.