### PR TITLE
Fix clouds_yaml_path type in openstack inventory

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -88,7 +88,7 @@ DOCUMENTATION = '''
                 ansible inventory adds /etc/ansible/openstack.yaml and
                 /etc/ansible/openstack.yml to the regular locations documented
                 at https://docs.openstack.org/os-client-config/latest/user/configuration.html#config-files
-            type: string
+            type: list
             env:
                 - name: OS_CLIENT_CONFIG_FILE
         compose:


### PR DESCRIPTION
Fixes: #59442

##### SUMMARY
clouds_yaml_path takes a list, but is currently defined as a string in openstack inventory

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
ansible/lib/ansible/plugins/inventory/openstack.py


