### PR TITLE
vars: Fail with warning for extra_vars filename without @ sign

### DIFF
--- a/changelogs/fragments/extra_vars_with_at_sign.yml
+++ b/changelogs/fragments/extra_vars_with_at_sign.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Ansible CLI fails with warning if extra_vars parameter is used with filename without @ sign (https://github.com/ansible/ansible/issues/51857).

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -125,10 +125,15 @@ def load_extra_vars(loader):
     for extra_vars_opt in context.CLIARGS.get('extra_vars', tuple()):
         data = None
         extra_vars_opt = to_text(extra_vars_opt, errors='surrogate_or_strict')
+        if extra_vars_opt is None or not extra_vars_opt:
+            continue
+
         if extra_vars_opt.startswith(u"@"):
             # Argument is a YAML file (JSON is a subset of YAML)
             data = loader.load_from_file(extra_vars_opt[1:])
-        elif extra_vars_opt and extra_vars_opt[0] in u'[{':
+        elif extra_vars_opt[0] in [u'/', u'.']:
+            raise AnsibleOptionsError("Please prepend extra_vars filename '%s' with '@'" % extra_vars_opt)
+        elif extra_vars_opt[0] in [u'[', u'{']:
             # Arguments as YAML
             data = loader.load(extra_vars_opt)
         else:

--- a/test/integration/targets/ansible/playbook.yml
+++ b/test/integration/targets/ansible/playbook.yml
@@ -1,0 +1,5 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: "{{ username }}"

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -36,3 +36,17 @@ if [[ $file_count -ne 1 ]]; then
     fi
     exit 1
 fi
+
+# Ensure extra vars filename is prepended with '@' sign
+if ansible-playbook -i ../../inventory --extra-vars /tmp/non-existing-file playbook.yml; then
+    echo "extra_vars filename without '@' sign should cause failure"
+    exit 1
+fi
+
+# Ensure extra vars filename is prepended with '@' sign
+if ansible-playbook -i ../../inventory --extra-vars ./vars.yml playbook.yml; then
+    echo "extra_vars filename without '@' sign should cause failure"
+    exit 1
+fi
+
+ansible-playbook -i ../../inventory --extra-vars @./vars.yml playbook.yml

--- a/test/integration/targets/ansible/vars.yml
+++ b/test/integration/targets/ansible/vars.yml
@@ -1,0 +1,1 @@
+username: ansiboy


### PR DESCRIPTION
##### SUMMARY
Rather than silently processing extra_vars filename without @ sign,
CLI now fails with appropriate warning about requirement.

Fixes: #51857

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/extra_vars_with_at_sign.yml
lib/ansible/utils/vars.py
test/integration/targets/ansible/playbook.yml
test/integration/targets/ansible/runme.sh
test/integration/targets/ansible/vars.yml