### PR TITLE
Update ansible-test sanity requirements.

### DIFF
--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -6,9 +6,9 @@ pycodestyle
 pylint ; python_version >= '3.5' # pylint 2.0.0 and later require python 3+
 pytest
 rstcheck ; python_version >= '2.7' # rstcheck requires python 2.7+
-sphinx
-sphinx-notfound-page
-straight.plugin  # needed for hacking/build-ansible.py which will host changelog generation
+sphinx ; python_version >= '3.5' # docs build requires python 3+
+sphinx-notfound-page ; python_version >= '3.5' # docs build requires python 3+
+straight.plugin ; python_version >= '3.5' # needed for hacking/build-ansible.py which will host changelog generation and requires python 3+
 virtualenv
 voluptuous ; python_version >= '2.7' # voluptuous 0.11.0 and later require python 2.7+
 yamllint


### PR DESCRIPTION
##### SUMMARY

Skip installation of packages on Python 2.x which are only used on 3.x.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
