### PR TITLE
Use EOL comment for ansible-test PEP8 skip file.

### DIFF
--- a/test/sanity/pep8/skip.txt
+++ b/test/sanity/pep8/skip.txt
@@ -1,3 +1,1 @@
-# _distro.py is being bundled and we don't want to modify bundled code in our repository.
-# We can retest anytime we update the bundled copy
-lib/ansible/module_utils/distro/_distro.py
+lib/ansible/module_utils/distro/_distro.py # bundled code we don't want to modify


### PR DESCRIPTION
##### SUMMARY

Use EOL comment for ansible-test PEP8 skip file.

This will make automated conversion to consolidated ignores easier.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
