### PR TITLE
prevent templating of passwords from prompt

### DIFF
--- a/changelogs/fragments/dont_template_passwords_from_prompt.yml
+++ b/changelogs/fragments/dont_template_passwords_from_prompt.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - resolves CVE-2019-10206, by avoiding templating passwords from prompt as it is probable they have special characters.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -256,7 +256,12 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # we 'wrap' the passwords to prevent templating as
         # they can contain special chars and trigger it incorrectly
-        return (AnsibleUnsafeBytes(sshpass), AnsibleUnsafeBytes(becomepass))
+        if sshpass:
+            sshpass = AnsibleUnsafeBytes(sshpass)
+        if becomepass:
+            becomepass = AnsibleUnsafeBytes(becomepass)
+
+        return (sshpass, becomepass)
 
     def validate_conflicts(self, op, runas_opts=False, fork_opts=False):
         ''' check for conflicting options '''

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -29,6 +29,7 @@ from ansible.release import __version__
 from ansible.utils.collection_loader import set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
+from ansible.utils.unsafe_proxy import wrap_var
 from ansible.vars.manager import VariableManager
 
 try:
@@ -253,7 +254,9 @@ class CLI(with_metaclass(ABCMeta, object)):
         except EOFError:
             pass
 
-        return (sshpass, becomepass)
+        # we 'wrap' the passwords to prevent templating as
+        # they can contain special chars and trigger it incorrectly
+        return (wrap_var(sshpass), wrap_var(becomepass))
 
     def validate_conflicts(self, op, runas_opts=False, fork_opts=False):
         ''' check for conflicting options '''

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -29,7 +29,7 @@ from ansible.release import __version__
 from ansible.utils.collection_loader import set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
-from ansible.utils.unsafe_proxy import wrap_var
+from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes
 from ansible.vars.manager import VariableManager
 
 try:
@@ -256,7 +256,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # we 'wrap' the passwords to prevent templating as
         # they can contain special chars and trigger it incorrectly
-        return (wrap_var(sshpass), wrap_var(becomepass))
+        return (AnsibleUnsafeBytes(sshpass), AnsibleUnsafeBytes(becomepass))
 
     def validate_conflicts(self, op, runas_opts=False, fork_opts=False):
         ''' check for conflicting options '''

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -53,7 +53,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils.six import string_types, text_type
+from ansible.module_utils.six import string_types, text_type, binary_type
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping, MutableSequence, Set
 
@@ -69,15 +69,18 @@ class AnsibleUnsafeText(text_type, AnsibleUnsafe):
     pass
 
 
+class AnsibleUnsafeBytes(binary_type, AnsibleUnsafe):
+    pass
+
+
 class UnsafeProxy(object):
     def __new__(cls, obj, *args, **kwargs):
         # In our usage we should only receive unicode strings.
         # This conditional and conversion exists to sanity check the values
         # we're given but we may want to take it out for testing and sanitize
         # our input instead.
-        if isinstance(obj, string_types):
-            obj = to_text(obj, errors='surrogate_or_strict')
-            return AnsibleUnsafeText(obj)
+        if isinstance(obj, string_types) and not isinstance(obj, AnsibleUnsafeBytes):
+            obj = AnsibleUnsafeText(to_text(obj, errors='surrogate_or_strict'))
         return obj
 
 


### PR DESCRIPTION
So `hello{{world` is now a valid password at the prompt

fixes CVE-2019-10206

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core