### PR TITLE
Minor docs fix for sanity test docs backport.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/boilerplate.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 boilerplate
 ===========
 

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-tests-as-filters.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-tests-as-filters.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 no-tests-as-filters
 ===================
 


### PR DESCRIPTION
##### SUMMARY

The backport https://github.com/ansible/ansible/pull/59653 had two merge conflicts that resulted in `:orphan:` entries being added that were not part of the original PR. This PR corrects that.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

sanity test docs
