### PR TITLE
Adding new options to na_ontap_nfs module

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_nfs.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_nfs.py
@@ -48,6 +48,7 @@ options:
     description:
     - status of if NFSv4 clients see change in FSID as they traverse filesystems.
     choices: ['enabled', 'disabled']
+    version_added: '2.9'
   nfsv4:
     description:
     - status of NFSv4.
@@ -61,10 +62,12 @@ options:
     description:
     - status of NFSv41 pNFS.
     choices: ['enabled', 'disabled']
+    version_added: '2.9'
   nfsv4_numeric_ids:
     description:
     - status of NFSv4 numeric ID's.
     choices: ['enabled', 'disabled']
+    version_added: '2.9'
   vstorage_state:
     description:
     - status of vstorage_state.
@@ -106,10 +109,12 @@ options:
     description:
     - status for NFS v4.0 referrals.
     choices: ['enabled', 'disabled']
+    version_added: '2.9'
   nfsv41_referrals:
     description:
     - status for NFS v4.1 referrals.
     choices: ['enabled', 'disabled']
+    version_added: '2.9'
   tcp:
     description:
     - Enable TCP (support from ONTAP 9.3 onward).

--- a/lib/ansible/modules/storage/netapp/na_ontap_nfs.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_nfs.py
@@ -44,6 +44,10 @@ options:
     - status of if NFSv3 clients see change in FSID as they traverse filesystems.
     choices: ['enabled', 'disabled']
     version_added: '2.7'
+  nfsv4_fsid_change:
+    description:
+    - status of if NFSv4 clients see change in FSID as they traverse filesystems.
+    choices: ['enabled', 'disabled']
   nfsv4:
     description:
     - status of NFSv4.
@@ -52,6 +56,14 @@ options:
     description:
     - status of NFSv41.
     aliases: ['nfsv4.1']
+    choices: ['enabled', 'disabled']
+  nfsv41_pnfs:
+    description:
+    - status of NFSv41 pNFS.
+    choices: ['enabled', 'disabled']
+  nfsv4_numeric_ids:
+    description:
+    - status of NFSv4 numeric ID's.
     choices: ['enabled', 'disabled']
   vstorage_state:
     description:
@@ -90,6 +102,14 @@ options:
     - status for NFS v4.1 write delegation feature.
     choices: ['enabled', 'disabled']
     version_added: '2.7'
+  nfsv40_referrals:
+    description:
+    - status for NFS v4.0 referrals.
+    choices: ['enabled', 'disabled']
+  nfsv41_referrals:
+    description:
+    - status for NFS v4.1 referrals.
+    choices: ['enabled', 'disabled']
   tcp:
     description:
     - Enable TCP (support from ONTAP 9.3 onward).
@@ -143,6 +163,7 @@ HAS_NETAPP_LIB = netapp_utils.has_netapp_lib()
 
 class NetAppONTAPNFS(object):
     """ object initialize and class methods """
+
     def __init__(self):
 
         self.argument_spec = netapp_utils.na_ontap_host_argument_spec()
@@ -152,17 +173,22 @@ class NetAppONTAPNFS(object):
             vserver=dict(required=True, type='str'),
             nfsv3=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv3_fsid_change=dict(required=False, default=None, choices=['enabled', 'disabled']),
+            nfsv4_fsid_change=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv4=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv41=dict(required=False, default=None, choices=['enabled', 'disabled'], aliases=['nfsv4.1']),
+            nfsv41_pnfs=dict(required=False, default=None, choices=['enabled', 'disabled']),
+            nfsv4_numeric_ids=dict(required=False, default=None, choices=['enabled', 'disabled']),
             vstorage_state=dict(required=False, default=None, choices=['enabled', 'disabled']),
             tcp=dict(required=False, default=None, choices=['enabled', 'disabled']),
             udp=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv4_id_domain=dict(required=False, type='str', default=None),
             nfsv40_acl=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv40_read_delegation=dict(required=False, default=None, choices=['enabled', 'disabled']),
+            nfsv40_referrals=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv40_write_delegation=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv41_acl=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv41_read_delegation=dict(required=False, default=None, choices=['enabled', 'disabled']),
+            nfsv41_referrals=dict(required=False, default=None, choices=['enabled', 'disabled']),
             nfsv41_write_delegation=dict(required=False, default=None, choices=['enabled', 'disabled']),
             showmount=dict(required=False, default=None, choices=['enabled', 'disabled']),
             tcp_max_xfer_size=dict(required=False, default=None, type='int')
