### PR TITLE
[stable-2.8] Mark Docker tests unstable (#59408)

### DIFF
--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,3 +2,4 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
+disabled

--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -8,3 +8,4 @@ skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # after finishing the tests to minimize potential effects
              # on other tests.
 needs/root
+unstable


### PR DESCRIPTION
##### SUMMARY
* Mark Docker tests unstable

- docker_swarm is unstable on RHEL 8
- docker_container is unstable on RHEL 7

* Disable docker_container test.

(cherry picked from commit 67c69f3)

Backport of https://github.com/ansible/ansible/pull/59408

Co-authored-by: Sam Doran <sdoran@redhat.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_container integration test
docker_swarm integration test
