### PR TITLE
Specify type-str for common NetApp E-Series documention options.

### DIFF
--- a/lib/ansible/plugins/doc_fragments/netapp.py
+++ b/lib/ansible/plugins/doc_fragments/netapp.py
@@ -163,14 +163,17 @@ notes:
 options:
   api_username:
     required: true
+    type: str
     description:
     - The username to authenticate with the SANtricity Web Services Proxy or Embedded Web Services API.
   api_password:
     required: true
+    type: str
     description:
     - The password to authenticate with the SANtricity Web Services Proxy or Embedded Web Services API.
   api_url:
     required: true
+    type: str
     description:
     - The url to the SANtricity Web Services Proxy or Embedded Web Services API.
       Example https://prod-1.wahoo.acme.com/devmgr/v2
@@ -182,6 +185,7 @@ options:
     type: bool
   ssid:
     required: false
+    type: str
     default: 1
     description:
     - The ID of the array to manage. This value must be unique for each array.

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -3516,7 +3516,6 @@ lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E324
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E326
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E335
 lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E337
-lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py E338
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E324
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E327
 lib/ansible/modules/storage/netapp/netapp_e_volume.py E337


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the netapp.py module documentation the NetApp E-Series options were missing type specifications.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]

```
