### PR TITLE
VMware: Fix ip facts gathered by vmware.py

### DIFF
--- a/contrib/inventory/mdt_dynamic_inventory.py
+++ b/contrib/inventory/mdt_dynamic_inventory.py
@@ -24,6 +24,8 @@ author: J Barnett 06/23/2016 01:15
 maintainer: J Barnett (github @jbarnett1981)
 '''
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 import argparse
 import json
 import pymssql

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -17,6 +17,9 @@ import time
 import traceback
 from random import randint
 from distutils.version import StrictVersion
+from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
+from ansible.module_utils.basic import env_fallback, missing_required_lib
 
 REQUESTS_IMP_ERR = None
 try:
@@ -37,10 +40,6 @@ except ImportError:
     PYVMOMI_IMP_ERR = traceback.format_exc()
     HAS_PYVMOMI = False
     HAS_PYVMOMIJSON = False
-
-from ansible.module_utils._text import to_text, to_native
-from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
-from ansible.module_utils.basic import env_fallback, missing_required_lib
 
 
 class TaskError(Exception):
@@ -363,7 +362,13 @@ def gather_vm_facts(content, vm):
     vmnet = _get_vm_prop(vm, ('guest', 'net'))
     if vmnet:
         for device in vmnet:
-            net_dict[device.macAddress] = list(device.ipAddress)
+            if device.ipAddress == []:
+                continue
+            if net_dict.get(device.macAddress) == None:
+                net_dict[device.macAddress] = list(device.ipAddress)
+            else:
+                net_dict[device.macAddress].extend(device.ipAddress)
+                net_dict[device.macAddress] = list(set(net_dict[device.macAddress]))
 
     if vm.guest.ipAddress:
         if ':' in vm.guest.ipAddress:
@@ -371,7 +376,6 @@ def gather_vm_facts(content, vm):
         else:
             facts['ipv4'] = vm.guest.ipAddress
 
-    ethernet_idx = 0
     for entry in vm.config.hardware.device:
         if not hasattr(entry, 'macAddress'):
             continue
@@ -382,15 +386,14 @@ def gather_vm_facts(content, vm):
         else:
             mac_addr = mac_addr_dash = None
 
-        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and
-                hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
+        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
             port_group_key = entry.backing.port.portgroupKey
             port_key = entry.backing.port.portKey
         else:
             port_group_key = None
             port_key = None
 
-        factname = 'hw_eth' + str(ethernet_idx)
+        factname = entry.deviceInfo.label
         facts[factname] = {
             'addresstype': entry.addressType,
             'label': entry.deviceInfo.label,
@@ -401,8 +404,7 @@ def gather_vm_facts(content, vm):
             'portgroup_portkey': port_key,
             'portgroup_key': port_group_key,
         }
-        facts['hw_interfaces'].append('eth' + str(ethernet_idx))
-        ethernet_idx += 1
+        facts['hw_interfaces'].append(entry.deviceInfo.label)
 
     snapshot_facts = list_snapshots(vm)
     if 'snapshots' in snapshot_facts:
@@ -576,8 +578,7 @@ def run_command_in_guest(content, vm, username, password, program_path, program_
     result = {'failed': False}
 
     tools_status = vm.guest.toolsStatus
-    if (tools_status == 'toolsNotInstalled' or
-            tools_status == 'toolsNotRunning'):
+    if (tools_status == 'toolsNotInstalled' or tools_status == 'toolsNotRunning'):
         result['failed'] = True
         result['msg'] = "VMwareTools is not installed or is not running in the guest"
         return result

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -364,7 +364,7 @@ def gather_vm_facts(content, vm):
         for device in vmnet:
             if device.ipAddress == []:
                 continue
-            if net_dict.get(device.macAddress) == None:
+            if net_dict.get(device.macAddress) is None:
                 net_dict[device.macAddress] = list(device.ipAddress)
             else:
                 net_dict[device.macAddress].extend(device.ipAddress)
@@ -386,7 +386,8 @@ def gather_vm_facts(content, vm):
         else:
             mac_addr = mac_addr_dash = None
 
-        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
+        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and hasattr(entry.backing.port,
+                                                                                     'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
             port_group_key = entry.backing.port.portgroupKey
             port_key = entry.backing.port.portKey
         else:

--- a/mdt.ini
+++ b/mdt.ini
@@ -1,0 +1,17 @@
+[mdt]
+
+# Set the MDT server to connect to
+server = localhost.example.com
+
+# Set the MDT Instance
+instance = EXAMPLEINSTANCE
+
+# Set the MDT database
+database = MDTDB
+
+# Configure login credentials
+user = local.domain\admin
+password = adminpassword
+
+[tower]
+groupname = mdt

--- a/mdt_dynamic_inventory.py
+++ b/mdt_dynamic_inventory.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+'''
+MDT external inventory script
+=================================
+author: Julian Barnett 06/23/2016 01:15
+'''
+
+import argparse
+import ConfigParser
+import json
+import pymssql
+
+class MDTInventory(object):
+
+    def __init__(self):
+        ''' Main execution path '''
+        self.conn = None
+
+        # Initialize empty inventory
+        self.inventory = self._empty_inventory()
+
+        # Read CLI arguments
+        self.read_settings()
+        self.parse_cli_args()
+
+        # Get Hosts
+        if self.args.list:
+            self.get_hosts()
+
+        # NOT COMPLETE // TODO
+        if self.args.host:
+            data2 = { }
+            print json.dumps(data2, indent=2)
+
+    def _connect(self):
+        '''
+        Connect to MDT and dump contents of dbo.ComputerIdentity database
+        '''
+        if not self.conn:
+            self.conn = pymssql.connect(server=self.mdt_server + "\\" + self.mdt_instance, user=self.mdt_user, password=self.mdt_password, database=self.mdt_database)
+            cursor = self.conn.cursor()
+            cursor.execute('SELECT t1.ID, t1.Description, t1.MacAddress, t2.Role FROM ComputerIdentity as t1 join Settings_Roles as t2 on t1.ID = t2.ID')
+            self.mdt_dump = cursor.fetchall()
+            self.conn.close()
+
+    def get_hosts(self):
+        '''
+        Gets host from MDT Database
+        '''
+        self._connect()
+
+        # Configure to group name configured in Ansible Tower for this inventory
+        groupname = self.mdt_groupname
+
+        # Initialize empty host list
+        hostlist = []
+
+        # Parse through db dump and populate inventory
+        for hosts in self.mdt_dump:
+            self.inventory['_meta']['hostvars'][hosts[1]] = {'id': hosts[0], 'name': hosts[1], 'mac': hosts[2], 'role': hosts[3]}
+            hostlist.append(hosts[1])
+        self.inventory[groupname] = hostlist
+
+        # Print it all out
+        print json.dumps(self.inventory, indent=2)
+
+    def _empty_inventory(self):
+        '''
+        Create empty inventory dictionary
+        '''
+        return {"_meta" : {"hostvars" : {}}}
+
+    def read_settings(self):
+        '''
+        Reads the settings from the mdt.ini file
+        '''
+        config = ConfigParser.SafeConfigParser()
+        config.read('mdt.ini')
+
+        # MDT Server and instance and database
+        self.mdt_server = config.get('mdt', 'server')
+        self.mdt_instance = config.get('mdt', 'instance')
+        self.mdt_database = config.get('mdt', 'database')
+
+        # MDT Login credentials
+        if config.has_option('mdt', 'user'):
+            self.mdt_user = config.get('mdt', 'user')
+        if config.has_option('mdt', 'password'):
+            self.mdt_password = config.get('mdt', 'password')
+
+        # Group name in Tower
+        if config.has_option('tower', 'groupname'):
+            self.mdt_groupname = config.get('tower', 'groupname')
+
+
+    def parse_cli_args(self):
+        '''
+        Command line argument processing
+        '''
+        parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on MDT')
+        parser.add_argument('--list', action='store_true', default=True, help='List instances (default: True)')
+        parser.add_argument('--host', action='store', help='Get all the variables about a specific instance')
+        self.args = parser.parse_args()
+
+if __name__ == "__main__":
+    # Run the script
+    MDTInventory()
+

--- a/mdt_dynamic_inventory.py
+++ b/mdt_dynamic_inventory.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python
 
+# (c) 2016, Julian Barnett <jbarnett@tableau.com>
+#
+# This file is part of Ansible.
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 '''
 MDT external inventory script
 =================================

