### PR TITLE
[stable-2.8] Add pipelining to podman connection plugin

### DIFF
--- a/changelogs/fragments/57579-add-pipelining-to-podman-connection-plugin.yaml
+++ b/changelogs/fragments/57579-add-pipelining-to-podman-connection-plugin.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- The `podman` connection plugin now supports pipelining.

--- a/lib/ansible/plugins/connection/podman.py
+++ b/lib/ansible/plugins/connection/podman.py
@@ -58,6 +58,7 @@ class Connection(ConnectionBase):
 
     # String used to identify this Connection class from other classes
     transport = 'podman'
+    has_pipelining = True
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
@@ -112,7 +113,7 @@ class Connection(ConnectionBase):
         if self.user:
             cmd_args_list += ["--user", self.user]
 
-        rc, stdout, stderr = self._podman("exec", cmd_args_list)
+        rc, stdout, stderr = self._podman("exec", cmd_args_list, in_data)
 
         display.vvvvv("STDOUT %r STDERR %r" % (stderr, stderr))
         return rc, stdout, stderr


### PR DESCRIPTION
##### SUMMARY

This is a backport of https://github.com/ansible/ansible/pull/57579 to `stable-2.8`

This PR adds support for pipelining to the `podman` connection plugin. This is a very small adjustment -- everything needed to support it was already there, all that was needed was to pass along `in_data` and then declare support for it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`plugins/connection/podman.py`

##### ADDITIONAL INFORMATION

All that was missing here was to pass `in_data` over to `_podman`, and to set `has_pipelining` to `True`. cc @TomasTomecek @felixfontein 