### PR TITLE
Remove reference to Windows for assemble docs

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -26,9 +26,6 @@ description:
   together to produce a destination file.
 - Files are assembled in string sorting order.
 - Puppet calls this idea I(fragments).
-- This module is also supported for Windows targets.
-notes:
-- This module is also supported for Windows targets.
 version_added: '0.5'
 options:
   src:


### PR DESCRIPTION
##### SUMMARY
The assemble plugin/module does not support Windows and was mistakenly added with https://github.com/ansible/ansible/pull/46328. This PR removes the mention of Windows in the assemble docs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
assemble