### PR TITLE
New Windows module to chanage CDROM drive letter and unmount virt. cdroms

### DIFF
--- a/lib/ansible/modules/windows/win_cdrom_letter.ps1
+++ b/lib/ansible/modules/windows/win_cdrom_letter.ps1
@@ -78,7 +78,7 @@ function AllCDs {
         [Parameter(Position=0)][array]$driveletters
     )
     $counter=0
-    foreach ($drive in $driveletters) { 
+    foreach ($drive in $driveletters) {
         $drive =$drive +":"
         if (Get-CimInstance -ClassName Win32_CDROMDrive -filter "Drive = `"$drive`"") { $counter++ }
     }
@@ -125,7 +125,7 @@ if ($dismount_virtual -or $dismount_only) {
     $virtualCDROMs=Get-VirtualCDROMList
     if ($virtualCDROMs) {
         #Logic for when Single drive was provided
-        if ($single) {  
+        if ($single) {
             if ($virtualCDROMs.contains($single)) {
                 $virtualCDROMs=$single
             } elseif ($dismount_only) { #Fail if single is not Virtual CDROM and we dismount only
@@ -190,7 +190,7 @@ if (-not $dismount_only) {
         #Loop through the list and change the mapped letters
         for ($x=0; $x -le $objectsToCount-1; $x++) {
             $cdRomToChange=$null ; $letterToChange=$listToChange[$x] ; $letterToBe=$drvLetterArr[$x]+":"
-            $cdRomToChange=Get-CimInstance -ClassName Win32_Volume -filter "DriveLetter = `"$letterToChange`"" 
+            $cdRomToChange=Get-CimInstance -ClassName Win32_Volume -filter "DriveLetter = `"$letterToChange`""
             if ($cdRomToChange) {
                 if (-not $module.CheckMode) {
                     Set-CDROMLetter -from  $cdRomToChange -to $letterToBe

--- a/lib/ansible/modules/windows/win_cdrom_letter.ps1
+++ b/lib/ansible/modules/windows/win_cdrom_letter.ps1
@@ -1,0 +1,183 @@
+#!powershell
+
+# Copyright: (c) 2019, RusoSova 
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -OSVersion 6.2
+
+$ErrorActionPreference = "Stop"
+
+$spec = @{
+    options = @{
+        drive_letter = @{ type="str" }
+        change_single = @{ type="str" }
+        dismount_virtual = @{ type="bool"; default=$false }
+        dismount_only = @{ type="bool"; default=$false }
+    }
+    required_one_of = @(
+        ,@('drive_letter', 'dismount_only')
+    )
+    mutually_exclusive = @(
+        ,@('drive_letter', 'dismount_only')
+    )
+    supports_check_mode = $true
+}
+
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$drive_letter = $module.Params.drive_letter
+$single = $module.Params.change_single
+$dismount_virtual = $module.Params.dismount_virtual
+$dismount_only = $module.Params.dismount_only
+
+###Validate Input###
+if ($drive_letter -and $drive_letter -notmatch "^(?:([C-Zc-z])(?!.*?\1),)*[C-Zc-z]$") {
+    $module.FailJson("The parameter drive_letter should be a list of unique characters c-zC-Z separated by comma")
+}
+
+if ($single -and $single.trim() -notmatch "^[C-Zc-z]{1}$") {
+    $module.FailJson("The parameter change_single should be a single character c-zC-Z")
+} elseif ($single) {
+    $single=$single.Trim().ToUpper()+":" #.contains method is case sensitive, that will be used latter
+}
+###
+
+
+#Function to get the list of CDROMS Letters
+function Get-CDROMList {
+    param(
+        [Parameter(Position=0)][string]$failedMessge,
+        [Parameter(Position=1)][int]$skipError=$False
+      )
+    try {
+       [array]$cdroms=(get-wmiobject -class Win32_CDROMDrive).drive
+    } catch {
+        $module.FailJson("There was an error retrieving the list of CDROMs $($_.Exception.Message)")
+    }
+    if ($cdroms.count -eq 0 -and -not $skipError) {
+        $module.FailJson($failedMessge)
+    }
+    return $cdroms;
+}
+
+#Function to get the list of Virtual CDROMS Letters
+function Get-VirtualCDROMList {
+    try {
+        $vcdroms=(get-wmiobject -class Win32_CDROMDrive -filter "Caption = 'Microsoft Virtual DVD-ROM'").drive
+    } catch {
+        $module.FailJson("There was an error retrieving the list of virtual CDROMs $letter - $($_.Exception.Message)")
+    }
+    return $vcdroms;
+}
+
+#Collect the initial state of the CDROM drives and pass it to the module Result
+$initialListOfCDROMs=Get-CDROMList -failedMessge "There are no CDROMs on this system"
+$module.Result.before_change=$initialListOfCDROMs
+
+#Dismount Virtual CDROMs
+if ($dismount_virtual -or $dismount_only) {
+    $virtualCDROMs=Get-VirtualCDROMList
+    if ($virtualCDROMs) {
+        if ($single) {  #Check if single parameter was provided
+            if ($virtualCDROMs.contains($single)) {
+                $virtualCDROMs=$single
+            } else {
+                $module.FailJson("$single is not a Windows virtual CDROM")
+            }
+        }
+        foreach ($letter in $virtualCDROMs ) {
+            try {
+                if (-not $module.CheckMode) {
+                    (new-object -COM Shell.Application).NameSpace(17).ParseName($letter).InvokeVerb('Eject')
+                    start-sleep -Seconds 1 #need to pause after dismount, otherwise it might not register properly
+                }
+            } catch {
+                $module.FailJson("There was an error dismounting virtual CDROM $letter - $($_.Exception.Message)")
+            }
+        }
+        $module.Result.changed = $true
+    }
+    $module.Result.dismounted=$virtualCDROMs -join ","
+
+    ##Account for check mode. Since the Virtual CDROMs were not actually dismounted, we need to fix the array of remaining CDROM manually by removing "dismounted" virtual CDROMs
+    if ($module.CheckMode) {
+        [array]$checkmodepresentCDROMs = $initialListOfCDROMs | Where-Object { $virtualCDROMs -notcontains $_ } #Remove dismounted CDROMs from the list of available CDROMs on the system
+        if ($checkmodepresentCDROMs.count -eq 0 -and -not $dismount_only) {
+            $module.FailJson("There are no CDROMs left on this system after dismounting Windows virtual CDROMs")
+        }
+        if ($dismount_only) {
+            [array]$checkmodeChange=$checkmodepresentCDROMs
+        }
+    }
+}
+
+if (-not $dismount_only) {
+    #Collect the list if CDROM drives after possibly dismounting the Virtual ones and account for possible checkmode with virtual dismounts
+    if ($checkmodepresentCDROMs) {
+        $presentCDROMs=$checkmodepresentCDROMs
+    } else {
+        $presentCDROMs=Get-CDROMList -failedMessge "There are no CDROMs left on this system after dismounting Windows virtual CDROMs"
+    }
+    [array]$checkmodeChange=$presentCDROMs
+   
+    [array]$drvLetterArr=$drive_letter.split(",")
+    
+    #Check if change_single drive letter exists and then create an array with just a single drive letter, otherwise create an array with all the CDROMs
+    if ($single) {
+        if ($presentCDROMs.contains($single)) {
+            [array]$listToChange=$single
+        } else {
+            $module.FailJson("$single is not a CDROM")
+        }
+    } else {
+        [array]$listToChange=$presentCDROMs 
+    }
+   
+    $currentVolumes=get-volume | Select-Object -ExpandProperty DriveLetter #Collect all the letters in use
+    $listToChange=$listToChange | Where-Object { $drvLetterArr -notcontains $_.replace(":",'') } #Sanitize the list of affected CDROMs by removing any letter provided in drive_letter that are already CDROMs
+    $drvLetterArr=$drvLetterArr | Where-Object { $currentVolumes -notContains $_ }  #Sanitize $drvLetterArr and remove any letters that are already assigned to the volumes
+    
+    if ($drvLetterArr.count -gt 0 -or ($drvLetterArr.count -eq 0 -and $listToChange.count -eq 0)) {
+        if ($drvLetterArr.count -lt $listToChange.count ) { 
+            $objectsToCount=$drvLetterArr.count #If less drive letter than cdroms were provided, change the counter to the number drive letters
+        } else {
+            $objectsToCount=$listToChange.count #Default counter=number of CDROMS
+        }
+        #Loop through the list and change the mapped letters
+        for ($x=0; $x -le $objectsToCount-1; $x++) {
+            $cdRomToChange=$null ; $letterToChange=$listToChange[$x] ; $letterToBe=$drvLetterArr[$x]
+            $cdRomToChange=get-wmiObject win32_volume -filter "DriveLetter = `"$letterToChange`""
+            if ($cdRomToChange) {
+                $cdRomToChange.DriveLetter=$letterToBe+":"
+                try {
+                    if (-not $module.CheckMode) {
+                        $cdRomToChange.Put() | out-null
+                    } else {
+                        $checkmodeChange=$checkmodeChange.replace($letterToChange,$letterToBe +":") #Update Check mode variable with the change
+                    }
+                } catch {
+                    $module.FailJson("There was an error changing letter of the CDROM $letterToChange - $($_.Exception.Message)")
+                } 
+                    $changeCount="remap[$x]"
+                    $module.Result.$changeCount=("$letterToChange --> $letterToBe"+":")
+            } else {
+                $module.FailJson("There was an error finding CDROM $letterToChange")
+            }
+        }
+        $module.Result.changed = $true
+        $module.Result.number_of_cdroms=$presentCDROMs.count 
+        $module.Result.number_of_changes=$x
+    } else {
+        $module.FailJson("All the provided letter(s) [$drive_letter] are already in use")
+    }
+}
+
+if (-not $module.CheckMode) {
+    $module.Result.post_change=Get-CDROMList -skipError:$True
+} else {
+    $module.Result.post_change=$checkmodeChange
+}
+
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_cdrom_letter.py
+++ b/lib/ansible/modules/windows/win_cdrom_letter.py
@@ -62,8 +62,8 @@ options:
 
 version_added: 2.9
 
