### PR TITLE
iam_password_policy: boto expects pw_expire to be omitted when setting no expiration requirements

### DIFF
--- a/changelogs/fragments/59848-iam-password-policy-Fix-no-expiration.yml
+++ b/changelogs/fragments/59848-iam-password-policy-Fix-no-expiration.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iam_password_policy - Fix AWS/boto3 errors when setting no password expiration


### PR DESCRIPTION
##### SUMMARY
boto expects pw_expire to be omitted when setting no password expiration requirements

Fixes #59102 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/iam_password_policy.py

##### ADDITIONAL INFORMATION
See #59102

```
- name: 'Password policy for AWS account'
  iam_password_policy:
    # XXX doesn't seem to take these from group/aws... (see #59787)
    aws_access_key: '{{ current_account_sts_credentials.access_key }}'
    aws_secret_key: '{{ current_account_sts_credentials.secret_key }}'
    security_token: '{{ current_account_sts_credentials.session_token }}'
    state: present
    allow_pw_change: yes 
    # 2019-07-15 : Min length 14
    min_pw_length: 14
    # 2019-07-15 : Must include 3 of symbol/number/upper/lower
    #   Can't be described in AWS, require all 4 since that is stricter than
    #   minimum requirements
    require_symbols: yes 
    require_numbers: yes 
    require_uppercase: yes 
    require_lowercase: yes 
    pw_reuse_prevent: 6
    # 2019-07-15 : No expiry policy at this time
    #pw_max_age: 45
    pw_expire: false
```

