### PR TITLE
ovirt-host-network: support commit on success

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -186,6 +186,7 @@ from ansible.module_utils.ovirt import (
     get_link_name,
     ovirt_full_argument_spec,
     search_by_name,
+    engine_supported
 )
 
 
@@ -323,10 +324,9 @@ class HostNetworksModule(BaseModule):
         return update
 
     def _action_save_configuration(self, entity):
-        if self._module.params['save']:
-            if not self._module.check_mode:
-                self._service.service(entity.id).commit_net_config()
-            self.changed = True
+        if not self._module.check_mode:
+            self._service.service(entity.id).commit_net_config()
+        self.changed = True
 
 
 def needs_sync(nics_service):
@@ -414,10 +414,9 @@ def main():
                         removed_bonds.append(otypes.HostNic(id=host_nic.id))
 
             # Assign the networks:
-            host_networks_module.action(
+            setup_params = dict(
                 entity=host,
                 action='setup_networks',
-                post_action=host_networks_module._action_save_configuration,
                 check_connectivity=module.params['check'],
                 removed_bonds=removed_bonds if removed_bonds else None,
                 modified_bonds=[
@@ -466,6 +465,11 @@ def main():
                     ) for network in networks
                 ] if networks else None,
             )
+            if engine_supported(connection, '4.3'):
+                setup_params['commit_on_success'] = module.params['save']
+            elif module.params['save']:
+                setup_params['post_action'] = host_networks_module._action_save_configuration
+            host_networks_module.action(**setup_params)
         elif state == 'absent' and nic:
             attachments = []
             nic_service = nics_service.nic_service(nic.id)
@@ -491,10 +495,9 @@ def main():
             # Need to check if there are any labels to be removed, as backend fail
             # if we try to send remove non existing label, for bond and attachments it's OK:
             if (labels and set(labels).intersection(attached_labels)) or bond or attachments:
-                host_networks_module.action(
+                setup_params = dict(
                     entity=host,
                     action='setup_networks',
-                    post_action=host_networks_module._action_save_configuration,
                     check_connectivity=module.params['check'],
                     removed_bonds=[
                         otypes.HostNic(
@@ -506,6 +509,11 @@ def main():
                     ] if labels else None,
                     removed_network_attachments=attachments if attachments else None,
                 )
+                if engine_supported(connection, '4.3'):
+                    setup_params['commit_on_success'] = module.params['save']
+                elif module.params['save']:
+                    setup_params['post_action'] = host_networks_module._action_save_configuration
+                host_networks_module.action(**setup_params)
 
         nic = search_by_name(nics_service, nic_name)
         module.exit_json(**{


### PR DESCRIPTION
In ovirt-engine 4.3 and onwards a 'commit on success' parameter is
available. It is used to commit a network configuration automatically
upon successful application of the configuration without needing a
separate save request.

Therefore since ansible 2.8 if the 'save' parameter is specified as
'true' the commit on success parameter will be set to true and used
instead of making an additional save request.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
