### PR TITLE
[async_wrapper] exit early in case the job dir can not be created

### DIFF
--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -239,6 +239,8 @@ def main():
                 "failed": 1,
                 "msg": "could not create: %s" % jobdir
             }))
+            sys.exit(1)
+
     # immediately exit this process, leaving an orphaned process
     # running which immediately forks a supervisory timing process
 


### PR DESCRIPTION
##### SUMMARY
Trivial patch to  bail out in case of an error during the creation of the job directory.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
async_wrapper

##### ADDITIONAL INFORMATION
