### PR TITLE
Fix TypeError in ec2_group.py for Python3 when sorting dictionary list

### DIFF
--- a/changelogs/fragments/59844-ec2_group-fix-diff-mode-python3.yml
+++ b/changelogs/fragments/59844-ec2_group-fix-diff-mode-python3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_group - Fix traceback sorting dictionaries using Python 3 and ensure rules shown by diff mode are in a consistent order.

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -943,7 +943,7 @@ def get_diff_final_resource(client, module, security_group):
                         format_rule['user_id_group_pairs'][0].pop(k)
             final_rules.append(format_rule)
             # Order final rules consistently
-            final_rules = json.loads(json.dumps(final_rules, sort_keys=True))
+            final_rules.sort(key=get_ip_permissions_sort_key)
         return final_rules
     security_group_ingress = security_group.get('ip_permissions', [])
     specified_ingress = module.params['rules']
@@ -982,6 +982,31 @@ def flatten_nested_targets(module, rules):
                 rule[target_list_type] = list(_flatten(rule[target_list_type]))
     return rules
 
+def get_rule_sort_key(dicts):
+    if dicts.get('cidr_ip'):
+        return dicts.get('cidr_ip')
+    elif dicts.get('cidr_ipv6'):
+        return dicts.get('cidr_ipv6')
+    elif dicts.get('prefix_list_id'):
+        return dicts.get('prefix_list_id')
+    elif dicts.get('group_id'):
+        return dicts.get('group_id')
+    return None
+
+def get_ip_permissions_sort_key(rule):
+    if rule.get('ip_ranges'):
+        rule.get('ip_ranges').sort(key=get_rule_sort_key)
+        return rule.get('ip_ranges')[0]['cidr_ip']
+    elif rule.get('ipv6_ranges'):
+        rule.get('ipv6_ranges').sort(key=get_rule_sort_key)
+        return rule.get('ipv6_ranges')[0]['cidr_ipv6']
+    elif rule.get('prefix_list_ids'):
+        rule.get('prefix_list_ids').sort(key=get_rule_sort_key)
+        return rule.get('prefix_list_ids')[0]['prefix_list_id']
+    elif rule.get('user_id_group_pairs'):
+        rule.get('user_id_group_pairs').sort(key=get_rule_sort_key)
+        return rule.get('user_id_group_pairs')[0]['group_id']
+    return None
 
 def main():
     argument_spec = dict(
@@ -1182,6 +1207,8 @@ def main():
     if module._diff:
         if module.params['state'] == 'present':
             after = get_diff_final_resource(client, module, security_group)
+            if before.get('ip_permissions'):
+                before['ip_permissions'].sort(key=get_ip_permissions_sort_key)
 
         security_group['diff'] = [{'before': before, 'after': after}]
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -982,6 +982,7 @@ def flatten_nested_targets(module, rules):
                 rule[target_list_type] = list(_flatten(rule[target_list_type]))
     return rules
 
+
 def get_rule_sort_key(dicts):
     if dicts.get('cidr_ip'):
         return dicts.get('cidr_ip')
@@ -992,6 +993,7 @@ def get_rule_sort_key(dicts):
     elif dicts.get('group_id'):
         return dicts.get('group_id')
     return None
+
 
 def get_ip_permissions_sort_key(rule):
     if rule.get('ip_ranges'):
@@ -1007,6 +1009,7 @@ def get_ip_permissions_sort_key(rule):
         rule.get('user_id_group_pairs').sort(key=get_rule_sort_key)
         return rule.get('user_id_group_pairs')[0]['group_id']
     return None
+
 
 def main():
     argument_spec = dict(

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -943,7 +943,7 @@ def get_diff_final_resource(client, module, security_group):
                         format_rule['user_id_group_pairs'][0].pop(k)
             final_rules.append(format_rule)
             # Order final rules consistently
-            final_rules.sort(key=lambda x: json.dumps(x, sort_keys=True))
+            final_rules = json.loads(json.dumps(final_rules, sort_keys=True))
         return final_rules
     security_group_ingress = security_group.get('ip_permissions', [])
     specified_ingress = module.params['rules']

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -943,7 +943,7 @@ def get_diff_final_resource(client, module, security_group):
                         format_rule['user_id_group_pairs'][0].pop(k)
             final_rules.append(format_rule)
             # Order final rules consistently
-            final_rules.sort(key=lambda x: x.get('cidr_ip', x.get('ip_ranges', x.get('ipv6_ranges', x.get('prefix_list_ids', x.get('user_id_group_pairs'))))))
+            final_rules.sort(key=lambda x: json.dumps(x, sort_keys=True))
         return final_rules
     security_group_ingress = security_group.get('ip_permissions', [])
     specified_ingress = module.params['rules']

--- a/test/integration/targets/ec2_group/tasks/diff_mode.yml
+++ b/test/integration/targets/ec2_group/tasks/diff_mode.yml
@@ -1,0 +1,184 @@
+---
+  - name: set up aws connection info
+    set_fact:
+      aws_connection_info: &aws_connection_info
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+    no_log: yes
+
+  # ============================================================
+
+  - name: create a group with a rule (CHECK MODE + DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      rules_egress:
+      - proto: all
+        cidr_ip: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: check_mode_result
+    check_mode: true
+    diff: true
+
+  - assert:
+      that:
+        - check_mode_result.changed
+
+  - name: create a group with a rule (DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      rules_egress:
+      - proto: all
+        cidr_ip: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: result
+    diff: true
+
+  - assert:
+      that:
+        - result.changed
+        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+
+  - name: add rules to make sorting occur (CHECK MODE + DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 20.0.0.0/8
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 10.0.0.0/8
+      rules_egress:
+      - proto: all
+        cidr_ip: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: check_mode_result
+    check_mode: true
+    diff: true
+
+  - assert:
+      that:
+        - check_mode_result.changed
+
+  - name: add rules in a different order to test sorting consistency (DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 20.0.0.0/8
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 10.0.0.0/8
+      rules_egress:
+      - proto: all
+        cidr_ip: 0.0.0.0/0
+      <<: *aws_connection_info
+    register: result
+    diff: true
+
+  - assert:
+      that:
+        - result.changed
+        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+
+  - name: purge rules (CHECK MODE + DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      rules_egress: []
+      <<: *aws_connection_info
+    register: check_mode_result
+    check_mode: true
+    diff: true
+
+  - assert:
+      that:
+        - check_mode_result.changed
+
+  - name: purge rules (DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      description: '{{ ec2_group_description }}'
+      state: present
+      rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      rules_egress: []
+      <<: *aws_connection_info
+    register: result
+    diff: true
+
+  - assert:
+      that:
+        - result.changed
+        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+
+  - name: delete the security group (CHECK MODE + DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      state: absent
+      <<: *aws_connection_info
+    register: check_mode_result
+    diff: true
+    check_mode: true
+
+  - assert:
+      that:
+        - check_mode_result.changed
+
+  - name: delete the security group (DIFF)
+    ec2_group:
+      name: '{{ ec2_group_name }}'
+      state: absent
+      <<: *aws_connection_info
+    register: result
+    diff: true
+
+  - assert:
+      that:
+        - result.changed
+        - not result.diff.0.after and not check_mode_result.diff.0.after

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -50,6 +50,7 @@
       register: vpc_result
     #TODO(ryansb): Update CI for VPC peering permissions
     #- include: ./multi_account.yml
+    - include: ./diff_mode.yml
     - include: ./numeric_protos.yml
     - include: ./rule_group_create.yml
     - include: ./egress_tests.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- ec2_group throws TypeError: '<' not supported between instances of 'dict' and 'dict' in Python3 when using "--diff" option

Fixes #50072
Fixes #53944

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ec2_group.get_final_rules
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- If the cidr_ip is different, the error will occur: TypeError: '<' not supported between instances of 'dict' and 'dict'. Since Python3 will raise TypeError exception when the operands don’t have a meaningful natural ordering, so I parse the dict as string by using json.dump(), and then do the sorting. Please refer to: https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons

This one will fail on: TypeError: '<' not supported between instances of 'dict' and 'dict':
```paste below
[
    {
        'from_port': 8600, 
        'to_port': 8600, 
        'ip_protocol': 'tcp', 
        'ip_ranges': [
            {'cidr_ip': '10.0.0.0/16'}
        ], 
        'ipv6_ranges': [], 
        'prefix_list_ids': [], 
        'user_id_group_pairs': []
    }, 
    {
        'from_port': 8600, 
        'to_port': 8600, 
        'ip_protocol': 'udp', 
        'ip_ranges': [
            {'cidr_ip': '10.0.0.1/16'}
        ], 
        'ipv6_ranges': [], 
        'prefix_list_ids': [], 
        'user_id_group_pairs': []
    }
]
```

And this one works:
```paste below
[
    {
        'from_port': 8600, 
        'to_port': 8600, 
        'ip_protocol': 'tcp', 
        'ip_ranges': [
            {'cidr_ip': '10.0.0.0/16'}
        ], 
        'ipv6_ranges': [], 
        'prefix_list_ids': [], 
        'user_id_group_pairs': []
    }, 
    {
        'from_port': 8600, 
        'to_port': 8600, 
        'ip_protocol': 'udp', 
        'ip_ranges': [
            {'cidr_ip': '10.0.0.0/16'}
        ], 
        'ipv6_ranges': [], 
        'prefix_list_ids': [], 
        'user_id_group_pairs': []
    }
]
```
