### PR TITLE
Remove reference to Windows for assemble docs (#59082)

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -26,9 +26,6 @@ description:
   together to produce a destination file.
 - Files are assembled in string sorting order.
 - Puppet calls this idea I(fragments).
-- This module is also supported for Windows targets.
-notes:
-- This module is also supported for Windows targets.
 version_added: '0.5'
 options:
   src:


### PR DESCRIPTION
(cherry picked from commit 66a5ed64caa5d13b286988d5c75c35479add1369)

##### SUMMARY
Corrects mistake in the assemble module docs.

Assemble does NOT support Windows. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
assemble
