### PR TITLE
podman_image - Handle new output when building images

### DIFF
--- a/changelogs/fragments/podman_image-build-output-format.yaml
+++ b/changelogs/fragments/podman_image-build-output-format.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - podman_image - handle new output format for image build

--- a/lib/ansible/modules/cloud/podman/podman_image.py
+++ b/lib/ansible/modules/cloud/podman/podman_image.py
@@ -416,6 +416,10 @@ class PodmanImageManager(object):
                 splitline = line.rsplit(split_on, maxsplit)
                 layer_ids.append(splitline[1])
 
+        # Podman 1.4 changed the output to only include the layer id when run in quiet mode
+        if not layer_ids:
+            layer_ids = lines.splitlines()
+
         return(layer_ids[-1])
 
     def present(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Podman 1.4 changed the build output slightly from this:

```
--> Using cache 46c5e686388d3b1838b603152d68d8046d4f71b8bf1b70766a24a22fc353f570
--> Using cache 912c9204c7a8c638b11c21faa1672fde26af6ab5817c2116f2ef65f20168eb0e
912c9204c7a8c638b11c21faa1672fde26af6ab5817c2116f2ef65f20168eb0e
```

To this:
```
170bc36de1ceca61372886b5075ef1c9d7fb80ff0c0e81586392458c16369f03
64225793692ccb032c03653001d6d65661fbe6e8845226dc2e30c94924ebe222
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/podman/podman_image.py`