### PR TITLE
Fix #51755 and #53366 in aix_devices.py module

### DIFF
--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -299,7 +299,7 @@ def remove_device(module, device, force, recursive, state):
         rc, rmdev_out, err = module.run_command(cmd)
 
         if rc != 0:
-            msg = "Failed to run rmdev (%s) (raw: %s)" % (' '.join(cmd), cmd)
+            msg = "Failed to run rmdev (%s)" % (' '.join(cmd), cmd)
             module.fail_json(msg=msg, rc=rc, err=err)
 
         msg = rmdev_out

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -218,7 +218,7 @@ def change_device_attr(module, attributes, device, force):
     chdev_cmd = module.get_bin_path('chdev', True)
 
     # Force in chdev is -g:
-    # 7.1: https://www.ibm.com/support/knowledgecenter/ssw_aix_71/c_commands/chdev.html
+    # 7.1: https://www.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.cmds1/chdev.htm
     # 7.2: https://www.ibm.com/support/knowledgecenter/ssw_aix_72/c_commands/chdev.html
     if force:
         force = '-g'
@@ -269,6 +269,9 @@ def change_device_attr(module, attributes, device, force):
 
 def remove_device(module, device, force, recursive, state):
     """ Puts device in defined state or removes device. """
+
+    # 7.1: https://www.ibm.com/support/knowledgecenter/ssw_aix_71/com.ibm.aix.cmds4/rmdev.htm
+    # 7.2: https://www.ibm.com/support/knowledgecenter/ssw_aix_72/r_commands/rmdev.html
 
     state_opt = {
         'removed': '-d',

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -217,6 +217,12 @@ def change_device_attr(module, attributes, device, force):
     attr_invalid = []
     chdev_cmd = module.get_bin_path('chdev', True)
 
+    # Force in chdev is -g:
+    # 7.1: https://www.ibm.com/support/knowledgecenter/ssw_aix_71/c_commands/chdev.html
+    # 7.2: https://www.ibm.com/support/knowledgecenter/ssw_aix_72/c_commands/chdev.html
+    if force:
+        force = '-g'
+
     for attr in list(attributes.keys()):
         new_param = attributes[attr]
         current_param = _check_device_attr(module, device, attr)
@@ -275,6 +281,12 @@ def remove_device(module, device, force, recursive, state):
         False: ''
     }
 
+    # Force in rmdev is -g:
+    # 7.1: https://www.ibm.com/support/knowledgecenter/ssw_aix_71/r_commands/rmdev.html
+    # 7.2: https://www.ibm.com/support/knowledgecenter/ssw_aix_72/r_commands/rmdev.html
+    if force:
+        force = '-g'
+
     recursive = recursive_opt[recursive]
     state = state_opt[state]
 
@@ -309,14 +321,10 @@ def main():
         supports_check_mode=True,
     )
 
-    force_opt = {
-        True: '-f',
-        False: '',
-    }
 
     attributes = module.params['attributes']
     device = module.params['device']
-    force = force_opt[module.params['force']]
+    force = module.params['force']
     recursive = module.params['recursive']
     state = module.params['state']
 

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -296,10 +296,11 @@ def remove_device(module, device, force, recursive, state):
             cmd.append(force)
         if recursive:
             cmd.append(recursive)
+        
         rc, rmdev_out, err = module.run_command(cmd)
 
         if rc != 0:
-            msg = "Failed to run rmdev (%s)" % (' '.join(cmd), cmd)
+            msg = "Failed to run rmdev (%s)" % (' '.join(cmd))
             module.fail_json(msg=msg, rc=rc, err=err)
 
         msg = rmdev_out

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -182,7 +182,7 @@ def _check_device_attr(module, device, attr):
 
     elif rc != 0:
         msg = "Failed to run lsattr: %s" % err
-        module.fail_json(msg=msg , rc=rc, err=err)
+        module.fail_json(msg=msg, rc=rc, err=err)
 
     current_params = [line.split()[1] for line in lsattr_out.splitlines()]
     return current_params
@@ -295,7 +295,6 @@ def remove_device(module, device, force, recursive, state):
             cmd.append(force)
         if recursive:
             cmd.append(recursive)
-        
         rc, rmdev_out, err = module.run_command(cmd)
 
         if rc != 0:

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -233,7 +233,7 @@ def change_device_attr(module, attributes, device, force):
         elif current_param != new_param:
             cmd = ["%s" % chdev_cmd, '-l', "%s" % device, '-a', "%s=%s" % (attr, attributes[attr])]
             if force:
-                cmd.append(force)                
+                cmd.append(force)
             if not module.check_mode:
                 rc, chdev_out, err = module.run_command(cmd)
                 if rc != 0:
@@ -289,7 +289,7 @@ def remove_device(module, device, force, recursive, state):
     rmdev_cmd = module.get_bin_path('rmdev', True)
 
     if not module.check_mode:
-        cmd = ["%s" % rmdev_cmd, "-l", "%s" % device ]
+        cmd = ["%s" % rmdev_cmd, "-l", "%s" % device]
         if state:
             cmd.append(state)
         if force:
@@ -319,7 +319,6 @@ def main():
         ),
         supports_check_mode=True,
     )
-
 
     attributes = module.params['attributes']
     device = module.params['device']


### PR DESCRIPTION
## SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #51755 and #53366

### #51755 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_devices.py

##### ADDITIONAL INFORMATION
- Changed the approach to force and opts in `rmdev` and `chdev`
  - Instead of a cmd being set for each, just append the flags as required
- Removed 'handling' force in main() and instead pass a bool to deal with in specific functions.
- Removed a few dicts when a simpler `if thing: thing='-flag'` felt cleaner
- Switched from incorrect `-f` flag for force to correct `-g


### #53366
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_devices.py

##### ADDITIONAL INFORMATION
- Changed function _check_device_attr() to return a list instead of a single string.  
  - List will contain all possible values of attribute in given device.  This is used for alias4 and alias6 where it can have multiples of the same key name
- Updated change_device_attr to handle this list instead of a string