### PR TITLE
Backport/2.8/59511

### DIFF
--- a/changelogs/fragments/59511_mysql-remove-unused-import.yml
+++ b/changelogs/fragments/59511_mysql-remove-unused-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql - Remove the unused import of MySQLdb.cursor from ansible.module_utils.mysql (https://github.com/ansible/ansible/pull/59511)

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -35,7 +35,6 @@ try:
 except ImportError:
     try:
         import MySQLdb as mysql_driver
-        import MySQLdb.cursors
         _mysql_cursor_param = 'cursorclass'
     except ImportError:
         mysql_driver = None


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/59511 - remove an unused import from ```lib/ansible/module_utils/mysql.py```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Small Patch
##### COMPONENT NAME
lib/ansible/module_utils/mysql.py