### PR TITLE
[2.8] VMware: Accept 0 as valid value for memory reservation

### DIFF
--- a/changelogs/fragments/59190-vmware_guest-mem_reservation.yml
+++ b/changelogs/fragments/59190-vmware_guest-mem_reservation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest accepts 0 MB of memory reservation, fix regression introduced via 193f69064fb40a83e3e7d2112ef24868b45233b3 (https://github.com/ansible/ansible/issues/59190).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -897,9 +897,10 @@ class PyVmomiHelper(PyVmomi):
                 memory_allocation.limit = mem_limit
                 if vm_obj is None or memory_allocation.limit != vm_obj.config.memoryAllocation.limit:
                     rai_change_detected = True
-
             if 'mem_reservation' in self.params['hardware'] or 'memory_reservation' in self.params['hardware']:
-                mem_reservation = self.params['hardware'].get('mem_reservation') or self.params['hardware'].get('memory_reservation') or None
+                mem_reservation = self.params['hardware'].get('mem_reservation')
+                if mem_reservation is None:
+                    mem_reservation = self.params['hardware'].get('memory_reservation')
                 try:
                     mem_reservation = int(mem_reservation)
                 except ValueError:

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -29,3 +29,4 @@
 - include: boot_firmware_d1_c1_f0.yml
 - include: clone_with_convert.yml
 #- include: max_connections.yml
+- include: mem_reservation.yml

--- a/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
+++ b/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
@@ -1,0 +1,153 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- &add_mem_reserve
+  name: Create new VMs with mem_reservation as 0
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'vm_mem_res_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+      mem_reservation: 0
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: mem_reserve_result_0001
+
+- debug: var=mem_reserve_result_0001
+
+- name: Assert that changes were made
+  assert:
+    that:
+      - "mem_reserve_result_0001.results|map(attribute='changed')|unique|list == [true]"
+
+- <<: *add_mem_reserve
+  name: Again create new VMs with mem_reservation as 0
+  register: mem_reserve_result_0002
+
+- debug: var=mem_reserve_result_0002
+
+- name: Assert that changes were not made
+  assert:
+    that:
+      - "mem_reserve_result_0002.results|map(attribute='changed')|unique|list == [false]"
+
+- &add_memory_reserve
+  name: Create new VMs with memory_reservation as 0
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'vm_memory_res_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+      memory_reservation: 0
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: memory_reserve_result_0003
+
+- debug: var=memory_reserve_result_0003
+
+- name: Assert that changes were made
+  assert:
+    that:
+      - "memory_reserve_result_0003.results|map(attribute='changed')|unique|list == [true]"
+
+- <<: *add_memory_reserve
+  name: Again create new VMs with memory_reservation as 0
+  register: memory_reserve_result_0004
+
+- debug: var=memory_reserve_result_0004
+
+- name: Assert that changes were not made
+  assert:
+    that:
+      - "memory_reserve_result_0004.results|map(attribute='changed')|unique|list == [false]"
+
+- &without_memory_reserve
+  name: Create new VMs without mem_reservation or memory_reservation
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'vm_no_memory_res_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: no_memory_reserve_result_0004
+
+- debug: var=no_memory_reserve_result_0004
+
+- name: Assert that changes were made
+  assert:
+    that:
+      - "no_memory_reserve_result_0004.results|map(attribute='changed')|unique|list == [true]"
+
+- <<: *without_memory_reserve
+  name: Again create new VMs without mem_reservation or memory_reservation
+  register: no_memory_reserve_result_0005
+
+- debug: var=no_memory_reserve_result_0005
+
+- name: Assert that changes were not made
+  assert:
+    that:
+      - "no_memory_reserve_result_0005.results|map(attribute='changed')|unique|list == [false]"


### PR DESCRIPTION
##### SUMMARY
vmware_guest accepts 0MB as valid value for memory reservation in
virtual machine hardware configuration. This fixes the regression
introduced via 193f69064fb40a83e3e7d2112ef24868b45233b3.

Fixes: #59190

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 1f49abb51c208ac5e713740561952b8411c0761b)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/59190-vmware_guest-mem_reservation.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml
test/integration/targets/vmware_guest/tasks/mem_reservation.yml
