### PR TITLE
ce_config: Optimize multi-level views & fix a bug.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,9 +220,9 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import NetworkConfig, dumps
+from ansible.module_utils.network.common.config import _NetworkConfig, dumps, ConfigLine
 from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
-from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
+from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args
 import re
 
@@ -231,7 +231,7 @@ def check_args(module, warnings):
     ce_check_args(module, warnings)
 
 
-def load_config(module, config):
+def _load_config(module, config):
     """Sends configuration commands to the remote device
     """
     rc, out, err = exec_command(module, 'mmi-mode enable')
@@ -330,9 +330,67 @@ def run(module, result):
         result['updates'] = command_display
 
         if not module.check_mode:
-            load_config(module, commands)
+            if module.params['parents'] is not None:
+                load_config(module, commands)
+            else:
+                _load_config(module, commands)
 
         result['changed'] = True
+
+
+class NetworkConfig(_NetworkConfig):
+
+    def add(self, lines, parents=None):
+        ancestors = list()
+        offset = 0
+        obj = None
+
+        # global config command
+        if not parents:
+            for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
+                item = ConfigLine(line)
+                item.raw = line
+                self.items.append(item)
+
+        else:
+            for index, p in enumerate(parents):
+                try:
+                    i = index + 1
+                    obj = self.get_block(parents[:i])[0]
+                    ancestors.append(obj)
+
+                except ValueError:
+                    # add parent to config
+                    offset = index * self._indent
+                    obj = ConfigLine(p)
+                    obj.raw = p.rjust(len(p) + offset)
+                    if ancestors:
+                        obj._parents = list(ancestors)
+                        ancestors[-1]._children.append(obj)
+                    self.items.append(obj)
+                    ancestors.append(obj)
+
+            # add child objects
+            for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
+                # check if child already exists
+                for child in ancestors[-1]._children:
+                    if child.text == line:
+                        break
+                else:
+                    offset = len(parents) * self._indent
+                    item = ConfigLine(line)
+                    item.raw = line.rjust(len(line) + offset)
+                    item._parents = ancestors
+                    ancestors[-1]._children.append(item)
+                    self.items.append(item)
 
 
 def main():

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,7 +220,8 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import NetworkConfig as _NetworkConfig, dumps, ConfigLine, ignore_line
+from ansible.module_utils.network.common.config import NetworkConfig as _NetworkConfig
+from ansible.module_utils.network.common.config import dumps, ConfigLine, ignore_line
 from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,7 +220,7 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import _NetworkConfig, dumps, ConfigLine
+from ansible.module_utils.network.common.config import NetworkConfi as _NetworkConfig, dumps, ConfigLine
 from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,7 +220,7 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import NetworkConfi as _NetworkConfig, dumps, ConfigLine
+from ansible.module_utils.network.common.config import NetworkConfi as _NetworkConfig, dumps, ConfigLine, ignore_line
 from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,7 +220,7 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import NetworkConfi as _NetworkConfig, dumps, ConfigLine, ignore_line
+from ansible.module_utils.network.common.config import NetworkConfig as _NetworkConfig, dumps, ConfigLine, ignore_line
 from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Optimize multi-level views
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### test case
```paste below
  - name: "Step2.1.1 Loading command configuration from lines"
    ce_config:
      lines: 
        - interface vlanif 3111
        - description test_vlanif3111_1
        - interface vlanif 3112
        - description test_vlanif3112_1
      match: none
```
### error log
```
atal: [10.190.121.125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "after": null,
            "backup": false,
            "backup_options": null,
            "before": null,
            "config": null,
            "defaults": false,
            "host": "10.190.121.125",
            "lines": [
                "interface vlanif 3111",
                "description test_vlanif3111_1",
                "interface vlanif 3112",
                "description test_vlanif3112_1"
            ],
            "match": "none",
            "parents": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "replace": "line",
            "save": false,
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "msg": "Command: interface vlanif 3112, error[1]: unrecognized command found."
}

PLAY RECAP **************************************************************************
10.190.121.125             : ok=0    changed=0    unreachable=0    failed=1    skippe                                                                            d=0    rescued=0    ignored=0
```
### debug result
```
Module does not support multi-view jumps.
An error happened when commands try to change contexts.
```
### after fixed, test log
```
changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "commands": [
        "interface vlanif 3111",
        "description test_vlanif3111_1",
        "interface vlanif 3112",
        "description test_vlanif3112_1"
    ],
    "invocation": {
        "module_args": {
            "after": null,
            "backup": false,
            "backup_options": null,
            "before": null,
            "config": null,
            "defaults": false,
            "host": null,
            "lines": [
                "interface vlanif 3111",
                "description test_vlanif3111_1",
                "interface vlanif 3112",
                "description test_vlanif3112_1"
            ],
            "match": "none",
            "parents": null,
            "password": null,
            "port": null,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "replace": "line",
            "save": false,
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": null,
            "validate_certs": null
        }
    },
    "updates": [
        "interface vlanif 3111",
        "description test_vlanif3111_1",
        "interface vlanif 3112",
        "description test_vlanif3112_1"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
### show configure on device.
```

[~8850_130.12]di cu | section in Vlanif311
#
interface Vlanif3111
 description test_vlanif3111_1
 ospf enable 1 area 0.0.0.1
#
interface Vlanif3112
 description test_vlanif3112_1
[~8850_130.12]
```

