### PR TITLE
Use templated loop_var/index_var when looping include_*

### DIFF
--- a/changelogs/fragments/58820-use-templated-loop_var-in-include_tasks.yaml
+++ b/changelogs/fragments/58820-use-templated-loop_var-in-include_tasks.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use templated loop_var/index_var when looping include_* (https://github.com/ansible/ansible/issues/58820)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -382,6 +382,7 @@ class TaskExecutor:
             res['ansible_loop_var'] = loop_var
             if index_var:
                 res[index_var] = item_index
+                res['ansible_index_var'] = index_var
             if extended:
                 res['ansible_loop'] = task_vars['ansible_loop']
 

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -87,11 +87,8 @@ class IncludedFile:
 
                     include_args = include_result.get('include_args', dict())
                     special_vars = {}
-                    loop_var = 'item'
-                    index_var = None
-                    if original_task.loop_control:
-                        loop_var = original_task.loop_control.loop_var
-                        index_var = original_task.loop_control.index_var
+                    loop_var = include_result.get('ansible_loop_var', 'item')
+                    index_var = include_result.get('ansible_index_var')
                     if loop_var in include_result:
                         task_vars[loop_var] = special_vars[loop_var] = include_result[loop_var]
                     if index_var and index_var in include_result:

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -344,4 +344,3 @@
     loop_var: "{{ loop_var_name }}"
   vars:
     loop_var_name: templated_loop_var_name
-  register: templated_loop_var_name_result

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -334,3 +334,14 @@
     - 1
   loop_control:
     loop_var: alvin
+
+# https://github.com/ansible/ansible/issues/58820
+- name: Test using templated loop_var inside include_tasks
+  include_tasks: templated_loop_var_tasks.yml
+  loop:
+    - value
+  loop_control:
+    loop_var: "{{ loop_var_name }}"
+  vars:
+    loop_var_name: templated_loop_var_name
+  register: templated_loop_var_name_result

--- a/test/integration/targets/loops/tasks/templated_loop_var_tasks.yml
+++ b/test/integration/targets/loops/tasks/templated_loop_var_tasks.yml
@@ -1,0 +1,4 @@
+- name: Validate that the correct value was used
+  assert:
+    that:
+      - templated_loop_var_name == 'value'


### PR DESCRIPTION
##### SUMMARY
We seem to correctly template `loop_var` in `TaskExecutor`:
https://github.com/ansible/ansible/blob/894d19b1088d8d4872ca0dd2b9588f196b9a34ea/lib/ansible/executor/task_executor.py#L298

But then in `IncludedFile` we use the 'raw' value instead of re-using the templated one:
https://github.com/ansible/ansible/blob/894d19b1088d8d4872ca0dd2b9588f196b9a34ea/lib/ansible/playbook/included_file.py#L93

Fixes #58820

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_executor.py`
`lib/ansible/playbook/included_file.py`