### PR TITLE
[stable-2.8] Correct places where match was intended

### DIFF
--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -69,8 +69,10 @@ def test_invalid_template_json(placeboify):
         'TemplateBody': bad_json_tpl,
     }
     m = FakeModule(disable_rollback=False)
-    with pytest.raises(Exception, message='Malformed JSON should cause the test to fail') as exc_info:
+    with pytest.raises(Exception) as exc_info:
         cfn_module.create_stack(m, params, connection, default_events_limit)
+        pytest.fail('Expected malformed JSON to have caused the call to fail')
+
     assert exc_info.match('FAIL')
     assert "ValidationError" in m.exit_kwargs['msg']
 
@@ -122,13 +124,15 @@ def test_get_nonexistent_stack(placeboify):
 
 def test_missing_template_body():
     m = FakeModule()
-    with pytest.raises(Exception, message='Expected module to fail with no template') as exc_info:
+    with pytest.raises(Exception) as exc_info:
         cfn_module.create_stack(
             module=m,
             stack_params={},
             cfn=None,
             events_limit=default_events_limit
         )
+        pytest.fail('Expected module to have failed with no template')
+
     assert exc_info.match('FAIL')
     assert not m.exit_args
     assert "Either 'template', 'template_body' or 'template_url' is required when the stack does not exist." == m.exit_kwargs['msg']

--- a/test/units/parsing/test_metadata.py
+++ b/test/units/parsing/test_metadata.py
@@ -214,12 +214,12 @@ def test_string_metadata(code, expected):
 
 
 def test_required_params():
-    with pytest.raises(TypeError, message='One of module_ast or module_data must be given'):
+    with pytest.raises(TypeError, match='One of module_ast or module_data must be given'):
         assert md.extract_metadata()
 
 
 def test_module_data_param_given_with_offset():
-    with pytest.raises(TypeError, message='If offsets is True then module_data must also be given'):
+    with pytest.raises(TypeError, match='If offsets is True then module_data must also be given'):
         assert md.extract_metadata(module_ast='something', offsets=True)
 
 
@@ -227,13 +227,13 @@ def test_invalid_dict_metadata():
     with pytest.raises(SyntaxError):
         assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1",\n' + REGULAR_IMPORTS)
 
-    with pytest.raises(md.ParseError, message='Unable to find the end of dictionary'):
+    with pytest.raises(md.ParseError, match='Unable to find the end of dictionary'):
         assert md.extract_metadata(module_ast=ast.parse(LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1"}\n' + REGULAR_IMPORTS),
                                    module_data=LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1",\n' + REGULAR_IMPORTS,
                                    offsets=True)
 
 
 def test_multiple_statements_limitation():
-    with pytest.raises(md.ParseError, message='Multiple statements per line confuses the module metadata parser.'):
+    with pytest.raises(md.ParseError, match='Multiple statements per line confuses the module metadata parser.'):
         assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1"}; a=b\n' + REGULAR_IMPORTS,
                                    offsets=True)

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -78,9 +78,10 @@ class TestMax:
 
 class TestLogarithm:
     def test_log_non_number(self):
-        with pytest.raises(AnsibleFilterError, message='log() can only be used on numbers: a float is required'):
+        # Message changed in python3.6
+        with pytest.raises(AnsibleFilterError, match='log\\(\\) can only be used on numbers: (a float is required|must be real number, not str)'):
             ms.logarithm('a')
-        with pytest.raises(AnsibleFilterError, message='log() can only be used on numbers: a float is required'):
+        with pytest.raises(AnsibleFilterError, match='log\\(\\) can only be used on numbers: (a float is required|must be real number, not str)'):
             ms.logarithm(10, base='a')
 
     def test_log_ten(self):
@@ -96,10 +97,11 @@ class TestLogarithm:
 
 class TestPower:
     def test_power_non_number(self):
-        with pytest.raises(AnsibleFilterError, message='pow() can only be used on numbers: a float is required'):
+        # Message changed in python3.6
+        with pytest.raises(AnsibleFilterError, match='pow\\(\\) can only be used on numbers: (a float is required|must be real number, not str)'):
             ms.power('a', 10)
 
-        with pytest.raises(AnsibleFilterError, message='pow() can only be used on numbers: a float is required'):
+        with pytest.raises(AnsibleFilterError, match='pow\\(\\) can only be used on numbers: (a float is required|must be real number, not str)'):
             ms.power(10, 'a')
 
     def test_power_squared(self):
@@ -111,10 +113,14 @@ class TestPower:
 
 class TestInversePower:
     def test_root_non_number(self):
-        with pytest.raises(AnsibleFilterError, message='root() can only be used on numbers: a float is required'):
+        # Messages differed in python-2.6, python-2.7-3.5, and python-3.6+
+        with pytest.raises(AnsibleFilterError, match="root\\(\\) can only be used on numbers:"
+                           " (invalid literal for float\\(\\): a"
+                           "|could not convert string to float: a"
+                           "|could not convert string to float: 'a')"):
             ms.inversepower(10, 'a')
 
-        with pytest.raises(AnsibleFilterError, message='root() can only be used on numbers: a float is required'):
+        with pytest.raises(AnsibleFilterError, match="root\\(\\) can only be used on numbers: (a float is required|must be real number, not str)"):
             ms.inversepower('a', 10)
 
     def test_square_root(self):


### PR DESCRIPTION
pytest.raises has two parameters, message and match.  message is meant
to be the error message that pytest gives when the tested code does not
raise the expected exception.  match is the string that pytest expects
to be a match for the repr of the exception.  Unfortunately, it seems
that message is often mistakenly used where match is meant.  Fix those
cases.

message is also deprecated so removed our usage of it.  Perhaps we
should write a sanity test later that prevents the use of
pytest.raises(message) to avoid this mistake.

seealso: https://docs.pytest.org/en/4.6-maintenance/deprecations.html#message-parameter-of-pytest-raises

Also update the exception message tested for as we're now properly
detecting that the messages have changed..
(cherry picked from commit 87601969a3a9d9c793d3af6574aef0e8c15932c6)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
