### PR TITLE
Update ansible-test to properly skip unit tests.

### DIFF
--- a/test/runner/lib/provider/layout/__init__.py
+++ b/test/runner/lib/provider/layout/__init__.py
@@ -80,6 +80,7 @@ class ContentLayout(Layout):
                  util_path=None,  # type: t.Optional[str]
                  unit_path=None,  # type: t.Optional[str]
                  unit_module_path=None,  # type: t.Optional[str]
+                 unit_module_utils_path=None,  # type: t.Optional[str]
                  integration_path=None,  # type: t.Optional[str]
                  ):  # type: (...) -> None
         super(ContentLayout, self).__init__(root, paths)
@@ -91,6 +92,7 @@ class ContentLayout(Layout):
         self.util_path = util_path
         self.unit_path = unit_path
         self.unit_module_path = unit_module_path
+        self.unit_module_utils_path = unit_module_utils_path
         self.integration_path = integration_path
         self.is_ansible = root == ANSIBLE_ROOT
 

--- a/test/runner/lib/provider/layout/ansible.py
+++ b/test/runner/lib/provider/layout/ansible.py
@@ -41,5 +41,6 @@ class AnsibleLayout(LayoutProvider):
                              util_path='test/utils',
                              unit_path='test/units',
                              unit_module_path='test/units/modules',
+                             unit_module_utils_path='test/units/module_utils',
                              integration_path='test/integration',
                              )

--- a/test/runner/lib/provider/layout/collection.py
+++ b/test/runner/lib/provider/layout/collection.py
@@ -55,6 +55,7 @@ class CollectionLayout(LayoutProvider):
                              ),
                              util_path='test/util',
                              unit_path='test/unit',
-                             unit_module_path='test/units/plugins/modules',
+                             unit_module_path='test/unit/plugins/modules',
+                             unit_module_utils_path='test/unit/plugins/module_utils',
                              integration_path='test/integration',
                              )

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -15,14 +15,5 @@ fi
 
 ansible-test env --timeout "${timeout}" --color -v
 
-if [[ "${version}" = "2.6" ]]; then
-    # Python 2.6 is only supported for modules and module_utils.
-    # Eventually this logic will move into ansible-test itself.
-    targets=("test/units/(modules|module_utils)/")
-else
-    targets=("test/units/")
-fi
-
 # shellcheck disable=SC2086
 ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-    "${targets[@]}" \


### PR DESCRIPTION
##### SUMMARY

Update ansible-test to properly skip unit tests.

Unit tests will no longer run on "remote only" Python versions (2.6) for tests which are not "remote" (modules and module_utils).

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
