### PR TITLE
Add na_santricity_drive_firmware

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -29,8 +29,11 @@
 
 import json
 import os
+import random
+import mimetypes
 
 from pprint import pformat
+from ansible.module_utils import six
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
 from ansible.module_utils.urls import open_url
@@ -245,7 +248,8 @@ class NetAppESeriesModule(object):
     """
     DEFAULT_TIMEOUT = 60
     DEFAULT_SECURE_PORT = "8443"
-    DEFAULT_REST_API_PATH = "devmgr/v2"
+    DEFAULT_REST_API_PATH = "devmgr/v2/"
+    DEFAULT_REST_API_ABOUT_PATH = "devmgr/utils/about"
     DEFAULT_HEADERS = {"Content-Type": "application/json", "Accept": "application/json",
                        "netapp-client-type": "Ansible-%s" % ansible_version}
     HTTP_AGENT = "Ansible / %s" % ansible_version
@@ -264,122 +268,65 @@ class NetAppESeriesModule(object):
 
         args = self.module.params
         self.web_services_version = web_services_version if web_services_version else "02.00.0000.0000"
-        self.url = args["api_url"]
         self.ssid = args["ssid"]
+        self.url = args["api_url"]
+        self.log_requests = log_requests
         self.creds = dict(url_username=args["api_username"],
                           url_password=args["api_password"],
                           validate_certs=args["validate_certs"])
-        self.log_requests = log_requests
+
+        if not self.url.endswith("/"):
+            self.url += "/"
 
         self.is_embedded_mode = None
-        self.web_services_validate = None
+        self.is_web_services_valid_cache = None
 
-        self._tweak_url()
-
-    @property
-    def _about_url(self):
-        """Generates the about url based on the supplied web services rest api url.
-
-        :raise AnsibleFailJson: raised when supplied web services rest api is an invalid url.
-        :return: proxy or embedded about url.
-        """
-        about = list(urlparse(self.url))
-        about[2] = "devmgr/utils/about"
-        return urlunparse(about)
-
-    def _force_secure_url(self):
-        """Modifies supplied web services rest api to use secure https.
-
-        raise: AnsibleFailJson: raised when the url already utilizes the secure protocol
-        """
-        url_parts = list(urlparse(self.url))
-        if "https://" in self.url and ":8443" in self.url:
-            self.module.fail_json(msg="Secure HTTP protocol already used. URL path [%s]" % self.url)
-
-        url_parts[0] = "https"
-        url_parts[1] = "%s:8443" % url_parts[1].split(":")[0]
-
-        self.url = urlunparse(url_parts)
-        if not self.url.endswith("/"):
-            self.url += "/"
-
-        self.module.warn("forced use of the secure protocol: %s" % self.url)
-
-    def _tweak_url(self):
-        """Adjust the rest api url is necessary.
-
-        :raise AnsibleFailJson: raised when self.url fails to have a hostname or ipv4 address.
-        """
-        # ensure the protocol is either http or https
-        if self.url.split("://")[0] not in ["https", "http"]:
-
-            self.url = self.url.split("://")[1] if "://" in self.url else self.url
-
-            if ":8080" in self.url:
-                self.url = "http://%s" % self.url
-            else:
-                self.url = "https://%s" % self.url
-
-        # parse url and verify protocol, port and path are consistent with required web services rest api url.
-        url_parts = list(urlparse(self.url))
-        if url_parts[1] == "":
-            self.module.fail_json(msg="Failed to provide a valid hostname or IP address. URL [%s]." % self.url)
-
-        split_hostname = url_parts[1].split(":")
-        if url_parts[0] not in ["https", "http"] or (len(split_hostname) == 2 and split_hostname[1] != "8080"):
-            if len(split_hostname) == 2 and split_hostname[1] == "8080":
-                url_parts[0] = "http"
-                url_parts[1] = "%s:8080" % split_hostname[0]
-            else:
-                url_parts[0] = "https"
-                url_parts[1] = "%s:8443" % split_hostname[0]
-        elif len(split_hostname) == 1:
-            if url_parts[0] == "https":
-                url_parts[1] = "%s:8443" % split_hostname[0]
-            elif url_parts[0] == "http":
-                url_parts[1] = "%s:8080" % split_hostname[0]
-
-        if url_parts[2] == "" or url_parts[2] != self.DEFAULT_REST_API_PATH:
-            url_parts[2] = self.DEFAULT_REST_API_PATH
-
-        self.url = urlunparse(url_parts)
-        if not self.url.endswith("/"):
-            self.url += "/"
-
-        self.module.log("valid url: %s" % self.url)
-
-    def _is_web_services_valid(self):
+    def _check_web_services_version(self):
         """Verify proxy or embedded web services meets minimum version required for module.
 
         The minimum required web services version is evaluated against version supplied through the web services rest
         api. AnsibleFailJson exception will be raised when the minimum is not met or exceeded.
 
+        This helper function will update the supplied api url if secure http is not used for embedded web services
+
         :raise AnsibleFailJson: raised when the contacted api service does not meet the minimum required version.
         """
-        if not self.web_services_validate:
-            self.is_embedded()
-            try:
-                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
-                                   headers=self.DEFAULT_HEADERS, **self.creds)
-                major, minor, other, revision = data["version"].split(".")
-                minimum_major, minimum_minor, other, minimum_revision = self.web_services_version.split(".")
+        if not self.is_web_services_valid_cache:
 
-                if not (major > minimum_major or
-                        (major == minimum_major and minor > minimum_minor) or
-                        (major == minimum_major and minor == minimum_minor and revision >= minimum_revision)):
-                    self.module.fail_json(
-                        msg="Web services version does not meet minimum version required. Current version: [%s]."
-                            " Version required: [%s]." % (data["version"], self.web_services_version))
-            except Exception as error:
-                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                          " Error [%s]." % (self.ssid, to_native(error)))
+            url_parts = list(urlparse(self.url))
+            if not url_parts[0] or not url_parts[1]:
+                self.module.fail_json(msg="Failed to provide valid API URL. Example: https://192.168.1.100:8443/devmgr/v2. URL [%s]." % self.url)
 
-            self.module.warn("Web services rest api version met the minimum required version.")
-            self.web_services_validate = True
+            if url_parts[0] not in ["http", "https"]:
+                self.module.fail_json(msg="Protocol must be http or https. URL [%s]." % self.url)
 
-        return self.web_services_validate
+            self.url = "%s://%s/" % (url_parts[0], url_parts[1])
+            about_url = self.url + self.DEFAULT_REST_API_ABOUT_PATH
+            rc, data = request(about_url, timeout=self.DEFAULT_TIMEOUT, headers=self.DEFAULT_HEADERS, ignore_errors=True, **self.creds)
 
-    def is_embedded(self, retry=True):
+            if rc != 200:
+                self.module.warn("Failed to retrieve web services about information! Retrying with secure ports. Array Id [%s]." % self.ssid)
+                self.url = "https://%s:8443/" % url_parts[1].split(":")[0]
+                about_url = self.url + self.DEFAULT_REST_API_ABOUT_PATH
+                try:
+                    rc, data = request(about_url, timeout=self.DEFAULT_TIMEOUT, headers=self.DEFAULT_HEADERS, **self.creds)
+                except Exception as error:
+                    self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]. Error [%s]."
+                                              % (self.ssid, to_native(error)))
+
+            major, minor, other, revision = data["version"].split(".")
+            minimum_major, minimum_minor, other, minimum_revision = self.web_services_version.split(".")
+
+            if not (major > minimum_major or
+                    (major == minimum_major and minor > minimum_minor) or
+                    (major == minimum_major and minor == minimum_minor and revision >= minimum_revision)):
+                self.module.fail_json(msg="Web services version does not meet minimum version required. Current version: [%s]."
+                                          " Version required: [%s]." % (data["version"], self.web_services_version))
+
+            self.module.log("Web services rest api version met the minimum required version.")
+            self.is_web_services_valid_cache = True
+
+    def is_embedded(self):
         """Determine whether web services server is the embedded web services.
 
         If web services about endpoint fails based on an URLError then the request will be attempted again using
