### PR TITLE
Fix typo in purefa_user and purefa_dsrole documentation examples

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_dsrole.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_dsrole.py
@@ -59,7 +59,7 @@ EXAMPLES = r'''
   purefa_dsrole:
     role: array_admin
     state: absent
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
 - name: Create array_admin directory service role
@@ -67,7 +67,7 @@ EXAMPLES = r'''
     role: array_admin
     group_base: "OU=PureGroups,OU=SANManagers"
     group: pureadmins
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
 - name: Update ops_admin directory service role
@@ -75,7 +75,7 @@ EXAMPLES = r'''
     role: ops_admin
     group_base: "OU=PureGroups"
     group: opsgroup
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 '''
 

--- a/lib/ansible/modules/storage/purestorage/purefa_user.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_user.py
@@ -61,7 +61,7 @@ EXAMPLES = r'''
     password: apassword
     role: storage_admin
     api: true
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
   debug:
@@ -72,7 +72,7 @@ EXAMPLES = r'''
     name: ansible
     role: array_admin
     state: update
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
 - name: Change password type for existing user (NOT IDEMPOTENT)
@@ -80,7 +80,7 @@ EXAMPLES = r'''
     name: ansible
     password: anewpassword
     old_password: apassword
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
 - name: Change API token for existing user
@@ -88,7 +88,7 @@ EXAMPLES = r'''
     name: ansible
     api: true
     state: update
-    fb_url: 10.10.10.2
+    fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 
   debug:


### PR DESCRIPTION
##### SUMMARY
Fix incorrect reference of fb_url to be fa_url in documentation examples

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
purefa_user.py
purefa_dsrole.py