### PR TITLE
2.8: Use templated loop_var/index_var when looping include_* (#58866)

### DIFF
--- a/changelogs/fragments/58820-use-templated-loop_var-in-include_tasks.yaml
+++ b/changelogs/fragments/58820-use-templated-loop_var-in-include_tasks.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use templated loop_var/index_var when looping include_* (https://github.com/ansible/ansible/issues/58820)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -381,6 +381,7 @@ class TaskExecutor:
             res['ansible_loop_var'] = loop_var
             if index_var:
                 res[index_var] = item_index
+                res['ansible_index_var'] = index_var
             if extended:
                 res['ansible_loop'] = task_vars['ansible_loop']
 

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -87,11 +87,8 @@ class IncludedFile:
 
                     include_args = include_result.get('include_args', dict())
                     special_vars = {}
-                    loop_var = 'item'
-                    index_var = None
-                    if original_task.loop_control:
-                        loop_var = original_task.loop_control.loop_var
-                        index_var = original_task.loop_control.index_var
+                    loop_var = include_result.get('ansible_loop_var', 'item')
+                    index_var = include_result.get('ansible_index_var')
                     if loop_var in include_result:
                         task_vars[loop_var] = special_vars[loop_var] = include_result[loop_var]
                     if index_var and index_var in include_result:

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -334,3 +334,13 @@
     - 1
   loop_control:
     loop_var: alvin
+
+# https://github.com/ansible/ansible/issues/58820
+- name: Test using templated loop_var inside include_tasks
+  include_tasks: templated_loop_var_tasks.yml
+  loop:
+    - value
+  loop_control:
+    loop_var: "{{ loop_var_name }}"
+  vars:
+    loop_var_name: templated_loop_var_name

--- a/test/integration/targets/loops/tasks/templated_loop_var_tasks.yml
+++ b/test/integration/targets/loops/tasks/templated_loop_var_tasks.yml
@@ -1,0 +1,4 @@
+- name: Validate that the correct value was used
+  assert:
+    that:
+      - templated_loop_var_name == 'value'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/58866

(cherry picked from commit 7346b699eec99d7279da4175b99f07e08f0de283)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/executor/task_executor.py`
`lib/ansible/playbook/included_file.py`