### PR TITLE
Implements extra_hosts for docker_image module

### DIFF
--- a/changelogs/fragments/docker_image_etc_hosts.yml
+++ b/changelogs/fragments/docker_image_etc_hosts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_image module - added extra_hosts argument (https://github.com/ansible/ansible/issues/59233)

--- a/changelogs/fragments/docker_image_etc_hosts.yml
+++ b/changelogs/fragments/docker_image_etc_hosts.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_image module - added extra_hosts argument (https://github.com/ansible/ansible/issues/59233)
+  - docker_image - added ``extra_hosts`` argument (https://github.com/ansible/ansible/issues/59233)

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -94,7 +94,7 @@ options:
         default: no
       etc_hosts:
         description:
-          - Extra hosts to add to /etc/hosts in building containers, as a mapping of hostname to IP address.
+          - Extra hosts to add to C(/etc/hosts) in building containers, as a mapping of hostname to IP address.
         type: dict
         version_added: "2.9"
       args:

--- a/test/integration/targets/docker_image/files/EtcHostsDockerfile
+++ b/test/integration/targets/docker_image/files/EtcHostsDockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+# This should fail building if docker cannot resolve some-custom-host
+RUN ping -c3 some-custom-host

--- a/test/integration/targets/docker_image/files/EtcHostsDockerfile
+++ b/test/integration/targets/docker_image/files/EtcHostsDockerfile
@@ -1,3 +1,3 @@
 FROM busybox
 # This should fail building if docker cannot resolve some-custom-host
-RUN ping -c3 some-custom-host
+RUN ping -c1 some-custom-host

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -316,3 +316,29 @@
     that:
     - dockerfile_2 is changed
     - dockerfile_2.image.Config.WorkingDir == '/first'
+
+####################################################################
+## build.etc_hosts #################################################
+####################################################################
+
+- name: Build image with custom etc_hosts
+  docker_image:
+    name: "{{ iname }}"
+    build:
+      path: "{{ role_path }}/files"
+      dockefile: "EtcHostsDockerfile"
+      pull: no
+      etc_hosts:
+        some-custom-host: "127.0.0.1"
+    source: build
+  register: path_1
+
+- name: cleanup
+  docker_image:
+    name: "{{ iname }}"
+    state: absent
+    force_absent: yes
+
+- assert:
+    that:
+      - path_1 is changed


### PR DESCRIPTION
##### SUMMARY
Allows custom hosts on docker_image module via etc_hosts parameter. Same parameter is already supported by docker_container module.

Fixes: #59233

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_image

##### ADDITIONAL INFORMATION
This unblocks https://github.com/ansible/molecule/issues/2182