### PR TITLE
Module mail : Add Date header

### DIFF
--- a/changelogs/fragments/58808-mail-add-date-header.yaml
+++ b/changelogs/fragments/58808-mail-add-date-header.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add date header to the email based on local time

--- a/changelogs/fragments/58808-mail-add-date-header.yaml
+++ b/changelogs/fragments/58808-mail-add-date-header.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - add date header to the email based on local time
+  - Add date header to the email based on local time in mail module (https://github.com/ansible/ansible/issues/58808).

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -203,7 +203,7 @@ import smtplib
 import ssl
 import traceback
 from email import encoders
-from email.utils import parseaddr, formataddr
+from email.utils import parseaddr, formataddr, formatdate
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -326,6 +326,7 @@ def main():
 
     msg = MIMEMultipart(_charset=charset)
     msg['From'] = formataddr((sender_phrase, sender_addr))
+    msg['Date'] = = formatdate(localtime=True)
     msg['Subject'] = Header(subject, charset)
     msg.preamble = "Multipart message"
 

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -326,7 +326,7 @@ def main():
 
     msg = MIMEMultipart(_charset=charset)
     msg['From'] = formataddr((sender_phrase, sender_addr))
-    msg['Date'] = = formatdate(localtime=True)
+    msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = Header(subject, charset)
     msg.preamble = "Multipart message"
 


### PR DESCRIPTION
##### SUMMARY
Add Date header for emails sent by email module
Fixes #58808

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mail

##### ADDITIONAL INFORMATION
Add Date header to the email.
This header is "nice to have" if you need to send out your emails on Internet
