### PR TITLE
add test manipulation ability to Singleton

### DIFF
--- a/lib/ansible/utils/singleton.py
+++ b/lib/ansible/utils/singleton.py
@@ -27,3 +27,29 @@ class Singleton(type):
                 cls.__instance = super(Singleton, cls).__call__(*args, **kw)
 
         return cls.__instance
+
+    """Reset a singleton instance (mainly for unit tests to avoid
+    reaching into the classobj directly)"""
+    @staticmethod
+    def clear(singleton_class):
+        Singleton.assert_is_singleton(singleton_class)
+        singleton_class.__instance = None
+
+    """Force a singleton to a specific instance (mainly for unit tests
+    to avoid reaching into the classobj directly)"""
+    @staticmethod
+    def set(singleton_class, obj):
+        Singleton.assert_is_singleton(singleton_class)
+        singleton_class.__instance = obj
+
+    """Directly sample the singleton state without creating an instance
+    (mainly for unit tests to avoid reaching into the classobj directly)"""
+    @staticmethod
+    def get(singleton_class):
+        Singleton.assert_is_singleton(singleton_class)
+        return singleton_class.__instance
+
+    @staticmethod
+    def assert_is_singleton(singleton_class):
+        if not isinstance(singleton_class, Singleton):
+            raise TypeError("{0} must be a Singleton type object")

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -36,15 +36,16 @@ from ansible.cli.galaxy import GalaxyCLI
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.utils import context_objects as co
+from ansible.utils.singleton import Singleton
 from units.compat import unittest
 from units.compat.mock import call, patch, MagicMock
 
 
 @pytest.fixture(autouse='function')
 def reset_cli_args():
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
     yield
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
 
 
 class TestGalaxy(unittest.TestCase):
@@ -110,12 +111,12 @@ class TestGalaxy(unittest.TestCase):
 
     def setUp(self):
         # Reset the stored command line args
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
         self.default_args = ['ansible-galaxy']
 
     def tearDown(self):
         # Reset the stored command line args
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
 
     def test_init(self):
         galaxy_cli = GalaxyCLI(args=self.default_args)
@@ -158,7 +159,7 @@ class TestGalaxy(unittest.TestCase):
         # removing role
         # Have to reset the arguments in the context object manually since we're doing the
         # equivalent of running the command line program twice
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
         gc = GalaxyCLI(args=["ansible-galaxy", "remove", role_file, self.role_name])
         gc.run()
 
@@ -560,16 +561,16 @@ def collection_artifact(collection_skeleton, tmp_path_factory):
 
     # Because we call GalaxyCLI in collection_skeleton we need to reset the singleton back to None so it uses the new
     # args, we reset the original args once it is done.
-    orig_cli_args = co.GlobalCLIArgs._Singleton__instance
+    orig_cli_args = co.GlobalCLIArgs()
     try:
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
         galaxy_args = ['ansible-galaxy', 'collection', 'build', collection_skeleton, '--output-path', output_dir]
         gc = GalaxyCLI(args=galaxy_args)
         gc.run()
 
         yield output_dir
     finally:
-        co.GlobalCLIArgs._Singleton__instance = orig_cli_args
+        Singleton.set(co.GlobalCLIArgs, orig_cli_args)
 
 
 def test_invalid_skeleton_path():

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -26,7 +26,7 @@ from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook import Playbook
 from ansible.template import Templar
 from ansible.utils import context_objects as co
-
+from ansible.utils.singleton import Singleton
 from units.mock.loader import DictDataLoader
 
 
