### PR TITLE
ansible-galaxy - ignore cert failures for login

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -870,7 +870,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                                                 to_native(b_cert, errors='surrogate_or_strict')
                                             )
                                         )
-                                    except ValueError:
+                                    except Exception:
                                         continue
                                 else:
                                     os.write(tmp_fd, b_cert)


### PR DESCRIPTION
##### SUMMARY
The `-c` option was not being passed to the GitHub login logic. This PR also makes the urls validation logic more lenient on the type of errors that may come across when reading the certificate store as encountered in 59734.

Fixes https://github.com/ansible/ansible/issues/59734

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy login