### PR TITLE
Mark Docker tests unstable

### DIFF
--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,4 +2,4 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
-unstable
+disabled

--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,3 +2,4 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
+unstable

--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -8,3 +8,4 @@ skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # after finishing the tests to minimize potential effects
              # on other tests.
 needs/root
+unstable


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- docker_swarm is unstable on RHEL 8 [example](https://app.shippable.com/github/ansible/ansible/runs/133180/63/console)
- docker_container is unstable on RHEL 7 [example](https://app.shippable.com/github/ansible/ansible/runs/133170/88/tests)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_container/aliases`
`test/integration/targets/docker_swarm/aliases`