### PR TITLE
[stable-2.8] Re-enable docker_container tests (#59425)

### DIFF
--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -2,4 +2,3 @@ shippable/posix/group4
 skip/osx
 skip/freebsd
 destructive
-disabled

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -1822,6 +1822,7 @@
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
+    ipc_mode: shareable
   loop:
   - "{{ cname_h1 }}"
   loop_control:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #59425 for Ansible 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_container/`