### PR TITLE
ipa_dnsrecord.py: ttl is not required to change zones in ipa

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -57,6 +57,7 @@ options:
     - Set the TTL for the record.
     - Applies only when adding a new or changing the value of record_value.
     version_added: "2.7"
+    required: false
   state:
     description: State to ensure
     required: false
@@ -249,6 +250,10 @@ def ensure(module, client):
         record_ttl=to_native(record_ttl, nonstring='passthru'),
     )
 
+    # ttl is not required to change records
+    if module_dnsrecord['record_ttl'] is None:
+        module_dnsrecord.pop('record_ttl')
+
     changed = False
     if state == 'present':
         if not ipa_dnsrecord:
@@ -285,7 +290,7 @@ def main():
         record_type=dict(type='str', default='A', choices=record_types),
         record_value=dict(type='str', required=True),
         state=dict(type='str', default='present', choices=['present', 'absent']),
-        record_ttl=dict(type='int'),
+        record_ttl=dict(type='int', required=False),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
this fixes the error reported on issue #56872, if user not pass the argument
module 'record_ttl' it simples removes from json dictionary to make the
correct post request.

reproduction of this problem is cited on issue, I also made some tests changing 
values of TTL, and of course, WITHOUT the ttl record.

Fixes #56872