### PR TITLE
Volume dev upstream new options

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_volume.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume.py
@@ -316,7 +316,7 @@ class NetAppESeriesVolume(NetAppESeriesModule):
         self.size_unit = args["size_unit"]
         self.segment_size_kb = args["segment_size_kb"]
         if args["size"]:
-            self.size_b = int(args["size"] * self.SIZE_UNIT_MAP[self.size_unit])
+            self.size_b = self.convert_to_aligned_bytes(args["size"])
 
         self.owning_controller_id = None
         if args["owning_controller"]:
@@ -336,10 +336,9 @@ class NetAppESeriesVolume(NetAppESeriesModule):
         self.thin_volume_max_repo_size_b = None
 
         if args["thin_volume_repo_size"]:
-            self.thin_volume_repo_size_b = args["thin_volume_repo_size"] * self.SIZE_UNIT_MAP[self.size_unit]
+            self.thin_volume_repo_size_b = self.convert_to_aligned_bytes(args["thin_volume_repo_size"])
         if args["thin_volume_max_repo_size"]:
-            self.thin_volume_max_repo_size_b = int(args["thin_volume_max_repo_size"] *
-                                                   self.SIZE_UNIT_MAP[self.size_unit])
+            self.thin_volume_max_repo_size_b = self.convert_to_aligned_bytes(args["thin_volume_max_repo_size"])
 
         self.workload_name = args["workload_name"]
         self.metadata = args["metadata"]
@@ -381,6 +380,13 @@ class NetAppESeriesVolume(NetAppESeriesModule):
         self.volume_detail = None
         self.pool_detail = None
         self.workload_id = None
+
+    def convert_to_aligned_bytes(self, size):
+        """Convert size to the truncated byte size that aligns on the segment size."""
+        size_bytes = int(size * self.SIZE_UNIT_MAP[self.size_unit])
+        segment_size_bytes = int(self.segment_size_kb * self.SIZE_UNIT_MAP["kb"])
+        segment_count = int(size_bytes / segment_size_bytes)
+        return segment_count * segment_size_bytes
 
     def get_volume(self):
         """Retrieve volume details from storage array."""

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -1,7 +1,3 @@
 ---
 win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
-netapp_e_api_host: 10.113.1.192
-netapp_e_api_username: admin
-netapp_e_api_password: infiniti
-netapp_e_ssid: 1

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -1,3 +1,7 @@
 ---
 win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
+netapp_e_api_host: 10.113.1.192
+netapp_e_api_username: admin
+netapp_e_api_password: infiniti
+netapp_e_ssid: 1

--- a/test/units/modules/storage/netapp/test_netapp_e_volume.py
+++ b/test/units/modules/storage/netapp/test_netapp_e_volume.py
@@ -502,7 +502,7 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
              "read_ahead_enable": True, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1}, "flashCached": True,
                                        "segmentSize": str(128 * 1024)}
         self.assertEqual(volume_object.get_volume_property_changes(), dict())
@@ -514,7 +514,7 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
              "thin_volume_max_repo_size": 1000, "thin_volume_growth_alert_threshold": 90})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1},
                                        "flashCached": True, "growthAlertThreshold": "90",
                                        "expansionPolicy": "automatic", "segmentSize": str(128 * 1024)}
