### PR TITLE
Backport/2.8/59332 ce_switchport:add link-type hybrid and dot1qtunnel to mode.and fix bugs.(#59332)

### DIFF
--- a/changelogs/fragments/59389-update-ce_switchport-to-fix-a-bug.yml
+++ b/changelogs/fragments/59389-update-ce_switchport-to-fix-a-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix misssing link-type hybrid and dot1qtunnel bug(https://github.com/ansible/ansible/pull/59332)

--- a/lib/ansible/modules/network/cloudengine/ce_switchport.py
+++ b/lib/ansible/modules/network/cloudengine/ce_switchport.py
@@ -47,11 +47,11 @@ options:
             - The link type of an interface.
         choices: ['access','trunk', 'hybrid', 'dot1qtunnel']
     default_vlan:
-        version_added: 2.9
+        version_added: 2.8
         description:
             - If C(mode=access, or mode=dot1qtunnel), used as the access VLAN ID, in the range from 1 to 4094.
     pvid_vlan:
-        version_added: 2.9
+        version_added: 2.8
         description:
             - If C(mode=trunk, or mode=hybrid), used as the trunk native VLAN ID, in the range from 1 to 4094.
     trunk_vlans:
@@ -59,12 +59,12 @@ options:
             - If C(mode=trunk), used as the VLAN range to ADD or REMOVE
               from the trunk, such as 2-10 or 2,5,10-15, etc.
     untagged_vlans:
-        version_added: 2.9
+        version_added: 2.8
         description:
             - If C(mode=hybrid), used as the VLAN range to ADD or REMOVE
               from the trunk, such as 2-10 or 2,5,10-15, etc.
     tagged_vlans:
-        version_added: 2.9
+        version_added: 2.8
         description:
             - If C(mode=hybrid), used as the VLAN range to ADD or REMOVE
               from the trunk, such as 2-10 or 2,5,10-15, etc.


### PR DESCRIPTION
… bugs. (#59332)

* add link-type hybrid and dot1qtunnel to mode.and fix bugs.

* add verstion_add option for doc.

* update for shippable:E319.

* Update ce_switchport.py

(cherry picked from commit c8697a4864f95672c58598eff207548b0bcc63e5)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 add link-type hybrid and dot1qtunnel to mode.and fix bugs.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_switchport.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
