### PR TITLE
[win_credential] Fix example in docs

### DIFF
--- a/lib/ansible/modules/windows/win_credential.py
+++ b/lib/ansible/modules/windows/win_credential.py
@@ -194,7 +194,7 @@ EXAMPLES = r'''
     name: smbhost
     type: generic_password
     username: smbuser
-    password: smbuser
+    secret: smbuser
     state: present
 
 - name: Remove a generic credential


### PR DESCRIPTION
##### SUMMARY
Just a small update to the latest example. 


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
I've faced an issue when tried to create a playbook with win_credential task. I've copy-pasted the example and it was slightly wrong - there should be `secret` parameter instead of `password`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_credential

