### PR TITLE
Fix LXC virtualization facts

### DIFF
--- a/changelogs/fragments/lxc_virtualization_facts.yaml
+++ b/changelogs/fragments/lxc_virtualization_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - LXC is now detected more reliably for the virtualization_type and virtualization_role facts

--- a/changelogs/fragments/lxc_virtualization_facts.yaml
+++ b/changelogs/fragments/lxc_virtualization_facts.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - LXC is now detected more reliably for the virtualization_type and virtualization_role facts
+  - linux virtualization facts - LXC is now detected more reliably (https://github.com/ansible/ansible/pull/58881).

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -71,13 +71,18 @@ class LinuxVirtual(Virtual):
         # the lxd communication sockets are good indicators for lxc guest/host
         # https://lxd.readthedocs.io/en/latest/dev-lxd/
         if os.path.exists('/dev/lxd/sock'):
-            virtual_facts['virtualization_type'] = 'lxc'
-            virtual_facts['virtualization_role'] = 'guest'
-            return virtual_facts
+            guest_tech.add('lxc')
+            if not found_virt:
+                virtual_facts['virtualization_type'] = 'lxc'
+                virtual_facts['virtualization_role'] = 'guest'
+                found_virt = True
+
         if os.path.exists('/var/lib/lxd/devlxd/sock'):
-            virtual_facts['virtualization_type'] = 'lxc'
-            virtual_facts['virtualization_role'] = 'host'
-            return virtual_facts
+            host_tech.add('lxc')
+            if not found_virt:
+                virtual_facts['virtualization_type'] = 'lxc'
+                virtual_facts['virtualization_role'] = 'host'
+                found_virt = True
 
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -68,6 +68,17 @@ class LinuxVirtual(Virtual):
                         virtual_facts['virtualization_role'] = 'guest'
                         found_virt = True
 
+        # the lxd communication sockets are good indicators for lxc guest/host
+        # https://lxd.readthedocs.io/en/latest/dev-lxd/
+        if os.path.exists('/dev/lxd/sock'):
+            virtual_facts['virtualization_type'] = 'lxc'
+            virtual_facts['virtualization_role'] = 'guest'
+            return virtual_facts
+        if os.path.exists('/var/lib/lxd/devlxd/sock'):
+            virtual_facts['virtualization_type'] = 'lxc'
+            virtual_facts['virtualization_role'] = 'host'
+            return virtual_facts
+
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):
             for line in get_file_lines('/proc/1/environ', line_sep='\x00'):

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -69,7 +69,7 @@ class LinuxVirtual(Virtual):
                         found_virt = True
 
         # the lxd communication sockets are good indicators for lxc guest/host
-        # https://lxd.readthedocs.io/en/latest/dev-lxd/
+        # https://linuxcontainers.org/lxd/docs/master/
         if os.path.exists('/dev/lxd/sock'):
             guest_tech.add('lxc')
             if not found_virt:


### PR DESCRIPTION
##### SUMMARY
LXD guests were wrongly detected when running as non-root (making the check for `/proc/1/environ fail`) and when systemd was absent (making the check for `/run/systemd/container` fail).

Fixed this by adding a check for the LXD host <-> guest communication socket `/dev/lxd/sock` which is almost guaranteed to exist, thought it can theoretically be disabled by configuration.

Ref: https://github.com/lxc/lxd/issues/5923#issuecomment-509705074
Ref: https://lxd.readthedocs.io/en/latest/dev-lxd/

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
facts

##### ADDITIONAL INFORMATION
Before
```
"ansible_virtualization_role": "host",
"ansible_virtualization_type": "kvm",
```

After
```
"ansible_virtualization_role": "lxc",
"ansible_virtualization_type": "guest",
```
