### PR TITLE
win_firewall_rule - removed deprecated force option

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -140,6 +140,7 @@ Noteworthy module changes
 * The ``rds_snapshot_facts`` module was renamed to :ref:`rds_snapshot_info <rds_snapshot_info_module>`.
 * The ``redshift_facts`` module was renamed to :ref:`redshift_info <redshift_info_module>`.
 * The ``route53_facts`` module was renamed to :ref:`route53_info <route53_info_module>`.
+* The deprecated ``force`` option in ``win_firewall_rule`` has been removed.
 
 
 Plugins

--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -131,11 +131,6 @@ $security = Get-AnsibleParam -obj $params -name "security" -type "str" -validate
 
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
 
-$force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
-if ($force) {
-    Add-DeprecationWarning -obj $result -message "'force' isn't required anymore" -version 2.9
-}
-
 if ($diff_support) {
     $result.diff = @{}
     $result.diff.prepared = ""

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -99,13 +99,6 @@ options:
       - Defaults to C(domain,private,public) when creating a new rule.
     type: list
     aliases: [ profile ]
-  force:
-    description:
-    - Replace any existing rule by removing it first.
-    - This is no longer required in Ansible 2.4 as rules no longer need replacing when being modified.
-    - DEPRECATED in Ansible 2.4 and will be removed in Ansible 2.9.
-    type: bool
-    default: no
 seealso:
 - module: win_firewall
 author:


### PR DESCRIPTION
##### SUMMARY
Removed unused deprecation module option that was set to be removed in Ansible 2.9.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_firewall_rule