### PR TITLE
ce_file_copy: update to Compatible with multiple version of NETCONF API.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -99,7 +99,7 @@ import sys
 import time
 from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
+from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, get_nc_config
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.common.utils import validate_ip_v6_address
 

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -144,25 +144,11 @@ CE_NC_GET_FILE_INFO = """
 </filter>
 """
 
-CE_NC_GET_SCP_ENABLE_R19 = """
+CE_NC_GET_SCP_ENABLE = """
 <filter type="subtree">
       <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-        <sshServerEnable>
-          <scpIpv4Enable></scpIpv4Enable>
-          <scpIpv6Enable></scpIpv6Enable>
-        </sshServerEnable>
       </sshs>
     </filter>
-"""
-
-CE_NC_GET_SCP_ENABLE_R3 = """
-<filter type="subtree">
-  <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-    <sshServer>
-      <scpEnable></scpEnable>
-    </sshServer>
-  </sshs>
-</filter>
 """
 
 
@@ -324,12 +310,9 @@ class FileCopy(object):
 
         ret_xml = ''
         try:
-            ret_xml = get_nc_config(self.module, CE_NC_GET_SCP_ENABLE_R3)
+            ret_xml = get_nc_config(self.module, CE_NC_GET_SCP_ENABLE)
         except ConnectionError:
-            try:
-                ret_xml = get_nc_config(self.module, CE_NC_GET_SCP_ENABLE_R19)
-            except ConnectionError:
-                self.module.fail_json(msg='Error: The NETCONF API of scp_enable is not supported.')
+            self.module.fail_json(msg='Error: The NETCONF API of scp_enable is not supported.')
 
         if "<data/>" in ret_xml:
             return False

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -100,6 +100,8 @@ import time
 from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
+from ansible.module_utils.connection import ConnectionError
+from ansible.module_utils.network.common.utils import validate_ip_v6_address
 
 try:
     import paramiko
@@ -142,7 +144,7 @@ CE_NC_GET_FILE_INFO = """
 </filter>
 """
 
-CE_NC_GET_SCP_ENABLE = """
+CE_NC_GET_SCP_ENABLE_R19 = """
 <filter type="subtree">
       <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
         <sshServerEnable>
@@ -153,6 +155,15 @@ CE_NC_GET_SCP_ENABLE = """
     </filter>
 """
 
+CE_NC_GET_SCP_ENABLE_R3 = """
+<filter type="subtree">
+  <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <sshServer>
+      <scpEnable></scpEnable>
+    </sshServer>
+  </sshs>
+</filter>
+"""
 
 def get_cli_exception(exc=None):
     """Get cli exception message"""
@@ -202,6 +213,7 @@ class FileCopy(object):
         self.local_file = self.module.params['local_file']
         self.remote_file = self.module.params['remote_file']
         self.file_system = self.module.params['file_system']
+        self.host_is_ipv6 = validate_ip_v6_address(self.module.params['provider']['host'])
 
         # state
         self.transfer_result = None
@@ -309,11 +321,17 @@ class FileCopy(object):
     def get_scp_enable(self):
         """Get scp enable state"""
 
-        xml_str = CE_NC_GET_SCP_ENABLE
-        scp_enable = dict()
-        ret_xml = get_nc_config(self.module, xml_str)
+        ret_xml = ''
+        try:
+            ret_xml = get_nc_config(self.module, CE_NC_GET_SCP_ENABLE_R3)
+        except ConnectionError:
+            try:
+                ret_xml = get_nc_config(self.module, CE_NC_GET_SCP_ENABLE_R19)
+            except ConnectionError:
+                self.module.fail_json(msg='Error: The NETCONF API of scp_enable is not supported.')
+
         if "<data/>" in ret_xml:
-            return scp_enable
+            return False
 
         xml_str = ret_xml.replace('\r', '').replace('\n', '').\
             replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
@@ -321,14 +339,16 @@ class FileCopy(object):
 
         # get file info
         root = ElementTree.fromstring(xml_str)
-        topo = root.find("sshs/sshServerEnable")
-        if topo is None:
-            return scp_enable
-
-        for eles in topo:
-            scp_enable[eles.tag] = eles.text
-
-        return scp_enable
+        topo1 = root.find("sshs/sshServer/scpEnable")
+        topo2 = root.find("sshs/sshServerEnable/scpIpv4Enable")
+        topo3 = root.find("sshs/sshServerEnable/scpIpv6Enable")
+        if topo1 is not None:
+            return str(topo1.tag).strip().lower() == 'enable'
+        elif self.is_ipv6 and topo3 is not None:
+            return str(topo3.tag).strip().lower() == 'enable'
+        elif topo2 is not None:
+            return str(topo2.tag).strip().lower() == 'enable'
+        return False
 
     def work(self):
         """Excute task """
@@ -349,13 +369,14 @@ class FileCopy(object):
             self.module.fail_json(
                 msg="'Error: The maximum length of remote_file is 4096.'")
 
-        cur_state = self.get_scp_enable()
-        if len(cur_state) > 0 and (cur_state.get('scpIpv4Enable').lower() == 'disable' or cur_state.get('scpIpv6Enable').lower() == 'disable'):
-            self.module.fail_json(
-                msg="'Error: Please ensure ipv4 and ipv6 SCP server are enabled.'")
-        elif len(cur_state) == 0:
-            self.module.fail_json(
-                msg="'Error: Please ensure ipv4 and ipv6 SCP server are enabled.'")
+        scp_enable = self.get_scp_enable()
+        if not scp_enable:
+            if self.host_is_ipv6:
+                self.module.fail_json(
+                    msg="'Error: Please ensure ipv6 SCP server are enabled.'")
+            else:
+                self.module.fail_json(
+                    msg="'Error: Please ensure ipv4 SCP server are enabled.'")
 
         if not os.path.isfile(self.local_file):
             self.module.fail_json(

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -188,8 +188,7 @@ def get_cli_exception(exc=None):
             if err[-1] == ".":
                 err = err[:-1]
             if err.replace(" ", "") == "":
-                continue
-            msg.append(err)
+                continue3)
     else:
         msg = ["Error: Fail to get cli exception message."]
 
@@ -344,11 +343,11 @@ class FileCopy(object):
         topo2 = root.find("sshs/sshServerEnable/scpIpv4Enable")
         topo3 = root.find("sshs/sshServerEnable/scpIpv6Enable")
         if topo1 is not None:
-            return str(topo1.tag).strip().lower() == 'enable'
-        elif self.is_ipv6 and topo3 is not None:
-            return str(topo3.tag).strip().lower() == 'enable'
+            return str(topo1.text).strip().lower() == 'enable'
+        elif self.host_is_ipv6 and topo3 is not None:
+            return str(topo3.text).strip().lower() == 'enable'
         elif topo2 is not None:
-            return str(topo2.tag).strip().lower() == 'enable'
+            return str(topo2.text).strip().lower() == 'enable'
         return False
 
     def work(self):

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -146,9 +146,9 @@ CE_NC_GET_FILE_INFO = """
 
 CE_NC_GET_SCP_ENABLE = """
 <filter type="subtree">
-      <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
-      </sshs>
-    </filter>
+  <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+  </sshs>
+</filter>
 """
 
 

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -165,6 +165,7 @@ CE_NC_GET_SCP_ENABLE_R3 = """
 </filter>
 """
 
