### PR TITLE
Re-enable ec2_vpc_vpn_facts test

### DIFF
--- a/test/integration/targets/ec2_vpc_vpn_facts/aliases
+++ b/test/integration/targets/ec2_vpc_vpn_facts/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group2
-disabled


### PR DESCRIPTION
Unable to reproduce failure locally, let's see if shippable still fails

##### SUMMARY
Test re-enabling ec2_vpc_vpn_facts test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_vpn_facts integration test

##### ADDITIONAL INFORMATION
Unable to reproduce timeout failures locally in us-east-1 or us-west-2 though nothing has changed in the test or the module.  ¯\_(ツ)_/¯