### PR TITLE
VMware: Use managed object id to find VM

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -880,7 +880,7 @@ class PyVmomi(object):
     # Virtual Machine related functions
     def get_vm(self):
         """
-        Find unique virtual machine either by UUID or Name.
+        Find unique virtual machine either by UUID, MoID or Name.
         Returns: virtual machine object if found, else None.
 
         """
@@ -959,6 +959,8 @@ class PyVmomi(object):
             elif vms:
                 # Unique virtual machine found.
                 vm_obj = vms[0]
+        elif self.params['moid']:
+            vm_obj = VmomiSupport.templateOf('VirtualMachine')(self.params['moid'], self.si._stub)
 
         if vm_obj:
             self.current_vm_obj = vm_obj

--- a/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
@@ -28,11 +28,17 @@ options:
   name:
     description:
     - Name of the virtual machine to export.
-    - This is a required parameter, if parameter C(uuid) is not supplied.
+    - This is a required parameter, if parameter C(uuid) or C(moid) is not supplied.
   uuid:
     description:
     - Uuid of the virtual machine to export.
-    - This is a required parameter, if parameter C(name) is not supplied.
+    - This is a required parameter, if parameter C(name) or C(moid) is not supplied.
+  moid:
+    description:
+    - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+    - This is required if C(name) or C(uuid) is not supplied.
+    version_added: '2.9'
+    type: str
   datacenter:
     default: ha-datacenter
     description:
@@ -304,6 +310,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', default='ha-datacenter'),
         export_dir=dict(type='str'),
@@ -313,7 +320,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_one_of=[
-                               ['name', 'uuid'],
+                               ['name', 'uuid', 'moid'],
                            ],
                            )
     pyv = VMwareExportVmOvf(module)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
@@ -20,10 +20,10 @@ DOCUMENTATION = '''
 module: vmware_guest_boot_facts
 short_description: Gather facts about boot options for the given virtual machine
 description:
-    - This module can be used to gather facts aboyt boot options for the given virtual machine.
+    - Gather facts about boot options for the given virtual machine.
 version_added: 2.7
 author:
-    - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
+    - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5
 requirements:
@@ -33,11 +33,17 @@ options:
    name:
      description:
      - Name of the VM to work with.
-     - This is required if C(uuid) parameter is not supplied.
+     - This is required if C(uuid) or C(moid) parameter is not supplied.
    uuid:
      description:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
-     - This is required if C(name) parameter is not supplied.
+     - This is required if C(name) or C(moid) parameter is not supplied.
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
+     version_added: '2.9'
+     type: str
    use_instance_uuid:
      description:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
@@ -61,6 +67,15 @@ EXAMPLES = r'''
     validate_certs: no
     name: "{{ vm_name }}"
   register: vm_boot_order_facts
