### PR TITLE
Add examples (#58819)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_vlan.py
+++ b/lib/ansible/modules/network/ios/ios_vlan.py
@@ -85,6 +85,19 @@ EXAMPLES = """
   ios_vlan:
     vlan_id: 100
     state: absent
+
+- name: Add vlan using aggregate
+  ios_vlan:
+    aggregate:
+    - { vlan_id: 100, name: test-vlan, interfaces: [GigabitEthernet0/1, GigabitEthernet0/2], delay: 15, state: suspend }
+    - { vlan_id: 101, name: test-vlan, interfaces: GigabitEthernet0/3 }
+
+- name: Move interfaces to a different VLAN
+  ios_vlan:
+    vlan_id: 102
+    interfaces:
+      - GigabitEthernet0/0
+      - GigabitEthernet0/1
 """
 
 RETURN = """


### PR DESCRIPTION
* Add examples to the ios_vlan docs: vlan using aggregate and move vlan interface example

(cherry picked from commit 5689cc08cea71ce8bfbe15d74af4622d2913bcc1)

##### SUMMARY
Add 2 more examples to the ios_vlan docs: 
vlan using aggregate and move vlan associated interface

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlan.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
