### PR TITLE
Tower inventory

### DIFF
--- a/lib/ansible/plugins/inventory/tower.py
+++ b/lib/ansible/plugins/inventory/tower.py
@@ -11,6 +11,7 @@ DOCUMENTATION = '''
     author:
       - Matthew Jones (@matburt)
       - Yunfan Zhang (@YunfanZhang42)
+      - Will Tome (@willtome)
     short_description: Ansible dynamic inventory plugin for Ansible Tower.
     version_added: "2.7"
     description:
@@ -72,6 +73,8 @@ DOCUMENTATION = '''
             env:
                 - name: TOWER_PARENT_GROUP
             required: False
+    requirements:
+        - networkx >= 2.3
 '''
 
 EXAMPLES = '''
@@ -163,7 +166,7 @@ class InventoryModule(BaseInventoryPlugin):
                 elif inv_graph.node[start]['type'] == 'group':
                     self.inventory.add_child(parent, start)
 
-            self.populate_inventory(inv_graph, parent)
+                self.populate_inventory(inv_graph, parent)
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)


### PR DESCRIPTION
##### SUMMARY

This modification the the Tower inventory plugin allows a user to import a subset of an existing inventory by specifying a "starting" point (group). For example, if an inventory exists with groups for the owners of a selection of hosts, an inventory can be created with a dynamic source to only import hosts that are "owned" (grouped) for a specific user. This allows RBAC to be implemented to limit a user to just the systems they own without losing group structure that may impact group_vars. Since not all all inventory plugins contain sufficient filtering and smart inventories do not maintain group structure, implementing in the Tower plugin provides a consistent filtering capability despite original source of inventory. 