### PR TITLE
Make ansible_index_var accessible as a magic var

### DIFF
--- a/changelogs/fragments/add-ansible_index_var-to-tasks_vars.yaml
+++ b/changelogs/fragments/add-ansible_index_var-to-tasks_vars.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Make ``ansible_index_var`` accessible as a magic variable.

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -31,6 +31,9 @@ ansible_loop
 ansible_loop_var
     The name of the value provided to ``loop_control.loop_var``. Added in ``2.8``
 
+ansible_index_var
+    The name of the value provided to ``loop_control.index_var``. Added in ``2.9``
+
 ansible_parent_role_names
     When the current role is being executed by means of an :ref:`include_role <include_role_module>` or :ref:`import_role <import_role_module>` action, this variable contains a list of all parent roles, with the most recent role (i.e. the role that included/imported this role) being the first item in the list.
     When multiple inclusions occur, this list lists the *last* role (i.e. the role that included this role) as the *first* item in the list. It is also possible that a specific role exists more than once in this list.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -324,6 +324,7 @@ class TaskExecutor:
 
             task_vars[loop_var] = item
             if index_var:
+                task_vars['ansible_index_var'] = index_var
                 task_vars[index_var] = item_index
 
             if extended:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`ansible_index_var` was added to a task result in https://github.com/ansible/ansible/pull/58866 so that`IncludeFile` can reuse its (potentially templated) value. This makes it accessible as a magic variable too, like `ansible_loop_var`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_executor.py`