### PR TITLE
add vfat to selinux special_context_filesystems

### DIFF
--- a/changelogs/fragments/vfat_selinux_fs.yaml
+++ b/changelogs/fragments/vfat_selinux_fs.yaml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+- vfat - changed default value of selinux_special_filesystems to include vfat,
+  the filesystem of ``/boot/efi`` on UEFI systems
+minor_changes:
+- selinux_special_filesystems config can be specified via environment variable
+  ``ANSIBLE_SELINUX_SPECIAL_FS``

--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -429,7 +429,7 @@ files (changing attributes, moving, and copying). To set, add a comma separated 
 
   # ansible.cfg
   [selinux]
-  special_context_filesystems=nfs,vboxsf,fuse,ramfs
+  special_context_filesystems=nfs,vboxsf,fuse,ramfs,vfat
 
 Most modules can use the built-in ``AnsibleModule`` methods to manipulate
 files. To access in a module that needs to know about these special context filesystems, instantiate an ``AnsibleModule`` and examine the list in

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -461,7 +461,7 @@
 # file systems that require special treatment when dealing with security context
 # the default behaviour that copies the existing context or uses the user default
 # needs to be changed to use the file system dependent context.
-#special_context_filesystems=nfs,vboxsf,fuse,ramfs,9p
+#special_context_filesystems=nfs,vboxsf,fuse,ramfs,9p,vfat
 
 # Set this to yes to allow libvirt_lxc connections to work without SELinux.
 #libvirt_lxc_noseclabel = yes

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -955,12 +955,14 @@ DEFAULT_SCP_IF_SSH:
   - {key: scp_if_ssh, section: ssh_connection}
 DEFAULT_SELINUX_SPECIAL_FS:
   name: Problematic file systems
-  default: fuse, nfs, vboxsf, ramfs, 9p
+  default: fuse, nfs, vboxsf, ramfs, 9p, vfat
   description:
     - "Some filesystems do not support safe operations and/or return inconsistent errors,
        this setting makes Ansible 'tolerate' those in the list w/o causing fatal errors."
     - Data corruption may occur and writes are not always verified when a filesystem is in the list.
-  env: []
+  env:
+  - name: ANSIBLE_SELINUX_SPECIAL_FS
+    version_added: "2.9"
   ini:
   - {key: special_context_filesystems, section: selinux}
   type: list

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -28,7 +28,7 @@ PASS_VARS = {
     'module_name': ('_name', None),
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),
-    'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p']),
+    'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p', 'vfat']),
     'shell_executable': ('_shell', '/bin/sh'),
     'socket': ('_socket_path', None),
     'string_conversion_action': ('_string_conversion_action', 'warn'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
vfat is the format of the /boot/efi partition on UEFI hosts and does
not support SELinux labels

add an environment variable for this config option

The absence of vfat here requires ugly workarounds such as this one in ansible-lockdown; https://github.com/MindPointGroup/RHEL7-STIG/pull/250
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
