### PR TITLE
Update pbrun.py

### DIFF
--- a/lib/ansible/plugins/become/pbrun.py
+++ b/lib/ansible/plugins/become/pbrun.py
@@ -95,7 +95,7 @@ class BecomeModule(BecomeBase):
 
         become_exe = self.get_option('become_exe') or self.name
         flags = self.get_option('become_flags') or ''
-        user = self.get_option('become_user')
+        user = self.get_option('become_user') or ''
         if user:
             user = '-u %s' % (user)
         noexe = not self.get_option('wrap_exe')

--- a/lib/ansible/plugins/become/pbrun.py
+++ b/lib/ansible/plugins/become/pbrun.py
@@ -14,6 +14,7 @@ DOCUMENTATION = """
     options:
         become_user:
             description: User you 'become' to execute the task
+            default: ''
             ini:
               - section: privilege_escalation
                 key: become_user


### PR DESCRIPTION
Added ternary operator to user variable assignment to ensure if get_option returns NoneType Object that it's set to ''.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With all other become plugins user assignment is done with a ternary operator to default to '' if no user option is returned. This should be the same for pbrun become plugin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pbrun

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
