### PR TITLE
[stable-2.8] Handle situation where ansible_architecure may not be defined when gathering facts (#55466)

### DIFF
--- a/changelogs/fragments/facts-linux-cpu-arm-architecture.yml
+++ b/changelogs/fragments/facts-linux-cpu-arm-architecture.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - handle situation where ``ansible_architecture`` may not be defined (https://github.com/ansible/ansible/issues/55400)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -240,7 +240,7 @@ class LinuxHardware(Hardware):
         # The fields for ARM CPUs do not always include 'vendor_id' or 'model name',
         # and sometimes includes both 'processor' and 'Processor'.
         # Always use 'processor' count for ARM systems
-        if collected_facts.get('ansible_architecture').startswith(('armv', 'aarch')):
+        if collected_facts.get('ansible_architecture', '').startswith(('armv', 'aarch')):
             i = processor_occurence
 
         # FIXME

--- a/test/units/module_utils/facts/hardware/test_linux_get_cpu_info.py
+++ b/test/units/module_utils/facts/hardware/test_linux_get_cpu_info.py
@@ -20,3 +20,19 @@ def test_get_cpu_info(mocker):
         mocker.patch('ansible.module_utils.facts.hardware.linux.get_file_lines', side_effect=[[], test['cpuinfo']])
         collected_facts = {'ansible_architecture': test['architecture']}
         assert test['expected_result'] == inst.get_cpu_facts(collected_facts=collected_facts)
+
+
+def test_get_cpu_info_missing_arch(mocker):
+    module = mocker.Mock()
+    inst = linux.LinuxHardware(module)
+
+    # ARM will report incorrect processor count if architecture is not available
+    mocker.patch('os.path.exists', return_value=False)
+    mocker.patch('os.access', return_value=True)
+    for test in CPU_INFO_TEST_SCENARIOS:
+        mocker.patch('ansible.module_utils.facts.hardware.linux.get_file_lines', side_effect=[[], test['cpuinfo']])
+        test_result = inst.get_cpu_facts()
+        if test['architecture'].startswith(('armv', 'aarch')):
+            assert test['expected_result'] != test_result
+        else:
+            assert test['expected_result'] == test_result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #55466 for Ansible 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/hardware/linux.py`