### PR TITLE
[WIP] Basic handling of remount options. (#59460)

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -422,7 +422,10 @@ def remount(module, args):
     if get_platform().lower().endswith('bsd'):
         cmd += ['-u']
     else:
-        cmd += ['-o', 'remount']
+        if args['opts'] != 'defaults':
+            cmd += ['-o', 'remount,' + args['opts']]
+        else:
+            cmd += ['-o', 'remount']
 
     if get_platform().lower() == 'openbsd':
         # Use module.params['fstab'] here as args['fstab'] has been set to the

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -76,7 +76,11 @@ options:
         point.
       - C(remounted) specifies that the device will be remounted for when you
         want to force a refresh on the mount itself (added in 2.9). This will
-        always return changed=true.
+        always return changed=true. If I(opts) is set, the options will be
+        applied to the remount, but will not change I(fstab).  Additionally,
+        if I(opts) is set, and the remount command fails, the module will
+        error to prevent unexpected mount changes.  Try using C(mounted)
+        instead to work around this issue.
     type: str
     required: true
     choices: [ absent, mounted, present, unmounted, remounted ]
@@ -137,6 +141,20 @@ EXAMPLES = r'''
   mount:
     path: /tmp/mnt-pnt
     state: unmounted
+
+- name: Remount a mounted volume
+  mount:
+    path: /tmp/mnt-pnt
+    state: remounted
+
+# The following will not save changes to fstab, and only be temporary until
+# a reboot, or until calling "state: unmounted" followed by "state: mounted"
+# on the same "path"
+- name: Remount a mounted volume with different options
+  mount:
+    path: /tmp
+    state: remounted
+    opts: exec
 
 - name: Mount and bind a volume
   mount:

--- a/test/integration/targets/mount/tasks/main.yml
+++ b/test/integration/targets/mount/tasks/main.yml
@@ -126,6 +126,26 @@
       - "'1' in remount_options.stdout"
       - "1 == remount_options.stdout_lines | length"
   when: ansible_system in ('FreeBSD', 'Linux')
+  
+- name: Remount filesystem with different opts using new remounted option (Linux only)
+  mount:
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
+    state: "remounted"
+    opts: "rw,noexec"
+  when: ansible_system == 'Linux'
+
+- name: Get remounted options (Linux only)
+  shell: mount | grep mount_dest | grep -E -w 'noexec' | wc -l
+  register: remounted_options
+  when: ansible_system == 'Linux'
+
+- name: Make sure the filesystem now has the new opts after using remounted (Linux only)
+  assert:
+    that:
+      - "'1' in remounted_options.stdout"
+      - "1 == remounted_options.stdout_lines | length"
+  when: ansible_system == 'Linux'
 
 - name: Unmount the bind mount
   mount:


### PR DESCRIPTION
##### SUMMARY
**Work in progress**

Goal: Handle remount with new options.  

Current problems: Directly calls `mount -o remount,[new_opts]`, which results in appending to existing mount options, which may result in an unknown state if the existing mount is using undesired options that will not be overwritten with any new options.

Missing changes: Tests and `umount`/`mount` fall back path handling.

Fixes #59460

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
Without change:
```
remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)

controller $ ansible all -i "[REDACTED]," -m mount -a 'path=/tmp state=remounted opts=exec' --user [REDACTED] --ask-pass --become --ask-become-pass --become-user root
[REDACTED] | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "dump": "0",
    "fstab": "/etc/fstab",
    "name": "/tmp",
    "opts": "exec",
    "passno": "0"
}

remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)
```



With change:
```
remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)

controller $ ansible all -i "[REDACTED]," -m mount -a 'path=/tmp state=remounted opts=exec' --user [REDACTED] --ask-pass --become --ask-become-pass --become-user root
[REDACTED] | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "dump": "0",
    "fstab": "/etc/fstab",
    "name": "/tmp",
    "opts": "exec",
    "passno": "0"
}

remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,relatime,data=ordered)
```
