### PR TITLE
Remove extra print statement

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -317,7 +317,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :return a dict with key/value pairs for each in list.
         '''
         new_metadata = {}
-        print(metadata)
         for pair in metadata:
             new_metadata[pair["key"]] = pair["value"]
         return new_metadata


### PR DESCRIPTION
Let ansible-inventory handle all output
Fixes #59101

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`ansible-inventory` should handle all output from inventory plugins, debugging print statements are not helpful

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/59101
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp compute inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

https://github.com/ansible/ansible/issues/59101

tested out locally and fixes problem for me

