### PR TITLE
Add TCP and UNIX socket options to callback syslog_json plugin

### DIFF
--- a/changelogs/fragments/59741-add_tcp_and_unix_socket_options_to_syslog_json.yaml
+++ b/changelogs/fragments/59741-add_tcp_and_unix_socket_options_to_syslog_json.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - syslog_json - Add TCP and UNIX socket options to callback syslog_json plugin


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Callback plugin _syslog_json_ doesn't currently have a means to select the transport protocol, by default it uses the socket.SOCK_DGRAM (udp) option when instantiating a logger instance.  This patch will allow the ability to set either TCP for the transport, or use a UNIX socket (e.g. Linux /dev/log, or macOS /var/run/syslog).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
syslog_json.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
