### PR TITLE
clarifies nmcli option 'conn_name'

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -48,7 +48,7 @@ options:
         default: yes
     conn_name:
         description:
-            - 'Where conn_name will be the name used to call the connection. when not provided a default name is generated: <type>[-<ifname>][-<num>]'
+            - The name used to call the connection. Pattern is <type>[-<ifname>][-<num>].
         type: str
         required: true
     ifname:


### PR DESCRIPTION
##### SUMMARY
Fixes #58337.

Clarifies documentation of the `conn_name` option on the nmcli module. The option is required. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
nmcli
