### PR TITLE
get rid of Sphinx 2.1.2 errors

### DIFF
--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -366,10 +366,7 @@ The first two methods above only work when the host has access to the internet.
 When a host does not have internet access, the module must first be installed
 using the methods above on another host with internet access and then copied
 across. To save a module to a local filepath, the following PowerShell cmdlet
-can be run:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+can be run::
 
     Save-Module -Name xWebAdministration -Path C:\temp
 

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -10,7 +10,7 @@ This document discusses the setup that is required before Ansible can communicat
 Host Requirements
 `````````````````
 For Ansible to communicate to a Windows host and use Windows modules, the
-Windows host must meet the following requirements:
+Windows host must meet these requirements:
 
 * Ansible's supported Windows versions generally match those under current
   and extended support from Microsoft. Supported desktop OSs include
@@ -148,9 +148,7 @@ following command:
 
     winrm enumerate winrm/config/Listener
 
-This will output something like the following:
-
-.. code-block:: guess
+This will output something like::
 
     Listener
         Address = *
@@ -193,10 +191,7 @@ the key options that are useful to understand are:
 * ``CertificateThumbprint``: If running over an HTTPS listener, this is the
   thumbprint of the certificate in the Windows Certificate Store that is used
   in the connection. To get the details of the certificate itself, run this
-  command with the relevant certificate thumbprint in PowerShell:
-
-  .. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-  .. code-block:: guess
+  command with the relevant certificate thumbprint in PowerShell::
 
     $thumbprint = "E6CDAA82EEAF2ECE8546E05DB7F3E01AA47D76CE"
     Get-ChildItem -Path cert:\LocalMachine\My -Recurse | Where-Object { $_.Thumbprint -eq $thumbprint } | Select-Object *
@@ -240,10 +235,7 @@ There are three ways to set up a WinRM listener:
 
 Delete WinRM Listener
 +++++++++++++++++++++
-To remove a WinRM listener:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+To remove a WinRM listener::
 
     # Remove all listeners
     Remove-Item -Path WSMan:\localhost\Listener\* -Recurse -Force
@@ -268,9 +260,7 @@ following command:
     winrm get winrm/config/Service
     winrm get winrm/config/Winrs
 
-This will output something like the following:
-
-.. code-block:: guess
+This will output something like::
 
     Service
         RootSDDL = O:NSG:BAD:P(A;;GA;;;BA)(A;;GR;;;IU)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)
@@ -338,11 +328,7 @@ options are:
 * ``Winrs\MaxMemoryPerShellMB``: This is the maximum amount of memory allocated
   per shell, including the shell's child processes.
 
-To modify a setting under the ``Service`` key in PowerShell, the following
-command can be used:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+To modify a setting under the ``Service`` key in PowerShell::
 
     # substitute {path} with the path to the option after winrm/config/Service
     Set-Item -Path WSMan:\localhost\Service\{path} -Value "value here"
@@ -350,11 +336,7 @@ command can be used:
     # for example, to change Service\Auth\CbtHardeningLevel run
     Set-Item -Path WSMan:\localhost\Service\Auth\CbtHardeningLevel -Value Strict
 
-To modify a setting under the ``Winrs`` key in PowerShell, the following
-command can be used:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+To modify a setting under the ``Winrs`` key in PowerShell::
 
     # Substitute {path} with the path to the option after winrm/config/Winrs
     Set-Item -Path WSMan:\localhost\Shell\{path} -Value "value here"
@@ -374,10 +356,7 @@ could in fact be issues with the host setup instead.
 
 One easy way to determine whether a problem is a host issue is to
 run the following command from another Windows host to connect to the
-target Windows host:
-
-.. comment: Pygments powershell lexer does not support -u:Username
-.. code-block:: guess
+target Windows host::
 
     # Test out HTTP
     winrs -r:http://server:5985/wsman -u:Username -p:Password ipconfig

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -66,10 +66,7 @@ The following example shows host vars configured for basic authentication:
     ansible_winrm_transport: basic
 
 Basic authentication is not enabled by default on a Windows host but can be
-enabled by running the following in PowerShell:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+enabled by running the following in PowerShell::
 
     Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
 
@@ -88,10 +85,7 @@ The following example shows host vars configured for certificate authentication:
     ansible_winrm_transport: certificate
 
 Certificate authentication is not enabled by default on a Windows host but can
-be enabled by running the following in PowerShell:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+be enabled by running the following in PowerShell::
 
     Set-Item -Path WSMan:\localhost\Service\Auth\Certificate -Value $true
 
@@ -212,12 +206,7 @@ The code to import the client certificate public key is:
 
 Mapping a Certificate to an Account
 +++++++++++++++++++++++++++++++++++
-Once the certificate has been imported, it needs to be mapped to the local user account.
-
-This can be done with the following PowerShell command:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+Once the certificate has been imported, map it to the local user account::
 
     $username = "username"
     $password = ConvertTo-SecureString -String "password" -AsPlainText -Force
@@ -514,10 +503,7 @@ another certificate.
     certificate. With CredSSP, message transport still occurs over the WinRM listener,
     but the TLS-encrypted messages inside the channel use the service-level certificate.
 
-To explicitly set the certificate to use for CredSSP:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+To explicitly set the certificate to use for CredSSP::
 
     # Note the value $certificate_thumbprint will be different in each
     # situation, this needs to be set based on the cert that is used.
@@ -566,10 +552,7 @@ A last resort is to disable the encryption requirement on the Windows host. This
 should only be used for development and debugging purposes, as anything sent
 from Ansible can be viewed, manipulated and also the remote session can completely
 be taken over by anyone on the same network. To disable the encryption
-requirement, run the following from PowerShell on the target host:
-
-.. comment: Pygments powershell lexer does not support colons (i.e. URLs)
-.. code-block:: guess
+requirement::
 
     Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $true
 


### PR DESCRIPTION
##### SUMMARY
Fixes #57709 

Currently we pin the docs build to Sphinx 1.x. This PR makes all the changes necessary to run a clean  `make webdocs` using Sphinx 2.1.2 on Python 3.7.3.

Takes the same approach to fixing the PowerShell lexer concerns as https://github.com/ansible/ansible/pull/57508/files#diff-1653c8c6462362632397ce0e9c948610R405.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
