### PR TITLE
Fix return values types for find module in docs

### DIFF
--- a/changelogs/fragments/59456-find-return-values.yaml
+++ b/changelogs/fragments/59456-find-return-values.yaml
@@ -1,0 +1,2 @@
+minor_changes
+  - Correct the return values of "matched" and "examined" from string to int

--- a/changelogs/fragments/59456-find-return-values.yaml
+++ b/changelogs/fragments/59456-find-return-values.yaml
@@ -1,2 +1,2 @@
-minor_changes
-  - Correct the return values of "matched" and "examined" from string to int
+minor_changes:
+  - Correct the return values of matched and examined from string to int

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -197,12 +197,12 @@ files:
 matched:
     description: Number of matches
     returned: success
-    type: str
+    type: int
     sample: 14
 examined:
     description: Number of filesystem objects looked at
     returned: success
-    type: str
+    type: int
     sample: 34
 '''
 


### PR DESCRIPTION
##### SUMMARY
The "find" module returns "matched" and "examined" as integers, but the docs say they are returned as strings. This fixes it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
find module
