### PR TITLE
Add ability to force immeadiate replication of a pgroup

### DIFF
--- a/changelogs/fragments/59785-add-replicate-now-to-purefa_pgsnap.yml
+++ b/changelogs/fragments/59785-add-replicate-now-to-purefa_pgsnap.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add ability to force a protection group snapshot to immeadiatley replicate to a remote array (if configured)
+  - Add support for `check_mode`


### PR DESCRIPTION
##### SUMMARY
Add ability to force an immediate replication of a protection group to a remote array (assuming the pgroup has a target defined).
Support `check_mode`.
Cleanup logic.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
purefa_pgsnap.py