@@ -181,6 +207,7 @@ class NetAppONTAPNFS(object):
         self.vserver = parameters['vserver']
         self.nfsv3 = parameters['nfsv3']
         self.nfsv3_fsid_change = parameters['nfsv3_fsid_change']
+        self.nfsv4_fsid_change = parameters['nfsv4_fsid_change']
         self.nfsv4 = parameters['nfsv4']
         self.nfsv41 = parameters['nfsv41']
         self.vstorage_state = parameters['vstorage_state']
@@ -189,10 +216,14 @@ class NetAppONTAPNFS(object):
         self.tcp = parameters['tcp']
         self.nfsv40_acl = parameters['nfsv40_acl']
         self.nfsv40_read_delegation = parameters['nfsv40_read_delegation']
+        self.nfsv40_referrals = parameters['nfsv40_referrals']
         self.nfsv40_write_delegation = parameters['nfsv40_write_delegation']
         self.nfsv41_acl = parameters['nfsv41_acl']
         self.nfsv41_read_delegation = parameters['nfsv41_read_delegation']
+        self.nfsv41_referrals = parameters['nfsv41_referrals']
         self.nfsv41_write_delegation = parameters['nfsv41_write_delegation']
+        self.nfsv41_pnfs = parameters['nfsv41_pnfs']
+        self.nfsv4_numeric_ids = parameters['nfsv4_numeric_ids']
         self.showmount = parameters['showmount']
         self.tcp_max_xfer_size = parameters['tcp_max_xfer_size']
 
@@ -223,6 +254,7 @@ class NetAppONTAPNFS(object):
             attributes_list = result.get_child_by_name('attributes-list').get_child_by_name('nfs-info')
             is_nfsv3_enabled = attributes_list.get_child_content('is-nfsv3-enabled')
             is_nfsv3_fsid_change_enabled = attributes_list.get_child_content('is-nfsv3-fsid-change-enabled')
+            is_nfsv4_fsid_change_enabled = attributes_list.get_child_content('is-nfsv4-fsid-change-enabled')
             is_nfsv40_enabled = attributes_list.get_child_content('is-nfsv40-enabled')
             is_nfsv41_enabled = attributes_list.get_child_content('is-nfsv41-enabled')
             is_vstorage_enabled = attributes_list.get_child_content('is-vstorage-enabled')
@@ -232,26 +264,35 @@ class NetAppONTAPNFS(object):
             is_nfsv40_acl_enabled = attributes_list.get_child_content('is-nfsv40-acl-enabled')
             is_nfsv40_write_delegation_enabled = attributes_list.get_child_content('is-nfsv40-write-delegation-enabled')
             is_nfsv40_read_delegation_enabled = attributes_list.get_child_content('is-nfsv40-read-delegation-enabled')
+            is_nfsv40_referrals_enabled = attributes_list.get_child_content('is-nfsv40-referrals-enabled')
             is_nfsv41_acl_enabled = attributes_list.get_child_content('is-nfsv41-acl-enabled')
             is_nfsv41_write_delegation_enabled = attributes_list.get_child_content('is-nfsv41-write-delegation-enabled')
             is_nfsv41_read_delegation_enabled = attributes_list.get_child_content('is-nfsv41-read-delegation-enabled')
