### PR TITLE
cron: add integration tests

### DIFF
--- a/test/integration/targets/cron/aliases
+++ b/test/integration/targets/cron/aliases
@@ -1,4 +1,3 @@
 destructive
 shippable/posix/group4
 skip/osx
-skip/freebsd

--- a/test/integration/targets/cron/aliases
+++ b/test/integration/targets/cron/aliases
@@ -1,0 +1,4 @@
+destructive
+shippable/posix/group4
+skip/osx
+skip/freebsd

--- a/test/integration/targets/cron/defaults/cron.debian.yml
+++ b/test/integration/targets/cron/defaults/cron.debian.yml
@@ -1,4 +1,4 @@
 ---
-faketime_pkg: faketime
 cron_pkg: cron
 cron_service: cron
+list_pkg_files: dpkg -L

--- a/test/integration/targets/cron/defaults/cron.defaults.yml
+++ b/test/integration/targets/cron/defaults/cron.defaults.yml
@@ -1,0 +1,4 @@
+---
+faketime_pkg: faketime
+cron_pkg: cron
+cron_service: cron

--- a/test/integration/targets/cron/defaults/cron.fedora.yml
+++ b/test/integration/targets/cron/defaults/cron.fedora.yml
@@ -1,4 +1,4 @@
 ---
-faketime_pkg: libfaketime
 cron_pkg: cronie
 cron_service: crond
+list_pkg_files: rpm -ql

--- a/test/integration/targets/cron/defaults/cron.fedora.yml
+++ b/test/integration/targets/cron/defaults/cron.fedora.yml
@@ -1,0 +1,4 @@
+---
+faketime_pkg: libfaketime
+cron_pkg: cronie
+cron_service: crond

--- a/test/integration/targets/cron/defaults/cron.freebsd.yml
+++ b/test/integration/targets/cron/defaults/cron.freebsd.yml
@@ -1,0 +1,4 @@
+---
+cron_pkg:
+cron_service: cron
+list_pkg_files: pkg info --list-files

--- a/test/integration/targets/cron/defaults/cron.redhat.yml
+++ b/test/integration/targets/cron/defaults/cron.redhat.yml
@@ -1,0 +1,4 @@
+---
+faketime_pkg:
+cron_pkg: cronie
+cron_service: crond

--- a/test/integration/targets/cron/defaults/cron.redhat.yml
+++ b/test/integration/targets/cron/defaults/cron.redhat.yml
@@ -1,4 +1,5 @@
 ---
-faketime_pkg:
 cron_pkg: cronie
 cron_service: crond
+faketime_pkg:
+list_pkg_files: rpm -ql

--- a/test/integration/targets/cron/defaults/cron.suse.yml
+++ b/test/integration/targets/cron/defaults/cron.suse.yml
@@ -1,4 +1,4 @@
 ---
-faketime_pkg: libfaketime
 cron_pkg: cron
 cron_service: cron
+list_pkg_files: rpm -ql

--- a/test/integration/targets/cron/defaults/cron.suse.yml
+++ b/test/integration/targets/cron/defaults/cron.suse.yml
@@ -1,0 +1,4 @@
+---
+faketime_pkg: libfaketime
+cron_pkg: cron
+cron_service: cron

--- a/test/integration/targets/cron/defaults/main.yml
+++ b/test/integration/targets/cron/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cron_pkg: cron
+faketime_pkg: libfaketime

--- a/test/integration/targets/cron/defaults/main.yml
+++ b/test/integration/targets/cron/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-cron_pkg: cron
 faketime_pkg: libfaketime

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -4,7 +4,6 @@
       files:
         - 'cron.{{ ansible_distribution | lower }}.yml'
         - 'cron.{{ ansible_distribution_file_variety | lower }}.yml'
-        - cron.defaults.yml
       paths:
         - '../defaults/'
 
@@ -38,22 +37,18 @@
           register: faketime_package_installed
           until: faketime_package_installed is success
 
-        - name: 'Cron unit: fetch path'
-          command: 'systemctl show -p FragmentPath {{ cron_service }}.service'
-          changed_when: false
-          register: cron_unit_path
-
-        - name: 'Cron unit: fetch ExecStart property'
-          command: "grep ExecStart {{ cron_unit_path.stdout.split('=', 1)[1] }}"
-          changed_when: false
-          register: cron_exec_start
+        - name: Find libfaketime path
+          shell: '{{ list_pkg_files }} {{ faketime_pkg }} | grep -F libfaketime.so.1'
+          args:
+            warn: false
+          register: libfaketime_path
 
         - name: Use faketime with cron service
           copy:
             content: |-
               [Service]
-              ExecStart=
-              ExecStart=/usr/bin/faketime -f '+0y x10' {{ cron_exec_start.stdout.split('=', 1)[1] }}
+              Environment=LD_PRELOAD={{ libfaketime_path.stdout_lines[0] }}
+              Environment="FAKETIME=+0y x10"
               Environment=RANDOM_DELAY=0
             dest: '/etc/systemd/system/{{ cron_service }}.service.d/faketime.conf'
             owner: root

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -65,3 +65,7 @@
       wait_for:
         path: '{{ remote_dir }}/cron_canary1'
         timeout: '{{ 20 if faketime_pkg else 70 }}'
+      register: wait_canary
+
+    - debug:
+        msg: 'elapsed time waiting for canary: {{ wait_canary.elapsed }}'

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -1,0 +1,77 @@
+- include_vars: "{{ lookup('first_found', search) }}"
+  vars:
+    search:
+      files:
+        - 'cron.{{ ansible_distribution | lower }}.yml'
+        - 'cron.{{ ansible_distribution_file_variety | lower }}.yml'
+        - cron.defaults.yml
+      paths:
+        - '../defaults/'
+
+- vars:
+    remote_dir: '{{ echo_output_dir.stdout }}'
+  block:
+    # output_dir is hardcoded/created in test/runner/lib/executor.py and
+    # contains '~': expand remote path
+    - command: 'echo {{ output_dir }}'
+      register: echo_output_dir
+
+    - name: install cron package
+      package:
+        name: '{{ cron_pkg }}'
+      register: cron_package_installed
+      until: cron_package_installed is success
+
+    - when: faketime_pkg|default(false, true)
+      block:
+        - name: create directory for cron drop-in file
+          file:
+            path: '/etc/systemd/system/{{ cron_service }}.service.d'
+            state: directory
+            owner: root
+            group: root
+            mode: 0755
+
+        - name: install cron and faketime packages
+          package:
+            name: '{{ faketime_pkg }}'
+          register: faketime_package_installed
+          until: faketime_package_installed is success
+
+        - name: 'Cron unit: fetch path'
+          command: 'systemctl show -p FragmentPath {{ cron_service }}.service'
+          changed_when: false
+          register: cron_unit_path
+
+        - name: 'Cron unit: fetch ExecStart property'
+          command: "grep ExecStart {{ cron_unit_path.stdout.split('=', 1)[1] }}"
+          changed_when: false
+          register: cron_exec_start
+
+        - name: Use faketime with cron service
+          copy:
+            content: |-
+              [Service]
+              ExecStart=
+              ExecStart=/usr/bin/faketime -f '+0y x10' {{ cron_exec_start.stdout.split('=', 1)[1] }}
+              Environment=RANDOM_DELAY=0
+            dest: '/etc/systemd/system/{{ cron_service }}.service.d/faketime.conf'
+            owner: root
+            group: root
+            mode: 0644
+
+    - name: enable cron service
+      service:
+        daemon-reload: "{{ (ansible_service_mgr == 'systemd')|ternary(true, omit) }}"
+        name: '{{ cron_service }}'
+        state: restarted
+
+    - name: add cron task
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+
+    - name: wait for canary creation
+      wait_for:
+        path: '{{ output_dir }}/cron_canary1'
+        timeout: '{{ 20 if faketime_pkg else 70 }}'

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -2,8 +2,9 @@
   vars:
     search:
       files:
+        - 'cron.{{ ansible_system | lower }}.yml'
         - 'cron.{{ ansible_distribution | lower }}.yml'
-        - 'cron.{{ ansible_distribution_file_variety | lower }}.yml'
+        - 'cron.{{ ansible_os_family | lower }}.yml'
       paths:
         - '../defaults/'
 
@@ -13,19 +14,12 @@
     - name: install cron package
       package:
         name: '{{ cron_pkg }}'
+      when: cron_pkg|default(false, true)
       register: cron_package_installed
       until: cron_package_installed is success
 
     - when: faketime_pkg|default(false, true)
       block:
-        - name: create directory for cron drop-in file
-          file:
-            path: '/etc/systemd/system/{{ cron_service }}.service.d'
-            state: directory
-            owner: root
-            group: root
-            mode: 0755
-
         - name: install cron and faketime packages
           package:
             name: '{{ faketime_pkg }}'
@@ -38,16 +32,36 @@
             warn: false
           register: libfaketime_path
 
-        - name: Use faketime with cron service
+        - when: ansible_service_mgr == 'systemd'
+          block:
+            - name: create directory for cron drop-in file
+              file:
+                path: '/etc/systemd/system/{{ cron_service }}.service.d'
+                state: directory
+                owner: root
+                group: root
+                mode: 0755
+
+            - name: Use faketime with cron service
+              copy:
+                content: |-
+                  [Service]
+                  Environment=LD_PRELOAD={{ libfaketime_path.stdout_lines[0].strip() }}
+                  Environment="FAKETIME=+0y x10"
+                  Environment=RANDOM_DELAY=0
+                dest: '/etc/systemd/system/{{ cron_service }}.service.d/faketime.conf'
+                owner: root
+                group: root
+                mode: 0644
+
+        - when: ansible_system == 'FreeBSD'
+          name: Use faketime with cron service
           copy:
             content: |-
-              [Service]
-              Environment=LD_PRELOAD={{ libfaketime_path.stdout_lines[0] }}
-              Environment="FAKETIME=+0y x10"
-              Environment=RANDOM_DELAY=0
-            dest: '/etc/systemd/system/{{ cron_service }}.service.d/faketime.conf'
+              cron_env='LD_PRELOAD={{ libfaketime_path.stdout_lines[0].strip() }} FAKETIME="+0y x10"'
+            dest: '/etc/rc.conf.d/cron'
             owner: root
-            group: root
+            group: wheel
             mode: 0644
 
     - name: enable cron service

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -61,11 +61,16 @@
         name: test cron task
         job: 'date > {{ remote_dir }}/cron_canary1'
 
-    - name: wait for canary creation
-      wait_for:
-        path: '{{ remote_dir }}/cron_canary1'
-        timeout: '{{ 20 if faketime_pkg else 70 }}'
-      register: wait_canary
+    - block:
+        - name: wait for canary creation
+          wait_for:
+            path: '{{ remote_dir }}/cron_canary1'
+            timeout: '{{ 20 if faketime_pkg else 70 }}'
+          register: wait_canary
+      always:
+        - name: display some logs in case of failure
+          command: 'journalctl -u {{ cron_service }}'
+          when: wait_canary is failed and ansible_service_mgr == 'systemd'
 
     - debug:
         msg: 'elapsed time waiting for canary: {{ wait_canary.elapsed }}'

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -8,13 +8,8 @@
         - '../defaults/'
 
 - vars:
-    remote_dir: '{{ echo_output_dir.stdout }}'
+    remote_dir: "{{ lookup('env', 'OUTPUT_DIR') }}"
   block:
