### PR TITLE
Minimize collection loader ansible imports

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -826,7 +826,7 @@ def _load_plugin_filter():
 
 def _configure_collection_loader():
     if not any((isinstance(l, AnsibleCollectionLoader) for l in sys.meta_path)):
-        sys.meta_path.insert(0, AnsibleCollectionLoader())
+        sys.meta_path.insert(0, AnsibleCollectionLoader(C.config))
 
 
 # TODO: All of the following is initialization code   It should be moved inside of an initialization

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import os.path
 import pkgutil
 import re
@@ -11,7 +12,6 @@ import sys
 
 from types import ModuleType
 
-from ansible import constants as C
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
 from ansible.utils.singleton import Singleton
@@ -36,8 +36,11 @@ _collection_qualified_re = re.compile(to_text(r'^(\w+)\.(\w+)\.(\w+)$'))
 
 # FIXME: exception handling/error logging
 class AnsibleCollectionLoader(with_metaclass(Singleton, object)):
-    def __init__(self):
-        self._n_configured_paths = C.config.get_config_value('COLLECTIONS_PATHS')
+    def __init__(self, config=None):
+        if config:
+            self._n_configured_paths = config.get_config_value('COLLECTIONS_PATHS')
+        else:
+            self._n_configured_paths = os.environ.get('ANSIBLE_COLLECTIONS_PATHS', '').split(os.pathsep)
 
         if isinstance(self._n_configured_paths, string_types):
             self._n_configured_paths = [self._n_configured_paths]


### PR DESCRIPTION
##### SUMMARY
* pass in optional config instead of importing, so other things (eg ansible-test, units) don't have to take a config dependency

fixes #59479 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
AnsibleCollectionLoader

##### ADDITIONAL INFORMATION