@@ -388,59 +335,101 @@ class NetAppESeriesModule(object):
         :raise AnsibleFailJson: raised when web services about endpoint failed to be contacted.
         :return bool: whether contacted web services is running from storage array (embedded) or from a proxy.
         """
+        self._check_web_services_version()
+
         if self.is_embedded_mode is None:
+            about_url = self.url + self.DEFAULT_REST_API_ABOUT_PATH
             try:
-                rc, data = request(self._about_url, timeout=self.DEFAULT_TIMEOUT,
-                                   headers=self.DEFAULT_HEADERS, **self.creds)
+                rc, data = request(about_url, timeout=self.DEFAULT_TIMEOUT, headers=self.DEFAULT_HEADERS, **self.creds)
                 self.is_embedded_mode = not data["runningAsProxy"]
-            except URLError as error:
-                if not retry:
-                    self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                              " Error [%s]." % (self.ssid, to_native(error)))
-                self.module.warn("Failed to retrieve the webservices about information! Will retry using secure"
-                                 " http. Array Id [%s]." % self.ssid)
-                self._force_secure_url()
-                return self.is_embedded(retry=False)
             except Exception as error:
-                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]."
-                                          " Error [%s]." % (self.ssid, to_native(error)))
+                self.module.fail_json(msg="Failed to retrieve the webservices about information! Array Id [%s]. Error [%s]."
+                                          % (self.ssid, to_native(error)))
 
         return self.is_embedded_mode
 
-    def request(self, path, data=None, method='GET', ignore_errors=False):
+    def request(self, path, data=None, method='GET', headers=None, ignore_errors=False):
         """Issue an HTTP request to a url, retrieving an optional JSON response.
 
         :param str path: web services rest api endpoint path (Example: storage-systems/1/graph). Note that when the
         full url path is specified then that will be used without supplying the protocol, hostname, port and rest path.
         :param data: data required for the request (data may be json or any python structured data)
         :param str method: request method such as GET, POST, DELETE.
