### PR TITLE
Order data in xml integration test

### DIFF
--- a/test/integration/targets/xml/tasks/test-set-children-elements-level.yml
+++ b/test/integration/targets/xml/tasks/test-set-children-elements-level.yml
@@ -11,12 +11,12 @@
       xpath: /business/beers
       set_children: &children
         - beer:
-            name: 90 Minute IPA
             alcohol: "0.5"
+            name: 90 Minute IPA
             _:
               - Water:
-                  quantity: 200g
                   liter: "0.2"
+                  quantity: 200g
               - Starch:
                   quantity: 10g
               - Hops:
@@ -24,12 +24,12 @@
               - Yeast:
                   quantity: 20g
         - beer:
-            name: Harvest Pumpkin Ale
             alcohol: "0.3"
+            name: Harvest Pumpkin Ale
             _:
               - Water:
-                  quantity: 200g
                   liter: "0.2"
+                  quantity: 200g
               - Hops:
                   quantity: 25g
               - Yeast:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A [recent update to lxml (4.4.0)](https://lxml.de/4.4/changes-4.4.0.html) now preserves key insertion order for Python >= 3.6.

> When creating attributes or namespaces from a dict in Python 3.6+, lxml now preserves the original insertion order of that dict, instead of always sorting the items by name.

Change the test input so the input keys are in sorted order, making tests pass on previous versions of `lxml` as well as the latest version.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/xml/tasks/test-set-children-elements-level.yml`

##### ADDITIONAL INFORMATION
I am not sure if this requires more work to the module to make the behavior consistent across versions of `lxml` as it will result in changes in the output of the XML file. I will leave that to the community to decide.