### PR TITLE
Detect AWS ECS task_definitions cpu and memory limit changes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -392,8 +392,14 @@ def main():
 
                 return True
 
-            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, existing_task_definition):
+            def _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, existing_task_definition):
                 if td['status'] != "ACTIVE":
+                    return None
+
+                # Check if task limits have been changed.
+                if requested_cpu_limit != td.get('cpu', None):
+                    return None
+                if requested_mem_limit != td.get('memory', None):
                     return None
 
                 if requested_task_role_arn != td.get('taskRoleArn', ""):
@@ -441,7 +447,9 @@ def main():
                 requested_volumes = module.params['volumes'] or []
                 requested_containers = module.params['containers'] or []
                 requested_task_role_arn = module.params['task_role_arn']
-                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, td)
+                requested_cpu_limit = module.params['cpu']
+                requested_mem_limit = module.params['memory']
+                existing = _task_definition_matches(requested_volumes, requested_containers, requested_task_role_arn, requested_cpu_limit, requested_mem_limit, td)
 
                 if existing:
                     break


### PR DESCRIPTION
##### SUMMARY
AWS ECS Task Definitions can have cpu and memory limits and they should be checked when determining if an existing Task Definition needs to be updated.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
amazon/ecs_taskdefinition

##### ADDITIONAL INFORMATION
