### PR TITLE
Fix proxmox_kvm compatibilty with proxmox 6

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -898,7 +898,7 @@ def main():
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
         global PVE_MAJOR_VERSION
-        PVE_MAJOR_VERSION = 3 if float(proxmox.version.get()['version']) < 4.0 else 4
+        PVE_MAJOR_VERSION = int(proxmox.version.get()['version'].split('.', 1)[0])
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 


### PR DESCRIPTION
##### SUMMARY
With version 6 of proxmox, the `proxmox.version.get()['version']` return something like `6.0-4` instead of something like `5.0`. The cast as a float is not possible anymore, but the variable `PVE_MAJOR_VERSION` should only contain the first number of the version string. So a _split_ with the first `.` and an `int` cast should be enough to fix it.

Please note that `PVE_MAJOR_VERSION` will now be `5` instead of `4` when proxmox is at version 5. Before this patch the variable could only take `3` or `4` as a value. However this should not create any bug because the only line where this variable is used is `PVE_MAJOR_VERSION < 4`, so 4 and 5 will give the same behavior anyway.

Fixes #59340

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm