### PR TITLE
Fix idempotencies issues for ovirt instance type

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -801,6 +801,13 @@ class BaseModule(object):
         if not search by `name`.
         """
         entity = None
+        headers = {'All-content': 'true'}
+        if list_params is None:
+            list_params = {'headers': headers}
+        elif list_params['headers'] is None:
+            list_params['headers'] = headers
+        else:
+            list_params['headers'].update(headers)
 
         if 'id' in self._module.params and self._module.params['id'] is not None:
             entity = get_entity(self._service.service(self._module.params['id']), get_params=list_params)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_instance_type.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_instance_type.py
@@ -489,30 +489,26 @@ class InstanceTypeModule(BaseModule):
         cpu_mode = getattr(entity.cpu, 'mode')
         it_display = entity.display
         return (
-            not self.param('kernel_params_persist') and
             equal(convert_to_bytes(self.param('memory_guaranteed')), entity.memory_policy.guaranteed) and
             equal(convert_to_bytes(self.param('memory_max')), entity.memory_policy.max) and
+            equal(convert_to_bytes(self.param('memory')), entity.memory) and
             equal(self.param('cpu_cores'), entity.cpu.topology.cores) and
             equal(self.param('cpu_sockets'), entity.cpu.topology.sockets) and
             equal(self.param('cpu_threads'), entity.cpu.topology.threads) and
             equal(self.param('cpu_mode'), str(cpu_mode) if cpu_mode else None) and
-            equal(self.param('type'), str(entity.type)) and
             equal(self.param('name'), str(entity.name)) and
-            equal(self.param('operating_system'), str(entity.os.type)) and
             equal(self.param('soundcard_enabled'), entity.soundcard_enabled) and
             equal(self.param('smartcard_enabled'), getattr(it_display, 'smartcard_enabled', False)) and
             equal(self.param('io_threads'), entity.io.threads) and
             equal(self.param('ballooning_enabled'), entity.memory_policy.ballooning) and
             equal(self.param('serial_console'), getattr(entity.console, 'enabled', None)) and
             equal(self.param('usb_support'), entity.usb.enabled) and
-            equal(self.param('virtio_scsi'), getattr(entity, 'smartcard_enabled', False)) and
+            equal(self.param('virtio_scsi'), getattr(entity.virtio_scsi, 'enabled', None)) and
             equal(self.param('high_availability'), entity.high_availability.enabled) and
             equal(self.param('high_availability_priority'), entity.high_availability.priority) and
             equal(self.param('boot_devices'), [str(dev) for dev in getattr(entity.os.boot, 'devices', [])]) and
             equal(self.param('description'), entity.description) and
             equal(self.param('rng_device'), str(entity.rng_device.source) if entity.rng_device else None) and
-            equal(self.param('rng_bytes'), entity.rng_device.rate.bytes if entity.rng_device else None) and
-            equal(self.param('rng_period'), entity.rng_device.rate.period if entity.rng_device else None) and
             equal(self.param('placement_policy'), str(entity.placement_policy.affinity) if entity.placement_policy else None)
         )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes some idem-potency issues with instance type
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_instance_type

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This first iteration don't remove all params that are not supported by current oVirt API (http://ovirt.github.io/ovirt-engine-api-model/4.3/#types/instance_type) and so are not usable by ansible module because I didn't know how to do that (simply remove them ? deprecate them ?)
There is some remaining issues at least with watchdog that are not fixed here.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
cat > playbook.yml <<EOF
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Obtain SSO token with using username/password credentials
      ovirt_auth:
         url: 'https://192.168.201.2/ovirt-engine/api'
         username: 'admin@internal'
         insecure: true
         password: '123'
    - name: "Import instance"
      ovirt_instance_type:
        auth: "{{ ovirt_auth }}"
        name: myinstance_type2
        description: "my description"
        memory: 4GiB
        cpu_cores: 2
        cpu_sockets: 1
        cpu_threads: 1
        boot_devices:
          - network
          - hd
        usb_support: true
        serial_console: true
        high_availability: true
        high_availability_priority: 1
        soundcard_enabled: true
        smartcard_enabled: true
        io_threads: 2
        ballooning_enabled: false
        rng_device: urandom
        graphical_console:
          headless_mode: false
          protocol:
            - spice
        virtio_scsi: true
        state: present
EOF
ansible-playbook playbook.yml
```
