### PR TITLE
Verify package data in setup.py installs all files

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/package-data.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/package-data.rst
@@ -1,0 +1,5 @@
+Sanity Tests » package-data
+===========================
+
+Verifies that the combination of ``MANIFEST.in`` and ``package_data`` from ``setup.py``
+properly installs data files from within ``lib/ansible``

--- a/setup.py
+++ b/setup.py
@@ -270,6 +270,7 @@ static_setup_params = dict(
             'galaxy/data/*/.*',
             'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',
+            'galaxy/data/*/tests/inventory',
             'galaxy/data/*/role/tests/inventory',
             'config/base.yml',
             'config/module_defaults.yml',

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ static_setup_params = dict(
             'galaxy/data/*/.*',
             'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',
-            'galaxy/data/*/tests/inventory',
+            'galaxy/data/default/role/tests/inventory',
             'config/base.yml',
             'config/module_defaults.yml',
         ],

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ static_setup_params = dict(
             'galaxy/data/*/.*',
             'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',
-            'galaxy/data/default/role/tests/inventory',
+            'galaxy/data/*/role/tests/inventory',
             'config/base.yml',
             'config/module_defaults.yml',
         ],

--- a/test/sanity/code-smell/ansible-only.txt
+++ b/test/sanity/code-smell/ansible-only.txt
@@ -6,3 +6,4 @@ deprecated-config.py
 docs-build.py
 test-constraints.py
 update-bundled.py
+package-data.py

--- a/test/sanity/code-smell/package-data.json
+++ b/test/sanity/code-smell/package-data.json
@@ -1,0 +1,4 @@
+{
+    "always": true,
+    "output": "path-message"
+}

--- a/test/sanity/code-smell/package-data.json
+++ b/test/sanity/code-smell/package-data.json
@@ -1,4 +1,5 @@
 {
+    "disabled": true,
     "always": true,
     "output": "path-message"
 }

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import fnmatch
+import os
+import re
+import tempfile
+import subprocess
+
+
+def main():
+    ignore_files = frozenset((
+        '*/.git_keep',
+        '*/galaxy/data/default/role/*/main.yml.j2',
+        '*/galaxy/data/default/role/*/test.yml.j2',
+        '*/galaxy/data/default/collection/plugins/README.md.j2',
+    ))
+
+    non_py_files = []
+    for root, dirs, files in os.walk('lib/ansible/'):
+        for filename in files:
+            path = os.path.join(root, filename)
+            if os.path.splitext(path)[-1] not in ('.py', '.pyc', '.pyo'):
+                add = True
+                for ignore in ignore_files:
+                    if fnmatch.fnmatch(path, ignore):
+                        add = False
+                if add:
+                    non_py_files.append(path[12:])
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        p = subprocess.Popen(
+            ['python', 'setup.py', 'install', '--root=%s' % tmp_dir],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        stdout, stderr = p.communicate()
+
+        match = re.search('^creating (%s/.+/site-packages/ansible)$' % tmp_dir, stdout, flags=re.M)
+
+        for filename in non_py_files:
+            path = os.path.join(match.group(1), filename)
+            if not os.path.exists(path):
+                print('lib/ansible/%s: File not installed' % filename)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -27,7 +27,7 @@ def main():
                     if fnmatch.fnmatch(path, ignore):
                         add = False
                 if add:
-                    non_py_files.append(path[12:])
+                    non_py_files.append(os.path.relpath(path, 'lib/ansible'))
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         stdout, _dummy = subprocess.Popen(
@@ -41,7 +41,7 @@ def main():
         for filename in non_py_files:
             path = os.path.join(match.group(1), filename)
             if not os.path.exists(path):
-                print('lib/ansible/%s: File not installed' % filename)
+                print('%s: File not installed' % os.path.join('lib', 'ansible', filename))
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -18,7 +18,7 @@ def main():
     ))
 
     non_py_files = []
-    for root, dirs, files in os.walk('lib/ansible/'):
+    for root, _dummy, files in os.walk('lib/ansible/'):
         for filename in files:
             path = os.path.join(root, filename)
             if os.path.splitext(path)[-1] not in ('.py', '.pyc', '.pyo'):
@@ -30,13 +30,12 @@ def main():
                     non_py_files.append(path[12:])
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        p = subprocess.Popen(
+        stdout, _dummy = subprocess.Popen(
             ['python', 'setup.py', 'install', '--root=%s' % tmp_dir],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,
-        )
-        stdout, stderr = p.communicate()
+        ).communicate()
         match = re.search('^creating (%s/.*?/(?:site|dist)-packages/ansible)$' % tmp_dir, stdout, flags=re.M)
 
         for filename in non_py_files:

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -37,8 +37,7 @@ def main():
             universal_newlines=True,
         )
         stdout, stderr = p.communicate()
-
-        match = re.search('^creating (%s/.+/site-packages/ansible)$' % tmp_dir, stdout, flags=re.M)
+        match = re.search('^creating (%s/.*?/(?:site|dist)-packages/ansible)$' % tmp_dir, stdout, flags=re.M)
 
         for filename in non_py_files:
             path = os.path.join(match.group(1), filename)

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -21,7 +21,7 @@ def main():
     for root, _dummy, files in os.walk('lib/ansible/'):
         for filename in files:
             path = os.path.join(root, filename)
-            if os.path.splitext(path)[-1] not in ('.py', '.pyc', '.pyo'):
+            if os.path.splitext(path)[1] not in ('.py', '.pyc', '.pyo'):
                 add = True
                 for ignore in ignore_files:
                     if fnmatch.fnmatch(path, ignore):

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -17,7 +17,7 @@ fi
 
 case "${group}" in
     1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build) ;;
-    2) options=(--test ansible-doc --test docs-build) ;;
+    2) options=(--test ansible-doc --test docs-build --test package-data) ;;
     3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/ --exclude lib/ansible/modules/network/) ;;
     4) options=(--test pylint           test/units/           lib/ansible/module_utils/           lib/ansible/modules/network/) ;;
 esac


### PR DESCRIPTION
##### SUMMARY
Verify package data in setup.py installs all files

We recently added a new data file and it was not matched by `package_data` and thus not installed: https://github.com/ansible/ansible/pull/59452

This test will help ensure new data files are properly installed, as we have missed several in the past.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/sanity/code-smell/package-data.py 

##### ADDITIONAL INFORMATION
before the change to setup.py:

```
ERROR: Found 1 package-data issue(s) which need to be resolved:
ERROR: lib/ansible/galaxy/data/default/role/tests/inventory:0:0: File not installed
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
```