### PR TITLE
playbooks_reuse.rst - documentation - consistent order of dynamic/static

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse.rst
@@ -24,23 +24,23 @@ Ansible has two modes of operation for reusable content: dynamic and static.
 
 In Ansible 2.0, the concept of *dynamic* includes was introduced. Due to some limitations with making all includes dynamic in this way, the ability to force includes to be *static* was introduced in Ansible 2.1. Because the *include* task became overloaded to encompass both static and dynamic syntaxes, and because the default behavior of an include could change based on other options set on the Task, Ansible 2.4 introduces the concept of ``include`` vs. ``import``.
 
-If you use any ``import*`` Task (``import_playbook``, ``import_tasks``, etc.), it will be *static*.
 If you use any ``include*`` Task (``include_tasks``, ``include_role``, etc.), it will be *dynamic*.
+If you use any ``import*`` Task (``import_playbook``, ``import_tasks``, etc.), it will be *static*.
 
 The bare ``include`` task (which was used for both Task files and Playbook-level includes) is still available, however it is now considered *deprecated*.
 
-Differences Between Static and Dynamic
+Differences Between Dynamic and Static
 ``````````````````````````````````````
 
 The two modes of operation are pretty simple:
 
-* Ansible pre-processes all static imports during Playbook parsing time.
 * Dynamic includes are processed during runtime at the point in which that task is encountered.
+* Ansible pre-processes all static imports during Playbook parsing time.
 
 When it comes to Ansible task options like ``tags`` and conditional statements (``when:``):
 
-* For static imports, the parent task options will be copied to all child tasks contained within the import.
 * For dynamic includes, the task options will *only* apply to the dynamic task as it is evaluated, and will not be copied to child tasks.
+* For static imports, the parent task options will be copied to all child tasks contained within the import.
 
 .. note::
     Roles are a somewhat special case. Prior to Ansible 2.3, roles were always statically included via the special ``roles:`` option for a given play and were always executed first before any other play tasks (unless ``pre_tasks`` were used). Roles can still be used this way, however, Ansible 2.3 introduced the ``include_role`` option to allow roles to be executed inline with other tasks.

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -859,7 +859,7 @@ class AIXTimezone(Timezone):
             #  change.
             TZ = self.__get_timezone()
             if TZ != value:
-                msg = 'TZ value does not match post-change (Actual: %s, Expected: %s).' % (match.group(0), value)
+                msg = 'TZ value does not match post-change (Actual: %s, Expected: %s).' % (TZ, value)
                 self.module.fail_json(msg=msg)
 
         else:

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -135,7 +135,7 @@ class Timezone(object):
             if AIXoslevel >= 61:
                 return super(Timezone, AIXTimezone).__new__(AIXTimezone)
             else:
-                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel )
+                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel)
         else:
             # Not supported yet
             return super(Timezone, Timezone).__new__(Timezone)
@@ -785,7 +785,7 @@ class AIXTimezone(Timezone):
     inspects C(/etc/environment) to determine the current timezone.
 
     While AIX time zones can be set using two formats (POSIX and
-    Olson) the prefered method is Olson.  
+    Olson) the prefered method is Olson.
     See the following article for more information:
     https://developer.ibm.com/articles/au-aix-posix/
 
@@ -821,8 +821,8 @@ class AIXTimezone(Timezone):
         """
         if key == 'name':
             # chtz seems to always return 0 on AIX 7.2, even for invalid timezone values.
-            # It will only return non-zero if the chtz command itself fails, it does not check for 
-            #  valid timezones. We need to perform a basic check to confirm that the timezone 
+            # It will only return non-zero if the chtz command itself fails, it does not check for
+            #  valid timezones. We need to perform a basic check to confirm that the timezone
             #  definition exists in /usr/share/lib/zoneinfo
             # This does mean that we can only support Olson for now. The below commented out regex
             #  detects Olson date formats, so in the future we could detect Posix or Olson and
@@ -848,8 +848,8 @@ class AIXTimezone(Timezone):
 
             if rc != 0:
                 self.module.fail_json(msg=stderr)
-            
-            # The best condition check we can do is to check the environment file after making the 
+
+            # The best condition check we can do is to check the environment file after making the
             #  change.
             try:
                 p = re.compile('^TZ=(.*)$')

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -795,9 +795,7 @@ class AIXTimezone(Timezone):
 
     def __init__(self, module):
         super(AIXTimezone, self).__init__(module)
-        self.settimezone = self.module.get_bin_path('chtz', required=False)
-        if not self.settimezone:
-            module.fail_json(msg='chtz not found.')
+        self.settimezone = self.module.get_bin_path('chtz', required=True)
 
     def get(self, key, phase):
         """Lookup the current timezone name in `/etc/environment`. If anything else

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -21,9 +21,11 @@ description:
   - Several different tools are used depending on the OS/Distribution involved.
     For Linux it can use C(timedatectl) or edit C(/etc/sysconfig/clock) or C(/etc/timezone) and C(hwclock).
     On SmartOS, C(sm-set-timezone), for macOS, C(systemsetup), for BSD, C(/etc/localtime) is modified.
+    On AIX, C(chtz) is used.
   - As of Ansible 2.3 support was added for SmartOS and BSDs.
   - As of Ansible 2.4 support was added for macOS.
-  - Windows, AIX and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
+  - As of Ansible 2.9 support was added for AIX 6.1+
+  - Windows and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
 version_added: "2.2"
 options:
   name:
