### PR TITLE
psrp - Added proper reconnection variable name

### DIFF
--- a/changelogs/fragments/psrp-reconnection.yaml
+++ b/changelogs/fragments/psrp-reconnection.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- psrp - Added the ``ansible_psrp_reconnection_backoff`` variable to control the reconnection backoff setting - https://github.com/ansible/ansible/issues/58714

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -118,8 +118,11 @@ options:
     - The backoff time to use in between reconnection attempts.
       (First sleeps X, then sleeps 2*X, then sleeps 4*X, ...)
     - This is measured in seconds.
+    - The C(ansible_psrp_reconnection_backoff) variable was added in Ansible
+      2.9.
     vars:
     - name: ansible_psrp_connection_backoff
+    - name: ansible_psrp_reconnection_backoff
     default: 2
     version_added: '2.8'
   message_encryption:


### PR DESCRIPTION
##### SUMMARY
Added the `ansible_psrp_reconnection_backoff` variable to better match the option name. The original variable will still work this just aligns the names a bit better.

Fixes https://github.com/ansible/ansible/issues/58714

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
psrp