### PR TITLE
VMware: Accept 0 as valid value for memory reservation

### DIFF
--- a/changelogs/fragments/59190-vmware_guest-mem_reservation.yml
+++ b/changelogs/fragments/59190-vmware_guest-mem_reservation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest accepts 0 MB of memory reservation, fix regression introduced via 193f69064fb40a83e3e7d2112ef24868b45233b3 (https://github.com/ansible/ansible/issues/59190).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -896,7 +896,7 @@ class PyVmomiHelper(PyVmomi):
                     rai_change_detected = True
 
             if 'mem_reservation' in self.params['hardware'] or 'memory_reservation' in self.params['hardware']:
-                mem_reservation = self.params['hardware'].get('mem_reservation') or self.params['hardware'].get('memory_reservation') or None
+                mem_reservation = self.params['hardware'].get('mem_reservation') or self.params['hardware'].get('memory_reservation')
                 try:
                     mem_reservation = int(mem_reservation)
                 except ValueError:

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -95,6 +95,7 @@
     # - include: clone_with_convert.yml
     # - include: clone_customize_guest_test.yml
     - include: max_connections.yml
+    - include: mem_reservation.yml
   always:
     - name: Remove VM
       vmware_guest:
@@ -113,6 +114,8 @@
         - newvm_efi_DC0_H0_VM1
         - newvm_mk_conn_DC0_H0_VM0
         - newvm_mk_conn_DC0_H0_VM1
+        - newvm_mem_res_DC0_H0_VM0
+        - newvm_mem_res_DC0_H0_VM1
         - thin_DC0_H0_VM0
         - thin_DC0_H0_VM1
         - thick_DC0_H0_VM0

--- a/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
+++ b/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
@@ -1,0 +1,46 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+    - &add_mem_reserve
+      name: Create new VMs with mem_reservation as 0
+      vmware_guest:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        name: "{{ 'newvm_mem_res_' + item.name }}"
+        guest_id: centos64Guest
+        datacenter: "{{ dc1 }}"
+        hardware:
+          num_cpus: 4
+          memory_mb: 512
+          mem_reservation: 0
+        disk:
+          - size: 1gb
+            type: thin
+            autoselect_datastore: True
+        state: present
+        folder: "{{ item.folder }}"
+      with_items: "{{ virtual_machines }}"
+      register: mem_reserve_result_0001
+
+    - debug: var=mem_reserve_result_0001
+
+    - name: Assert that changes were made
+      assert:
+        that:
+          - "mem_reserve_result_0001.results|map(attribute='changed')|unique|list == [true]"
+
+    - <<: *add_mem_reserve
+      name: Again create new VMs with mem_reservation as 0
+      register: mem_reserve_result_0002
+
+    - debug: var=mem_reserve_result_0002
+
+    - name: Assert that changes were not made
+      assert:
+        that:
+          - "mem_reserve_result_0002.results|map(attribute='changed')|unique|list == [false]"


### PR DESCRIPTION
##### SUMMARY
vmware_guest accepts 0MB as valid value for memory reservation in
virtual machine hardware configuration. This fixes the regression
introduced via 193f69064fb40a83e3e7d2112ef24868b45233b3.

Fixes: #59190

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/59190-vmware_guest-mem_reservation.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml
test/integration/targets/vmware_guest/tasks/mem_reservation.yml