### PR TITLE
Fix inconsistency nxos->ios role

### DIFF
--- a/docs/docsite/rst/network/getting_started/network_roles.rst
+++ b/docs/docsite/rst/network/getting_started/network_roles.rst
@@ -270,7 +270,7 @@ For example, to use the ``config_manager`` role with Cisco IOS devices, you woul
 
 .. code-block:: bash
 
-   [user@ansible]$ ansible-galaxy install ansible-network.cisco_nxos
+   [user@ansible]$ ansible-galaxy install ansible-network.cisco_ios
    [user@ansible]$ ansible-galaxy install ansible-network.config_manager
 
 Roles are fully documented with examples in Ansible Galaxy on the **Read Me** tab for each role.


### PR DESCRIPTION
Chapter "Ansible supported network roles"
+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Mismatch between the sentence "For example, to use the config_manager role with Cisco IOS devices, you would use the following commands:" and the role installed in the code block (nxos instead of ios)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