+            is_nfsv41_referrals_enabled = attributes_list.get_child_content('is-nfsv41-referrals-enabled')
+            is_nfsv41_pnfs_enabled = attributes_list.get_child_content('is-nfsv41-pnfs-enabled')
+            is_nfsv4_numeric_ids_enabled = attributes_list.get_child_content('is-nfsv4-numeric-ids-enabled')
             is_showmount_enabled = attributes_list.get_child_content('showmount')
             tcp_max_xfer_size = attributes_list.get_child_content('tcp-max-xfer-size')
             nfs_details = {
                 'is_nfsv3_enabled': is_nfsv3_enabled,
                 'is_nfsv3_fsid_change_enabled': is_nfsv3_fsid_change_enabled,
+                'is_nfsv4_fsid_change_enabled': is_nfsv4_fsid_change_enabled,
                 'is_nfsv40_enabled': is_nfsv40_enabled,
                 'is_nfsv41_enabled': is_nfsv41_enabled,
+                'is_nfsv41_pnfs_enabled': is_nfsv41_pnfs_enabled,
+                'is_nfsv4_numeric_ids_enabled': is_nfsv4_numeric_ids_enabled,
                 'is_vstorage_enabled': is_vstorage_enabled,
                 'nfsv4_id_domain': nfsv4_id_domain_value,
                 'is_tcp_enabled': is_tcp_enabled,
                 'is_udp_enabled': is_udp_enabled,
                 'is_nfsv40_acl_enabled': is_nfsv40_acl_enabled,
-                'is_nfsv40_write_delegation_enabled': is_nfsv40_write_delegation_enabled,
                 'is_nfsv40_read_delegation_enabled': is_nfsv40_read_delegation_enabled,
+                'is_nfsv40_referrals_enabled': is_nfsv40_referrals_enabled,
+                'is_nfsv40_write_delegation_enabled': is_nfsv40_write_delegation_enabled,
                 'is_nfsv41_acl_enabled': is_nfsv41_acl_enabled,
-                'is_nfsv41_write_delegation_enabled': is_nfsv41_write_delegation_enabled,
                 'is_nfsv41_read_delegation_enabled': is_nfsv41_read_delegation_enabled,
+                'is_nfsv41_referrals_enabled': is_nfsv41_referrals_enabled,
+                'is_nfsv41_write_delegation_enabled': is_nfsv41_write_delegation_enabled,
                 'is_showmount_enabled': is_showmount_enabled,
                 'tcp_max_xfer_size': tcp_max_xfer_size
             }
@@ -311,6 +352,10 @@ class NetAppONTAPNFS(object):
             nfs_modify.add_new_child('is-nfsv3-fsid-change-enabled', 'true')
         elif self.nfsv3_fsid_change == 'disabled':
             nfs_modify.add_new_child('is-nfsv3-fsid-change-enabled', 'false')
+        if self.nfsv4_fsid_change == 'enabled':
+            nfs_modify.add_new_child('is-nfsv4-fsid-change-enabled', 'true')
+        elif self.nfsv4_fsid_change == 'disabled':
+            nfs_modify.add_new_child('is-nfsv4-fsid-change-enabled', 'false')
         if self.nfsv4 == 'enabled':
             nfs_modify.add_new_child('is-nfsv40-enabled', 'true')
         elif self.nfsv4 == 'disabled':
@@ -339,6 +384,10 @@ class NetAppONTAPNFS(object):
             nfs_modify.add_new_child('is-nfsv40-read-delegation-enabled', 'true')
         elif self.nfsv40_read_delegation == 'disabled':
             nfs_modify.add_new_child('is-nfsv40-read-delegation-enabled', 'false')
+        if self.nfsv40_referrals == 'enabled':
+            nfs_modify.add_new_child('is-nfsv40-referrals-enabled', 'true')
+        elif self.nfsv40_referrals == 'disabled':
+            nfs_modify.add_new_child('is-nfsv40-referrals-enabled', 'false')
         if self.nfsv40_write_delegation == 'enabled':
             nfs_modify.add_new_child('is-nfsv40-write-delegation-enabled', 'true')
         elif self.nfsv40_write_delegation == 'disabled':
@@ -351,10 +400,22 @@ class NetAppONTAPNFS(object):
             nfs_modify.add_new_child('is-nfsv41-read-delegation-enabled', 'true')
         elif self.nfsv41_read_delegation == 'disabled':
             nfs_modify.add_new_child('is-nfsv41-read-delegation-enabled', 'false')
+        if self.nfsv41_referrals == 'enabled':
+            nfs_modify.add_new_child('is-nfsv41-referrals-enabled', 'true')
+        elif self.nfsv41_referrals == 'disabled':
+            nfs_modify.add_new_child('is-nfsv41-referrals-enabled', 'false')
         if self.nfsv41_write_delegation == 'enabled':
             nfs_modify.add_new_child('is-nfsv41-write-delegation-enabled', 'true')
         elif self.nfsv41_write_delegation == 'disabled':
             nfs_modify.add_new_child('is-nfsv41-write-delegation-enabled', 'false')
