### PR TITLE
gather_facts action plugin: Fix loading network facts modules for smart gathering

### DIFF
--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -56,7 +56,7 @@ class ActionModule(ActionBase):
         parallel = task_vars.pop('ansible_facts_parallel', self._task.args.pop('parallel', None))
         if 'smart' in modules:
             connection_map = C.config.get_config_value('CONNECTION_FACTS_MODULES', variables=task_vars)
-            network_os = self._task.args.get('network_os', task_vars.get('ansible_network_os',  task_vars.get('ansible_facts', {}).get('network_os')))
+            network_os = self._task.args.get('network_os', task_vars.get('ansible_network_os', task_vars.get('ansible_facts', {}).get('network_os')))
             modules.extend([connection_map.get(network_os or self._connection._load_name, 'setup')])
             modules.pop(modules.index('smart'))
 

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os, q
+import os
 import time
 
 from ansible import constants as C
@@ -49,13 +49,10 @@ class ActionModule(ActionBase):
         network_os = ''
         if 'network_os' in self._task.args and self._task.args['network_os']:
             network_os = self._task.args['network_os']
-            q(network_os)
         elif self._play_context.network_os:
             network_os = self._play_context.network_os
-            q(network_os)
         elif 'network_os' in task_vars.get('ansible_facts', {}) and task_vars['ansible_facts']['network_os']:
             network_os = task_vars['ansible_facts']['network_os']
-            q(network_os)
 
         return network_os
 
@@ -68,7 +65,6 @@ class ActionModule(ActionBase):
 
         modules = C.config.get_config_value('FACTS_MODULES', variables=task_vars)
         parallel = task_vars.pop('ansible_facts_parallel', self._task.args.pop('parallel', None))
-        q(modules)
         if 'smart' in modules:
             connection_map = C.config.get_config_value('CONNECTION_FACTS_MODULES', variables=task_vars)
             network_os = self._get_network_os(task_vars)
@@ -85,9 +81,7 @@ class ActionModule(ActionBase):
             for fact_module in modules:
                 # just one module, no need for fancy async
                 mod_args = self._get_module_args(fact_module, task_vars)
-                q(mod_args)
                 res = self._execute_module(module_name=fact_module, module_args=mod_args, task_vars=task_vars, wrap_async=False)
-                q(res)
                 if res.get('failed', False):
                     failed[fact_module] = res
                 elif res.get('skipped', False):

--- a/test/units/plugins/action/test_gather_facts.py
+++ b/test/units/plugins/action/test_gather_facts.py
@@ -1,0 +1,64 @@
+# (c) 2016, Saran Ahluwalia <ahlusar.ahluwalia@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+from units.compat.mock import MagicMock
+
+from ansible import constants as C
+from ansible.plugins.action.gather_facts import ActionModule
+from ansible.playbook.task import Task
+from ansible.template import Templar
+
+from units.mock.loader import DictDataLoader
+
+
+class TestNetworkFacts(unittest.TestCase):
+    task = MagicMock(Task)
+    task_vars = {'ansible_network_os': 'ios'}
+    play_context = MagicMock()
+    play_context.check_mode = False
+    connection = MagicMock()
+    fake_loader = DictDataLoader({
+    })
+    templar = Templar(loader=fake_loader)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_network_gather_facts(self):
+        self.task.action = 'gather_facts'
+        self.task.async_val = False
+        self.task.args = {'gather_subset': 'min'}
+        self.task.module_defaults = [{'ios_facts': {'gather_subset': 'min'}}]
+
+        plugin = ActionModule(self.task, self.connection, self.play_context, loader=None, templar=self.templar, shared_loader_obj=None)
+        plugin._execute_module = MagicMock()
+
+        res = plugin.run(task_vars=self.task_vars)
+        self.assertEqual(res['ansible_facts']['_ansible_facts_gathered'], True)
+
+        mod_args = plugin._get_module_args('ios_facts', task_vars=self.task_vars)
+        self.assertEqual(mod_args['gather_subset'], 'min')
+
+        facts_modules = C.config.get_config_value('FACTS_MODULES', variables=self.task_vars)
+        self.assertEqual(facts_modules, ['ios_facts'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix loading network facts modules for smart gathering.
Currently the connection plugin is loaded but not the network_os which is why the <network_os>_facts module is not invoked.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/gather_facts.py
