### PR TITLE
[WIP]: PR to add Vendor specific dhcp option for Avaya 

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_network.py
+++ b/lib/ansible/modules/net_tools/nios/nios_network.py
@@ -240,7 +240,9 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
         if isinstance(module.params[key], list):
             temp_dict = module.params[key][0]
             if 'num' in temp_dict:
-                if temp_dict['num'] in (43, 124, 125):
+                # use_option only applies to special options that are displayed separately
+                # from other options as per NIOS use_option flags documentation
+                if temp_dict['num'] in (43, 124, 125, 119, 242):
                     del module.params[key][0]['use_option']
     return ib_spec
 


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to resolve bug #55722, where vendor-specific DHCP option for Avaya was failing coz of `use_option` flag. Added Avaya specific DHCP option.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_network
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
