### PR TITLE
Fix power command ResetType mapping logic

### DIFF
--- a/changelogs/fragments/59927-fix-redfish-power-reset-type-mapping.yaml
+++ b/changelogs/fragments/59927-fix-redfish-power-reset-type-mapping.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - fix power ResetType mapping logic (https://github.com/ansible/ansible/issues/59804)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the Power* command logic to map ResetType to an allowable value if appropriate.

Fixes #59804

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue a Power command, like PowerGracefulShutdown, to a system that does not support GracefulShutdown, but doers support ForceOff.

**Before:**
 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/power_graceful_shutdown.yml 

PLAY [Manage System Power - Graceful shutdown] *********************************

TASK [Shutdown system power gracefully] ****************************************
 [WARNING]: Platform darwin on host mockup-localstorage is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/deve
l/reference_appendices/interpreter_discovery.html for more information.

fatal: [mockup-localstorage]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false,
"msg": "HTTP Error 400 on POST request to 'http://127.0.0.1:8007/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset',
extended message: 'The parameter GracefulShutdown for the action ComputerSystem.Reset is not supported on the target resource.'"}

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

**After:**
 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/power_graceful_shutdown.yml 

PLAY [Manage System Power - Graceful shutdown] *********************************

TASK [Shutdown system power gracefully] ****************************************
 [WARNING]: Platform darwin on host mockup-localstorage is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/deve
l/reference_appendices/interpreter_discovery.html for more information.

changed: [mockup-localstorage]

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
