### PR TITLE
PR to resolve ios plugin cliconf unit test error 

### DIFF
--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -211,7 +211,8 @@ class Cliconf(CliconfBase):
         for item in model_search_strs:
             match = re.search(item, data, re.M)
             if match:
-                device_info['network_os_model'] = match.group(1)
+                version = match.group(1).split(' ')
+                device_info['network_os_model'] = version[0]
                 break
 
         match = re.search(r'^(.+) uptime', data, re.M)


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sjaiswal@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR to resolves the test error faced in PR #59550, where ios plugin cliconf unit test was failing coz of getting wrong device model from regex update in respective PR.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cliconf/ios.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