+        :param dict headers: dictionary containing request headers.
         :param bool ignore_errors: forces the request to ignore any raised exceptions.
         """
-        if self._is_web_services_valid():
-            url = list(urlparse(path.strip("/")))
-            if url[2] == "":
-                self.module.fail_json(msg="Web services rest api endpoint path must be specified. Path [%s]." % path)
+        self._check_web_services_version()
 
-            # if either the protocol or hostname/port are missing then add them.
-            if url[0] == "" or url[1] == "":
-                url[0], url[1] = list(urlparse(self.url))[:2]
+        if headers is None:
+            headers = self.DEFAULT_HEADERS
 
-            # add rest api path if the supplied path does not begin with it.
-            if not all([word in url[2].split("/")[:2] for word in self.DEFAULT_REST_API_PATH.split("/")]):
-                if not url[2].startswith("/"):
-                    url[2] = "/" + url[2]
-                url[2] = self.DEFAULT_REST_API_PATH + url[2]
+        if not isinstance(data, str) and headers["Content-Type"] == "application/json":
+            data = json.dumps(data)
 
-            # ensure data is json formatted
-            if not isinstance(data, str):
-                data = json.dumps(data)
+        if path.startswith("/"):
+            path = path[1:]
+        request_url = self.url + self.DEFAULT_REST_API_PATH + path
 
-            if self.log_requests:
-                self.module.log(pformat(dict(url=urlunparse(url), data=data, method=method)))
+        if self.log_requests or True:
+            self.module.log(pformat(dict(url=request_url, data=data, method=method)))
 
-            return request(url=urlunparse(url), data=data, method=method, headers=self.DEFAULT_HEADERS, use_proxy=True,
-                           force=False, last_mod_time=None, timeout=self.DEFAULT_TIMEOUT, http_agent=self.HTTP_AGENT,
-                           force_basic_auth=True, ignore_errors=ignore_errors, **self.creds)
+        return request(url=request_url, data=data, method=method, headers=headers, use_proxy=True, force=False, last_mod_time=None,
+                       timeout=self.DEFAULT_TIMEOUT, http_agent=self.HTTP_AGENT, force_basic_auth=True, ignore_errors=ignore_errors, **self.creds)
+
+
+def create_multipart_formdata(files, fields=None, send_8kb=False):
+    """Create the data for a multipart/form request."""
+    boundary = "---------------------------" + "".join([str(random.randint(0, 9)) for x in range(27)])
+    data_parts = list()
+    data = None
+
+    if six.PY2:  # Generate payload for Python 2
+        newline = "\r\n"
+        if fields is not None:
+            for key, value in fields:
+                data_parts.extend(["--%s" % boundary,
+                                   'Content-Disposition: form-data; name="%s"' % key,
+                                   "",
+                                   value])
+
+        for name, filename, path in files:
+            with open(path, "rb") as fh:
+                value = fh.read(8192) if send_8kb else fh.read()
+
+                data_parts.extend(["--%s" % boundary,
+                                   'Content-Disposition: form-data; name="%s"; filename="%s"' % (name, filename),
+                                   "Content-Type: %s" % (mimetypes.guess_type(path)[0] or "application/octet-stream"),
+                                   "",
+                                   value])
+        data_parts.extend(["--%s--" % boundary, ""])
+        data = newline.join(data_parts)
+
+    else:
+        newline = six.b("\r\n")
+        if fields is not None:
+            for key, value in fields:
+                data_parts.extend([six.b("--%s" % boundary),
+                                   six.b('Content-Disposition: form-data; name="%s"' % key),
+                                   six.b(""),
+                                   six.b(value)])
+
+        for name, filename, path in files:
+            with open(path, "rb") as fh:
+                value = fh.read(8192) if send_8kb else fh.read()
+
+                data_parts.extend([six.b("--%s" % boundary),
+                                   six.b('Content-Disposition: form-data; name="%s"; filename="%s"' % (name, filename)),
+                                   six.b("Content-Type: %s" % (mimetypes.guess_type(path)[0] or "application/octet-stream")),
+                                   six.b(""),
+                                   value])
+        data_parts.extend([six.b("--%s--" % boundary), b""])
+        data = newline.join(data_parts)
+
+    headers = {
+        "Content-Type": "multipart/form-data; boundary=%s" % boundary,
+        "Content-Length": str(len(data))}
+
+    return headers, data
 
 
 def request(url, data=None, headers=None, method='GET', use_proxy=True,

--- a/lib/ansible/modules/storage/netapp/na_santricity_drive_firmware.py
+++ b/lib/ansible/modules/storage/netapp/na_santricity_drive_firmware.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+
+# (c) 2016, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: na_santricity_drive_firmware
+version_added: "2.9"
+short_description: NetApp E-Series manage drive firmware
+description:
+    - Ensure drive firmware version is activated on specified drive model.
+author:
+    - Nathan Swartz (@ndswartz)
+extends_documentation_fragment:
+    - netapp.eseries
+options:
+    firmware:
+        description:
+            - list of drive firmware file paths.
+            - NetApp E-Series drives require special firmware which can be download from https://mysupport.netapp.com/NOW/download/tools/diskfw_eseries/
+        type: list
+        required: True
+    wait_for_completion:
+        description:
+            - This flag will cause module to wait for any upgrade actions to complete.
+        type: bool
+        default: false
+    ignore_inaccessible_drives:
+        description:
+            - This flag will determine whether drive firmware upgrade should fail if any effected drives are inaccessible.
+        type: bool
+        default: false
+    upgrade_drives_online:
+        description:
+            - This flag will determine whether drive firmware is upgrade while drives are accepting I/O.
+            - When I(upgrade_drives_online==False) stop all I/O before running task.
+        type: bool
+        default: true
+"""
+EXAMPLES = """
+- name: Ensure correct firmware versions
+  na_santricity_drive_firmware:
+    ssid: "{{ eseries_ssid }}"
+    api_url: "{{ eseries_api_url }}"
+    api_username: "{{ eseries_api_username }}"
+    api_password: "{{ eseries_api_password }}"
+    validate_certs: "{{ eseries_validate_certs }}"
+    firmware: "path/to/drive_firmware"
+    wait_for_completion: true
+    ignore_inaccessible_drives: false
+"""
+RETURN = """
+msg:
+    description: Whether any drive firmware was upgraded and whether it is in progress.
+    type: str
+    returned: always
+    sample:
+        { changed: True, upgrade_in_process: True }
+"""
+import re
+
+from time import sleep
+from ansible.module_utils.netapp import NetAppESeriesModule, create_multipart_formdata
+from ansible.module_utils._text import to_native, to_text, to_bytes
+
+
+class NetAppESeriesDriveFirmware(NetAppESeriesModule):
+    WAIT_TIMEOUT_SEC = 60 * 15
+
+    def __init__(self):
+        ansible_options = dict(
+            firmware=dict(type="list", required=True),
+            wait_for_completion=dict(type="bool", default=False),
+            ignore_inaccessible_drives=dict(type="bool", default=False),
+            upgrade_drives_online=dict(type="bool", default=True))
+
+        super(NetAppESeriesDriveFirmware, self).__init__(ansible_options=ansible_options,
+                                                         web_services_version="02.00.0000.0000",
+                                                         supports_check_mode=True)
+
+        args = self.module.params
+        self.firmware_list = args["firmware"]
+        self.wait_for_completion = args["wait_for_completion"]
+        self.ignore_inaccessible_drives = args["ignore_inaccessible_drives"]
+        self.upgrade_drives_online = args["upgrade_drives_online"]
+
+        self.upgrade_list_cache = None
+
+        self.upgrade_required_cache = None
+        self.upgrade_in_progress = False
+        self.drive_info_cache = None
+
+    def upload_firmware(self):
+        """Ensure firmware has been upload prior to upgrade."""
+        for firmware in self.firmware_list:
+            firmware_name = re.split(r"/", firmware)[-1]
+            files = [("file", firmware_name, firmware)]
+            headers, data = create_multipart_formdata(files)
+            try:
+                rc, response = self.request("/files/drive", method="POST", headers=headers, data=data)
+            except Exception as error:
+                self.module.fail_json(msg="Failed to upload drive firmware [%s]. Array [%s]. Error [%s]." % (firmware_name, self.ssid, to_native(error)))
+
+    def upgrade_list(self):
+        """Determine whether firmware is compatible with the specified drives."""
+        if self.upgrade_list_cache is None:
+            self.upgrade_list_cache = list()
+            try:
+                rc, response = self.request("storage-systems/%s/firmware/drives" % self.ssid)
+
+                # Create upgrade list, this ensures only the firmware uploaded is applied
+                for firmware in self.firmware_list:
+                    filename = re.split(r"/", firmware)[-1]
+
+                    for uploaded_firmware in response["compatibilities"]:
+                        if uploaded_firmware["filename"] == filename:
+
+                            # Determine whether upgrade is required
+                            drive_reference_list = []
+                            for drive in uploaded_firmware["compatibleDrives"]:
+                                try:
+                                    rc, drive_info = self.request("storage-systems/%s/drives/%s" % (self.ssid, drive["driveRef"]))
+
+                                    # Add drive references that are supported and differ from current firmware
+                                    if (drive_info["firmwareVersion"] != uploaded_firmware["firmwareVersion"] and
+                                            uploaded_firmware["firmwareVersion"] in uploaded_firmware["supportedFirmwareVersions"]):
+
+                                        if self.ignore_inaccessible_drives or (not drive_info["offline"] and drive_info["available"]):
+                                            drive_reference_list.append(drive["driveRef"])
+
+                                        if not drive["onlineUpgradeCapable"] and self.upgrade_drives_online:
+                                            self.module.fail_json(msg="Drive is not capable of online upgrade. Array [%s]. Drive [%s]."
+                                                                      % (self.ssid, drive["driveRef"]))
+
+                                except Exception as error:
+                                    self.module.fail_json(msg="Failed to retrieve drive information. Array [%s]. Drive [%s]. Error [%s]."
+                                                              % (self.ssid, drive["driveRef"], to_native(error)))
+
+                            if drive_reference_list:
+                                self.upgrade_list_cache.extend([{"filename": filename, "driveRefList": drive_reference_list}])
+
+            except Exception as error:
+                self.module.fail_json(msg="Failed to complete compatibility and health check. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+        return self.upgrade_list_cache
+
+    def wait_for_upgrade_completion(self):
+        """Wait for drive firmware upgrade to complete."""
+        drive_references = [reference for drive in self.upgrade_list() for reference in drive["driveRefList"]]
+        last_status = None
+        for attempt in range(int(self.WAIT_TIMEOUT_SEC / 5)):
+            try:
+                rc, response = self.request("storage-systems/%s/firmware/drives/state" % self.ssid)
+
+                # Check drive status
+                for status in response["driveStatus"]:
+                    last_status = status
+                    if status["driveRef"] in drive_references:
+                        if status["status"] == "okay":
+                            continue
+                        elif status["status"] in ["inProgress", "inProgressRecon", "pending", "notAttempted"]:
+                            break
+                        else:
+                            self.module.fail_json(msg="Drive firmware upgrade failed. Array [%s]. Drive [%s]. Status [%s]."
+                                                      % (self.ssid, status["driveRef"], status["status"]))
+                else:
+                    self.upgrade_in_progress = False
+                    break
+            except Exception as error:
+                self.module.fail_json(msg="Failed to retrieve drive status. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+            sleep(5)
+        else:
+            self.module.fail_json(msg="Timed out waiting for drive firmware upgrade. Array [%s]. Status [%s]." % (self.ssid, last_status))
+
+    def upgrade(self):
+        """Apply firmware to applicable drives."""
+        try:
+            rc, response = self.request("storage-systems/%s/firmware/drives/initiate-upgrade?onlineUpdate=%s"
+                                        % (self.ssid, "true" if self.upgrade_drives_online else "false"), method="POST", data=self.upgrade_list())
+            self.upgrade_in_progress = True
+        except Exception as error:
+            self.module.fail_json(msg="Failed to upgrade drive firmware. Array [%s]. Error [%s]." % (self.ssid, to_native(error)))
+
+        if self.wait_for_completion:
+            self.wait_for_upgrade_completion()
+
+    def apply(self):
+        """Apply firmware policy has been enforced on E-Series storage system."""
+        self.upload_firmware()
+
+        if self.upgrade_list() and not self.module.check_mode:
+            self.upgrade()
+
+        self.module.exit_json(changed=True if self.upgrade_list() else False,
+                              upgrade_in_process=self.upgrade_in_progress)
+
+
+def main():
+    drive_firmware = NetAppESeriesDriveFirmware()
+    drive_firmware.apply()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/na_santricity_drive_firmware/aliases
+++ b/test/integration/targets/na_santricity_drive_firmware/aliases
@@ -1,0 +1,10 @@
+# This test is not enabled by default, but can be utilized by defining required variables in integration_config.yml
+# Example integration_config.yml:
+# ---
+#netapp_e_api_host: 192.168.1.1000
+#netapp_e_api_username: admin
+#netapp_e_api_password: myPass
+#netapp_e_ssid: 1
+
+unsupported
+netapp/eseries

--- a/test/integration/targets/na_santricity_drive_firmware/tasks/main.yml
+++ b/test/integration/targets/na_santricity_drive_firmware/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: run.yml

--- a/test/integration/targets/na_santricity_drive_firmware/tasks/run.yml
+++ b/test/integration/targets/na_santricity_drive_firmware/tasks/run.yml
@@ -1,0 +1,209 @@
+# Test code for the netapp_e_iscsi_interface module
+# (c) 2018, NetApp, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Existing symbol issue: occasionally symbol will return 422 which causes Ansible to fail; however the drive firmware download will complete.
+#     Work-around: Remove all storage provisioning before commencing test.
+
+- name: NetApp Test ASUP module
+  fail:
+    msg: 'Please define netapp_e_api_username, netapp_e_api_password, netapp_e_api_host, and netapp_e_ssid.'
+  when:  netapp_e_api_username is undefined or netapp_e_api_password is undefined
+          or netapp_e_api_host is undefined or netapp_e_ssid is undefined
+
+- set_fact:
+    firmware:
+      downgrade:
+        list:
+          - "/home/swartzn/Downloads/drive firmware/D_PX04SVQ160_DOWNGRADE_MS00toMSB6_801.dlp"
+          - "/home/swartzn/Downloads/drive firmware/D_ST1200MM0017_DNGRADE_MS02toMS00_6600_802.dlp"
+        check:
+          - firmware: "D_PX04SVQ160_DOWNGRADE_MS00toMSB6_801.dlp"
+            drive: "PX04SVQ160"
+            version: "MSB6"
+          - firmware: "D_ST1200MM0017_DNGRADE_MS02toMS00_6600_802.dlp"
+            drive: "ST1200MM0017"
+            version: "MS00"
+      upgrade:
+        list:
+          - "/home/swartzn/Downloads/drive firmware/D_PX04SVQ160_30603183_MS00_6600_001.dlp"
+          - "/home/swartzn/Downloads/drive firmware/D_ST1200MM0017_30602214_MS02_5600_002.dlp"
+        check:
+          - firmware: "D_PX04SVQ160_30603183_MS00_6600_001.dlp"
+            drive: "PX04SVQ160"
+            version: "MS00"
+          - firmware: "D_ST1200MM0017_30602214_MS02_5600_002.dlp"
+            drive: "ST1200MM0017"
+            version: "MS02"
+
+- name: Set drive firmware (baseline, maybe change)
+  na_santricity_drive_firmware:
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    ssid: "{{ netapp_e_ssid }}"
+    validate_certs: false
+    firmware: "{{ firmware['downgrade']['list'] }}"
+    wait_for_completion: true
+    ignore_inaccessible_drives: true
+    upgrade_drives_online: false
+  register: drive_firmware
+- pause:
+    seconds: 60
+- name: Retrieve current firmware version
+  uri:
+    url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2/storage-systems/{{ netapp_e_ssid }}/drives"
+    user: "{{ netapp_e_api_username }}"
+    password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+  register: current_drive_firmware
+- name: Check if drive firmware is the expected versions
+  assert:
+    that: "{{ (item['productID'].strip() not in [firmware['downgrade']['check'][0]['drive'], firmware['downgrade']['check'][1]['drive']]) or
+              (firmware['downgrade']['check'][0]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][0]['version'] == item['softwareVersion']) or
+              (firmware['downgrade']['check'][1]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][1]['version'] == item['softwareVersion']) }}"
+    msg: "Drive firmware failed to update all drives"
+  loop: "{{ lookup('list', current_drive_firmware['json']) }}"
+
+- name: Set drive firmware (upgrade, change-checkmode)
+  na_santricity_drive_firmware:
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    ssid: "{{ netapp_e_ssid }}"
+    validate_certs: false
+    firmware: "{{ firmware['upgrade']['list'] }}"
+    wait_for_completion: true
+    ignore_inaccessible_drives: true
+    upgrade_drives_online: false
+  register: drive_firmware
+  check_mode: true
+- pause:
+    seconds: 60
+- name: Retrieve current firmware version
+  uri:
+    url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2/storage-systems/{{ netapp_e_ssid }}/drives"
+    user: "{{ netapp_e_api_username }}"
+    password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+  register: current_drive_firmware
+- name: Validate change status
+  assert:
+    that: "{{ drive_firmware.changed }}"
+    msg: "Change status is incorrect."
+- name: Check if drive firmware is the expected versions
+  assert:
+    that: "{{ (item['productID'].strip() not in [firmware['downgrade']['check'][0]['drive'], firmware['downgrade']['check'][1]['drive']]) or
+              (firmware['downgrade']['check'][0]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][0]['version'] == item['softwareVersion']) or
+              (firmware['downgrade']['check'][1]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][1]['version'] == item['softwareVersion']) }}"
+    msg: "Drive firmware failed to update all drives"
+  loop: "{{ lookup('list', current_drive_firmware['json']) }}"
+
+- name: Set drive firmware (upgrade, change)
+  na_santricity_drive_firmware:
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    ssid: "{{ netapp_e_ssid }}"
+    validate_certs: false
+    firmware: "{{ firmware['upgrade']['list'] }}"
+    wait_for_completion: true
+    ignore_inaccessible_drives: true
+    upgrade_drives_online: false
+  register: drive_firmware
+- pause:
+    seconds: 60
+- name: Retrieve current firmware version
+  uri:
+    url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2/storage-systems/{{ netapp_e_ssid }}/drives"
+    user: "{{ netapp_e_api_username }}"
+    password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+  register: current_drive_firmware
+- name: Validate change status
+  assert:
+    that: "{{ drive_firmware.changed }}"
+    msg: "Change status is incorrect."
+- name: Check if drive firmware is the expected versions
+  assert:
+    that: "{{ (item['productID'].strip() not in [firmware['downgrade']['check'][0]['drive'], firmware['downgrade']['check'][1]['drive']]) or
+              (firmware['upgrade']['check'][0]['drive'] == item['productID'].strip() and
+               firmware['upgrade']['check'][0]['version'] == item['softwareVersion']) or
+              (firmware['upgrade']['check'][1]['drive'] == item['productID'].strip() and
+               firmware['upgrade']['check'][1]['version'] == item['softwareVersion']) }}"
+    msg: "Drive firmware failed to update all drives"
+  loop: "{{ lookup('list', current_drive_firmware['json']) }}"
+
+- name: Set drive firmware (upgrade, no change)
+  na_santricity_drive_firmware:
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    ssid: "{{ netapp_e_ssid }}"
+    validate_certs: false
+    firmware: "{{ firmware['upgrade']['list'] }}"
+    wait_for_completion: true
+    ignore_inaccessible_drives: true
+    upgrade_drives_online: false
+  register: drive_firmware
+- pause:
+    seconds: 60
+- name: Retrieve current firmware version
+  uri:
+    url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2/storage-systems/{{ netapp_e_ssid }}/drives"
+    user: "{{ netapp_e_api_username }}"
+    password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+  register: current_drive_firmware
+- name: Validate change status
+  assert:
+    that: "{{ not drive_firmware.changed }}"
+    msg: "Change status is incorrect."
+- name: Check if drive firmware is the expected versions
+  assert:
+    that: "{{ (item['productID'].strip() not in [firmware['downgrade']['check'][0]['drive'], firmware['downgrade']['check'][1]['drive']]) or
+              (firmware['upgrade']['check'][0]['drive'] == item['productID'].strip() and
+               firmware['upgrade']['check'][0]['version'] == item['softwareVersion']) or
+              (firmware['upgrade']['check'][1]['drive'] == item['productID'].strip() and
+               firmware['upgrade']['check'][1]['version'] == item['softwareVersion']) }}"
+    msg: "Drive firmware failed to update all drives"
+  loop: "{{ lookup('list', current_drive_firmware['json']) }}"
+
+- name: Set drive firmware (downgrade, change)
+  na_santricity_drive_firmware:
+    api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
+    api_username: "{{ netapp_e_api_username }}"
+    api_password: "{{ netapp_e_api_password }}"
+    ssid: "{{ netapp_e_ssid }}"
+    validate_certs: false
+    firmware: "{{ firmware['downgrade']['list'] }}"
+    wait_for_completion: true
+    ignore_inaccessible_drives: true
+    upgrade_drives_online: false
+  register: drive_firmware
+- pause:
+    seconds: 60
+- name: Retrieve current firmware version
+  uri:
+    url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2/storage-systems/{{ netapp_e_ssid }}/drives"
+    user: "{{ netapp_e_api_username }}"
+    password: "{{ netapp_e_api_password }}"
+    validate_certs: no
+  register: current_drive_firmware
+- name: Validate change status
+  assert:
+    that: "{{ drive_firmware.changed }}"
+    msg: "Change status is incorrect."
+- name: Check if drive firmware is the expected versions
+  assert:
+    that: "{{ (item['productID'].strip() not in [firmware['downgrade']['check'][0]['drive'], firmware['downgrade']['check'][1]['drive']]) or
+              (firmware['downgrade']['check'][0]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][0]['version'] == item['softwareVersion']) or
+              (firmware['downgrade']['check'][1]['drive'] == item['productID'].strip() and
+               firmware['downgrade']['check'][1]['version'] == item['softwareVersion']) }}"
+    msg: "Drive firmware failed to update all drives"
+  loop: "{{ lookup('list', current_drive_firmware['json']) }}"