+        if self.nfsv41_pnfs == 'enabled':
+            nfs_modify.add_new_child('is-nfsv41-pnfs-enabled', 'true')
+        elif self.nfsv41_pnfs == 'disabled':
+            nfs_modify.add_new_child('is-nfsv41-pnfs-enabled', 'false')
+        if self.nfsv4_numeric_ids == 'enabled':
+            nfs_modify.add_new_child('is-nfsv4-numeric-ids-enabled', 'true')
+        elif self.nfsv4_numeric_ids == 'disabled':
+            nfs_modify.add_new_child('is-nfsv4-numeric-ids-enabled', 'false')
         if self.showmount == 'enabled':
             nfs_modify.add_new_child('showmount', 'true')
         elif self.showmount == 'disabled':
@@ -419,15 +480,27 @@ class NetAppONTAPNFS(object):
         def is_modify_needed():
             if (((self.nfsv3 is not None) and state_changed(self.nfsv3, nfs_service_details['is_nfsv3_enabled'])) or
                 ((self.nfsv3_fsid_change is not None) and state_changed(self.nfsv3_fsid_change, nfs_service_details['is_nfsv3_fsid_change_enabled'])) or
+                ((self.nfsv4_fsid_change is not None) and state_changed(self.nfsv4_fsid_change, nfs_service_details['is_nfsv4_fsid_change_enabled'])) or
                 ((self.nfsv4 is not None) and state_changed(self.nfsv4, nfs_service_details['is_nfsv40_enabled'])) or
                 ((self.nfsv41 is not None) and state_changed(self.nfsv41, nfs_service_details['is_nfsv41_enabled'])) or
+                ((self.nfsv41_pnfs is not None) and state_changed(self.nfsv41_pnfs, nfs_service_details['is_nfsv41_pnfs_enabled'])) or
+                ((self.nfsv4_numeric_ids is not None) and state_changed(self.nfsv4_numeric_ids, nfs_service_details['is_nfsv4_numeric_ids_enabled'])) or
                 ((self.tcp is not None) and state_changed(self.tcp, nfs_service_details['is_tcp_enabled'])) or
                 ((self.udp is not None) and state_changed(self.udp, nfs_service_details['is_udp_enabled'])) or
                 ((self.nfsv40_acl is not None) and state_changed(self.nfsv40_acl, nfs_service_details['is_nfsv40_acl_enabled'])) or
+                ((self.nfsv40_read_delegation is not None) and state_changed(self.nfsv40_read_delegation,
+                                                                             nfs_service_details['is_nfsv40_read_delegation_enabled'])) or
                 ((self.nfsv40_write_delegation is not None) and state_changed(self.nfsv40_write_delegation,
                                                                               nfs_service_details['is_nfsv40_write_delegation_enabled'])) or
-                ((self.nfsv40_write_delegation is not None) and state_changed(self.nfsv40_write_delegation,
-                                                                              nfs_service_details['is_nfsv40_write_delegation_enabled'])) or
+                ((self.nfsv41_acl is not None) and state_changed(self.nfsv41_acl, nfs_service_details['is_nfsv41_acl_enabled'])) or
+                ((self.nfsv41_read_delegation is not None) and state_changed(self.nfsv41_read_delegation,
+                                                                             nfs_service_details['is_nfsv41_read_delegation_enabled'])) or
+                ((self.nfsv41_write_delegation is not None) and state_changed(self.nfsv41_write_delegation,
+                                                                              nfs_service_details['is_nfsv41_write_delegation_enabled'])) or
+                ((self.nfsv40_referrals is not None) and state_changed(self.nfsv40_referrals,
+                                                                       nfs_service_details['is_nfsv40_referrals_enabled'])) or
+                ((self.nfsv41_referrals is not None) and state_changed(self.nfsv41_referrals,
+                                                                       nfs_service_details['is_nfsv41_referrals_enabled'])) or
                 ((self.showmount is not None) and state_changed(self.showmount, nfs_service_details['is_showmount_enabled'])) or
                     ((self.vstorage_state is not None) and state_changed(self.vstorage_state, nfs_service_details['is_vstorage_enabled'])) or
                     ((self.tcp_max_xfer_size is not None) and int(self.tcp_max_xfer_size) != int(nfs_service_details['tcp_max_xfer_size']))):


### PR DESCRIPTION
##### SUMMARY
Adding new options to na_ontap_nfs module, extending functionality
- nfsv4_fsid_change
- nfsv4_numeric_ids
- nfsv40_referrals
- nfsv41_pnfs
- nfsv41_referrals


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
na_ontap_nfs