### PR TITLE
vmware_guest_network: fix the network look up

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -1195,7 +1195,7 @@ class PyVmomi(object):
             if len(temp_vm_object.propSet) != 1:
                 continue
             for temp_vm_object_property in temp_vm_object.propSet:
-                if temp_vm_object_property.val == self.params['name']:
+                if temp_vm_object_property.val == network_name:
                     networks.append(temp_vm_object.obj)
                     break
         return networks

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -17,7 +17,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines[0].name }}"
       gather_network_facts: true
     register: netadapter_facts
 
@@ -33,7 +33,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines[0].name }}"
       networks:
         - name: "VM Network"
           state: new
@@ -59,7 +59,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines[0].name }}"
       networks:
         - state: absent
           mac: "00:50:56:58:59:60"
@@ -79,7 +79,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines[0].name }}"
       networks:
         - state: present
           mac: "00:50:56:58:59:61"
@@ -100,7 +100,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines[0].name }}"
       networks:
         - name: non-existing-nw
           manual_mac: "00:50:56:11:22:33"


### PR DESCRIPTION
##### SUMMARY

Before this fix, the module was not able to look up a `VM Network` located at
`/DC0/network/VM Network`. As a consequence, the test module was failing
with a real environment (Non-govcsim).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network
