### PR TITLE
VMware: Gather facts about vlan id from DVS Portgroup in vmware_dvs_portgroup_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup_facts.py
@@ -4,6 +4,7 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -34,6 +35,12 @@ options:
     - Name of the datacenter.
     required: true
     type: str
+  dvswitch:
+    description:
+    - Name of a dvswitch to look for.
+    required: false
+    type: str
+    version_added: "2.9"
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -49,6 +56,12 @@ options:
     - Show or hide teaming policies of DVS portgroup.
     type: bool
     default: True
+  show_vlan_info:
+    description:
+    - Show or hide vlan information of the DVS portgroup.
+    type: bool
+    default: False
+    version_added: "2.9"
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -61,7 +74,6 @@ EXAMPLES = r'''
     validate_certs: no
     datacenter: "{{ datacenter_name }}"
   register: dvpg_facts
-
 - name: Get number of ports for portgroup 'dvpg_001' in 'dvs_001'
   debug:
     msg: "{{ item.num_ports }}"
@@ -107,6 +119,11 @@ dvs_portgroup_facts:
                     "policy": "loadbalance_srcid",
                     "rolling_order": false
                 },
+                "vlan_info": {
+                    "trunk": false,
+                    "pvlan": false,
+                    "vlan_id": 0
+                },
                 "type": "earlyBinding"
             },
         ]
@@ -119,21 +136,58 @@ except ImportError as e:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs
+from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs, find_dvs_by_name
 
 
 class DVSPortgroupFactsManager(PyVmomi):
     def __init__(self, module):
         super(DVSPortgroupFactsManager, self).__init__(module)
         self.dc_name = self.params['datacenter']
+        self.dvs_name = self.params['dvswitch']
 
-    def gather_dvs_portgroup_facts(self):
         datacenter = self.find_datacenter_by_name(self.dc_name)
         if datacenter is None:
             self.module.fail_json(msg="Failed to find the datacenter %s" % self.dc_name)
+        if self.dvs_name:
+            # User specified specific dvswitch name to gather information
+            dvsn = find_dvs_by_name(self.content, self.dvs_name)
+            if dvsn is None:
+                self.module.fail_json(msg="Failed to find the dvswitch %s" % self.dvs_name)
 
-        dvs_lists = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
+            self.dvsls = [dvsn]
+        else:
+            # default behaviour, gather information about all dvswitches
+            self.dvsls = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
 
+    def get_vlan_info(self, vlan_obj=None):
+        """
+        Return vlan information from given object
+        Args:
+            vlan_obj: vlan managed object
+        Returns: Dict of vlan details of the specific object
+        """
+
+        vdret = dict()
+        if not vlan_obj:
+            return vdret
+
+        if isinstance(vlan_obj, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+            vlan_id_list = []
+            for vli in vlan_obj.vlanId:
+                if vli.start == vli.end:
+                    vlan_id_list.append(str(vli.start))
+                else:
+                    vlan_id_list.append(str(vli.start) + "-" + str(vli.end))
+            vdret = dict(trunk=True, pvlan=False, vlan_id=vlan_id_list)
+        elif isinstance(vlan_obj, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+            vdret = dict(trunk=False, pvlan=True, vlan_id=str(vlan_obj.pvlanId))
+        else:
+            vdret = dict(trunk=False, pvlan=False, vlan_id=str(vlan_obj.vlanId))
+
+        return vdret
+
+    def gather_dvs_portgroup_facts(self):
+        dvs_lists = self.dvsls
         result = dict()
         for dvs in dvs_lists:
             result[dvs.name] = list()
@@ -141,6 +195,7 @@ class DVSPortgroupFactsManager(PyVmomi):
                 network_policy = dict()
                 teaming_policy = dict()
                 port_policy = dict()
+                vlan_info = dict()
 
                 if self.module.params['show_network_policy'] and dvs_pg.config.defaultPortConfig.securityPolicy:
                     network_policy = dict(
@@ -171,6 +226,9 @@ class DVSPortgroupFactsManager(PyVmomi):
                         vlan_override=dvs_pg.config.policy.vlanOverrideAllowed
                     )
 
+                if self.params['show_vlan_info']:
+                    vlan_info = self.get_vlan_info(dvs_pg.config.defaultPortConfig.vlan)
+
                 dvpg_details = dict(
                     portgroup_name=dvs_pg.name,
                     num_ports=dvs_pg.config.numPorts,
@@ -180,6 +238,7 @@ class DVSPortgroupFactsManager(PyVmomi):
                     teaming_policy=teaming_policy,
                     port_policy=port_policy,
                     network_policy=network_policy,
+                    vlan_info=vlan_info,
                 )
                 result[dvs.name].append(dvpg_details)
 
@@ -193,6 +252,8 @@ def main():
         show_network_policy=dict(type='bool', default=True),
         show_teaming_policy=dict(type='bool', default=True),
         show_port_policy=dict(type='bool', default=True),
+        dvswitch=dict(),
+        show_vlan_info=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
New arguments

##### SUMMARY

two items that I found very useful and needed to add to my project:
 

- wouldn't be great to add a variable for particular dvswitch?

 

- wouldn't be great to get also the vlan information of the port group?

I added it to the code
##### ISSUE TYPE

    Feature Pull Request

##### COMPONENT NAME

vmware_dvs_portgroup_facts