### PR TITLE
Issue #41447 - support AWS Aurora S3 privileges in mysql_user module

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -229,7 +229,8 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'REPLICATION SLAVE ADMIN', 'RESOURCE GROUP ADMIN',
                          'RESOURCE GROUP USER', 'ROLE ADMIN', 'SET USER ID',
                          'SESSION VARIABLES ADMIN', 'SYSTEM VARIABLES ADMIN',
-                         'VERSION TOKEN ADMIN', 'XA RECOVER ADMIN'))
+                         'VERSION TOKEN ADMIN', 'XA RECOVER ADMIN',
+                         'LOAD FROM S3', 'SELECT INTO S3'))
 
 
 class InvalidPrivsError(Exception):


### PR DESCRIPTION

##### SUMMARY
Adds 'LOAD FROM S3' and 'SELECT INTO S3' to the list of valid privileges so AWS Aurora accounts can include them.

Fixes #41447
Merge Conflict resolved from this pullreq: https://github.com/ansible/ansible/pull/50454#issue-241789464


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ADDITIONAL INFORMATION
See the discussion in #41447 for details.

In a nutshell, this PR allows AWS Aurora users to include the above mentioned privileges. This will not break exiting use of the mysql_user module in any way as it only adds to the list of valid privileges that the module checks for. Even if a regular mysql user were to attempt to reference these privileges they would simply receive an error from the mysql server rather than an error from ansible itself.

Example before adding this PR:
TASK [mysql-users : manage mysql role users] **************************************************************************************************************************
failed: [localhost] (item=uat1) => {"changed": false, "item": {"key": "uat1", "value": {"password": "xxxxxx", "priv": "uat1.*:ALL/*.*:LOAD FROM S3,SELECT INTO S3"}}, "msg": "invalid privileges string: Invalid privileges specified: frozenset(['LOAD FROM S3', 'SELECT INTO S3'])"}
After:

TASK [mysql-users : manage mysql role users] **************************************************************************************************************************
changed: [localhost] => (item=uat1)
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
