### PR TITLE
Fix junos_interfaces integration test failure

### DIFF
--- a/test/integration/targets/junos_interfaces/tests/netconf/_remove_config.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/_remove_config.yaml
@@ -2,12 +2,13 @@
 - debug:
     msg: "Start junos_nterfaces deleted remove interface config ansible_connection={{ ansible_connection }}"
 
-- name: Remove interface config
+- name: "Setup - remove interface config"
   junos_config:
     lines:
       - delete interfaces ge-0/0/1
       - delete interfaces ge-0/0/2
       - delete interfaces ge-0/0/3
+      - delete interfaces lo0
 
 - debug:
     msg: "End junos_nterfaces deleted remove interface config ansible_connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
@@ -8,8 +8,6 @@
     expected_deleted_output:
       - name: fxp0
         enable: true
-      - name: lo0
-        enable: true
 
 - block:
     - name: Configure initial state for interface

--- a/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
@@ -25,8 +25,6 @@
           down: 3200
       - name: fxp0
         enable: true
-      - name: lo0
-        enable: true
 
 - block:
     - name: Merge the provided configuration with the exisiting running configuration

--- a/test/integration/targets/junos_interfaces/tests/netconf/overridden.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/overridden.yaml
@@ -11,8 +11,6 @@
         enable: true
       - name: fxp0
         enable: true
-      - name: lo0
-        enable: true
 
 - block:
     - name: Configure initial state for interface

--- a/test/integration/targets/junos_interfaces/tests/netconf/replaced.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/replaced.yaml
@@ -21,8 +21,6 @@
           down: 3200
       - name: fxp0
         enable: true
-      - name: lo0
-        enable: true
 
 - block:
     - name: Configure initial state for interface

--- a/test/integration/targets/junos_interfaces/tests/netconf/rtt.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/rtt.yaml
@@ -25,8 +25,6 @@
           down: 3200
       - name: fxp0
         enable: true
-      - name: lo0
-        enable: true
 
 - block:
     - name: Apply the provided configuration (base config)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Remove lo0 interface by default since
   vsrz zuul env seems to add it intermittently
   as part of device initial config
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
targets/junos_interfaces/tests/netconf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
