### PR TITLE
fix azure_rm_rediscache notify notify_keyspace_events type

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_rediscache.py
@@ -92,6 +92,7 @@ options:
         description:
             - Allows clients to receive notifications when certain events occur.
             - Please see U(https://docs.microsoft.com/en-us/azure/redis-cache/cache-configure#advanced-settings) for more detail.
+        type: str
     shard_count:
         description:
             - The number of shards to be created when I(sku=premium).
@@ -353,7 +354,7 @@ class AzureRMRedisCaches(AzureRMModuleBase):
                 ]
             ),
             notify_keyspace_events=dict(
-                type='int'
+                type='str'
             ),
             shard_count=dict(
                 type='int'


### PR DESCRIPTION
##### SUMMARY
The parameter **notify_keyspace_events** of the azure cloud module **azure_rm_rediscache** requires an int, but it should require a string.

`fatal: [HOST -> localhost]: FAILED! => {"changed": false, "msg": "argument notify_keyspace_events is of type <type 'str'> and we were unable to convert to int: <type 'str'> cannot be converted to an int"}   `

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_rediscache