### PR TITLE
ASA: fixes #59007

### DIFF
--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -36,7 +36,8 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"error:", re.I),
-        re.compile(br"Removing.* not allowed, it is being used")
+        re.compile(br"Removing.* not allowed, it is being used"),
+        re.compile(br"^Command authorization failed\r?$", re.MULTILINE)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fixes #59007
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 lib/ansible/plugins/terminal/asa.py
##### ADDITIONAL INFO
After this change, the execution of the forbidden command causes an error. In addition, if the `no terminal pager` command is not enabled, a error is displayed during the connection with the device (`unable to disable terminal pager`), which makes diagnosing and fixing problems with the allowed command list easier.