### PR TITLE
win_dsc - be more lenient with datetime parsing

### DIFF
--- a/changelogs/fragments/win_dsc-datetime.yaml
+++ b/changelogs/fragments/win_dsc-datetime.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dsc - Be more leniant around the accepted DateTime values for backwards compatibility - https://github.com/ansible/ansible/issues/59667

--- a/lib/ansible/modules/windows/win_dsc.ps1
+++ b/lib/ansible/modules/windows/win_dsc.ps1
@@ -19,11 +19,7 @@ Function ConvertTo-ArgSpecType {
     $arg_type = switch($CimType) {
         Boolean { "bool" }
         Char16 { [Func[[Object], [Char]]]{ [System.Char]::Parse($args[0].ToString()) } }
-        DateTime { [Func[[Object], [DateTime]]]{
-            # o == ISO 8601 format
-            [System.DateTime]::ParseExact($args[0].ToString(), "o", [CultureInfo]::InvariantCulture,
-                [System.Globalization.DateTimeStyles]::None)
-        }}
+        DateTime { [Func[[Object], [DateTime]]]{ [System.DateTime]($args[0].ToString()) } }
         Instance { "dict" }
         Real32 { "float" }
         Real64 { [Func[[Object], [Double]]]{ [System.Double]::Parse($args[0].ToString()) } }

--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -54,7 +54,7 @@ options:
       provided but a comma separated string also work. Use a list where
       possible as no escaping is required and it works with more complex types
       list C(CimInstance[]).
-    - If the type of the DSC resource option is a C(DateTime), youl should use
+    - If the type of the DSC resource option is a C(DateTime), you should use
       a string in the form of an ISO 8901 string to ensure the exact date is
       used.
     - Since Ansible 2.8, Ansible will now validate the input fields against the

--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -54,8 +54,9 @@ options:
       provided but a comma separated string also work. Use a list where
       possible as no escaping is required and it works with more complex types
       list C(CimInstance[]).
-    - If the type of the DSC resource option is a C(DateTime), use a string in
-      the form of an ISO 8901 string.
+    - If the type of the DSC resource option is a C(DateTime), youl should use
+      a string in the form of an ISO 8901 string to ensure the exact date is
+      used.
     - Since Ansible 2.8, Ansible will now validate the input fields against the
       DSC resource definition automatically. Older versions will silently
       ignore invalid fields.


### PR DESCRIPTION
##### SUMMARY
The win_dsc module before 2.8 would accept many forms with DateTime properties but the changes in 2.8 made this too strict and only accepted the ISO 8601 format. This PR re-adds the older behaviour and relies on the explicit casting of a String to a DateTime object just like before.

Fixes https://github.com/ansible/ansible/issues/59667

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dsc