### PR TITLE
fix: greedy match may cause unwanted replacement

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -282,6 +282,8 @@ def main():
             n0 = i
         if line == marker1:
             n1 = i
+            if (n0 != None):
+              break
 
     if None in (n0, n1):
         n0 = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
say we have below 2 existing blocks in file, and we specify "marker_begin_text_1" in playbook to do an update.
But because of greedy match, the content of block 2 will also be overwritten.
So this pull request is to resolve this issue.


marker_begin_text_1
    content1
end
marker_begin_text_2
    content2
end

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`files/blockinfile.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
