### PR TITLE
Fix netconf connection command timeout issue (#58322)

### DIFF
--- a/changelogs/fragments/netconf_command_timeout.yaml
+++ b/changelogs/fragments/netconf_command_timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix netconf connection command timeout issue (https://github.com/ansible/ansible/pull/58322)

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -321,6 +321,8 @@ class Connection(NetworkConnectionBase):
                 timeout=self.get_option('persistent_connect_timeout'),
                 ssh_config=ssh_config
             )
+
+            self._manager._timeout = self.get_option('persistent_command_timeout')
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(to_native(exc))
         except ImportError as exc:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  ncclient uses same timeout value at the time
   of connection initialization and waiting response
*  Ansible has connect_timeout to control the waiting
   time during initial connection and `command_timeout`
   to control the wait time for response. Hence set the
   ncclient timeout separately to Ansible command_timeout
   after the connection object is created successfully.

(cherry picked from commit db0fe4b1884e6bb9c25e970c7585abb7edd9d664)

Merged to devel https://github.com/ansible/ansible/pull/58322
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/plugins/connection/netconf.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
