### PR TITLE
allow composite vars to override inferred ones

### DIFF
--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -248,13 +248,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # set vars in inventory from hostvars
         for host in hostvars:
 
-            # create composite vars
-            self._set_composite_vars(
-                self._config_data.get('compose'), hostvars[host], host)
-
             # actually update inventory
             for key in hostvars[host]:
                 self.inventory.set_variable(host, key, hostvars[host][key])
+
+            # create composite vars
+            self._set_composite_vars(
+                self._config_data.get('compose'), hostvars[host], host)
 
             # constructed groups based on conditionals
             self._add_host_to_composed_groups(


### PR DESCRIPTION
##### SUMMARY
Using the `openstack` inventory plugin, `ansible_host` and `ansible_ssh_host` are set to the cloud-returned server `interface_ip` attribute and can't be overridden using `compose:` defined variables

This happens because in https://github.com/ansible/ansible/blob/0e9f002073829aa1cc8367763ab556dce0bf36ea/lib/ansible/plugins/inventory/openstack.py#L256 the variables `ansible_host` and `ansible_ssh_host` are set to the values returned by `_append_hostvars` in https://github.com/ansible/ansible/blob/0e9f002073829aa1cc8367763ab556dce0bf36ea/lib/ansible/plugins/inventory/openstack.py#L240  _*after*_ the `compose` ones have been set

This PR switches these operations order, giving priority to the `compose` defined variables

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openstack.py

##### ADDITIONAL INFORMATION
See #59680 for test case.

Fixes #59680 
