### PR TITLE
nmcli: Fixed modifying bond and team slaves

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -856,7 +856,7 @@ class Nmcli(object):
         return cmd
 
     def modify_connection_team_slave(self):
-        cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name, 'connection.master', self.master]
+        cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name, 'connection.slave-type', 'team', 'connection.master', self.master]
         # format for modifying team-slave interface
         if self.mtu is not None:
             cmd.append('802-3-ethernet.mtu')
@@ -944,7 +944,7 @@ class Nmcli(object):
         return cmd
 
     def modify_connection_bond_slave(self):
-        cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name, 'connection.master', self.master]
+        cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name, 'connection.slave-type', 'bond', 'connection.master', self.master]
         # format for modifying bond-slave interface
         return cmd
 


### PR DESCRIPTION
Fixed modifying bond and team slaves by adding required option connection.slave-type

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`modify_connection_bond_slave()` and `modify_connection_team_slave()` doesn't include the required option `connection.slave-type` and therefor modifying a slave interface in combination with bond or team does not work.

Fixes #58392

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nmcli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