-    # output_dir is hardcoded/created in test/runner/lib/executor.py and
-    # contains '~': expand remote path
-    - command: 'echo {{ output_dir }}'
-      register: echo_output_dir
-
     - name: install cron package
       package:
         name: '{{ cron_pkg }}'
@@ -68,5 +63,5 @@
 
     - name: wait for canary creation
       wait_for:
-        path: '{{ output_dir }}/cron_canary1'
+        path: '{{ remote_dir }}/cron_canary1'
         timeout: '{{ 20 if faketime_pkg else 70 }}'

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -70,10 +70,43 @@
         name: '{{ cron_service }}'
         state: restarted
 
-    - name: add cron task
+    - name: add cron task (check mode enabled, cron task not already created)
       cron:
         name: test cron task
         job: 'date > {{ remote_dir }}/cron_canary1'
+      check_mode: yes
+      register: check_mode_enabled_state_present
+
+    - assert:
+        that: check_mode_enabled_state_present is changed
+
+    - name: add cron task (check mode disabled, task hasn't already been created)
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+      register: add_cron_task
+
+    - assert:
+        that: add_cron_task is changed
+
+    - name: add cron task (check mode enabled, cron task already exists)
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+      check_mode: yes
+      register: check_mode_enabled_state_present_cron_task_already_exists
+
+    - assert:
+        that: check_mode_enabled_state_present_cron_task_already_exists is not changed
+
+    - name: add cron task (check mode disabled, cron task already created)
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+      register: cron_task_already_created
+
+    - assert:
+        that: cron_task_already_created is not changed
 
     - block:
         - name: wait for canary creation
@@ -88,3 +121,53 @@
 
     - debug:
         msg: 'elapsed time waiting for canary: {{ wait_canary.elapsed }}'
+
+    - name: Check check_mode
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+        state: absent
+      check_mode: yes
+      register: check_check_mode
+
+    - assert:
+        that: check_check_mode is changed
+
+    - name: Remove a cron task
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+        state: absent
+      register: remove_task
+
+    - assert:
+        that: remove_task is changed
+
+    - name: 'cron task missing: check idempotence (check mode enabled, state=absent)'
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+        state: absent
+      register: check_mode_enabled_remove_task_idempotence
+
+    - assert:
+        that: check_mode_enabled_remove_task_idempotence is not changed
+
+    - name: 'cron task missing: check idempotence (check mode disabled, state=absent)'
+      cron:
+        name: test cron task
+        job: 'date > {{ remote_dir }}/cron_canary1'
+        state: absent
+      register: remove_task_idempotence
+
+    - assert:
+        that: remove_task_idempotence is not changed
+
+    - name: Check that removing a cron task with cron_file and without specifying an user is allowed (#58493)
+      cron:
+        cron_file: unexistent_cron_file
+        state: absent
+      register: remove_cron_file
+
+    - assert:
+        that: remove_cron_file is not changed


### PR DESCRIPTION
##### SUMMARY

`cron` module: add integration tests

Use faketime in order to reduce waiting time.

    Tuesday 30 July 2019  23:03:19 +0000 (0:00:05.410)       0:01:28.291 
    ==========================================================
    cron : install cron and faketime packages ---------------------- 78.65s
    cron : wait 70 seconds max -------------------------------------- 5.41s
    Gathering Facts ------------------------------------------------- 0.97s
    cron : enable cron service -------------------------------------- 0.72s
    cron : Use faketime with cron service --------------------------- 0.71s
    cron : command -------------------------------------------------- 0.41s
    cron : create directory for cron drop-in file ------------------- 0.41s
    cron : add cron task -------------------------------------------- 0.40s
    cron : command -------------------------------------------------- 0.25s
    cron : command -------------------------------------------------- 0.25s
    cron : include_vars --------------------------------------------- 0.06s


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cron

##### ADDITIONAL INFORMATION

Work in progress