-author: 
-- RusoSova
+author:
+ - RusoSova
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_cdrom_letter.py
+++ b/lib/ansible/modules/windows/win_cdrom_letter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, RusoSova 
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: win_cdrom_letter
+short_description: Change drive letter of CDROMs
+
+description:
+ - Change drive letter of CDROMs present on the system. The amount of CDROMs that will be affected is determinated
+   by the number of CDROMs or the number of drive_letter provided, whichever is smaller.
+ - Module can also dismount Windows virtual CDROMs.
+ - On changed, a summary of CDROM's state is provided.
+
+options:
+ drive_letter:
+   description:
+     - List of the drive letters to assign to the CDROMs separated by comma.
+     - The letters in the list are of equal cost. If CDROM is already mapped to one of the letter provided no change will happen to this device.
+     - If less drive letters than CDROMs are avaliable, the module will only change the number of CDROMs equal to drive letters.
+     - Accepted characters C-Z
+   example: O,S,U,R
+   required: false
+   type: str
+ change_single:
+   description:
+     - Specify the drive letter of a single CDROM to change or dismount.
+     - Usefull when multiple CDROMs are present on the system but you need to change or dismount only one of them
+     - Note, it's not advisable to use change_single in conjunction with both dismount_virtual and drive_letter simultaneously. In most cases it will result in failed status.
+   required: false
+   type: str
+ dismount_virtual:
+   description:
+     - Dismount all Windows virtual CDROMs before changing any letters. Unless change_single is provided, which will only affect one drive.
+     - Yes|No or True|False
+   required: false
+   default: false
+   type: bool
+ dismount_only:
+   description:
+     - Only dismount Windows virtual CDROMs, do not change any drive letters
+     - Mutually exclusive with drive_letter parameter
+     - Yes|No or True|False
+   required: false
+   default: false
+   type: bool
+
+author:
+ - RusoSova
+'''
+
+EXAMPLES = r'''
+- name: Change CDROM letter to Z
+  win_cdrom_letter:
+   drive_letter: Z
+  register: result
+
+#If single CDROM present, the letter will be changed to one from the list
+#If multiple CDROM are present, up to 3 CDROM's will be updated
+- name: Change CDROM letter to Z or Y if Z is in use or to K if Z and Y are in use
+  win_cdrom_letter:
+   drive_letter: Z,Y,K
+  register: result
+
+- name: Change CDROM letter for up to 4 CDROMs and dismount any Windows virtual ones
+  win_cdrom_letter:
+   drive_letter: O,S,U,R
+   dismount_virtual: yes
+  register: result
+
+- name: Change single CDROM from letter D to the first avaliable from the list Z,Y,X
+  win_cdrom_letter:
+   drive_letter: Z,Y,X
+   change_single: D
+  register: result
+
+- name: Dismount all Windows virtual CDROMs
+  win_cdrom_letter:
+   dismount_only: yes
+  register: result 
+'''
+
+RETURN = r'''
+before_change:
+  description: List the initial state of CDROMs
+  returned: When at least one CDROM is present on the system
+  type: list
+  sample: ["O:","P:","E:"]
+dismounted:
+  description: List of the Windows virtual CDROMs that were dismounted
+  returned: When dismount_virtual = yes or dismount_only = yes
+  type: str
+  sample:"G:,V:"
+number_of_cdroms:
+  description: Total number of CDROMs thats are susceptible to the change
+  returned: When dismount_only = no
+  type: int
+  sample: 3
+number_of_changes:
+  description: How many drive letters were changed
+  returned: When dismount_only = no
+  type: int
+  sample: 3
+post_change:
+  description: List the state of CDROMs after the module had run
+  returned: On success
+  type: list
+  sample: ["Z:","X:","T:"]
+remap[n]:
+  description: Show the change that was performed. There will be an entry for each change. remap[n] remap[n++] remap[n++] etc..
+  returned: When any drive letters were successfully changed
+  type: str
+  sample:
+    - "remap[0]": "O: --> Z:"
+    - "remap[1]": "P: --> X:"
+    - "remap[2]": "E: --> T:"
+'''

--- a/lib/ansible/modules/windows/win_cdrom_letter.py
+++ b/lib/ansible/modules/windows/win_cdrom_letter.py
@@ -62,7 +62,8 @@ options:
 
 version_added: 2.9
 
-author: RusoSova
+author: 
+- RusoSova
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_cdrom_letter.py
+++ b/lib/ansible/modules/windows/win_cdrom_letter.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2019, RusoSova 
+# Copyright: (c) 2019, RusoSova
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
@@ -31,14 +34,14 @@ options:
      - The letters in the list are of equal cost. If CDROM is already mapped to one of the letter provided no change will happen to this device.
      - If less drive letters than CDROMs are avaliable, the module will only change the number of CDROMs equal to drive letters.
      - Accepted characters C-Z
-   example: O,S,U,R
+     - Example O,S,U,R
    required: false
    type: str
  change_single:
    description:
      - Specify the drive letter of a single CDROM to change or dismount.
      - Usefull when multiple CDROMs are present on the system but you need to change or dismount only one of them
-     - Note, it's not advisable to use change_single in conjunction with both dismount_virtual and drive_letter simultaneously. In most cases it will result in failed status.
+     - Note, it's not advisable to use change_single in conjunction with both dismount_virtual and drive_letter simultaneously.
    required: false
    type: str
  dismount_virtual:
@@ -57,8 +60,9 @@ options:
    default: false
    type: bool
 
-author:
- - RusoSova
+version_added: 2.9
+
+author: RusoSova
 '''
 
 EXAMPLES = r'''
@@ -89,7 +93,7 @@ EXAMPLES = r'''
 - name: Dismount all Windows virtual CDROMs
   win_cdrom_letter:
    dismount_only: yes
