### PR TITLE
Modified blockinfile module's exmple using loop keyword

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -145,10 +145,10 @@ EXAMPLES = r'''
     block: |
       {{ item.ip }} {{ item.name }}
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.name }}"
-  with_items:
-  - { name: host1, ip: 10.10.1.10 }
-  - { name: host2, ip: 10.10.1.11 }
-  - { name: host3, ip: 10.10.1.12 }
+  loop:
+    - { name: host1, ip: 10.10.1.10 }
+    - { name: host2, ip: 10.10.1.11 }
+    - { name: host3, ip: 10.10.1.12 }
 '''
 
 import re


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a small patch for fixing a tiny indentation and replacing with_items with loop keyword in the example of blockinfile module just like #58865.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
blockinfile

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
None
<!--- Paste verbatim command output below, e.g. before and after your change -->