### PR TITLE
Add missing @property to ansible-test sanity.

### DIFF
--- a/test/runner/lib/sanity/pep8.py
+++ b/test/runner/lib/sanity/pep8.py
@@ -31,6 +31,7 @@ from lib.config import (
 
 class Pep8Test(SanitySingleVersion):
     """Sanity test for PEP 8 style guidelines using pycodestyle."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'A100'

--- a/test/runner/lib/sanity/pslint.py
+++ b/test/runner/lib/sanity/pslint.py
@@ -37,6 +37,7 @@ from lib.data import (
 
 class PslintTest(SanitySingleVersion):
     """Sanity test using PSScriptAnalyzer."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'AnsibleTest'

--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -50,6 +50,7 @@ UNSUPPORTED_PYTHON_VERSIONS = (
 
 class PylintTest(SanitySingleVersion):
     """Sanity test using pylint."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'ansible-test'

--- a/test/runner/lib/sanity/shellcheck.py
+++ b/test/runner/lib/sanity/shellcheck.py
@@ -36,6 +36,7 @@ from lib.config import (
 
 class ShellcheckTest(SanitySingleVersion):
     """Sanity test using shellcheck."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'AT1000'

--- a/test/runner/lib/sanity/validate_modules.py
+++ b/test/runner/lib/sanity/validate_modules.py
@@ -45,6 +45,7 @@ UNSUPPORTED_PYTHON_VERSIONS = (
 
 class ValidateModulesTest(SanitySingleVersion):
     """Sanity test using validate-modules."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'A100'

--- a/test/runner/lib/sanity/yamllint.py
+++ b/test/runner/lib/sanity/yamllint.py
@@ -37,6 +37,7 @@ from lib.data import (
 
 class YamllintTest(SanitySingleVersion):
     """Sanity test using yamllint."""
+    @property
     def error_code(self):  # type: () -> t.Optional[str]
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'ansible-test'


### PR DESCRIPTION
##### SUMMARY

Add missing `@property` to ansible-test sanity.

This fixes sanity test errors so they show the proper error code instead of "bound method".

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
