### PR TITLE
use pagination on gcp_compute inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -189,14 +189,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 return True
         return False
 
-    def fetch_list(self, params, link, query, token = None):
+    def fetch_list(self, params, link, query, token=None):
         '''
             :param params: a dict containing all of the fields relevant to build URL
             :param link: a formatted URL
             :param query: a formatted query string
             :return the JSON response containing a list of instances.
         '''
-        url_params = { 'filter': query }
+        url_params = {'filter': query}
         if token:
             url_params['pageToken'] = token
         response = self.auth_session.get(link, params=url_params)
@@ -518,7 +518,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                             if not zones or zone in zones:
                                 self._add_hosts(value['instances'], config_data, project_disks=project_disks)
                                 cached_data[project][zone] = value['instances']
-
 
         if cache_needs_update:
             self._cache[cache_key] = cached_data


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/59135

Uses pagination to grab many instances on gcp_compute dynamic inventory plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
