### PR TITLE
[2.8] fixed _merge_dictionaries calls in GcpSession class

### DIFF
--- a/changelogs/fragments/gcp-session-merge_dict.yml
+++ b/changelogs/fragments/gcp-session-merge_dict.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fix call from "merge_dictionaries" to "_merge_dictionaries" in GcpSession object (https://github.com/ansible/ansible/issues/57140).

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -87,7 +87,7 @@ class GcpSession(object):
 
     def post(self, url, body=None, headers=None, **kwargs):
         if headers:
-            headers = self.merge_dictionaries(headers, self._headers())
+            headers = self._merge_dictionaries(headers, self._headers())
         else:
             headers = self._headers()
 
@@ -98,7 +98,7 @@ class GcpSession(object):
 
     def post_contents(self, url, file_contents=None, headers=None, **kwargs):
         if headers:
-            headers = self.merge_dictionaries(headers, self._headers())
+            headers = self._merge_dictionaries(headers, self._headers())
         else:
             headers = self._headers()
 


### PR DESCRIPTION

##### SUMMARY
(cherry picked from commit c24b841c0a8ec60f8eabafc2dbba99358ecbf294)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/gcp-session-merge_dict.yml
lib/ansible/module_utils/gcp_utils.py
