### PR TITLE
Added requirement of zipinfo command

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -97,7 +97,7 @@ todo:
     - Re-implement tar support using native tarfile module.
     - Re-implement zip support using native zipfile module.
 notes:
-    - Requires C(gtar)/C(unzip) command on target host.
+    - Requires C(zipinfo) and C(gtar)/C(unzip) command on target host.
     - Can handle I(.zip) files using C(unzip) as well as I(.tar), I(.tar.gz), I(.tar.bz2) and I(.tar.xz) files using C(gtar).
     - Does not handle I(.gz) files, I(.bz2) files or I(.xz) files that do not contain a I(.tar) archive.
     - Uses gtar's C(--diff) arg to calculate if changed or not. If this C(arg) is not


### PR DESCRIPTION
##### SUMMARY

Ran into issues with using this task type on OpenELEC as it does not have `zipinfo` installed. This causes the task to fail with `No such file or directory`. Updating the documentation to make this requirement more obvious.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The full traceback is:
WARNING: The below traceback may *not* be related to the actual failure.
  File "/tmp/ansible_unarchive_payload_cHYu5e/ansible_unarchive_payload.zip/ansible/module_utils/basic.py", line 2561, in run_command
    cmd = subprocess.Popen(args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
  File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child

fatal: [quorra]: FAILED! => {
    "changed": false, 
    "cmd": "-T -s /storage/.ansible/tmp/ansible-tmp-1564000635.4-69851806202185/script.json-cec-0.0.1VwZwOe.zip", 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": null, 
            "content": null, 
            "creates": null, 
            "delimiter": null, 
            "dest": "/storage/.kodi/addons/script.json-cec/", 
            "directory_mode": null, 
            "exclude": [], 
            "extra_opts": [], 
            "follow": false, 
            "force": null, 
            "group": null, 
            "keep_newer": false, 
            "list_files": false, 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": true, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "https://raw.githubusercontent.com/OliPassey/repository.olipassey/master/zips/script.json-cec/script.json-cec-0.0.1.zip", 
            "unsafe_writes": null, 
            "validate_certs": true
        }
    }, 
    "msg": "[Errno 2] No such file or directory", 
    "rc": 2
}
```
