### PR TITLE
2.8: group: detect duplicate GIDs when local=yes (#58469)

### DIFF
--- a/changelogs/fragments/56481-group-detect-duplicate-gids-local.yaml
+++ b/changelogs/fragments/56481-group-detect-duplicate-gids-local.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - group - properly detect duplicate GIDs when local=yes (https://github.com/ansible/ansible/issues/56481)

--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -120,9 +120,14 @@ class Group(object):
         cmd = [self.module.get_bin_path(command_name, True), self.name]
         return self.execute_command(cmd)
 
+    def _local_check_gid_exists(self):
+        if self.gid and self.gid in [gr.gr_gid for gr in grp.getgrall()]:
+            self.module.fail_json(msg="GID '{0}' already exists".format(self.gid))
+
     def group_add(self, **kwargs):
         if self.local:
             command_name = 'lgroupadd'
+            self._local_check_gid_exists()
         else:
             command_name = 'groupadd'
         cmd = [self.module.get_bin_path(command_name, True)]
@@ -140,6 +145,7 @@ class Group(object):
     def group_mod(self, **kwargs):
         if self.local:
             command_name = 'lgroupmod'
+            self._local_check_gid_exists()
         else:
             command_name = 'groupmod'
         cmd = [self.module.get_bin_path(command_name, True)]

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -192,3 +192,28 @@
   assert:
     that:
     - not delete_group_again is changed
+
+# https://github.com/ansible/ansible/issues/56481
+- block:
+  - name: Test duplicate GID with local=yes
+    group:
+      name: "{{ item }}"
+      gid: 1337
+      local: yes
+    loop:
+      - group1_local_test
+      - group2_local_test
+    ignore_errors: yes
+    register: local_duplicate_gid_result
+
+  - assert:
+     that:
+       - local_duplicate_gid_result['results'][0] is success
+       - local_duplicate_gid_result['results'][1]['msg'] == "GID '1337' already exists"
+  always:
+    - name: Cleanup
+      group:
+        name: group1_local_test
+        state: absent
+  # only applicable to Linux, limit further to CentOS where 'luseradd' is installed
+  when: ansible_distribution == 'CentOS'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/58469

(cherry picked from commit 4898b0a4a298448677c2aee2a03157ba5b662759)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/group.py`