### PR TITLE
dzdo: set default become_user

### DIFF
--- a/changelogs/fragments/dzdo_user.yml
+++ b/changelogs/fragments/dzdo_user.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >
+  dzdo - setting ``become: yes`` with dzdo become_method had no effect because
+  there was no default set for become_user.

--- a/lib/ansible/plugins/become/dzdo.py
+++ b/lib/ansible/plugins/become/dzdo.py
@@ -13,6 +13,7 @@ DOCUMENTATION = """
     options:
         become_user:
             description: User you 'become' to execute the task
+            default: root
             ini:
               - section: privilege_escalation
                 key: become_user


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
setting "become: yes" with dzdo become_method does not attempt to become root.  This is because no become_user was set by default.  This restores the behavior to that of 2.7.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dzdo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
