### PR TITLE
Disable pylint import-error for collections.

### DIFF
--- a/test/sanity/pylint/config/collection
+++ b/test/sanity/pylint/config/collection
@@ -34,6 +34,7 @@ disable=
     function-redefined,
     global-statement,
     global-variable-undefined,
+    import-error,
     import-self,
     inconsistent-return-statements,
     invalid-envvar-default,


### PR DESCRIPTION
##### SUMMARY

Disable pylint import-error for collections.

This matches the Ansible configuration.

Resolves https://github.com/ansible/ansible/issues/59835

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
