### PR TITLE
Disable mongodb_shard and mongodb_replicaset tests

### DIFF
--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -4,3 +4,4 @@ skip/osx
 skip/freebsd
 skip/rhel
 needs/root
+disabled

--- a/test/integration/targets/mongodb_shard/aliases
+++ b/test/integration/targets/mongodb_shard/aliases
@@ -4,3 +4,4 @@ skip/osx
 skip/freebsd
 skip/rhel
 needs/root
+disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Recently merged tests (dacfd72bd6c661a3ee2565ca081bfe75882e6d0c) are causing failures when run as part of the  entire group `shippable/posix/group1/`, but do not fail when run in isolation.

Reported in https://github.com/ansible/ansible/issues/59918
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/mongodb_replicaset/aliases`
`test/integration/targets/mongodb_shard/aliases`