### PR TITLE
Add netapp_e_firmware module and unit test

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_firmware.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_firmware.py
@@ -1,0 +1,554 @@
+#!/usr/bin/python
+
+# (c) 2016, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: netapp_e_firmware
+version_added: "2.9"
+short_description: NetApp E-Series manage firmware bundles and for legacy systems manage embedded firmware, and nvsram file.
+description:
+    - Ensure specific firmware versions are activated on E-Series storage system.
+author:
+    - Nathan Swartz (@ndswartz)
+extends_documentation_fragment:
+    - netapp.eseries
+options:
+    nvsram:
+        description:
+            - Path to the NVSRAM file.
+        type: str
+        required: true
+    firmware:
+        description:
+            - Path to the firmware file.
+        type: str
+        required: true
+    wait_for_completion:
+        description:
+            - This flag will cause module to wait for any upgrade actions to complete.
+        type: bool
+        default: false
+    ignore_health_check:
+        description:
+            - This flag will force firmware to be activated in spite of the health check.
+            - Use at you own risk. Certain non-optimal states could result in data loss.
+        type: bool
+        default: false
+"""
+EXAMPLES = """
+- name: Ensure correct firmware versions
+  netapp_e_firmware:
+    ssid: "{{ eseries_ssid }}"
+    api_url: "{{ eseries_api_url }}"
+    api_username: "{{ eseries_api_username }}"
+    api_password: "{{ eseries_api_password }}"
+    validate_certs: "{{ eseries_validate_certs }}"
+    nvsram: "path/to/nvsram"
+    bundle: "path/to/bundle"
+    wait_for_completion: true
+- name: Ensure correct firmware versions
+  netapp_e_firmware:
+    ssid: "{{ eseries_ssid }}"
+    api_url: "{{ eseries_api_url }}"
+    api_username: "{{ eseries_api_username }}"
+    api_password: "{{ eseries_api_password }}"
+    validate_certs: "{{ eseries_validate_certs }}"
+    nvsram: "path/to/nvsram"
+    firmware: "path/to/firmware"
+"""
+RETURN = """
+msg:
+    description: Status and version of firmware and NVSRAM.
+    type: str
+    returned: always
+    sample:
+"""
+import random
+import re
+import mimetypes
+
+from time import sleep
+from ansible.module_utils import six
+from ansible.module_utils.netapp import NetAppESeriesModule, request
+from ansible.module_utils._text import to_native, to_text, to_bytes
+
+
+def create_multipart_formdata(files, fields=None, send_8kb=False):
+    """Create the data for a multipart/form request."""
+    boundary = "---------------------------" + "".join([str(random.randint(0, 9)) for x in range(27)])
+    data_parts = list()
+    data = None
+
+    if six.PY2:  # Generate payload for Python 2
+        newline = "\r\n"
+        if fields is not None:
+            for key, value in fields:
+                data_parts.extend(["--%s" % boundary,
+                                   'Content-Disposition: form-data; name="%s"' % key,
+                                   "",
+                                   value])
+
+        for name, filename, path in files:
+            with open(path, "rb") as fh:
+                value = fh.read(8192) if send_8kb else fh.read()
+
+                data_parts.extend(["--%s" % boundary,
+                                   'Content-Disposition: form-data; name="%s"; filename="%s"' % (name, filename),
+                                   "Content-Type: %s" % (mimetypes.guess_type(path)[0] or "application/octet-stream"),
+                                   "",
+                                   value])
+        data_parts.extend(["--%s--" % boundary, ""])
+        data = newline.join(data_parts)
+
+    else:
+        newline = six.b("\r\n")
+        if fields is not None:
+            for key, value in fields:
+                data_parts.extend([six.b("--%s" % boundary),
+                                   six.b('Content-Disposition: form-data; name="%s"' % key),
+                                   six.b(""),
+                                   six.b(value)])
+
+        for name, filename, path in files:
+            with open(path, "rb") as fh:
+                value = fh.read(8192) if send_8kb else fh.read()
+
+                data_parts.extend([six.b("--%s" % boundary),
+                                   six.b('Content-Disposition: form-data; name="%s"; filename="%s"' % (name, filename)),
+                                   six.b("Content-Type: %s" % (mimetypes.guess_type(path)[0] or "application/octet-stream")),
+                                   six.b(""),
+                                   value])
+        data_parts.extend([six.b("--%s--" % boundary), b""])
+        data = newline.join(data_parts)
+
+    headers = {
+        "Content-Type": "multipart/form-data; boundary=%s" % boundary,
+        "Content-Length": str(len(data))}
+
+    return headers, data
+
+
+class NetAppESeriesFirmware(NetAppESeriesModule):
+    HEALTH_CHECK_TIMEOUT_MS = 120000
+    REBOOT_TIMEOUT_SEC = 15 * 60
+    FIRMWARE_COMPATIBILITY_CHECK_TIMEOUT_SEC = 60
+    DEFAULT_TIMEOUT = 60 * 15       # This will override the NetAppESeriesModule request method timeout.
+
+    def __init__(self):
+        ansible_options = dict(
+            nvsram=dict(type="str", required=True),
+            firmware=dict(type="str", required=True),
+            wait_for_completion=dict(type="bool", default=False),
+            ignore_health_check=dict(type="bool", default=False))
+
+        super(NetAppESeriesFirmware, self).__init__(ansible_options=ansible_options,
+                                                    web_services_version="02.00.0000.0000",
+                                                    supports_check_mode=True)
+
+        args = self.module.params
+        self.nvsram = args["nvsram"]
+        self.firmware = args["firmware"]
+        self.wait_for_completion = args["wait_for_completion"]
+        self.ignore_health_check = args["ignore_health_check"]
+
+        self.nvsram_name = None
+        self.firmware_name = None
+        self.is_bundle_cache = None
+        self.firmware_version_cache = None
+        self.nvsram_version_cache = None
+        self.upgrade_required = False
+        self.upgrade_in_progress = False
+        self.module_info = dict()
+
+        self.nvsram_name = re.split(r"/", self.nvsram)[-1]
+        self.firmware_name = re.split(r"/", self.firmware)[-1]
+
+    def is_firmware_bundled(self):
+        """Determine whether supplied firmware is bundle."""
+        if self.is_bundle_cache is None:
+            with open(self.firmware, "rb") as fh:
+                signature = fh.read(16).lower()
+
+                if b"firmware" in signature:
+                    self.is_bundle_cache = False
+                elif b"combined_content" in signature:
+                    self.is_bundle_cache = True
+                else:
+                    self.module.fail_json(msg="Firmware file is invalid. File [%s]. Array [%s]" % (self.firmware, self.ssid))
+
+        return self.is_bundle_cache
+
+    @property
+    def firmware_version(self):
+        """Retrieve firmware version. Return: bytes string"""
+        if self.firmware_version_cache is None:
+
+            # Search firmware file for bundle or firmware version
+            with open(self.firmware, "rb") as fh:
+                line = fh.readline()
+                while line:
+                    if self.is_firmware_bundled():
+                        if b'displayableAttributeList=' in line:
+                            for item in line[25:].split(b','):
+                                key, value = item.split(b"|")
+                                if key == b'VERSION':
+                                    self.firmware_version_cache = value.strip(b"\n")    # [int(num) for num in value.split(b".")]
+                            break
+                    elif b"Version:" in line:
+                        self.firmware_version_cache = line.split()[-1].strip(b"\n")  # [int(num) for num in line.split()[-1]]
+                        break
+                    line = fh.readline()
+                else:
+                    self.module.fail_json(msg="Failed to determine firmware version. File [%s]. Array [%s]." % (self.firmware, self.ssid))
+        return self.firmware_version_cache
+
+    @property
+    def nvsram_version(self):
+        """Retrieve NVSRAM version. Return: byte string"""
+        if self.nvsram_version_cache is None:
+
+            with open(self.nvsram, "rb") as fh:
+                line = fh.readline()
+                while line:
+                    if b".NVSRAM Configuration Number" in line:
+                        self.nvsram_version_cache = line.split(b'"')[-2]
+                        break
+                    line = fh.readline()
+                else:
+                    self.module.fail_json(msg="Failed to determine NVSRAM file version. File [%s]. Array [%s]." % (self.nvsram, self.ssid))
+        return self.nvsram_version_cache
+
+    def check_system_health(self):
+        """Ensure E-Series storage system is healthy. Works for both embedded and proxy web services."""
+        try:
+            rc, request_id = self.request("health-check", method="POST", data={"onlineOnly": True, "storageDeviceIds": [self.ssid]})
+
+            while True:
+                sleep(1)
+
+                try:
+                    rc, response = self.request("health-check?requestId=%s" % request_id["requestId"])
+
+                    if not response["healthCheckRunning"]:
+                        return response["results"][0]["successful"]
+                    elif int(response["results"][0]["processingTimeMS"]) > self.HEALTH_CHECK_TIMEOUT_MS:
+                        self.module.fail_json(msg="Health check failed to complete. Array Id [%s]." % self.ssid)
+
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve health check status. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+        except Exception as error:
+            self.module.fail_json(msg="Failed to initiate health check. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+
+        self.module.fail_json(msg="Failed to retrieve health check status. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+
+    def embedded_check_compatibility(self):
+        """Verify files are compatible with E-Series storage system."""
+        self.embedded_check_nvsram_compatibility()
+        self.embedded_check_bundle_compatibility()
+
+    def embedded_check_nvsram_compatibility(self):
+        """Verify the provided NVSRAM is compatible with E-Series storage system."""
+
+        # Check nvsram compatibility
+        try:
+            files = [("nvsramimage", self.nvsram_name, self.nvsram)]
+            headers, data = create_multipart_formdata(files=files)
+
+            rc, nvsram_compatible = self.request("firmware/embedded-firmware/%s/nvsram-compatibility-check" % self.ssid,
+                                                 method="POST", data=data, headers=headers)
+
+            if not nvsram_compatible["signatureTestingPassed"]:
+                self.module.fail_json(msg="Invalid NVSRAM file. File [%s]." % self.nvsram)
+            if not nvsram_compatible["fileCompatible"]:
+                self.module.fail_json(msg="Incompatible NVSRAM file. File [%s]." % self.nvsram)
+
+            # Determine whether nvsram is required
+            for module in nvsram_compatible["versionContents"]:
+                if module["bundledVersion"] != module["onboardVersion"]:
+                    self.upgrade_required = True
+
+                # Update bundle info
+                self.module_info.update({module["module"]: {"onboard_version": module["onboardVersion"], "bundled_version": module["bundledVersion"]}})
+
+        except Exception as error:
+            self.module.fail_json(msg="Failed to retrieve NVSRAM compatibility results. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+
+    def embedded_check_bundle_compatibility(self):
+        """Verify the provided firmware bundle is compatible with E-Series storage system."""
+        try:
+            files = [("files[]", "blob", self.firmware)]
+            headers, data = create_multipart_formdata(files=files, send_8kb=True)
+            rc, bundle_compatible = self.request("firmware/embedded-firmware/%s/bundle-compatibility-check" % self.ssid,
+                                                 method="POST", data=data, headers=headers)
+
+            # Determine whether valid and compatible firmware
+            if not bundle_compatible["signatureTestingPassed"]:
+                self.module.fail_json(msg="Invalid firmware bundle file. File [%s]." % self.firmware)
+            if not bundle_compatible["fileCompatible"]:
+                self.module.fail_json(msg="Incompatible firmware bundle file. File [%s]." % self.firmware)
+
+            # Determine whether upgrade is required
+            for module in bundle_compatible["versionContents"]:
+
+                bundle_module_version = module["bundledVersion"].split(".")
+                onboard_module_version = module["onboardVersion"].split(".")
+                version_minimum_length = min(len(bundle_module_version), len(onboard_module_version))
+                if bundle_module_version[:version_minimum_length] != onboard_module_version[:version_minimum_length]:
+                    self.upgrade_required = True
+
+                    # Check whether downgrade is being attempted
+                    bundle_version = module["bundledVersion"].split(".")[:2]
+                    onboard_version = module["onboardVersion"].split(".")[:2]
+                    if bundle_version[0] < onboard_version[0] or (bundle_version[0] == onboard_version[0] and bundle_version[1] < onboard_version[1]):
+                        self.module.fail_json(msg="Downgrades are not permitted. onboard [%s] > bundled[%s]."
+                                                  % (module["onboardVersion"], module["bundledVersion"]))
+
+                # Update bundle info
+                self.module_info.update({module["module"]: {"onboard_version": module["onboardVersion"], "bundled_version": module["bundledVersion"]}})
+
+        except Exception as error:
+            self.module.fail_json(msg="Failed to retrieve bundle compatibility results. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+
+    def embedded_wait_for_controller_reboot(self):
+        """Wait for SANtricity Web Services Embedded to be available after reboot."""
+        sleep(60)  # wait for controller to reboot
+        about_url = self.url + self.DEFAULT_REST_API_ABOUT_PATH
+        for count in range(0, int((self.REBOOT_TIMEOUT_SEC - 60) / 5)):
+            sleep(5)
+            try:
+                rc, data = request(about_url, timeout=self.DEFAULT_TIMEOUT, headers=self.DEFAULT_HEADERS, ignore_errors=True, **self.creds)
+                if rc == 200:
+                    self.upgrade_in_progress = False
+                    break
+            except Exception as error:
+                pass
+        else:
+            self.module.fail_json(msg="Timeout waiting for Santricity Web Services Embedded. Array [%s]" % self.ssid)
+
+    def embedded_upgrade(self):
+        """Upload and activate both firmware and NVSRAM."""
+        files = [("nvsramfile", self.nvsram_name, self.nvsram),
+                 ("dlpfile", self.firmware_name, self.firmware)]
+        headers, data = create_multipart_formdata(files=files)
+        try:
+            rc, response = self.request("firmware/embedded-firmware?staged=false&nvsram=true", method="POST", data=data, headers=headers)
+            self.upgrade_in_progress = True
+        except Exception as error:
+            self.module.fail_json(msg="Failed to upload and activate firmware. Array Id [%s]. Error[%s]." % (self.ssid, to_native(error)))
+
+        if self.wait_for_completion:
+            self.embedded_wait_for_controller_reboot()
+
+    def proxy_check_nvsram_compatibility(self):
+        """Verify nvsram is compatible with E-Series storage system."""
+        data = {"storageDeviceIds": [self.ssid]}
+        try:
+            rc, check = self.request("firmware/compatibility-check", method="POST", data=data)
+
+            for count in range(0, int((self.FIRMWARE_COMPATIBILITY_CHECK_TIMEOUT_SEC / 5 - 60))):
+                sleep(5)
+                try:
+                    rc, response = self.request("firmware/compatibility-check?requestId=%s" % check["requestId"])
+
+                    if not response["checkRunning"]:
+                        for result in response["results"]["nvsramFiles"]:
+                            if result["filename"] == self.nvsram_name:
+                                break
+                        else:
+                            self.module.fail_json(msg="NVSRAM is not compatible. NVSRAM [%s]. Array [%s]." % (self.nvsram_name, self.ssid))
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve status update from proxy. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+        except Exception as error:
+            self.module.fail_json(msg="Failed to receive NVSRAM compatibility information. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+    def proxy_check_firmware_compatibility(self):
+        """Verify firmware is compatible with E-Series storage system."""
+        data = {"storageDeviceIds": [self.ssid]}
+        try:
+            rc, check = self.request("firmware/compatibility-check", method="POST", data=data)
+
+            for count in range(0, int((self.FIRMWARE_COMPATIBILITY_CHECK_TIMEOUT_SEC / 5 - 60))):
+                sleep(5)
+                try:
+                    rc, response = self.request("firmware/compatibility-check?requestId=%s" % check["requestId"])
+                    if not response["checkRunning"]:
+                        for result in response["results"]["cfwFiles"]:
+                            if result["filename"] == self.firmware_name:
+                                break
+                        else:
+                            self.module.fail_json(msg="Firmware bundle is not compatible. firmware [%s]. Array [%s]." % (self.firmware_name, self.ssid))
+
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve status update from proxy. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+        except Exception as error:
+            self.module.fail_json(msg="Failed to receive firmware compatibility information. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+    def proxy_upload_and_check_compatibility(self):
+        """Ensure firmware is uploaded and verify compatibility."""
+        try:
+            rc, response = self.request("firmware/cfw-files")
+            for file in response:
+                if file["filename"] == self.nvsram_name:
+                    break
+            else:
+                fields = [("validate", "true")]
+                files = [("firmwareFile", self.nvsram_name, self.nvsram)]
+                headers, data = create_multipart_formdata(files=files, fields=fields)
+                try:
+                    rc, response = self.request("firmware/upload", method="POST", data=data, headers=headers)
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to upload NVSRAM file. File [%s]. Array [%s]. Error [%s]."
+                                              % (self.nvsram_name, self.ssid, to_native(error)))
+
+            self.proxy_check_nvsram_compatibility()
+
+            for file in response:
+                if file["filename"] == self.firmware_name:
+                    break
+            else:
+                fields = [("validate", "true")]
+                files = [("firmwareFile", self.firmware_name, self.firmware)]
+                headers, data = create_multipart_formdata(files=files, fields=fields)
+                try:
+                    rc, response = self.request("firmware/upload", method="POST", data=data, headers=headers)
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to upload firmware bundle file. File [%s]. Array [%s]. Error [%s]."
+                                              % (self.firmware_name, self.ssid, to_native(error)))
+
+                self.proxy_check_firmware_compatibility()
+        except Exception as error:
+            self.module.fail_json(msg="Failed to retrieve existing existing firmware files. Error [%s]" % to_native(error))
+
+    def proxy_check_upgrade_required(self):
+        """Staging is required to collect firmware information from the web services proxy."""
+        # Verify controller consistency and get firmware versions
+        try:
+            # Retrieve current bundle version
+            if self.is_firmware_bundled():
+                rc, response = self.request("storage-systems/%s/graph/xpath-filter?query=/controller/codeVersions[codeModule='bundleDisplay']" % self.ssid)
+                current_firmware_version = six.b(response[0]["versionString"])
+            else:
+                rc, response = self.request("storage-systems/%s/graph/xpath-filter?query=/sa/saData/fwVersion" % self.ssid)
+                current_firmware_version = six.b(response[0])
+
+            # Determine whether upgrade is required
+            if current_firmware_version != self.firmware_version:
+
+                current = current_firmware_version.split(b".")[:2]
+                upgrade = self.firmware_version.split(b".")[:2]
+                if current[0] < upgrade[0] or (current[0] == upgrade[0] and current[1] <= upgrade[1]):
+                    self.upgrade_required = True
+                else:
+                    self.module.fail_json(msg="Downgrades are not permitted. Firmware [%s]. Array [%s]." % (self.firmware, self.ssid))
+        except Exception as error:
+            self.module.fail_json(msg="Failed to retrieve controller firmware information. Array [%s]. Error [%s]" % (self.ssid, to_native(error)))
+
+        # Determine current NVSRAM version and whether change is required
+        try:
+            rc, response = self.request("storage-systems/%s/graph/xpath-filter?query=/sa/saData/nvsramVersion" % self.ssid)
+            if six.b(response[0]) != self.nvsram_version:
+                self.upgrade_required = True
+
+        except Exception as error:
+            self.module.fail_json(msg="Failed to retrieve storage system's NVSRAM version. Array [%s]. Error [%s]" % (self.ssid, to_native(error)))
+
+    def proxy_wait_for_upgrade(self, request_id):
+        """Wait for SANtricity Web Services Proxy to report upgrade complete"""
+        if self.is_firmware_bundled():
+            while True:
+                try:
+                    sleep(5)
+                    rc, response = self.request("batch/cfw-upgrade/%s" % request_id)
+
+                    if response["status"] == "complete":
+                        self.upgrade_in_progress = False
+                        break
+                    elif response["status"] in ["failed", "cancelled"]:
+                        self.module.fail_json(msg="Firmware upgrade failed to complete. Array [%s]." % self.ssid)
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve firmware upgrade status. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+        else:
+            while True:
+                try:
+                    sleep(5)
+                    rc, response = self.request("batch/cfw-upgrade/%s" % request_id)
+
+                    if response["status"] == "complete":
+                        self.upgrade_in_progress = False
+                        break
+                    elif response["status"] in ["failed", "cancelled"]:
+                        self.module.fail_json(msg="Firmware upgrade failed to complete. Array [%s]." % self.ssid)
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve firmware upgrade status. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+    def proxy_upgrade(self):
+        """Activate previously uploaded firmware related files."""
+        request_id = None
+        if self.is_firmware_bundled:
+            data = {"activate": True,
+                    "firmwareFile": self.firmware_name,
+                    "nvsramFile": self.nvsram_name,
+                    "systemInfos": [{"systemId": self.ssid,
+                                     "allowNonOptimalActivation": self.ignore_health_check}]}
+            try:
+                rc, response = self.request("batch/cfw-upgrade", method="POST", data=data)
+                request_id = response["requestId"]
+            except Exception as error:
+                self.module.fail_json(msg="Failed to initiate firmware upgrade. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+        else:
+            data = {"stageFirmware": False,
+                    "skipMelCheck": self.ignore_health_check,
+                    "cfwFile": self.firmware_name,
+                    "nvsramFile": self.nvsram_name}
+            try:
+                rc, response = self.request("batch/cfw-upgrade", method="POST", data=data)
+                request_id = response["requestId"]
+            except Exception as error:
+                self.module.fail_json(msg="Failed to initiate firmware upgrade. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+        self.upgrade_in_progress = True
+        if self.wait_for_completion:
+            self.proxy_wait_for_upgrade(request_id)
+
+    def apply(self):
+        """Upgrade controller firmware."""
+        self.check_system_health()
+
+        # Verify firmware compatibility and whether changes are required
+        if self.is_embedded():
+            self.embedded_check_compatibility()
+        else:
+            self.proxy_check_upgrade_required()
+
+            # This will upload the firmware files to the web services proxy but not to the controller
+            if self.upgrade_required:
+                self.proxy_upload_and_check_compatibility()
+
+        # Perform upgrade
+        if self.upgrade_required and not self.module.check_mode:
+            if self.is_embedded():
+                self.embedded_upgrade()
+            else:
+                self.proxy_upgrade()
+
+        self.module.exit_json(changed=self.upgrade_required, upgrade_in_process=self.upgrade_in_progress, status=self.module_info)
+
+
+def main():
+    firmware = NetAppESeriesFirmware()
+    firmware.apply()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/doc_fragments/netapp.py
+++ b/lib/ansible/plugins/doc_fragments/netapp.py
@@ -163,14 +163,17 @@ notes:
 options:
   api_username:
     required: true
+    type: str
     description:
     - The username to authenticate with the SANtricity Web Services Proxy or Embedded Web Services API.
   api_password:
     required: true
+    type: str
     description:
     - The password to authenticate with the SANtricity Web Services Proxy or Embedded Web Services API.
   api_url:
     required: true
+    type: str
     description:
     - The url to the SANtricity Web Services Proxy or Embedded Web Services API.
       Example https://prod-1.wahoo.acme.com/devmgr/v2
@@ -182,7 +185,8 @@ options:
     type: bool
   ssid:
     required: false
-    default: 1
+    default: "1"
+    type: str
     description:
     - The ID of the array to manage. This value must be unique for each array.
 

--- a/test/integration/targets/netapp_eseries_firmware/aliases
+++ b/test/integration/targets/netapp_eseries_firmware/aliases
@@ -1,0 +1,10 @@
+# This test is not enabled by default, but can be utilized by defining required variables in integration_config.yml
+# Example integration_config.yml:
+# ---
+#netapp_e_api_host: 10.113.1.111:8443
+#netapp_e_api_username: admin
+#netapp_e_api_password: myPass
+#netapp_e_ssid: 1
+
+unsupported
+netapp/eseries

--- a/test/integration/targets/netapp_eseries_firmware/tasks/main.yml
+++ b/test/integration/targets/netapp_eseries_firmware/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: run.yml

--- a/test/integration/targets/netapp_eseries_firmware/tasks/run.yml
+++ b/test/integration/targets/netapp_eseries_firmware/tasks/run.yml
@@ -1,0 +1,72 @@
+# Test code for the netapp_e_iscsi_interface module
+# (c) 2018, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# TODO: MUST BE DOWNGRADE BEFORE EXECUTING INTEGRATION TO RCB_11.40.3R2_280x_5c7d81b3.dlp and N280X-842834-D02.dlp
+#   loadControllerFirmware_MT swartzn@10.113.1.250 /home/swartzn/Downloads/RCB_11.40.3R2_280x_5c7d81b3.dlp /home/swartzn/Downloads/N280X-842834-D02.dlp
+
+# This integration test will validate upgrade functionality for firmware-only, firmware-and-nvsram, and checkmode.
+#   ***NOTE: Legacy system are not tested by this test.
+
+- name: NetApp Test ASUP module
+  fail:
+    msg: 'Please define netapp_e_api_username, netapp_e_api_password, netapp_e_api_host, and netapp_e_ssid.'
+  when:  netapp_e_api_username is undefined or netapp_e_api_password is undefined
+          or netapp_e_api_host is undefined or netapp_e_ssid is undefined
+
+- set_fact:
+    path: "/home/swartzn/Downloads/"
+    upgrades:
+    - firmware: "RCB_11.40.3R2_280x_5c7d81b3.dlp"  # RCB_11.40.5_280x_5ceef00e.dlp
+      nvsram: "N280X-842834-D02.dlp"
+    - firmware: "RCB_11.50.2_280x_5ce8501f.dlp"
+      nvsram: "N280X-852834-D02.dlp"
+
+- name: Perform firmware upgrade using the Web Services REST API (checkmode-change, firmware only)
+  netapp_e_firmware:
+    ssid: "{{ netapp_e_ssid }}"
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+    nvsram: "{{ path }}{{ upgrades[0]['nvsram'] }}"
+    firmware: "{{ path }}{{ upgrades[0]['firmware'] }}"
+    wait_for_completion: true
+    ignore_health_check: true
+  check_mode: true
+
+- name: Perform firmware upgrade using the Web Services REST API (change, firmware only)
+  netapp_e_firmware:
+    ssid: "{{ netapp_e_ssid }}"
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+    nvsram: "{{ path }}{{ upgrades[0]['nvsram'] }}"
+    firmware: "{{ path }}{{ upgrades[0]['firmware'] }}"
+    wait_for_completion: true
+    ignore_health_check: true
+
+- name: Perform firmware upgrade using the Web Services REST API (no change)
+  netapp_e_firmware:
+    ssid: "{{ netapp_e_ssid }}"
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+    nvsram: "{{ path }}{{ upgrades[0]['nvsram'] }}"
+    firmware: "{{ path }}{{ upgrades[0]['firmware'] }}"
+    wait_for_completion: true
+    ignore_health_check: true
+
+- name: Perform firmware upgrade using the Web Services REST API (change, firmware and nvsram)
+  netapp_e_firmware:
+    ssid: "{{ netapp_e_ssid }}"
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+    nvsram: "{{ path }}{{ upgrades[1]['nvsram'] }}"
+    firmware: "{{ path }}{{ upgrades[1]['firmware'] }}"
+    wait_for_completion: true
+    ignore_health_check: true

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -3516,7 +3516,6 @@ lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E324
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E326
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E335
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E337
-lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E338
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E324
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E327
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E337

--- a/test/units/modules/storage/netapp/test_netapp_e_firmware.py
+++ b/test/units/modules/storage/netapp/test_netapp_e_firmware.py
@@ -1,0 +1,127 @@
+# (c) 2018, NetApp Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+__metaclass__ = type
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from ansible.module_utils import six
+from ansible.modules.storage.netapp.netapp_e_firmware import NetAppESeriesFirmware, create_multipart_formdata
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+import re
+
+
+class FirmwareTest(ModuleTestCase):
+    REQUIRED_PARAMS = {"api_username": "username",
+                       "api_password": "password",
+                       "api_url": "http://localhost/devmgr/v2",
+                       "ssid": "1",
+                       "validate_certs": "no"}
+    REQUEST_FUNC = "ansible.modules.storage.netapp.netapp_e_firmware.NetAppESeriesFirmware.request"
+    BUNDLE_HEADER = b'combined_content\x00\x00\x00\x04\x00\x00\x07\xf8#Engenio Downloadable Package\n#Tue Jun 04 11:46:48 CDT 2019\ncheckList=compatibleBoard' \
+                    b'Map,compatibleSubmodelMap,compatibleFirmwareMap,fileManifest\ncompatibleSubmodelMap=261|true,262|true,263|true,264|true,276|true,277|t' \
+                    b'rue,278|true,282|true,300|true,301|true,302|true,318|true,319|true,320|true,321|true,322|true,323|true,324|true,325|true,326|true,328|t' \
+                    b'rue,329|true,330|true,331|true,332|true,333|true,338|true,339|true,340|true,341|true,342|true,343|true,344|true,345|true,346|true,347|t' \
+                    b'rue,356|true,357|true,390|true\nnonDisplayableAttributeList=512\ndisplayableAttributeList=FILENAME|RCB_11.40.5_280x_5ceef00e.dlp,VERSI' \
+                    b'ON|11.40.5\ndacStoreLimit=512\nfileManifest=metadata.tar|metadata|08.42.50.00.000|c04275f98fc2f07bd63126fc57cb0569|bundle|10240,084250' \
+                    b'00_m3_e30_842_root.img|linux|08.42.50.00|367c5216e5c4b15b904a025bff69f039|linux|1342177280,RC_08425000_m3_e30_842_280x.img|linux_cfw|0' \
+                    b'8.42.50.00|e6589b0a50b29ff34b34d3ced8ae3ccb|eos|1073741824,msw.img|sam|11.42.0000.0028|ef3ee5589ab4a019a3e6f83768364aa1|linux|41943040' \
+                    b'0,iom.img|iom|11.42.0G00.0003|9bb740f8d3a4e62a0f2da2ec83c254c4|linux|8177664\nmanagementVersionList=devmgr.v1142api8.Manager\ncompatib' \
+                    b'leFirmwareMap=08.30.*.*|true,08.30.*.30|false,08.30.*.31|false,08.30.*.32|false,08.30.*.33|false,08.30.*.34|false,08.30.*.35|false,08.' \
+                    b'30.*.36|false,08.30.*.37|false,08.30.*.38|false,08.30.*.39|false,08.40.*.*|true,08.40.*.30|false,08.40.*.31|false,08.40.*.32|false,08.4' \
+                    b'0.*.33|false,08.40.*.34|false,08.40.*.35|false,08.40.*.36|false,08.40.*.37|false,08.40.*.38|false,08.40.*.39|false,08.41.*.*|true,08.4' \
+                    b'1.*.30|false,08.41.*.31|false,08.41.*.32|false,08.41.*.33|false,08.41.*.34|false,08.41.*.35|false,08.41.*.36|false,08.41.*.37|false,08' \
+                    b'.41.*.38|false,08.41.*.39|false,08.42.*.*|true,08.42.*.30|false,08.42.*.31|false,08.42.*.32|false,08.42.*.33|false,08.42.*.34|false,08' \
+                    b'.42.*.35|false,08.42.*.36|false,08.42.*.37|false,08.42.*.38|false,08.42.*.39|false\nversion=08.42.50.00.000\ntype=tar\nversionTag=comb' \
+                    b'ined_content\n'
+
+    def _set_args(self, args=None):
+        module_args = self.REQUIRED_PARAMS.copy()
+        if args is not None:
+            module_args.update(args)
+        set_module_args(module_args)
+
+    def test_create_multipart_formdata_pass(self):
+        """Verify create_multipart_formdata properly creates request information."""
+        expected_headers = {'Content-Type': 'multipart/form-data; boundary=---------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXX', 'Content-Length': '708'}
+        expected_data = b'-----------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXX\r\nContent-Disposition: form-data; name="field_0_key"\r\n\r\nfield_0_value' \
+                        b'\r\n-----------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXX\r\nContent-Disposition: form-data; name="field_1_key"\r\n\r\nfield_1_v' \
+                        b'alue\r\n-----------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXX\r\nContent-Disposition: form-data; name="test_file_0"; filename="t' \
+                        b'est_file_0.dlp"\r\nContent-Type: application/octet-stream\r\n\r\ntest_file_0.dlp\r\n-----------------------------XXXXXXXXXXXXXXXXXX' \
+                        b'XXXXXXXXX\r\nContent-Disposition: form-data; name="test_file_1"; filename="test_file_1.dlp"\r\nContent-Type: application/octet-stre' \
+                        b'am\r\n\r\ntest_file_1.dlp\r\n-----------------------------XXXXXXXXXXXXXXXXXXXXXXXXXXX--\r\n'
+
+        # create test files and define create_multipart_formdata arguments
+        for index in range(2):
+            with open("test_file_%s.dlp" % index, "w") as fh:
+                fh.write("test_file_%s.dlp" % index)
+        fields = [("field_0_key", "field_0_value"),
+                  ("field_1_key", "field_1_value")]
+        files = [("test_file_0", "test_file_0.dlp", "test_file_0.dlp"),
+                 ("test_file_1", "test_file_1.dlp", "test_file_1.dlp")]
+        headers, data = create_multipart_formdata(files=files, fields=fields)
+
+        # update expected values with randomized boundary value
+        boundary = re.findall("[0-9]{27}", headers["Content-Type"])[0]
+        expected_headers["Content-Type"] = expected_headers["Content-Type"].replace("XXXXXXXXXXXXXXXXXXXXXXXXXXX", boundary)
+        expected_data = expected_data.replace(b"XXXXXXXXXXXXXXXXXXXXXXXXXXX", six.b(boundary))
+
+        self.assertEqual(headers, expected_headers)
+        self.assertEqual(data, expected_data)
+
+    def test_is_firmware_bundled_pass(self):
+        """Determine whether firmware file is bundled."""
+        self._set_args({"firmware": "test.dlp", "nvsram": "test.dlp"})
+        with open("test.dlp", "wb") as fh:
+            fh.write(b"firmwarexxxxxxxxxxxxxxxxxx")
+        firmware = NetAppESeriesFirmware()
+        self.assertEqual(firmware.is_firmware_bundled(), False)
+
+        self._set_args({"firmware": "test.dlp", "nvsram": "test.dlp"})
+        with open("test.dlp", "wb") as fh:
+            fh.write(self.BUNDLE_HEADER)
+        firmware = NetAppESeriesFirmware()
+        self.assertEqual(firmware.is_firmware_bundled(), True)
+
+    def test_is_firmware_bundles_fail(self):
+        """Verify non-firmware fails."""
+        self._set_args({"firmware": "test.dlp", "nvsram": "test.dlp"})
+        with open("test.dlp", "wb") as fh:
+            fh.write(b"xxxxxxxxxxxxxxxxxxxxxxxxxx")
+        firmware = NetAppESeriesFirmware()
+        with self.assertRaisesRegexp(AnsibleFailJson, "Firmware file is invalid."):
+            firmware.is_firmware_bundled()
+
+    def test_check_system_health_pass(self):
+        """Validate check_system_health method."""
+        self._set_args({"firmware": "test.dlp", "nvsram": "test.dlp"})
+        firmware = NetAppESeriesFirmware()
+        with mock.patch(self.REQUEST_FUNC, side_effect=[(200, {"requestId": "1"}),
+                                                        (200, {"healthCheckRunning": True,
+                                                               "results": [{"processingTimeMS": 0}]}),
+                                                        (200, {"healthCheckRunning": False,
+                                                               "results": [{"successful": True}]})]):
+            firmware.check_system_health()
+
+    def test_check_system_health_fail(self):
+        """Validate check_system_health method throws proper exceptions."""
+        self._set_args({"firmware": "test.dlp", "nvsram": "test.dlp"})
+        firmware = NetAppESeriesFirmware()
+        with mock.patch("time.sleep", return_value=None):
+            with self.assertRaisesRegexp(AnsibleFailJson, "Failed to initiate health check."):
+                with mock.patch(self.REQUEST_FUNC, return_value=(404, Exception())):
+                    firmware.check_system_health()
+
+            with self.assertRaisesRegexp(AnsibleFailJson, "Failed to retrieve health check status."):
+                with mock.patch(self.REQUEST_FUNC, side_effect=[(200, {"requestId": "1"}),
+                                                                (404, Exception())]):
+                    firmware.check_system_health()
+
+            with self.assertRaisesRegexp(AnsibleFailJson, "Health check failed to complete."):
+                with mock.patch(self.REQUEST_FUNC, side_effect=[(200, {"requestId": "1"}),
+                                                                (200, {"healthCheckRunning": True,
+                                                                       "results": [{"processingTimeMS": 120001}]})]):
+                    firmware.check_system_health()


### PR DESCRIPTION
##### SUMMARY
Module performs controller firmware downloads on NetApp E-Series storage systems.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_firmware

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.8.0.post0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
```
