### PR TITLE
disable s3_lifecycle tests

### DIFF
--- a/test/integration/targets/s3_lifecycle/aliases
+++ b/test/integration/targets/s3_lifecycle/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group1
+disabled


### PR DESCRIPTION
##### SUMMARY
Opened #59310 to track the problem

I can't get these to pass in https://github.com/ansible/ansible/pull/59302 to mark them as unstable, and @samdoran brought it to my attention that they were failing on the stable branches too and the fix needs to be backported.

I've disabled this because I don't see built-in waiters to check that the bucket policy has been updated, so it probably needs some custom logic which may not be good to backport to 2.6.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_lifecycle tests
