### PR TITLE
collections_tech_preview notes/example module_utils python imports

### DIFF
--- a/docs/docsite/rst/collections_tech_preview.rst
+++ b/docs/docsite/rst/collections_tech_preview.rst
@@ -123,7 +123,7 @@ module_utils
 When working with ``module_utils`` in a collection, the Python ``import`` statement will need to take into account the FQCN along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
 Example snippet of a module using both default Ansible ``module_utils`` and
-those provided by a collection. In this example the Collection is
+those provided by a collection. In this example the collection is
 ``ansible_security``, the namespace is ``community``, and the ``module_util`` in
 question is called ``qradar`` such that the Fully Qualified Collection Name
 (FQCN) is ``ansible_security.community.plugins.module_utils.qradar``:

--- a/docs/docsite/rst/collections_tech_preview.rst
+++ b/docs/docsite/rst/collections_tech_preview.rst
@@ -120,7 +120,7 @@ Add a 'per plugin type' specific subdirectory here, including ``module_utils`` w
 module_utils
 ~~~~~~~~~~~~
 
-When working with ``module_utils`` in a Collection, the python ``import`` statement will need to take into account the Fully Qualified Collection Name (FQCN) along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
+When working with ``module_utils`` in a collection, the Python ``import`` statement will need to take into account the FQCN along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
 Example snippet of a module using both default Ansible ``module_utils`` and
 those provided by a collection. In this example the Collection is

--- a/docs/docsite/rst/collections_tech_preview.rst
+++ b/docs/docsite/rst/collections_tech_preview.rst
@@ -115,8 +115,43 @@ The ``ansible-doc`` command requires the fully qualified collection name (FQCN) 
 plugins directory
 ------------------
 
- Add a 'per plugin type' specific subdirectory here, including ``module_utils`` which is usable not only by modules, but by any other plugin by using their FQCN. This is a way to distribute modules, lookups, filters, and so on, without having to import a role in every play.
+Add a 'per plugin type' specific subdirectory here, including ``module_utils`` which is usable not only by modules, but by any other plugin by using their Fully Qualified Collection Name (FQCN). This is a way to distribute modules, lookups, filters, and so on, without having to import a role in every play.
 
+module_utils
+~~~~~~~~~~~~
+
+When working with ``module_utils`` in a Collection, the python ``import`` statement will need to take into account the Fully Qualified Collection Name (FQDN) along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
+
+Example snippet of a module using both default Ansible ``module_utils`` and
+those provided by a collection. In this example the Collection is
+``ansible_security``, the namespace is ``community``, and the ``module_util`` in
+question is called ``qradar`` such that the Fully Qualified Collection Name
+(FQCN) is ``ansible_security.community.plugins.module_utils.qradar``:
+
+::
+
+    from ansible.module_utils.basic import AnsibleModule
+    from ansible.module_utils._text import to_text
+
+    from ansible.module_utils.six.moves.urllib.parse import urlencode, quote_plus
+    from ansible.module_utils.six.moves.urllib.error import HTTPError
+    from ansible_collections.ansible_security.community.plugins.module_utils.qradar import QRadarRequest
+
+    argspec = dict(
+        name=dict(required=True, type='str'),
+        state=dict(choices=['present', 'absent'], required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argspec,
+        supports_check_mode=True
+    )
+
+    qradar_request = QRadarRequest(
+        module,
+        headers={"Content-Type": "application/json"},
+        not_rest_data_keys=['state']
+    )
 
 roles directory
 ----------------

--- a/docs/docsite/rst/collections_tech_preview.rst
+++ b/docs/docsite/rst/collections_tech_preview.rst
@@ -122,7 +122,7 @@ module_utils
 
 When working with ``module_utils`` in a collection, the Python ``import`` statement will need to take into account the FQCN along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
-Example snippet of a module using both default Ansible ``module_utils`` and
+The following example snippet shows a module using both default Ansible ``module_utils`` and
 those provided by a collection. In this example the collection is
 ``ansible_security``, the namespace is ``community``, and the ``module_util`` in
 question is called ``qradar`` such that the Fully Qualified Collection Name

--- a/docs/docsite/rst/collections_tech_preview.rst
+++ b/docs/docsite/rst/collections_tech_preview.rst
@@ -120,7 +120,7 @@ Add a 'per plugin type' specific subdirectory here, including ``module_utils`` w
 module_utils
 ~~~~~~~~~~~~
 
-When working with ``module_utils`` in a Collection, the python ``import`` statement will need to take into account the Fully Qualified Collection Name (FQDN) along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
+When working with ``module_utils`` in a Collection, the python ``import`` statement will need to take into account the Fully Qualified Collection Name (FQCN) along with the ``ansible_collections`` convention. The resulting import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
 Example snippet of a module using both default Ansible ``module_utils`` and
 those provided by a collection. In this example the Collection is


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add notes and example for using `module_utils` that are delivered as part of a Collection.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/collections_tech_preview.rst