+
+- name: Gather facts about virtual machine's boot order using MoID
+  vmware_guest_boot_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    moid: "vm-42"
+  register: vm_moid_boot_order_facts
 '''
 
 RETURN = r"""
@@ -89,7 +104,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, find_vm_by_id
 
 try:
-    from pyVmomi import vim
+    from pyVmomi import vim, VmomiSupport
 except ImportError:
     pass
 
@@ -99,6 +114,7 @@ class VmBootFactsManager(PyVmomi):
         super(VmBootFactsManager, self).__init__(module)
         self.name = self.params['name']
         self.uuid = self.params['uuid']
+        self.moid = self.params['moid']
         self.use_instance_uuid = self.params['use_instance_uuid']
         self.vm = None
 
@@ -120,13 +136,18 @@ class VmBootFactsManager(PyVmomi):
                 if temp_vm_object.obj.name == self.name:
                     vms.append(temp_vm_object.obj)
 
+        elif self.moid:
+            vm_obj = VmomiSupport.templateOf('VirtualMachine')(self.module.params['moid'], self.si._stub)
+            if vm_obj:
+                vms.append(vm_obj)
+
         if vms:
             if self.params.get('name_match') == 'first':
                 self.vm = vms[0]
             elif self.params.get('name_match') == 'last':
                 self.vm = vms[-1]
         else:
-            self.module.fail_json(msg="Failed to find virtual machine using %s" % (self.name or self.uuid))
+            self.module.fail_json(msg="Failed to find virtual machine using %s" % (self.name or self.uuid or self.moid))
 
     @staticmethod
     def humanize_boot_order(boot_order):
@@ -165,6 +186,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         name_match=dict(
             choices=['first', 'last'],
@@ -175,10 +197,10 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_one_of=[
-            ['name', 'uuid']
+            ['name', 'uuid', 'moid']
         ],
         mutually_exclusive=[
-            ['name', 'uuid']
+            ['name', 'uuid', 'moid']
         ],
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -36,11 +36,17 @@ options:
    name:
      description:
      - Name of the virtual machine.
-     - This is a required parameter, if parameter C(uuid) is not supplied.
+     - This is a required parameter, if parameter C(uuid) or C(moid) is not supplied.
    uuid:
      description:
      - UUID of the instance to gather facts if known, this is VMware's unique identifier.
-     - This is a required parameter, if parameter C(name) is not supplied.
+     - This is a required parameter, if parameter C(name) or C(moid) is not supplied.
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
+     version_added: '2.9'
+     type: str
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -74,7 +80,7 @@ options:
      - 'Valid attributes are:'
      - ' - C(size[_tb,_gb,_mb,_kb]) (integer): Disk storage size in specified unit.'
      - '   If C(size) specified then unit must be specified. There is no space allowed in between size number and unit.'
-     - '   Only first occurance in disk element will be considered, even if there are multiple size* parameters available.'
+     - '   Only first occurrence in disk element will be considered, even if there are multiple size* parameters available.'
      - ' - C(type) (string): Valid values are:'
      - '     - C(thin) thin disk'
      - '     - C(eagerzeroedthick) eagerzeroedthick disk'
@@ -141,6 +147,21 @@ EXAMPLES = '''
     datacenter: "{{ datacenter_name }}"
     validate_certs: no
     name: VM_225
+    disk:
+      - state: absent
+        scsi_controller: 1
+        unit_number: 1
+  delegate_to: localhost
+  register: disk_facts
+
+- name: Remove disks from virtual machine using moid
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    validate_certs: no
+    moid: vm-42
     disk:
       - state: absent
         scsi_controller: 1
@@ -578,7 +599,7 @@ class PyVmomiHelper(PyVmomi):
                 rec = self.content.storageResourceManager.RecommendDatastores(storageSpec=storage_spec)
                 rec_action = rec.recommendations[0].action[0]
                 return rec_action.destination.name
-            except Exception as e:
+            except Exception:
                 # There is some error so we fall back to general workflow
                 pass
         datastore = None
@@ -633,13 +654,18 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
         disk=dict(type='list', default=[]),
         use_instance_uuid=dict(type='bool', default=False),
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']])
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['name', 'uuid', 'moid']
+        ]
+    )
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path
@@ -653,8 +679,9 @@ def main():
     if not vm:
         # We unable to find the virtual machine user specified
         # Bail out
+        vm_id = (module.params.get('name') or module.params.get('uuid') or module.params.get('moid'))
         module.fail_json(msg="Unable to manage disks for non-existing"
-                             " virtual machine '%s'." % (module.params.get('uuid') or module.params.get('name')))
+                             " virtual machine '%s'." % vm_id)
 
     # VM exists
     try:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -34,7 +34,7 @@ options:
    name:
      description:
      - Name of the VM to work with
-     - This is required if UUID is not supplied.
+     - This is required if C(uuid) or C(moid) is not supplied.
    name_match:
      description:
      - If multiple VMs matching the name, use the first or last found
@@ -43,13 +43,19 @@ options:
    uuid:
      description:
      - UUID of the instance to manage if known, this is VMware's unique identifier.
-     - This is required if name is not supplied.
+     - This is required if C(name) or C(moid) is not supplied.
    use_instance_uuid:
      description:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
      default: no
      type: bool
      version_added: '2.8'
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
+     version_added: '2.9'
+     type: str
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
@@ -65,8 +71,6 @@ options:
      - '   folder: /folder1/datacenter1/vm'
      - '   folder: folder1/datacenter1/vm'
      - '   folder: /folder1/datacenter1/vm/folder2'
-     - '   folder: vm/folder2'
-     - '   folder: folder2'
    datacenter:
      description:
      - Destination datacenter for the deploy operation
