### PR TITLE
clean "changed" only after it has been processed

### DIFF
--- a/changelogs/fragments/debug_loop_changed.yaml
+++ b/changelogs/fragments/debug_loop_changed.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- debug - fixed an issue introduced in Ansible 2.4 where a loop of debug tasks
+  would lose the "changed" status on each item.

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -290,7 +290,6 @@ class CallbackModule(CallbackBase):
     def v2_runner_item_on_ok(self, result):
 
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
-        self._clean_results(result._result, result._task.action)
         if isinstance(result._task, TaskInclude):
             return
         elif result._result.get('changed', False):
@@ -316,6 +315,7 @@ class CallbackModule(CallbackBase):
 
         msg += " => (item=%s)" % (self._get_item_label(result._result),)
 
+        self._clean_results(result._result, result._task.action)
         if self._run_is_verbose(result):
             msg += " => %s" % self._dump_results(result._result)
         self._display.display(msg, color=color)

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -22,6 +22,20 @@ changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+ok: [testhost] => (item=debug-3) => {
+    "msg": "debug-3"
+}
+skipping: [testhost] => (item=debug-4) 
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
 
@@ -46,5 +60,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=1    rescued=1    ignored=1   
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stderr
@@ -1,4 +1,5 @@
 + ansible-playbook -i inventory test.yml
 ++ set +x
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -21,6 +21,19 @@ changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+ok: [testhost] => (item=debug-3) => {
+    "msg": "debug-3"
+}
+skipping: [testhost] => (item=debug-4) 
+...ignoring
+
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 
 TASK [Rescue task] *************************************************************
@@ -44,5 +57,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=1    rescued=1    ignored=1   
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -19,6 +19,17 @@ changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+skipping: [testhost] => (item=debug-4) 
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
 
@@ -40,5 +51,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=1    rescued=1    ignored=1   
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -19,6 +19,19 @@ changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+ok: [testhost] => (item=debug-3) => {
+    "msg": "debug-3"
+}
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
 
@@ -43,5 +56,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=1    rescued=1    ignored=1   
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -16,6 +16,16 @@ changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
 
@@ -37,5 +47,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=11   changed=8    unreachable=0    failed=0    skipped=1    rescued=1    ignored=1   
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -34,6 +34,22 @@
       loop_control:
         label: foo-{{ item }}
 
+    # detect "changed" debug tasks being hidden with display_ok_tasks=false
+    - name: debug loop
+      debug:
+        msg: debug-{{ item }}
+      changed_when: item == 1
+      failed_when: item == 2
+      when: item != 4
+      ignore_errors: yes
+      loop:
+        - 1
+        - 2
+        - 3
+        - 4
+      loop_control:
+        label: debug-{{ item }}
+
     - block:
         - name: EXPECTED FAILURE Failed task to be rescued
           fail:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
without this change, a loop of `debug` tasks with `changed_when`
causes the "changed" status to get lost before output

updates position of `_clean_results()` in `v2_runner_item_on_ok` to match the position in `v2_runner_on_ok`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #57958
fixes https://github.com/ansible/ansible/issues/38974

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
debug
loop
default callback

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
