### PR TITLE
Switch sanity ignores to EOL comments.

### DIFF
--- a/test/sanity/compile/python2.6-skip.txt
+++ b/test/sanity/compile/python2.6-skip.txt
@@ -1,11 +1,6 @@
-# The following are only run by release engineers who can be asked to have newer Python3 on their systems
-hacking/build_library/build_ansible/command_plugins/porting_guide.py
-hacking/build_library/build_ansible/command_plugins/release_announcement.py
-
-# The following are used to build docs.  Since we explicitly say that the controller won't run on
-# Python-2.6 (docs are built controller-side) and EPEL-6, the only LTS platform with Python-2.6,
-# doesn't have a new enough sphinx to build docs, do not test these under Python-2.6
-hacking/build_library/build_ansible/command_plugins/dump_config.py
-hacking/build_library/build_ansible/command_plugins/dump_keywords.py
-hacking/build_library/build_ansible/command_plugins/generate_man.py
-hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+hacking/build_library/build_ansible/command_plugins/porting_guide.py # release process only, 3.6+ required
+hacking/build_library/build_ansible/command_plugins/release_announcement.py # release process only, 3.6+ required
+hacking/build_library/build_ansible/command_plugins/dump_config.py # docs build only, 2.7+ required
+hacking/build_library/build_ansible/command_plugins/dump_keywords.py # docs build only, 2.7+ required
+hacking/build_library/build_ansible/command_plugins/generate_man.py # docs build only, 2.7+ required
+hacking/build_library/build_ansible/command_plugins/plugin_formatter.py # docs build only, 2.7+ required

--- a/test/sanity/compile/python2.7-skip.txt
+++ b/test/sanity/compile/python2.7-skip.txt
@@ -1,3 +1,2 @@
-# The following are only run by release engineers who can be asked to have newer Python3 on their systems
-hacking/build_library/build_ansible/command_plugins/porting_guide.py
-hacking/build_library/build_ansible/command_plugins/release_announcement.py
+hacking/build_library/build_ansible/command_plugins/porting_guide.py # release process only, 3.6+ required
+hacking/build_library/build_ansible/command_plugins/release_announcement.py # release process only, 3.6+ required

--- a/test/sanity/compile/python3.5-skip.txt
+++ b/test/sanity/compile/python3.5-skip.txt
@@ -1,3 +1,2 @@
-# The following are only run by release engineers who can be asked to have newer Python3 on their systems
-hacking/build_library/build_ansible/command_plugins/porting_guide.py
-hacking/build_library/build_ansible/command_plugins/release_announcement.py
+hacking/build_library/build_ansible/command_plugins/porting_guide.py # release process only, 3.6+ required
+hacking/build_library/build_ansible/command_plugins/release_announcement.py # release process only, 3.6+ required


### PR DESCRIPTION
##### SUMMARY

Switch sanity ignores to EOL comments.

This will make automated conversion to consolidated ignores easier.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
