### PR TITLE
Search project in domain when it's defined

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -172,8 +172,8 @@ def _get_domain_id(cloud, domain):
     return domain_id
 
 
-def _get_default_project_id(cloud, default_project, module):
-    project = cloud.get_project(default_project)
+def _get_default_project_id(cloud, default_project, domain_id, module):
+    project = cloud.get_project(default_project, domain_id=domain_id)
     if not project:
         module.fail_json(msg='Default project %s is not valid' % default_project)
 
@@ -224,7 +224,7 @@ def main():
                     module.fail_json(msg=msg)
             default_project_id = None
             if default_project:
-                default_project_id = _get_default_project_id(cloud, default_project, module)
+                default_project_id = _get_default_project_id(cloud, default_project, domain_id, module)
 
             if user is None:
                 if description is not None:


### PR DESCRIPTION
### SUMMARY

Since there might be several projects with the same name in different
domains, it's required to define domain_id during project search,
especially if domain is provided by user.
Otherwise openstacksdk will raise "Multiple matches found" error

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1. Create domain in openstack
2. Create project admin in new domain
3. Run os_user module with providing domain and default_project

Expected behavior is that default_project will be searched in provided domain.
