### PR TITLE
[2.8] nmcli: Argument vlanid (int) is changed internally to string

### DIFF
--- a/changelogs/fragments/58949-nmcli-vlanid-typecast.yml
+++ b/changelogs/fragments/58949-nmcli-vlanid-typecast.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Typecast vlan id to string in nmcli module (https://github.com/ansible/ansible/issues/58949).

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1145,7 +1145,7 @@ class Nmcli(object):
             cmd.append('vlan%s' % self.vlanid)
 
         params = {'dev': self.vlandev,
-                  'id': self.vlanid,
+                  'id': str(self.vlanid),
                   'ip4': self.ip4 or '',
                   'gw4': self.gw4 or '',
                   'ip6': self.ip6 or '',
@@ -1170,7 +1170,7 @@ class Nmcli(object):
             cmd.append('vlan%s' % self.vlanid)
 
         params = {'vlan.parent': self.vlandev,
-                  'vlan.id': self.vlanid,
+                  'vlan.id': str(self.vlanid),
                   'ipv4.address': self.ip4 or '',
                   'ipv4.gateway': self.gw4 or '',
                   'ipv4.dns': self.dns4 or '',

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -144,6 +144,7 @@ TESTCASE_VLAN = [
         'ifname': 'vlan_not_exists',
         'ip4': '10.10.10.10',
         'gw4': '10.10.10.1',
+        'vlanid': 10,
         'state': 'present',
         '_ansible_check_mode': False,
     }
@@ -466,7 +467,7 @@ def test_create_vlan_con(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1']:
+    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'id', '10']:
         assert param in args[0]
 
 
@@ -488,7 +489,7 @@ def test_mod_vlan_conn(mocked_generic_connection_modify):
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
 
-    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1']:
+    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'vlan.id', '10']:
         assert param in args[0]
 
 


### PR DESCRIPTION
##### SUMMARY
* Argument vlanid (int) is changed internally to string
* Modified test case to check vlan id

Fixes: #58949
(cherry picked from commit e8f4ebb22ce2413bf26b111516c858adc2b0c083)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/nmcli.py
