### PR TITLE
snow: Support for env variables

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -69,7 +69,7 @@ Noteworthy module changes
 * `vmware_dvswitch <vmware_dvswitch_module>` accepts `folder` parameter to place dvswitch in user defined folder. This option makes `datacenter` as an optional parameter.
 * `vmware_datastore_cluster <vmware_datastore_cluster_module>` accepts `folder` parameter to place datastore cluster in user defined folder. This option makes `datacenter` as an optional parameter.
 * `mysql_db <mysql_db_module>` returns new `db_list` parameter in addition to `db` parameter. This `db_list` parameter refers to list of database names. `db` parameter will be deprecated in version `2.13`.
-
+* `snow_record <snow_record_module>` and `snow_record_find <snow_record_find_module>` now takes environment variables for `instance`, `username` and `password` parameters. This changes marks these parameters as optional.
 * The ``python_requirements_facts`` module was renamed to :ref:`python_requirements_info <python_requirements_info_module>`.
 * The ``jenkins_job_facts`` module was renamed to :ref:`jenkins_job_info <jenkins_job_info_module>`.
 * The ``intersight_facts`` module was renamed to :ref:`intersight_info <intersight_info_module>`.

--- a/lib/ansible/module_utils/service_now.py
+++ b/lib/ansible/module_utils/service_now.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import traceback
-from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.basic import env_fallback, missing_required_lib
 
 # Pull in pysnow
 HAS_PYSNOW = False
@@ -87,9 +87,9 @@ class ServiceNowClient(object):
     @staticmethod
     def snow_argument_spec():
         return dict(
-            instance=dict(type='str', required=True),
-            username=dict(type='str', required=True),
-            password=dict(type='str', required=True, no_log=True),
+            instance=dict(type='str', required=False, fallback=(env_fallback, ['SN_INSTANCE'])),
+            username=dict(type='str', required=False, fallback=(env_fallback, ['SN_USERNAME'])),
+            password=dict(type='str', required=False, no_log=True, fallback=(env_fallback, ['SN_PASSWORD'])),
             client_id=dict(type='str', no_log=True),
             client_secret=dict(type='str', no_log=True),
         )

--- a/lib/ansible/plugins/doc_fragments/service_now.py
+++ b/lib/ansible/plugins/doc_fragments/service_now.py
@@ -13,19 +13,25 @@ options:
     instance:
       description:
       - The ServiceNow instance name, without the domain, service-now.com.
-      required: true
+      - If the value is not specified in the task, the value of environment variable C(SN_INSTANCE) will be used instead.
+      - Environment variable support added in Ansible 2.9.
+      required: false
       type: str
     username:
       description:
       - Name of user for connection to ServiceNow.
       - Required whether using Basic or OAuth authentication.
-      required: true
+      - If the value is not specified in the task, the value of environment variable C(SN_USERNAME) will be used instead.
+      - Environment variable support added in Ansible 2.9.
+      required: false
       type: str
     password:
       description:
       - Password for username.
       - Required whether using Basic or OAuth authentication.
-      required: true
+      - If the value is not specified in the task, the value of environment variable C(SN_PASSWORD) will be used instead.
+      - Environment variable support added in Ansible 2.9.
+      required: false
       type: str
     client_id:
       description:


### PR DESCRIPTION
##### SUMMARY
snow_record and snow_record_find modules now supports env variables
for `instance`, `password` and `username`.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guide_2.9.rst
lib/ansible/module_utils/service_now.py
lib/ansible/plugins/doc_fragments/service_now.py