### PR TITLE
ec2_eip - added support for BYOIP and filtering reuse addresses by tag/value

### DIFF
--- a/changelogs/fragments/59180-aws_support_byoip.yaml
+++ b/changelogs/fragments/59180-aws_support_byoip.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Added support for BYOIP to ec2_eip module and filtering reusable addresses based on tags (https://github.com/ansible/ansible/pull/59180).
+  - ec2_eip - Added support for BYOIP to ec2_eip module and filtering reusable addresses based on tags (https://github.com/ansible/ansible/pull/59180).

--- a/changelogs/fragments/59180-aws_support_byoip.yaml
+++ b/changelogs/fragments/59180-aws_support_byoip.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added support for BYOIP to ec2_eip module and filtering reusable addresses based on tags (https://github.com/ansible/ansible/pull/59180).

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -71,22 +71,22 @@ options:
     version_added: "2.5"
   tag_name:
     description:
-      -  When reuse_existing_ip_allowed is true, suppplement with this option to only reuse
-      an Elastic IP if it is tagged with tag_name.
+      - When reuse_existing_ip_allowed is true, suppplement with this option to only reuse
+        an Elastic IP if it is tagged with tag_name.
     default: 'no'
-    version_added "2.9"
+    version_added: "2.9"
   tag_value:
     description:
-      -  Supplements tag_name but also checks that the value of the tag provided in tag_name matches tag_value.
-      matches the tag_value
+      - Supplements tag_name but also checks that the value of the tag provided in tag_name matches tag_value.
+        matches the tag_value
     default: 'no'
-    version_added "2.9"
+    version_added: "2.9"
   public_ipv4_pool:
     description:
       - Allocates the new Elastic IP from the provided public IPv4 pool (BYOIP)
-      only applies to newly allocated Elastic IPs, isn't validated when reuse_existing_ip_allowed is true.
+        only applies to newly allocated Elastic IPs, isn't validated when reuse_existing_ip_allowed is true.
     default: 'no'
-    version_added "2.9"
+    version_added: "2.9"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -482,8 +482,8 @@ def main():
         allow_reassociation=dict(type='bool', default=False),
         wait_timeout=dict(default=300, type='int'),
         private_ip_address=dict(required=False, default=None, type='str'),
-        tag_name=dict(required=False, default=None, type='str', aliases=['tag-key', 'if_tagged_with']),
-        tag_value=dict(required=False, default=None, type='str', aliases=['ta']),
+        tag_name=dict(required=False, default=None, type='str'),
+        tag_value=dict(required=False, default=None, type='str'),
         public_ipv4_pool=dict(required=False, default=None, type='str')
     ))
 

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -169,6 +169,44 @@ EXAMPLES = '''
 - name: output the IP
   debug:
     msg: "Allocated IP inside a VPC is {{ eip.public_ip }}"
+
+- name: allocate eip - reuse unallocated ips (if found) with FREE tag
+  ec2_eip:
+    region: us-east-1
+    in_vpc: yes
+    reuse_existing_ip_allowed: yes
+    tag_name: FREE
+
+- name: allocate eip - reuse unallocted ips if tag reserved is nope
+  ec2_eip:
+    region: us-east-1
+    in_vpc: yes
+    reuse_existing_ip_allowed: yes
+    tag_name: reserved
+    tag_value: nope
+
+- name: allocate new eip - from servers given ipv4 pool
+  ec2_eip:
+    region: us-east-1
+    in_vpc: yes
+    public_ipv4_pool: ipv4pool-ec2-0588c9b75a25d1a02
+
+- name: allocate eip - from a given pool (if no free addresses where dev-servers tag is dynamic)
+  ec2_eip:
+    region: us-east-1
+    in_vpc: yes
+    reuse_existing_ip_allowed: yes
+    tag_name: dev-servers
+    public_ipv4_pool: ipv4pool-ec2-0588c9b75a25d1a02
+
+- name: allocate eip from pool - check if tag reserved_for exists and value is our hostname
+  ec2_eip:
+    region: us-east-1
+    in_vpc: yes
+    reuse_existing_ip_allowed: yes
+    tag_name: reserved_for
+    tag_value: "{{ inventory_hostname }}"
+    public_ipv4_pool: ipv4pool-ec2-0588c9b75a25d1a02
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -481,10 +481,10 @@ def main():
         release_on_disassociation=dict(required=False, type='bool', default=False),
         allow_reassociation=dict(type='bool', default=False),
         wait_timeout=dict(default=300, type='int'),
-        private_ip_address=dict(required=False, default=None, type='str'),
-        tag_name=dict(required=False, default=None, type='str'),
-        tag_value=dict(required=False, default=None, type='str'),
-        public_ipv4_pool=dict(required=False, default=None, type='str')
+        private_ip_address=dict(),
+        tag_name=dict(),
+        tag_value=dict(),
+        public_ipv4_pool=dict()
     ))
 
     module = AnsibleModule(

--- a/test/integration/targets/ec2_eip/aliases
+++ b/test/integration/targets/ec2_eip/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/ec2_eip/defaults/main.yml
+++ b/test/integration/targets/ec2_eip/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+aws_region: us-east-1

--- a/test/integration/targets/ec2_eip/meta/main.yml
+++ b/test/integration/targets/ec2_eip/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_eip/tasks/main.yml
+++ b/test/integration/targets/ec2_eip/tasks/main.yml
@@ -1,0 +1,146 @@
+---
+    - name: Integration testing for ec2_eip
+      block:
+
+        - name: set up aws connection info
+          set_fact:
+            aws_connection_info: &aws_connection_info
+              aws_access_key: "{{ aws_access_key }}"
+              aws_secret_key: "{{ aws_secret_key }}"
+              security_token: "{{ security_token }}"
+              region: "{{ aws_region }}"
+          no_log: True
+
+        - name: Allocate a new eip - attempt reusing unallocated ones
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            reuse_existing_ip_allowed: yes
+            <<: *aws_connection_info
+          register: eip
+
+        - assert:
+            that:
+              - eip is defined
+              - eip.public_ip is defined and eip.public_ip != ""
+              - eip.allocation_id is defined and eip.allocation_id != ""
+
+        - name: Allocate a new eip
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+          register: new_eip
+
+        - assert:
+            that:
+              - new_eip is defined
+              - new_eip is changed
+              - new_eip.public_ip is defined and new_eip.public_ip != ""
+              - new_eip.allocation_id is defined and new_eip.allocation_id != ""
+
+        - name: Match an existing eip (changed == false)
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+            public_ip: "{{ eip.public_ip }}"
+          register: existing_eip
+
+        - assert:
+            that:
+              - existing_eip is defined
+              - existing_eip is not changed
+              - existing_eip.public_ip is defined and existing_eip.public_ip != ""
+              - existing_eip.allocation_id is defined and existing_eip.allocation_id != ""
+
+        - name: attempt reusing an existing eip with a tag (or allocate a new one)
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+            reuse_existing_ip_allowed: yes
+            tag_name: Team
+          register: tagged_eip
+
+        - assert:
+            that:
+              - tagged_eip is defined
+              - tagged_eip.public_ip is defined and tagged_eip.public_ip != ""
+              - tagged_eip.allocation_id is defined and tagged_eip.allocation_id != ""
+
+        - name: attempt reusing an existing eip with a tag and it's value (or allocate a new one)
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+            public_ip: "{{ eip.public_ip }}"
+            reuse_existing_ip_allowed: yes
+            tag_name: Team
+            tag_value: Backend
+          register: backend_eip
+
+        - assert:
+            that:
+              - backend_eip is defined
+              - backend_eip.public_ip is defined and backend_eip.public_ip != ""
+              - backend_eip.allocation_id is defined and backend_eip.allocation_id != ""
+
+        - name: attempt reusing an existing eip with a tag and it's value (or allocate a new one from pool)
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+            reuse_existing_ip_allowed: yes
+            tag_name: Team
+            tag_value: Backend
+            public_ipv4_pool: amazon
+          register: amazon_eip
+
+        - assert:
+            that:
+              - amazon_eip is defined
+              - amazon_eip.public_ip is defined and amazon_eip.public_ip != ""
+              - amazon_eip.allocation_id is defined and amazon_eip.allocation_id != ""
+
+        - name: allocate a new eip from a pool
+          ec2_eip:
+            state: present
+            in_vpc: yes
+            <<: *aws_connection_info
+            public_ipv4_pool: amazon
+          register: pool_eip
+
+        - assert:
+            that:
+              - pool_eip is defined
+              - pool_eip is changed
+              - pool_eip.public_ip is defined and pool_eip.public_ip != ""
+              - pool_eip.allocation_id is defined and pool_eip.allocation_id != ""
+
+      always:
+
+        - debug: msg="{{ item }}"
+          when: item is defined and item.public_ip is defined and item.allocation_id is defined
+          loop:
+            - eip
+            - new_eip
+            - pool_eip
+            - tagged_eip
+            - backend_eip
+            - amazon_eip
+        - name: Cleanup newly allocated eip
+          ec2_eip:
+            state: absent
+            public_ip: "{{ item.public_ip }}"
+            in_vpc: yes
+            <<: *aws_connection_info
+          when: item is defined and item is changed and item.public_ip is defined and item.public_ip != ""
+          loop:
+            - "{{ eip }}"
+            - "{{ new_eip }}"
+            - "{{ pool_eip }}"
+            - "{{ tagged_eip }}"
+            - "{{ backend_eip }}"
+            - "{{ amazon_eip }}"
+...

--- a/test/integration/targets/ec2_eip/tasks/main.yml
+++ b/test/integration/targets/ec2_eip/tasks/main.yml
@@ -119,7 +119,6 @@
               - pool_eip.allocation_id is defined and pool_eip.allocation_id != ""
 
       always:
-
         - debug: msg="{{ item }}"
           when: item is defined and item.public_ip is defined and item.allocation_id is defined
           loop:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This feature adds support for allocating elastic IPs from a specific IPv4 pool (aka BYOIP).
When allocating a new EIP, provide the pool name to allocate an address from that pool. 
In addition, a mechanism for filtering reusable addresses based on a tag name / value was added.
##
#### Logic
Allocation of EIP when provided a pool:
- provide the public_ipv4_pool and the address will be alllocated from that pool
 
Filtering reusable addresses based on tags: 
  - if reuse_existing_ip_allowed is set, following logic applies
  - if tag_name is provided: only reuse addresses with that tag (regardless of it's value)
  - if tag_name is  supplemented with tag_value: ensure the tag_name (key) has a value of (tag_value)
  - if no reusable addresses -  allocate a new elastic IP from the default pool
  - if no reusable addresses and public_ipv4_pool was provided - allocate elastic IP from pool

NOTE: filtering will not take place if reuse_existing_ip_allowed is not set
##
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ec2_eip
##
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Boto's allocate_address function does not currently support the PublicIpv4Pool attribute. 
- In order to make Amazon recognize the above attribute, a workaround was made
- The function allocate_address_from_pool() modifies the API Version before sending the request.
- It is used only for that specific use case (when attempting to allocate an EIP from a given pool).

#### Additional changes:
- Changed variable name isinstance toto is_instance (prevent overriding python's builtin function).
- Removed unused variable domain from the function ensure_absent