### PR TITLE
Use comprehensions rather than map() in container_to_bytes() and container_to_text()

### DIFF
--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -8,8 +8,6 @@ __metaclass__ = type
 import datetime
 import json
 
-from itertools import repeat
-
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import Set
 from ansible.module_utils.six import (
@@ -17,7 +15,6 @@ from ansible.module_utils.six import (
     iteritems,
     text_type,
 )
-from ansible.module_utils.six.moves import map
 
 
 def _json_encode_fallback(obj):
@@ -54,11 +51,11 @@ def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
     if isinstance(d, text_type):
         return to_bytes(d, encoding=encoding, errors=errors)
     elif isinstance(d, dict):
-        return dict(map(container_to_bytes, iteritems(d), repeat(encoding), repeat(errors)))
+        return dict(container_to_bytes(o, encoding, errors) for o in iteritems(d))
     elif isinstance(d, list):
-        return list(map(container_to_bytes, d, repeat(encoding), repeat(errors)))
+        return [container_to_bytes(o, encoding, errors) for o in d]
     elif isinstance(d, tuple):
-        return tuple(map(container_to_bytes, d, repeat(encoding), repeat(errors)))
+        return tuple(container_to_bytes(o, encoding, errors) for o in d)
     else:
         return d
 
@@ -74,10 +71,10 @@ def container_to_text(d, encoding='utf-8', errors='surrogate_or_strict'):
         # Warning, can traceback
         return to_text(d, encoding=encoding, errors=errors)
     elif isinstance(d, dict):
-        return dict(map(container_to_text, iteritems(d), repeat(encoding), repeat(errors)))
+        return dict(container_to_text(o, encoding, errors) for o in iteritems(d))
     elif isinstance(d, list):
-        return list(map(container_to_text, d, repeat(encoding), repeat(errors)))
+        return [container_to_text(o, encoding, errors) for o in d]
     elif isinstance(d, tuple):
-        return tuple(map(container_to_text, d, repeat(encoding), repeat(errors)))
+        return tuple(container_to_text(o, encoding, errors) for o in d)
     else:
         return d


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since we now require Python > 2.6 on the controller, we can drop the use of map() here
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/common/text/converters.py`