### PR TITLE
Warn for reserved vars when using ansible-inventory and adhoc

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -16,6 +16,7 @@ from ansible.parsing.splitter import parse_kv
 from ansible.playbook import Playbook
 from ansible.playbook.play import Play
 from ansible.utils.display import Display
+from ansible.vars.reserved import warn_if_reserved
 
 display = Display()
 
@@ -121,6 +122,10 @@ class AdHocCLI(CLI):
         if context.CLIARGS['module_name'] in ('import_playbook',):
             raise AnsibleOptionsError("'%s' is not a valid action for ad-hoc commands"
                                       % context.CLIARGS['module_name'])
+
+        for host in hosts:
+            host_vars = variable_manager.get_vars(host=host)
+            warn_if_reserved(host_vars)
 
         play_ds = self._play_ds(pattern, context.CLIARGS['seconds'], context.CLIARGS['poll_interval'])
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -18,6 +18,7 @@ from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.loader import vars_loader
 from ansible.utils.vars import combine_vars
 from ansible.utils.display import Display
+from ansible.vars.reserved import warn_if_reserved
 
 display = Display()
 
@@ -132,6 +133,7 @@ class InventoryCLI(CLI):
                 raise AnsibleOptionsError("You must pass a single valid host to --host parameter")
 
             myvars = self._get_host_variables(host=hosts[0])
+            warn_if_reserved(myvars)
 
             # FIXME: should we template first?
             results = self.dump(myvars)
@@ -330,6 +332,7 @@ class InventoryCLI(CLI):
         for host in hosts:
             hvars = self._get_host_variables(host)
             if hvars:
+                warn_if_reserved(hvars)
                 results['_meta']['hostvars'][host.name] = hvars
 
         return results


### PR DESCRIPTION
##### SUMMARY
Warn for reserved vars when using ansible-inventory and adhoc rather than only with ansible-playbook

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/cli/inventory.py
ansible/cli/adhoc.py
