### PR TITLE
[2.8] Address regression causing bootproto=dhcp for manual IP addresses

### DIFF
--- a/changelogs/fragments/56376-bootproto_dhcp_regression.yaml
+++ b/changelogs/fragments/56376-bootproto_dhcp_regression.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nmcli - fixed regression caused by commit b7724fd, github issue #36615 (https://github.com/ansible/ansible/issues/36615)

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -801,10 +801,10 @@ class Nmcli(object):
             cmd.append(self.conn_name)
 
         options = {
-            'ipv4.address': self.ip4,
-            'ipv4.gateway': self.gw4,
-            'ipv6.address': self.ip6,
-            'ipv6.gateway': self.gw6,
+            'ip4': self.ip4,
+            'gw4': self.gw4,
+            'ip6': self.ip6,
+            'gw6': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
@@ -877,10 +877,10 @@ class Nmcli(object):
             cmd.append(self.conn_name)
         options = {
             'mode': self.mode,
-            'ipv4.address': self.ip4,
-            'ipv4.gateway': self.gw4,
-            'ipv6.address': self.ip6,
-            'ipv6.gateway': self.gw6,
+            'ip4': self.ip4,
+            'gw4': self.gw4,
+            'ip6': self.ip6,
+            'gw6': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
@@ -970,10 +970,10 @@ class Nmcli(object):
             cmd.append(self.conn_name)
 
         options = {
-            'ipv4.address': self.ip4,
-            'ipv4.gateway': self.gw4,
-            'ipv6.address': self.ip6,
-            'ipv6.gateway': self.gw6,
+            'ip4': self.ip4,
+            'gw4': self.gw4,
+            'ip6': self.ip6,
+            'gw6': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
@@ -991,7 +991,7 @@ class Nmcli(object):
         # format for modifying ethernet interface
         # To modify an Ethernet connection with static IP configuration, issue a command as follows
         # - nmcli: conn_name=my-eth1 ifname=eth1 type=ethernet ip4=192.0.2.100/24 gw4=192.0.2.1 state=present
-        # nmcli con mod con-name my-eth1 ifname eth1 type ethernet ip4 192.0.2.100/24 gw4 192.0.2.1
+        # nmcli con mod con-name my-eth1 ifname eth1 type ethernet ipv4.address 192.0.2.100/24 ipv4.gateway 192.0.2.1
         options = {
             'ipv4.address': self.ip4,
             'ipv4.gateway': self.gw4,
@@ -1059,10 +1059,10 @@ class Nmcli(object):
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
 
         options = {
-            'ip4': self.ip4,
-            'gw4': self.gw4,
-            'ip6': self.ip6,
-            'gw6': self.gw6,
+            'ipv4.address': self.ip4,
+            'ipv4.gateway': self.gw4,
+            'ipv6.address': self.ip6,
+            'ipv6.gateway': self.gw6,
             'autoconnect': self.bool_to_string(self.autoconnect),
             'bridge.ageing-time': self.ageingtime,
             'bridge.forward-delay': self.forwarddelay,

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -260,7 +260,7 @@ def test_bond_connection_create(mocked_generic_connection_create):
     assert args[0][7] == 'ifname'
     assert args[0][8] == 'bond_non_existant'
 
-    for param in ['ipv4.gateway', 'primary', 'autoconnect', 'mode', 'active-backup', 'ipv4.address']:
+    for param in ['gw4', 'primary', 'autoconnect', 'mode', 'active-backup', 'ip4']:
         assert param in args[0]
 
 
@@ -284,7 +284,7 @@ def test_generic_connection_create(mocked_generic_connection_create):
     assert args[0][5] == 'con-name'
     assert args[0][6] == 'non_existent_nw_device'
 
-    for param in ['autoconnect', 'ipv4.gateway', 'ipv4.address']:
+    for param in ['autoconnect', 'gw4', 'ip4']:
         assert param in args[0]
 
 
@@ -395,7 +395,7 @@ def test_mod_bridge(mocked_generic_connection_modify):
     assert args[0][1] == 'con'
     assert args[0][2] == 'mod'
     assert args[0][3] == 'non_existent_nw_device'
-    for param in ['ip4', '10.10.10.10', 'gw4', '10.10.10.1', 'bridge.max-age', 100, 'bridge.stp', 'yes']:
+    for param in ['ipv4.address', '10.10.10.10', 'ipv4.gateway', '10.10.10.1', 'bridge.max-age', 100, 'bridge.stp', 'yes']:
         assert param in args[0]
 
 


### PR DESCRIPTION
##### SUMMARY
Commit b7724fdf857c9d57b50f94b6573f5ae2516547b5
appears to have caused a regression, where `ip4`, `gw4`, `ip6`, `gw6`
were converted to `ipv4.address`, `ipv4.gateway` etc.

This causes bootproto (or `ipv4.method`) to remain `dhcp`, as noted in https://github.com/ansible/ansible/issues/36615

This commit only reverts the key-value pairs to the original names,
which is in line with both expectation (manual ip addr == no dhcp) and
the language used in the playbook, which is, for example, "ip4" not
"ipv4.address"

Co-authored-by: Stuart Pollock <spollock@pivotal.io>
Co-authored-by: Tyler Ramer <tramer@pivotal.io>
(cherry picked from commit 8d0f2e5725c9f1d2fdeab080d0652bc3945d781d)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56376-bootproto_dhcp_regression.yaml
lib/ansible/modules/net_tools/nmcli.py
test/units/modules/net_tools/test_nmcli.py
