### PR TITLE
vmware: ro=False datastores for the functional tests

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -9,7 +9,9 @@ infra:
       type: nfs
       server: gateway.test
       path: /srv/share/isos
-      ro: true
+      # https://github.com/ansible/ansible/issues/58541 prevents us
+      # from using the "ro: true" mode
+      ro: false
     LocalDS_1:
       type: nfs
       server: gateway.test


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/ansible/issues/58541 prevents us from using
read-only datastore. So for now, we mount everything read-write.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware