### PR TITLE
Fix pipelining in buildah connection plugin

### DIFF
--- a/changelogs/fragments/59745-fix-pipelining-in-buildah-connection-plugin.yml
+++ b/changelogs/fragments/59745-fix-pipelining-in-buildah-connection-plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Pipelining now works with the buildah plugin.

--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -120,7 +120,7 @@ class Connection(ConnectionBase):
         # shlex.split has a bug with text strings on Python-2.6 and can only handle text strings on Python-3
         cmd_args_list = shlex.split(to_native(cmd, errors='surrogate_or_strict'))
 
-        rc, stdout, stderr = self._buildah("run", cmd_args_list)
+        rc, stdout, stderr = self._buildah("run", cmd_args_list, in_data)
 
         display.vvvvv("STDOUT %r STDERR %r" % (stderr, stderr))
         return rc, stdout, stderr


### PR DESCRIPTION
##### SUMMARY

This PR fixes pipelining support in the buildah connection plugin - offered as a much simpler alternative to https://github.com/ansible/ansible/pull/57552 / the buildah version of https://github.com/ansible/ansible/pull/57579

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

```plugins/connection/buildah.py```

##### ADDITIONAL INFORMATION

Unlike the podman plugin, this plugin declares that it supports pipelining, but like the podman plugin, it does not actually pass `in_data` along. cc @TomasTomecek 
