### PR TITLE
ce_bfd_session: update & add 2 params.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
@@ -53,6 +53,14 @@ options:
     src_addr:
         description:
             - Indicates the source IP address carried in BFD packets.
+    local_discr:
+	    version_added: 2.9
+        description:
+            - The BFD session local identifier does not need to be configured when the mode is auto.
+    remote_discr:
+	    version_added: 2.9
+        description:
+            - The BFD session remote identifier does not need to be configured when the mode is auto.
     vrf_name:
         description:
             - Specifies the name of a Virtual Private Network (VPN) instance that is bound to a BFD session.
@@ -93,6 +101,8 @@ EXAMPLES = '''
       session_name: bfd_l2link
       use_default_ip: true
       out_if_name: 10GE1/0/1
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 
   - name: Configuring Single-Hop BFD on a VLANIF Interface
@@ -100,12 +110,16 @@ EXAMPLES = '''
       session_name: bfd_vlanif
       dest_addr: 10.1.1.6
       out_if_name: Vlanif100
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 
   - name: Configuring Multi-Hop BFD
     ce_bfd_session:
       session_name: bfd_multi_hop
       dest_addr: 10.1.1.1
+      local_discr: 163
+      remote_discr: 163
       provider: '{{ cli }}'
 '''
 
@@ -172,19 +186,10 @@ from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_co
 CE_NC_GET_BFD = """
     <filter type="subtree">
       <bfd xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-      %s
-      </bfd>
-    </filter>
-"""
-
-CE_NC_GET_BFD_GLB = """
         <bfdSchGlobal>
           <bfdEnable></bfdEnable>
           <defaultIp></defaultIp>
         </bfdSchGlobal>
-"""
-
-CE_NC_GET_BFD_SESSION = """
         <bfdCfgSessions>
           <bfdCfgSession>
             <sessName>%s</sessName>
@@ -192,11 +197,15 @@ CE_NC_GET_BFD_SESSION = """
             <addrType></addrType>
             <outIfName></outIfName>
             <destAddr></destAddr>
+            <localDiscr></localDiscr>
+            <remoteDiscr></remoteDiscr>
             <srcAddr></srcAddr>
             <vrfName></vrfName>
             <useDefaultIp></useDefaultIp>
           </bfdCfgSession>
         </bfdCfgSessions>
+      </bfd>
+    </filter>
 """
 
 
@@ -301,7 +310,8 @@ class BfdSession(object):
         self.vrf_name = self.module.params['vrf_name']
         self.use_default_ip = self.module.params['use_default_ip']
         self.state = self.module.params['state']
-
+        self.local_discr = self.module.params['local_discr']
+        self.remote_discr = self.module.params['remote_discr']
         # host info
         self.host = self.module.params['host']
         self.username = self.module.params['username']
@@ -331,7 +341,7 @@ class BfdSession(object):
         bfd_dict = dict()
         bfd_dict["global"] = dict()
         bfd_dict["session"] = dict()
-        conf_str = CE_NC_GET_BFD % (CE_NC_GET_BFD_GLB + (CE_NC_GET_BFD_SESSION % self.session_name))
+        conf_str = CE_NC_GET_BFD % self.session_name
 
         xml_str = get_nc_config(self.module, conf_str)
         if "<data/>" in xml_str:
@@ -343,13 +353,13 @@ class BfdSession(object):
         root = ElementTree.fromstring(xml_str)
 
         # get bfd global info
-        glb = root.find("data/bfd/bfdSchGlobal")
+        glb = root.find("bfd/bfdSchGlobal")
         if glb:
             for attr in glb:
                 bfd_dict["global"][attr.tag] = attr.text
 
         # get bfd session info
-        sess = root.find("data/bfd/bfdCfgSessions/bfdCfgSession")
+        sess = root.find("bfd/bfdCfgSessions/bfdCfgSession")
         if sess:
             for attr in sess:
                 bfd_dict["session"][attr.tag] = attr.text
@@ -390,6 +400,12 @@ class BfdSession(object):
         if str(self.use_default_ip).lower() != session.get("useDefaultIp"):
             return False
 
+        if self.create_type == "static" and self.state == "present":
+            if str(self.local_discr).lower() != session.get("localDiscr", ""):
+                return False
+            if str(self.remote_discr).lower() != session.get("remoteDiscr", ""):
+                return False
+
         return True
 
     def config_session(self):
@@ -397,6 +413,7 @@ class BfdSession(object):
 
         xml_str = ""
         cmd_list = list()
+        discr = list()
 
         if not self.session_name:
             return xml_str
@@ -415,7 +432,7 @@ class BfdSession(object):
                         msg="Error: dest_addr or use_default_ip must be set when bfd session is creating.")
 
                 # Creates a BFD session
-                if self.create_type:
+                if self.create_type == "auto":
                     xml_str += "<createType>SESS_%s</createType>" % self.create_type.upper()
                 else:
                     xml_str += "<createType>SESS_STATIC</createType>"
@@ -440,8 +457,14 @@ class BfdSession(object):
                 if self.src_addr:
                     xml_str += "<srcAddr>%s</srcAddr>" % self.src_addr
                     cmd_session += " source-%s %s" % ("ipv6" if self.addr_type == "ipv6" else "ip", self.src_addr)
+
                 if self.create_type == "auto":
                     cmd_session += " auto"
+                else:
+                    xml_str += "<localDiscr>%s</localDiscr>" % self.local_discr
+                    discr.append("discriminator local %s" % self.local_discr)
+                    xml_str += "<remoteDiscr>%s</remoteDiscr>" % self.remote_discr
+                    discr.append("discriminator remote %s" % self.remote_discr)
 
             elif not self.is_session_match():
                 # Bfd session is not match
@@ -460,6 +483,7 @@ class BfdSession(object):
                 return ""
             else:
                 cmd_list.insert(0, cmd_session)
+                cmd_list.extend(discr)
                 self.updates_cmd.extend(cmd_list)
                 return '<bfdCfgSessions><bfdCfgSession operation="merge">' + xml_str\
                        + '</bfdCfgSession></bfdCfgSessions>'
@@ -494,6 +518,22 @@ class BfdSession(object):
         if self.session_name:
             if len(self.session_name) < 1 or len(self.session_name) > 15:
                 self.module.fail_json(msg="Error: Session name is invalid.")
+
+        # check local_discr
+        # check remote_discr
+
+        if self.local_discr:
+            if self.local_discr < 1 or self.local_discr > 16384:
+                self.module.fail_json(msg="Error: Session local_discr is not ranges from 1 to 16384.")
+        if self.remote_discr:
+            if self.remote_discr < 1 or self.remote_discr > 4294967295:
+                self.module.fail_json(msg="Error: Session remote_discr is not ranges from 1 to 4294967295.")
+
+        if self.state == "present" and self.create_type == "static":
+            if not self.local_discr:
+                self.module.fail_json(msg="Error: Missing required arguments: local_discr.")
+            if not self.remote_discr:
+                self.module.fail_json(msg="Error: Missing required arguments: remote_discr.")
 
         # check out_if_name
         if self.out_if_name:
@@ -534,6 +574,8 @@ class BfdSession(object):
         self.proposed["vrf_name"] = self.vrf_name
         self.proposed["use_default_ip"] = self.use_default_ip
         self.proposed["state"] = self.state
+        self.proposed["local_discr"] = self.local_discr
+        self.proposed["remote_discr"] = self.remote_discr
 
     def get_existing(self):
         """get existing info"""
@@ -551,6 +593,8 @@ class BfdSession(object):
             return
 
         self.end_state["session"] = bfd_dict.get("session")
+        if self.end_state == self.existing:
+            self.changed = False
 
     def work(self):
         """worker"""
@@ -588,14 +632,16 @@ def main():
 
     argument_spec = dict(
         session_name=dict(required=True, type='str'),
-        create_type=dict(required=False, type='str', choices=['static', 'auto']),
+        create_type=dict(required=False, default='static', type='str', choices=['static', 'auto']),
         addr_type=dict(required=False, type='str', choices=['ipv4']),
         out_if_name=dict(required=False, type='str'),
         dest_addr=dict(required=False, type='str'),
         src_addr=dict(required=False, type='str'),
         vrf_name=dict(required=False, type='str'),
         use_default_ip=dict(required=False, type='bool', default=False),
-        state=dict(required=False, default='present', choices=['present', 'absent'])
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        local_discr=dict(required=False, type='int'),
+        remote_discr=dict(required=False, type='int')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
@@ -54,11 +54,11 @@ options:
         description:
             - Indicates the source IP address carried in BFD packets.
     local_discr:
-	    version_added: 2.9
+        version_added: 2.9
         description:
             - The BFD session local identifier does not need to be configured when the mode is auto.
     remote_discr:
-	    version_added: 2.9
+        version_added: 2.9
         description:
             - The BFD session remote identifier does not need to be configured when the mode is auto.
     vrf_name:

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_session.py
@@ -40,6 +40,7 @@ options:
             - BFD session creation mode, the currently created BFD session
               only supports static or static auto-negotiation mode.
         choices: ['static', 'auto']
+        default: static
     addr_type:
         description:
             - Specifies the peer IP address type.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ce_bfd_session: update & add 2 params.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_bfd_session.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
## Before
```paste below
---
- name: test
  gather_facts: no
  hosts: switch6
  tasks:
  - name: "Step1.1.1 test the correct session_name"  
    ce_bfd_session:
      session_name: bfd_multi_2
      dest_addr: 10.1.1.1
```
##  Error log
````
fatal: [10.190.121.125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "module_stderr": "/tmp/ansible_ce_bfd_session_payload_lPeNb7/__main__.py:347: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.\n  if glb:\nTraceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1561079949.39-143866297285102/AnsiballZ_ce_bfd_session.py\", line 125, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1561079949.39-143866297285102/AnsiballZ_ce_bfd_session.py\", line 117, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1561079949.39-143866297285102/AnsiballZ_ce_bfd_session.py\", line 54, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/__main__.py\", line 607, in <module>\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/__main__.py\", line 603, in main\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/__main__.py\", line 570, in work\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/__main__.py\", line 484, in netconf_load_config\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/ansible_ce_bfd_session_payload.zip/ansible/module_utils/network/cloudengine/ce.py\", line 339, in set_nc_config\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/ansible_ce_bfd_session_payload.zip/ansible/module_utils/network/common/netconf.py\", line 76, in __rpc__\n  File \"/tmp/ansible_ce_bfd_session_payload_lPeNb7/ansible_ce_bfd_session_payload.zip/ansible/module_utils/network/common/netconf.py\", line 105, in parse_rpc_error\nansible.module_utils.connection.ConnectionError: <?xml version=\"1.0\" encoding=\"UTF-8\"?><rpc-error xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n    <error-type>application</error-type>\n    <error-tag>invalid-value</error-tag>\n    <error-severity>error</error-severity>\n    <error-app-tag>31608</error-app-tag>\n    <error-message>The local and remote discriminators must be configured for the current session type.</error-message>\n    <error-info>\n      <bfd xmlns=\"http://www.huawei.com/netconf/vrp\" format-version=\"1.0\" content-version=\"1.0\">\n        <bfdCfgSessions>\n          <bfdCfgSession>\n            <sessName>bfd_multi_2</sessName>\n            <createType>SESS_STATIC</createType>\n            <linkType>IP</linkType>\n            <addrType>IPV4</addrType>\n            <destAddr>10.1.1.1</destAddr>\n          </bfdCfgSession>\n        </bfdCfgSessions>\n      </bfd>\n    </error-info>\n  </rpc-error>\n\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP **************************************************************************************
10.190.121.125             : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

```
## debug
```
localDiscr and  remoteDiscr is required when  createType   is set as SESS_STATIC;
---

- name: test
  gather_facts: no
  hosts: switch6
  tasks:
  - name: "Step1.1.1 test the correct session_name"  
    ce_bfd_session:
      session_name: bfd_multi_2
      dest_addr: 10.11.11.11
      local_discr: 2
      remote_discr: 2
      state: present

```
Test log after modify
```
changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "session": {
            "addrType": "IPV4",
            "createType": "SESS_STATIC",
            "destAddr": "10.11.11.11",
            "localDiscr": "2",
            "outIfName": null,
            "remoteDiscr": "2",
            "sessName": "bfd_multi_2",
            "srcAddr": null,
            "useDefaultIp": "false",
            "vrfName": null
        }
    },
    "existing": {
        "session": {}
    },
    "invocation": {
        "module_args": {
            "addr_type": null,
            "create_type": "static",
            "dest_addr": "10.11.11.11",
            "host": "10.190.121.125",
            "local_discr": 2,
            "out_if_name": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "remote_discr": 2,
            "session_name": "bfd_multi_2",
            "src_addr": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": "cli",
            "use_default_ip": false,
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null,
            "vrf_name": null
        }
    },
    "proposed": {
        "addr_type": null,
        "create_type": "static",
        "dest_addr": "10.11.11.11",
        "local_discr": 2,
        "out_if_name": null,
        "remote_discr": 2,
        "session_name": "bfd_multi_2",
        "src_addr": null,
        "state": "present",
        "use_default_ip": false,
        "vrf_name": null
    },
    "updates": [
        "bfd bfd_multi_2 bind peer-ip 10.11.11.11",
        "discriminator local 2",
        "discriminator remote 2"
    ]
}
```
