### PR TITLE
Fix podman_image integration tests

### DIFF
--- a/test/integration/targets/podman_image/aliases
+++ b/test/integration/targets/podman_image/aliases
@@ -1,4 +1,4 @@
-unsupported
+shippable/posix/group3
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/setup_podman/tasks/main.yml
+++ b/test/integration/targets/setup_podman/tasks/main.yml
@@ -1,10 +1,13 @@
 - block:
+    - name: Include distribution specific variables
+      include_vars: "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+
     - name: Enable extras repo
       command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version] | default('echo') }}"
 
     - name: Install podman
       yum:
-        name: podman
+        name: "{{ podman_package }}"
         state: present
       when: ansible_facts.pkg_mgr in ['yum', 'dnf']
   when:

--- a/test/integration/targets/setup_podman/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-7.yml
@@ -1,0 +1,1 @@
+podman_package: podman-1.3.*

--- a/test/integration/targets/setup_podman/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-8.yml
@@ -1,0 +1,1 @@
+podman_package: '@container-tools:1.0'

--- a/test/integration/targets/setup_podman/vars/main.yml
+++ b/test/integration/targets/setup_podman/vars/main.yml
@@ -1,3 +1,2 @@
 repo_command:
   RedHat7: yum-config-manager --enable rhui-REGION-rhel-server-extras
-  # RedHat8: dnf config-manager --enablerepo rhui-REGION-rhel-server-extras


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pin podman package at a specific version on RHEL 7 and RHEL8.

RHEL 8 is using 1.0.0 whereas RHEL 7 is getting `podman` from extras, which is pretty much always the latest upstream release. It looks like RHEL 7 has the latest version of the most recent two minor releases. I pinned RHEL 7 at `1.3.*` just in case they don't keep exact minor releases in the repo to prevent this test from failing every time there is a point release.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/podman_image/`

##### ADDITIONAL INFORMATION
The current test failure is due to a change in output in Podman 1.4.4. That will need to be fixed in the `podman_image` module.

RHEL 8.1 will include `podman` 1.4.

RHEL 7:
```
$ yum list --showduplicates podman
Loaded plugins: amazon-id, rhui-lb, search-disabled-repos
Installed Packages
podman.x86_64                        1.4.4-2.el7                                      @rhui-REGION-rhel-server-extras
Available Packages
podman.x86_64                        0.4.1-4.gitb51d327.el7                           rhui-REGION-rhel-server-extras
podman.x86_64                        0.6.1-3.git3e0ff12.el7                           rhui-REGION-rhel-server-extras
podman.x86_64                        0.7.3-1.git0791210.el7                           rhui-REGION-rhel-server-extras
podman.x86_64                        0.9.2-5.git37a2afe.el7_5                         rhui-REGION-rhel-server-extras
podman.x86_64                        0.10.1.3-1.gitdb08685.el7                        rhui-REGION-rhel-server-extras
podman.x86_64                        0.11.1.1-3.git594495d.el7                        rhui-REGION-rhel-server-extras
podman.x86_64                        0.12.1.2-2.git9551f6b.el7                        rhui-REGION-rhel-server-extras
podman.x86_64                        1.3.2-1.git14fdcd0.el7                           rhui-REGION-rhel-server-extras
podman.x86_64                        1.4.4-2.el7                                      rhui-REGION-rhel-server-extras
```


RHEL 8:
```
$ yum module list container-tools
Last metadata expiration check: 0:15:33 ago on Tue 30 Jul 2019 05:50:16 PM UTC.
Red Hat Enterprise Linux 8 for x86_64 - AppStream from RHUI (RPMs)
Name                  Stream          Profiles             Summary
container-tools       1.0 [e]         common [d] [i]       Common tools and dependencies for container runtimes
container-tools       rhel8 [d]       common [d]           Common tools and dependencies for container runtimes

Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled


$ yum list --showduplicates podman
Last metadata expiration check: 0:15:14 ago on Tue 30 Jul 2019 05:50:16 PM UTC.
Installed Packages
podman.x86_64            1.0.0-2.git921f98f.module+el8+2784+9a0c1dfe                 @rhui-rhel-8-appstream-rhui-rpms
Available Packages
podman.x86_64            1.0.0-2.git921f98f.module+el8.0.0+2956+30df4692             rhui-rhel-8-appstream-rhui-rpms
podman.x86_64            1.0.0-2.git921f98f.module+el8+2784+9a0c1dfe                 @rhui-rhel-8-appstream-rhui-rpms
podman.x86_64            1.0.0-2.git921f98f.module+el8+2784+9a0c1dfe                 rhui-rhel-8-appstream-rhui-rpms
```