### PR TITLE
inventory: Fail on non-existing limit file

### DIFF
--- a/changelogs/fragments/limit-file-exception.yml
+++ b/changelogs/fragments/limit-file-exception.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Ansible should fail with error when non-existing limit file is provided in command line.

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -611,10 +611,15 @@ class InventoryManager(object):
             results = []
             # allow Unix style @filename data
             for x in subset_patterns:
+                if not x:
+                    continue
+
                 if x[0] == "@":
-                    fd = open(x[1:])
-                    results.extend([to_text(l.strip()) for l in fd.read().split("\n")])
-                    fd.close()
+                    b_limit_file = to_bytes(x[1:])
+                    if not os.path.exists(b_limit_file):
+                        raise AnsibleError(u'Unable to find limit file %s' % b_limit_file)
+                    with open(b_limit_file) as fd:
+                        results.extend([to_text(l.strip()) for l in fd.read().split("\n")])
                 else:
                     results.append(to_text(x))
             self._subset = results

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -21,6 +21,13 @@ if [ "$?" != "1" ]; then
     exit 1
 fi
 
+# Ensure that non-existing limit file causes failure with rc 1
+ansible-playbook -i ../../inventory --limit @foo playbook.yml
+if [ "$?" != "1" ]; then
+    echo "Non-existing limit file should cause failure"
+    exit 1
+fi
+
 # Ensure that non-matching limit causes failure with rc 1
 ansible-playbook -i ../../inventory --limit @"${empty_limit_file}" playbook.yml
 


### PR DESCRIPTION
##### SUMMARY
Ansible now fails with error message when user provides
non-existing limit file.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/limit-file-exception.yml
lib/ansible/inventory/manager.py
test/integration/targets/inventory/runme.sh