@@ -45,6 +47,8 @@ options:
     choices: [ local, UTC ]
 notes:
   - On SmartOS the C(sm-set-timezone) utility (part of the smtools package) is required to set the zone timezone
+  - On AIX only Olson/tz database timezones are useable (POSIX is not supported).
+    - An OS reboot is also required on AIX for the new timezone setting to take effect.
 author:
   - Shinichi TAMURA (@tmshn)
   - Jasper Lievisse Adriaanse (@jasperla)
@@ -126,6 +130,12 @@ class Timezone(object):
             return super(Timezone, DarwinTimezone).__new__(DarwinTimezone)
         elif re.match('^(Free|Net|Open)BSD', platform.platform()):
             return super(Timezone, BSDTimezone).__new__(BSDTimezone)
+        elif platform.system() == 'AIX':
+            AIXoslevel = int(platform.version() + platform.release())
+            if AIXoslevel >= 61:
+                return super(Timezone, AIXTimezone).__new__(AIXTimezone)
+            else:
+                module.fail_json(msg='AIX os level must be >= 61 for timezone module (Target: %s).' % AIXoslevel )
         else:
             # Not supported yet
             return super(Timezone, Timezone).__new__(Timezone)
@@ -764,6 +774,95 @@ class BSDTimezone(Timezone):
             except Exception:
                 os.remove(new_localtime)
                 self.module.fail_json(msg='Could not update /etc/localtime')
+        else:
+            self.module.fail_json(msg='%s is not a supported option on target platform' % key)
+
+
+class AIXTimezone(Timezone):
+    """This is a Timezone manipulation class for AIX instances.
+
+    It uses the C(chtz) utility to set the timezone, and
+    inspects C(/etc/environment) to determine the current timezone.
+
+    While AIX time zones can be set using two formats (POSIX and
+    Olson) the prefered method is Olson.  
+    See the following article for more information:
+    https://developer.ibm.com/articles/au-aix-posix/
+
+    NB: AIX needs to be rebooted in order for the change to be
+    activated.
+    """
+
+    def __init__(self, module):
+        super(AIXTimezone, self).__init__(module)
+        self.settimezone = self.module.get_bin_path('chtz', required=False)
+        if not self.settimezone:
+            module.fail_json(msg='chtz not found.')
+
+    def get(self, key, phase):
+        """Lookup the current timezone name in `/etc/environment`. If anything else
+        is requested, or if the TZ field is not set we fail.
+        """
+        if key == 'name':
+            try:
+                f = open('/etc/environment', 'r')
+                for line in f:
+                    m = re.match('^TZ=(.*)$', line.strip())
+                    if m:
+                        return m.groups()[0]
+            except Exception:
+                self.module.fail_json(msg='Failed to read /etc/environment')
+        else:
+            self.module.fail_json(msg='%s is not a supported option on target platform' % key)
+
+    def set(self, key, value):
+        """Set the requested timezone through chtz, an invalid timezone name
+        will be rejected and we have no further input validation to perform.
+        """
+        if key == 'name':
+            # chtz seems to always return 0 on AIX 7.2, even for invalid timezone values.
+            # It will only return non-zero if the chtz command itself fails, it does not check for 
+            #  valid timezones. We need to perform a basic check to confirm that the timezone 
+            #  definition exists in /usr/share/lib/zoneinfo
+            # This does mean that we can only support Olson for now. The below commented out regex
+            #  detects Olson date formats, so in the future we could detect Posix or Olson and
+            #  act accordingly.
+
+            # regex_olson = re.compile('^([a-z0-9_\-\+]+\/?)+$', re.IGNORECASE)
+            # if not regex_olson.match(value):
+            #     msg = 'Supplied timezone (%s) does not appear to a be valid Olson string' % value
+            #     self.module.fail_json(msg=msg)
+
+            # First determine if the requested timezone is valid by looking in the zoneinfo
+            #  directory.
+            zonefile = '/usr/share/lib/zoneinfo/' + value
+            try:
+                if not os.path.isfile(zonefile):
+                    self.module.fail_json(msg='%s is not a recognized timezone.' % value)
+            except Exception:
+                self.module.fail_json(msg='Failed to check %s.' % zonefile)
+
+            # Now set the TZ using chtz
+            cmd = 'chtz %s' % value
+            (rc, stdout, stderr) = self.module.run_command(cmd)
+
+            if rc != 0:
+                self.module.fail_json(msg=stderr)
+            
+            # The best condition check we can do is to check the environment file after making the 
+            #  change.
+            try:
+                p = re.compile('^TZ=(.*)$')
+                f = open('/etc/environment', 'r')
+                for line in f:
+                    line = line.strip()
+                    if p.match(line):
+                        check = line.split('=')[1]
+                        if check != value:
+                            msg = 'Post-change check does not match supplied value (%s - %s)' % (check, value)
+                            self.module.fail_json(msg=msg)
+            except Exception:
+                self.module.fail_json(msg='Failed to check status of change; issue reading /etc/environment')
         else:
             self.module.fail_json(msg='%s is not a supported option on target platform' % key)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I found myself having trouble with this documentation during my own self-learning.  The inconsistent order of references to dynamic/include vs. static/import caused me to keep scrolling back up to check if `include` was Dynamic or Static, and the same with was `import`.  

This PR simply re-orders a few dotpoints and references to ensure that Dynamic/Include is always mentioned before Static/Import in a consistent manner.  This should help to re-enforce which is which without scrolling throughout the page.

I chose Dynamic to be 'first' as the first paragraph refers to 'Dynamic vs. Static' with the footnote tagged as _dynamic_vs_static.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbooks_reuse.rst

