### PR TITLE
fix network_cli connection plugin: ConnectionError: unsupported operand type(s) for ^: 'str' and 'str'

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -207,6 +207,7 @@ from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.network.common.utils import to_list
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import NetworkConnectionBase
@@ -299,7 +300,7 @@ class Connection(NetworkConnectionBase):
         play_context.deserialize(pc_data)
 
         self.queue_message('vvvv', 'updating play_context for connection')
-        if self._play_context.become ^ play_context.become:
+        if boolean(self._play_context.become) ^ boolean(play_context.become):
             if play_context.become is True:
                 auth_pass = play_context.become_pass
                 self._terminal.on_become(passwd=auth_pass)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/4325#event-2482904750
Fixes https://github.com/ansible/ansible/issues/48093

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
network_cli.py

##### ADDITIONAL INFORMATION
network_cli.py breaks when used in AWX 6.0.0. AWX seems to define credentials in special the become with some string, e.g. "true". This leads to a failure:

```
The full traceback is:
Traceback (most recent call last):
  File "/usr/bin/ansible-connection", line 302, in main
    conn.update_play_context(pc_data)
  File "/usr/lib/python2.7/site-packages/ansible/module_utils/connection.py", line 186, in __rpc__
    raise ConnectionError(to_text(msg, errors='surrogate_then_replace'), code=code)
ConnectionError: unsupported operand type(s) for ^: 'str' and 'str'
```

With this bugfix the become gets converted to boolean and checked correctly.
