### PR TITLE
ansible-test - vcenter provider: avoid a TypeError exception

### DIFF
--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -214,8 +214,8 @@ class VcenterProvider(CloudProvider):
     def _setup_static(self):
         parser = ConfigParser({
             'vcenter_port': '443',
-            'vmware_proxy_host': None,
-            'vmware_proxy_port': None})
+            'vmware_proxy_host': '',
+            'vmware_proxy_port': ''})
         parser.read(self.config_static_path)
 
         self.endpoint = parser.get('DEFAULT', 'vcenter_hostname')


### PR DESCRIPTION
##### SUMMARY

Avoid `TypeError: option values must be strings` with `ConfigParser`.
Default values must be string, not `None`.

The error happens when `test/integration/cloud-config-vcenter.ini` does
not have the `vmware_proxy_host` or `vmware_proxy_port` keys defined.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware