### PR TITLE
ec2_instance: Force int when ebs.volume_size or ebs.iops is specified

### DIFF
--- a/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
+++ b/changelogs/fragments/55716-ec2_instance_int_volume_size.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - Ensures ``ebs.volume_size`` and ``ebs.iops`` are ``int`` to avoid issues with Jinja2 templating

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -818,6 +818,11 @@ def manage_tags(match, new_tags, purge_tags, ec2):
 
 def build_volume_spec(params):
     volumes = params.get('volumes') or []
+    for volume in volumes:
+        if 'ebs' in volume:
+            for int_value in ['volume_size', 'iops']:
+                if int_value in volume['ebs']:
+                    volume['ebs'][int_value] = int(volume['ebs'][int_value])
     return [ec2_utils.snake_dict_to_camel_dict(v, capitalize_first=True) for v in volumes]
 
 


### PR DESCRIPTION
##### SUMMARY

* Force int when volume_size is specified

* changelog

* both volume_size and iops must be int

* updated changelog fragment

(cherry picked from commit 5a6f8880360c3d4096b7e26ff9b00854f125337e)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
Backport of #55716