### PR TITLE
Fix ansible-galaxy import command to use argspec instead

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -913,11 +913,8 @@ class GalaxyCLI(CLI):
             'FAILED': C.COLOR_ERROR,
         }
 
-        if len(context.CLIARGS['args']) < 2:
-            raise AnsibleError("Expected a github_username and github_repository. Use --help.")
-
-        github_user = to_text(context.CLIARGS['args'][0], errors='surrogate_or_strict')
-        github_repo = to_text(context.CLIARGS['args'][1], errors='surrogate_or_strict')
+        github_user = to_text(context.CLIARGS['github_user'], errors='surrogate_or_strict')
+        github_repo = to_text(context.CLIARGS['github_repo'], errors='surrogate_or_strict')
 
         if context.CLIARGS['check_status']:
             task = self.api.get_import_task(github_user=github_user, github_repo=github_repo)


### PR DESCRIPTION
##### SUMMARY
`ansible-galaxy import` fails in devel due to the change in the positional arg formatting since collection was added. This change makes sure we get the `github_user` and `github_repo` based on the arg name that argparse sets up for us.

Fixes https://github.com/ansible/ansible/issues/59195

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy