### PR TITLE
[s3_bucket] access the bucket encryption response gracefully

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -419,12 +419,14 @@ def put_bucket_versioning(s3_client, bucket_name, required_versioning):
 def get_bucket_encryption(s3_client, bucket_name):
     try:
         result = s3_client.get_bucket_encryption(Bucket=bucket_name)
-        return result.get('ServerSideEncryptionConfiguration').get('Rules')[0].get('ApplyServerSideEncryptionByDefault')
+        return result.get('ServerSideEncryptionConfiguration', {}).get('Rules', [])[0].get('ApplyServerSideEncryptionByDefault')
     except ClientError as e:
         if e.response['Error']['Code'] == 'ServerSideEncryptionConfigurationNotFoundError':
             return None
         else:
             raise e
+    except (IndexError, KeyError):
+        return None
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])


### PR DESCRIPTION
##### SUMMARY
Working with non-aws s3 providers may require graceful access on the responses, as they do not implement all fancy features.
[minio](https://github.com/minio/minio) for example has an empty `ServerSideEncryptionConfiguration` entry in its response for a bucket encryption request.

This PR adds empty fallback objects for the response access and catches any access errors.

Related: https://github.com/ansible/ansible/issues/42501

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket

##### ADDITIONAL INFORMATION

<details><summary> Minimal Playbook </summary>

~~~
- hosts: insert_host
  gather_facts: no
  vars:
    minio_access_key: WFOOWqK7XhUwssKFGrmo
    minio_secret_key: G4r8tgHzkwkmpmNxHm2u
    container_name: s3_demo
  tasks:
    - name: create the minio container
      docker_container:
        name: "{{ container_name }}"
        image: minio/minio
        command: server /data
        env:
          MINIO_ACCESS_KEY: "{{ minio_access_key }}"
          MINIO_SECRET_KEY: "{{ minio_secret_key }}"
        state: started

    - name: retrieve minio container ip
      docker_container_info:
        name: "{{ container_name }}"
      register: inspect

    - block:
      - name: wait for minio to startup
        wait_for:
          host: "{{ minio_ip }}"
          port: 9000
          timeout: 10

      - name: create the dummy bucket
        s3_bucket:
          name: dummy
          s3_url: "http://{{ minio_ip }}:9000"
          access_key: "{{ minio_access_key }}"
          secret_key: "{{ minio_secret_key }}"

      vars:
        minio_ip: >-
          {{ inspect.container.NetworkSettings.Networks.bridge.IPAddress }}

    - name: drop the minio container
      docker_container:
        name: "{{ container_name }}"
        state: absent
~~~
</details>

The current access on the minio response can be simplified as
```
{'ServerSideEncryptionConfiguration': {}}.get('Rules')[0]
```
Which resolves to: `None[0]`

note: The bad access is shadowed by the retry-wrapping.
```
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 125, in <module>
  File "<stdin>", line 117, in _ansiballz_main
  File "<stdin>", line 54, in invoke_module
  File "/tmp/ansible_s3_bucket_payload_OywaxB/__main__.py", line 697, in <module>
  File "/tmp/ansible_s3_bucket_payload_OywaxB/__main__.py", line 691, in main
  File "/tmp/ansible_s3_bucket_payload_OywaxB/__main__.py", line 298, in create_or_update_bucket
  File "/tmp/ansible_s3_bucket_payload_OywaxB/ansible_s3_bucket_payload.zip/ansible/module_utils/cloud.py", line 153, in retry_func
TypeError: 'NoneType' object has no attribute '__getitem__'
```
