### PR TITLE
PR to fix ansible_net_model not being populated when "C" in Cisco is lowercase in `show version`

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -207,7 +207,7 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_version'] = match.group(1).strip(',')
 
-        model_search_strs = [r'^Cisco (.+) \(revision', r'^[Cc]isco (\S+).+bytes of .*memory']
+        model_search_strs = [r'^[Cc]isco (.+) \(revision', r'^[Cc]isco (\S+).+bytes of .*memory']
         for item in model_search_strs:
             match = re.search(item, data, re.M)
             if match:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to fix issue: https://github.com/ansible/ansible/issues/59549, where ansible_net_model was not being populated appropriately due to the "C" in Cisco being lowercase in the `show version`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts

