### PR TITLE
[2.8] Add wait_sleep parameter for the k8s module

### DIFF
--- a/changelogs/fragments/k8s_wait_sleep.yml
+++ b/changelogs/fragments/k8s_wait_sleep.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s - add `wait_sleep` parameter (number of seconds to sleep between checks).

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -80,6 +80,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         argument_spec.update(copy.deepcopy(AUTH_ARG_SPEC))
         argument_spec['merge_type'] = dict(type='list', choices=['json', 'merge', 'strategic-merge'])
         argument_spec['wait'] = dict(type='bool', default=False)
+        argument_spec['wait_sleep'] = dict(type='int', default=1)
         argument_spec['wait_timeout'] = dict(type='int', default=120)
         argument_spec['wait_condition'] = dict(type='dict', default=None, options=self.condition_spec)
         argument_spec['validate'] = dict(type='dict', default=None, options=self.validate_spec)
@@ -219,6 +220,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         namespace = definition['metadata'].get('namespace')
         existing = None
         wait = self.params.get('wait')
+        wait_sleep = self.params.get('wait_sleep')
         wait_timeout = self.params.get('wait_timeout')
         wait_condition = None
         if self.params.get('wait_condition') and self.params['wait_condition'].get('type'):
@@ -265,7 +267,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                         self.fail_json(msg="Failed to delete object: {0}".format(exc.body),
                                        error=exc.status, status=exc.status, reason=exc.reason)
                     if wait:
-                        success, resource, duration = self.wait(resource, definition, wait_timeout, 'absent')
+                        success, resource, duration = self.wait(resource, definition, wait_sleep, wait_timeout, 'absent')
                         result['duration'] = duration
                         if not success:
                             self.fail_json(msg="Resource deletion timed out", **result)
@@ -292,7 +294,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 success = True
                 result['result'] = k8s_obj
                 if wait and not self.check_mode:
-                    success, result['result'], result['duration'] = self.wait(resource, definition, wait_timeout, condition=wait_condition)
+                    success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
                 result['changed'] = True
                 result['method'] = 'create'
                 if not success:
@@ -317,7 +319,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                 success = True
                 result['result'] = k8s_obj
                 if wait:
-                    success, result['result'], result['duration'] = self.wait(resource, definition, wait_timeout, condition=wait_condition)
+                    success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
                 match, diffs = self.diff_objects(existing.to_dict(), result['result'])
                 result['changed'] = not match
                 result['method'] = 'replace'
@@ -345,7 +347,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             success = True
             result['result'] = k8s_obj
             if wait:
-                success, result['result'], result['duration'] = self.wait(resource, definition, wait_timeout, condition=wait_condition)
+                success, result['result'], result['duration'] = self.wait(resource, definition, wait_sleep, wait_timeout, condition=wait_condition)
             match, diffs = self.diff_objects(existing.to_dict(), result['result'])
             result['result'] = k8s_obj
             result['changed'] = not match
@@ -387,7 +389,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         result['method'] = 'create'
         return result
 
-    def _wait_for(self, resource, name, namespace, predicate, timeout, state):
+    def _wait_for(self, resource, name, namespace, predicate, sleep, timeout, state):
         start = datetime.now()
 
         def _wait_for_elapsed():
@@ -402,7 +404,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                         return True, response.to_dict(), _wait_for_elapsed()
                     else:
                         return True, {}, _wait_for_elapsed()
-                time.sleep(timeout // 20)
+                time.sleep(sleep)
             except NotFoundError:
                 if state == 'absent':
                     return True, {}, _wait_for_elapsed()
@@ -410,7 +412,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             response = response.to_dict()
         return False, response, _wait_for_elapsed()
 
-    def wait(self, resource, definition, timeout, state='present', condition=None):
+    def wait(self, resource, definition, sleep, timeout, state='present', condition=None):
 
         def _deployment_ready(deployment):
             # FIXME: frustratingly bool(deployment.status) is True even if status is empty
@@ -460,4 +462,4 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             predicate = _custom_condition
         else:
             predicate = _resource_absent
-        return self._wait_for(resource, definition['metadata']['name'], definition['metadata'].get('namespace'), predicate, timeout, state)
+        return self._wait_for(resource, definition['metadata']['name'], definition['metadata'].get('namespace'), predicate, sleep, timeout, state)

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -68,6 +68,11 @@ options:
     default: no
     type: bool
     version_added: "2.8"
+  wait_sleep:
+    description:
+    - Number of seconds to sleep between checks.
+    default: 1
+    version_added: "2.8"
   wait_timeout:
     description:
     - How long in seconds to wait for the resource to end up in the desired state. Ignored if C(wait) is not set.

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -52,6 +52,7 @@
                 app: "{{ wait_pod_name }}"
             template: "{{ wait_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         wait_pod_name: wait-ds
@@ -79,6 +80,7 @@
               type: RollingUpdate
             template: "{{ wait_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         wait_pod_name: wait-ds
@@ -106,6 +108,7 @@
               type: RollingUpdate
             template: "{{ wait_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         wait_pod_name: wait-ds
@@ -137,6 +140,7 @@
             namespace: "{{ wait_namespace }}"
           spec: "{{ wait_pod_spec }}"
         wait: yes
+        wait_sleep: 1
         wait_timeout: 30
       vars:
         wait_pod_name: wait-crash-pod
@@ -161,6 +165,7 @@
             namespace: "{{ wait_namespace }}"
           spec: "{{ wait_pod_spec }}"
         wait: yes
+        wait_sleep: 1
         wait_timeout: 30
       vars:
         wait_pod_name: wait-no-image-pod
@@ -328,6 +333,7 @@
         namespace: "{{ wait_namespace }}"
         state: absent
         wait: yes
+        wait_sleep: 2
         wait_timeout: 5
       ignore_errors: yes
       register: short_wait_remove_pod


### PR DESCRIPTION
##### SUMMARY
Currently there is no way to specify number of seconds to sleep between checks while waiting for Kubernetes response. It's hardcoded in awkward way:
https://github.com/ansible/ansible/blob/08d7905be2a45e51ceed315974e25d1008bf4263/lib/ansible/module_utils/k8s/raw.py#L440
I suggest to add `wait_sleep` parameter with default value of 1 second for convenience (by analogy with `sleep` parameter of `wait_for` module).

Fixes #59714

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`k8s` module