@@ -133,6 +137,19 @@ EXAMPLES = '''
     properties: ["config.hardware.memoryMB", "guest.disk", "overallStatus"]
   delegate_to: localhost
   register: facts
+
+- name: Gather some facts from a guest using MoID
+  vmware_guest_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ datacenter_name }}"
+    moid: vm-42
+    schema: "vsphere"
+    properties: ["config.hardware.memoryMB", "guest.disk", "overallStatus"]
+  delegate_to: localhost
+  register: vm_moid_facts
 
 - name: Gather Managed object ID (moid) from a guest using the vSphere API output schema for REST Calls
   vmware_guest_facts:
@@ -237,6 +254,7 @@ def main():
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
         tags=dict(type='bool', default=False),
@@ -244,7 +262,7 @@ def main():
         properties=dict(type='list')
     )
     module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']],
+                           required_one_of=[['name', 'uuid', 'moid']],
                            supports_check_mode=True)
 
     if module.params.get('folder'):
@@ -282,8 +300,8 @@ def main():
         except Exception as exc:
             module.fail_json(msg="Fact gather failed with exception %s" % to_text(exc))
     else:
-        module.fail_json(msg="Unable to gather facts for non-existing VM %s" % (module.params.get('uuid') or
-                                                                                module.params.get('name')))
+        vm_id = (module.params.get('uuid') or module.params.get('name') or module.params.get('moid'))
+        module.fail_json(msg="Unable to gather facts for non-existing VM %s" % vm_id)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -32,12 +32,17 @@ options:
    name:
      description:
      - Name of the virtual machine.
-     - This is a required parameter, if parameter C(uuid) is not supplied.
+     - This is a required parameter, if parameter C(uuid) or C(moid) is not supplied.
      type: str
    uuid:
      description:
      - UUID of the instance to gather facts if known, this is VMware's unique identifier.
-     - This is a required parameter, if parameter C(name) is not supplied.
+     - This is a required parameter, if parameter C(name) or C(moid) is not supplied.
+     type: str
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
      type: str
    folder:
      description:
@@ -134,6 +139,20 @@ EXAMPLES = '''
         mac: "00:50:56:44:55:77"
   delegate_to: localhost
   register: network_facts
+
+- name: Change network adapter settings of virtual machine using MoID
+  vmware_guest_network:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    validate_certs: no
+    moid: vm-42
+    gather_network_facts: false
+    networks:
+      - state: absent
+        mac: "00:50:56:44:55:77"
+  delegate_to: localhost
 '''
 
 RETURN = """
@@ -156,8 +175,6 @@ network_data:
     }
 """
 
-import re
-
 try:
     from pyVmomi import vim
 except ImportError:
@@ -166,7 +183,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.network import is_mac
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task, find_obj, get_all_objs, get_parent_datacenter
+from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task, get_all_objs, get_parent_datacenter
 
 
 class PyVmomiHelper(PyVmomi):
@@ -435,6 +452,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', default='ha-datacenter'),
         esxi_hostname=dict(type='str'),
@@ -443,12 +461,18 @@ def main():
         networks=dict(type='list', default=[])
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, required_one_of=[['name', 'uuid']])
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['name', 'uuid', 'moid']
+        ]
+    )
+
     pyv = PyVmomiHelper(module)
     vm = pyv.get_vm()
     if not vm:
-        module.fail_json(msg='Unable to find the specified virtual machine uuid: %s, name: %s '
-                             % ((module.params.get('uuid')), (module.params.get('name'))))
+        vm_id = (module.params.get('uuid') or module.params.get('name') or module.params.get('moid'))
+        module.fail_json(msg='Unable to find the specified virtual machine using %s' % vm_id)
 
     result = pyv.reconfigure_vm_network(vm)
     if result['failed']:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
@@ -22,7 +22,7 @@ description:
     - This module can be used to gather facts about virtual machine's snapshots.
 version_added: 2.6
 author:
-    - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
+    - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.0 and 6.5
 requirements:
@@ -32,12 +32,18 @@ options:
    name:
      description:
      - Name of the VM to work with.
-     - This is required if C(uuid) is not supplied.
+     - This is required if C(uuid) or C(moid) is not supplied.
    uuid:
      description:
      - UUID of the instance to manage if known, this is VMware's BIOS UUID by default.
-     - This is required if C(name) parameter is not supplied.
+     - This is required if C(name) or C(moid) parameter is not supplied.
      - The C(folder) is ignored, if C(uuid) is provided.
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
+     version_added: '2.9'
+     type: str
    use_instance_uuid:
      description:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
@@ -67,15 +73,25 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-  - name: Gather snapshot facts about the virtual machine in the given vCenter
-    vmware_guest_snapshot_facts:
-      hostname: "{{ vcenter_hostname }}"
-      username: "{{ vcenter_username }}"
-      password: "{{ vcenter_password }}"
-      datacenter: "{{ datacenter_name }}"
-      name: "{{ guest_name }}"
-    delegate_to: localhost
-    register: snapshot_facts
+- name: Gather snapshot facts about the virtual machine in the given vCenter
+  vmware_guest_snapshot_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    name: "{{ guest_name }}"
+  delegate_to: localhost
+  register: snapshot_facts
+
+- name: Gather snapshot facts about the virtual machine using MoID
+  vmware_guest_snapshot_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    moid: vm-42
+  delegate_to: localhost
+  register: snapshot_facts
 '''
 
 RETURN = """
@@ -114,7 +130,7 @@ class PyVmomiHelper(PyVmomi):
     @staticmethod
     def gather_guest_snapshot_facts(vm_obj=None):
         """
-        Function to return snpashot related facts about given virtual machine
+        Return snapshot related facts about given virtual machine
         Args:
             vm_obj: Virtual Machine Managed object
 
@@ -131,15 +147,21 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_together=[['name', 'folder']],
-                           required_one_of=[['name', 'uuid']],
-                           supports_check_mode=True,
-                           )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_together=[
+            ['name', 'folder']
+        ],
+        required_one_of=[
+            ['name', 'uuid', 'moid']
+        ],
+        supports_check_mode=True,
+    )
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path
@@ -151,10 +173,10 @@ def main():
     vm = pyv.get_vm()
 
     if not vm:
-        # If UUID is set, getvm select UUID, show error message accordingly.
+        # If UUID is set, get_vm select UUID, show error message accordingly.
+        vm_id = (module.params.get('uuid') or module.params.get('name') or module.params.get('moid'))
         module.fail_json(msg="Unable to gather facts about snapshots for"
-                             " non-existing VM ['%s']" % (module.params.get('uuid') or
-                                                          module.params.get('name')))
+                             " non-existing VM ['%s']" % vm_id)
 
     results = dict(changed=False, guest_snapshots=pyv.gather_guest_snapshot_facts(vm_obj=vm))
     module.exit_json(**results)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
@@ -30,7 +30,7 @@ options:
    name:
         description:
             - Name of the virtual machine to work with.
-            - This is required if C(UUID) is not supplied.
+            - This is required if C(uuid) or C(moid) is not supplied.
    name_match:
         description:
             - If multiple virtual machines matching the name, use the first or last found.
@@ -39,7 +39,13 @@ options:
    uuid:
         description:
             - UUID of the instance to manage if known, this is VMware's unique identifier.
-            - This is required if C(name) is not supplied.
+            - This is required if C(name) or C(moid) is not supplied.
+   moid:
+        description:
+            - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+            - This is required if C(name) or C(uuid) is not supplied.
+        version_added: '2.9'
+        type: str
    folder:
         description:
             - Destination folder, absolute or relative path to find an existing guest.
@@ -55,7 +61,6 @@ options:
             - '   folder: /folder1/datacenter1/vm'
             - '   folder: folder1/datacenter1/vm'
             - '   folder: /folder1/datacenter1/vm/folder2'
-            - '   folder: vm/folder2'
    datacenter:
         description:
             - Destination datacenter where the virtual machine exists.
@@ -66,13 +71,22 @@ author:
 '''
 
 EXAMPLES = '''
-- name: Upgrade VMware Tools
+- name: Upgrade VMware Tools using uuid
   vmware_guest_tools_upgrade:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
     uuid: 421e4592-c069-924d-ce20-7e7533fab926
