### PR TITLE
fetch: Acknowledge validate_checksum flag

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -133,7 +133,7 @@ class ActionModule(ActionBase):
 
             dest = dest.replace("//", "/")
 
-            if remote_checksum in ('0', '1', '2', '3', '4', '5'):
+            if validate_checksum and remote_checksum in ('0', '1', '2', '3', '4', '5'):
                 result['changed'] = False
                 result['file'] = source
                 if remote_checksum == '0':


### PR DESCRIPTION
Without this check, the "validate_checksum" flag won't be acknowledged even if the flag is set to "no" in the playbook.

##### SUMMARY
Running a playbook using Fetch action e.g. copy files from Windows remote server to Linux as the destination would result in the error message:

"unable to calculate the checksum of the remote file"

This issue persists even if the flag validate_checksum is set to "no" in the playbook.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Fetch plugin

##### ADDITIONAL INFORMATION

```
