### PR TITLE
Update file.py's help doc, and narrow down diff logic, for recent pull 56353

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -33,7 +33,8 @@ options:
   state:
     description:
     - If C(absent), directories will be recursively deleted, and files or symlinks will
-      be unlinked. Note that C(absent) will not cause C(file) to fail if the C(path) does
+      be unlinked. In the case of a directory, if C(diff) is declared, you will see the files and folders deleted listed
+      under C(path_contents). Note that C(absent) will not cause C(file) to fail if the C(path) does
       not exist as the state did not change.
     - If C(directory), all intermediate subdirectories will be created if they
       do not exist. Since Ansible 1.7 they will be created with the supplied permissions.

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -378,7 +378,7 @@ def initial_diff(path, state, prev_state):
     if prev_state != state:
         diff['before']['state'] = prev_state
         diff['after']['state'] = state
-        if state == 'absent' and prev_state == 'directory' :
+        if state == 'absent' and prev_state == 'directory':
             walklist = {
                 'directories': [],
                 'files': [],

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -377,7 +377,7 @@ def initial_diff(path, state, prev_state):
     if prev_state != state:
         diff['before']['state'] = prev_state
         diff['after']['state'] = state
-        if state == 'absent':
+        if state == 'absent' and prev_state == 'directory' :
             walklist = {
                 'directories': [],
                 'files': [],

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -270,17 +270,21 @@
     state: absent
   check_mode: yes
   diff: yes
+  with_items:
+    - "{{ output_dir }}"
+    - "{{ output_dir }}/foobar/fileA"
   register: folder_absent_result
 
-- name: assert that the absent check lists expected files and folders
+- name: 'assert that the "absent" state lists expected files and folders for only directories'
   assert:
     that:
-      - folder_absent_result.diff.before.path_content is defined
+      - folder_absent_result[0].diff.before.path_content is defined
+      - folder_absent_result[1].diff.before.path_content is not defined
       - test_folder in folder_absent_result.diff.before.path_content.directories
       - test_file in folder_absent_result.diff.before.path_content.files
   vars:
-    test_folder: "{{ folder_absent_result.path }}/foobar"
-    test_file: "{{ folder_absent_result.path }}/foobar/fileA"
+    test_folder: "{{ folder_absent_result[0].path }}/foobar"
+    test_file: "{{ folder_absent_result[0].path }}/foobar/fileA"
 
 - name: Change ownership of a directory with recurse=no(default)
   file: path={{output_dir}}/foobar owner=1234

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -278,13 +278,13 @@
 - name: 'assert that the "absent" state lists expected files and folders for only directories'
   assert:
     that:
-      - folder_absent_result[0].diff.before.path_content is defined
-      - folder_absent_result[1].diff.before.path_content is not defined
-      - test_folder in folder_absent_result.diff.before.path_content.directories
-      - test_file in folder_absent_result.diff.before.path_content.files
+      - folder_absent_result.results[0].diff.before.path_content is defined
+      - folder_absent_result.results[1].diff.before.path_content is not defined
+      - test_folder in folder_absent_result.results[0].diff.before.path_content.directories
+      - test_file in folder_absent_result.results[0].diff.before.path_content.files
   vars:
-    test_folder: "{{ folder_absent_result[0].path }}/foobar"
-    test_file: "{{ folder_absent_result[0].path }}/foobar/fileA"
+    test_folder: "{{ folder_absent_result.results[0].path }}/foobar"
+    test_file: "{{ folder_absent_result.results[0].path }}/foobar/fileA"
 
 - name: Change ownership of a directory with recurse=no(default)
   file: path={{output_dir}}/foobar owner=1234

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -266,7 +266,7 @@
 
 - name: check what would be removed if folder state was absent and diff is enabled
   file: 
-    path: "{{ output_dir }}"
+    path: "{{ item }}"
     state: absent
   check_mode: yes
   diff: yes


### PR DESCRIPTION
##### SUMMARY
Following a recent pull request (#56353), I missed out updating the help documentation to cover the new diff functionality.
On top of this, in the scenario of `state: absent` for a file, I don't believe the `path_content` property makes sense to be included as the object will always be blank.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
[Modules/Files/File.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/files/file.py)

##### ADDITIONAL INFORMATION
Following a recent pull request (#56353), I missed out updating the help documentation to cover the new diff functionality.
On top of this, in the scenario of `state: absent` for a file, I don't believe the `path_content` property makes sense to be included as the object will always be blank.  
  
Tests have been updated to reflect the change in behaviour between absent for file and absent for directory

###### Example playbook tested with stable 2.8 branch
```yaml
- name: Example playbook
  hosts: localhost
  tasks:
    - name: Create example folders
      file:
        path: "{{ item }}"
        state: directory
      with_items:
        - /tmp/example_folder
        - /tmp/example_folder/sub_folder

    - name: Create example files
      file:
        path: "{{ item }}"
        state: touch
      with_items:
        - /tmp/example_folder/example_file.tmp
        - /tmp/example_folder/example_file2.tmp
        - /tmp/example_folder/sub_folder/sub_file.tmp

    - name: Remove example folders and files
      file:
        path: "{{ item }}"
        state: absent
      with_items:
        - "/tmp/example_folder/example_file2.tmp"
        - "/tmp/example_folder"
      diff: yes
```

###### Output before change
```log
TASK [remove example folders and files] ********************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
     "path": "/tmp/example_folder/example_file2.tmp",
-    "state": "file"
+    "state": "absent"
 }

changed: [localhost] => (item=/tmp/example_folder/example_file2.tmp)
--- before
+++ after
@@ -1,4 +1,4 @@
 {
     "path": "/tmp/example_folder",
-    "state": "directory"
+    "state": "absent"
 }

changed: [localhost] => (item=/tmp/example_folder)
```
###### Output after change
```log
TASK [remove example folders and files] ********************************************************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
     "path": "/tmp/example_folder/example_file2.tmp",
-    "state": "file"
+    "state": "absent"
 }

changed: [localhost] => (item=/tmp/example_folder/example_file2.tmp)
--- before
+++ after
@@ -1,13 +1,4 @@
 {
     "path": "/tmp/example_folder",
-    "path_content": {
-        "directories": [
-            "/tmp/example_folder/sub_folder"
-        ],
-        "files": [
-            "/tmp/example_folder/example_file.tmp",
-            "/tmp/example_folder/sub_folder/sub_file.tmp"
-        ]
-    },
-    "state": "directory"
+    "state": "absent"
 }

changed: [localhost] => (item=/tmp/example_folder)
```
