### PR TITLE
Allow encryption of volumes based off snapshots

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -800,8 +800,6 @@ def create_block_device(module, ec2, volume):
             size = volume.get('volume_size', snapshot.volume_size)
             if int(volume['iops']) > MAX_IOPS_TO_SIZE_RATIO * size:
                 module.fail_json(msg='IOPS must be at most %d times greater than size' % MAX_IOPS_TO_SIZE_RATIO)
-        if 'encrypted' in volume:
-            module.fail_json(msg='You can not set encryption when creating a volume from a snapshot')
     if 'ephemeral' in volume:
         if 'snapshot' in volume:
             module.fail_json(msg='Cannot set both ephemeral and snapshot')


### PR DESCRIPTION
##### SUMMARY
Since May 10, 2019 AWS have allowed encrypted volumes to be created from snapshots.  BOTO3 allows this, but the EC2 module does not.  This change removes the restriction.

https://aws.amazon.com/about-aws/whats-new/2019/05/launch-encrypted-ebs-backed-ec2-instances-from-unencrypted-amis-in-a-single-step/

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
EC2.PY

##### ADDITIONAL INFORMATION
Prevents the error message "You can not set encryption when creating a volume from a snapshot"