### PR TITLE
[stable-2.8] User - Create parent directories if they do not exist in the specified home path (#51043)

### DIFF
--- a/changelogs/fragments/user-home-dir-with-no-parents.yaml
+++ b/changelogs/fragments/user-home-dir-with-no-parents.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - create parent directories when the specified home path has parent directiries that do not exist (https://github.com/ansible/ansible/issues/41393)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2892,7 +2892,7 @@ def main():
             # that do not exist.
             path_needs_parents = False
             if user.home:
-                parent = os.path.basename(user.home)
+                parent = os.path.dirname(user.home)
                 if not os.path.isdir(parent):
                     path_needs_parents = True
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -197,6 +197,22 @@
     state: absent
 
 
+# https://github.com/ansible/ansible/issues/60307
+# Make sure we can create a user when the home directory is missing
+- name: Create user with home path that does not exist
+  user:
+    name: ansibulluser3
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/nosuchdir"
+    createhome: no
+
+- name: Cleanup test account
+  user:
+    name: ansibulluser3
+    state: absent
+    remove: yes
+
+
 ## user check
 
 - name: run existing user check tests

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -154,6 +154,49 @@
   when: ansible_facts.system != 'Darwin'
 
 
+# https://github.com/ansible/ansible/issues/41393
+# Create a new user account with a path that has parent directories that do not exist
+- name: Create user with home path that has parents that do not exist
+  user:
+    name: ansibulluser2
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: create_home_with_no_parent_1
+
+- name: Create user with home path that has parents that do not exist again
+  user:
+    name: ansibulluser2
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: create_home_with_no_parent_2
+
+- name: Check the created home directory
+  stat:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+  register: home_with_no_parent_3
+
+- name: Ensure user with non-existing parent paths was created successfully
+  assert:
+    that:
+      - create_home_with_no_parent_1 is changed
+      - create_home_with_no_parent_1.home == user_home_prefix[ansible_facts.system] ~ '/in2deep/ansibulluser2'
+      - create_home_with_no_parent_2 is not changed
+      - home_with_no_parent_3.stat.uid == create_home_with_no_parent_1.uid
+      - home_with_no_parent_3.stat.gr_name == default_user_group[ansible_facts.distribution] | default('ansibulluser2')
+
+- name: Cleanup test account
+  user:
+    name: ansibulluser2
+    home: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/ansibulluser2"
+    state: absent
+    remove: yes
+
+- name: Remove testing dir
+  file:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/in2deep/"
+    state: absent
+
+
 ## user check
 
 - name: run existing user check tests

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -7,3 +7,7 @@ user_home_prefix:
 status_command:
   OpenBSD: "grep ansibulluser /etc/master.passwd | cut -d ':' -f 2"
   FreeBSD: 'pw user show ansibulluser'
+
+default_user_group:
+  openSUSE Leap: users
+  MacOSX: admin


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #51043 for Ansible 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/user.py`
