### PR TITLE
Fix os_quota when volume service not available

### DIFF
--- a/changelogs/fragments/41240-fix-os_quota-without-cinder.yaml
+++ b/changelogs/fragments/41240-fix-os_quota-without-cinder.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "os_quota - fix failure to set compute or network quota when volume service is not available"

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -107,6 +107,7 @@ options:
 requirements:
     - "python >= 2.7"
     - "openstacksdk >= 0.13.0"
+    - "keystoneauth1 >= 3.4.0"
 '''
 
 EXAMPLES = '''
@@ -225,6 +226,14 @@ openstack_quotas:
 
 '''
 
+import traceback
+
+try:
+    from keystoneauth1 import exceptions as ksa_exceptions
+    HAS_KEYSTONEAUTH1 = True
+except ImportError:
+    HAS_KEYSTONEAUTH1 = False
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
@@ -249,12 +258,12 @@ def _get_quotas(sdk, module, cloud, project):
     quota = {}
     try:
         quota['volume'] = _get_volume_quotas(cloud, project)
-    except sdk.exceptions.NotFoundException:
+    except ksa_exceptions.EndpointNotFound:
         module.warn("No public endpoint for volumev2 service was found. Ignoring volume quotas.")
 
     try:
         quota['network'] = _get_network_quotas(cloud, project)
-    except sdk.exceptions.NotFoundException:
+    except ksa_exceptions.EndpointNotFound:
         module.warn("No public endpoint for network service was found. Ignoring network quotas.")
 
     quota['compute'] = _get_compute_quotas(cloud, project)
@@ -363,6 +372,9 @@ def main():
     module = AnsibleModule(argument_spec,
                            supports_check_mode=True
                            )
+
+    if not HAS_KEYSTONEAUTH1:
+        module.fail_json(msg='The keystoneauth1 Python module is required')
 
     sdk, cloud = openstack_cloud_from_module(module)
     try:


### PR DESCRIPTION
(cherry picked from commit 1aca1f21f97a8d78898f63f4a25ca37c9ca0c8ee)

##### SUMMARY

os_quota checks the current quotas for compute, network and volume services and fails when no volume service is found in the catalog.

Since openstack test deployments without volume services are common os_quota shouldn't fail if such service is missing.

This was originally fixed in d31a09ceb7d337521fcfa7cecd0d6523749fad41 and later adapted to catch exceptions raised by shade. Since then, this module moved to using openstacksdk, which doesn't catch the exception raised by keystoneauth1.

Fixes #41240

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- os_quota

##### ADDITIONAL INFORMATION

Without this commit, setting compute and network quotas on a cloud without volume service results in:

```keystoneauth1.exceptions.catalog.EndpointNotFound: public endpoint for block-storage service in RegionOne region not found```

With this commit, compute and network quotas are set.