### PR TITLE
[WIP] Use Ansible Tower 3.5.1 in integration tests

### DIFF
--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -75,6 +75,7 @@ class TowerCloudProvider(CloudProvider):
             '3.2.3': '3.3.0',
             '3.3.5': '3.3.3',
             '3.4.3': '3.3.3',
+            '3.5.1': '3.3.6',
         }
 
         cli_version = tower_cli_version_map.get(self.version, fallback)
@@ -103,7 +104,7 @@ class TowerCloudProvider(CloudProvider):
         display.info('Provisioning %s cloud environment.' % self.platform, verbosity=1)
 
         # temporary solution to allow version selection
-        self.version = os.environ.get('TOWER_VERSION', '3.2.3')
+        self.version = os.environ.get('TOWER_VERSION', '3.5.1')
         self.check_tower_version(os.environ.get('TOWER_CLI_VERSION'))
 
         aci = get_tower_aci(self.args, self.version)
@@ -143,6 +144,10 @@ class TowerCloudEnvironment(CloudEnvironment):
 
         cmd = self.args.pip_command + ['install', '--disable-pip-version-check', 'ansible-tower-cli==%s' % tower_cli_version]
 
+        run_command(self.args, cmd)
+
+        display.info('Disabling TLS validation')
+        cmd = ['tower-cli', 'config', 'verify_ssl', 'false']
         run_command(self.args, cmd)
 
     def disable_pendo(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use latest version of Ansible Tower in integration tests.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/runner/lib/cloud/tower.py`

##### ADDITIONAL INFORMATION
The tests are currently failing, so changes to the modules are likely needed.
Related to #57490