### PR TITLE
[2.8] Fix ec2_eip parameter logic

### DIFF
--- a/changelogs/fragments/55194-ec2_eip-required_together.yml
+++ b/changelogs/fragments/55194-ec2_eip-required_together.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - In ec2_eip, device_id is required when private_ip_address is set, but the reverse is not true (https://github.com/ansible/ansible/pull/55194).

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -388,9 +388,9 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_together=[
-            ['device_id', 'private_ip_address'],
-        ],
+        required_by={
+            'private_ip_address': ['device_id'],
+        },
     )
 
     if not HAS_BOTO:


### PR DESCRIPTION
##### SUMMARY
device_id is required when private_ip_address is set, but the reverse is not true.

(cherry picked from commit 6273574eb4fce33cab70c5ab749fa71cc85e3855)

Signed-off-by: flowerysong <junk+github@flowerysong.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/55194-ec2_eip-required_together.yml
lib/ansible/modules/cloud/amazon/ec2_eip.py