### PR TITLE
Fix win_reg_stat for HKU hives

### DIFF
--- a/changelogs/fragments/win_reg_stat-hku.yaml
+++ b/changelogs/fragments/win_reg_stat-hku.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reg_stat - fix issue when trying to check keys in ``HKU:\`` - https://github.com/ansible/ansible/issues/59337

--- a/lib/ansible/modules/windows/win_reg_stat.ps1
+++ b/lib/ansible/modules/windows/win_reg_stat.ps1
@@ -80,7 +80,7 @@ $registry_hive = switch(Split-Path -Path $path -Qualifier) {
     "HKCC:" { [Microsoft.Win32.Registry]::CurrentConfig }
     "HKCU:" { [Microsoft.Win32.Registry]::CurrentUser }
     "HKLM:" { [Microsoft.Win32.Registry]::LocalMachine }
-    "HKU" { [Microsoft.Win32.Registry]::Users }
+    "HKU:" { [Microsoft.Win32.Registry]::Users }
 }
 
 $key = $null

--- a/test/integration/targets/win_reg_stat/tasks/tests.yml
+++ b/test/integration/targets/win_reg_stat/tasks/tests.yml
@@ -362,3 +362,16 @@
   assert:
     that:
     - not actual.exists
+
+# Tests https://github.com/ansible/ansible/issues/59337
+- name: test out all registry hives
+  win_reg_stat:
+    path: '{{ item }}'
+  register: reg_hive_stat
+  failed_when: not reg_hive_stat.exists
+  with_items:
+  - HKCR:\*
+  - HKCC:\Software
+  - HKCU:\Software
+  - HKLM:\Software
+  - HKU:\.DEFAULT


### PR DESCRIPTION
##### SUMMARY
An unfortunately typo in win_reg_stat has stopped it working for any registry path in `HKU:\`. This PR fixes this typo and adds a test to help make sure this issue won't pop up again.

Fixes https://github.com/ansible/ansible/issues/59337

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reg_stat