### PR TITLE
ce_netstream_global: update to fix a bug.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_netstream_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_global.py
@@ -214,7 +214,7 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import load_config
-from ansible.module_utils.network.cloudengine.ce import get_connection
+from ansible.module_utils.network.cloudengine.ce import get_connection, rm_config_prefix
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 

--- a/lib/ansible/modules/network/cloudengine/ce_netstream_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_global.py
@@ -213,7 +213,8 @@ changed:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import load_config
+from ansible.module_utils.network.cloudengine.ce import get_connection
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 
@@ -245,6 +246,38 @@ def get_interface_type(interface):
         return None
 
     return iftype.lower()
+
+
+def get_config(module, flags):
+
+    """Retrieves the current config from the device or cache
+    """
+    flags = [] if flags is None else flags
+    if isinstance(flags, str):
+        flags = [flags]
+    elif not isinstance(flags, list):
+        flags = []
+
+    cmd = 'display current-configuration '
+    cmd += ' '.join(flags)
+    cmd = cmd.strip()
+    conn = get_connection(module)
+    rc, out, err = conn.exec_command(cmd)
+    if rc != 0:
+        module.fail_json(msg=err)
+    cfg = str(out).strip()
+    # remove default configuration prefix '~'
+    for flag in flags:
+        if "include-default" in flag:
+            cfg = rm_config_prefix(cfg)
+            break
+    if cfg.startswith('display'):
+        lines = cfg.split('\n')
+        if len(lines) > 1:
+            return '\n'.join(lines[1:])
+        else:
+            return ''
+    return cfg
 
 
 class NetStreamGlobal(object):
@@ -342,8 +375,8 @@ class NetStreamGlobal(object):
         self.existing["sampler"].append(sampler_tmp)
         if self.interface != "all":
             flags = list()
-            exp = " | ignore-case  section include ^interface %s$" \
-                  " | include netstream sampler random-packets" % self.interface
+            exp = r" | ignore-case  section include ^#\s+interface %s" \
+                  r" | include netstream sampler random-packets" % self.interface
             flags.append(exp)
             config = get_config(self.module, flags)
             if not config:
@@ -376,8 +409,8 @@ class NetStreamGlobal(object):
         statistic_tmp1["statistics_record"] = list()
         statistic_tmp1["interface"] = self.interface
         flags = list()
-        exp = " | ignore-case  section include ^interface %s$" \
-              " | include netstream record"\
+        exp = r" | ignore-case  section include ^#\s+interface %s" \
+              r" | include netstream record"\
               % (self.interface)
         flags.append(exp)
         config = get_config(self.module, flags)
@@ -414,8 +447,8 @@ class NetStreamGlobal(object):
         statistic_tmp1 = dict()
         statistic_tmp1["statistics_direction"] = list()
         flags = list()
-        exp = " | ignore-case  section include ^interface %s$" \
-              " | include netstream inbound|outbound"\
+        exp = r" | ignore-case  section include ^#\s+interface %s" \
+              r" | include netstream inbound|outbound"\
               % self.interface
         flags.append(exp)
         config = get_config(self.module, flags)
@@ -501,8 +534,8 @@ class NetStreamGlobal(object):
         self.end_state["sampler"].append(sampler_tmp)
         if self.interface != "all":
             flags = list()
-            exp = " | ignore-case  section include ^interface %s$" \
-                  " | include netstream sampler random-packets" % self.interface
+            exp = r" | ignore-case  section include ^#\s+interface %s" \
+                  r" | include netstream sampler random-packets" % self.interface
             flags.append(exp)
             config = get_config(self.module, flags)
             if not config:
@@ -535,8 +568,8 @@ class NetStreamGlobal(object):
         statistic_tmp1["statistics_record"] = list()
         statistic_tmp1["interface"] = self.interface
         flags = list()
-        exp = " | ignore-case  section include ^interface %s$" \
-              " | include netstream record"\
+        exp = r" | ignore-case  section include ^#\s+interface %s" \
+              r" | include netstream record"\
               % (self.interface)
         flags.append(exp)
         config = get_config(self.module, flags)
@@ -573,8 +606,8 @@ class NetStreamGlobal(object):
         statistic_tmp1 = dict()
         statistic_tmp1["statistics_direction"] = list()
         flags = list()
-        exp = " | ignore-case  section include ^interface %s$" \
-              " | include netstream inbound|outbound"\
+        exp = r" | ignore-case  section include ^#\s+interface %s" \
+              r" | include netstream inbound|outbound"\
               % self.interface
         flags.append(exp)
         config = get_config(self.module, flags)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_netstream_global.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
```
The below method, which is from ‘ansible.module_utils.network.cloudengine.ce’，
try to return the result from cache, if a result with the same flags is existing.
That is not the result we expected when 'get_config' is called at two different places , such as 'get_existing' and  'get_end_state' 
 which all call the 'get_config' at a different time whenever the configure on device has changed. So refactor it to fix the bug.
```
```paste below
    def get_config(self, flags=None):
        """Retrieves the current config from the device or cache
        """
        flags = [] if flags is None else flags

        cmd = 'display current-configuration '
        cmd += ' '.join(flags)
        cmd = cmd.strip()

        try:
            return self._device_configs[cmd]
        except KeyError:
            rc, out, err = self.exec_command(cmd)
            if rc != 0:
                self._module.fail_json(msg=err)
            cfg = str(out).strip()
            # remove default configuration prefix '~'
            for flag in flags:
                if "include-default" in flag:
                    cfg = rm_config_prefix(cfg)
                    break

            self._device_configs[cmd] = cfg
            return cfg
```