### PR TITLE
profile_tasks: error handling and python3 compability

### DIFF
--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -130,12 +130,15 @@ class CallbackModule(CallbackBase):
 
         self.sort_order = self.get_option('sort_order')
         if self.sort_order is not None:
-            if self.sort_order == 'ascending':
+            if self.sort_order == 'none':
+                self.sort_order = None
+            elif self.sort_order == 'ascending':
                 self.sort_order = False
             elif self.sort_order == 'descending':
                 self.sort_order = True
-            elif self.sort_order == 'none':
-                self.sort_order = None
+            else:
+                self._display.warning('Invalid value configured for sort_order, using default value')
+                self.sort_order = True
 
         self.task_output_limit = self.get_option('output_limit')
         if self.task_output_limit is not None:
@@ -182,6 +185,8 @@ class CallbackModule(CallbackBase):
                 key=lambda x: x[1]['time'],
                 reverse=self.sort_order,
             )
+        else:
+            results = list(results)
 
         # Display the number of tasks specified or the default of 20
         results = results[:self.task_output_limit]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Solves the python3.6 compability issues where OrderedDict is not subscriptable by casting to list.

I also accidently ran into an error when I configured sort_order = None instead of none which resulted in another error which I fixed. The reordering of the if statement might be a bit unnessecary but to me it felt more logical to have the two cases with the same result next to each other

Fixes #59059
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
profile_tasks
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A