### PR TITLE
2.8: assign a sane default to yum/dnf lock_timeout, in line with cli (#57383)

### DIFF
--- a/changelogs/fragments/yum-sane-default-lockfile-timeout.yml
+++ b/changelogs/fragments/yum-sane-default-lockfile-timeout.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - yum - set lock_timeout to a sane default (30 seconds, as is the cli)
+  - dnf - set lock_timeout to a sane default (30 seconds, as is the cli)

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -46,7 +46,7 @@ yumdnf_argument_spec = dict(
         update_cache=dict(type='bool', default=False, aliases=['expire-cache']),
         update_only=dict(required=False, default="no", type='bool'),
         validate_certs=dict(type='bool', default=True),
-        lock_timeout=dict(type='int', default=0),
+        lock_timeout=dict(type='int', default=30),
     ),
     required_one_of=[['name', 'list', 'update_cache']],
     mutually_exclusive=[['name', 'list']],

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -181,7 +181,7 @@ options:
     description:
       - Amount of time to wait for the dnf lockfile to be freed.
     required: false
-    default: 0
+    default: 30
     type: int
     version_added: "2.8"
   install_weak_deps:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -187,7 +187,7 @@ options:
     description:
       - Amount of time to wait for the yum lockfile to be freed.
     required: false
-    default: 0
+    default: 30
     type: int
     version_added: "2.8"
   install_weak_deps:


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/57383

(cherry picked from commit d2dc4c9bc43aae4e1b46098ac1e006fa3dda00ae)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
dnf