### PR TITLE
[2.8] docker_* modules: fix typo in import package name

### DIFF
--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -75,7 +75,7 @@ except ImportError:
 
 
 try:
-    from request.exceptions import RequestException
+    from requests.exceptions import RequestException
 except ImportError:
     # Either docker-py is no longer using requests, or docker-py isn't around either,
     # or docker-py's dependency requests is missing. In any case, define an exception


### PR DESCRIPTION
##### SUMMARY
Backport of #59229 to stable-2.8. Fix-up (stupid typo) for merged backport #59061; since it has just been merged for the 2.8.3 release, and this backport should make it in time for 2.8.3 as well, there's no changelog.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker/common.py
