### PR TITLE
Remove extra blank line from galaxy .travis.yml.

### DIFF
--- a/lib/ansible/galaxy/data/container/.travis.yml
+++ b/lib/ansible/galaxy/data/container/.travis.yml
@@ -43,4 +43,3 @@ script:
 notifications:
   email: false
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
-


### PR DESCRIPTION
##### SUMMARY

Remove extra blank line from galaxy .travis.yml.

This fixes the last yamllint error on the file.

The file is currently ignored by CI, but that will be changing soon.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/galaxy/data/container/.travis.yml
