### PR TITLE
Lookup URL HTTP request headers

### DIFF
--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -39,7 +39,7 @@ options:
   headers:
     description: HTTP request headers
     type: dictionary
-    default: None
+    default: {}
 """
 
 EXAMPLES = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -36,6 +36,10 @@ options:
     type: string
     default: None
     version_added: "2.8"
+  headers:
+    description: HTTP request headers
+    type: dictionary
+    default: None
 """
 
 EXAMPLES = """
@@ -48,6 +52,9 @@ EXAMPLES = """
 
 - name: url lookup using authentication
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
+
+- name: url lookup with headers
+  debug: msg=""{{ lookup('url', 'https://some.private.site.com/file.txt', headers={'HeaderName':'HeaderValue'} ) }}"
 """
 
 RETURN = """
@@ -78,7 +85,8 @@ class LookupModule(LookupBase):
                 response = open_url(term, validate_certs=self.get_option('validate_certs'),
                                     use_proxy=self.get_option('use_proxy'),
                                     url_username=self.get_option('username'),
-                                    url_password=self.get_option('password'))
+                                    url_password=self.get_option('password'),
+                                    headers=self.get_option('headers'))
             except HTTPError as e:
                 raise AnsibleError("Received HTTP error for %s : %s" % (term, to_native(e)))
             except URLError as e:

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -53,7 +53,7 @@ EXAMPLES = """
 - name: url lookup using authentication
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
 
-- name: url lookup with headers
+- name: url lookup using headers
   debug: msg=""{{ lookup('url', 'https://some.private.site.com/api/service', headers={'HeaderName':'HeaderValue'} ) }}"
 """
 

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -54,7 +54,7 @@ EXAMPLES = """
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
 
 - name: url lookup with headers
-  debug: msg=""{{ lookup('url', 'https://some.private.site.com/file.txt', headers={'HeaderName':'HeaderValue'} ) }}"
+  debug: msg=""{{ lookup('url', 'https://some.private.site.com/api/service', headers={'HeaderName':'HeaderValue'} ) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -54,7 +54,7 @@ EXAMPLES = """
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
 
 - name: url lookup using headers
-  debug: msg="{{ lookup('url', 'https://some.private.site.com/api/service', headers={'Header1':'HeaderVal1', 'Header2':'HeaderVal2'} ) }}"
+  debug: msg="{{ lookup('url', 'https://some.private.site.com/api/service', headers={'header1':'value1', 'header2':'value2'} ) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -54,7 +54,7 @@ EXAMPLES = """
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
 
 - name: url lookup using headers
-  debug: msg=""{{ lookup('url', 'https://some.private.site.com/api/service', headers={'Header1':'HeaderVal1', 'Header2':'HeaderVal2'} ) }}"
+  debug: msg="{{ lookup('url', 'https://some.private.site.com/api/service', headers={'Header1':'HeaderVal1', 'Header2':'HeaderVal2'} ) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -54,7 +54,7 @@ EXAMPLES = """
   debug: msg="{{ lookup('url', 'https://some.private.site.com/file.txt', username='bob', password='hunter2') }}"
 
 - name: url lookup using headers
-  debug: msg=""{{ lookup('url', 'https://some.private.site.com/api/service', headers={'HeaderName':'HeaderValue'} ) }}"
+  debug: msg=""{{ lookup('url', 'https://some.private.site.com/api/service', headers={'Header1':'HeaderVal1', 'Header2':'HeaderVal2'} ) }}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
Update lookup URL plugin to allow headers to be specified in the request

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lookup: url

##### ADDITIONAL INFORMATION
API's commonly authenticate with the use of API keys in host headers, this would allow lookup URL module to handle those easily. open_url module handles the request and already accepts headers, this pull request just allows those to be passed from the url lookup plugin.