### PR TITLE
if device == all, run 'bare' `cfgmgr`.  Else, run `cfgmgr -l device`

### DIFF
--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -198,7 +198,7 @@ def discover_device(module, device):
     if device == 'all':
         cmd = [cfgmgr_cmd]
     else:
-        cmd = ["%s" % cfgmgr_cmd, "%s" % device]
+        cmd = ["%s" % cfgmgr_cmd, "-l", "%s" % device]
 
     msg = ''
     if not module.check_mode:

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -195,7 +195,7 @@ def discover_device(module, device):
 
     # device is mandatory according to doc spec,
     #  if  device == 'all', run bare cfgmgr.  else, scan specific device
-    if device.lower() == 'all':
+    if device == 'all':
         cmd = [cfgmgr_cmd]
     else:
         cmd = ["%s" % cfgmgr_cmd, "%s" % device]

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -193,16 +193,17 @@ def discover_device(module, device):
     """ Discover AIX devices."""
     cfgmgr_cmd = module.get_bin_path('cfgmgr', True)
 
-    if device is not None:
-        device = "-l %s" % device
-
+    # device is mandatory according to doc spec,
+    #  if  device == 'all', run bare cfgmgr.  else, scan specific device
+    if device.lower() == 'all':
+        cmd = [cfgmgr_cmd]
     else:
-        device = ''
+        cmd = ["%s" % cfgmgr_cmd, "%s" % device]
 
     changed = True
     msg = ''
     if not module.check_mode:
-        rc, cfgmgr_out, err = module.run_command(["%s" % cfgmgr_cmd, "%s" % device])
+        rc, cfgmgr_out, err = module.run_command(cmd)
         changed = True
         msg = cfgmgr_out
 

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -200,7 +200,6 @@ def discover_device(module, device):
     else:
         cmd = ["%s" % cfgmgr_cmd, "%s" % device]
 
-    changed = True
     msg = ''
     if not module.check_mode:
         rc, cfgmgr_out, err = module.run_command(cmd)

--- a/lib/ansible/modules/system/aix_devices.py
+++ b/lib/ansible/modules/system/aix_devices.py
@@ -203,6 +203,9 @@ def discover_device(module, device):
     msg = ''
     if not module.check_mode:
         rc, cfgmgr_out, err = module.run_command(cmd)
+        if rc != 0:
+            msg = "Failed to run cfgmgr (%s)" % ' '.join(cmd)
+            module.fail_json(msg=msg, rc=rc, err=err)
         changed = True
         msg = cfgmgr_out
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #51754

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aix_devices

##### ADDITIONAL INFORMATION
Small PR.  We check to see if `devices` was passed as 'all', and if it is, we just run `cfgmgr` on the remote host.  If device is not 'all', run `cfgmgr -l device` instead.

```paste below
]# ansible-playbook -vvvi /etc/ansible/test.ini -u deploy test_cfgmgr.yml
ansible-playbook 2.8.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.8 (default, Apr 25 2019, 21:02:35) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /etc/ansible/test.ini as it did not pass it's verify_file() method
script declined parsing /etc/ansible/test.ini as it did not pass it's verify_file() method
auto declined parsing /etc/ansible/test.ini as it did not pass it's verify_file() method
yaml declined parsing /etc/ansible/test.ini as it did not pass it's verify_file() method
Parsed /etc/ansible/test.ini inventory source with ini plugin

PLAYBOOK: test_cfgmgr.yml *********************************************************************************************************************************************************************************************************
1 plays in test_cfgmgr.yml

PLAY [Test cfgmgr] ***********************************************************************************************************************************************************************************************************************
META: ran handlers

TASK [Test 'bare' cfgmgr] ****************************************************************************************************************************************************************************************************************
task path: /etc/ansible/test_cfgmgr.yml:8
~~~snip~~~
changed: [AIXTEST] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "invocation": {
        "module_args": {
            "attributes": null,
            "device": "all",
            "force": false,
            "recursive": false,
            "state": "available"
        }
    },
    "msg": ""
}

TASK [Test en0 scan] *

~~~SNIP~~~
<AIXSERVER> (0, b'\n{"msg": "", "invocation": {"module_args": {"device": "en0", "attributes": null, "state": "available", "force": false, "recursive": false}}, "changed": true}\n', b'')
changed: [AIXTEST] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "attributes": null,
            "device": "en0",
            "force": false,
            "recursive": false,
            "state": "available"
        }
    },
    "msg": ""
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************************************************************************************************************************************
AIXTEST                    : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
