### PR TITLE
Fix nxos_facts httpapi breakage

### DIFF
--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -212,7 +212,7 @@ def get_resource_connection(module):
 
     capabilities = get_capabilities(module)
     network_api = capabilities.get('network_api')
-    if network_api == 'cliconf':
+    if network_api == 'cliconf' or network_api == 'nxapi':
         module._connection = Connection(module._socket_path)
     elif network_api == 'netconf':
         module._connection = NetconfConnection(module._socket_path)

--- a/test/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -25,9 +25,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test cases (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run


### PR DESCRIPTION
##### SUMMARY
The nxos_facts integration tests have been failing for `httpapi` in our nightly tests.  This fix adds `httpapi` support in `lib/ansible/module_utils/network/common/network.py`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_facts

##### ADDITIONAL INFORMATION
Tested against n3k, n7k, n9k