### PR TITLE
Allow validate_certs: no to skip validation appropriately.  Addresses #52239

### DIFF
--- a/lib/ansible/modules/remote_management/cobbler/cobbler_system.py
+++ b/lib/ansible/modules/remote_management/cobbler/cobbler_system.py
@@ -225,10 +225,10 @@ def main():
     ssl_context = None
     if not validate_certs:
         try:  # Python 2.7.9 and newer
-            ssl_context = ssl.create_unverified_context()
+            ssl_context = ssl._create_unverified_context()
         except AttributeError:  # Legacy Python that doesn't verify HTTPS certificates by default
             ssl._create_default_context = ssl._create_unverified_context
-        else:  # Python 2.7.8 and older
+        except:  # Python 2.7.8 and older
             ssl._create_default_https_context = ssl._create_unverified_https_context
 
     url = '{proto}://{host}:{port}/cobbler_api'.format(**module.params)


### PR DESCRIPTION
Attempt to fix #52239

I believe there were two issues:
Line 228, create_unverified_context, needs an underscore in front - based on https://www.python.org/dev/peps/pep-0476/

Also, line 231, I believe should be 'except' rather than 'else'.  The comment states that this is to accommodate Python 2.7.8 and older, however using 'else' this line is executed when line 228 (for 2.7.9 and newer) succeeds, thus trying to set both rather than one or the other.  

I do not have the capacity to do thorough testing with various ansible & python versions, however this fixed the issue for me running ansible 2.8.0 on python 2.7.13


+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