--- a/test/units/module_utils/test_netapp.py
+++ b/test/units/module_utils/test_netapp.py
@@ -1,13 +1,17 @@
 # (c) 2018, NetApp Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.module_utils.six.moves.urllib.error import URLError
-
-from ansible.module_utils.netapp import NetAppESeriesModule
-from units.modules.utils import ModuleTestCase, set_module_args, AnsibleFailJson
 
 __metaclass__ = type
-from units.compat import mock
+
+try:
+    from unittest.mock import patch, mock_open
+except ImportError:
+    from mock import patch, mock_open
+
+from ansible.module_utils.six.moves.urllib.error import URLError
+from ansible.module_utils.netapp import NetAppESeriesModule, create_multipart_formdata
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
 
 
 class StubNetAppESeriesModule(NetAppESeriesModule):
@@ -28,42 +32,29 @@ class NetappTest(ModuleTestCase):
             module_args.update(args)
         set_module_args(module_args)
 
-    def test_about_url_pass(self):
-        """Verify about_url property returns expected about url."""
-        test_set = [("http://localhost/devmgr/v2", "http://localhost:8080/devmgr/utils/about"),
-                    ("http://localhost:8443/devmgr/v2", "https://localhost:8443/devmgr/utils/about"),
-                    ("http://localhost:8443/devmgr/v2/", "https://localhost:8443/devmgr/utils/about"),
-                    ("http://localhost:443/something_else", "https://localhost:8443/devmgr/utils/about"),
-                    ("http://localhost:8443", "https://localhost:8443/devmgr/utils/about"),
-                    ("http://localhost", "http://localhost:8080/devmgr/utils/about")]
-
-        for url in test_set:
-            self._set_args({"api_url": url[0]})
-            base = StubNetAppESeriesModule()
-            self.assertTrue(base._about_url == url[1])
-
     def test_is_embedded_embedded_pass(self):
         """Verify is_embedded successfully returns True when an embedded web service's rest api is inquired."""
         self._set_args()
