### PR TITLE
Wait for Ansible Tower instance to be ready

### DIFF
--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -108,6 +108,7 @@ class TowerCloudProvider(CloudProvider):
 
         aci = get_tower_aci(self.args, self.version)
         aci.start()
+        aci.wait()
 
         connection = aci.get()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Call `aci.wait()` after `aci.start()` to ensure we wait for the instance is ready before continuing with the test.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/runner/lib/cloud/tower.py`
