### PR TITLE
Fix os_quota when volume service not available

### DIFF
--- a/changelogs/fragments/41240-fix-os_quota-without-cinder.yaml
+++ b/changelogs/fragments/41240-fix-os_quota-without-cinder.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "os_quota - fix failure to set compute or network quota when volume service is not available"


### PR DESCRIPTION
(cherry picked from commit 1aca1f21f97a8d78898f63f4a25ca37c9ca0c8ee)

##### SUMMARY

os_quota checks the current quotas for compute, network and volume services and fails when no volume service is found in the catalog.

Since openstack test deployments without volume services are common os_quota shouldn't fail if such service is missing.

This was originally fixed in d31a09ceb7d337521fcfa7cecd0d6523749fad41 and later adapted to catch exceptions raised by shade. Since then, this module moved to using openstacksdk, which doesn't catch the exception raised by keystoneauth1.

Fixes #41240

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- os_quota

##### ADDITIONAL INFORMATION

Without this commit, setting compute and network quotas on a cloud without volume service results in:

```keystoneauth1.exceptions.catalog.EndpointNotFound: public endpoint for block-storage service in RegionOne region not found```

With this commit, compute and network quotas are set.