### PR TITLE
#59096 Fix for not working azure_rm_aks

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -333,7 +333,7 @@ class AzureRMModuleBase(object):
             try:
                 client_module = importlib.import_module(client_type.__module__)
                 client_version = client_module.VERSION
-            except RuntimeError:
+            except (RuntimeError, AttributeError):
                 # can't get at the module version for some reason, just fail silently...
                 return
             expected_version = package_version.get('expected_version')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Missing `VERSION` in the imported module raises `AttributeError`, which is not being caught here and causes Ansible to fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_common

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
