### PR TITLE
to_text - attempt to call __unicode__() before __str__()

### DIFF
--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -238,13 +238,17 @@ def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
     # value because we're optimizing the common case
     if nonstring == 'simplerepr':
         try:
-            value = str(obj)
-        except UnicodeError:
+            value = obj.__unicode__()
+        except (AttributeError, UnicodeError):
+            # AttributeError for Python3, UnicodeError defensively against poorly written classes
             try:
-                value = repr(obj)
+                value = str(obj)
             except UnicodeError:
-                # Giving up
-                return u''
+                try:
+                    value = repr(obj)
+                except UnicodeError:
+                    # Giving up
+                    return u''
     elif nonstring == 'passthru':
         return obj
     elif nonstring == 'empty':

--- a/test/units/module_utils/test_text.py
+++ b/test/units/module_utils/test_text.py
@@ -18,6 +18,15 @@ from ansible.module_utils.six import PY3
 from ansible.module_utils._text import to_text, to_bytes, to_native
 
 
+class BadStrClass:
+
+    def __str__(self):
+        return to_native(u"caf\xe9", encoding="ascii", errors="replace")
+
+    def __unicode__(self):
+        return u"caf\xe9"
+
+
 # Format: byte representation, text representation, encoding of byte representation
 VALID_STRINGS = (
     (b'abcde', u'abcde', 'ascii'),
@@ -35,6 +44,11 @@ VALID_STRINGS = (
 def test_to_text(in_string, encoding, expected):
     """test happy path of decoding to text"""
     assert to_text(in_string, encoding) == expected
+
+
+def test_to_text_unicode_method():
+    # Verifies __unicode__() is called before __str__() which would result in 'caf?'
+    assert to_text(BadStrClass(), 'utf-8') == u"caf\xe9"
 
 
 @pytest.mark.parametrize('in_string, encoding, expected',


### PR DESCRIPTION
##### SUMMARY
Attempt to get unicode string from the `.__unicode__()` method if present then fallback to `__str__()`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
_text.py