### PR TITLE
Remove redundant "Sanity Tests »" from page title.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/action-plugin-docs.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/action-plugin-docs.rst
@@ -1,4 +1,4 @@
-Sanity Tests » action-plugin-docs
-=================================
+action-plugin-docs
+==================
 
 Each action plugin should have a matching module of the same name to provide documentation.

--- a/docs/docsite/rst/dev_guide/testing/sanity/ansible-doc.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ansible-doc.rst
@@ -1,4 +1,4 @@
-Sanity Tests » ansible-doc
-==========================
+ansible-doc
+===========
 
 Verifies that ``ansible-doc`` can parse module documentation on all supported Python versions.

--- a/docs/docsite/rst/dev_guide/testing/sanity/ansible-var-precedence-check.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ansible-var-precedence-check.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-Sanity Tests » ansible-var-precedence-check
-===========================================
+ansible-var-precedence-check
+============================
 
 Check the order of precedence for Ansible variables against :ref:`ansible_variable_precedence`.

--- a/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
@@ -1,5 +1,5 @@
-Sanity Tests » azure-requirements
-=================================
+azure-requirements
+==================
 
 Update the Azure integration test requirements file when changes are made to the Azure packaging requirements file:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » boilerplate
-==========================
+boilerplate
+===========
 
 Most Python files should include the following boilerplate:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/botmeta.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/botmeta.rst
@@ -1,4 +1,4 @@
-Sanity Tests » botmeta
-======================
+botmeta
+=======
 
 Verifies that ``./github/BOTMETA.yml`` is valid.

--- a/docs/docsite/rst/dev_guide/testing/sanity/changelog.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/changelog.rst
@@ -1,5 +1,5 @@
-Sanity Tests » changelog
-========================
+changelog
+=========
 
 Basic linting of changelog fragments with yamllint and rstcheck.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -1,4 +1,4 @@
-Sanity Tests » compile
-======================
+compile
+=======
 
 See :ref:`testing_compile` for more information.

--- a/docs/docsite/rst/dev_guide/testing/sanity/configure-remoting-ps1.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/configure-remoting-ps1.rst
@@ -1,5 +1,5 @@
-Sanity Tests » configure-remoting-ps1
-=====================================
+configure-remoting-ps1
+======================
 
 The file ``examples/scripts/ConfigureRemotingForAnsible.ps1`` is required and must be a regular file.
 It is used by external automated processes and cannot be moved, renamed or replaced with a symbolic link.

--- a/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/deprecated-config.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-Sanity Tests » deprecated-config
-================================
+deprecated-config
+=================
 
 ``DOCUMENTATION`` config is scheduled for removal

--- a/docs/docsite/rst/dev_guide/testing/sanity/docs-build.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/docs-build.rst
@@ -1,4 +1,4 @@
-Sanity Tests » docs-build
-=========================
+docs-build
+==========
 
 Verifies that ``make singlehtmldocs`` in ``docs/docsite/`` completes without errors.

--- a/docs/docsite/rst/dev_guide/testing/sanity/empty-init.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/empty-init.rst
@@ -1,5 +1,5 @@
-Sanity Tests » empty-init
-=========================
+empty-init
+==========
 
 The ``__init__.py`` files under the following directories must be empty.  For some of these (modules
 and tests), ``__init__.py`` files with code won't be used.  For others (module_utils), we want the

--- a/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/future-import-boilerplate.rst
@@ -1,5 +1,5 @@
-Sanity Tests » future-import-boilerplate
-========================================
+future-import-boilerplate
+=========================
 
 Most Python files should include the following boilerplate at the top of the file, right after the
 comment header:

--- a/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
@@ -1,5 +1,5 @@
-Sanity Tests » ignores
-======================
+ignores
+=======
 
 Sanity tests for individual files can be skipped, and specific errors can be ignored.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/import.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/import.rst
@@ -1,5 +1,5 @@
-Sanity Tests » import
-=====================
+import
+======
 
 All Python imports in ``lib/ansible/modules/`` and ``lib/ansible/module_utils/`` which are not from the Python standard library
 must be imported in a try/except ImportError block.

--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -1,5 +1,5 @@
-Sanity Tests » integration-aliases
-==================================
+integration-aliases
+===================
 
 Integration tests are executed by ``ansible-test`` and reside in directories under ``test/integration/targets/``.
 Each test MUST have an ``aliases`` file to control test execution.

--- a/docs/docsite/rst/dev_guide/testing/sanity/line-endings.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/line-endings.rst
@@ -1,4 +1,4 @@
-Sanity Tests » line-endings
-===========================
+line-endings
+============
 
 All files must use ``\n`` for line endings instead of ``\r\n``.

--- a/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/metaclass-boilerplate.rst
@@ -1,5 +1,5 @@
-Sanity Tests » metaclass-boilerplate
-====================================
+metaclass-boilerplate
+=====================
 
 Most Python files should include the following boilerplate at the top of the file, right after the
 comment header and ``from __future__ import``:

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-assert.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-assert.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-assert
-========================
+no-assert
+=========
 
 Do not use ``assert`` in production Ansible python code. When running Python
 with optimizations, Python will remove ``assert`` statements, potentially

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-basestring.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-basestring.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-basestring
-============================
+no-basestring
+=============
 
 Do not use ``isinstance(s, basestring)`` as basestring has been removed in
 Python3.  You can import ``string_types``, ``binary_type``, or ``text_type``

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-dict-iteritems.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-dict-iteritems.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-dict-iteritems
-================================
+no-dict-iteritems
+=================
 
 The ``dict.iteritems`` method has been removed in Python 3. There are two recommended alternatives:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-dict-iterkeys.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-dict-iterkeys.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-dict-iterkeys
-===============================
+no-dict-iterkeys
+================
 
 The ``dict.iterkeys`` method has been removed in Python 3. Use the following instead:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-dict-itervalues.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-dict-itervalues.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-dict-itervalues
-=================================
+no-dict-itervalues
+==================
 
 The ``dict.itervalues`` method has been removed in Python 3. There are two recommended alternatives:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-get-exception.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-get-exception.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-get-exception
-===============================
+no-get-exception
+================
 
 We created a function, ``ansible.module_utils.pycompat24.get_exception`` to
 help retrieve exceptions in a manner compatible with Python 2.4 through

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-illegal-filenames.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-illegal-filenames.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-illegal-filenames
-===================================
+no-illegal-filenames
+====================
 
 Files and directories should not contain illegal characters or names so that
 Ansible can be checked out on any Operating System.

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-main-display.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-main-display.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-main-display
-==============================
+no-main-display
+===============
 
 As of Ansible 2.8, ``Display`` should no longer be imported from ``__main__``.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-smart-quotes.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-smart-quotes.rst
