### PR TITLE
proxmox: fix proxmox 6 version detection by using LooseVersion

### DIFF
--- a/changelogs/fragments/proxmox-6-version-detection.yaml
+++ b/changelogs/fragments/proxmox-6-version-detection.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "proxmox - fix version detection of proxmox 6 and up (Fixes https://github.com/ansible/ansible/issues/59164)"

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -332,12 +332,14 @@ def content_check(proxmox, node, ostemplate, template_store):
 def node_check(proxmox, node):
     return [True for nd in proxmox.nodes.get() if nd['node'] == node]
 
+
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
     if 'release' in apireturn:
-      return float(apireturn['release']) # >= Proxmox 6
+        return float(apireturn['release'])  # >= Proxmox 6
     else:
-      return float(apireturn['version']) # < Proxmox 6
+        return float(apireturn['version'])  # < Proxmox 6
+
 
 def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, **kwargs):
     proxmox_node = proxmox.nodes(node)

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-from distutils.version import LooseVersion
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -294,6 +293,7 @@ EXAMPLES = '''
 import os
 import time
 import traceback
+from distutils.version import LooseVersion
 
 try:
     from proxmoxer import ProxmoxAPI

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
+from distutils.version import LooseVersion
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -335,10 +335,7 @@ def node_check(proxmox, node):
 
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
-    if 'release' in apireturn:
-        return float(apireturn['release'])  # >= Proxmox 6
-    else:
-        return float(apireturn['version'])  # < Proxmox 6
+    return LooseVersion(apireturn['version'])
 
 
 def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, **kwargs):
@@ -355,7 +352,7 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
             kwargs.update(kwargs['mounts'])
             del kwargs['mounts']
         if 'pubkey' in kwargs:
-            if proxmox_version(proxmox) >= 4.2:
+            if proxmox_version(proxmox) >= LooseVersion('4.2'):
                 kwargs['ssh-public-keys'] = kwargs['pubkey']
             del kwargs['pubkey']
     else:
@@ -489,7 +486,7 @@ def main():
     try:
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
-        VZ_TYPE = 'openvz' if proxmox_version(proxmox) < 4.0 else 'lxc'
+        VZ_TYPE = 'openvz' if proxmox_version(proxmox) < LooseVersion('4.0') else 'lxc'
 
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -786,9 +786,10 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
     if 'release' in apireturn:
-      return float(apireturn['release']) # >= Proxmox 6
+        return float(apireturn['release'])  # >= Proxmox 6
     else:
-      return float(apireturn['version']) # < Proxmox 6
+        return float(apireturn['version'])  # < Proxmox 6
+
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -783,6 +783,13 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
     return False
 
 
+def proxmox_version(proxmox):
+    apireturn = proxmox.version.get()
+    if 'release' in apireturn:
+      return float(apireturn['release']) # >= Proxmox 6
+    else:
+      return float(apireturn['version']) # < Proxmox 6
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -898,7 +905,7 @@ def main():
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
         global PVE_MAJOR_VERSION
-        PVE_MAJOR_VERSION = 3 if float(proxmox.version.get()['version']) < 4.0 else 4
+        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < 4.0 else 4
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -6,7 +6,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-from distutils.version import LooseVersion
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -580,6 +579,7 @@ import os
 import re
 import time
 import traceback
+from distutils.version import LooseVersion
 
 try:
     from proxmoxer import ProxmoxAPI

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -785,7 +785,7 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
 
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
-    return LooseVersion(apireturn['version'])  # < Proxmox 6
+    return LooseVersion(apireturn['version'])
 
 
 def main():

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -6,7 +6,7 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
+from distutils.version import LooseVersion
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -785,10 +785,7 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
 
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
-    if 'release' in apireturn:
-        return float(apireturn['release'])  # >= Proxmox 6
-    else:
-        return float(apireturn['version'])  # < Proxmox 6
+    return LooseVersion(apireturn['version'])  # < Proxmox 6
 
 
 def main():
@@ -906,7 +903,7 @@ def main():
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
         global PVE_MAJOR_VERSION
-        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < 4.0 else 4
+        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 


### PR DESCRIPTION
##### SUMMARY
This should fix #59164

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
proxmox (https://github.com/mrdrogdrog/ansible/blob/6430205d396b7c1733de22a898c51823f67d5bf4/lib/ansible/modules/cloud/misc/proxmox.py#L484)


##### ADDITIONAL INFORMATION
Please add this fix as soon as possible. Otherweise you can't use the proxmox nor proxmox_kvm module.