### PR TITLE
Improve the extendability of the netbox inventory plugin.

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -338,8 +338,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         manufacturers = self.get_resource_list(api_url=url)
         self.manufacturers_lookup = dict((manufacturer["id"], manufacturer["name"]) for manufacturer in manufacturers)
 
-    def refresh_lookups(self):
-        lookup_processes = (
+    @property
+    def lookup_processes(self):
+        return [
             self.refresh_sites_lookup,
             self.refresh_regions_lookup,
             self.refresh_tenants_lookup,
@@ -348,10 +349,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.refresh_platforms_lookup,
             self.refresh_device_types_lookup,
             self.refresh_manufacturers_lookup,
-        )
+        ]
 
+    def refresh_lookups(self):
         thread_list = []
-        for p in lookup_processes:
+        for p in self.lookup_processes:
             t = Thread(target=p)
             thread_list.append(t)
             t.start()


### PR DESCRIPTION
##### SUMMARY
This change simply separates the list of lookup functions from the logic
that executes the lookups. This allows a subclass to simply add their
own lookups and extend the list without re-implementing the entire
refresh lookups method.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
inventory plugin - netbox

