### PR TITLE
ce_netstream_template: update to fix a bug.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
@@ -325,7 +325,7 @@ class NetstreamTemplate(object):
                 if tmp_value:
                     self.end_state["collect_interface"] = tmp_value
         if self.end_state == self.existing:
-            self.changed =False
+            self.changed = False
             self.updates_cmd = list()
 
     def present_netstream(self):

--- a/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
@@ -324,6 +324,9 @@ class NetstreamTemplate(object):
                 tmp_value = re.findall(r'collect interface (.*)', self.netstream_cfg)
                 if tmp_value:
                     self.end_state["collect_interface"] = tmp_value
+        if self.end_state == self.existing:
+            self.changed =False
+            self.updates_cmd = list()
 
     def present_netstream(self):
         """ Present netstream configuration """

--- a/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
@@ -139,7 +139,7 @@ updates:
 import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import load_config
-from ansible.module_utils.network.cloudengine.ce import get_connection
+from ansible.module_utils.network.cloudengine.ce import get_connection, rm_config_prefix
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_netstream_template.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The below method, which is from ‘ansible.module_utils.network.cloudengine.ce’，
try to return the result from cache, if a result with the same flags is existing.
That is not the result we expected when 'get_config' is called at two different moments, such as 'get_existing' and  'get_end_state' 
 which all call the 'get_config' at a different time whenever the configure on device has changed. So refactor it to fix the bug.
```
```paste below
    def get_config(self, flags=None):
        """Retrieves the current config from the device or cache
        """
        flags = [] if flags is None else flags

        cmd = 'display current-configuration '
        cmd += ' '.join(flags)
        cmd = cmd.strip()

        try:
            return self._device_configs[cmd]
        except KeyError:
            rc, out, err = self.exec_command(cmd)
            if rc != 0:
                self._module.fail_json(msg=err)
            cfg = str(out).strip()
            # remove default configuration prefix '~'
            for flag in flags:
                if "include-default" in flag:
                    cfg = rm_config_prefix(cfg)
                    break

            self._device_configs[cmd] = cfg
            return cfg
```