### PR TITLE
Ensure package_data matches collections_galaxy_meta.yml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -265,6 +265,7 @@ static_setup_params = dict(
             'module_utils/powershell/*/*.psm1',
             'modules/windows/*.ps1',
             'modules/windows/*/*.ps1',
+            'galaxy/data/*.*',
             'galaxy/data/*/*.*',
             'galaxy/data/*/.*',
             'galaxy/data/*/*/.*',


### PR DESCRIPTION
##### SUMMARY
Ensure package_data matches collections_galaxy_meta.yml. Fixes #59451

The previous `package_data` did not match the location of `galaxy/data/collections_galaxy_meta.yml`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```