### PR TITLE
Handle situation where DOCS.options is None

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -1257,7 +1257,7 @@ class ModuleValidator(Validator):
 
             try:
                 doc_default = None
-                doc_options_arg = docs.get('options', {}).get(arg, {})
+                doc_options_arg = (docs.get('options', {}) or {}).get(arg, {})
                 if 'default' in doc_options_arg and not is_empty(doc_options_arg['default']):
                     with CaptureStd():
                         doc_default = _type_checker(doc_options_arg['default'])


### PR DESCRIPTION
##### SUMMARY
Handle situation where DOCS.options is None

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/sanity/validate-modules/main.py

##### ADDITIONAL INFORMATION
Addresses

```
01:35 >>> Standard Error
01:35 Traceback (most recent call last):
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1231, in _validate_argument_spec
01:35     doc_options_arg = docs.get('options', {}).get(arg, {})
01:35 AttributeError: 'NoneType' object has no attribute 'get'
01:35 
01:35 During handling of the above exception, another exception occurred:
01:35 
01:35 Traceback (most recent call last):
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1768, in <module>
01:35     main()
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1667, in main
01:35     mv.validate()
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1548, in validate
01:35     self._validate_ansible_module_call(docs)
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1145, in _validate_ansible_module_call
01:35     self._validate_argument_spec(docs, spec, kwargs)
01:35   File "/root/ansible/test/sanity/validate-modules/validate-modules", line 1242, in _validate_argument_spec
01:35     "but this is incompatible with parameter type %r" % (arg, doc_options_arg.get('default'), _type))
01:35 UnboundLocalError: local variable 'doc_options_arg' referenced before assignment
```