### PR TITLE
remove useless overhead

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -168,8 +168,6 @@ EXAMPLES = '''
 
 - name: Install a list of packages
   apt:
-    name: "{{ packages }}"
-  vars:
     packages:
     - foo
     - foo-tools

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -168,7 +168,7 @@ EXAMPLES = '''
 
 - name: Install a list of packages
   apt:
-    packages:
+    pkg:
     - foo
     - foo-tools
 


### PR DESCRIPTION
##### SUMMARY

I'm unable to see why one would write:

    - name: Install a list of packages
      apt:
        name: "{{ packages }}"
      vars:
        packages:
        - foo
        - foo-tools

Instead of the simpler:

    - name: Install a list of packages
      apt:
        packages:
        - foo
        - foo-tools

So let's do just that, remove the mental and runtime overhead and use the simple form.
 
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
