### PR TITLE
[stable-2.8] Fix for skipping of gitlab_runner test.

### DIFF
--- a/test/units/modules/source_control/test_gitlab_runner.py
+++ b/test/units/modules/source_control/test_gitlab_runner.py
@@ -30,7 +30,7 @@ except ImportError:
     pytestmark.append(pytest.mark.skip("Could not load gitlab module required for testing"))
     # Need to set these to something so that we don't fail when parsing
     GitlabModuleTestCase = object
-    resp_find_runners = _dummy
+    resp_find_runners_list = _dummy
     resp_get_runner = _dummy
     resp_create_runner = _dummy
     resp_delete_runner = _dummy


### PR DESCRIPTION
Correct variable name for skipping of the gitlab test when gitlab python
client is not installed.
(cherry picked from commit 0c992d5ae4892653dc645a92bbc8992cc3dea58c)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
test/units/modules/source_control/test_gitlab_runner.py
