### PR TITLE
Improve error for missing documentation fragment

### DIFF
--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -65,7 +65,7 @@ def add_fragments(doc, filename, fragment_loader):
             fragment_var = 'DOCUMENTATION'
 
         if fragment_class is None:
-            raise AnsibleAssertionError('fragment_class is None')
+            raise AnsibleAssertionError('Could not find documentation fragment %s' % fragment_slug)
 
         fragment_yaml = getattr(fragment_class, fragment_var, '{}')
         fragment = AnsibleLoader(fragment_yaml, file_name=filename).get_single_data()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The existing error message is very obtuse and does not include the fragment name that it was trying to load.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin_docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
ERROR! module flowerysong.sensu_go.sensu_go_asset missing documentation
(or could not parse documentation): fragment_class is None
```

Now:
```
ERROR! module flowerysong.sensu_go.sensu_go_asset missing documentation
(or could not parse documentation): Could not find documentation
fragment flowerysong.sensu_go.invalid
```