### PR TITLE
VMware: only convert VirtualDisk in vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2212,7 +2212,7 @@ class PyVmomiHelper(PyVmomi):
                 # Convert disk present in template if is set
                 if self.params['convert']:
                     for device in vm_obj.config.hardware.device:
-                        if hasattr(device.backing, 'fileName'):
+                        if isinstance(device, vim.vm.device.VirtualDisk):
                             disk_locator = vim.vm.RelocateSpec.DiskLocator()
                             disk_locator.diskBackingInfo = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
                             if self.params['convert'] in ['thin']:

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -91,9 +91,8 @@
     setup_virtualmachines: true
 - block:
     - include: boot_firmware_d1_c1_f0.yml
-    # Failing, see: https://github.com/ansible/ansible/issues/57653
-    # - include: clone_with_convert.yml
-    # - include: clone_customize_guest_test.yml
+    - include: clone_with_convert.yml
+    - include: clone_customize_guest_test.yml
     - include: max_connections.yml
   always:
     - name: Remove VM


### PR DESCRIPTION
Fix for #57653 clone_with_convert is failing

##### SUMMARY
When cloning VM to template the option to convert to thick/thin was failing in some situations.
This was cause because the diskBackingInfo.diskMode can only be set for VirtualDisk but was also set for VirtualCdrom devices.

The fix does better type checking to find out if the device is a VirtualDisk.

Fixes #57653

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
No additional information
