### PR TITLE
Backport/2.8/59523 ce_config: Optimize multi-level views & fix a bug. (#59523)

### DIFF
--- a/changelogs/fragments/59728-ce_config-to-fix-bugs.yml
+++ b/changelogs/fragments/59728-ce_config-to-fix-bugs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ce_config - Optimize multi-level views & fix a bug. (https://github.com/ansible/ansible/pull/59523)

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -220,15 +220,62 @@ backup_path:
   sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.config import NetworkConfig, dumps
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config, run_commands
-from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
+from ansible.module_utils.network.common.config import NetworkConfig as _NetworkConfig
+from ansible.module_utils.network.common.config import dumps, ConfigLine, ignore_line
+from ansible.module_utils.network.cloudengine.ce import get_config, run_commands, exec_command, cli_err_msg
+from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, load_config
 from ansible.module_utils.network.cloudengine.ce import check_args as ce_check_args
 import re
 
 
 def check_args(module, warnings):
     ce_check_args(module, warnings)
+
+
+def _load_config(module, config):
+    """Sends configuration commands to the remote device
+    """
+    rc, out, err = exec_command(module, 'mmi-mode enable')
+    if rc != 0:
+        module.fail_json(msg='unable to set mmi-mode enable', output=err)
+    rc, out, err = exec_command(module, 'system-view immediately')
+    if rc != 0:
+        module.fail_json(msg='unable to enter system-view', output=err)
+
+    for index, cmd in enumerate(config):
+        rc, out, err = exec_command(module, cmd)
+        if rc != 0:
+            print_msg = cli_err_msg(cmd.strip(), err)
+            exec_command(module, "quit")
+            rc, out, err = exec_command(module, cmd)
+            if rc != 0:
+                print_msg1 = cli_err_msg(cmd.strip(), err)
+                if not re.findall(r"unrecognized command found", print_msg1):
+                    print_msg = print_msg1
+                exec_command(module, "return")
+                exec_command(module, "system-view immediately")
+                rc, out, err = exec_command(module, cmd)
+                if rc != 0:
+                    print_msg2 = cli_err_msg(cmd.strip(), err)
+                    if not re.findall(r"unrecognized command found", print_msg2):
+                        print_msg = print_msg2
+                    module.fail_json(msg=print_msg)
+
+    exec_command(module, 'return')
+
+
+def conversion_src(module):
+    src_list = module.params['src'].split('\n')
+    src_list_organize = []
+    if src_list[0].strip() == '#':
+        src_list.pop(0)
+    for per_config in src_list:
+        if per_config.strip() == '#':
+            src_list_organize.append('quit')
+        else:
+            src_list_organize.append(per_config)
+    src_str = '\n'.join(src_list_organize)
+    return src_str
 
 
 def get_running_config(module):
@@ -239,40 +286,6 @@ def get_running_config(module):
             flags.append('include-default')
         contents = get_config(module, flags=flags)
     return NetworkConfig(indent=1, contents=contents)
-
-
-def conversion_src(module):
-    src_list = module.params['src'].split('\n')
-    src_list_organize = []
-    exit_list = [' return', ' system-view']
-    if src_list[0].strip() == '#':
-        src_list.pop(0)
-    for per_config in src_list:
-        if per_config.strip() == '#':
-            if per_config.rstrip() == '#':
-                src_list_organize.extend(exit_list)
-            else:
-                src_list_organize.append('quit')
-        else:
-            src_list_organize.append(per_config)
-    src_str = '\n'.join(src_list_organize)
-    return src_str
-
-
-def conversion_lines(commands):
-    all_config = []
-    exit_list = [' return', ' system-view']
-    for per_command in commands:
-        if re.search(r',', per_command):
-            all_config.extend(exit_list)
-            per_config = per_command.split(',')
-            for config in per_config:
-                if config:
-                    all_config.append(config)
-            all_config.extend(exit_list)
-        else:
-            all_config.append(per_command)
-    return all_config
 
 
 def get_candidate(module):
@@ -289,6 +302,7 @@ def get_candidate(module):
 def run(module, result):
     match = module.params['match']
     replace = module.params['replace']
+
     candidate = get_candidate(module)
 
     if match != 'none':
@@ -300,10 +314,8 @@ def run(module, result):
 
     if configobjs:
         commands = dumps(configobjs, 'commands').split('\n')
+
         if module.params['lines']:
-
-            commands = conversion_lines(commands)
-
             if module.params['before']:
                 commands[:0] = module.params['before']
 
@@ -317,10 +329,69 @@ def run(module, result):
 
         result['commands'] = command_display
         result['updates'] = command_display
+
         if not module.check_mode:
-            load_config(module, commands)
-        if result['commands']:
-            result['changed'] = True
+            if module.params['parents'] is not None:
+                load_config(module, commands)
+            else:
+                _load_config(module, commands)
+
+        result['changed'] = True
+
+
+class NetworkConfig(_NetworkConfig):
+
+    def add(self, lines, parents=None):
+        ancestors = list()
+        offset = 0
+        obj = None
+
+        # global config command
+        if not parents:
+            for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
+                item = ConfigLine(line)
+                item.raw = line
+                self.items.append(item)
+
+        else:
+            for index, p in enumerate(parents):
+                try:
+                    i = index + 1
+                    obj = self.get_block(parents[:i])[0]
+                    ancestors.append(obj)
+
+                except ValueError:
+                    # add parent to config
+                    offset = index * self._indent
+                    obj = ConfigLine(p)
+                    obj.raw = p.rjust(len(p) + offset)
+                    if ancestors:
+                        obj._parents = list(ancestors)
+                        ancestors[-1]._children.append(obj)
+                    self.items.append(obj)
+                    ancestors.append(obj)
+
+            # add child objects
+            for line in lines:
+                # handle ignore lines
+                if ignore_line(line):
+                    continue
+
+                # check if child already exists
+                for child in ancestors[-1]._children:
+                    if child.text == line:
+                        break
+                else:
+                    offset = len(parents) * self._indent
+                    item = ConfigLine(line)
+                    item.raw = line.rjust(len(line) + offset)
+                    item._parents = ancestors
+                    ancestors[-1]._children.append(item)
+                    self.items.append(item)
 
 
 def main():


### PR DESCRIPTION
* Optimize multi-level views

* update to rewrite load_config.

* update.

* update.

* update.

* update.

(cherry picked from commit 9182d54e986c149e76d34ea42dd5d27cc1b77898)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### test case
```paste below
  - name: "Step2.1.1 Loading command configuration from lines"
    ce_config:
      lines: 
        - interface vlanif 3111
        - description test_vlanif3111_1
        - interface vlanif 3112
        - description test_vlanif3112_1
      match: none
```
### error log
```
atal: [10.190.121.125]: FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "after": null,
            "backup": false,
            "backup_options": null,
            "before": null,
            "config": null,
            "defaults": false,
            "host": "10.190.121.125",
            "lines": [
                "interface vlanif 3111",
                "description test_vlanif3111_1",
                "interface vlanif 3112",
                "description test_vlanif3112_1"
            ],
            "match": "none",
            "parents": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 10111,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "replace": "line",
            "save": false,
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": "huawei",
            "validate_certs": null
        }
    },
    "msg": "Command: interface vlanif 3112, error[1]: unrecognized command found."
}

PLAY RECAP **************************************************************************
10.190.121.125             : ok=0    changed=0    unreachable=0    failed=1    skippe                                                                            d=0    rescued=0    ignored=0
```
### debug result
```
Module does not support multi-view jumps.
An error happened when commands try to change contexts.
```
### after fixed, test log
```
changed: [10.190.121.125] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "commands": [
        "interface vlanif 3111",
        "description test_vlanif3111_1",
        "interface vlanif 3112",
        "description test_vlanif3112_1"
    ],
    "invocation": {
        "module_args": {
            "after": null,
            "backup": false,
            "backup_options": null,
            "before": null,
            "config": null,
            "defaults": false,
            "host": null,
            "lines": [
                "interface vlanif 3111",
                "description test_vlanif3111_1",
                "interface vlanif 3112",
                "description test_vlanif3112_1"
            ],
            "match": "none",
            "parents": null,
            "password": null,
            "port": null,
            "provider": {
                "host": "10.190.121.125",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 10111,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": "huawei",
                "validate_certs": null
            },
            "replace": "line",
            "save": false,
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": null,
            "username": null,
            "validate_certs": null
        }
    },
    "updates": [
        "interface vlanif 3111",
        "description test_vlanif3111_1",
        "interface vlanif 3112",
        "description test_vlanif3112_1"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************
10.190.121.125             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
### show configure on device.
```

[~8850_130.12]di cu | section in Vlanif311
#
interface Vlanif3111
 description test_vlanif3111_1
 ospf enable 1 area 0.0.0.1
#
interface Vlanif3112
 description test_vlanif3112_1
[~8850_130.12]
```

