### PR TITLE
lvg: update docs for pesize

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -35,7 +35,9 @@ options:
     type: list
   pesize:
     description:
-    - The size of the physical extent. pesize must be a power of 2.
+    - "The size of the physical extent. I(pesize) must be a power of 2 of at least 1 sector
+       (where the sector size is the largest sector size of the PVs currently used in the VG),
+       or at least 128KiB."
     - Since Ansible 2.6, pesize can be optionally suffixed by a UNIT (k/K/m/M/g/G), default unit is megabyte.
     type: str
     default: "4"


### PR DESCRIPTION
##### SUMMARY
Fixes #29295, fixes #59699. The text should now be correct since it closely follows the manpage of `vgcreate`:

> The value must be either a power of 2 of at least 1 sector (where the sector size is the largest sector size of the PVs currently used in the VG), or at least 128KiB.

CC @jpmahowald, @samccann

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lvg
