### PR TITLE
Backport/2.8/59071 ce_file_copy : update ce_file_copy to fix a bug. (#59071)

### DIFF
--- a/changelogs/fragments/59243-update-ce_file_copy-to-fix-a-bug.yml
+++ b/changelogs/fragments/59243-update-ce_file_copy-to-fix-a-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Using neconf API to send cli commands is a bug, now fix it(https://github.com/ansible/ansible/pull/59071)

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -113,6 +113,21 @@ try:
 except ImportError:
     HAS_SCP = False
 
+CE_NC_GET_DISK_INFO = """
+<filter type="subtree">
+  <vfm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dfs>
+      <df>
+        <fileSys></fileSys>
+        <inputPath></inputPath>
+        <totalSize></totalSize>
+        <freeSize></freeSize>
+      </df>
+    </dfs>
+  </vfm>
+</filter>
+"""
+
 CE_NC_GET_FILE_INFO = """
 <filter type="subtree">
   <vfm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
@@ -129,12 +144,13 @@ CE_NC_GET_FILE_INFO = """
 
 CE_NC_GET_SCP_ENABLE = """
 <filter type="subtree">
-  <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-    <sshServer>
-      <scpEnable></scpEnable>
-    </sshServer>
-  </sshs>
-</filter>
+      <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+        <sshServerEnable>
+          <scpIpv4Enable></scpIpv4Enable>
+          <scpIpv6Enable></scpIpv6Enable>
+        </sshServerEnable>
+      </sshs>
+    </filter>
 """
 
 
@@ -215,7 +231,7 @@ class FileCopy(object):
 
         # get file info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/vfm/dirs/dir")
+        topo = root.find("vfm/dirs/dir")
         if topo is None:
             return False, 0
 
@@ -233,16 +249,19 @@ class FileCopy(object):
     def enough_space(self):
         """Whether device has enough space"""
 
-        commands = list()
-        cmd = 'dir %s' % self.file_system
-        commands.append(cmd)
-        output = run_commands(self.module, commands)
-        if not output:
-            return True
+        xml_str = CE_NC_GET_DISK_INFO
+        ret_xml = get_nc_config(self.module, xml_str)
+        if "<data/>" in ret_xml:
+            return
 
-        match = re.search(r'\((.*) KB free\)', output[0])
-        kbytes_free = match.group(1)
-        kbytes_free = kbytes_free.replace(',', '')
+        xml_str = ret_xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("vfm/dfs/df/freeSize")
+        kbytes_free = topo.text
+
         file_size = os.path.getsize(self.local_file)
         if int(kbytes_free) * 1024 > file_size:
             return True
@@ -284,7 +303,6 @@ class FileCopy(object):
                 self.module.fail_json(msg='Could not transfer file. There was an error '
                                       'during transfer. Please make sure the format of '
                                       'input parameters is right.')
-
         scp.close()
         return True
 
@@ -292,9 +310,10 @@ class FileCopy(object):
         """Get scp enable state"""
 
         xml_str = CE_NC_GET_SCP_ENABLE
+        scp_enable = dict()
         ret_xml = get_nc_config(self.module, xml_str)
         if "<data/>" in ret_xml:
-            return False
+            return scp_enable
 
         xml_str = ret_xml.replace('\r', '').replace('\n', '').\
             replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
@@ -302,15 +321,14 @@ class FileCopy(object):
 
         # get file info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("data/sshs/sshServer")
+        topo = root.find("sshs/sshServerEnable")
         if topo is None:
-            return False
+            return scp_enable
 
         for eles in topo:
-            if eles.tag in ["scpEnable"]:
-                return True, eles.text
+            scp_enable[eles.tag] = eles.text
 
-        return False
+        return scp_enable
 
     def work(self):
         """Excute task """
@@ -331,10 +349,13 @@ class FileCopy(object):
             self.module.fail_json(
                 msg="'Error: The maximum length of remote_file is 4096.'")
 
-        retcode, cur_state = self.get_scp_enable()
-        if retcode and cur_state == 'Disable':
+        cur_state = self.get_scp_enable()
+        if len(cur_state) > 0 and (cur_state.get('scpIpv4Enable').lower() == 'disable' or cur_state.get('scpIpv6Enable').lower() == 'disable'):
             self.module.fail_json(
-                msg="'Error: Please ensure SCP server is enabled.'")
+                msg="'Error: Please ensure ipv4 and ipv6 SCP server are enabled.'")
+        elif len(cur_state) == 0:
+            self.module.fail_json(
+                msg="'Error: Please ensure ipv4 and ipv6 SCP server are enabled.'")
 
         if not os.path.isfile(self.local_file):
             self.module.fail_json(


### PR DESCRIPTION
* update ce_file_copy to fix a bug.

* Update ce_file_copy.py

* Update ce_file_copy.py

(cherry picked from commit 7a0a21ea7aa0d69bc6eb89967da47df85dca6a8d)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is not a good way that using netconf and network_cli together in one module will cause an error.
Network_cli commands can not be sent by netconf.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_file_copy.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Using neconf API to send cli commands is an error.
So fix it. 
```
