### PR TITLE
Fix default pylint config for collections.

### DIFF
--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -176,7 +176,10 @@ class PylintTest(SanitySingleVersion):
         rcfile = os.path.join(ANSIBLE_ROOT, 'test/sanity/pylint/config/%s' % context.split('/')[0])
 
         if not os.path.exists(rcfile):
-            rcfile = os.path.join(ANSIBLE_ROOT, 'test/sanity/pylint/config/default')
+            if data_context().content.collection:
+                rcfile = os.path.join(ANSIBLE_ROOT, 'test/sanity/pylint/config/collection')
+            else:
+                rcfile = os.path.join(ANSIBLE_ROOT, 'test/sanity/pylint/config/default')
 
         parser = ConfigParser()
         parser.read(rcfile)


### PR DESCRIPTION
##### SUMMARY

Fix default pylint config for collections.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
