### PR TITLE
[WIP] fix clear_host_errors

### DIFF
--- a/changelogs/fragments/59605-fix-clear_host_errors.yaml
+++ b/changelogs/fragments/59605-fix-clear_host_errors.yaml
@@ -1,3 +1,8 @@
 bugfixes:
   - clear_host_errors - Restore the HostState for failed hosts in the current play.
   - clear_host_errors - Forward unreachable and failed hosts to the task after clear_host_errors.
+breaking_changes:
+  - >-
+    The meta action ``clear_host_errors`` now reinstates failed hosts for the current play.
+    Playbooks relying on the hosts only for subsequent plays should move the ``clear_host_errors``
+    task to the beginning of the subsequent play's pre_tasks or tasks.

--- a/changelogs/fragments/59605-fix-clear_host_errors.yaml
+++ b/changelogs/fragments/59605-fix-clear_host_errors.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - clear_host_errors - Restore the HostState for failed hosts in the current play.
+  - clear_host_errors - Forward unreachable and failed hosts to the task after clear_host_errors.

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -50,8 +50,8 @@ And at the playbook level::
 
 .. _resetting_unreachable:
 
-Resetting unreachable hosts
-===========================
+Resetting unreachable and failed hosts
+======================================
 
 If Ansible cannot connect to a host, it marks that host as 'UNREACHABLE' and removes it from the list of active hosts for the run. You can use `meta: clear_host_errors` to reactivate all hosts, so subsequent tasks can try to reach them again.
 

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -117,7 +117,7 @@ class HostState:
         new_state.pending_setup = self.pending_setup
         new_state.did_rescue = self.did_rescue
         new_state.did_start_at_task = self.did_start_at_task
-        new_state._restore_state = self
+        new_state._restore_state = self._restore_state
         if self.tasks_child_state is not None:
             new_state.tasks_child_state = self.tasks_child_state.copy()
         if self.rescue_child_state is not None:

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -51,6 +51,7 @@ class HostState:
         self.always_child_state = None
         self.did_rescue = False
         self.did_start_at_task = False
+        self._restore_state = None
 
     def __repr__(self):
         return "HostState(%r)" % self._blocks
@@ -116,6 +117,7 @@ class HostState:
         new_state.pending_setup = self.pending_setup
         new_state.did_rescue = self.did_rescue
         new_state.did_start_at_task = self.did_start_at_task
+        new_state._restore_state = self
         if self.tasks_child_state is not None:
             new_state.tasks_child_state = self.tasks_child_state.copy()
         if self.rescue_child_state is not None:
@@ -458,6 +460,7 @@ class PlayIterator:
         return state
 
     def mark_host_failed(self, host):
+        self._host_states[host.name]._restore_state = self._host_states[host.name].copy()
         s = self.get_host_state(host)
         display.debug("marking host %s failed, current state: %s" % (host, s))
         s = self._set_failed_state(s)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -51,7 +51,6 @@ class HostState:
         self.always_child_state = None
         self.did_rescue = False
         self.did_start_at_task = False
-        self._restore_state = None
 
     def __repr__(self):
         return "HostState(%r)" % self._blocks
@@ -117,7 +116,6 @@ class HostState:
         new_state.pending_setup = self.pending_setup
         new_state.did_rescue = self.did_rescue
         new_state.did_start_at_task = self.did_start_at_task
-        new_state._restore_state = self._restore_state
         if self.tasks_child_state is not None:
             new_state.tasks_child_state = self.tasks_child_state.copy()
         if self.rescue_child_state is not None:
@@ -460,7 +458,7 @@ class PlayIterator:
         return state
 
     def mark_host_failed(self, host):
-        self._host_states[host.name]._restore_state = self._host_states[host.name].copy()
+        host.restore_state = self._host_states[host.name].copy()
         s = self.get_host_state(host)
         display.debug("marking host %s failed, current state: %s" % (host, s))
         s = self._set_failed_state(s)

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -66,6 +66,7 @@ class Host:
             uuid=self._uuid,
             groups=groups,
             implicit=self.implicit,
+            restore_state=self.restore_state,
         )
 
     def deserialize(self, data):
@@ -76,6 +77,7 @@ class Host:
         self.address = data.get('address', '')
         self._uuid = data.get('uuid', None)
         self.implicit = data.get('implicit', False)
+        self.restore_state = data.get('restore_state', None)
 
         groups = data.get('groups', [])
         for group_data in groups:
@@ -98,6 +100,9 @@ class Host:
         if gen_uuid:
             self._uuid = get_unique_id()
         self.implicit = False
+
+        # The HostState before the host is marked as failed by the PlayIterator
+        self.restore_state = None
 
     def get_name(self):
         return self.name

