### PR TITLE
extract_metadata: use unused DEFAULT_METADATA

### DIFF
--- a/lib/ansible/parsing/metadata.py
+++ b/lib/ansible/parsing/metadata.py
@@ -167,7 +167,7 @@ def extract_metadata(module_ast=None, module_data=None, offsets=False):
         column the metadata starts on, line the metadata ends on, column the
         metadata ends on, and the names the metadata is assigned to.  One of
         the names the metadata is assigned to will be ANSIBLE_METADATA.  If no
-        metadata is found, the tuple will be (None, -1, -1, -1, -1, None).
+        metadata is found, the tuple will be (``DEFAULT_METADATA``, -1, -1, -1, -1, None).
         If ``offsets`` is False then the tuple will consist of
         (metadata, -1, -1, -1, -1, None).
     :raises ansible.parsing.metadata.ParseError: if ``module_data`` does not parse
@@ -241,5 +241,8 @@ def extract_metadata(module_ast=None, module_data=None, offsets=False):
         if metadata is not None:
             # Once we've found the metadata we're done
             break
+
+    if not metadata:
+        metadata = DEFAULT_METADATA
 
     return metadata, start_line, start_col, end_line, end_col, targets

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -65,15 +65,11 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
         # Metadata is per-file and a dict rather than per-plugin/function and yaml
         data['metadata'] = extract_metadata(module_ast=M)[0]
 
-        if data['metadata']:
-            # remove version
-            for x in ('version', 'metadata_version'):
-                if x in data['metadata']:
-                    del data['metadata'][x]
-        else:
-            # Add default metadata
-            data['metadata'] = {'supported_by': 'community',
-                                'status': ['preview']}
+        # Remove version
+        for x in ('version', 'metadata_version'):
+            if x in data['metadata']:
+                del data['metadata'][x]
+
     except Exception:
         if verbose:
             display.error("unable to parse %s" % filename)

--- a/test/units/parsing/test_metadata.py
+++ b/test/units/parsing/test_metadata.py
@@ -240,6 +240,7 @@ def test_multiple_statements_limitation():
         assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1"}; a=b\n' + REGULAR_IMPORTS,
                                    offsets=True)
 
+
 @pytest.mark.parametrize("offsets", [True, False])
 def test_module_data_without_metadata(offsets):
     assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + REGULAR_IMPORTS, offsets=offsets) == DEF_METADATA_RET_TUPLE

--- a/test/units/parsing/test_metadata.py
+++ b/test/units/parsing/test_metadata.py
@@ -26,6 +26,8 @@ import pytest
 
 from ansible.parsing import metadata as md
 
+# Tuple returned when module_ast/module_data kwarg does not contein ANSIBLE_METADATA:
+DEF_METADATA_RET_TUPLE = (md.DEFAULT_METADATA, -1, -1, -1, -1, None)
 
 LICENSE = b"""# some license text boilerplate
 # That we have at the top of files
@@ -237,3 +239,9 @@ def test_multiple_statements_limitation():
     with pytest.raises(md.ParseError, match='Multiple statements per line confuses the module metadata parser.'):
         assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + b'ANSIBLE_METADATA={"metadata_version": "1.1"}; a=b\n' + REGULAR_IMPORTS,
                                    offsets=True)
+
+@pytest.mark.parametrize("offsets", [True, False])
+def test_module_data_without_metadata(offsets):
+    assert md.extract_metadata(module_data=LICENSE + FUTURE_IMPORTS + REGULAR_IMPORTS, offsets=offsets) == DEF_METADATA_RET_TUPLE
+    assert md.extract_metadata(module_ast=ast.parse(LICENSE + FUTURE_IMPORTS + REGULAR_IMPORTS),
+                               module_data=LICENSE + FUTURE_IMPORTS + REGULAR_IMPORTS, offsets=offsets) == DEF_METADATA_RET_TUPLE


### PR DESCRIPTION
##### SUMMARY
extract_metadata: use unused DEFAULT_METADATA
(+ unit tests)

DAFAULT_METADATA was presented before but not used and the comment says
```
 30 # There are currently defaults for all metadata fields so we can add it
 31 # automatically if a file doesn't specify it
 32 DEFAULT_METADATA = {'metadata_version': '1.1', 'status': ['preview'], 'supported_by': 'community'}
```
Using it when module_ast/module_data doesn't contain metadata allows us, at least:
1. implement initially expected behavior
2. remove ANSIBLE_METADATA block from modules where it is default

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Doc Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
```lib/ansible/parsing/metadata.py```

##### ADDITIONAL INFORMATION
extract_metadata is used in two places in the source tree:
```
1. lib/ansible/cli/doc.py
2. lib/ansible/parsing/plugin_docs.py
```
I checked both, fixed one