### PR TITLE
Docs scripts cleanup

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -84,10 +84,10 @@ cli:
 	PYTHONPATH=../../lib $(GENERATE_CLI) --template-file=../templates/cli_rst.j2 --output-dir=rst/cli/ --output-format rst ../../lib/ansible/cli/*.py
 
 keywords: ../templates/playbooks_keywords.rst.j2
-	PYTHONPATH=../../lib $(KEYWORD_DUMPER) --template-dir=../templates --output-dir=rst/reference_appendices/ -d ./keyword_desc.yml
+	PYTHONPATH=../../lib $(KEYWORD_DUMPER) --template-dir=../templates --output-dir=rst/reference_appendices/ ./keyword_desc.yml
 
 config: ../templates/config.rst.j2
-	PYTHONPATH=../../lib $(CONFIG_DUMPER) --template-file=../templates/config.rst.j2 --output-dir=rst/reference_appendices/ -d ../../lib/ansible/config/base.yml
+	PYTHONPATH=../../lib $(CONFIG_DUMPER) --template-file=../templates/config.rst.j2 --output-dir=rst/reference_appendices/ ../../lib/ansible/config/base.yml
 
 modules: ../templates/plugin.rst.j2
 	PYTHONPATH=../../lib $(PLUGIN_FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/modules/ $(MODULE_ARGS)

--- a/hacking/build_library/build_ansible/command_plugins/dump_config.py
+++ b/hacking/build_library/build_ansible/command_plugins/dump_config.py
@@ -60,13 +60,13 @@ class DocumentConfig(Command):
         template_file = os.path.basename(template_file_full_path)
         template_dir = os.path.dirname(template_file_full_path)
 
-        if args.docs:
-            with open(args.docs) as f:
-                docs = yaml.safe_load(f)
-        else:
-            docs = {}
+        if not args.docs:
+            print('Definitions for keywords must be specified via `--docs-source FILENAME`')
+            return 1
 
-        config_options = docs
+        with open(args.docs) as f:
+            config_options = yaml.safe_load(f)
+
         config_options = fix_description(config_options)
 
         env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True,)

--- a/hacking/build_library/build_ansible/command_plugins/dump_config.py
+++ b/hacking/build_library/build_ansible/command_plugins/dump_config.py
@@ -50,8 +50,8 @@ class DocumentConfig(Command):
                             help="directory containing Jinja2 templates")
         parser.add_argument("-o", "--output-dir", action="store", dest="output_dir", default='/tmp/',
                             help="Output directory for rst files")
-        parser.add_argument("-d", "--docs-source", action="store", dest="docs", default=None,
-                            help="Source for attribute docs")
+        parser.add_argument("config_defs", metavar="CONFIG-OPTION-DEFINITIONS.yml", type=str,
+                            help="Source for config option docs")
 
     @staticmethod
     def main(args):
@@ -60,11 +60,7 @@ class DocumentConfig(Command):
         template_file = os.path.basename(template_file_full_path)
         template_dir = os.path.dirname(template_file_full_path)
 
-        if not args.docs:
-            print('Definitions for keywords must be specified via `--docs-source FILENAME`')
-            return 1
-
-        with open(args.docs) as f:
+        with open(args.config_defs) as f:
             config_options = yaml.safe_load(f)
 
         config_options = fix_description(config_options)

--- a/hacking/build_library/build_ansible/command_plugins/dump_keywords.py
+++ b/hacking/build_library/build_ansible/command_plugins/dump_keywords.py
@@ -106,16 +106,12 @@ class DocumentKeywords(Command):
                             help="directory containing Jinja2 templates")
         parser.add_argument("-o", "--output-dir", action="store", dest="output_dir",
                             default='/tmp/', help="Output directory for rst files")
-        parser.add_argument("-d", "--docs-source", action="store", dest="docs", default=None,
-                            help="Source for attribute docs")
+        parser.add_argument("keyword_defs", metavar="KEYWORD-DEFINITIONS.yml", type=str,
+                            help="Source for playbook keyword docs")
 
     @staticmethod
     def main(args):
-        if not args.docs:
-            print('Definitions for keywords must be specified via `--docs-source FILENAME`')
-            return 1
-
-        keyword_definitions = load_definitions(args.docs)
+        keyword_definitions = load_definitions(args.keyword_defs)
         pb_keywords = extract_keywords(keyword_definitions)
 
         keyword_page = generate_page(pb_keywords, args.template_dir)


### PR DESCRIPTION
##### SUMMARY
As discussed in this thread: https://github.com/ansible/ansible/pull/55986#discussion_r302919125 the build subcommands for documentation should make the definition files mandatory.  Since they're mandatory, the files should be positional arguments instead of option arguments.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
@webknjaz @acozine