### PR TITLE
Backport/2.8/59344  ce_ntp_auth: update to fix "state is present but all of the following are missing: pas…

### DIFF
--- a/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
+++ b/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
@@ -1,0 +1,2 @@
+bugfixes:
+- update to fix "state is present but all of the following are missing: password" bug(https://github.com/ansible/ansible/pull/59344)

--- a/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
+++ b/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
@@ -1,2 +1,0 @@
-bugfixes:
-- update to fix "state is present but all of the following are missing-password" bug(https://github.com/ansible/ansible/pull/59344)

--- a/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
+++ b/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug..yml
@@ -1,2 +1,2 @@
 bugfixes:
-- update to fix "state is present but all of the following are missing: password" bug(https://github.com/ansible/ansible/pull/59344)
+- update to fix "state is present but all of the following are missing-password" bug(https://github.com/ansible/ansible/pull/59344)

--- a/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug.yml
+++ b/changelogs/fragments/59437-update-ce_ntp_auth-to-fix-a-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ce_ntp_auth - update to fix "state is present but all of the following are missing-password" bug(https://github.com/ansible/ansible/pull/59344)


### PR DESCRIPTION
…sword" bug

(cherry picked from commit 661b009f363b76885fb3d7860a7fc630db7f8d4f)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
update to  fix "state is present but all of the following are missing: password" bug

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_ntp_auth.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
## Test Case
```paste below
  - name: "Step1.1.1 test the correct key_id"
    ce_ntp_auth:
      key_id: 1
      auth_mode: md5
      auth_pwd: QWE@QWE123
      state: present
```
## Error log
```
fatal: [10.190.121.125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "auth_mode": "md5",
            "auth_pwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "auth_type": "encrypt",
            "key_id": "1",
            "provider": {
                "host": "10.190.121.125",
                "password": "huaweiDC",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "state": "present",
            "transport": "cli",
            "trusted_key": "disable"
        }
    },
    "msg": "state is present but all of the following are missing: password"
}

PLAY RECAP **********************************************************************************
10.190.121.125             : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
## Debug Result
```
Using netconf api to run commands is an error.
```
## After Modify
```

changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "end_state": {
        "authentication": "disable",
        "authentication-keyid": [
            {
                "auth_mode": "",
                "auth_pwd": "",
                "key_id": "1",
                "trusted_key": "disable"
            }
        ]
    },
    "existing": {
        "authentication": "disable",
        "authentication-keyid": [
            {
                "auth_mode": "md5",
                "auth_pwd": "%^%#;CCfVUy,KHmPT*Uoi|0<5Wva*Yf$6B'.@[3g_CwP)r0_*~|Bo(Sgw;4tIm0N%^%#",
                "key_id": "1",
                "trusted_key": "disable"
            }
        ]
    },
    "invocation": {
        "module_args": {
            "auth_mode": "md5",
            "auth_pwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "auth_type": "encrypt",
            "authentication": null,
            "host": "10.190.121.125",
            "key_id": "1",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "ssh_keyfile": null,
            "state": "absent",
            "timeout": null,
            "transport": "cli",
            "trusted_key": "disable",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "proposed": {
        "auth_mode": "md5",
        "auth_pwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
        "auth_type": null,
        "authentication": null,
        "key_id": "1",
        "state": "absent",
        "trusted_key": null
    },
    "updates": [
        "undo ntp authentication-keyid 1",
        "undo ntp trusted authentication-keyid 1"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
## display configure on device
```
[~8850_130.12]dis cu | in ntp
ntp server disable
ntp ipv6 server disable
ntp authentication-keyid 1 authentication-mode md5 cipher %^%#;CCfVUy,KHmPT*Uoi|0<5Wva*Yf$6B'.@[3g_CwP)r0_*~|Bo(Sgw;4tIm0N%^%#
[~8850_130.12]dis cu | in ntp
[~8850_130.12]

```

