### PR TITLE
VMware: refactoring and ip facts bug fix in vmware_guest

### DIFF
--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_clone_template.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_clone_template.rst
@@ -132,7 +132,7 @@ What to expect
                 "ds_215"
             ],
             "hw_esxi_host": "192.0.2.44",
-            "Network adapter 1": {
+            "network_adapter_1": {
                 "addresstype": "assigned",
                 "ipaddresses": null,
                 "label": "Network adapter 1",

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_clone_template.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_clone_template.rst
@@ -132,7 +132,7 @@ What to expect
                 "ds_215"
             ],
             "hw_esxi_host": "192.0.2.44",
-            "hw_eth0": {
+            "Network adapter 1": {
                 "addresstype": "assigned",
                 "ipaddresses": null,
                 "label": "Network adapter 1",

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_rename_vm.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_rename_vm.rst
@@ -128,7 +128,7 @@ Running this playbook can take some time, depending on your environment and netw
             "hw_cores_per_socket": 1,
             "hw_datastores": ["ds_204_2"],
             "hw_esxi_host": "10.x.x.x",
-            "Network adapter 1": {
+            "network_adapter_1": {
                 "addresstype": "assigned",
                 "ipaddresses": [],
                 "label": "Network adapter 1",

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_rename_vm.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/scenario_rename_vm.rst
@@ -128,7 +128,7 @@ Running this playbook can take some time, depending on your environment and netw
             "hw_cores_per_socket": 1,
             "hw_datastores": ["ds_204_2"],
             "hw_esxi_host": "10.x.x.x",
-            "hw_eth0": {
+            "Network adapter 1": {
                 "addresstype": "assigned",
                 "ipaddresses": [],
                 "label": "Network adapter 1",

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -396,7 +396,7 @@ def gather_vm_facts(content, vm):
             port_group_key = None
             port_key = None
 
-        factname = entry.deviceInfo.label
+        factname = entry.deviceInfo.label.replace(" ", "_").lower()
         facts[factname] = {
             'addresstype': entry.addressType,
             'label': entry.deviceInfo.label,

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -388,7 +388,8 @@ def gather_vm_facts(content, vm):
         else:
             mac_addr = mac_addr_dash = None
 
-        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port, 'portgroupKey')):
+        if (hasattr(entry, 'backing') and hasattr(entry.backing, 'port') and hasattr(entry.backing.port, 'portKey') and hasattr(entry.backing.port,
+                                                                                                                                'portgroupKey')):
             port_group_key = entry.backing.port.portgroupKey
             port_key = entry.backing.port.portKey
         else:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -211,7 +211,7 @@ instance:
         "hw_guest_ha_state": null,
         "hw_guest_id": null,
         "hw_interfaces": [
-            "eth0"
+            "Network adapter 1"
         ],
         "hw_is_template": false,
         "hw_memtotal_mb": 1024,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -189,7 +189,7 @@ instance:
             "ds_226_3"
         ],
         "hw_esxi_host": "10.76.33.226",
-        "hw_eth0": {
+        "Network adapter 1": {
             "addresstype": "assigned",
             "ipaddresses": null,
             "label": "Network adapter 1",

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -189,10 +189,10 @@ instance:
             "ds_226_3"
         ],
         "hw_esxi_host": "10.76.33.226",
-        "Network adapter 1": {
+        "Network Adapter 1": {
             "addresstype": "assigned",
             "ipaddresses": null,
-            "label": "Network adapter 1",
+            "label": "Network Adapter 1",
             "macaddress": "00:50:56:87:a5:9a",
             "macaddress_dash": "00-50-56-87-a5-9a",
             "portgroup_key": null,
@@ -211,7 +211,7 @@ instance:
         "hw_guest_ha_state": null,
         "hw_guest_id": null,
         "hw_interfaces": [
-            "Network adapter 1"
+            "Network Adapter 1"
         ],
         "hw_is_template": false,
         "hw_memtotal_mb": 1024,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -189,7 +189,7 @@ instance:
             "ds_226_3"
         ],
         "hw_esxi_host": "10.76.33.226",
-        "Network Adapter 1": {
+        "network_adapter_1": {
             "addresstype": "assigned",
             "ipaddresses": null,
             "label": "Network Adapter 1",
@@ -211,7 +211,7 @@ instance:
         "hw_guest_ha_state": null,
         "hw_guest_id": null,
         "hw_interfaces": [
-            "Network Adapter 1"
+            "network_adapter_1"
         ],
         "hw_is_template": false,
         "hw_memtotal_mb": 1024,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -148,7 +148,7 @@ instance:
             "LocalDS_0"
         ],
         "hw_esxi_host": "DC0_H0",
-        "Network adapter 1": {
+        "network_adapter_1": {
             "addresstype": "generated",
             "ipaddresses": null,
             "label": "ethernet-0",
@@ -164,7 +164,7 @@ instance:
         "hw_guest_ha_state": null,
         "hw_guest_id": "otherGuest",
         "hw_interfaces": [
-            "Network adapter 1"
+            "network_adapter_1"
         ],
         "hw_is_template": false,
         "hw_memtotal_mb": 32,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -148,7 +148,7 @@ instance:
             "LocalDS_0"
         ],
         "hw_esxi_host": "DC0_H0",
-        "hw_eth0": {
+        "Network adapter 1": {
             "addresstype": "generated",
             "ipaddresses": null,
             "label": "ethernet-0",

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_move.py
@@ -164,7 +164,7 @@ instance:
         "hw_guest_ha_state": null,
         "hw_guest_id": "otherGuest",
         "hw_interfaces": [
-            "eth0"
+            "Network adapter 1"
         ],
         "hw_is_template": false,
         "hw_memtotal_mb": 32,

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -34,4 +34,4 @@
   assert:
     that:
         - "clone_d1_c1_f0['instance']['Network adapter 1']['addresstype'] == 'manual'"
-        - "clone_d1_c1_f0['instance']['Network adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"
+        - "clone_d1_c1_f0['instance']['Network Adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -33,5 +33,5 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0['instance']['Network adapter 1]['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0['instance']['Network adapter 1']['addresstype'] == 'manual'"
         - "clone_d1_c1_f0['instance']['Network adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -33,5 +33,5 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0['instance']['Network Adapter 1']['addresstype'] == 'manual'"
-        - "clone_d1_c1_f0['instance']['Network Adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"
+        - "clone_d1_c1_f0['instance']['network_adapter_1']['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0['instance']['network_adapter_1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -33,5 +33,5 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0['instance']['hw_eth0']['addresstype'] == 'manual'"
-        - "clone_d1_c1_f0['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:42'"
+        - "clone_d1_c1_f0['instance']['Network adapter 1]['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0['instance']['Network adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -33,5 +33,5 @@
 - name: assert that changes were made
   assert:
     that:
-        - "clone_d1_c1_f0['instance']['Network adapter 1']['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0['instance']['Network Adapter 1']['addresstype'] == 'manual'"
         - "clone_d1_c1_f0['instance']['Network Adapter 1']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -40,8 +40,8 @@
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0001['instance']['moid'] is defined"
       - "guest_facts_0001['instance']['vimref'] is defined"
-      - "'portgroup_portkey' in guest_facts_0001['instance']['hw_eth0']"
-      - "'portgroup_key' in guest_facts_0001['instance']['hw_eth0']"
+      - "'portgroup_portkey' in guest_facts_0001['instance']['Network adapter 1']"
+      - "'portgroup_key' in guest_facts_0001['instance']['Network adapter 1']"
       - "guest_facts_0001['instance']['instance_uuid'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -40,8 +40,8 @@
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0001['instance']['moid'] is defined"
       - "guest_facts_0001['instance']['vimref'] is defined"
-      - "'portgroup_portkey' in guest_facts_0001['instance']['Network Adapter 1']"
-      - "'portgroup_key' in guest_facts_0001['instance']['Network Adapter 1']"
+      - "'portgroup_portkey' in guest_facts_0001['instance']['network_adapter_1']"
+      - "'portgroup_key' in guest_facts_0001['instance']['network_adapter_1']"
       - "guest_facts_0001['instance']['instance_uuid'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -41,7 +41,7 @@
       - "guest_facts_0001['instance']['moid'] is defined"
       - "guest_facts_0001['instance']['vimref'] is defined"
       - "'portgroup_portkey' in guest_facts_0001['instance']['Network adapter 1']"
-      - "'portgroup_key' in guest_facts_0001['instance']['Network adapter 1']"
+      - "'portgroup_key' in guest_facts_0001['instance']['Network Adapter 1']"
       - "guest_facts_0001['instance']['instance_uuid'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -40,7 +40,7 @@
       - "guest_facts_0001['instance']['guest_consolidation_needed'] is defined"
       - "guest_facts_0001['instance']['moid'] is defined"
       - "guest_facts_0001['instance']['vimref'] is defined"
-      - "'portgroup_portkey' in guest_facts_0001['instance']['Network adapter 1']"
+      - "'portgroup_portkey' in guest_facts_0001['instance']['Network Adapter 1']"
       - "'portgroup_key' in guest_facts_0001['instance']['Network Adapter 1']"
       - "guest_facts_0001['instance']['instance_uuid'] is defined"
 


### PR DESCRIPTION
##### SUMMARY
Currently, the vmware.py module does not gather network interface IP address information correctly if the host VM has a bond/team configuration. A bond interface utilizes the same mac address for its interface as the slave interfaces it contains. In this module when iterating over the interfaces, the dictionary (net_dict) containing the mac address (key) and list of IPs (value) will have an entry for the bond interface (with the correct IP), but then when it hits the same mac address while iterating, it will find the slave interface with that mac (with no IP information) and overwrite the value in the dictionary. This patch is to skip empty IP lists, create the mac address key if necessary, and then extend the the value list, and reset the final list for that key to only unique values. This ensures that the interfaces return valid IP information if found and won't be accidentally overwritten.

Additionally, when enumerating the interfaces, "hw_eth" + num was used to identify the interfaces. This is misrepresentative, as the interface name on the target vm may not actually be eth[num]. I've replaced this to use the adapter label instead (entry.deviceInfo.label) which I think is much more representative and not as misleading.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
n/a

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware.py patch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
