### PR TITLE
template - move backup to its own doc

### DIFF
--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -18,6 +18,13 @@ DOCUMENTATION = r'''
 module: template
 version_added: historical
 options:
+  backup:
+    description:
+    - Determine whether a backup should be created.
+    - When set to C(yes), create a backup file including the timestamp information
+      so you can get the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: no
   follow:
     description:
     - Determine whether symbolic links should be followed.

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -18,13 +18,6 @@ DOCUMENTATION = r'''
 module: template
 version_added: historical
 options:
-  backup:
-    description:
-    - Determine whether a backup should be created.
-    - When set to C(yes), create a backup file including the timestamp information
-      so you can get the original file back if you somehow clobbered it incorrectly.
-    type: bool
-    default: no
   follow:
     description:
     - Determine whether symbolic links should be followed.
@@ -46,6 +39,7 @@ author:
 - Ansible Core Team
 - Michael DeHaan
 extends_documentation_fragment:
+- backup
 - files
 - template_common
 - validate

--- a/lib/ansible/modules/windows/win_template.py
+++ b/lib/ansible/modules/windows/win_template.py
@@ -15,6 +15,12 @@ module: win_template
 version_added: "1.9.2"
 options:
   backup:
+    description:
+    - Determine whether a backup should be created.
+    - When set to C(yes), create a backup file including the timestamp information
+      so you can get the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: no
     version_added: '2.8'
   newline_sequence:
     default: '\r\n'

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -39,13 +39,6 @@ options:
     - Location to render the template to on the remote machine.
     type: path
     required: yes
-  backup:
-    description:
-    - Determine whether a backup should be created.
-    - When set to C(yes), create a backup file including the timestamp information
-      so you can get the original file back if you somehow clobbered it incorrectly.
-    type: bool
-    default: no
   newline_sequence:
     description:
     - Specify the newline sequence to use for templating files.


### PR DESCRIPTION
##### SUMMARY
As per https://github.com/ansible/ansible/pull/59828#issuecomment-516914901 this moves the `backup` option to each individual doc as they are implemented in different module_utils; template uses the Python module_util while win_template uses the PowerShell module_util.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
template
win_template