### PR TITLE
Fix sanity docs page titles.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
@@ -1,5 +1,5 @@
-Sanity Tests » from __future__ boilerplate
-==========================================
+Sanity Tests » future-import-boilerplate
+========================================
 
 Most Python files should include the following boilerplate at the top of the file, right after the
 comment header:

--- a/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
@@ -1,5 +1,5 @@
-Sanity Tests » __metaclass__ = type boilerplate
-===============================================
+Sanity Tests » metaclass-boilerplate
+====================================
 
 Most Python files should include the following boilerplate at the top of the file, right after the
 comment header and ``from __future__ import``:


### PR DESCRIPTION
##### SUMMARY

Fix sanity docs page titles.

The titles are used to generate the index of sanity tests, so they should match the name of the test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

sanity test docs
