### PR TITLE
Iptables - negation operator

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -370,6 +370,12 @@ EXAMPLES = r'''
     jump: ACCEPT
     comment: Accept new SSH connections.
 
+- name: Drop all protocols except TCP protocol
+  iptables:
+    chain: INPUT
+    protocol: '!tcp' # or '! tcp'
+    jump: DROP
+
 - name: Match on IP ranges
   iptables:
     chain: FORWARD

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -474,7 +474,7 @@ def append_param(rule, param, flag, is_list):
     else:
         if param is not None:
             if param[0] == '!':
-                rule.extend(['!', flag, param[1:]])
+                rule.extend(['!', flag, param[1:].replace(" ", "")])
             else:
                 rule.extend([flag, param])
 


### PR DESCRIPTION
#### iptables - not operator

The documentation does not include an example how to use the not operator and also, does not describe the use of this operator in details.

> A `!` argument before the protocol inverts the test.

There are some cases (see below) that this will lead to a failure.

Modifications:
* added docs-example with `!` operator
* added string.strim() to avoid 3rd case

#### ISSUE TYPE
Bugfix Pull Request

#### COMPONENT NAME
iptables

#### ADDITIONAL INFORMATION

#### Version
ansible 2.8.2

#### 1. Case
RULE:
```yml
- chain: INPUT
  protocol: !icmp
  reject_with: icmp-port-unreachable
  jump: REJECT
```
OUTPUT:
```
ERROR! Syntax Error while loading YAML.
  could not determine a constructor for the tag '!icmp'

The error appears to be in '/home/adrian/Documents/playbook.yml': line 35, column 21, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

        - chain: INPUT
          protocol: !icmp
                    ^ here
```
RESULT:
**Error.**

#### 2. Case
RULE:
```yml
- chain: INPUT
  protocol: ! icmp
  reject_with: icmp-port-unreachable
  jump: REJECT
```
OUTPUT:
```
changed: [localhost] => (item={u'jump': u'REJECT', u'protocol': u'icmp', u'chain': u'INPUT', u'reject_with': u'icmp-port-unreachable'})
```
RESULT:
```
-A INPUT -p icmp -j REJECT --reject-with icmp-port-unreachable
```
NOTE:
The NOT operator is missing. **Failure.**

#### 3. Case
RULE:
```yml
- chain: INPUT
  protocol: "! icmp"
  reject_with: icmp-port-unreachable
  jump: REJECT
```
OUTPUT:
```
failed: [localhost] (item={u'jump': u'REJECT', u'protocol': u'! icmp', u'chain': u'INPUT', u'reject_with': u'icmp-port-unreachable'}) => {"ansible_loop_var": "item", "changed": false, "cmd": "/sbin/iptables -t filter -A INPUT '!' -p ' icmp' -j REJECT --reject-with icmp-port-unreachable", "item": {"chain": "INPUT", "jump": "REJECT", "protocol": "! icmp", "reject_with": "icmp-port-unreachable"}, "msg": "iptables v1.6.1: unknown protocol \" icmp\" specified\nTry `iptables -h' or 'iptables --help' for more information.", "rc": 2, "stderr": "iptables v1.6.1: unknown protocol \" icmp\" specified\nTry `iptables -h' or 'iptables --help' for more information.\n", "stderr_lines": ["iptables v1.6.1: unknown protocol \" icmp\" specified", "Try `iptables -h' or 'iptables --help' for more information."], "stdout": "", "stdout_lines": []}
```
RESULT:
**Error.**

#### 4. Case
RULE:
```yml
- chain: INPUT
  protocol: "!icmp"
  reject_with: icmp-port-unreachable
  jump: REJECT
```
OUTPUT:
```
changed: [localhost] => (item={u'jump': u'REJECT', u'protocol': u'!icmp', u'chain': u'INPUT', u'reject_with': u'icmp-port-unreachable'})
```
RESULT:
```
-A INPUT ! -p icmp -j REJECT --reject-with icmp-port-unreachable
```
NOTE:
**Success.**
