### PR TITLE
aws_ec2 inv plugin - fix author field

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1194,6 +1194,8 @@ files:
 # plugins/inventory
   $plugins/inventory/__init__.py:
     support: core
+  $plugins/inventory/aws_ec2.py:
+    maintainers: s-hertel
   $plugins/inventory/docker: *docker
   $plugins/inventory/docker_swarm.py:
     <<: *docker

--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -21,6 +21,8 @@ DOCUMENTATION = '''
     notes:
         - If no credentials are provided and the control node has an associated IAM instance profile then the
           role will be used for authentication.
+    author:
+        - Sloane Hertel (@s-hertel)
     options:
         plugin:
             description: Token that ensures this is a source file for the plugin.


### PR DESCRIPTION
##### SUMMARY
Realized via https://github.com/ansible/ansible/pull/59638 that I wasn't getting normal notifications for the aws_ec2 inventory plugin. Added plugin in b94198f9de31bb667c266e2ced995bfdcc1f3f4f.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_ec2