### PR TITLE
Add exclusive configuration mode support in IOS-XR

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -433,7 +433,7 @@ def check_existing_commit_labels(conn, label):
 
 
 def load_config(module, command_filter, commit=False, replace=False,
-                comment=None, admin=False, running=None, nc_get_filter=None,
+                comment=None, admin=False, exclusive=False, running=None, nc_get_filter=None,
                 label=None):
 
     conn = get_connection(module)
@@ -472,7 +472,8 @@ def load_config(module, command_filter, commit=False, replace=False,
                         ' and rerun task' % label
                     )
 
-            response = conn.edit_config(candidate=command_filter, commit=commit, admin=admin, replace=replace, comment=comment, label=label)
+            response = conn.edit_config(candidate=command_filter, commit=commit, admin=admin,
+                                        exclusive=exclusive, replace=replace, comment=comment, label=label)
             if module._diff:
                 diff = response.get('diff')
 

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -165,6 +165,13 @@ options:
         type: path
     type: dict
     version_added: "2.8"
+  exclusive:
+    description:
+      - Enters into exclusive configuration mode that locks out all users from committing
+        configuration changes until the exclusive session ends.
+    type: bool
+    default: false
+    version_added: "2.9"
 """
 
 EXAMPLES = """
@@ -308,6 +315,7 @@ def run(module, result):
     path = module.params['parents']
     comment = module.params['comment']
     admin = module.params['admin']
+    exclusive = module.params['exclusive']
     check_mode = module.check_mode
     label = module.params['label']
 
@@ -350,7 +358,7 @@ def run(module, result):
         commit = not check_mode
         diff = load_config(
             module, commands, commit=commit,
-            replace=replace_file_path, comment=comment, admin=admin,
+            replace=replace_file_path, comment=comment, admin=admin, exclusive=exclusive,
             label=label
         )
         if diff:
@@ -387,6 +395,7 @@ def main():
         backup_options=dict(type='dict', options=backup_spec),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
         admin=dict(type='bool', default=False),
+        exclusive=dict(type='bool', default=False),
         label=dict()
     )
 

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -73,11 +73,14 @@ class Cliconf(CliconfBase):
 
         return device_info
 
-    def configure(self, admin=False):
+    def configure(self, admin=False, exclusive=False):
         prompt = to_text(self._connection.get_prompt(), errors='surrogate_or_strict').strip()
         if not prompt.endswith(')#'):
             if admin and 'admin-' not in prompt:
                 self.send_command('admin')
+            if exclusive:
+                self.send_command('configure exclusive')
+                return
             self.send_command('configure terminal')
 
     def abort(self, admin=False):
@@ -99,7 +102,7 @@ class Cliconf(CliconfBase):
 
         return self.send_command(cmd)
 
-    def edit_config(self, candidate=None, commit=True, admin=False, replace=None, comment=None, label=None):
+    def edit_config(self, candidate=None, commit=True, admin=False, exclusive=False, replace=None, comment=None, label=None):
         operations = self.get_device_operations()
         self.check_edit_config_capability(operations, candidate, commit, replace, comment)
 
@@ -107,7 +110,7 @@ class Cliconf(CliconfBase):
         results = []
         requests = []
 
-        self.configure(admin=admin)
+        self.configure(admin=admin, exclusive=exclusive)
 
         if replace:
             candidate = 'load {0}'.format(replace)

--- a/test/integration/targets/iosxr_config/tests/cli/comment.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/comment.yaml
@@ -14,6 +14,7 @@
   iosxr_config:
     src: basic/config.j2
     comment: "this is sensible commit message"
+    exclusive: true
   register: result
 
 - assert:
@@ -24,6 +25,7 @@
 - name: check device with config
   iosxr_config:
     src: basic/config.j2
+    exclusive: true
   register: result
 
 - assert:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Closes https://github.com/ansible/ansible/issues/55613
- Adds the ability to enter exclusive configuration mode

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/iosxr.py
module_utils/iosxr.py
iosxr_config.py
