### PR TITLE
Improve docs for win_service for custom account rights

### DIFF
--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -111,11 +111,15 @@ options:
       a local or domain account.
     - Set to C(LocalSystem) to use the SYSTEM account.
     - A newly created service will default to C(LocalSystem).
+    - If using a custom user account, it must have the C(SeServiceLogonRight)
+      granted to be able to start up. You can use the M(win_user_right) module
+      to grant this user right for you.
     type: str
     version_added: '2.3'
 seealso:
 - module: service
 - module: win_nssm
+- module: win_user_right
 author:
 - Chris Hoffman (@chrishoffman)
 '''
@@ -167,6 +171,14 @@ EXAMPLES = r'''
   win_service:
     name: service name
   register: service_info
+
+# This is required to be set for non-service accounts that need to run as a service
+- name: Grant domain account the SeServiceLogonRight user right
+  win_user_right:
+    name: SeServiceLogonRight
+    users:
+    - DOMAIN\User
+    action: add
 
 - name: Set the log on user to a domain account
   win_service:


### PR DESCRIPTION
##### SUMMARY
Improve the docs for a Windows service username that is not an existing service account. These accounts must have the [SeServiceLogonRight](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/log-on-as-a-service) user right assigned if they need to run a service.

Fixes https://github.com/ansible/ansible/issues/59100

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_service