### PR TITLE
systemd module will now wait on deactivating state

### DIFF
--- a/changelogs/fragments/59471-systemd-wait-while-deactivating.yaml
+++ b/changelogs/fragments/59471-systemd-wait-while-deactivating.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - systemd - wait for a service which is in deactivating state when using ``state=stopped`` (https://github.com/ansible/ansible/pull/59471)

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -270,7 +270,11 @@ from ansible.module_utils._text import to_native
 
 
 def is_running_service(service_status):
-    return service_status['ActiveState'] in set(['active', 'activating'])
+    return service_status['ActiveState'] in set(['active', 'activating', 'deactivating'])
+
+
+def is_deactivating_service(service_status):
+    return service_status['ActiveState'] in set(['deactivating'])
 
 
 def request_was_ignored(out):
@@ -498,7 +502,7 @@ def main():
                     if not is_running_service(result['status']):
                         action = 'start'
                 elif module.params['state'] == 'stopped':
-                    if is_running_service(result['status']):
+                    if is_running_service(result['status']) or is_deactivating_service(result['status']):
                         action = 'stop'
                 else:
                     if not is_running_service(result['status']):


### PR DESCRIPTION
##### SUMMARY
If a service is in the 'deactivating' state running `systemctl stop foo`, would wait for the `foo` service to actually stop before it exits. The module didn't behave like that and it considered the deactivating state
as if the service wasn't running. This change will align the module with the `systemctl` behaviour.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemctl
