### PR TITLE
Fixed "dictionary changed size during iteration" for zabbix_template …

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -353,7 +353,7 @@ class Template(object):
 
         # Filter empty attributes from template object to allow accurate comparison
         for template in template_json['zabbix_export']['templates']:
-            for key in template.keys():
+            for key in list(template.keys()):
                 if not template[key] or (key == 'description' and desc_not_supported):
                     template.pop(key)
 


### PR DESCRIPTION
…when used with newest Python3

##### SUMMARY
Fixes #57942 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ADDITIONAL INFORMATION
Affects all Zabbix server versions. Playbook template.yml:

```yaml
- hosts: all
  vars:
    mytemplates:
      - mytemp_name: FirstTemplateTest
        mytemp_desc: This is first template
      - mytemp_name: SecondTemplateTest
        mytemp_desc: This is second template

  tasks:
    - name: Create template in Zabbix
      zabbix_template:
        server_url: "{{ zbx_server_url }}"
        login_user: "{{ zbx_user }}"
        login_password: "{{ zbx_password }}"
        validate_certs: "{{ zbx_validate_certs }}"
        template_name: "{{ item.mytemp_name }}"
        template_groups:
          - Templates
        template_json: "{{ lookup('template', 'template.j2') }}"
      loop: "{{ mytemplates }}"
      delegate_to: localhost
```
Jinja2 template.j2:
```json
{
  "zabbix_export" : {
     "templates" : [
        {
           "groups" : [
              {
                 "name" : "Templates"
              }
           ],
           "applications" : [],
           "description" : "{{ item.mytemp_desc }}",
           "name" : "{{ item.mytemp_name }}",
           "items" : [],
           "macros" : [],
           "template" : "{{ item.mytemp_name }}",
           "discovery_rules" : [],
           "screens" : []
        }
     ],
     "version" : "3.0",
     "groups" : [
        {
           "name" : "Templates"
        }
     ]
  }
}
```
