### PR TITLE
Fixing race condition in ec2 inventory plugin

### DIFF
--- a/changelogs/fragments/59638-aws-ec2-plugin-fix-race.yaml
+++ b/changelogs/fragments/59638-aws-ec2-plugin-fix-race.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ec2 inventory plugin - fixed race condition when trying to fetch IAM instance profile(role) credentials (https://github.com/ansible/ansible/pull/59638)

--- a/changelogs/fragments/59638-aws-ec2-plugin-fix-race.yaml
+++ b/changelogs/fragments/59638-aws-ec2-plugin-fix-race.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - aws_ec2 inventory plugin - fixed race condition when trying to fetch IAM instance profile(role) credentials (https://github.com/ansible/ansible/pull/59638)
+  - aws_ec2 inventory plugin - fixed race condition when trying to fetch IAM instance profile (role) credentials (https://github.com/ansible/ansible/pull/59638)

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -577,7 +577,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             session = botocore.session.get_session()
-            credentials = session.get_credentials()
+            try:
+                credentials = session.get_credentials().get_frozen_credentials()
+            except AttributeError:
+            	pass
+            else:
+            	self.aws_access_key_id = credentials.access_key
+                self.aws_secret_access_key = credentials.secret_key
+                self.aws_security_token = credentials.token
+
             if credentials is not None:
                 frozen_credentials = credentials.get_frozen_credentials()
                 if frozen_credentials is not None:

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -580,9 +580,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             try:
                 credentials = session.get_credentials().get_frozen_credentials()
             except AttributeError:
-            	pass
+                pass
             else:
-            	self.aws_access_key_id = credentials.access_key
+                self.aws_access_key_id = credentials.access_key
                 self.aws_secret_access_key = credentials.secret_key
                 self.aws_security_token = credentials.token
 

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -578,11 +578,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             session = botocore.session.get_session()
             credentials = session.get_credentials()
-            frozen_credentials = credentials.get_frozen_credentials()
-            if frozen_credentials is not None:
-                self.aws_access_key_id = frozen_credentials.access_key
-                self.aws_secret_access_key = frozen_credentials.secret_key
-                self.aws_security_token = frozen_credentials.token
+            if credentials is not None:
+                frozen_credentials = credentials.get_frozen_credentials()
+                if frozen_credentials is not None:
+                    self.aws_access_key_id = frozen_credentials.access_key
+                    self.aws_secret_access_key = frozen_credentials.secret_key
+                    self.aws_security_token = frozen_credentials.token
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             raise AnsibleError("Insufficient boto credentials found. Please provide them in your "

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -586,13 +586,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.aws_secret_access_key = credentials.secret_key
                 self.aws_security_token = credentials.token
 
-            if credentials is not None:
-                frozen_credentials = credentials.get_frozen_credentials()
-                if frozen_credentials is not None:
-                    self.aws_access_key_id = frozen_credentials.access_key
-                    self.aws_secret_access_key = frozen_credentials.secret_key
-                    self.aws_security_token = frozen_credentials.token
-
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             raise AnsibleError("Insufficient boto credentials found. Please provide them in your "
                                "inventory configuration file or set them as environment variables.")

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -577,10 +577,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             session = botocore.session.get_session()
-            if session.get_credentials() is not None:
-                self.aws_access_key_id = session.get_credentials().access_key
-                self.aws_secret_access_key = session.get_credentials().secret_key
-                self.aws_security_token = session.get_credentials().token
+            credentials = session.get_credentials()
+            frozen_credentials = credentials.get_frozen_credentials()
+            if frozen_credentials is not None:
+                self.aws_access_key_id = frozen_credentials.access_key
+                self.aws_secret_access_key = frozen_credentials.secret_key
+                self.aws_security_token = frozen_credentials.token
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             raise AnsibleError("Insufficient boto credentials found. Please provide them in your "


### PR DESCRIPTION
##### SUMMARY
Apparently there is a race condition in AWS EC2 dynamic inventory plugin, in a part responsible for fetching IAM instance role as a "last resort" in a chain of credential sources. This should fix it by requesting session credentials only once using get_frozen_credentials() method, which is recommended for cases like this in botocore docs. With this code, botocore will try to get IAM role only once instead of doing it at least 3+ times with previous implementation (i've tried to debug AWS calls and saw the abnormal amount of GETs which led to a race condition and eventually to broken creds used by the plugin).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
/lib/ansible/plugins/inventory/aws_ec2.py

##### ADDITIONAL INFORMATION
Some botocore documentation depicting the issue: https://github.com/boto/botocore/blob/develop/botocore/credentials.py#L529-L543

The issue and its fix should be self-explanatory. Please let me know if you have any questions.