### PR TITLE
Add team_foreman to contrib/inventory/foreman.py

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -426,7 +426,7 @@ files:
     ignored: skvidal
   $modules/packaging/os/zypper.py:
     ignored: dirtyharrycallahan robinro
-  $modules/remote_management/foreman/: $team_foreman 
+  $modules/remote_management/foreman/: $team_foreman
   $modules/remote_management/hpilo/:
     ignored: dagwieers
     maintainers: haad
@@ -544,6 +544,8 @@ files:
     support: community
   contrib/inventory/digital_ocean.py: *digital_ocean
   contrib/inventory/docker: *docker
+  contrib/inventory/foreman.py:
+    maintainers: $team_foreman
   contrib/inventory/linode:
     keywords:
       - linode dynamic inventory script


### PR DESCRIPTION
##### SUMMARY
This will allow team_foreman to merge fixes, but mostly I'd prefer to close as wontfix to point users to the inventory plugin that also exists.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
foreman

##### ADDITIONAL INFORMATION
Not sure if this is the correct issue type.