### PR TITLE
Change sub_plugin check to completely ignore napalm

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -926,7 +926,7 @@ class TaskExecutor:
 
         option_vars = C.config.get_plugin_vars('connection', connection._load_name)
         plugin = connection._sub_plugin
-        if plugin['type'] != 'external':
+        if plugin.get('type'):
             option_vars.extend(C.config.get_plugin_vars(plugin['type'], plugin['name']))
 
         options = {}

--- a/lib/ansible/plugins/connection/napalm.py
+++ b/lib/ansible/plugins/connection/napalm.py
@@ -183,7 +183,7 @@ class Connection(NetworkConnectionBase):
 
             self.napalm.open()
 
-            self._sub_plugin = {'type': 'external', 'name': 'napalm', 'obj': self.napalm}
+            self._sub_plugin = {'name': 'napalm', 'obj': self.napalm}
             self.queue_message('vvvv', 'created napalm device for network_os %s' % self._network_os)
             self._connected = True
 


### PR DESCRIPTION
This also fixes cases where sub_plugin might not be loaded in executor

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Hopefully unmasks the real problem in #58985.
`type: external` isn't any more useful than not having it at all, and adds weirdness that I'd rather avoid.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task_executor