@@ -527,7 +527,7 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
              "read_ahead_enable": True, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": False, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": False, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1}, "flashCached": True,
                                        "segmentSize": str(128 * 1024)}
         self.assertEqual(volume_object.get_volume_property_changes(),
@@ -535,11 +535,11 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
                           'flashCache': True})
         self._set_args(
             {"state": "present", "name": "Matthew", "storage_pool_name": "pool", "size": 100, "ssd_cache_enabled": True,
-             "read_cache_enable": True, "write_cache_enable": True,
+             "read_cache_enable": True, "write_cache_enable": True, "cache_without_batteries": False,
              "read_ahead_enable": True, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": False,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": False,
                                                          "readAheadMultiplier": 1}, "flashCached": True,
                                        "segmentSize": str(128 * 1024)}
         self.assertEqual(volume_object.get_volume_property_changes(),
@@ -547,29 +547,30 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
                           'flashCache': True})
         self._set_args(
             {"state": "present", "name": "Matthew", "storage_pool_name": "pool", "size": 100, "ssd_cache_enabled": True,
-             "read_cache_enable": True, "write_cache_enable": True,
+             "read_cache_enable": True, "write_cache_enable": True, "cache_without_batteries": True,
              "read_ahead_enable": True, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1}, "flashCached": False,
                                        "segmentSize": str(128 * 1024)}
         self.assertEqual(volume_object.get_volume_property_changes(),
-                         {"metaTags": [], 'cacheSettings': {'readCacheEnable': True, 'writeCacheEnable': True},
+                         {"metaTags": [], 'cacheSettings': {'readCacheEnable': True, 'writeCacheEnable': True, "cacheWithoutBatteries": True},
                           'flashCache': True})
         self._set_args(
             {"state": "present", "name": "Matthew", "storage_pool_name": "pool", "size": 100, "ssd_cache_enabled": True,
-             "read_cache_enable": True, "write_cache_enable": True,
+             "read_cache_enable": True, "write_cache_enable": True, "cache_without_batteries": True,
              "read_ahead_enable": False, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1}, "flashCached": False,
                                        "segmentSize": str(128 * 1024)}
         self.assertEqual(volume_object.get_volume_property_changes(), {"metaTags": [],
                                                                        'cacheSettings': {'readCacheEnable': True,
                                                                                          'writeCacheEnable': True,
-                                                                                         'readAheadEnable': False},
+                                                                                         'readAheadEnable': False,
+                                                                                         "cacheWithoutBatteries": True},
                                                                        'flashCache': True})
 
         self._set_args(
@@ -579,7 +580,7 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
              "thin_volume_max_repo_size": 1000, "thin_volume_growth_alert_threshold": 90})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {"metadata": [],
-                                       "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True,
+                                       "cacheSettings": {"cwob": True, "readCacheEnable": True, "writeCacheEnable": True,
                                                          "readAheadMultiplier": 1},
                                        "flashCached": True, "growthAlertThreshold": "95",
                                        "expansionPolicy": "automatic", "segmentSize": str(128 * 1024)}
@@ -594,7 +595,7 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
              "read_cache_enable": True, "write_cache_enable": True, "read_ahead_enable": True, "thin_provision": False})
         volume_object = NetAppESeriesVolume()
         volume_object.volume_detail = {
-            "cacheSettings": {"readCacheEnable": True, "writeCacheEnable": True, "readAheadMultiplier": 1},
+            "cacheSettings": {"cwob": False, "readCacheEnable": True, "writeCacheEnable": True, "readAheadMultiplier": 1},
             "flashCached": True, "segmentSize": str(512 * 1024)}
         with self.assertRaisesRegexp(AnsibleFailJson, "Existing volume segment size is"):
             volume_object.get_volume_property_changes()

--- a/test/units/modules/storage/netapp/test_netapp_e_volume.py
+++ b/test/units/modules/storage/netapp/test_netapp_e_volume.py
@@ -238,16 +238,14 @@ class NetAppESeriesVolumeTest(ModuleTestCase):
             self._set_args(arg_set)
             volume_object = NetAppESeriesVolume()
 
-            size_unit_multiplier = NetAppESeriesModule.SIZE_UNIT_MAP[arg_set["size_unit"]]
-            self.assertEqual(volume_object.size_b, arg_set["size"] * size_unit_multiplier)
-            self.assertEqual(volume_object.thin_volume_repo_size_b,
-                             arg_set["thin_volume_repo_size"] * size_unit_multiplier)
+            self.assertEqual(volume_object.size_b, volume_object.convert_to_aligned_bytes(arg_set["size"]))
+            self.assertEqual(volume_object.thin_volume_repo_size_b, volume_object.convert_to_aligned_bytes(arg_set["thin_volume_repo_size"]))
             self.assertEqual(volume_object.thin_volume_expansion_policy, "automatic")
             if "thin_volume_max_repo_size" not in arg_set.keys():
-                self.assertEqual(volume_object.thin_volume_max_repo_size_b, arg_set["size"] * size_unit_multiplier)
+                self.assertEqual(volume_object.thin_volume_max_repo_size_b, volume_object.convert_to_aligned_bytes(arg_set["size"]))
             else:
                 self.assertEqual(volume_object.thin_volume_max_repo_size_b,
-                                 arg_set["thin_volume_max_repo_size"] * size_unit_multiplier)
+                                 volume_object.convert_to_aligned_bytes(arg_set["thin_volume_max_repo_size"]))
 
         # validate metadata form
         self._set_args(


### PR DESCRIPTION
##### SUMMARY
Add controller ownership and cache without batteries option 
Add integration tests
Fix off-segment aligned volume size in netapp_e_volume module.
Update unit tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
```
