### PR TITLE
certificate_complete_chain: remove no longer necessary check

### DIFF
--- a/lib/ansible/modules/crypto/certificate_complete_chain.py
+++ b/lib/ansible/modules/crypto/certificate_complete_chain.py
@@ -310,12 +310,12 @@ def main():
     # Load intermediate certificates
     intermediates = CertificateSet(module)
     for path in module.params['intermediate_certificates']:
-        intermediates.load(os.path.expanduser(os.path.expandvars(path)))
+        intermediates.load(path)
 
     # Load root certificates
     roots = CertificateSet(module)
     for path in module.params['root_certificates']:
-        roots.load(os.path.expanduser(os.path.expandvars(path)))
+        roots.load(path)
 
     # Try to complete chain
     current = chain[-1]

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2224,7 +2224,6 @@ lib/ansible/modules/commands/command.py validate-modules:E322
 lib/ansible/modules/commands/command.py validate-modules:E323
 lib/ansible/modules/commands/command.py validate-modules:E338
 lib/ansible/modules/commands/expect.py validate-modules:E338
-lib/ansible/modules/crypto/certificate_complete_chain.py use-argspec-type-path # would need something like type=list(path)
 lib/ansible/modules/database/influxdb/influxdb_database.py validate-modules:E324
 lib/ansible/modules/database/influxdb/influxdb_database.py validate-modules:E337
 lib/ansible/modules/database/influxdb/influxdb_query.py validate-modules:E324


### PR DESCRIPTION
##### SUMMARY
This should have been removed in the past, when support for validating list elements was added to module_utils/basic.py.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
certificate_complete_chain
