### PR TITLE
Fix plugin names when loading all plugins.

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -678,7 +678,7 @@ class PluginLoader:
 
             if path not in self._module_cache:
                 try:
-                    module = self._load_module_source(name, path)
+                    module = self._load_module_source(basename, path)
                     self._load_config_defs(basename, module, path)
                 except Exception as e:
                     display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -678,7 +678,13 @@ class PluginLoader:
 
             if path not in self._module_cache:
                 try:
-                    module = self._load_module_source(basename, path)
+                    if self.subdir in ('filter_plugins', 'test_plugins'):
+                        # filter and test plugin files can contain multiple plugins
+                        # they must have a unique python module name to prevent them from shadowing each other
+                        full_name = '{0}_{1}'.format(abs(hash(path)), basename)
+                    else:
+                        full_name = basename
+                    module = self._load_module_source(full_name, path)
                     self._load_config_defs(basename, module, path)
                 except Exception as e:
                     display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))

--- a/test/integration/targets/plugin_namespace/aliases
+++ b/test/integration/targets/plugin_namespace/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/plugin_namespace/filter_plugins/test_filter.py
+++ b/test/integration/targets/plugin_namespace/filter_plugins/test_filter.py
@@ -1,0 +1,20 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def filter_package(a):
+    return __package__
+
+
+def filter_name(a):
+    return __name__
+
+
+class FilterModule(object):
+    def filters(self):
+        filters = {
+            'filter_package': filter_package,
+            'filter_name': filter_name,
+        }
+
+        return filters

--- a/test/integration/targets/plugin_namespace/filter_plugins/test_filter.py
+++ b/test/integration/targets/plugin_namespace/filter_plugins/test_filter.py
@@ -2,10 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-def filter_package(a):
-    return __package__
-
-
 def filter_name(a):
     return __name__
 
@@ -13,7 +9,6 @@ def filter_name(a):
 class FilterModule(object):
     def filters(self):
         filters = {
-            'filter_package': filter_package,
             'filter_name': filter_name,
         }
 

--- a/test/integration/targets/plugin_namespace/lookup_plugins/lookup_name.py
+++ b/test/integration/targets/plugin_namespace/lookup_plugins/lookup_name.py
@@ -1,0 +1,9 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__name__]

--- a/test/integration/targets/plugin_namespace/lookup_plugins/lookup_package.py
+++ b/test/integration/targets/plugin_namespace/lookup_plugins/lookup_package.py
@@ -1,9 +1,0 @@
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
-from ansible.plugins.lookup import LookupBase
-
-
-class LookupModule(LookupBase):
-    def run(self, terms, variables, **kwargs):
-        return [__package__]

--- a/test/integration/targets/plugin_namespace/lookup_plugins/lookup_package.py
+++ b/test/integration/targets/plugin_namespace/lookup_plugins/lookup_package.py
@@ -1,0 +1,9 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__package__]

--- a/test/integration/targets/plugin_namespace/tasks/main.yml
+++ b/test/integration/targets/plugin_namespace/tasks/main.yml
@@ -1,0 +1,16 @@
+- set_fact:
+    filter_package: "{{ 1 | filter_package }}"
+    filter_name: "{{ 1 | filter_name }}"
+    lookup_package: "{{ lookup('lookup_package') }}"
+    lookup_name: "{{ lookup('lookup_name') }}"
+    test_package_ok: "{{ 1 is test_package_ok }}"
+    test_name_ok: "{{ 1 is test_name_ok }}"
+
+- assert:
+    that:
+      - filter_package == 'ansible.plugins.filter'
+      - filter_name == 'ansible.plugins.filter.test_filter'
+      - lookup_package == 'ansible.plugins.lookup'
+      - lookup_name == 'ansible.plugins.lookup.lookup_name'
+      - test_package_ok
+      - test_name_ok

