### PR TITLE
[stable-2.6] Fix nightly rpm release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ RELEASE ?= 1
 
 # Get the branch information from git
 ifneq ($(shell which git),)
-GIT_DATE := $(shell git log -n 1 --format="%ai")
+GIT_DATE := $(shell git log -n 1 --format="%ci")
 GIT_HASH := $(shell git log -n 1 --format="%h")
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD | sed 's/[-_.\/]//g')
 GITINFO = .$(GIT_HASH).$(GIT_BRANCH)
@@ -57,7 +57,7 @@ GITINFO = ""
 endif
 
 ifeq ($(shell echo $(OS) | egrep -c 'Darwin|FreeBSD|OpenBSD|DragonFly'),1)
-DATE := $(shell date -j -r $(shell git log -n 1 --format="%at") +%Y%m%d%H%M)
+DATE := $(shell date -j -r $(shell git log -n 1 --format="%ct") +%Y%m%d%H%M)
 CPUS ?= $(shell sysctl hw.ncpu|awk '{print $$2}')
 else
 DATE := $(shell date --utc --date="$(GIT_DATE)" +%Y%m%d%H%M)


### PR DESCRIPTION
The nightly rpm builds were using a timestamp from the last git commit
in their Release field.  Unfortunately, that was using author timestamp
which is nonsequential.  Change to using commit timestamp which is
sequential.

note that this still has a cornercase if the branch's history is ever
rewritten.
(cherry picked from commit 97edfcc)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

