### PR TITLE
pids: Search for process name matches in the cmdline

### DIFF
--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -62,8 +62,8 @@ def get_pid(name):
     pids = []
     
     for proc in psutil.process_iter(attrs=['name', 'cmdline']):
-        if compare_lower(proc.info['name'], pgname) or \
-                proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], pgname):
+        if compare_lower(proc.info['name'], name) or \
+                proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], name):
             pids.append(proc.pid)
 
     return pids

--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -60,10 +60,12 @@ def compare_lower(a, b):
 
 def get_pid(name):
     pids = []
+    
     for proc in psutil.process_iter(attrs=['name', 'cmdline']):
         if compare_lower(proc.info['name'], pgname) or \
                 proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], pgname):
-            pids.append(str(proc.pid))
+            pids.append(proc.pid)
+
     return pids
 
 def main():

--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -50,23 +50,26 @@ try:
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
-    
+
+
 def compare_lower(a, b):
     if a is None or b is None:
         # this could just be "return False" but would lead to surprising behavior if both a and b are None
         return a == b
-    
+
     return a.lower() == b.lower()
+
 
 def get_pid(name):
     pids = []
-    
+
     for proc in psutil.process_iter(attrs=['name', 'cmdline']):
         if compare_lower(proc.info['name'], name) or \
                 proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], name):
             pids.append(proc.pid)
 
     return pids
+
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/system/pids.py
+++ b/lib/ansible/modules/system/pids.py
@@ -50,11 +50,21 @@ try:
     HAS_PSUTIL = True
 except ImportError:
     HAS_PSUTIL = False
-
+    
+def compare_lower(a, b):
+    if a is None or b is None:
+        # this could just be "return False" but would lead to surprising behavior if both a and b are None
+        return a == b
+    
+    return a.lower() == b.lower()
 
 def get_pid(name):
-    return [p.info['pid'] for p in psutil.process_iter(attrs=['pid', 'name']) if p.info and p.info.get('name', None) and p.info['name'].lower() == name.lower()]
-
+    pids = []
+    for proc in psutil.process_iter(attrs=['name', 'cmdline']):
+        if compare_lower(proc.info['name'], pgname) or \
+                proc.info['cmdline'] and compare_lower(proc.info['cmdline'][0], pgname):
+            pids.append(str(proc.pid))
+    return pids
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
This more appropriately matches the behavior of `pidof` and allows the `pids` module to work with processes invoked with `exec -a SOMENAME`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pids

##### ADDITIONAL INFORMATION
`pidof` behavior:

```shell
$ (exec -a PIDOF-TEST sleep 100) &
[1] 373
$ pidof PIDOF-TEST
373
```

`pids` module behavior prior to this change:

```shell
$ cat playbook.yaml
- hosts: localhost
  tasks:
  - name: fire off a test process
    shell: (exec -a ANSIBLE-PIDS-TEST sleep 99999) &
    args:
      executable: /bin/bash

  - name: locate the test process
    pids: name=ANSIBLE-PIDS-TEST
    register: p

  - debug:
      var: p.pids

$ ansible-playbook playbook.yaml
TASK [fire off a test process] ***************************************************************************
changed: [localhost]

TASK [locate the test process] ***************************************************************************
ok: [localhost]

TASK [debug] *********************************************************************************************
ok: [localhost] =>
  p.pids: []
```

`pids` module behavior after this change:

```shell
$ ansible-playbook playbook.yaml
TASK [fire off a test process] ***************************************************************************
changed: [localhost]

TASK [locate the test process] ***************************************************************************
ok: [localhost]

TASK [debug] *********************************************************************************************
ok: [localhost] =>
  p.pids: [420]
```

This code is inspired by [psutil's Python clone of pidof](https://github.com/giampaolo/psutil/blob/master/scripts/pidof.py).

