### PR TITLE
doc: add documentation for "vars" magic variable

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -121,6 +121,9 @@ role_names
 role_path
     The path to the dir of the currently running role
 
+vars
+    Shorthand for `hostvars[inventory_hostname]`
+
 Facts
 -----
 These are variables that contain information pertinent to the current host (`inventory_hostname`). They are only available if gathered first.


### PR DESCRIPTION
##### SUMMARY

Document the `vars` magic variable.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

special_variables

##### ADDITIONAL INFORMATION

This variable is define:

https://github.com/ansible/ansible/blob/c2253c8133e6b0e97c456ef38ad27b13d65fac4d/lib/ansible/vars/manager.py#L421-L424