--- a/test/integration/targets/plugin_namespace/tasks/main.yml
+++ b/test/integration/targets/plugin_namespace/tasks/main.yml
@@ -1,17 +1,11 @@
 - set_fact:
-    filter_package: "{{ 1 | filter_package }}"
     filter_name: "{{ 1 | filter_name }}"
-    lookup_package: "{{ lookup('lookup_package') }}"
     lookup_name: "{{ lookup('lookup_name') }}"
-    test_package_ok: "{{ 1 is test_package_ok }}"
     test_name_ok: "{{ 1 is test_name_ok }}"
 
 - assert:
     that:
-      - filter_package == 'ansible.plugins.filter'
       # filter names are prefixed with a unique hash value to prevent shadowing of other plugins
       - filter_name | regex_search('^ansible\.plugins\.filter\.[0-9]+_test_filter$')
-      - lookup_package == 'ansible.plugins.lookup'
       - lookup_name == 'ansible.plugins.lookup.lookup_name'
-      - test_package_ok
       - test_name_ok

--- a/test/integration/targets/plugin_namespace/tasks/main.yml
+++ b/test/integration/targets/plugin_namespace/tasks/main.yml
@@ -9,7 +9,8 @@
 - assert:
     that:
       - filter_package == 'ansible.plugins.filter'
-      - filter_name == 'ansible.plugins.filter.test_filter'
+      # filter names are prefixed with a unique hash value to prevent shadowing of other plugins
+      - filter_name | regex_search('^ansible\.plugins\.filter\.[0-9]+_test_filter$')
       - lookup_package == 'ansible.plugins.lookup'
       - lookup_name == 'ansible.plugins.lookup.lookup_name'
       - test_package_ok

--- a/test/integration/targets/plugin_namespace/test_plugins/test_test.py
+++ b/test/integration/targets/plugin_namespace/test_plugins/test_test.py
@@ -1,13 +1,16 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import re
+
 
 def test_package_ok(value):
     return __package__ == 'ansible.plugins.test'
 
 
 def test_name_ok(value):
-    return __name__ == 'ansible.plugins.test.test_test'
+    # test names are prefixed with a unique hash value to prevent shadowing of other plugins
+    return bool(re.match(r'^ansible\.plugins\.test\.[0-9]+_test_test$', __name__))
 
 
 class TestModule:

--- a/test/integration/targets/plugin_namespace/test_plugins/test_test.py
+++ b/test/integration/targets/plugin_namespace/test_plugins/test_test.py
@@ -1,0 +1,18 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def test_package_ok(value):
+    return __package__ == 'ansible.plugins.test'
+
+
+def test_name_ok(value):
+    return __name__ == 'ansible.plugins.test.test_test'
+
+
+class TestModule:
+    def tests(self):
+        return {
+            'test_package_ok': test_package_ok,
+            'test_name_ok': test_name_ok,
+        }

--- a/test/integration/targets/plugin_namespace/test_plugins/test_test.py
+++ b/test/integration/targets/plugin_namespace/test_plugins/test_test.py
@@ -4,10 +4,6 @@ __metaclass__ = type
 import re
 
 
-def test_package_ok(value):
-    return __package__ == 'ansible.plugins.test'
-
-
 def test_name_ok(value):
     # test names are prefixed with a unique hash value to prevent shadowing of other plugins
     return bool(re.match(r'^ansible\.plugins\.test\.[0-9]+_test_test$', __name__))
@@ -16,6 +12,5 @@ def test_name_ok(value):
 class TestModule:
     def tests(self):
         return {
-            'test_package_ok': test_package_ok,
             'test_name_ok': test_name_ok,
         }


### PR DESCRIPTION
##### SUMMARY

Fix plugin names when loading all plugins.

Add an integration test to verify plugin `__package__` and `__name__` are correct.

This fix is needed for collections to support relative imports. That feature request is: https://github.com/ansible/ansible/issues/59465

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/plugins/loader.py
