### PR TITLE
Remove incorrect usage of UnsafeProxy

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -28,7 +28,7 @@ from ansible.plugins.loader import become_loader, cliconf_loader, connection_loa
 from ansible.template import Templar
 from ansible.utils.collection_loader import AnsibleCollectionLoader
 from ansible.utils.listify import listify_lookup_plugin_terms
-from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
+from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var, AnsibleUnsafe
 from ansible.vars.clean import namespace_facts, clean_facts
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars, isidentifier
@@ -151,9 +151,7 @@ class TaskExecutor:
                 res['changed'] = False
 
             def _clean_res(res, errors='surrogate_or_strict'):
-                if isinstance(res, UnsafeProxy):
-                    return res._obj
-                elif isinstance(res, binary_type):
+                if isinstance(res, binary_type):
                     return to_text(res, errors=errors)
                 elif isinstance(res, dict):
                     for k in res:
@@ -268,7 +266,7 @@ class TaskExecutor:
 
         if items:
             for idx, item in enumerate(items):
-                if item is not None and not isinstance(item, UnsafeProxy):
+                if item is not None and not isinstance(item, AnsibleUnsafe):
                     items[idx] = UnsafeProxy(item)
 
         return items


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This removes couple of uses of UnsafeProxy that relies on the
implementation that is no longer present in the codebase.

Noticed when looking at https://github.com/ansible/ansible/issues/59606.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_executor.py`