-  register: result 
+  register: result
 '''
 
 RETURN = r'''
@@ -102,7 +106,7 @@ dismounted:
   description: List of the Windows virtual CDROMs that were dismounted
   returned: When dismount_virtual = yes or dismount_only = yes
   type: str
-  sample:"G:,V:"
+  sample: "G:,V:"
 number_of_cdroms:
   description: Total number of CDROMs thats are susceptible to the change
   returned: When dismount_only = no
@@ -126,4 +130,5 @@ remap[n]:
     - "remap[0]": "O: --> Z:"
     - "remap[1]": "P: --> X:"
     - "remap[2]": "E: --> T:"
+
 '''

--- a/lib/ansible/modules/windows/win_cdrom_letter.py
+++ b/lib/ansible/modules/windows/win_cdrom_letter.py
@@ -63,7 +63,7 @@ options:
 version_added: 2.9
 
 author:
- - RusoSova
+ - RusoSova (@RusoSova)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_description.ps1
+++ b/lib/ansible/modules/windows/win_description.ps1
@@ -1,0 +1,114 @@
+#!powershell
+
+# Copyright: (c) 2019, RusoSova
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -OSVersion 6.2
+
+$ErrorActionPreference = "Stop"
+
+$spec = @{
+    options = @{
+        owner = @{ type="str" }
+        organization = @{ type="str" }
+        description = @{ type="str" }
+    }
+    required_one_of = @(
+        ,@('owner', 'organization', 'description')
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$owner = $module.Params.owner
+$organization = $module.Params.organization
+$description = $module.Params.description
+$regPath="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\"
+
+#Function to create a CIM object
+Function GetCimsObject {
+    param(
+        [Parameter(Position=0)][string]$class #Class to query
+    )
+    try {
+        $cimObj=Get-CimInstance -class $class
+    } catch {
+        $module.FailJson("There was an error retrieving Windows description $($_.Exception.Message)")
+    }
+    return $cimObj;
+}
+
+#Function to change CIM's object property. In this case used to change computer description
+Function SetWinDescription {
+    param(
+        [Parameter(Position=0)]$object, #CIMs Object to apply the change too
+        [Parameter(Position=0)]$property, #CIMs property to change
+        [Parameter(Position=2)][string]$value #New value for the property
+    )
+    try {
+        Set-CimInstance -InputObject $object -Property @{$property="$value"}
+    } catch {
+        $module.FailJson("There was an error changing Windows description $($_.Exception.Message)")
+    }
+}
+
+#Function to update registry, in order to change license Owner and Organization
+Function WinOwnership {
+    param(
+        [Parameter(Position=0)][ValidateSet("RegisteredOrganization","RegisteredOwner")][string]$type, #Organization or user
+        [Parameter(Position=1)][ValidateSet("set","get")][string]$action, #Get Information or set information
+        [Parameter(Position=2)][String]$value #Value to set
+    )
+	if ($action -eq "get") {
+        try {
+            $regObj=Get-ItemProperty -Path $regPath
+        } catch {
+            $module.FailJson("There was an error fetching registry $($_.Exception.Message)")
+        }
+		return $regObj.$type
+    }
+    #Upate Owner or Organization
+    if ($action -eq "set") {
+        try {
+            Set-ItemProperty -Path $regPath -Name $type -Value $value
+        } catch {
+            $module.FailJson("There was an error updating $type $($_.Exception.Message)")
+        }
+    }
+}
+
+#Change description
+if ($description -or $description -eq "") {
+    $descriptionObject=GetCimsObject -class "Win32_OperatingSystem"
+    if ($description -cne $descriptionObject.description) {
+        if (-not $module.CheckMode) {
+            SetWinDescription -object $descriptionObject -property "Description" -value $description
+        }
+        $module.Result.changed = $true
+    }
+}
+
+#Change owner
+if ($owner -or $owner -eq "") {
+    $curentOwner=WinOwnership -type "RegisteredOwner"  -action "get"
+    if ($curentOwner -cne $owner) {
+        if (-not $module.CheckMode) {
+            WinOwnership -type "RegisteredOwner"  -action "set" -value $owner
+        }
+        $module.Result.changed = $true
+    }
+}
+
+#Change organization
+if ($organization -or $organization -eq "") {
+    $curentOrganization=WinOwnership -type "RegisteredOrganization"  -action "get"
+    if ($curentOrganization -cne $organization) {
+        if (-not $module.CheckMode) {
+            WinOwnership -type "RegisteredOrganization"  -action "set" -value $organization
+        }
+        $module.Result.changed = $true
+    }
+}
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_description.py
+++ b/lib/ansible/modules/windows/win_description.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, RusoSova
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
+---
+module: win_description
+short_description: Set windows description, owner and organization
+description:
+ - This module sets Windows description that is shown under My Computer properties. Module also sets
+   Windows license owner and organization. License information can be viewed by running winver commad.
+options:
+ description:
+   description:
+     - String value to apply to Windows descripton. Specify value of "" to clear the value.
+   required: false
+   type: str
+ organization:
+   description:
+     - String value of organization that the Windows is licensed to. Specify value of "" to clear the value.
+   required: false
+   type: str
+ owner:
+   description:
+     - String value of the persona that the Windows is licensed to. Specify value of "" to clear the value.
+   required: false
+   type: str
+version_added: 2.9
+author:
+ - RusoSova (@RusoSova)
+'''
+
+EXAMPLES = r'''
+- name: Set Windows description, owner and organization
+  win_description:
+   description: Best Box
+   owner: RusoSova
+   organization: MyOrg
+  register: result
+
+- name: Set Windows description only
+  win_description:
+   description: This is my Windows machine
+  register: result
+
+- name: Set organization and clear owner field
+  win_description:
+   owner: ''
+   organization: Black Mesa
+
+- name: Clear organization, description and owner
+  win_description:
+   organization: ""
+   owner: ""
+   description: ""
+  register: result
+'''
+
+RETURN = r'''
+#
+'''


### PR DESCRIPTION
##### SUMMARY
New module for Windows to have cdroms remapped to the list of desired drives. The list of drive is provided in comma separated fashion. Module will ensure that all CDROMs are mapped to one of the letters provided. In case that are less letters provided than CDROMs, only number of CDROMs=number of drive letters will be changed.
Module can also dismount Windows virtual CDROMs as part of drive letter change or as a stand alone action.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_cdrom_letter

##### ADDITIONAL INFORMATION
It's useful to know what your CDROM(s) are mapped as. I was tiered to rely on win_shell and win_command to invoke commands on my hosts. Does not look clean. I hope this will be useful for more people as well.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