--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -29,7 +29,8 @@ options:
         - C(noop) (added in Ansible 2.0) This literally does 'nothing'. It is mainly used internally and not recommended for general use.
         - C(clear_facts) (added in Ansible 2.1) causes the gathered facts for the hosts specified in the play's list of hosts to be cleared,
           including the fact cache.
-        - C(clear_host_errors) (added in Ansible 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts.
+        - C(clear_host_errors) (added in Ansible 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts. The recovered
+          hosts will be available to run tasks following the meta task.
         - C(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.
         - C(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)
         - C(end_host) (added in Ansible 2.8) is a per-host variation of C(end_play). Causes the play to end for the current host without failing it.

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1175,7 +1175,6 @@ class StrategyBase:
                     # Iterate over tasks until we get to clear_host_errors
                     s, t = iterator.get_next_task_for_host(host, peek=False)
                     while t is not None and t.args.get('_raw_params') != 'clear_host_errors':
-                        iterator._host_states[host.name].run_state = s.run_state
                         s, t = iterator.get_next_task_for_host(host, peek=False)
                 msg = "cleared host errors"
                 if missing_restore_state:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1170,6 +1170,7 @@ class StrategyBase:
 
                     if failed:
                         iterator._host_states[host.name] = host.restore_state
+                        host.restore_state = None
 
                     # Iterate over tasks until we get to clear_host_errors
                     s, t = iterator.get_next_task_for_host(host, peek=False)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1148,20 +1148,40 @@ class StrategyBase:
                 skip_reason += ', not clearing facts and fact cache for %s' % target_host.name
         elif meta_action == 'clear_host_errors':
             if _evaluate_conditional(target_host):
+                missing_restore_state = []
                 for host in self._inventory.get_hosts(iterator._play.hosts):
                     failed = self._tqm._failed_hosts.pop(host.name, False)
                     unreachable = self._tqm._unreachable_hosts.pop(host.name, False)
+
+                    # TQM exists across plays but resets its failed hosts for every play.
+                    # It passes previously failed hosts off to PlayIterator and then
+                    # reincorporates them after running the Play.
+                    failed |= (iterator._host_states[host.name].fail_state != iterator.FAILED_NONE)
+
                     iterator._host_states[host.name].fail_state = iterator.FAILED_NONE
+
+                    if failed and host.restore_state is None:
+                        # Just in case a third-party strategy plugin is not marking hosts as failed
+                        # via the PlayIterator, keep a list of the hosts that can't be restored to
+                        # provide a helpful message.
+                        missing_restore_state.append(host.name)
+                        continue
+
                     if failed and host.name in self._tqm._stats.rescued and self._tqm._stats.rescued[host.name]:
-                        iterator._host_states[host.name].run_state = iterator._host_states[host.name]._restore_state.run_state
+                        iterator._host_states[host.name].run_state = host.restore_state.run_state
                     elif failed:
-                        iterator._host_states[host.name] = iterator._host_states[host.name]._restore_state
+                        iterator._host_states[host.name] = host.restore_state
+
+                    # Iterate over tasks until we get to clear_host_errors
                     if failed or unreachable:
                         s, t = iterator.get_next_task_for_host(host, peek=False)
                         while t is not None and t.args.get('_raw_params') != 'clear_host_errors':
                             iterator._host_states[host.name].run_state = s.run_state
                             s, t = iterator.get_next_task_for_host(host, peek=False)
                 msg = "cleared host errors"
+                if missing_restore_state:
+                    msg += '\nUnable to restore state for %s. ' % ','.join(missing_restore_state)
+                    msg += 'This is most likely a bug in the strategy plugin. Hosts should be marked as failed via the PlayIterator.'
             else:
                 skipped = True
                 skip_reason += ', not clearing host error state for %s' % target_host.name

--- a/test/integration/targets/meta_tasks/inventory.yml
+++ b/test/integration/targets/meta_tasks/inventory.yml
@@ -4,6 +4,8 @@ local:
       host_var_role_name: role3
     testhost2:
       host_var_role_name: role2
+    testhost3:
+      host_var_role_name: role1
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/test/integration/targets/meta_tasks/runme.sh
+++ b/test/integration/targets/meta_tasks/runme.sh
@@ -64,16 +64,19 @@ for test_strategy in linear free; do
         grep -q "second post-failure and pre-recovery for $host_left" <<< "$out"
         grep -q "block post-failure and pre-recovery for $host_left" <<< "$out"
         grep -q "second in block post-failure and pre-recovery for $host_left" <<< "$out"
+	grep -q "next play pre-recovery for $host_left" <<< "$out"
     done
 
     grep -qv "post-failure and pre-recovery for testhost2" <<< "$out"
     grep -qv "second post-failure and pre-recovery for testhost2" <<< "$out"
     grep -qv "block post-failure and pre-recovery for testhost2" <<< "$out"
     grep -qv "second in block post-failure and pre-recovery for testhost2" <<< "$out"
+    grep -qv "next play pre-recovery for testhost2" <<< "$out"
 
     for host in testhost testhost2 testhost3; do
         grep -q "$host in block" <<< "$out"
         grep -q "post-recovery for $host" <<< "$out"
         grep -q "second post-recovery for $host" <<< "$out"
+	grep -q "next play post-recovery for $host" <<< "$out"
     done
 done

--- a/test/integration/targets/meta_tasks/test_clear_host_errors.yml
+++ b/test/integration/targets/meta_tasks/test_clear_host_errors.yml
@@ -1,0 +1,46 @@
+- name: "Testing end_host with strategy={{ test_strategy | default('linear') }}"
+  hosts:
+    - testhost
+    - testhost2
+    - testhost3
+  gather_facts: no
+  strategy: "{{ test_strategy | default('linear') }}"
+  tasks:
+
+    - name: run all three hosts
+      debug: msg='starting play for {{ inventory_hostname }}'
+
+    - name: fail testhost2 (EXPECTED FAILURE)
+      fail:
+      when: "host_var_role_name == 'role2'"
+
+    - debug: msg='post-failure and pre-recovery for {{ inventory_hostname }}'
+
+    - debug: msg='second post-failure and pre-recovery for {{ inventory_hostname }}'
+
+    - meta: clear_host_errors
+
+    - name: run all three hosts
+      debug: msg='post-recovery for {{ inventory_hostname }}'
+
+    - block:
+      - block:
+        - debug: msg="{{ inventory_hostname }} in block"
+
+        - debug: msg="{{ inventory_hostname }} in block2"
+
+        - name: fail testhost2 again (EXPECTED FAILURE)
+          fail:
+          when: "host_var_role_name == 'role2'"
+
+        - debug: msg='block post-failure and pre-recovery for {{ inventory_hostname }}'
+
+        - debug: msg='second in block post-failure and pre-recovery for {{ inventory_hostname }}'
+
+      - block:
+
+        - meta: clear_host_errors
+
+        - debug: msg='third in block post-recovery {{ inventory_hostname }}'
+
+    - debug: msg='second post-recovery for {{ inventory_hostname }}'

--- a/test/integration/targets/meta_tasks/test_clear_host_errors.yml
+++ b/test/integration/targets/meta_tasks/test_clear_host_errors.yml
@@ -1,4 +1,4 @@
-- name: "Testing end_host with strategy={{ test_strategy | default('linear') }}"
+- name: "Testing clear_host_errors with strategy={{ test_strategy | default('linear') }}"
   hosts:
     - testhost
     - testhost2
@@ -44,3 +44,21 @@
         - debug: msg='third in block post-recovery {{ inventory_hostname }}'
 
     - debug: msg='second post-recovery for {{ inventory_hostname }}'
+
+    - name: fail testhost2 (EXPECTED FAILURE)
+      fail:
+      when: "host_var_role_name == 'role2'"
+
+- name: "Testing clear_host_errors across plays with strategy={{ test_strategy | default('linear') }}"
+  hosts:
+    - testhost
+    - testhost2
+    - testhost3
+  gather_facts: no
+  strategy: "{{ test_strategy | default('linear') }}"
+  pre_tasks:
+    - debug: msg="next play pre-recovery for {{ inventory_hostname }}"
+
+    - meta: clear_host_errors
+
+    - debug: msg="next play post-recovery for {{ inventory_hostname }}"


### PR DESCRIPTION
##### SUMMARY
Fixes that following `meta: clear_host_errors` failed hosts are not able to get subsequent tasks (due to run_state being ITERATING_COMPLETE) and unreachable hosts getting out of sync (due to being any arbitrary number of tasks behind).

Fixes #35086

Example playbook this fixes:
```
---
- hosts: localhost
  connection: local
  gather_facts: no
  tasks:
  - add_host:
      name: "{{item}}"
      ansible_connection: local
    loop:
    - host0
    - host1

- hosts: host0,host1
  gather_facts: no
  tasks:
    - name: "check host status"
      ping:
        data: success
      failed_when: inventory_hostname == "host0"
      register: ping_result

    - meta: clear_host_errors

    - name: "group by host_status"
      group_by:
        key: "host_status_{{ ping_result.ping | default('fail') }}"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/strategy/__init__.py`