### PR TITLE
[2.8] Fix traceback when using gluster_volume

### DIFF
--- a/changelogs/fragments/56844-glusterfs_volume-fix_compare.yml
+++ b/changelogs/fragments/56844-glusterfs_volume-fix_compare.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fixes comparison of list to integer in gluster_volume (https://github.com/ansible/ansible/issues/56844).

--- a/lib/ansible/modules/storage/glusterfs/gluster_volume.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_volume.py
@@ -548,7 +548,7 @@ def main():
                     if brick not in bricks_in_volume:
                         new_bricks.append(brick)
 
-            if not new_bricks and len(all_bricks) < bricks_in_volume:
+            if not new_bricks and len(all_bricks) < len(bricks_in_volume):
                 for brick in bricks_in_volume:
                     if brick not in all_bricks:
                         removed_bricks.append(brick)


### PR DESCRIPTION
##### SUMMARY
Since bricks_in_volume is a list, it can't be compared to a int.

(cherry picked from commit 06651d105526c803ce24a4b3feeebab35876fdcf)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56844-glusterfs_volume-fix_compare.yml
lib/ansible/modules/storage/glusterfs/gluster_volume.py