### PR TITLE
FortiOS System Fimrware Upgrade Module

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -24,14 +24,15 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: fortios_system_firmware_upgrade
-short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
+short_description: Perform firmware upgrade on FortiGate or FortiOS (FOS) device.
 description:
-    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
-      user to set and modify system feature and firmware category.
+    - This module is able to perform firmware upgrade on FortiGate or FortiOS (FOS) device by specifying
+      firmware upgrade source, filename and whether format boot partition before upgrade.
       Examples include all parameters and values need to be adjusted to datasources before usage.
       Tested with FOS v6.0.2
 version_added: "2.9"
 author:
+    - Don Yao (@fortinetps)
     - Miguel Angel Munoz (@mamunozgonzalez)
     - Nicolas Thomas (@thomnico)
 notes:
@@ -62,40 +63,49 @@ options:
               used as a different unit.
         type: str
         default: root
+        required: false
     https:
         description:
             - Indicates if the requests towards FortiGate must use HTTPS protocol.
         type: bool
         default: true
+        required: false
     ssl_verify:
         description:
             - Ensures FortiGate certificate must be verified by a proper CA.
         type: bool
         default: true
+        required: false
     system_firmware:
         description:
-            - Perform firmware upgrade with local firmware file.
+            - Possible parameters to go in the body for the request.
+              Specify firmware upgrade source, filename and whether
+              format boot partition before upgrade
         default: null
         type: dict
+        required: true
         suboptions:
             file_content:
                 description:
                     - "Provided when uploading a file: base64 encoded file data. Must not contain whitespace or other invalid base64 characters. Must be
                        included in HTTP body."
                 type: str
+                required: false
             filename:
                 description:
                     - Name and path of the local firmware file.
                 type: str
+                required: true
             format_partition:
                 description:
                     - Set to true to format boot partition before upgrade.
                 type: bool
+                required: false
             source:
                 description:
                     - Firmware file data source [upload|usb|fortiguard].
-                required: true
                 type: str
+                required: true
                 choices:
                     - upload
                     - usb
@@ -249,10 +259,6 @@ def filter_system_firmware_data(json):
             dictionary[attribute] = json[attribute]
 
     return dictionary
-
-
-def underscore_to_hyphen(data):
-    return data
 
 
 def system_firmware(data, fos, check_mode=False):

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -26,7 +26,7 @@ DOCUMENTATION = '''
 module: fortios_system_firmware_upgrade
 short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
 description:
-    - This module is able to configure a FortiGate or FortiOS device by allowing the
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
       user to set and modify system feature and firmware category.
       Examples include all parameters and values need to be adjusted to datasources before usage.
       Tested with FOS v6.0.2
@@ -82,7 +82,7 @@ options:
                 description:
                     - "Provided when uploading a file: base64 encoded file data. Must not contain whitespace or other invalid base64 characters. Must be
                        included in HTTP body."
-                type: var-string
+                type: str
             filename:
                 description:
                     - Name and path of the local firmware file.
@@ -109,9 +109,10 @@ EXAMPLES = '''
    username: "admin"
    password: ""
    vdom: "root"
+   ssl_verify: "False"
   tasks:
   - name: Perform firmware upgrade with local firmware file.
