### PR TITLE
pip: Remove unused option use_mirrors and remove all ignore.txt entries

### DIFF
--- a/changelogs/fragments/58977-pip-remove_use_mirrors.yml
+++ b/changelogs/fragments/58977-pip-remove_use_mirrors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pip - Remove the unused and undocumented option ``use_mirrors``."

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -587,7 +587,6 @@ def main():
             virtualenv_site_packages=dict(type='bool', default=False),
             virtualenv_command=dict(type='path', default='virtualenv'),
             virtualenv_python=dict(type='str'),
-            use_mirrors=dict(type='bool', default=True),
             extra_args=dict(type='str'),
             editable=dict(type='bool', default=False),
             chdir=dict(type='path'),

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -3032,9 +3032,6 @@ lib/ansible/modules/packaging/language/pear.py E322
 lib/ansible/modules/packaging/language/pear.py E326
 lib/ansible/modules/packaging/language/pear.py E337
 lib/ansible/modules/packaging/language/pear.py E338
-lib/ansible/modules/packaging/language/pip.py E322
-lib/ansible/modules/packaging/language/pip.py E324
-lib/ansible/modules/packaging/language/pip.py E337
 lib/ansible/modules/packaging/language/yarn.py E337
 lib/ansible/modules/packaging/language/yarn.py E338
 lib/ansible/modules/packaging/os/apk.py E326


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR removes the unused option `use_mirrors`. I've tried to find when this option was actually used but I couldn't find it, I guess it predates the current mono-repo? Anyway since this option hasn't been documented for at least the last 4 current major versions it should be alright to be removed.

Together with https://github.com/ansible/ansible/pull/58966 this allows us to remove all ignored sanity checks from ignore.txt. This PR will keep failing until https://github.com/ansible/ansible/pull/58966 is merged this branch is rebased.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip
