### PR TITLE
Delay persistent connection until needed

### DIFF
--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -101,12 +101,9 @@ class ConnectionProcess(object):
                                                     ansible_playbook_pid=self._ansible_playbook_pid)
             self.connection.set_options(var_options=variables)
 
-            self.connection._connect()
-
             self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
             messages.extend([('vvvv', msg) for msg in sys.stdout.getvalue().splitlines()])
-            messages.append(('vvvv', 'connection to remote device started successfully'))
 
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.sock.bind(self.socket_path)
@@ -123,7 +120,7 @@ class ConnectionProcess(object):
 
     def run(self):
         try:
-            while self.connection.connected:
+            while True:
                 signal.signal(signal.SIGALRM, self.connect_timeout)
                 signal.signal(signal.SIGTERM, self.handler)
                 signal.alarm(self.connection.get_option('persistent_connect_timeout'))

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -174,7 +174,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import httpapi_loader
-from ansible.plugins.connection import NetworkConnectionBase
+from ansible.plugins.connection import NetworkConnectionBase, ensure_connect
 
 
 class Connection(NetworkConnectionBase):
@@ -250,6 +250,7 @@ class Connection(NetworkConnectionBase):
 
         super(Connection, self).close()
 
+    @ensure_connect
     def send(self, path, data, **kwargs):
         '''
         Sends the command to the device over api

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -600,5 +600,7 @@ class Connection(NetworkConnectionBase):
         purposes only and should be properly cleaned up.
         """
 
+        # Force a fresh connect if for some reason we have connected before.
+        self.close()
         self._connect()
         self.close()

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -590,3 +590,15 @@ class Connection(NetworkConnectionBase):
     def _validate_timeout_value(self, timeout, timer_name):
         if timeout < 0:
             raise AnsibleConnectionFailure("'%s' timer value '%s' is invalid, value should be greater than or equal to zero." % (timer_name, timeout))
+
+    def transport_test(self, connect_timeout):
+        """This method enables wait_for_connection to work.
+
+        As it is used by wait_for_connection, it is called by that module's action plugin,
+        which is on the controller process, which means that nothing done on this instance
+        should impact the actual persistent conneciton... this check is for informational
+        purposes only and should be properly cleaned up.
+        """
+
+        self._connect()
+        self.close()

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -596,7 +596,7 @@ class Connection(NetworkConnectionBase):
 
         As it is used by wait_for_connection, it is called by that module's action plugin,
         which is on the controller process, which means that nothing done on this instance
-        should impact the actual persistent conneciton... this check is for informational
+        should impact the actual persistent connection... this check is for informational
         purposes only and should be properly cleaned up.
         """
 

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -113,7 +113,8 @@ class TestConnectionClass(unittest.TestCase):
         self.assertEqual(out, b'command response')
         mock_send.assert_called_with(command=b'command')
 
-    def test_network_cli_send(self):
+    @patch("ansible.plugins.connection.network_cli.Connection._connect")
+    def test_network_cli_send(self, mocked_connect):
         pc = PlayContext()
         pc.network_os = 'ios'
         conn = connection_loader.get('network_cli', pc, '/dev/null')
@@ -133,7 +134,7 @@ class TestConnectionClass(unittest.TestCase):
         """
 
         mock__shell.recv.side_effect = [response, None]
-        output = conn.send(b'command', None, None, None)
+        output = conn.send(b'command')
 
         mock__shell.sendall.assert_called_with(b'command\r')
         self.assertEqual(to_text(conn._command_response), 'command response')
@@ -142,5 +143,5 @@ class TestConnectionClass(unittest.TestCase):
         mock__shell.recv.side_effect = [b"ERROR: error message device#"]
 
         with self.assertRaises(AnsibleConnectionFailure) as exc:
-            conn.send(b'command', None, None, None)
+            conn.send(b'command')
         self.assertEqual(str(exc.exception), 'ERROR: error message device#')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Presently, `ansible-connection` tries to connect to a device immediately, before running any tasks. This PR aims to change that to instead connect right before the first action requiring said connection.

Also while we're in here, allow `wait_for_connection` to work on persistent connections.

This PR covers network_cli, but needs to cover all persistent connection types before merging.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connecitons/network_cli
ansible-connection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Test playbook for EOS
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- hosts: eos
  connection: network_cli

  tasks:
    - cli_command:
        command: reload power
        prompt: "confirm]"
        answer: y
        newline: no
      become: yes

    - wait_for_connection:
        delay: 20
        sleep: 10

    - cli_command:
        command: show version
```
