### PR TITLE
Fix nxos_ospf_vrf python3 compatibility issue

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -299,7 +299,7 @@ def state_present(module, existing, proposed, candidate):
                 if len(value) < 5:
                     command = '{0} {1} Mbps'.format(key, value)
                 else:
-                    value = str(int(value) / 1000)
+                    value = str(int(value) // 1000)
                     command = '{0} {1} Gbps'.format(key, value)
             elif key == 'bfd':
                 command = 'no bfd' if value == 'disable' else 'bfd'


### PR DESCRIPTION
Make sure division results in an integer since NXOS can't
handle a floating point value for the auto-cost reference-bandwidth

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In python 3, the / operator yields a float even when both operands are ints. When python3 is used as the interpreter, the module will fail when trying to set the auto-cost reference bandwidth:

fatal: [switchname]: FAILED! => {"changed": false, "msg": "auto-cost reference-bandwidth 100.0 Gbps\r\r\n ^\r\n% Invalid number at '^' marker.\r\n\switchname(config-router)# "}

This patch implements the python3 '//' operator for integer floor division 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
