### PR TITLE
dzdo: fix password prompt

### DIFF
--- a/changelogs/fragments/dzdo_password_prompt.yml
+++ b/changelogs/fragments/dzdo_password_prompt.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- dzdo did not work with password authentication

--- a/lib/ansible/plugins/become/dzdo.py
+++ b/lib/ansible/plugins/become/dzdo.py
@@ -25,7 +25,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_BECOME_USER
               - name: ANSIBLE_DZDO_USER
         become_exe:
-            description: Sudo executable
+            description: Dzdo executable
             default: dzdo
             ini:
               - section: privilege_escalation
@@ -87,8 +87,8 @@ class BecomeModule(BecomeBase):
 
         flags = self.get_option('become_flags') or ''
         if self.get_option('become_pass'):
-            self._prompt = '[dzdo via ansible, key=%s] password:' % self._id
-            flags = '%s -p "%s"' % (flags.replace('-n', ''), self._prompt)
+            self.prompt = '[dzdo via ansible, key=%s] password:' % self._id
+            flags = '%s -p "%s"' % (flags.replace('-n', ''), self.prompt)
 
         user = self.get_option('become_user') or ''
         if user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
dzdo does not work with passwords on ansible 2.8.2.  This fixes that.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dzdo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
