### PR TITLE
Backport/2.8/59689 ce_netstream_global: update to fix a bug. (#59689)

### DIFF
--- a/changelogs/fragments/59786-ce_netstream_global-to-fix-bugs.yml
+++ b/changelogs/fragments/59786-ce_netstream_global-to-fix-bugs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ce_netstream_global - The 'get_config', which is from 'ansible.module_utils.network.cloudengine.ce', try to return the result from cache,however the configure has changed. (https://github.com/ansible/ansible/pull/59689)


### PR DESCRIPTION
* update to fix a bug.

* Update ce_netstream_global.py

(cherry picked from commit 3c7e8f79050912d435b5bb50755129c73d83b24c)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_netstream_global.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The below method, which is from ‘ansible.module_utils.network.cloudengine.ce’，
try to return the result from cache, if a result with the same flags is existing.
That is not the result we expected when 'get_config' is called at two different places , such as 'get_existing' and  'get_end_state' 
 which all call the 'get_config' at a different time whenever the configure on device has changed. So refactor it to fix the bug.
```
```paste below
    def get_config(self, flags=None):
        """Retrieves the current config from the device or cache
        """
        flags = [] if flags is None else flags

        cmd = 'display current-configuration '
        cmd += ' '.join(flags)
        cmd = cmd.strip()

        try:
            return self._device_configs[cmd]
        except KeyError:
            rc, out, err = self.exec_command(cmd)
            if rc != 0:
                self._module.fail_json(msg=err)
            cfg = str(out).strip()
            # remove default configuration prefix '~'
            for flag in flags:
                if "include-default" in flag:
                    cfg = rm_config_prefix(cfg)
                    break

            self._device_configs[cmd] = cfg
            return cfg
```