--- a/mdt_dynamic_inventory.py
+++ b/mdt_dynamic_inventory.py
@@ -3,13 +3,17 @@
 '''
 MDT external inventory script
 =================================
-author: Julian Barnett 06/23/2016 01:15
+author: J Barnett 06/23/2016 01:15
+maintainer: J Barnett (github @jbarnett1981)
 '''
 
 import argparse
-import ConfigParser
 import json
 import pymssql
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 class MDTInventory(object):
 
@@ -31,7 +35,7 @@ class MDTInventory(object):
         # NOT COMPLETE // TODO
         if self.args.host:
             data2 = { }
-            print json.dumps(data2, indent=2)
+            print(json.dumps(data2, indent=2))
 
     def _connect(self):
         '''
@@ -63,7 +67,7 @@ class MDTInventory(object):
         self.inventory[groupname] = hostlist
 
         # Print it all out
-        print json.dumps(self.inventory, indent=2)
+        print(json.dumps(self.inventory, indent=2))
 
     def _empty_inventory(self):
         '''
@@ -75,7 +79,7 @@ class MDTInventory(object):
         '''
         Reads the settings from the mdt.ini file
         '''
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.SafeConfigParser()
         config.read('mdt.ini')
 
         # MDT Server and instance and database
@@ -106,4 +110,3 @@ class MDTInventory(object):
 if __name__ == "__main__":
     # Run the script
     MDTInventory()
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the vmware.py module does not gather network interface IP address information correctly if the host VM has a bond/team configuration. A bond interface utilizes the same mac address for its interface as the slave interfaces it contains. In this module when iterating over the interfaces, the dictionary (net_dict) containing the mac address (key) and list of IPs (value) will have an entry for the bond interface (with the correct IP), but then when it hits the same mac address while iterating, it will find the slave interface with that mac (with no IP information) and overwrite the value in the dictionary. This patch is to skip empty IP lists, create the mac address key if necessary, and then extend the the value list, and reset the final list for that key to only unique values. This ensures that the interfaces return valid IP information if found and won't be accidentally overwritten. 

Additionally, when enumerating the interfaces, "hw_eth" + num was used to identify the interfaces. This is misrepresentative, as the interface name on the target vm may not actually be eth[num]. I've replaced this to use the adapter label instead (entry.deviceInfo.label) which I think is much more representative and not as misleading. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
n/a

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware.py patch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
