### PR TITLE
VMware: Correct network_exists_by_name API call

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -314,8 +314,8 @@ class PyVmomiHelper(PyVmomi):
                         self.module.fail_json(msg="networks.start_connected parameter should be boolean.")
                     if network['state'].lower() == 'new' and not network['start_connected']:
                         network['connected'] = False
-                # specified network not exist
-                if 'name' in network and not self.network_exists_by_name(self.content, network['name']):
+                # specified network does not exist
+                if 'name' in network and not self.network_exists_by_name(network['name']):
                     self.module.fail_json(msg="Network '%(name)s' does not exist." % network)
                 elif 'vlan' in network:
                     objects = get_all_objs(self.content, [vim.dvs.DistributedVirtualPortgroup])

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -20,7 +20,9 @@
       name: "{{ infra.vm_list[0] }}"
       gather_network_facts: true
     register: netadapter_facts
+
   - debug: var=netadapter_facts
+
   - name: get number of existing netowrk adapters
     set_fact:
       netadapter_num: "{{ netadapter_facts.network_data | length }}"
@@ -42,7 +44,9 @@
           device_type: vmxnet3
           manual_mac: "00:50:56:58:59:61"
     register: add_netadapter
+
   - debug: var=add_netadapter
+
   - name: assert the new netowrk adapters were added to VM
     assert:
       that:
@@ -60,7 +64,9 @@
         - state: absent
           mac: "00:50:56:58:59:60"
     register: del_netadapter
+
   - debug: var=del_netadapter
+
   - name: assert the network adapter was removed
     assert:
       that:
@@ -79,9 +85,33 @@
           mac: "00:50:56:58:59:61"
           connected: false
     register: disc_netadapter
+
   - debug: var=disc_netadapter
+
   - name: assert the network adapter was disconnected
     assert:
       that:
         - "disc_netadapter.changed == true"
         - "{{ disc_netadapter.network_data[netadapter_num]['connected'] }} == false"
+
+  - name: Check if network does not exists
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ infra.vm_list[0] }}"
+      networks:
+        - name: non-existing-nw
+          manual_mac: "00:50:56:11:22:33"
+          state: new
+    register: no_nw_details
+    ignore_errors: yes
+
+  - debug: var=no_nw_details
+
+  - name: Check if network does not exists
+    assert:
+      that:
+        - not no_nw_details.changed
+        - no_nw_details.failed


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_network.py
test/integration/targets/vmware_guest_network/tasks/main.yml