@@ -34,11 +34,11 @@ class TestPlaybookExecutor(unittest.TestCase):
 
     def setUp(self):
         # Reset command line args for every test
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
 
     def tearDown(self):
         # And cleanup after ourselves too
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
 
     def test_get_serialized_batches(self):
         fake_loader = DictDataLoader({

--- a/test/units/executor/test_task_queue_manager_callbacks.py
+++ b/test/units/executor/test_task_queue_manager_callbacks.py
@@ -26,6 +26,7 @@ from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook
 from ansible.plugins.callback import CallbackBase
 from ansible.utils import context_objects as co
+from ansible.utils.singleton import Singleton
 
 __metaclass__ = type
 
@@ -38,7 +39,7 @@ class TestTaskQueueManagerCallbacks(unittest.TestCase):
         passwords = []
 
         # Reset the stored command line args
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
         self._tqm = TaskQueueManager(inventory, variable_manager, loader, passwords)
         self._playbook = Playbook(loader)
 
@@ -51,7 +52,7 @@ class TestTaskQueueManagerCallbacks(unittest.TestCase):
 
     def tearDown(self):
         # Reset the stored command line args
-        co.GlobalCLIArgs._Singleton__instance = None
+        Singleton.clear(co.GlobalCLIArgs)
 
     def test_task_queue_manager_callbacks_v2_playbook_on_start(self):
         """

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -28,13 +28,14 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils import context_objects as co
 from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash_s
+from ansible.utils.singleton import Singleton
 
 
 @pytest.fixture(autouse='function')
 def reset_cli_args():
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
     yield
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
 
 
 @pytest.fixture()

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -25,15 +25,16 @@ from ansible.galaxy import collection
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils import context_objects as co
 from ansible.utils.display import Display
+from ansible.utils.singleton import Singleton
 
 
 def call_galaxy_cli(args):
-    orig = co.GlobalCLIArgs._Singleton__instance
-    co.GlobalCLIArgs._Singleton__instance = None
+    orig = Singleton.get(co.GlobalCLIArgs)
+    Singleton.clear(co.GlobalCLIArgs)
     try:
         GalaxyCLI(args=['ansible-galaxy', 'collection'] + args).run()
     finally:
-        co.GlobalCLIArgs._Singleton__instance = orig
+        Singleton.set(co.GlobalCLIArgs, orig)
 
 
 def artifact_json(namespace, name, version, dependencies, server):

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -18,6 +18,7 @@ from ansible.playbook.play_context import PlayContext
 from ansible.playbook.play import Play
 from ansible.plugins.loader import become_loader
 from ansible.utils import context_objects as co
+from ansible.utils.singleton import Singleton
 
 
 @pytest.fixture
@@ -39,9 +40,9 @@ def parser():
 
 @pytest.fixture
 def reset_cli_args():
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
     yield
-    co.GlobalCLIArgs._Singleton__instance = None
+    Singleton.clear(co.GlobalCLIArgs)
 
 
 def test_play_context(mocker, parser, reset_cli_args):

--- a/test/units/utils/test_singleton.py
+++ b/test/units/utils/test_singleton.py
@@ -1,0 +1,77 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.six import with_metaclass
+from ansible.utils.singleton import Singleton
+
+
+class FooSingleton(with_metaclass(Singleton, object)):
+    pass
+
+
+class BarSingleton(with_metaclass(Singleton, object)):
+    pass
+
+
+def test_multiple_creation_and_isolation():
+    # ensure that we have the same instance of the same type, but that each type gets its own singleton instance
+    a = FooSingleton()
+    b = FooSingleton()
+    c = BarSingleton()
+    d = BarSingleton()
+
+    assert isinstance(a, FooSingleton)
+    assert isinstance(b, FooSingleton)
+    assert isinstance(c, BarSingleton)
+    assert isinstance(d, BarSingleton)
+    assert a is b
+    assert c is d
+    assert a is not c
+
+
+def test_set_clear_get():
+    a = FooSingleton()
+    Singleton.clear(FooSingleton)
+    b = FooSingleton()
+
+    assert isinstance(a, FooSingleton)
+    assert isinstance(b, FooSingleton)
+    assert a is not b
+
+    Singleton.set(FooSingleton, a)
+
+    c = FooSingleton()
+
+    # ensure that set() gives us back the instance we passed in
+    assert isinstance(c, FooSingleton)
+    assert c is a
+
+    direct_value = Singleton.get(FooSingleton)
+    assert direct_value is c
+
+    Singleton.clear(FooSingleton)
+
+    # ensure that get doesn't create an instance
+    direct_value = Singleton.get(FooSingleton)
+    assert direct_value is None
+
+    # and again to be sure
+    direct_value = Singleton.get(FooSingleton)
+    assert direct_value is None
+
+    # finally, ensure the default behavior works properly after a get
+    a = FooSingleton()
+    b = FooSingleton()
+    assert a is b
+
+
+def test_assert_is_singleton():
+    Singleton.assert_is_singleton(FooSingleton)
+    with pytest.raises(TypeError):
+        Singleton.assert_is_singleton(int)


### PR DESCRIPTION
##### SUMMARY

* add set/get/clear staticmethods to Singleton metaclass so tests can inspect/manipulate Singleton state without worrying about name munging, etc
* add tests for Singleton itself
* update tests that were manipulating Singleton state to use new methods on the metaclass instead

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
singleton.py

