### PR TITLE
Add version_added to ec2 inv iam_role_arn option

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -29,6 +29,7 @@ DOCUMENTATION = '''
         iam_role_arn:
           description: The ARN of the IAM role to assume to perform the inventory lookup. You should still provide AWS
               credentials with enough privilege to perform the AssumeRole action.
+          version_added: '2.9'
         regions:
           description:
               - A list of regions in which to describe EC2 instances.


### PR DESCRIPTION
##### SUMMARY
Add version_added to ec2 inv iam_role_arn option; feature was added in #41637 but did not include this

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
aws_ec2 inventory plugin