-        with mock.patch(self.REQ_FUNC, return_value=(200, {"runningAsProxy": False})):
+        with patch(self.REQ_FUNC, side_effect=[(200, {"version": "03.10.9000.0009"}),
+                                               (200, {"runningAsProxy": False})]):
             base = StubNetAppESeriesModule()
             self.assertTrue(base.is_embedded())
-        with mock.patch(self.REQ_FUNC, return_value=(200, {"runningAsProxy": True})):
+        with patch(self.REQ_FUNC, side_effect=[(200, {"version": "03.10.9000.0009"}),
+                                               (200, {"runningAsProxy": True})]):
             base = StubNetAppESeriesModule()
             self.assertFalse(base.is_embedded())
 
-    def test_check_web_services_version_pass(self):
-        """Verify that an acceptable rest api version passes."""
-        minimum_required = "02.10.9000.0010"
-        test_set = ["03.9.9000.0010", "03.10.9000.0009", "02.11.9000.0009", "02.10.9000.0010"]
-
+    def test_is_embedded_fail(self):
+        """Verify exception is thrown when a web service's rest api fails to return about information."""
         self._set_args()
-        base = StubNetAppESeriesModule()
-        base.web_services_version = minimum_required
-        base.is_embedded = lambda: True
-        for current_version in test_set:
-            with mock.patch(self.REQ_FUNC, return_value=(200, {"version": current_version})):
-                self.assertTrue(base._is_web_services_valid())
+        with patch(self.REQ_FUNC, side_effect=[(200, {"version": "03.10.9000.0009"}), Exception()]):
+            with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to retrieve the webservices about information!"):
+                base = StubNetAppESeriesModule()
+                base.is_embedded()
+        with patch(self.REQ_FUNC, side_effect=[(200, {"version": "03.10.9000.0009"}), URLError(""), Exception()]):
+            with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to retrieve the webservices about information!"):
+                base = StubNetAppESeriesModule()
+                base.is_embedded()
 
     def test_check_web_services_version_fail(self):
         """Verify that an unacceptable rest api version fails."""
