### PR TITLE
Preserve original variables when using a loop

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -412,20 +412,6 @@ class TaskExecutor:
             results.append(res)
             del task_vars[loop_var]
 
-            # clear 'connection related' plugin variables for next iteration
-            if self._connection:
-                clear_plugins = {
-                    'connection': self._connection._load_name,
-                    'shell': self._connection._shell._load_name
-                }
-                if self._connection.become:
-                    clear_plugins['become'] = self._connection.become._load_name
-
-                for plugin_type, plugin_name in iteritems(clear_plugins):
-                    for var in C.config.get_plugin_vars(plugin_type, plugin_name):
-                        if var in task_vars:
-                            del task_vars[var]
-
         self._task.no_log = no_log
 
         return results
@@ -523,6 +509,11 @@ class TaskExecutor:
 
         if variables is None:
             variables = self._job_vars
+
+        # the code below can modify the variables, take a copy so future loop
+        # iterations are not tainted by "magic" variables that are a result of
+        # the loops item.
+        variables = variables.copy()
 
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=variables)
 


### PR DESCRIPTION
##### SUMMARY
The fix in https://github.com/ansible/ansible/pull/59024 resulted in any task variables defined that were used in the connection/shell/become options would no longer be defined in future loop iterations. This is an alternative way to solve https://github.com/ansible/ansible/issues/58876 by taking a copy of the variables before they are modified by `self._play_context.update_vars(variables)` ensuring future loop iterations will still honour the task directive value.

This could be a potential memory issue so will need others to chime in.

Fixes https://github.com/ansible/ansible/issues/59414

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
task_executor