### PR TITLE
Fix race condition with async folder generation

### DIFF
--- a/changelogs/fragments/59394-local-async-race-condition.yml
+++ b/changelogs/fragments/59394-local-async-race-condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix race condition with ``~/.ansible_async`` folder generation when running async tasks with local connection (https://github.com/ansible/ansible/issues/59394).

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -21,6 +21,7 @@ import syslog
 import multiprocessing
 
 from ansible.module_utils._text import to_text
+from ansible.utils.path import makedirs_safe
 
 PY3 = sys.version_info[0] == 3
 
@@ -231,14 +232,13 @@ def main():
     jobdir = os.path.expanduser(async_dir)
     job_path = os.path.join(jobdir, jid)
 
-    if not os.path.exists(jobdir):
-        try:
-            os.makedirs(jobdir)
-        except Exception:
-            print(json.dumps({
-                "failed": 1,
-                "msg": "could not create: %s" % jobdir
-            }))
+    try:
+        makedirs_safe(jobdir)
+    except Exception as e:
+        print(json.dumps({
+            "failed": 1,
+            "msg": "could not create %s: %s" % (jobdir, to_text(e))
+        }))
     # immediately exit this process, leaving an orphaned process
     # running which immediately forks a supervisory timing process
 


### PR DESCRIPTION
##### SUMMARY
Proposed solution to https://github.com/ansible/ansible/issues/59306

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/async_wrapper.py

##### ADDITIONAL INFORMATION
Unfortunately, due to the flaky nature of the error, I have only verified the fix manually, and doing so takes a good deal of time.

The method implemented in the safe mkdirs method seems to be a canned answer to the problem:

https://stackoverflow.com/a/273227/1092940

That's exactly how I would solve it. The docstring gives a lot of warnings about the appropriate place to use it, and I believe this case to fit that situation rather well.

Randomized files are used for anything actually _written_ to this directory. Even though the var name is `jobdir`, it refers to the global async directory, so the check for `EEXIST` is 100% appropriate.

Here are job runs inside of AWX, they start passing after this patch is applied:

![Screen Shot 2019-07-22 at 11 11 50 AM](https://user-images.githubusercontent.com/1385596/61643791-9144d500-ac71-11e9-834c-8dbafd292913.png)
