### PR TITLE
prevent recursive logging csharp stackoverflow.

### DIFF
--- a/changelogs/fragments/59503-fix-recursive-csharp-logging.yml
+++ b/changelogs/fragments/59503-fix-recursive-csharp-logging.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible.basics - fix core C# recursive call when logging fails (e.g. if insufficient permissions are held) (https://github.com/ansible/ansible/pull/59503)

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -304,7 +304,8 @@ namespace Ansible.Basic
                 }
                 catch (System.Security.SecurityException)
                 {
-                    Warn(String.Format("Access error when creating EventLog source {0}, logging to the Application source instead", logSource));
+                    // Cannot call Warn as that calls LogEvent and we get stuck in a loop
+                    warnings.Add(String.Format("Access error when creating EventLog source {0}, logging to the Application source instead", logSource));
                     logSource = "Application";
                 }
             }


### PR DESCRIPTION
##### SUMMARY
Simple bugfix to avoid recursive function calls in C# code causing Stack overflow on windows / powershell. Note the already present [comment].(https://github.com/ansible/ansible/blob/5228133d742fc35ce9f3ada2d22729b525b2f417/lib/ansible/module_utils/csharp/Ansible.Basic.cs#L325)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.basics (core C#)

##### ADDITIONAL INFORMATION
To reproduce:
Call `win_ping` via `vmware_tools` connection plugin. It will crash powershell and hang (whilst WerFault.exe dumps proc). `vmware_tools` does not support privilege escalation and so the line: `EventLog.CreateEventSource(logSource, "Application");` fails and we get into a cycle.

