### PR TITLE
vmware_dvs_portgroup_facts: test depends on a dvswitch

### DIFF
--- a/test/integration/targets/vmware_dvs_portgroup_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup_facts/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - import_role:
     name: prepare_vmware_tests
+  vars:
+    setup_dvswitch: true
 
 - when: vcsim is not defined
   block:


### PR DESCRIPTION
##### SUMMARY

Creates the missing dvswitch that is used by the test.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_dvs_portgroup_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
