### PR TITLE
[WIP]Add debug logs in network_cli connection

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -460,8 +460,13 @@ class Connection(NetworkConnectionBase):
             if prompt_len != answer_len:
                 raise AnsibleConnectionFailure("Number of prompts (%s) is not same as that of answers (%s)" % (prompt_len, answer_len))
         try:
-            self._history.append(command)
-            self._ssh_shell.sendall(b'%s\r' % command)
+            cmd = b'%s\r' % command
+            self._history.append(cmd)
+            self._log_messages("command executed: %s" % cmd)
+            self._log_messages("prompt: %s" % prompt)
+            self._log_messages("answer: %s" % answer)
+            self._log_messages("sendonly: %s" % sendonly)
+            self._ssh_shell.sendall(cmd)
             if sendonly:
                 return
             response = self.receive(command, prompt, answer, newline, prompt_retry_check, check_all)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
DO NOT MERGE
*  iosxr integration test fails intermittently in zuul CI
   This PR adds curated logs in network_cli connection plugin
   to debug the root cause
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/network_cli.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/163