### PR TITLE
vmware_vcenter_settings: Specify defaults inside parameter dict

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vcenter_settings.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vcenter_settings.py
@@ -576,11 +576,11 @@ def main():
         database=dict(
             type='dict',
             options=dict(
-                max_connections=dict(type='int'),
-                task_cleanup=dict(type='bool'),
-                task_retention=dict(type='int'),
-                event_cleanup=dict(type='bool'),
-                event_retention=dict(type='int'),
+                max_connections=dict(type='int', default=50),
+                task_cleanup=dict(type='bool', default=True),
+                task_retention=dict(type='int', default=30),
+                event_cleanup=dict(type='bool', default=True),
+                event_retention=dict(type='int', default=30),
             ),
             default=dict(
                 max_connections=50,
@@ -601,11 +601,11 @@ def main():
         user_directory=dict(
             type='dict',
             options=dict(
-                timeout=dict(type='int'),
-                query_limit=dict(type='bool'),
-                query_limit_size=dict(type='int'),
-                validation=dict(type='bool'),
-                validation_period=dict(type='int'),
+                timeout=dict(type='int', default=60),
+                query_limit=dict(type='bool', default=True),
+                query_limit_size=dict(type='int', default=5000),
+                validation=dict(type='bool', default=True),
+                validation_period=dict(type='int', default=1440),
             ),
             default=dict(
                 timeout=60,
@@ -620,6 +620,10 @@ def main():
             options=dict(
                 server=dict(type='str'),
                 sender=dict(type='str'),
+            ),
+            default=dict(
+                server='',
+                sender='',
             ),
         ),
         snmp_receivers=dict(
@@ -664,8 +668,8 @@ def main():
         timeout_settings=dict(
             type='dict',
             options=dict(
-                normal_operations=dict(type='int'),
-                long_operations=dict(type='int'),
+                normal_operations=dict(type='int', default=30),
+                long_operations=dict(type='int', default=120),
             ),
             default=dict(
                 normal_operations=30,

--- a/lib/ansible/modules/cloud/vmware/vmware_vcenter_settings.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vcenter_settings.py
@@ -80,6 +80,10 @@ options:
             - '- C(server) (str): Mail server'
             - '- C(sender) (str): Mail sender address'
         type: dict
+        default: {
+            server: '',
+            sender: '',
+        }
     snmp_receivers:
         description:
             - SNMP trap destinations for vCenter server alerts.
@@ -153,7 +157,7 @@ EXAMPLES = r'''
       event_retention: 30
     runtime_settings:
       unique_id: 1
-      managed_address: "{{ ansible_default_ipv4.address }}"
+      managed_address: "{{ lookup('dig', inventory_hostname) }}"
       vcenter_server_name: "{{ inventory_hostname }}"
     user_directory:
       timeout: 60


### PR DESCRIPTION
##### SUMMARY
Specify the defaults inside each dictionary. This allows for a few settings to be changed from the default without having to specify all settings in the dictionary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vcenter_settings

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The example also had a bug where the managed address was being set to `ansible_default_ipv4.address`, however since this module must be run locally that IPv4 address is of the machine running Ansible instead of the vCenter. I changed this to a dig lookup instead.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

vars:
```
vcenter_unique_id: 1
vcenter_settings_task_retention: 7
vcenter_settings_event_retention: 7
vcenter_logging_level: info
```

task:
```
- name: Configure vCenter general settings
  vmware_vcenter_settings:
    hostname: '{{ vcenter_hostname }}'
    username: '{{ vcenter_username }}'
    password: '{{ vcenter_password }}'
    validate_certs: '{{ validate_certs }}'
    database:
      task_retention: '{{ vcenter_settings_task_retention | default(30) }}'
      event_retention: '{{ vcenter_settings_event_retention | default(30) }}'
    runtime_settings:
      unique_id: '{{ vcenter_unique_id }}'
      managed_address: '{{ inventory_hostname }}'
      vcenter_server_name: '{{ inventory_hostname }}'
      #mail:
      #server: '{{ vcenter_mail_server | default("") }}'
      #sender: '{{ vcenter_mail_sender | default("") }}'
    logging_options: '{{ vcenter_logging_level | default("info") }}'
  delegate_to: localhost
```

task results:
```
ok: [100.115.221.250 -> localhost] => {
    "changed": false,
    "db_event_cleanup": true,
    "db_event_retention": 7,
    "db_max_connections": 50,
    "db_task_cleanup": true,
    "db_task_retention": 7,
    "directory_query_limit": true,
    "directory_query_limit_size": 5000,
    "directory_timeout": 60,
    "directory_validation": true,
    "directory_validation_period": 1440,
    "invocation": {
        "module_args": {
            "database": {
                "event_cleanup": true,
                "event_retention": 7,
                "max_connections": 50,
                "task_cleanup": true,
                "task_retention": 7
            },
            "hostname": "100.115.221.250",
            "logging_options": "info",
            "mail": {
                "sender": "",
                "server": ""
            },
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "runtime_settings": {
                "managed_address": "100.123.228.44",
                "unique_id": 1,
                "vcenter_server_name": "100.115.221.250"
            },
            "snmp_receivers": {
                "snmp_receiver_1_community": "public",
                "snmp_receiver_1_enabled": true,
                "snmp_receiver_1_port": 162,
                "snmp_receiver_1_url": "localhost",
                "snmp_receiver_2_community": "",
                "snmp_receiver_2_enabled": false,
                "snmp_receiver_2_port": 162,
                "snmp_receiver_2_url": "",
                "snmp_receiver_3_community": "",
                "snmp_receiver_3_enabled": false,
                "snmp_receiver_3_port": 162,
                "snmp_receiver_3_url": "",
                "snmp_receiver_4_community": "",
                "snmp_receiver_4_enabled": false,
                "snmp_receiver_4_port": 162,
                "snmp_receiver_4_url": ""
            },
            "timeout_settings": {
                "long_operations": 120,
                "normal_operations": 30
            },
            "user_directory": {
                "query_limit": true,
                "query_limit_size": 5000,
                "timeout": 60,
                "validation": true,
                "validation_period": 1440
            },
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "logging_options": "info",
    "mail_sender": "",
    "mail_server": "",
    "msg": "vCenter settings already configured properly",
    "runtime_managed_address": "100.115.221.250",
    "runtime_server_name": "100.115.221.250",
    "runtime_unique_id": 1,
    "timeout_long_operations": 120,
    "timeout_normal_operations": 30
}
```
