### PR TITLE
VMware: Add suboption for vmware_dvs_host

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
@@ -58,9 +58,15 @@ options:
     vendor_specific_config:
         description:
             - List of key,value dictionaries for the Vendor Specific Configuration.
-            - 'Element attributes are:'
-            - '- C(key) (str): Key of setting. (default: None)'
-            - '- C(value) (str): Value of setting. (default: None)'
+        suboptions:
+            key:
+                description:
+                - Key of setting. Default is None.
+                type: str
+            value:
+                description:
+                - Value of setting. Default is None.
+                type: str
         required: False
         version_added: '2.9'
         type: list


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_dvs_host.py
