### PR TITLE
Only error out if the gid exists with a different group name

### DIFF
--- a/changelogs/fragments/59769-fix_ansible_issue_58469_regression.yaml
+++ b/changelogs/fragments/59769-fix_ansible_issue_58469_regression.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >
+     group - The group module errored of if the gid exists with the
+     same group name. This prevents reruns of the playbook. This fixes
+     a regression introduced by 4898b0a.

--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -121,8 +121,10 @@ class Group(object):
         return self.execute_command(cmd)
 
     def _local_check_gid_exists(self):
-        if self.gid and self.gid in [gr.gr_gid for gr in grp.getgrall()]:
-            self.module.fail_json(msg="GID '{0}' already exists".format(self.gid))
+        if self.gid:
+            for gr in grp.getgrall():
+                if self.gid == gr.gr_gid and self.name != gr.gr_name:
+                    self.module.fail_json(msg="GID '{0}' already exists with group '{1}'".format(self.gid, gr.gr_name))
 
     def group_add(self, **kwargs):
         if self.local:

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -217,3 +217,44 @@
         state: absent
   # only applicable to Linux, limit further to CentOS where 'luseradd' is installed
   when: ansible_distribution == 'CentOS'
+
+# https://github.com/ansible/ansible/pull/59769
+- block:
+  - name: create a local group with a gid
+    group:
+      name: group1_local_test
+      gid: 1337
+      local: yes
+      state: present
+    register: create_local_group_gid
+
+  - name: get gid of created local group
+    command: "{{ ansible_python_interpreter | quote }} -c \"import grp; print(grp.getgrnam('group1_local_test').gr_gid)\""
+    register: create_local_group_gid_actual
+
+  - name: assert create group with a gid
+    assert:
+        that:
+        - create_local_group_gid is changed
+        - create_local_group_gid.gid | int == 1337 | int
+        - create_local_group_gid_actual.stdout | trim | int == 1337 | int
+
+  - name: create a local group with a gid (idempotent)
+    group:
+      name: group1_local_test
+      gid: 1337
+      state: present
+    register: create_local_group_gid_again
+
+  - name: assert create group with a gid (idempotent)
+    assert:
+        that:
+        - not create_local_group_gid_again is changed
+        - create_local_group_gid_again.gid | int == 1337 | int
+  always:
+    - name: Cleanup
+      group:
+        name: group1_local_test
+        state: absent
+  # only applicable to Linux, limit further to CentOS where 'luseradd' is installed
+  when: ansible_distribution == 'CentOS'

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -209,7 +209,7 @@
   - assert:
      that:
        - local_duplicate_gid_result['results'][0] is success
-       - local_duplicate_gid_result['results'][1]['msg'] == "GID '1337' already exists"
+       - local_duplicate_gid_result['results'][1]['msg'] == "GID '1337' already exists with group 'group1_local_test'"
   always:
     - name: Cleanup
       group:

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -232,7 +232,7 @@
     command: "{{ ansible_python_interpreter | quote }} -c \"import grp; print(grp.getgrnam('group1_local_test').gr_gid)\""
     register: create_local_group_gid_actual
 
-  - name: assert create group with a gid
+  - name: assert create local group with a gid
     assert:
         that:
         - create_local_group_gid is changed
@@ -246,13 +246,13 @@
       state: present
     register: create_local_group_gid_again
 
-  - name: assert create group with a gid (idempotent)
+  - name: assert create local group with a gid (idempotent)
     assert:
         that:
         - not create_local_group_gid_again is changed
         - create_local_group_gid_again.gid | int == 1337 | int
   always:
-    - name: Cleanup
+    - name: Cleanup create local group with a gid 
       group:
         name: group1_local_test
         state: absent


### PR DESCRIPTION
##### SUMMARY
Only error out if the gid exists with a different group name as
otherwise it will error out if the group with this gid already
exists, like on a rerun of the playbook. This fixes a regression
introduced by 4898b0a4a298448677c2aee2a03157ba5b662759.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
group