### PR TITLE
podman_image: Disable unstable test

### DIFF
--- a/test/integration/targets/podman_image/aliases
+++ b/test/integration/targets/podman_image/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+unsupported
 skip/osx
 skip/freebsd
 destructive


### PR DESCRIPTION

##### SUMMARY
Disabling tests for podman_image until CI is green.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/podman_image/aliases