### PR TITLE
postgresql_pg_hba: Exception when two lines with same weight are compared

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -573,11 +573,11 @@ class PgHbaRule(dict):
             return myweight < hisweight
         try:
             return self['src'] < other['src']
-        except (TypeError, KeyError):
+        except TypeError:
             return self.source_type_weight() < other.source_type_weight()
-        errormessage = 'We have two rules ({1}, {2})'.format(self, other)
-        errormessage += ' with exact same weight. Please file a bug.'
-        raise PgHbaValueError(errormessage)
+        except Exception:
+            # When all else fails, just compare the exact line.
+            return self.line() < other.line()
 
     def source_weight(self):
         """Report the weight of this source net.

--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -12,7 +12,7 @@ db_session_role2: 'session_role2'
 
 pg_hba_test_ips:
 - contype: local
-  users: 'all,postgres'
+  users: 'all,postgres,test'
 - source: '0000:ffff::'
   netmask: 'ffff:fff0::'
 - source: '192.168.0.0/24'

--- a/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
@@ -143,8 +143,9 @@
 - assert:
     that:
     - 'pg_hba.pg_hba == [
-           { "db": "all", "method": "md5", "type": "local", "usr": "postgres" },
            { "db": "all", "method": "ldap", "type": "local", "usr": "+some", "options": "ldapserver=example.com ldapport=389 ldapprefix=\"cn=\"" },
+           { "db": "all", "method": "md5", "type": "local", "usr": "postgres" },
+           { "db": "all", "method": "md5", "type": "local", "usr": "test" },
            { "db": "all", "method": "md5", "type": "local", "usr": "all" },
            { "db": "all", "method": "cert", "src": "blue", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },
            { "db": "all", "method": "cert", "src": "red", "type": "hostssl", "usr": "+some", "options": "clientcert=1 map=mymap" },


### PR DESCRIPTION
##### SUMMARY
akasurde@redhat.com mentioned:
I feel this block code is not right - https://github.com/ansible/ansible/blob/a688d2ee39860cdb22e5ecd4ca927f22744f7f9e/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py#L578 

1. It seems to be unreachable code 
2. String formatting should start 0 not with 1

He is correct. Furthermore, KeyErrors where not managed correctly, and in some cases, unnecessary Exceptions still occurred.
- Bugfix Pull Request

##### COMPONENT NAME
module postgresql_pg_hba

##### ADDITIONAL INFORMATION
I added another test for this.
Furthermore, order is now managed correctly in the specific cases.