### PR TITLE
Typo in the Warning block eneabled -> enabled

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -112,7 +112,7 @@ option in Ansible configuration file or by set :envvar:`ANSIBLE_LOG_PATH` as men
   The device interaction messages consist of command executed on target device and the returned response, as this
   log data can contain sensitive information including passwords in plain text it is disabled by default.
   Additionally, in order to prevent accidental leakage of data, a warning will be shown on every task with this
-  setting eneabled specifying which host has it enabled and where the data is being logged.
+  setting enabled specifying which host has it enabled and where the data is being logged.
 
 Be sure to fully understand the security implications of enabling this option. The device interaction logging can be enabled either globally by setting in configuration file or by setting environment or enabled on per task basis by passing special variable to task.
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -588,6 +588,7 @@ For example:
 
 Suggestions to resolve:
 
+In Ansible prior to 2.5 :
 Add ``authorize: yes`` to the task. For example:
 
 .. code-block:: yaml
@@ -613,6 +614,9 @@ Add ``authorize: yes`` to the task. For example:
       authorize: yes
       auth_pass: "{{ mypasswordvar }}"
   register: result
+
+
+.. note:: Starting with Ansible 2.5 we recommend using ``connection: network_cli`` and ``become: yes``
 
 
 Proxy Issues


### PR DESCRIPTION
Chapter : Enabling Networking device interaction logging

Regarding the "Error: “connecting to host <hostname> returned an error” or “Bad address”" chapter about ssh-keys
It advises to add the following to ansible.cfg
[paramiko_connection]
host_key_auto_add = True

Is it the same as :
[defaults]
host_key_checking = False

If yes, should it be added to the documentation there ?

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Typo eneabled -> enabled
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
