### PR TITLE
Bugfix for aggregate function in junos_user module

### DIFF
--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -224,8 +224,7 @@ def map_obj_to_ele(module, want):
                 SubElement(user, 'full-name').text = item['full_name']
 
             if item.get('sshkey'):
-                if 'auth' not in locals():
-                    auth = SubElement(user, 'authentication')
+                auth = SubElement(user, 'authentication')
                 if 'ssh-rsa' in item['sshkey']:
                     ssh_rsa = SubElement(auth, 'ssh-rsa')
                 elif 'ssh-dss' in item['sshkey']:
@@ -237,8 +236,7 @@ def map_obj_to_ele(module, want):
                 key = SubElement(ssh_rsa, 'name').text = item['sshkey']
 
             if item.get('encrypted_password'):
-                if 'auth' not in locals():
-                    auth = SubElement(user, 'authentication')
+                auth = SubElement(user, 'authentication')
                 SubElement(auth, 'encrypted-password').text = item['encrypted_password']
 
     return element


### PR DESCRIPTION
Removed unnecessary conditionals that break the aggregate function of the module.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fixes bug described in bug "junos_user: wrong SSH-key assignment in aggregate mode #58978".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Please see bug report "junos_user: wrong SSH-key assignment in aggregate mode #58978".
<!--- Paste verbatim command output below, e.g. before and after your change -->

