### PR TITLE
[2.7] disable s3_lifecycle tests (#59311)

### DIFF
--- a/test/integration/targets/s3_lifecycle/aliases
+++ b/test/integration/targets/s3_lifecycle/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 shippable/aws/group1
+disabled


### PR DESCRIPTION
##### SUMMARY
More details: #59310
Affects 2.6+

backport #59311
(cherry picked from commit 1d3f2c77642bcd4f0cef761bad7e30ebf9d33906)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_lifecycle tests
