### PR TITLE
k8s: Fix a bug when manifest file ends with '---'

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -162,13 +162,14 @@ class KubernetesRawModule(KubernetesAnsibleModule):
 
         flattened_definitions = []
         for definition in self.resource_definitions:
-            kind = definition.get('kind', self.kind)
-            api_version = definition.get('apiVersion', self.api_version)
-            if kind.endswith('List'):
-                resource = self.find_resource(kind, api_version, fail=False)
-                flattened_definitions.extend(self.flatten_list_kind(resource, definition))
-            else:
-                resource = self.find_resource(kind, api_version, fail=True)
+            if definition is not None:
+                kind = definition.get('kind', self.kind)
+                api_version = definition.get('apiVersion', self.api_version)
+                if kind.endswith('List'):
+                    resource = self.find_resource(kind, api_version, fail=False)
+                    flattened_definitions.extend(self.flatten_list_kind(resource, definition))
+                else:
+                    resource = self.find_resource(kind, api_version, fail=True)
                 flattened_definitions.append((resource, definition))
 
         for (resource, definition) in flattened_definitions:


### PR DESCRIPTION
##### SUMMARY

Fix an issue in 'k8s' module:

Any kubernetes manifest file ending with '---' will generate an error when applied using 'k8s' module

Although this may not be 'legal' YAML, this is quite frequent, specially on helm's generated manifest files.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

k8s module

##### ADDITIONAL INFORMATION

Given a manifest like the following:
```
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: local-storage-provisioner-node-binding
 ...
roleRef:
  kind: ClusterRole
  name: local-storage-provisioner-node-clusterrole
  apiGroup: rbac.authorization.k8s.io

---
# Source: provisioner/templates/namespace.yaml
```
The last '---' introduce a new YAML fragment, which  is empty in this case. 

If doing:
```
 - name: Apply generated manifest
  k8s:
    state: present
    src: "{{working_folder}}/generated.yml"
```
You got something like (of course line number vary depending of version):
```
File \"/tmp/ansible_k8s_payload_iRKWFs/ansible_k8s_payload.zip/ansible/module_utils/k8s/raw.py\", line 158, in execute_module\nAttributeError: 'NoneType' object has no attribute 'get'\n"  
```
This could be fixed by adding a test
```
       if definition is not None:
```
in execute_module(self)

Regards