### PR TITLE
Fix for pagination problems, issue #55828

### DIFF
--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -56,7 +56,7 @@ class TerminalModule(TerminalBase):
     terminal_inital_prompt_newline = False
 
     def on_become(self, passwd=None):
-        if self._get_prompt().endswith(b'#'):
+        if self._get_prompt().endswith(b')#'):
             return
 
         cmd = {u'command': u'enable'}


### PR DESCRIPTION
##### SUMMARY
Fixes #55828, "dellos6 modules not handling pagination". If a Dell OS6 switch is configured to bypass the Privileged Exec (enable) mode prompt when a user logs in, the on_become() function fails to issue the "terminal length 0" command. Ansible will consequently hang and time out on any task that involves paginated output from the switch. Modifying the if statement at line 59 fixes the issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/plugins/terminal/dellos6.py

##### ADDITIONAL INFORMATION
Dell OS6 switches can be configured to bypass the Privileged Exec (enable) mode prompt and go directly to enable mode when a user logs in, without the user having to manually issue the "enable" command and enter the enable password (if one is set). A factory-default switch can be configured to bypass the enable mode prompt by adding a local user and entering the following two commands in global configuration mode (the second line is what makes the switch bypass the enable mode prompt):

```
aaa authentication login default local
aaa authorization exec default local
```

The on_become() function in ansible/lib/ansible/plugins/terminal/dellos6.py is responsible for issuing the "enable" command (enters enable mode) and the "terminal length 0" command (disables pagination of output from the switch, Ansible will hang and time out if this command is not entered).

The "enable" and "terminal length 0" commands can not be issued if the switch is in any type of configuration mode, including (but not limited to) global configuration mode. Doing so will result in an error message.

```
DellOS6Switch(config)#enable

Command not found / Incomplete command. Use ? to list commands.

DellOS6Switch(config)#terminal length 0
                                ^
% Invalid input detected at '^' marker.

DellOS6Switch(config)#
```

Issuing the "enable" command while already in enable mode does not result in an error message, and neither does repeatedly issuing the "terminal length 0" command from enable  mode.

```
DellOS6Switch#enable

DellOS6Switch#enable

DellOS6Switch#terminal length 0

DellOS6Switch#terminal length 0

DellOS6Switch#
```

With this in mind, the on_become() function needs to detect if the switch is in a configuration mode and avoid issuing the "enable" and "terminal length 0" commands. The function does not necessarily need to detect if the switch is already in enable mode or if the "terminal length 0" command has already been issued, as there are no adverse consequences to issuing the commands multiple times.

The on_become() function uses the self._get_prompt().endswith() method to check if the switch prompt ends in "#", and if that is the case the function returns immediately without issuing the "enable" and "terminal length 0" commands. This avoids both issuing the commands while the switch is in a configuration mode and unnecessarily issuing the "enable" command if the switch is already in enable mode. However, it also causes the function to fail to issue the "terminal length 0" on a switch that is configured to bypass the enable mode prompt.

My proposed fix is to change the argument to the self._get_prompt().endswith() method at line 59 from "b'#'" to "b')#'". This causes the on_become() function return immediately if it detects that the switch is in a configuration mode, but otherwise it will always issue the "enable" and "terminal length 0" commands.

The change has been tested with Ansible 2.8.3 running on Ubuntu 18.04.2 LTS against a Dell EMC N1148P-ON running v6.6.0.2 firmware. Ansible was installed from the official Ubuntu PPA.