+  delegate_to: localhost
+
+- name: Upgrade VMware Tools using MoID
+  vmware_guest_tools_upgrade:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    moid: vm-42
   delegate_to: localhost
 '''
 
@@ -145,11 +159,16 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
     )
-    module = AnsibleModule(argument_spec=argument_spec,
-                           required_one_of=[['name', 'uuid']])
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['name', 'uuid', 'moid']
+        ]
+    )
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path
@@ -173,7 +192,8 @@ def main():
         except Exception as exc:
             module.fail_json(msg='Unknown error: %s' % to_native(exc))
     else:
-        module.fail_json(msg='Unable to find VM %s' % (module.params.get('uuid') or module.params.get('name')))
+        vm_id = module.params.get('uuid') or module.params.get('name') or module.params.get('moid')
+        module.fail_json(msg='Unable to find VM %s' % vm_id)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -31,7 +31,7 @@ options:
    name:
      description:
      - Name of the VM for which to wait until the tools become available.
-     - This is required if uuid is not supplied.
+     - This is required if C(uuid) or C(moid) is not supplied.
    name_match:
      description:
      - If multiple VMs match the name, use the first or last found.
@@ -55,7 +55,13 @@ options:
    uuid:
      description:
      - UUID of the VM  for which to wait until the tools become available, if known. This is VMware's unique identifier.
-     - This is required, if C(name) is not supplied.
+     - This is required, if C(name) or C(moid) is not supplied.
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - This is required if C(name) or C(uuid) is not supplied.
+     version_added: '2.9'
+     type: str
    use_instance_uuid:
      description:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
@@ -88,6 +94,16 @@ EXAMPLES = '''
   delegate_to: localhost
   register: facts
 
+
+- name: Wait for VMware tools to become available by MoID
+  vmware_guest_tools_wait:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    moid: vm-42
+  delegate_to: localhost
+  register: facts
 
 - name: Wait for VMware tools to become available by name
   vmware_guest_tools_wait:
@@ -152,11 +168,15 @@ def main():
         name_match=dict(type='str', default='first', choices=['first', 'last']),
         folder=dict(type='str'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_one_of=[['name', 'uuid']])
+        required_one_of=[
+            ['name', 'uuid', 'moid']
+        ]
+    )
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path
@@ -168,9 +188,8 @@ def main():
     vm = pyv.get_vm()
 
     if not vm:
-        module.fail_json(msg="Unable to wait for VMware tools for "
-                             "non-existing VM '%s'." % (module.params.get('name') or
-                                                        module.params.get('uuid')))
+        vm_id = module.params.get('name') or module.params.get('uuid') or module.params.get('moid')
+        module.fail_json(msg="Unable to wait for VMware tools for non-existing VM '%s'." % vm_id)
 
     result = dict(changed=False)
     try:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_vnc.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_vnc.py
@@ -51,8 +51,14 @@ options:
   uuid:
     description:
       - UUID of the instance to manage if known, this is VMware's unique identifier.
-      - This is required, if C(name) is not supplied.
+      - This is required, if C(name) or C(moid) is not supplied.
     required: false
+  moid:
+    description:
+      - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+      - This is required if C(name) or C(uuid) is not supplied.
+    version_added: '2.9'
+    type: str
   folder:
     description:
       - Destination folder, absolute or relative path to find an existing guest.
