### PR TITLE
Backport 2.8: Populate ansible_net_model for iosxr_facts module

### DIFF
--- a/changelogs/fragments/fix_iosxr_facts.yaml
+++ b/changelogs/fragments/fix_iosxr_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixed issue where `ansible_net_model` was not being populated in iosxr_facts (https://github.com/ansible/ansible/pull/58488)

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -84,6 +84,10 @@ ansible_net_python_version:
   description: The Python version Ansible controller is using
   returned: always
   type: str
+ansible_net_model:
+  description: The model name returned from the device
+  returned: always
+  type: str
 
 # hardware
 ansible_net_filesystems:

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -60,9 +60,12 @@ class Cliconf(CliconfBase):
         if match:
             device_info['network_os_image'] = match.group(1)
 
-        match = re.search(r'^Cisco (.+) \(revision', data, re.M)
-        if match:
-            device_info['network_os_model'] = match.group(1)
+        model_search_strs = [r'^[Cc]isco (.+) \(revision', r'^[Cc]isco (\S+ \S+).+bytes of .*memory']
+        for item in model_search_strs:
+            match = re.search(item, data, re.M)
+            if match:
+                device_info['network_os_model'] = match.group(1)
+                break
 
         match = re.search(r'^(.+) uptime', data, re.M)
         if match:

--- a/test/integration/targets/iosxr_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/iosxr_facts/tests/cli/all_facts.yaml
@@ -9,8 +9,6 @@
     provider: "{{ cli }}"
   register: result
 
-
-
 - assert:
     that:
       # _facts modules should never report a change
@@ -21,7 +19,7 @@
       - "'hardware' in result.ansible_facts.ansible_net_gather_subset"
       - "'default' in result.ansible_facts.ansible_net_gather_subset"
       - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
-
+      - "result.ansible_facts.ansible_net_model == 'IOS XRv'"
       # Items from those subsets are present
       - "result.ansible_facts.ansible_net_filesystems is defined"
 


### PR DESCRIPTION
##### SUMMARY
- CP https://github.com/ansible/ansible/pull/58488 and related minor change in https://github.com/ansible/ansible/pull/59565
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/iosxr.py
