### PR TITLE
More sanity test updates for collections.

### DIFF
--- a/test/sanity/code-smell/action-plugin-docs.py
+++ b/test/sanity/code-smell/action-plugin-docs.py
@@ -9,40 +9,6 @@ import sys
 
 def main():
     """Main entry point."""
-    skip = set([
-        '__init__',  # action plugin base class, not an actual action plugin
-        'net_base',  # base class for other net_* action plugins which have a matching module
-        'normal',  # default action plugin for modules without a dedicated action plugin
-        'network',  # base class for network action plugins
-
-        # The following action plugins existed without modules to document them before this test was put in place.
-        # They should either be removed, have a module added to document them, or have the exception documented here.
-        'bigip',
-        'bigiq',
-        'ce_template',
-
-        # The following action plugins provide base classes for network platform specific modules to support `connection: local`.
-        # Once we fully deprecate the use of connection local, the base classes will go away.
-        'aireos',
-        'aruba',
-        'asa',
-        'ce',
-        'cnos',
-        'dellos10',
-        'dellos6',
-        'dellos9',
-        'enos',
-        'eos',
-        'ios',
-        'iosxr',
-        'ironware',
-        'junos',
-        'netconf',
-        'nxos',
-        'sros',
-        'vyos',
-    ])
-
     paths = sys.argv[1:] or sys.stdin.read().splitlines()
 
     module_names = set()
@@ -59,8 +25,6 @@ def main():
 
             module_names.add(name)
 
-    unused_skip = set(skip)
-
     for path in paths:
         if not path.startswith('lib/ansible/plugins/action/'):
             continue
@@ -68,14 +32,7 @@ def main():
         name = os.path.splitext(os.path.basename(path))[0]
 
         if name not in module_names:
-            if name in skip:
-                unused_skip.remove(name)
-                continue
-
             print('%s: action plugin has no matching module to provide documentation' % path)
-
-    for filename in sorted(unused_skip):
-        print("%s: remove '%s' from skip list since it does not exist" % ('test/sanity/code-smell/action-plugin-docs.py', filename))
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/package-data.json
+++ b/test/sanity/code-smell/package-data.json
@@ -1,5 +1,8 @@
 {
     "disabled": true,
-    "no_targets": true,
+    "all_targets": true,
+    "prefixes": [
+        "lib/ansible/"
+    ],
     "output": "path-message"
 }

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -5,29 +5,28 @@ __metaclass__ = type
 import fnmatch
 import os
 import re
+import sys
 import tempfile
 import subprocess
 
 
 def main():
     ignore_files = frozenset((
-        '*/.git_keep',
+        '*/galaxy/data/default/*/.git_keep',
         '*/galaxy/data/default/role/*/main.yml.j2',
         '*/galaxy/data/default/role/*/test.yml.j2',
         '*/galaxy/data/default/collection/plugins/README.md.j2',
     ))
 
     non_py_files = []
-    for root, _dummy, files in os.walk('lib/ansible/'):
-        for filename in files:
-            path = os.path.join(root, filename)
-            if os.path.splitext(path)[1] not in ('.py', '.pyc', '.pyo'):
-                add = True
-                for ignore in ignore_files:
-                    if fnmatch.fnmatch(path, ignore):
-                        add = False
-                if add:
-                    non_py_files.append(os.path.relpath(path, 'lib/ansible'))
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
+        if os.path.splitext(path)[1] != '.py':
+            add = True
+            for ignore in ignore_files:
+                if fnmatch.fnmatch(path, ignore):
+                    add = False
+            if add:
+                non_py_files.append(os.path.relpath(path, 'lib/ansible'))
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         stdout, _dummy = subprocess.Popen(

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6889,6 +6889,31 @@ lib/ansible/parsing/vault/__init__.py pylint:blacklisted-name
 lib/ansible/playbook/base.py pylint:blacklisted-name
 lib/ansible/playbook/helpers.py pylint:blacklisted-name
 lib/ansible/playbook/role/__init__.py pylint:blacklisted-name
+lib/ansible/plugins/action/__init__.py action-plugin-docs # action plugin base class, not an actual action plugin
+lib/ansible/plugins/action/aireos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/aruba.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/asa.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/bigip.py action-plugin-docs # undocumented action plugin to fix, existed before sanity test was added
+lib/ansible/plugins/action/bigiq.py action-plugin-docs # undocumented action plugin to fix, existed before sanity test was added
+lib/ansible/plugins/action/ce.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/ce_template.py action-plugin-docs # undocumented action plugin to fix, existed before sanity test was added
+lib/ansible/plugins/action/cnos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/dellos10.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/dellos6.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/dellos9.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/enos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/eos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/ios.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/iosxr.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/ironware.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/junos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/net_base.py action-plugin-docs # base class for other net_* action plugins which have a matching module
+lib/ansible/plugins/action/netconf.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/network.py action-plugin-docs # base class for network action plugins
+lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
+lib/ansible/plugins/action/nxos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/sros.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
+lib/ansible/plugins/action/vyos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
 lib/ansible/plugins/cache/base.py ansible-doc  # not a plugin, but a stub for backwards compatibility
 lib/ansible/plugins/callback/hipchat.py pylint:blacklisted-name
 lib/ansible/plugins/connection/lxc.py pylint:blacklisted-name


### PR DESCRIPTION
##### SUMMARY

More sanity test updates for collections:

- Move action-plugin-docs ignores into ignore file. 
- Update package-data sanity test.

The second one is not really collection related, but does fix the test to take advantage of the file list provided by ansible-test, which was added as part of supporting collections.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