@@ -103,6 +109,18 @@ EXAMPLES = '''
     validate_certs: no
     datacenter: "{{ datacenter_name }}"
     uuid: 32074771-7d6b-699a-66a8-2d9cf8236fff
+    state: absent
+  delegate_to: localhost
+  register: vnc_result
+
+- name: Disable VNC remote display on the VM using MoID
+  vmware_guest_vnc:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ datacenter_name }}"
+    moid: vm-42
     state: absent
   delegate_to: localhost
   register: vnc_result
@@ -195,6 +213,7 @@ def main():
         name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
+        moid=dict(type='str'),
         folder=dict(type='str'),
         vnc_ip=dict(type='str', default='0.0.0.0'),
         vnc_port=dict(type='int', default=0),
@@ -206,10 +225,10 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_one_of=[
-            ['name', 'uuid']
+            ['name', 'uuid', 'moid']
         ],
         mutually_exclusive=[
-            ['name', 'uuid']
+            ['name', 'uuid', 'moid']
         ]
     )
 
@@ -227,8 +246,8 @@ def main():
             module.params['vnc_password']
         )
     else:
-        module.fail_json(msg="Unable to set VNC config for non-existing virtual machine : '%s'" % (module.params.get('uuid') or
-                                                                                                   module.params.get('name')))
+        vm_id = module.params.get('uuid') or module.params.get('name') or module.params.get('moid')
+        module.fail_json(msg="Unable to set VNC config for non-existing virtual machine : '%s'" % vm_id)
 
     if result.get('failed') is True:
         module.fail_json(**result)

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -48,6 +48,8 @@
 
 - set_fact: vm1_instance_uuid="{{ guest_facts_0001['instance']['instance_uuid'] }}"
 
+- set_fact: vm1_moid="{{ guest_facts_0001['instance']['moid'] }}"
+
 - debug:
     var: vm1_uuid
 
@@ -153,7 +155,7 @@
      - "guest_facts_0004['instance']['snapshots'][0]['name'] == 'snap1'"
      - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
      - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"
-     - "guest_facts_0002['instance']['hw_folder'] is defined"
+     - "guest_facts_0004['instance']['hw_folder'] is defined"
 
 # Testcase 0005: Get details about virtual machines using UUID
 - name: get list of facts about virtual machines using instance UUID
@@ -186,5 +188,39 @@
       - "guest_facts_0005['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] is defined"
       - "guest_facts_0005['instance']['instance_uuid'] == vm1_instance_uuid"
-      - "guest_facts_0001['instance']['moid'] is defined"
-      - "guest_facts_0001['instance']['vimref'] is defined"
+      - "guest_facts_0005['instance']['moid'] is defined"
+      - "guest_facts_0005['instance']['vimref'] is defined"
+
+# Testcase 0006: Get details about virtual machines using MoID
+- name: get list of facts about virtual machines using instance MoID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    moid: "{{ vm1_moid }}"
+    use_instance_uuid: True
+  register: guest_facts_0006
+
+- debug:
+    msg: "{{ guest_facts_0006 }}"
+
+- assert:
+    that:
+      - "guest_facts_0006['instance']['hw_name'] == virtual_machines[0].name"
+      - "guest_facts_0006['instance']['hw_product_uuid'] is defined"
+      - "guest_facts_0006['instance']['hw_product_uuid'] == vm1_uuid"
+      - "guest_facts_0006['instance']['hw_cores_per_socket'] is defined"
+      - "guest_facts_0006['instance']['hw_datastores'] is defined"
+      - "guest_facts_0006['instance']['hw_esxi_host'] is defined"
+      - "guest_facts_0006['instance']['hw_files'] is defined"
+      - "guest_facts_0006['instance']['hw_guest_ha_state'] is defined"
+      - "guest_facts_0006['instance']['hw_is_template'] is defined"
+      - "guest_facts_0006['instance']['hw_folder'] is defined"
+      - "guest_facts_0006['instance']['guest_question'] is defined"
+      - "guest_facts_0006['instance']['guest_consolidation_needed'] is defined"
+      - "guest_facts_0006['instance']['instance_uuid'] is defined"
+      - "guest_facts_0006['instance']['instance_uuid'] == vm1_instance_uuid"
+      - "guest_facts_0006['instance']['moid'] is defined"
+      - "guest_facts_0006['instance']['vimref'] is defined"


### PR DESCRIPTION
##### SUMMARY
* Based upon partial work of wilmardo
* Now, user can specify managed object id of virtual machine to find
an existing virtual machine

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
lib/ansible/modules/cloud/vmware/vmware_guest_boot_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_boot_manager.py
lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
lib/ansible/modules/cloud/vmware/vmware_guest_disk_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_move.py
lib/ansible/modules/cloud/vmware/vmware_guest_network.py
lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
lib/ansible/modules/cloud/vmware/vmware_guest_screenshot.py
lib/ansible/modules/cloud/vmware/vmware_guest_sendkey.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
lib/ansible/modules/cloud/vmware/vmware_guest_video.py
lib/ansible/modules/cloud/vmware/vmware_guest_vnc.py
lib/ansible/modules/cloud/vmware/vmware_vmotion.py
test/integration/targets/vmware_guest_facts/tasks/main.yml
