### PR TITLE
Update vmware_dvs_portgroup_facts.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup_facts.py
@@ -4,6 +4,7 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -34,6 +35,12 @@ options:
     - Name of the datacenter.
     required: true
     type: str
+  dvswitch:
+    description:
+    - Name of a dvswitch to look for.
+    required: false
+    type: str
+    default: all
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -49,6 +56,11 @@ options:
     - Show or hide teaming policies of DVS portgroup.
     type: bool
     default: True
+  show_vlan_info:
+    description:
+    - Show or hide vlan information of the DVS portgroup.
+    type: bool
+    default: False
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -61,7 +73,6 @@ EXAMPLES = r'''
     validate_certs: no
     datacenter: "{{ datacenter_name }}"
   register: dvpg_facts
-
 - name: Get number of ports for portgroup 'dvpg_001' in 'dvs_001'
   debug:
     msg: "{{ item.num_ports }}"
@@ -107,6 +118,10 @@ dvs_portgroup_facts:
                     "policy": "loadbalance_srcid",
                     "rolling_order": false
                 },
+                "vlan_info": {
+                    "trunk": false,
+                    "vlan_id": true,
+                },
                 "type": "earlyBinding"
             },
         ]
@@ -119,20 +134,30 @@ except ImportError as e:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs
+from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs, find_dvs_by_name
 
 
 class DVSPortgroupFactsManager(PyVmomi):
     def __init__(self, module):
         super(DVSPortgroupFactsManager, self).__init__(module)
         self.dc_name = self.params['datacenter']
+        self.dvs_name = self.params['dvsname']
 
     def gather_dvs_portgroup_facts(self):
         datacenter = self.find_datacenter_by_name(self.dc_name)
+
         if datacenter is None:
             self.module.fail_json(msg="Failed to find the datacenter %s" % self.dc_name)
+        
+        if self.dvs_name == 'all':
+            dvs_lists = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
+        else:
+            dvsn = find_dvs_by_name(self.content, self.dvs_name)
+            if dvsn is None:
+                self.module.fail_json(msg="Failed to find the dvswitch %s" % self.dvs_name)
+            else:
+                dvs_lists = [dvsn]
 
-        dvs_lists = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
 
         result = dict()
         for dvs in dvs_lists:
@@ -141,6 +166,7 @@ class DVSPortgroupFactsManager(PyVmomi):
                 network_policy = dict()
                 teaming_policy = dict()
                 port_policy = dict()
+                vlan_info = dict()
 
                 if self.module.params['show_network_policy'] and dvs_pg.config.defaultPortConfig.securityPolicy:
                     network_policy = dict(
@@ -171,6 +197,25 @@ class DVSPortgroupFactsManager(PyVmomi):
                         vlan_override=dvs_pg.config.policy.vlanOverrideAllowed
                     )
 
+                if self.params['show_vlan_info']:
+                    vlanInfo = dvs_pg.config.defaultPortConfig.vlan
+                    if isinstance(vlanInfo, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+                        vlan_id_list = []
+                        for vli in vlanInfo.vlanId:
+                            if vli.start == vli.end:
+                                vlan_id_list.append(str(vli.start))
+                            else:
+                                vlan_id_list.append(str(vli.start) + "-" + str(vli.end))
+                        vlan_info = dict(
+                            trunk=True,
+                            vlan_id=vlan_id_list
+                        )
+                    else:
+                        vlan_info = dict(
+                            trunk=False,
+                            vlan_id=vlanInfo.vlanId
+                        )
+
                 dvpg_details = dict(
                     portgroup_name=dvs_pg.name,
                     num_ports=dvs_pg.config.numPorts,
@@ -180,6 +225,7 @@ class DVSPortgroupFactsManager(PyVmomi):
                     teaming_policy=teaming_policy,
                     port_policy=port_policy,
                     network_policy=network_policy,
+                    vlan_info=vlan_info,
                 )
                 result[dvs.name].append(dvpg_details)
 
@@ -193,6 +239,8 @@ def main():
         show_network_policy=dict(type='bool', default=True),
         show_teaming_policy=dict(type='bool', default=True),
         show_port_policy=dict(type='bool', default=True),
+        dvsname=dict(type='str', default='all'),
+        show_vlan_info=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
New options for vlan and dvswitch


##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_dvs_portgroup_facts

##### SUMMARY
two items that I found very useful and needed to add to my project:

1. wouldn't be great to add a variable for particular dvswitch?
2. wouldn't be great to get also the vlan information of the port group?

I added it to the code

for item 1, adding new arg similar to datacenter and building a list (default is all to keep module as it was)

if self.dvs_name == 'all':
    dvs_lists = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
else:
    dvsn = find_dvs_by_name(self.content, self.dvs_name)
    if dvsn is None:
        self.module.fail_json(msg="Failed to find the dvswitch %s" % self.dvs_name)
    else:
        dvs_lists=[dvsn]

for item 2, adding new entry to the existing construct without modifying much:

        if self.params['show_vlan_info']:
            vlanInfo=dvs_pg.config.defaultPortConfig.vlan
            if isinstance(vlanInfo,vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
                vlan_id_list = []
                for vli in vlanInfo.vlanId:
                    vlan_id_list.append(str(vli.start)+"-"+str(vli.end))
                vlan_info = dict(
                    trunk=True,
                    vlan_id=vlan_id_list
                )
            else:
                vlan_info = dict(
                    trunk=False,
                    vlan_id=vlanInfo.vlanId
                )

is working for me so hopefully will help someone else.
