### PR TITLE
Don't truncate cidr_ipv6 addresses in ec2_group.py

### DIFF
--- a/changelogs/fragments/59106-fix-ipv6-truncating-in-ec2_group.yml
+++ b/changelogs/fragments/59106-fix-ipv6-truncating-in-ec2_group.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ec2_group - Don't truncate the host bits off of IPv6 CIDRs.
+    CIDRs will be passed thru to EC2 as-is provided they are valid IPv6
+    representations.  (https://github.com/ansible/ansible/issues/53297)

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -732,9 +732,13 @@ def validate_ip(module, cidr_ip):
                             "check the network mask and make sure that only network bits are set: {1}.".format(cidr_ip, ip))
         except ValueError:
             # IPv6 works a little differently. We don't want to modify the cidr_ip, just make sure it's valid.
-            if not isinstance(ip_network(cidr_ip), IPv6Network):
-                # TODO: warn or fail?  probably better to let aws decide what it'll accept?
-                module.fail_json("One of your IPv6 CIDR addresses is invalid: {0}".format(cidr_ip))
+            if not isinstance(ip_network(to_text(cidr_ip)), IPv6Network):
+                module.fail_json("One of your IPv6 CIDR addresses ({0}) is not a valid IPv6 network.".format(cidr_ip))
+            ip6 = to_ipv6_subnet(split_addr[0]) + "/" + split_addr[1]
+            if ip6 != cidr_ip:
+                module.warn("One of your IPv6 CIDR addresses ({0}) has host bits set. If you did not intend to specify"
+                            "a device address or range of devices, check the network mask and make sure that only "
+                            "network bits are set: {1}. Proceeding with address {0}.".format(cidr_ip, ip6))
             ip = cidr_ip
         return ip
     return cidr_ip

--- a/test/units/modules/cloud/amazon/test_ec2_group.py
+++ b/test/units/modules/cloud/amazon/test_ec2_group.py
@@ -71,8 +71,8 @@ def test_validate_ip():
     ips = [
         ('1.1.1.1/24', '1.1.1.0/24'),
         ('192.168.56.101/16', '192.168.0.0/16'),
-        # 64 bits make 8 octets, or 4 hextets
-        ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/64', '1203:8fe0:fe80:b897::/64'),
+        # Don't modify IPv6 CIDRs, AWS supports /128 and device ranges
+        ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128', '1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128'),
     ]
 
     for ip, net in ips:


### PR DESCRIPTION
##### SUMMARY
EC2 security groups accept /128's and IPv6 CIDRs that are technically just a range of devices, so don't truncate host bits.  

Fixes #53297

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

