### PR TITLE
Add wait_sleep parameter for the k8s module

### DIFF
--- a/changelogs/fragments/k8s_wait_sleep.yml
+++ b/changelogs/fragments/k8s_wait_sleep.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - k8s - add `wait_sleep` parameter (number of seconds to sleep between checks).

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -76,6 +76,11 @@ options:
     default: no
     type: bool
     version_added: "2.8"
+  wait_sleep:
+    description:
+    - Number of seconds to sleep between checks.
+    default: 5
+    version_added: "2.9"
   wait_timeout:
     description:
     - How long in seconds to wait for the resource to end up in the desired state. Ignored if C(wait) is not set.

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -53,6 +53,7 @@
                 app: "{{ k8s_pod_name }}"
             template: "{{ k8s_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         k8s_pod_name: wait-ds
@@ -80,6 +81,7 @@
               type: RollingUpdate
             template: "{{ k8s_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         k8s_pod_name: wait-ds
@@ -107,6 +109,7 @@
               type: RollingUpdate
             template: "{{ k8s_pod_template }}"
         wait: yes
+        wait_sleep: 3
         wait_timeout: 180
       vars:
         k8s_pod_name: wait-ds
@@ -138,6 +141,7 @@
             namespace: "{{ wait_namespace }}"
           spec: "{{ k8s_pod_spec }}"
         wait: yes
+        wait_sleep: 1
         wait_timeout: 30
       vars:
         k8s_pod_name: wait-crash-pod
@@ -162,6 +166,7 @@
             namespace: "{{ wait_namespace }}"
           spec: "{{ k8s_pod_spec }}"
         wait: yes
+        wait_sleep: 1
         wait_timeout: 30
       vars:
         k8s_pod_name: wait-no-image-pod
@@ -330,6 +335,7 @@
         namespace: "{{ wait_namespace }}"
         state: absent
         wait: yes
+        wait_sleep: 2
         wait_timeout: 5
       ignore_errors: yes
       register: short_wait_remove_pod


### PR DESCRIPTION
##### SUMMARY
Add `wait_sleep` parameter for the `k8s` module.

##### ISSUE TYPE
- Feature Idea

##### COMPONENT NAME
`k8s` module

##### ADDITIONAL INFORMATION
Currently there is no way to specify number of seconds to sleep between checks while waiting for Kubernetes response. It's hardcoded in awkward way:
https://github.com/ansible/ansible/blob/08d7905be2a45e51ceed315974e25d1008bf4263/lib/ansible/module_utils/k8s/raw.py#L440
I suggest to add `wait_sleep` parameter with default value of 1 second for convenience (by analogy with `sleep` parameter of `wait_for` module).