### PR TITLE
Fix async output with adhoc callbacks

### DIFF
--- a/changelogs/fragments/adhoc-command-async-output.yaml
+++ b/changelogs/fragments/adhoc-command-async-output.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- async - Fix async callback plugins to allow async output to be displayed
+  when running command/shell (https://github.com/ansible/ansible/issues/15988)

--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -62,7 +62,7 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_OK
             state = 'SUCCESS'
 
-        if result._task.action in C.MODULE_NO_JSON:
+        if result._task.action in C.MODULE_NO_JSON and 'ansible_job_id' not in result._result:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, state), color=color)
         else:
             self._display.display("%s | %s => %s" % (result._host.get_name(), state, self._dump_results(result._result, indent=4)), color=color)

--- a/lib/ansible/plugins/callback/oneline.py
+++ b/lib/ansible/plugins/callback/oneline.py
@@ -64,7 +64,7 @@ class CallbackModule(CallbackBase):
             color = C.COLOR_OK
             state = 'SUCCESS'
 
-        if result._task.action in C.MODULE_NO_JSON:
+        if result._task.action in C.MODULE_NO_JSON and 'ansible_job_id' not in result._result:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, state), color=color)
         else:
             self._display.display("%s | %s => %s" % (result._host.get_name(), state, self._dump_results(result._result, indent=0).replace('\n', '')),


### PR DESCRIPTION
##### SUMMARY
Fix async output with adhoc callbacks. Fixes #15988

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/minimal.py
lib/ansible/plugins/callback/oneline.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```