@@ -75,51 +66,41 @@ class NetappTest(ModuleTestCase):
         base.web_services_version = minimum_required
         base.is_embedded = lambda: True
         for current_version in test_set:
-            with mock.patch(self.REQ_FUNC, return_value=(200, {"version": current_version})):
+            with patch(self.REQ_FUNC, return_value=(200, {"version": current_version})):
                 with self.assertRaisesRegexp(AnsibleFailJson, r"version does not meet minimum version required."):
-                    base._is_web_services_valid()
+                    base._check_web_services_version()
 
-    def test_is_embedded_fail(self):
-        """Verify exception is thrown when a web service's rest api fails to return about information."""
+    def test_check_web_services_version_pass(self):
+        """Verify that an unacceptable rest api version fails."""
+        minimum_required = "02.10.9000.0010"
+        test_set = ["02.10.9000.0009", "02.09.9000.0010", "01.10.9000.0010"]
+
         self._set_args()
-        with mock.patch(self.REQ_FUNC, return_value=Exception()):
-            with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to retrieve the webservices about information!"):
-                base = StubNetAppESeriesModule()
-                base.is_embedded()
-        with mock.patch(self.REQ_FUNC, side_effect=[URLError(""), Exception()]):
-            with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to retrieve the webservices about information!"):
-                base = StubNetAppESeriesModule()
-                base.is_embedded()
+        base = StubNetAppESeriesModule()
+        base.web_services_version = minimum_required
+        base.is_embedded = lambda: True
+        for current_version in test_set:
+            with patch(self.REQ_FUNC, return_value=(200, {"version": current_version})):
+                with self.assertRaisesRegexp(AnsibleFailJson, r"version does not meet minimum version required."):
+                    base._check_web_services_version()
 
