### PR TITLE
Enhancement: replaced with_items keyword for loop keyword in file module's example

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -145,7 +145,7 @@ EXAMPLES = r'''
     src: '/tmp/{{ item.src }}'
     dest: '{{ item.dest }}'
     state: hard
-  with_items:
+  loop:
     - { src: x, dest: y }
     - { src: z, dest: k }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In example code of file module, with_items keyword is used but loop keyword is currently recommended for loop. A list in that example is simple and flat, so I just replaced with_items for loop without any filter.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
file module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
None
<!--- Paste verbatim command output below, e.g. before and after your change -->
