### PR TITLE
gcp_compute_address_facts: state wasn't a valid value

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_address_facts.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_address_facts.py
@@ -62,7 +62,6 @@ EXAMPLES = '''
     project: test_project
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
-    state: facts
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
State isn't a valid value for the module

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
This will fix the issue regarding usage from the example. 

Example results in:
`failed: [localhost] => {"changed": false, "msg": "Unsupported parameters for (gcp_compute_address_facts) module: state Supported parameters include: auth_kind, filters, project, region, scopes, service_account_contents, service_account_email, service_account_file"}`


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
gcp_compute_address_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
