### PR TITLE
force_basic_auth for default httpapi connection auth

### DIFF
--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -265,6 +265,7 @@ class Connection(NetworkConnectionBase):
             headers.update(self._auth)
             url_kwargs['headers'] = headers
         else:
+            url_kwargs['force_basic_auth'] = True
             url_kwargs['url_username'] = self.get_option('remote_user')
             url_kwargs['url_password'] = self.get_option('password')
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The default for a httpapi connection is to do basic auth, however
when setting the url_username and url_password without
force_basic_auth, the call to ansible.module_utils.open_url would
not always properly handle the basic auth headers based on the
combinations of **kwargs passed. This ensures that is always the
case when no session token exists and as the goal is to use basic
auth in the event of not having a session token, this should be
a safe operation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/connection/httpapi.py

