### PR TITLE
remove ambiguity: use "my_test" as module name

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -52,7 +52,7 @@ Starting a new module
 To create a new module:
 
 1. Navigate to the correct directory for your new module: ``$ cd lib/ansible/modules/cloud/azure/``
-2. Create your new module file: ``$ touch my_new_test_module.py``
+2. Create your new module file: ``$ touch my_test.py``
 3. Paste the content below into your new module file. It includes the :ref:`required Ansible format and documentation <developing_modules_documenting>` and some example code.
 4. Modify and extend the code to do what you want your new module to do. See the :ref:`programming tips <developing_modules_best_practices>` and :ref:`Python 3 compatibility <developing_python_3>` pages for pointers on writing clean, concise module code.
 
@@ -71,19 +71,19 @@ To create a new module:
 
     DOCUMENTATION = '''
     ---
-    module: my_sample_module
+    module: my_test
 
-    short_description: This is my sample module
+    short_description: This is my test module
 
     version_added: "2.4"
 
     description:
-        - "This is my longer description explaining my sample module"
+        - "This is my longer description explaining my test module"
 
     options:
         name:
             description:
-                - This is the message to send to the sample module
+                - This is the message to send to the test module
             required: true
         new:
             description:
@@ -100,18 +100,18 @@ To create a new module:
     EXAMPLES = '''
     # Pass in a message
     - name: Test with a message
-      my_new_test_module:
+      my_test:
         name: hello world
 
     # pass in a message and have changed true
     - name: Test with a message and changed output
-      my_new_test_module:
+      my_test:
         name: hello world
         new: true
 
     # fail the module
     - name: Test failure of the module
-      my_new_test_module:
+      my_test:
         name: fail me
     '''
 
@@ -121,7 +121,7 @@ To create a new module:
         type: str
         returned: always
     message:
-        description: The output message that the sample module generates
+        description: The output message that the test module generates
         type: str
         returned: always
     '''
@@ -214,7 +214,7 @@ If your module does not need to target a remote host, you can quickly and easily
    development) activate it: ``$ . venv/bin/activate``
 -  Setup the environment for development: ``$ . hacking/env-setup``
 -  Run your test module locally and directly:
-   ``$ python -m ansible.modules.cloud.azure.my_new_test_module /tmp/args.json``
+   ``$ python -m ansible.modules.cloud.azure.my_test /tmp/args.json``
 
 This should return output like this:
 
@@ -235,7 +235,7 @@ The next step in testing your new module is to consume it with an Ansible playbo
       hosts: localhost
       tasks:
       - name: run the new module
-        my_new_test_module:
+        my_test:
           name: 'hello'
           new: true
         register: testout
@@ -274,7 +274,7 @@ You can add unit tests for your module in ``./test/units/modules``. You must fir
 To run pytest against a single test module, you can do the following (provide the path to the test module appropriately):
 
 ``$ pytest -r a --cov=. --cov-report=html --fulltrace --color yes
-test/units/modules/.../test/my_new_test_module.py``
+test/units/modules/.../test/my_test.py``
 
 Contributing back to Ansible
 ============================


### PR DESCRIPTION
When creating my own module I followed this guide here.

So I created a `foo_module.py`, assuming that modules must have the postfix `_module.py` to be recognized. Then I used the module in a playbook like:

    - action: foo

However ansible kept complaining that it can't find no "foo module". Turns out it was looking for `foo.py` (as oposed to `foo_module.py`).

After close re-reading of the guide I realized that the example module is actually called `my_new_test_module`. So when talking about that module one would f.ex. say: "as seen in the my_new_test_module module".

Calling a module "something_module" is awkward and does not follow ansible's general module naming convention, where f.ex. copying is called "copy" and not "copy_module". It's also misleading as anecdotically shown above. So I suggest to drop the `_module` postfix everywhere in the example and just call the module "my_test" (I'm also dropping the `_sample_` part, as that doesn't help with comprehension either).

Please apply

##### SUMMARY
Naming a module "something_module" is misleading (see below). Let's drop the "_module" part of the module name.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
