### PR TITLE
inventory: Handle IndexError while parsing limit file

### DIFF
--- a/changelogs/fragments/limit_file_parsing.yml
+++ b/changelogs/fragments/limit_file_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Handle IndexError while parsing empty limit file (https://github.com/ansible/ansible/issues/59695).

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -69,11 +69,14 @@ def order_patterns(patterns):
     pattern_intersection = []
     pattern_exclude = []
     for p in patterns:
+        if not p:
+            continue
+
         if p[0] == "!":
             pattern_exclude.append(p)
         elif p[0] == "&":
             pattern_intersection.append(p)
-        elif p:
+        else:
             pattern_regular.append(p)
 
     # if no regular pattern was given, hence only exclude and/or intersection

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -2,6 +2,17 @@
 
 set -x
 
+empty_limit_file="/tmp/limit_file"
+touch "${empty_limit_file}"
+
+cleanup() {
+    if [[ -f "${empty_limit_file}" ]]; then
+            rm -rf "${empty_limit_file}"
+    fi
+}
+
+trap 'cleanup' EXIT
+
 # https://github.com/ansible/ansible/issues/52152
 # Ensure that non-matching limit causes failure with rc 1
 ansible-playbook -i ../../inventory --limit foo playbook.yml
@@ -9,6 +20,9 @@ if [ "$?" != "1" ]; then
     echo "Non-matching limit should cause failure"
     exit 1
 fi
+
+# Ensure that non-matching limit causes failure with rc 1
+ansible-playbook -i ../../inventory --limit @"${empty_limit_file}" playbook.yml
 
 ansible-playbook -i ../../inventory "$@" strategy.yml
 ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=always ansible-playbook -i ../../inventory "$@" strategy.yml


### PR DESCRIPTION
##### SUMMARY
Handle IndexError exception raised while parsing the limit file.

Fixes: #59695

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/limit_file_parsing.yml
lib/ansible/inventory/manager.py
test/integration/targets/inventory/runme.sh