### PR TITLE
[stable-2.8] Update default test container to use Python 3.8.0b2 (#58877)

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:1.8.2 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7

--- a/test/sanity/pslint/ignore.txt
+++ b/test/sanity/pslint/ignore.txt
@@ -14,6 +14,7 @@ lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 PSProvi
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSCustomUseLiteralPath
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1 PSProvideCommentHelp
+lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSAvoidUsingPositionalParameters
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSAvoidUsingWMICmdlet
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSCustomUseLiteralPath
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 PSUseApprovedVerbs
@@ -88,6 +89,7 @@ lib/ansible/modules/windows/win_iis_website.ps1 PSAvoidUsingCmdletAliases
 lib/ansible/modules/windows/win_iis_website.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_iis_website.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_iis_website.ps1 PSUseDeclaredVarsMoreThanAssignments
+lib/ansible/modules/windows/win_lineinfile.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_lineinfile.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_mapped_drive.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_msg.ps1 PSAvoidTrailingWhitespace
@@ -149,6 +151,7 @@ lib/ansible/modules/windows/win_user_profile.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_wait_for.ps1 PSAvoidUsingEmptyCatchBlock
 lib/ansible/modules/windows/win_wait_for.ps1 PSCustomUseLiteralPath
 lib/ansible/modules/windows/win_webpicmd.ps1 PSAvoidUsingInvokeExpression
+lib/ansible/modules/windows/win_xml.ps1 PSAvoidUsingPositionalParameters
 lib/ansible/modules/windows/win_xml.ps1 PSCustomUseLiteralPath
 test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1 PSUseApprovedVerbs
 test/integration/targets/win_audit_rule/library/test_get_audit_rule.ps1 PSAvoidUsingCmdletAliases


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #58877 for Ansible 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/runner/completion/docker.txt`