+
 def get_cli_exception(exc=None):
     """Get cli exception message"""
 

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -188,7 +188,8 @@ def get_cli_exception(exc=None):
             if err[-1] == ".":
                 err = err[:-1]
             if err.replace(" ", "") == "":
-                continue3)
+                continue
+            msg.append(err)
     else:
         msg = ["Error: Fail to get cli exception message."]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
update to Compatible with multiple version of NETCONF API.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
It is necessary to  compatible with V2R1/V2R3/V2R5/V2R19 which have tow different NETCONF APIs.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_file_copy.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
```
### test case.
```
---
- name: test ce_file_copy
  gather_facts: no
  hosts: switch6
  tasks:
  - name: "Test1.1.1 test the corrent local file "
    ce_file_copy:
      local_file: /usr/huawei/zhangyan/playbook1.yml
      remote_file: /playbook2.yml
      file_system: 'flash:'
```
### error log befor modify.
```
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py", line 125, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py", line 117, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py", line 54, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py", line 385, in <module>
  File "/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py", line 381, in main
  File "/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py", line 334, in work
  File "/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py", line 295, in get_scp_enable
  File "/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/cloudengine/ce.py", line 351, in get_nc_config
  File "/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/common/netconf.py", line 76, in __rpc__
  File "/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/common/netconf.py", line 105, in parse_rpc_error
ansible.module_utils.connection.ConnectionError: <?xml version="1.0" encoding="UTF-8"?><rpc-error xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
    <error-type>application</error-type>
    <error-tag>unknown-element</error-tag>
    <error-severity>error</error-severity>
    <error-app-tag>313</error-app-tag>
    <error-message>Unexpected element: scpEnable.&#13;
</error-message>
    <error-info>
      <sshs xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
        <sshServer/>
      </sshs>
      <error-paras>
        <error-para>scpEnable</error-para>
      </error-paras>
    </error-info>
  </rpc-error>