@@ -1,4 +1,4 @@
-Sanity Tests » no-smart-quotes
-==============================
+no-smart-quotes
+===============
 
 Smart quotes (``”“‘’``) should not be used.  Use plain ascii quotes (``"'``) instead.

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-tests-as-filters.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-tests-as-filters.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » no-tests-as-filters
-==================================
+no-tests-as-filters
+===================
 
 Using Ansible provided Jinja2 tests as filters will be removed in Ansible 2.9.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-underscore-variable.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-underscore-variable.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » no-underscore-variable
-=====================================
+no-underscore-variable
+======================
 
 In the future, Ansible may use the identifier ``_`` to internationalize its
 message strings.  To be ready for that, we need to make sure that there are

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-unicode-literals.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-unicode-literals.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-unicode_literals
-==================================
+no-unicode_literals
+===================
 
 The use of :code:`from __future__ import unicode_literals` has been deemed an anti-pattern.  The
 problems with it are:

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-unwanted-files.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-unwanted-files.rst
@@ -1,5 +1,5 @@
-Sanity Tests » no-unwanted-files
-================================
+no-unwanted-files
+=================
 
 Specific file types are allowed in certain directories:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-wildcard-import.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-wildcard-import.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » no-wildcard-import
-=================================
+no-wildcard-import
+==================
 
 Using :code:`import *` is a bad habit which pollutes your namespace, hinders
 debugging, and interferes with static analysis of code.  For those reasons, we

--- a/docs/docsite/rst/dev_guide/testing/sanity/package-data.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/package-data.rst
@@ -1,5 +1,5 @@
-Sanity Tests » package-data
-===========================
+package-data
+============
 
 Verifies that the combination of ``MANIFEST.in`` and ``package_data`` from ``setup.py``
 properly installs data files from within ``lib/ansible``

--- a/docs/docsite/rst/dev_guide/testing/sanity/pep8.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/pep8.rst
@@ -1,5 +1,5 @@
-Sanity Tests » pep8
-===================
+pep8
+====
 
 Python static analysis for PEP 8 style guideline compliance.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/pslint.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/pslint.rst
@@ -1,4 +1,4 @@
-Sanity Tests » pslint
-=====================
+pslint
+======
 
 PowerShell static analysis for common programming errors using `PSScriptAnalyzer <https://github.com/PowerShell/PSScriptAnalyzer/>`_.

--- a/docs/docsite/rst/dev_guide/testing/sanity/pylint-ansible-test.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/pylint-ansible-test.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » pylint-ansible-test
-==================================
+pylint-ansible-test
+===================
 
 Python static analysis for common programming errors.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/pylint.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/pylint.rst
@@ -1,4 +1,4 @@
-Sanity Tests » pylint
-=====================
+pylint
+======
 
 Python static analysis for common programming errors.

--- a/docs/docsite/rst/dev_guide/testing/sanity/replace-urlopen.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/replace-urlopen.rst
@@ -1,4 +1,4 @@
-Sanity Tests » replace-urlopen
-==============================
+replace-urlopen
+===============
 
 Use ``open_url`` from ``module_utils`` instead of ``urlopen``.

--- a/docs/docsite/rst/dev_guide/testing/sanity/required-and-default-attributes.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/required-and-default-attributes.rst
@@ -1,5 +1,5 @@
-Sanity Tests » required-and-default-attributes
-==============================================
+required-and-default-attributes
+===============================
 
 Use only one of ``default`` or ``required`` with ``FieldAttribute``.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/rstcheck.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/rstcheck.rst
@@ -1,4 +1,4 @@
-Sanity Tests » rstcheck
-=======================
+rstcheck
+========
 
 Check reStructuredText files for syntax and formatting issues.

--- a/docs/docsite/rst/dev_guide/testing/sanity/sanity-docs.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/sanity-docs.rst
@@ -1,4 +1,4 @@
-Sanity Tests » sanity-docs
-==========================
+sanity-docs
+===========
 
 Documentation for each ``ansible-test sanity`` test is required.

--- a/docs/docsite/rst/dev_guide/testing/sanity/shebang.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/shebang.rst
@@ -1,5 +1,5 @@
-Sanity Tests » shebang
-======================
+shebang
+=======
 
 Most executable files should only use one of the following shebangs:
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/shellcheck.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/shellcheck.rst
@@ -1,4 +1,4 @@
-Sanity Tests » shellcheck
-=========================
+shellcheck
+==========
 
 Static code analysis for shell scripts using the excellent `shellcheck <https://www.shellcheck.net/>`_ tool.

--- a/docs/docsite/rst/dev_guide/testing/sanity/symlinks.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/symlinks.rst
@@ -1,5 +1,5 @@
-Sanity Tests » symlinks
-=======================
+symlinks
+========
 
 Symbolic links are only permitted for files that exist to ensure proper tarball generation during a release.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/test-constraints.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/test-constraints.rst
@@ -1,4 +1,4 @@
-Sanity Tests » test-constraints
-===============================
+test-constraints
+================
 
 Constraints for test requirements should be in ``test/runner/requirements/constraints.txt``.

--- a/docs/docsite/rst/dev_guide/testing/sanity/update-bundled.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/update-bundled.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Sanity Tests » update-bundled
-=============================
+update-bundled
+==============
 
 Check whether any of our known bundled code needs to be updated for a new upstream release.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
@@ -1,5 +1,5 @@
-Sanity Tests » use-argspec-type-path
-====================================
+use-argspec-type-path
+=====================
 
 The AnsibleModule argument_spec knows of several types beyond the standard python types.  One of
 these is ``path``.  When used, type ``path`` ensures that an argument is a string and expands any

--- a/docs/docsite/rst/dev_guide/testing/sanity/use-compat-six.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/use-compat-six.rst
@@ -1,4 +1,4 @@
-Sanity Tests » use-compat-six
-=============================
+use-compat-six
+==============
 
 Use ``six`` from ``module_utils`` instead of ``six``.

--- a/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/validate-modules.rst
@@ -1,5 +1,5 @@
-Sanity Tests » validate-modules
-===============================
+validate-modules
+================
 
 Analyze modules for common issues in code and documentation.
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/yamllint.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/yamllint.rst
@@ -1,4 +1,4 @@
-Sanity Tests » yamllint
-=======================
+yamllint
+========
 
 Check YAML files for syntax and formatting issues.


### PR DESCRIPTION
##### SUMMARY

Remove redundant "Sanity Tests »" from page title.

The docs now have multi-level breadcrumbs so including "Sanity Tests »" in the title on a sanity test page is redundant.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

sanity test docs