### PR TITLE
Add metaclass-boilerplate to elb_target lamda test function

### DIFF
--- a/test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py
+++ b/test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 import json
+
 
 def lambda_handler(event, context):
     return {

--- a/test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py
+++ b/test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py
@@ -1,5 +1,5 @@
+from __future__ import (absolute_import, division, print_function)
 import json
-
 
 def lambda_handler(event, context):
     return {


### PR DESCRIPTION
This change makes elb_target pass after #59749

##### SUMMARY
Add metaclass-boilerplate to elb_target lamda test function

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py
