### PR TITLE
Backport 59342, postgresql_schema: parameter ensure replaced by state

### DIFF
--- a/changelogs/fragments/59342_postgresql_schema-fix-example.yml
+++ b/changelogs/fragments/59342_postgresql_schema-fix-example.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_schema - Parameter ensure replaced by state in the drop schema example (https://github.com/ansible/ansible/pull/59342)

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -102,7 +102,7 @@ EXAMPLES = r'''
 - name: Drop schema "acme" with cascade
   postgresql_schema:
     name: acme
-    ensure: absent
+    state: absent
     cascade_drop: yes
 '''
 


### PR DESCRIPTION
##### SUMMARY
Backport #59342, postgresql_schema: parameter ensure replaced by state

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_schema