### PR TITLE
Fail earlier if junos_ping is used with connection netconf

### DIFF
--- a/lib/ansible/modules/network/junos/junos_ping.py
+++ b/lib/ansible/modules/network/junos/junos_ping.py
@@ -61,6 +61,7 @@ notes:
   - For a general purpose network module, see the M(net_ping) module.
   - For Windows targets, use the M(win_ping) module instead.
   - For targets running Python, use the M(ping) module instead.
+  - This module works only with connection C(network_cli).
 extends_documentation_fragment: junos
 """
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -31,7 +31,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
-CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_command']
+CLI_SUPPORTED_MODULES = ['junos_netconf', 'junos_ping', 'junos_command']
 
 
 class ActionModule(ActionNetworkModule):
@@ -88,7 +88,7 @@ class ActionModule(ActionNetworkModule):
                     del self._task.args['provider']
 
             if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
-                    (self._play_context.connection == 'netconf' and self._task.action == 'junos_netconf'):
+                    (self._play_context.connection == 'netconf' and self._task.action in CLI_SUPPORTED_MODULES[0:2]):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, self._task.action)}


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Closes #59326
- Fail earlier if junos_ping is used with netconf connection type.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
junos_ping.py