### PR TITLE
fix chunk_size calculation by using boto3 S3 Transport defaults

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -230,7 +230,6 @@ except ImportError:
     # Handled by imported HAS_BOTO3
     pass
 
-
 # the following function, calculate_multipart_etag, is from tlastowka
 # on github and is used under its (compatible) GPL license. So this
 # license applies to the following function.
@@ -254,7 +253,11 @@ except ImportError:
 # You should have received a copy of the GNU General Public License
 # along with calculate_multipart_etag.  If not, see <http://www.gnu.org/licenses/>.
 
-DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024
+if HAS_BOTO3:
+    from boto3.s3.transfer import TransferConfig
+    DEFAULT_CHUNK_SIZE = TransferConfig().multipart_chunksize
+else:
+    DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024
 
 
 def calculate_multipart_etag(source_path, chunk_size=DEFAULT_CHUNK_SIZE):
@@ -342,12 +345,11 @@ def calculate_s3_path(filelist, key_prefix=''):
 def calculate_local_etag(filelist, key_prefix=''):
     '''Really, "calculate md5", but since AWS uses their own format, we'll just call
        it a "local etag". TODO optimization: only calculate if remote key exists.'''
-    chunk_size = TransferConfig().multipart_chunksize
     ret = []
     for fileentry in filelist:
         # don't modify the input dict
         retentry = fileentry.copy()
-        retentry['local_etag'] = calculate_multipart_etag(fileentry['fullpath'], chunk_size=chunk_size)
+        retentry['local_etag'] = calculate_multipart_etag(fileentry['fullpath'])
         ret.append(retentry)
     return ret
 

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -216,6 +216,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3, boto_exception
 from ansible.module_utils._text import to_text
+from boto3.s3.transfer import TransferConfig
 
 try:
     from dateutil import tz
@@ -341,11 +342,12 @@ def calculate_s3_path(filelist, key_prefix=''):
 def calculate_local_etag(filelist, key_prefix=''):
     '''Really, "calculate md5", but since AWS uses their own format, we'll just call
        it a "local etag". TODO optimization: only calculate if remote key exists.'''
+    chunk_size = TransferConfig().multipart_chunksize
     ret = []
     for fileentry in filelist:
         # don't modify the input dict
         retentry = fileentry.copy()
-        retentry['local_etag'] = calculate_multipart_etag(fileentry['fullpath'])
+        retentry['local_etag'] = calculate_multipart_etag(fileentry['fullpath'], chunk_size=chunk_size)
         ret.append(retentry)
     return ret
 

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -216,7 +216,6 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3, boto_exception
 from ansible.module_utils._text import to_text
-from boto3.s3.transfer import TransferConfig
 
 try:
     from dateutil import tz


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix chunk_size calculation by using boto3 S3 Transport defaults since defaults are used also for the upload function
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #59090

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules / cloud / amazon / s3_sync.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
