### PR TITLE
openssh_keypair - Add key comment to return value

### DIFF
--- a/changelogs/fragments/59268-openssh_keypair-add-key-comment-to-return-value.yml
+++ b/changelogs/fragments/59268-openssh_keypair-add-key-comment-to-return-value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - openssh_keypair - add key ``comment`` to return value

--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -113,6 +113,11 @@ public_key:
     returned: changed or success
     type: str
     sample: ssh-rsa AAAAB3Nza(...omitted...)veL4E3Xcw== test_key
+comment:
+    description: The comment of the generated key
+    returned: changed or success
+    type: str
+    sample: test@comment
 '''
 
 import os
@@ -313,6 +318,7 @@ class Keypair(object):
             # On removal this has no value
             'fingerprint': self.fingerprint[1] if self.fingerprint else '',
             'public_key': self.public_key,
+            'comment': self.comment if self.comment else '',
         }
 
         return result

--- a/test/integration/targets/openssh_keypair/tests/validate.yml
+++ b/test/integration/targets/openssh_keypair/tests/validate.yml
@@ -97,3 +97,13 @@
   assert:
     that:
       - privatekey7_result.public_key == privatekey7_modified_result.public_key
+
+- name: Validate privatekey7 comment on creation
+  assert:
+    that:
+      - privatekey7_result.comment == 'test@privatekey7'
+
+- name: Validate privatekey7 comment update
+  assert:
+    that:
+      - privatekey7_modified_result.comment == 'test_modified@privatekey7'


### PR DESCRIPTION
##### SUMMARY
If the comment will be provided during the key creation, it will be
displayed in the return values.
Same will be on the comment change.

"Fixes #57991"

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openssh_keypair

##### ADDITIONAL INFORMATION
Depens on #57993