### PR TITLE
psexec - update example for for delegation example

### DIFF
--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -281,7 +281,7 @@ EXAMPLES = r'''
 
 - name: Download and run ConfigureRemotingForAnsible.ps1 to setup WinRM
   psexec:
-    hostname: '{{ ansible_host }}'
+    hostname: '{{ hostvars[inventory_hostname]["ansible_host"] | default(inventory_hostname) }}'
     connection_username: '{{ ansible_user }}'
     connection_password: '{{ ansible_password }}'
     encrypt: yes


### PR DESCRIPTION
##### SUMMARY
The docs for psexec won't work on a host that does not have an explicit `ansible_host` var defined. This completes the example to handle a host that does and does not have `ansible_host` defined.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
psexec