### PR TITLE
Update hpilo_boot.py

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -71,7 +71,7 @@ options:
     choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
     version_added: '2.4'
 requirements:
-- hpilo
+- python-hpilo
 notes:
 - To use a USB key image you need to specify floppy as boot media.
 - This module ought to be run from a system that can access the HP iLO


### PR DESCRIPTION
Change `hpilo` requirement to `python-hpilo` to avoid being confused in installation with pip.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
when read this document you may try install with a command like this `pip install hpilo` because in the document the requirement referred as `hpilo`. It is better to change the requirement name to python-hpilo because it is just the name you can install it from pypi.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hpilo-boot
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