-    def test_tweak_url_pass(self):
-        """Verify a range of valid netapp eseries rest api urls pass."""
-        test_set = [("http://localhost/devmgr/v2", "http://localhost:8080/devmgr/v2/"),
-                    ("localhost", "https://localhost:8443/devmgr/v2/"),
-                    ("localhost:8443/devmgr/v2", "https://localhost:8443/devmgr/v2/"),
-                    ("https://localhost/devmgr/v2", "https://localhost:8443/devmgr/v2/"),
-                    ("http://localhost:8443", "https://localhost:8443/devmgr/v2/"),
-                    ("http://localhost:/devmgr/v2", "https://localhost:8443/devmgr/v2/"),
-                    ("http://localhost:8080", "http://localhost:8080/devmgr/v2/"),
-                    ("http://localhost", "http://localhost:8080/devmgr/v2/"),
-                    ("localhost/devmgr/v2", "https://localhost:8443/devmgr/v2/"),
-                    ("localhost/devmgr", "https://localhost:8443/devmgr/v2/"),
-                    ("localhost/devmgr/v3", "https://localhost:8443/devmgr/v2/"),
-                    ("localhost/something", "https://localhost:8443/devmgr/v2/"),
-                    ("ftp://localhost", "https://localhost:8443/devmgr/v2/"),
-                    ("ftp://localhost:8080", "http://localhost:8080/devmgr/v2/"),
-                    ("ftp://localhost/devmgr/v2/", "https://localhost:8443/devmgr/v2/")]
+    def test_check_check_web_services_version_fail(self):
+        """Verify exception is thrown when api url is invalid."""
+        invalid_url_forms = ["localhost:8080/devmgr/v2",
+                             "http:///devmgr/v2"]
 
-        for test in test_set:
-            self._set_args({"api_url": test[0]})
-            with mock.patch(self.REQ_FUNC, side_effect=[URLError(""), (200, {"runningAsProxy": False})]):
-                base = StubNetAppESeriesModule()
-                base._tweak_url()
-                self.assertTrue(base.url == test[1])
+        invalid_url_protocols = ["ssh://localhost:8080/devmgr/v2"]
 
-    def test_check_url_missing_hostname_fail(self):
-        """Verify exception is thrown when hostname or ip address is missing."""
-        self._set_args({"api_url": "http:///devmgr/v2"})
-        with mock.patch(self.REQ_FUNC, return_value=(200, {"runningAsProxy": True})):
-            with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to provide a valid hostname or IP address."):
-                base = StubNetAppESeriesModule()
-                base._tweak_url()
+        for url in invalid_url_forms:
+            self._set_args({"api_url": url})
+            with patch(self.REQ_FUNC, return_value=(200, {"runningAsProxy": True})):
+                with self.assertRaisesRegexp(AnsibleFailJson, r"Failed to provide valid API URL."):
+                    base = StubNetAppESeriesModule()
+                    base._check_web_services_version()
+
+        for url in invalid_url_protocols:
+            self._set_args({"api_url": url})
+            with patch(self.REQ_FUNC, return_value=(200, {"runningAsProxy": True})):
+                with self.assertRaisesRegexp(AnsibleFailJson, r"Protocol must be http or https."):
+                    base = StubNetAppESeriesModule()
+                    base._check_web_services_version()

