### PR TITLE
vmware_content_library_info: init the functional test

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
@@ -25,3 +25,5 @@
       when: setup_category is defined
     - include_tasks: setup_tag.yml
       when: setup_tag is defined
+    - include_tasks: setup_content_library.yml
+      when: setup_content_library is defined

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
@@ -1,0 +1,11 @@
+- name: Create Content Library
+  vmware_content_library_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    library_name: test-content-lib
+    library_description: 'Library created by the prepare_vmware_tests role'
+    library_type: local
+    datastore_name: '{{ ds2 }}'
+    validate_certs: False
+    state: present

--- a/test/integration/targets/vmware_content_library_info/tasks/main.yml
+++ b/test/integration/targets/vmware_content_library_info/tasks/main.yml
@@ -4,6 +4,14 @@
 
 - when: vcsim is not defined
   block:
+
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
+        setup_content_library: true
+
     # Get List of Content Libraries
     - name: Get List of Content Libraries
       vmware_content_library_info:
@@ -13,6 +21,7 @@
         validate_certs: false
       register: content_library_info
 
+    - debug: var=content_library_info
     - set_fact: content_library="{{ content_library_info['content_libs'][0] }}"
 
     # Get Details of content library


### PR DESCRIPTION
##### SUMMARY

`vmware_content_library_info` functional test is currently broken because it
assumes the vCenter content library is not empty.
With this commit, the test inits the vCenter content library database using
`prepapre_vmware_tests`, this before the functional test execution.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_content_library_info
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
