### PR TITLE
Label kubectl connection plugin as community

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1098,6 +1098,10 @@ files:
     support: network
     maintainers: $team_networking
     labels: networking
+  $plugins/connection/kubectl.py:
+    support: community
+    maintainers: chouseknecht maxamillion fabianvf flaper87 willthames
+    labels: k8s
   $plugins/connection/lxd.py:
     maintainers: mattclay
   $plugins/connection/netconf.py:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is labeled as `support: core` by default
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`BOTMETA.yml`