### PR TITLE
Iptables wait and improved error handling

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -483,11 +483,13 @@ def append_param(rule, param, flag, is_list):
         for item in param:
             append_param(rule, item, flag, False)
     else:
-        if isinstance(param, str):
+        if isinstance(param, int):
+            rule.extend([flag, str(param)])
+        elif param is not None:
             if param[0] == '!':
                 rule.extend(['!', flag, param[1:]])
-        elif param is not None:
-            rule.extend([flag, str(param)])
+            else
+                rule.extend([flag, param])
 
 
 def append_tcp_flags(rule, param, flag):

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -488,7 +488,7 @@ def append_param(rule, param, flag, is_list):
         elif param is not None:
             if param[0] == '!':
                 rule.extend(['!', flag, param[1:]])
-            else
+            else:
                 rule.extend([flag, param])
 
 

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -335,6 +335,11 @@ options:
     type: str
     choices: [ ACCEPT, DROP, QUEUE, RETURN ]
     version_added: "2.2"
+  wait:
+    description:
+      - Wait N seconds for the xtables lock to prevent multiple instances of
+        the program from running concurrently.
+    version_added: "2.8"
 '''
 
 EXAMPLES = r'''
@@ -514,6 +519,7 @@ def append_jump(rule, param, jump):
 
 def construct_rule(params):
     rule = []
+    append_param(rule, params['wait'], '-w', False)
     append_param(rule, params['protocol'], '-p', False)
     append_param(rule, params['source'], '-s', False)
     append_param(rule, params['destination'], '-d', False)
@@ -641,6 +647,7 @@ def main():
             chain=dict(type='str'),
             rule_num=dict(type='str'),
             protocol=dict(type='str'),
+            wait=dict(type='str'),
             source=dict(type='str'),
             to_source=dict(type='str'),
             destination=dict(type='str'),

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -340,7 +340,7 @@ options:
       - Wait N seconds for the xtables lock to prevent multiple instances of
         the program from running concurrently.
     type: str
-    version_added: "2.8"
+    version_added: "2.9"
 '''
 
 EXAMPLES = r'''
@@ -598,13 +598,14 @@ def push_arguments(iptables_path, action, params, make_rule=True):
 def check_present(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-C', params)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
-    if rc == 0: # Rule exists
-      return True
-    elif rc == 1: # Rule doesn't exist
-      return False
-    else: # Some other error
-      msg = heuristic_log_sanitize(stderr.rstrip(), module.no_log_values)
-      module.fail_json(cmd=module._clean_args(cmd), rc=rc, stdout=stdout, stderr=stderr, msg=msg)
+    if rc == 0:  # Rule exists
+        return True
+    elif rc == 1:  # Rule doesn't exist
+        return False
+    else:  # Some other error
+        msg = heuristic_log_sanitize(stderr.rstrip(), module.no_log_values)
+        module.fail_json(cmd=module._clean_args(cmd), rc=rc, stdout=stdout, stderr=stderr, msg=msg)
+
 
 def append_rule(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-A', params)

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -339,6 +339,7 @@ options:
     description:
       - Wait N seconds for the xtables lock to prevent multiple instances of
         the program from running concurrently.
+    type: str
     version_added: "2.8"
 '''
 

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -339,7 +339,7 @@ options:
     description:
       - Wait N seconds for the xtables lock to prevent multiple instances of
         the program from running concurrently.
-    type: str
+    type: int
     version_added: "2.9"
 '''
 
@@ -483,11 +483,11 @@ def append_param(rule, param, flag, is_list):
         for item in param:
             append_param(rule, item, flag, False)
     else:
-        if param is not None:
+        if isinstance(param, str):
             if param[0] == '!':
                 rule.extend(['!', flag, param[1:]])
-            else:
-                rule.extend([flag, param])
+        elif param is not None:
+            rule.extend([flag, str(param)])
 
 
 def append_tcp_flags(rule, param, flag):
@@ -654,7 +654,7 @@ def main():
             chain=dict(type='str'),
             rule_num=dict(type='str'),
             protocol=dict(type='str'),
-            wait=dict(type='str'),
+            wait=dict(type='int'),
             source=dict(type='str'),
             to_source=dict(type='str'),
             destination=dict(type='str'),

--- a/test/units/modules/system/test_iptables.py
+++ b/test/units/modules/system/test_iptables.py
@@ -828,3 +828,41 @@ class TestIptables(ModuleTestCase):
             '--dst-range',
             '10.0.0.50-10.0.0.100'
         ])
+
+    def test_insert_rule_with_wait(self):
+        """Test flush without parameters"""
+        set_module_args({
+            'chain': 'OUTPUT',
+            'source': '1.2.3.4/32',
+            'destination': '7.8.9.10/42',
+            'jump': 'ACCEPT',
+            'action': 'insert',
+            'wait': '10'
+        })
+
+        commands_results = [
+            (0, '', '')
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+        self.assertEqual(run_command.call_count, 1)
+        self.assertEqual(run_command.call_args_list[0][0][0], [
+            '/sbin/iptables',
+            '-t',
+            'filter',
+            '-C',
+            'OUTPUT',
+            '-w',
+            '10',
+            '-s',
+            '1.2.3.4/32',
+            '-d',
+            '7.8.9.10/42',
+            '-j',
+            'ACCEPT'
+        ])


### PR DESCRIPTION
##### SUMMARY
Support `--wait` command for `iptables`. 

`check_present()` was only checking if the rc was zero or other, but `iptables -C` can fail in a few ways that don't indicate the rule is missing.

Fixes #59002
Borrows from stale PR #47877

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iptables

##### ADDITIONAL INFORMATION
Because --wait \[seconds\] was added to iptables in [2014](https://git.netfilter.org/iptables/commit/iptables/iptables.c?id=aaa4ace72ba1d195bbf436134a336816c33f7bd0) via version [1.6.0](https://netfilter.org/projects/iptables/files/changes-iptables-1.6.0.txt) we don't want to just include -w in all commands by default to work around locking, it should be an option available to the playbook writer.

`iptables -C` will exit 4 if the lock is being held by another process. Previously this would result in the task presuming the rule was already missing and either creating a duplicate or failing to remove it if `state: absent`. I also found that `iptables` will exit 3 if run as non-root.

Playbook:
```
---
- name: Test iptables contention
  hosts: localhost
  tasks:
    - name: Remove a rule
      iptables:
        action: insert
        chain: INPUT
        protocol: tcp
        source: "1.2.3.4"
        destination_port: "80"
        jump: REJECT
        state: absent
```

Before:
```
TASK [Remove a rule] *****************************************************************************************************
ok: [localhost]
```

After:
```
TASK [Remove a rule] *****************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/sbin/iptables -t filter -C INPUT -p tcp -s 1.2.3.4 -j REJECT --destination-port 80", "msg": "Another app is currently holding the xtables lock. Perhaps you want to use the -w option?", "rc": 4, "stderr": "Another app is currently holding the xtables lock. Perhaps you want to use the -w option?\n", "stderr_lines": ["Another app is currently holding the xtables lock. Perhaps you want to use the -w option?"], "stdout": "", "stdout_lines": []}
```

Adjust playbook to add `wait: "15"`, release the lock before 15s

```
TASK [Remove a rule] *****************************************************************************************************
changed: [localhost]
```