### PR TITLE
mysql.py: remove unused import

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -35,7 +35,6 @@ try:
 except ImportError:
     try:
         import MySQLdb as mysql_driver
-        import MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'
     except ImportError:
         mysql_driver = None


### PR DESCRIPTION
##### SUMMARY
remove an unused import from ```lib/ansible/module_utils/mysql.py```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Small Patch

##### COMPONENT NAME
lib/ansible/module_utils/mysql.py

##### ADDITIONAL INFORMATION
I checked all mysql modules and didn't find any unused imports there