### PR TITLE
Strip whitespaces in import_playbook

### DIFF
--- a/changelogs/fragments/56626-import_playbook-whitespaces.yml
+++ b/changelogs/fragments/56626-import_playbook-whitespaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Strip whitespaces from import_playbook filename (https://github.com/ansible/ansible/issues/56626).

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -144,7 +144,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
         if len(items) == 0:
             raise AnsibleParserError("import_playbook statements must specify the file name to import", obj=ds)
         else:
-            new_ds['import_playbook'] = items[0]
+            new_ds['import_playbook'] = items[0].rstrip()
             if len(items) > 1:
                 # rejoin the parameter portion of the arguments and
                 # then use parse_kv() to get a dict of params back

--- a/test/integration/targets/include_import/playbook/playbook5.yml
+++ b/test/integration/targets/include_import/playbook/playbook5.yml
@@ -1,0 +1,7 @@
+- name: Playbook 5
+  hosts: testhost2
+
+  tasks:
+    - name: Set fact in playbook 5
+      debug:
+        msg: playbook5 imported

--- a/test/integration/targets/include_import/playbook/test_import_playbook_tags.yml
+++ b/test/integration/targets/include_import/playbook/test_import_playbook_tags.yml
@@ -8,3 +8,5 @@
     - skipme
 
 - import_playbook: validate_tags.yml        # Validate
+
+- import_playbook: playbook5.yml   tags=test_import

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -20,6 +20,7 @@ ansible -m include_role -a name=role1 localhost
 ANSIBLE_STRATEGY='linear' ansible-playbook playbook/test_import_playbook.yml -i inventory "$@"
 ANSIBLE_STRATEGY='free' ansible-playbook playbook/test_import_playbook.yml -i inventory "$@"
 ANSIBLE_STRATEGY='linear' ansible-playbook playbook/test_import_playbook_tags.yml -i inventory "$@" --tags canary1,canary22,validate --skip-tags skipme
+ANSIBLE_STRATEGY='linear' ansible-playbook playbook/test_import_playbook_tags.yml -i inventory "$@" --tags test_import
 
 # Tasks
 ANSIBLE_STRATEGY='linear' ansible-playbook tasks/test_import_tasks.yml -i inventory "$@"


### PR DESCRIPTION
##### SUMMARY
Fixes: #56626

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56626-import_playbook-whitespaces.yml
lib/ansible/playbook/playbook_include.py
test/integration/targets/include_import/playbook/playbook5.yml
test/integration/targets/include_import/playbook/test_import_playbook_tags.yml
test/integration/targets/include_import/runme.sh