### PR TITLE
lvg: simplify pesize description

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -35,7 +35,7 @@ options:
     type: list
   pesize:
     description:
-    - The size of the physical extent. pesize must be a power of 2, or multiple of 128KiB.
+    - The size of the physical extent. pesize must be a power of 2.
     - Since Ansible 2.6, pesize can be optionally suffixed by a UNIT (k/K/m/M/g/G), default unit is megabyte.
     type: str
     default: "4"


### PR DESCRIPTION

##### SUMMARY
Remove confusing phrase about pesize as a "multiple of 128KiB".
Allowed values are anything accepted by vgcreate -s,
powers of 2, minimum 1K for lvm2.

As pesize less than 1M is accepted since Ansible 2.6,
close #29295

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lvg

##### ADDITIONAL INFORMATION
```

```