--- a/test/units/modules/storage/netapp/test_na_santricity_drive_firmware.py
+++ b/test/units/modules/storage/netapp/test_na_santricity_drive_firmware.py
@@ -1,0 +1,214 @@
+# (c) 2018, NetApp Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from ansible.modules.storage.netapp.na_santricity_drive_firmware import NetAppESeriesDriveFirmware
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+
+class HostTest(ModuleTestCase):
+    REQUIRED_PARAMS = {"api_username": "rw",
+                       "api_password": "password",
+                       "api_url": "http://localhost",
+                       "ssid": "1"}
+
+    REQUEST_FUNC = "ansible.modules.storage.netapp.na_santricity_drive_firmware.NetAppESeriesDriveFirmware.request"
+    CREATE_MULTIPART_FORMDATA_FUNC = "ansible.modules.storage.netapp.na_santricity_drive_firmware.create_multipart_formdata"
+    SLEEP_FUNC = "ansible.modules.storage.netapp.na_santricity_drive_firmware.sleep"
+    UPGRADE_LIST_RESPONSE = ({"filename": "test_drive_firmware_1",
+                              "driveRefList": ["010000005000C5007EDE4ECF0000000000000000",
+                                               "010000005000C5007EDF9AAB0000000000000000",
+                                               "010000005000C5007EDBE3C70000000000000000"]},
+                             {"filename": "test_drive_firmware_2",
+                              "driveRefList": ["010000005000C5007EDE4ECF0000000000000001",
+                                               "010000005000C5007EDF9AAB0000000000000001",
+                                               "010000005000C5007EDBE3C70000000000000001"]})
+
+    FIRMWARE_DRIVES_RESPONSE = {"compatibilities": [
+        {"filename": "test_drive_firmware_1",
+         "firmwareVersion": "MS02",
+         "supportedFirmwareVersions": ["MSB6", "MSB8", "MS00", "MS02"],
+         "compatibleDrives": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "onlineUpgradeCapable": True},
+                              {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "onlineUpgradeCapable": True},
+                              {"driveRef": "010000005000C5007EDBE3C70000000000000000", "onlineUpgradeCapable": True}]},
+        {"filename": "test_drive_firmware_2",
+         "firmwareVersion": "MS01",
+         "supportedFirmwareVersions": ["MSB8", "MS00", "MS01"],
+         "compatibleDrives": [{"driveRef": "010000005000C5007EDE4ECF0000000000000001", "onlineUpgradeCapable": True},
+                              {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "onlineUpgradeCapable": False},
+                              {"driveRef": "010000005000C5007EDBE3C70000000000000001", "onlineUpgradeCapable": True}]}]}
+
+    def _set_args(self, args):
+        module_args = self.REQUIRED_PARAMS.copy()
+        module_args.update(args)
+        set_module_args(module_args)
+
+    def test_upload_firmware(self):
+        """Verify exception is thrown"""
+        self._set_args({"firmware": ["path_to_test_drive_firmware_1", "path_to_test_drive_firmware_2"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+
+        with self.assertRaisesRegexp(AnsibleFailJson, "Failed to upload drive firmware"):
+            with mock.patch(self.REQUEST_FUNC, return_value=Exception()):
+                with mock.patch(self.CREATE_MULTIPART_FORMDATA_FUNC, return_value=("", {})):
+                    firmware_object.upload_firmware()
+
+    def test_upgrade_list_pass(self):
+        """Verify upgrade_list method pass"""
+        side_effects = [(200, self.FIRMWARE_DRIVES_RESPONSE),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS00"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS01"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS02"})]
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with mock.patch(self.REQUEST_FUNC, side_effect=side_effects):
+            self.assertEqual(firmware_object.upgrade_list(), [{"driveRefList": ["010000005000C5007EDE4ECF0000000000000000",
+                                                                                "010000005000C5007EDF9AAB0000000000000000"],
+                                                               "filename": "test_drive_firmware_1"}])
+
+        side_effects = [(200, self.FIRMWARE_DRIVES_RESPONSE),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS02"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS02"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS02"})]
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with mock.patch(self.REQUEST_FUNC, side_effect=side_effects):
+            self.assertEqual(firmware_object.upgrade_list(), [])
+
+    def test_upgrade_list_fail(self):
+        """Verify upgrade_list method throws expected exceptions."""
+        self._set_args({"firmware": ["path_to_test_drive_firmware_1"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with self.assertRaisesRegexp(AnsibleFailJson, "Failed to complete compatibility and health check."):
+            with mock.patch(self.REQUEST_FUNC, response=Exception()):
+                firmware_object.upgrade_list()
+
+        side_effects = [(200, self.FIRMWARE_DRIVES_RESPONSE),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS01"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS00"}),
+                        Exception()]
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with self.assertRaisesRegexp(AnsibleFailJson, "Failed to retrieve drive information."):
+            with mock.patch(self.REQUEST_FUNC, side_effect=side_effects):
+                firmware_object.upgrade_list()
+
+        side_effects = [(200, self.FIRMWARE_DRIVES_RESPONSE),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS01"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS00"}),
+                        (200, {"offline": False, "available": True, "firmwareVersion": "MS00"})]
+        self._set_args({"firmware": ["path/to/test_drive_firmware_2"], "upgrade_drives_online": True})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with self.assertRaisesRegexp(AnsibleFailJson, "Drive is not capable of online upgrade."):
+            with mock.patch(self.REQUEST_FUNC, side_effect=side_effects):
+                firmware_object.upgrade_list()
+
+    def test_wait_for_upgrade_completion_pass(self):
+        """Verify function waits for okay status."""
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1", "path/to/test_drive_firmware_2"], "wait_for_completion": True})
+        firmware_object = NetAppESeriesDriveFirmware()
+        firmware_object.upgrade_drives_online = True
+        firmware_object.upgrade_list = lambda: self.UPGRADE_LIST_RESPONSE
+        with mock.patch(self.SLEEP_FUNC, return_value=None):
+            with mock.patch(self.REQUEST_FUNC, side_effect=[
+                (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "inProgress"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]}),
+                (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "inProgressRecon"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]}),
+                (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "pending"},
+                                       {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]}),
+                (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "notAttempted"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]}),
+                (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                       {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]})]):
+                firmware_object.wait_for_upgrade_completion()
+
+    def test_wait_for_upgrade_completion_fail(self):
+        """Verify wait for upgrade completion exceptions."""
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1", "path/to/test_drive_firmware_2"], "wait_for_completion": True})
+        firmware_object = NetAppESeriesDriveFirmware()
+        firmware_object.upgrade_drives_online = True
+        firmware_object.upgrade_list = lambda: self.UPGRADE_LIST_RESPONSE
+        firmware_object.WAIT_TIMEOUT_SEC = 5
+        response = (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "inProgress"},
+                                          {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "inProgressRecon"},
+                                          {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "pending"},
+                                          {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "notAttempted"},
+                                          {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                          {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]})
+        with self.assertRaisesRegexp(AnsibleFailJson, "Timed out waiting for drive firmware upgrade."):
+            with mock.patch(self.SLEEP_FUNC, return_value=None):
+                with mock.patch(self.REQUEST_FUNC, return_value=response):
+                    firmware_object.wait_for_upgrade_completion()
+
+        with self.assertRaisesRegexp(AnsibleFailJson, "Failed to retrieve drive status."):
+            with mock.patch(self.SLEEP_FUNC, return_value=None):
+                with mock.patch(self.REQUEST_FUNC, return_value=Exception()):
+                    firmware_object.wait_for_upgrade_completion()
+
+        response = (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "_UNDEFINED"},
+                                          {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "inProgressRecon"},
+                                          {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "pending"},
+                                          {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "notAttempted"},
+                                          {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                          {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]})
+        with self.assertRaisesRegexp(AnsibleFailJson, "Drive firmware upgrade failed."):
+            with mock.patch(self.SLEEP_FUNC, return_value=None):
+                with mock.patch(self.REQUEST_FUNC, return_value=response):
+                    firmware_object.wait_for_upgrade_completion()
+
+    def test_upgrade_pass(self):
+        """Verify upgrade upgrade in progress variable properly reports."""
+        self._set_args({"firmware": ["path/to/test_drive_firmware_1", "path/to/test_drive_firmware_2"], "wait_for_completion": False})
+        firmware_object = NetAppESeriesDriveFirmware()
+        firmware_object.upgrade_drives_online = True
+        firmware_object.upgrade_list = lambda: {}
+        with mock.patch(self.REQUEST_FUNC, return_value=(200, {})):
+            firmware_object.upgrade()
+            self.assertTrue(firmware_object.upgrade_in_progress)
+
+        self._set_args({"firmware": ["path_to_test_drive_firmware_1", "path_to_test_drive_firmware_2"], "wait_for_completion": True})
+        firmware_object = NetAppESeriesDriveFirmware()
+        firmware_object.upgrade_drives_online = True
+        firmware_object.upgrade_list = lambda: self.UPGRADE_LIST_RESPONSE
+        with mock.patch(self.REQUEST_FUNC, side_effect=[(200, {}),
+                                                        (200, {"driveStatus": [{"driveRef": "010000005000C5007EDE4ECF0000000000000000", "status": "okay"},
+                                                                               {"driveRef": "010000005000C5007EDF9AAB0000000000000000", "status": "okay"},
+                                                                               {"driveRef": "010000005000C5007EDBE3C70000000000000000", "status": "okay"},
+                                                                               {"driveRef": "010000005000C5007EDE4ECF0000000000000001", "status": "okay"},
+                                                                               {"driveRef": "010000005000C5007EDF9AAB0000000000000001", "status": "okay"},
+                                                                               {"driveRef": "010000005000C5007EDBE3C70000000000000001", "status": "okay"}]})]):
+            firmware_object.upgrade()
+            self.assertFalse(firmware_object.upgrade_in_progress)
+
+    def test_upgrade_fail(self):
+        """Verify upgrade method exceptions."""
+        self._set_args({"firmware": ["path_to_test_drive_firmware_1", "path_to_test_drive_firmware_2"]})
+        firmware_object = NetAppESeriesDriveFirmware()
+        with self.assertRaisesRegexp(AnsibleFailJson, "Failed to upgrade drive firmware."):
+            with mock.patch(self.REQUEST_FUNC, return_value=Exception()):
+                firmware_object.upgrade()


### PR DESCRIPTION
##### SUMMARY
Manage NetApp E-Series drive firmware downloads
Includes unit and integration tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Add na_santricity_drive_firmware

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
```