fatal: [10.190.121.125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py\", line 125, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py\", line 117, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1561099790.63-168170006153913/AnsiballZ_ce_file_copy.py\", line 54, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py\", line 385, in <module>\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py\", line 381, in main\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py\", line 334, in work\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/__main__.py\", line 295, in get_scp_enable\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/cloudengine/ce.py\", line 351, in get_nc_config\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/common/netconf.py\", line 76, in __rpc__\n  File \"/tmp/ansible_ce_file_copy_payload_WWUche/ansible_ce_file_copy_payload.zip/ansible/module_utils/network/common/netconf.py\", line 105, in parse_rpc_error\nansible.module_utils.connection.ConnectionError: <?xml version=\"1.0\" encoding=\"UTF-8\"?><rpc-error xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\">\n    <error-type>application</error-type>\n    <error-tag>unknown-element</error-tag>\n    <error-severity>error</error-severity>\n    <error-app-tag>313</error-app-tag>\n    <error-message>Unexpected element: scpEnable.&#13;\n</error-message>\n    <error-info>\n      <sshs xmlns=\"http://www.huawei.com/netconf/vrp\" format-version=\"1.0\" content-version=\"1.0\">\n        <sshServer/>\n      </sshs>\n      <error-paras>\n        <error-para>scpEnable</error-para>\n      </error-paras>\n    </error-info>\n  </rpc-error>\n\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP **************************************************************************************
10.190.121.125             : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
### it should be necessay to compatible with two versions NETCONF API.
```
```
### log after fixed it.
```
changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "file_system": "flash:",
    "invocation": {
        "module_args": {
            "file_system": "flash:",
            "host": "10.190.121.125",
            "local_file": "/usr/huawei/zhangyan/playbook1.yml",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "remote_file": "/playbook2.yml",
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "local_file": "/usr/huawei/zhangyan/playbook1.yml",
    "remote_file": "/playbook2.yml",
"transfer_result": "The local file has been successfully transferred to the device."
```
### show result on device
```
<8850_130.12>dir
Directory of flash:/

  Idx  Attr     Size(Byte)  Date        Time       FileName
    0  dr-x              -  Aug 18 2007 08:21:48   $_checkpoint
    1  dr-x              -  Feb 19 2019 09:33:51   $_install_mod
    2  dr-x              -  Jan 10 2008 14:35:07   $_license
    3  dr-x              -  Aug 14 2007 09:25:53   $_security_info
    4  dr-x              -  Sep 17 2007 21:45:01   $_startup
    5  dr-x              -  Aug 13 2007 17:08:34   $_system
    6  -rw-          3,610  Aug 18 2007 19:13:04   0223.zip
    7  -rw-          3,639  Oct 04 2007 18:21:10   1016-00474991.cfg
    8  -rw-          3,791  Aug 15 2007 14:10:02   11-vxlan.cfg
    9  -rw-         16,565  Sep 17 2007 22:02:24   111.cfg
   10  -rw-         35,402  Aug 13 2007 17:10:13   20181016.cfg
   11  -rw-    222,016,980  Aug 18 2007 19:08:56   CE8850EI-V200R019C00_B157.cc
   12  -rw-    210,074,460  Sep 17 2007 22:00:43   CE8850EI-V200R019C10.cc
   13  -rw-     11,410,632  Aug 17 2007 13:48:44   FESCID0x806a040f__0_THREAD_0_FES_DBG
   14  -rw-      9,393,639  Aug 17 2007 13:48:49   FESCID0x806a040f__1_THREAD_0_FES_DBG
   15  drwx              -  Aug 28 2007 19:17:46   HUTAF_LLT
   16  -rw-          3,003  Aug 14 2007 14:16:57   LICCloudEngine8800_V200R005_20181017MPIT50.dat
   17  -rw-          3,026  Jan 10 2008 14:34:54   LICCloudEngine8800_V200R019_20190315QLQL50.dat
   18  -rw-          6,106  Dec 20 2007 19:15:39   NULL_CONFIG_EXCEPT_TELNET.cfg
   19  drwx              -  Aug 14 2007 12:25:51   POST
   20  -rw-         43,640  Dec 16 2007 19:22:10   a
   21  -rw-             97  Aug 31 2007 23:18:47   collect_diag_info.bat
   22  -rw-         26,772  Sep 17 2007 22:02:24   device.sys
   23  -rw-      5,000,090  Jan 30 2008 21:47:08   diagnostic_information.zip
   24  drwx              -  Aug 14 2007 21:33:48   ic_log
   25  drwx              -  Aug 18 2007 06:23:06   logfile
   26  -rw-            134  Aug 18 2007 08:22:01   playbook2.yml
   27  -rw-          3,081  Aug 13 2007 18:35:52   portsplit.cfg
   28  -rw-          6,089  Aug 14 2007 00:17:54   vrpcfg_classic.zip
   29  -rw-          3,705  Aug 16 2007 22:29:21   vxlan-1018.cfg
   30  -rw-         47,736  Jan 13 2008 23:55:54   ys3.PAt
   31  -rw-         16,425  Aug 18 2007 18:42:00   yuyang.cfg
   32  -rw-          9,573  Dec 20 2007 19:37:49   ztp_20071220193531.log
   33  -rw-          5,956  Dec 20 2007 19:37:23   ztp_20071220193531.log.1
   34  -rw-          8,711  Dec 20 2007 19:35:53   ztp_20071220193531.log.2

1,002,012 KB total (237,964 KB free)
<8850_130.12>
	
```
