### PR TITLE
Update version in metadata for bundled distro

### DIFF
--- a/lib/ansible/module_utils/distro/__init__.py
+++ b/lib/ansible/module_utils/distro/__init__.py
@@ -23,7 +23,7 @@ __metaclass__ = type
 Compat distro library.
 '''
 # The following makes it easier for us to script updates of the bundled code
-_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.3.0"}
+_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.4.0"}
 
 # The following additional changes have been made:
 # * The import of argparse has been moved to __main__ (py2.6 compat)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The bundeled version of `distro` was updated to 1.4.0 in 8f2976dcee88c48bc20bbfa126248e22111e77a8 but the metadata bumping the version was not.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/distro/__init__.py`