### PR TITLE
There's no `merge_dictionaries` in GPCSession

### DIFF
--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -86,7 +86,7 @@ class GcpSession(object):
 
     def post(self, url, body=None, headers=None, **kwargs):
         if headers:
-            headers = self.merge_dictionaries(headers, self._headers())
+            headers = self._merge_dictionaries(headers, self._headers())
         else:
             headers = self._headers()
 
@@ -97,7 +97,7 @@ class GcpSession(object):
 
     def post_contents(self, url, file_contents=None, headers=None, **kwargs):
         if headers:
-            headers = self.merge_dictionaries(headers, self._headers())
+            headers = self._merge_dictionaries(headers, self._headers())
         else:
             headers = self._headers()
 


### PR DESCRIPTION
##### SUMMARY

The method name is `_merge_dictionaries` not `merge_dictionaries`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
gpc_utils (all gpc_* modules)
