### PR TITLE
unit tests: remove unused imports

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -31,13 +31,12 @@ import yaml
 
 import ansible.constants as C
 from ansible import context
-from ansible.cli.arguments import option_helpers as opt_help
 from ansible.cli.galaxy import GalaxyCLI
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 from ansible.utils import context_objects as co
 from units.compat import unittest
-from units.compat.mock import call, patch, MagicMock
+from units.compat.mock import patch, MagicMock
 
 
 @pytest.fixture(autouse='function')

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -22,10 +22,8 @@ __metaclass__ = type
 from units.compat import unittest
 from units.compat.mock import patch, MagicMock
 
-from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.executor.play_iterator import HostState, PlayIterator
 from ansible.playbook import Playbook
-from ansible.playbook.task import Task
 from ansible.playbook.play_context import PlayContext
 
 from units.mock.loader import DictDataLoader

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -21,9 +21,8 @@ __metaclass__ = type
 
 from units.compat import unittest
 from units.compat.mock import patch, MagicMock
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.executor.task_executor import TaskExecutor, remove_omit
-from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import action_loader, lookup_loader
 from ansible.parsing.yaml.objects import AnsibleUnicode
 

--- a/test/units/executor/test_task_queue_manager_callbacks.py
+++ b/test/units/executor/test_task_queue_manager_callbacks.py
@@ -21,7 +21,6 @@ from __future__ import (absolute_import, division, print_function)
 from units.compat import unittest
 from units.compat.mock import MagicMock
 
-from ansible import context
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook
 from ansible.plugins.callback import CallbackBase

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -12,12 +12,11 @@ import os
 
 import pytest
 
-from units.compat.mock import MagicMock, patch
+from units.compat.mock import MagicMock
 from ansible.module_utils import basic
-from ansible.module_utils.six import string_types, integer_types
+from ansible.module_utils.six import integer_types
 from ansible.module_utils.six.moves import builtins
 
-from units.mock.procenv import ModuleTestCase, swap_stdin_and_argv
 
 MOCK_VALIDATOR_FAIL = MagicMock(side_effect=TypeError("bad conversion"))
 # Data is argspec, argument, expected

--- a/test/units/module_utils/basic/test_imports.py
+++ b/test/units/module_utils/basic/test_imports.py
@@ -12,7 +12,7 @@ import sys
 from units.mock.procenv import ModuleTestCase
 
 from units.compat import unittest
-from units.compat.mock import patch, MagicMock
+from units.compat.mock import patch
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -9,8 +9,6 @@ __metaclass__ = type
 
 import pytest
 
-from units.mock.procenv import ModuleTestCase
-
 from units.compat.mock import patch
 
 from ansible.module_utils.six.moves import builtins

--- a/test/units/module_utils/facts/network/test_fc_wwn.py
+++ b/test/units/module_utils/facts/network/test_fc_wwn.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import fc_wwn
-from units.compat.mock import Mock, patch
+from units.compat.mock import Mock
 
 
 # AIX lsdev

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import iscsi
-from units.compat.mock import Mock, patch
+from units.compat.mock import Mock
 
 
 # AIX # lsattr -E -l iscsi0

--- a/test/units/module_utils/gcp/test_auth.py
+++ b/test/units/module_utils/gcp/test_auth.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 import os
-import sys
 
 import pytest
 
@@ -95,7 +94,7 @@ class GCPAuthTestCase(unittest.TestCase):
         # of this function
         module = FakeModule()
         with mock.patch("ansible.module_utils.gcp.open",
-                        mock.mock_open(read_data='foobar'), create=True) as m:
+                        mock.mock_open(read_data='foobar'), create=True):
             # pem condition, warning is suppressed with the return_value
             credentials_file = '/foopath/pem.pem'
             with self.assertRaises(ValueError):

--- a/test/units/module_utils/gcp/test_utils.py
+++ b/test/units/module_utils/gcp/test_utils.py
@@ -15,8 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-import os
-import sys
 
 from units.compat import mock, unittest
 from ansible.module_utils.gcp import check_min_pkg_version, GCPUtils, GCPInvalidURLError

--- a/test/units/module_utils/json_utils/test_filter_non_json_lines.py
+++ b/test/units/module_utils/json_utils/test_filter_non_json_lines.py
@@ -20,8 +20,6 @@
 from __future__ import (absolute_import, division)
 __metaclass__ = type
 
-import json
-
 from units.compat import unittest
 from ansible.module_utils.json_utils import _filter_non_json_lines
 

--- a/test/units/module_utils/net_tools/nios/test_api.py
+++ b/test/units/module_utils/net_tools/nios/test_api.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import sys
 import copy
 
 from units.compat import unittest

--- a/test/units/module_utils/network/nos/test_nos.py
+++ b/test/units/module_utils/network/nos/test_nos.py
@@ -19,7 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from os import path
 import json
 
 from mock import MagicMock, patch, call

--- a/test/units/module_utils/network/slxos/test_slxos.py
+++ b/test/units/module_utils/network/slxos/test_slxos.py
@@ -19,7 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from os import path
 import json
 
 from mock import MagicMock, patch, call

--- a/test/units/module_utils/test_known_hosts.py
+++ b/test/units/module_utils/test_known_hosts.py
@@ -6,9 +6,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-import os.path
-
 import pytest
 
 from ansible.module_utils import known_hosts


### PR DESCRIPTION
##### SUMMARY
removed unused imports from unit test files.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```
test/units/cli/test_galaxy.py
test/units/executor/test_play_iterator.py
test/units/executor/test_task_executor.py
test/units/executor/test_task_queue_manager_callbacks.py
test/units/module_utils/basic/test_argument_spec.py
test/units/module_utils/basic/test_imports.py
test/units/module_utils/basic/test_platform_distribution.py
test/units/module_utils/facts/network/test_fc_wwn.py
test/units/module_utils/facts/network/test_iscsi_get_initiator.py
test/units/module_utils/gcp/test_auth.py
test/units/module_utils/gcp/test_utils.py
test/units/module_utils/json_utils/test_filter_non_json_lines.py
test/units/module_utils/net_tools/nios/test_api.py
test/units/module_utils/network/nos/test_nos.py
test/units/module_utils/network/slxos/test_slxos.py
test/units/module_utils/test_known_hosts.py
```
