### PR TITLE
[2.8] tower_role: ensure alias of "validate_certs" parameter is handled

### DIFF
--- a/changelogs/fragments/57518-tower_role-fix_validate_certs.yml
+++ b/changelogs/fragments/57518-tower_role-fix_validate_certs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fix exception when tower_verify_ssl parameter is used in tower_role module (https://github.com/ansible/ansible/pull/57518).

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -70,6 +70,7 @@ def tower_auth_config(module):
         password = module.params.pop('tower_password', None)
         if password:
             auth_config['password'] = password
+        module.params.pop('tower_verify_ssl', None)  # pop alias if used
         verify_ssl = module.params.pop('validate_certs', None)
         if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl

--- a/test/integration/targets/tower_role/tasks/main.yml
+++ b/test/integration/targets/tower_role/tasks/main.yml
@@ -27,6 +27,14 @@
     that:
       - "result is changed"
 
+- name: Test tower_verify_ssl alias
+  tower_role:
+    user: joe
+    role: update
+    project: Demo Project
+    tower_verify_ssl: true
+    state: absent
+
 - name: Delete a User
   tower_user:
     username: joe


### PR DESCRIPTION
##### SUMMARY
* tower_role: ensure alias of validate_certs is handled
* tower modules: remove tower_verify_ssl alias too

(cherry picked from commit 77e01e6abc67efe4056924c620281f29a42c0159)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/57518-tower_role-fix_validate_certs.yml
lib/ansible/module_utils/ansible_tower.py
test/integration/targets/tower_role/tasks/main.yml
