### PR TITLE
2.8: Clear 'connection related' plugin vars for next loop iteration (#59024) v2

### DIFF
--- a/changelogs/fragments/58876-do-not-reuse-remote_user-from-prev-loop.yaml
+++ b/changelogs/fragments/58876-do-not-reuse-remote_user-from-prev-loop.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Do not re-use remote_user from previous loop iteration (https://github.com/ansible/ansible/issues/58876)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -421,7 +421,7 @@ class TaskExecutor:
 
                 for plugin_type, plugin_name in iteritems(clear_plugins):
                     for var in C.config.get_plugin_vars(plugin_type, plugin_name):
-                        if var in task_vars:
+                        if var in task_vars and var not in self._job_vars:
                             del task_vars[var]
 
         self._task.no_log = no_log

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -410,6 +410,20 @@ class TaskExecutor:
             results.append(res)
             del task_vars[loop_var]
 
+            # clear 'connection related' plugin variables for next iteration
+            if self._connection:
+                clear_plugins = {
+                    'connection': self._connection._load_name,
+                    'shell': self._connection._shell._load_name
+                }
+                if self._connection.become:
+                    clear_plugins['become'] = self._connection.become._load_name
+
+                for plugin_type, plugin_name in iteritems(clear_plugins):
+                    for var in C.config.get_plugin_vars(plugin_type, plugin_name):
+                        if var in task_vars:
+                            del task_vars[var]
+
         self._task.no_log = no_log
 
         return results

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -344,3 +344,18 @@
     loop_var: "{{ loop_var_name }}"
   vars:
     loop_var_name: templated_loop_var_name
+
+# https://github.com/ansible/ansible/issues/59414
+- name: Test preserving original connection related vars
+  debug:
+    var: ansible_remote_tmp
+  vars:
+    ansible_remote_tmp: /tmp/test1
+  with_items:
+  - 1
+  - 2
+  register: loop_out
+
+- assert:
+    that:
+      - loop_out['results'][1]['ansible_remote_tmp'] == '/tmp/test1'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of:
https://github.com/ansible/ansible/pull/59024
https://github.com/ansible/ansible/pull/59426

Originally in https://github.com/ansible/ansible/pull/59284
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_executor.py`