-    fortios_system_firmware_upgrade:
+    fortios_system_firmware:
       host:  "{{ host }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -296,14 +297,14 @@ def main():
     fields = {
         "host": {"required": False, "type": "str"},
         "username": {"required": False, "type": "str"},
-        "password": {"required": False, "type": "str", "no_log": True},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
         "https": {"required": False, "type": "bool", "default": True},
         "ssl_verify": {"required": False, "type": "bool", "default": True},
         "system_firmware": {
             "required": True, "type": "dict",
             "options": {
-                "file_content": {"required": False, "type": "var-string"},
+                "file_content": {"required": False, "type": "str"},
                 "filename": {"required": True, "type": "str"},
                 "format_partition": {"required": False, "type": "bool"},
                 "source": {"required": True, "type": "str",
@@ -316,6 +317,7 @@ def main():
     module = AnsibleModule(argument_spec=fields,
                            supports_check_mode=False)
 
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
     legacy_mode = 'host' in module.params and module.params['host'] is not None and \
                   'username' in module.params and module.params['username'] is not None and \
                   'password' in module.params and module.params['password'] is not None

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -44,12 +44,12 @@ options:
         description:
             - FortiOS or FortiGate IP address.
         type: str
-        required: true
+        required: false
     username:
         description:
             - FortiOS or FortiGate username.
         type: str
-        required: true
+        required: false
     password:
         description:
             - FortiOS or FortiGate password.

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -67,12 +67,22 @@ options:
             - Indicates if the requests towards FortiGate must use HTTPS protocol.
         type: bool
         default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
     system_firmware:
         description:
             - Perform firmware upgrade with local firmware file.
         default: null
         type: dict
         suboptions:
+            file_content:
+                description:
+                    - "Provided when uploading a file: base64 encoded file data. Must not contain whitespace or other invalid base64 characters. Must be
+                       included in HTTP body."
+                type: var-string
             filename:
                 description:
                     - Name and path of the local firmware file.
@@ -84,8 +94,8 @@ options:
             source:
                 description:
                     - Firmware file data source [upload|usb|fortiguard].
-                type: str
                 required: true
+                type: str
                 choices:
                     - upload
                     - usb
@@ -106,8 +116,9 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       vdom:  "{{ vdom }}"
-      https: "False"
+      ssl_verify: "False"
       system_firmware:
+        file_content: "<your_own_value>"
         filename: "<your_own_value>"
         format_partition: "<your_own_value>"
         source: "upload"
@@ -124,7 +135,7 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       vdom:  "{{ vdom }}"
-      https: "False"
+      ssl_verify: "False"
       system_firmware:
         filename: "<your_own_value>"
         format_partition: "<your_own_value>"
@@ -142,7 +153,7 @@ EXAMPLES = '''
       username: "{{ username }}"
       password: "{{ password }}"
       vdom:  "{{ vdom }}"
-      https: "False"
+      ssl_verify: "False"
       system_firmware:
         filename: "<your_own_value>"
         format_partition: "<your_own_value>"
@@ -216,6 +227,7 @@ def login(data, fos):
     host = data['host']
     username = data['username']
     password = data['password']
+    ssl_verify = data['ssl_verify']
 
     fos.debug('on')
     if 'https' in data and not data['https']:
@@ -223,11 +235,12 @@ def login(data, fos):
     else:
         fos.https('on')
 
-    fos.login(host, username, password, timeout=300)
+    fos.login(host, username, password, timeout=300, verify=ssl_verify)
 
 
 def filter_system_firmware_data(json):
-    option_list = ['filename', 'format_partition', 'source']
+    option_list = ['file_content', 'filename', 'format_partition',
+                   'source']
     dictionary = {}
 
     for attribute in option_list:
@@ -286,9 +299,11 @@ def main():
         "password": {"required": False, "type": "str", "no_log": True},
         "vdom": {"required": False, "type": "str", "default": "root"},
         "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
         "system_firmware": {
             "required": True, "type": "dict",
             "options": {
+                "file_content": {"required": False, "type": "var-string"},
                 "filename": {"required": True, "type": "str"},
                 "format_partition": {"required": False, "type": "bool"},
                 "source": {"required": True, "type": "str",

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -223,7 +223,7 @@ def login(data, fos):
     else:
         fos.https('on')
 
-    fos.login(host, username, password)
+    fos.login(host, username, password, timeout=300)
 
 
 def filter_system_firmware_data(json):

--- a/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_firmware_upgrade.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_firmware_upgrade
+short_description: Perform firmware upgrade with local firmware file in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and firmware category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.2
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: true
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: true
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    system_firmware:
+        description:
+            - Perform firmware upgrade with local firmware file.
+        default: null
+        type: dict
+        suboptions:
+            filename:
+                description:
+                    - Name and path of the local firmware file.
+                type: str
+            format_partition:
+                description:
+                    - Set to true to format boot partition before upgrade.
+                type: bool
+            source:
+                description:
+                    - Firmware file data source [upload|usb|fortiguard].
+                type: str
+                required: true
+                choices:
+                    - upload
+                    - usb
+                    - fortiguard
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Perform firmware upgrade with local firmware file.
+    fortios_system_firmware_upgrade:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_firmware:
+        filename: "<your_own_value>"
+        format_partition: "<your_own_value>"
+        source: "upload"
+    register: fortios_system_firmware_upgrade_result
+
+  - debug:
+      var:
+        # please check the following status to confirm
+        fortios_system_firmware_upgrade_result.meta.results.status
+
+  - name: Perform firmware upgrade with firmware file on USB.
+    fortios_system_firmware_upgrade:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_firmware:
+        filename: "<your_own_value>"
+        format_partition: "<your_own_value>"
+        source: "usb"
+    register: fortios_system_firmware_upgrade_result
+
+  - debug:
+      var:
+        # please check the following status to confirm
+        fortios_system_firmware_upgrade_result.meta.results.status
+
+  - name: Perform firmware upgrade from FortiGuard.
+    fortios_system_firmware_upgrade:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_firmware:
+        filename: "<your_own_value>"
+        format_partition: "<your_own_value>"
+        source: "fortiguard"
+    register: fortios_system_firmware_upgrade_result
+
+  - debug:
+      var:
+        # please check the following status to confirm
+        fortios_system_firmware_upgrade_result.meta.results.status
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'POST'
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "firmware"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "system"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+import os
+import base64
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password)
+
+
+def filter_system_firmware_data(json):
+    option_list = ['filename', 'format_partition', 'source']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    return data
+
+
+def system_firmware(data, fos, check_mode=False):
+    vdom = data['vdom']
+
+    system_firmware_data = data['system_firmware']
+
+    filtered_data = {}
+    filtered_data['source'] = system_firmware_data['source']
+    if hasattr(system_firmware_data, 'format_partition'):
+        filtered_data['format_partition'] = system_firmware_data['format_partition']
+    if filtered_data['source'] == 'upload':
+        try:
+            filtered_data['file_content'] = base64.b64encode(open(system_firmware_data['filename'], 'rb').read()).decode('utf-8')
+        except Exception:
+            filtered_data['file_content'] = ''
+    else:
+        filtered_data['filename'] = system_firmware_data['filename']
+
+    return fos.execute('system',
+                       'firmware/upgrade',
+                       data=filtered_data,
+                       vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_firmware']:
+        resp = system_firmware(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "system_firmware": {
+            "required": True, "type": "dict",
+            "options": {
+                "filename": {"required": True, "type": "str"},
+                "format_partition": {"required": False, "type": "bool"},
+                "source": {"required": True, "type": "str",
+                           "choices": ["upload", "usb", "fortiguard"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/fortios/test_fortios_system_firmware_upgrade.py
+++ b/test/units/modules/network/fortios/test_fortios_system_firmware_upgrade.py
@@ -22,7 +22,6 @@ import json
 import pytest
 from mock import ANY
 from ansible.module_utils.network.fortios.fortios import FortiOSHandler
-from fortiosapi import FortiOSAPI
 
 try:
     from ansible.modules.network.fortios import fortios_system_firmware_upgrade
@@ -36,22 +35,20 @@ def connection_mock(mocker):
     return connection_class_mock
 
 
-fos_instance = FortiOSAPI()
+fos_instance = FortiOSHandler(connection_mock)
 
 
 def test_system_firmware_upgrade_execute(mocker):
     execute_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
-    execute_method_mock = mocker.patch('fortiosapi.FortiOSAPI.execute', return_value=execute_method_result)
+    execute_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.execute', return_value=execute_method_result)
 
     input_data = {
-        'host': 'host',
         'username': 'admin',
-        'password': 'pass',
         'system_firmware': {
-                'file_content': 'test_value_3',
-                'filename': 'test_value_4',
-                'format_partition': 'test_value_5',
-                'source': 'upload'
+            'file_content': 'test_value_3',
+            'filename': 'test_value_4',
+            'format_partition': 'test_value_5',
+            'source': 'upload'
         },
         'vdom': 'root'}
 

--- a/test/units/modules/network/fortios/test_fortios_system_firmware_upgrade.py
+++ b/test/units/modules/network/fortios/test_fortios_system_firmware_upgrade.py
@@ -1,0 +1,71 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from fortiosapi import FortiOSAPI
+
+try:
+    from ansible.modules.network.fortios import fortios_system_firmware_upgrade
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_firmware_upgrade.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSAPI()
+
+
+def test_system_firmware_upgrade_execute(mocker):
+    execute_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    execute_method_mock = mocker.patch('fortiosapi.FortiOSAPI.execute', return_value=execute_method_result)
+
+    input_data = {
+        'host': 'host',
+        'username': 'admin',
+        'password': 'pass',
+        'system_firmware': {
+                'file_content': 'test_value_3',
+                'filename': 'test_value_4',
+                'format_partition': 'test_value_5',
+                'source': 'upload'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_firmware_upgrade.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'file-content': 'test_value_3',
+        'filename': 'test_value_4',
+        'format-partition': 'test_value_5',
+        'source': 'upload'
+    }
+
+    execute_method_mock.assert_called_with('system', 'firmware/upgrade', data=ANY, vdom='root')
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200


### PR DESCRIPTION
##### SUMMARY
Fortinet is adding Ansible support for FortiOS and FortiGate products. This module follows the same structure, guidelines and ideas given in previous approved module for a parallel feature of FortiGate (user device): #56447
In this case we are providing a different functionality: "Fortios System Firmware Upgrade".

Please note that this will be part of other modules to come for FortiGate, including different functionalities: system, wireless-controller, firewall, webfilter, ips, web-proxy, wanopt, application, dlp spamfilter, log, vpn, certificate, user, dnsfilter, antivirus, report, waf, authentication, switch controller, endpoint-control and router. We plan to follow the same style, structure and usage as in the previous module in order to make it easier to comply with Ansible guidelines.

This PR has been updated according to suggestions and code reviews given in previous submissions of Fortinet modules.

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
fortios_system_firmware_upgrade

##### ANSIBLE VERSION
ansible 2.9.0.dev0
python version = 3.7.4 (default, Jul 13 2019, 14:04:11) [GCC 8.3.0]