### PR TITLE
yum: enable_plugin description is not sufficient for the end user

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -149,7 +149,8 @@ options:
   enable_plugin:
     description:
       - I(Plugin) name to enable for the install/update operation.
-        The enabled plugin will not persist beyond the transaction.
+        The enabled plugin will not persist beyond the transaction. This description does not seem to enough. I tried this for yum-version
+        lock plugin for upgrade/downgrade use-cases based on yum version lock plugin , but it does not seem to work.
     version_added: "2.5"
   disable_plugin:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
enable_plugin option is shown in documentation but it does not seem to work for plugins like yum version lock or the description is not sufficient.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/packaging/os/yum.py`
