### PR TITLE
Fix LXC creation for Proxmox 6.0

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -347,7 +347,7 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
             kwargs.update(kwargs['mounts'])
             del kwargs['mounts']
         if 'pubkey' in kwargs:
-            if float(proxmox.version.get()['version']) >= 4.2:
+            if int(proxmox.version.get()['version'].split('.', 1)[0])
                 kwargs['ssh-public-keys'] = kwargs['pubkey']
             del kwargs['pubkey']
     else:


### PR DESCRIPTION
##### SUMMARY
Fixes #59340
authorization on proxmox cluster failed with exception: invalid literal for float(): 6.0-4

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Proxmox lib

##### ADDITIONAL INFORMATION
See:
https://github.com/ansible/ansible/issues/59340#issuecomment-515419951

<pre>
failed: [localhost] (item={u'id': 110, u'hostname': u'radegastjn2', u'netif': u'{"net0":"name=eth0,bridge=vmbr0,firewall=1,hwaddr=XXX,ip=dhcp,ip6=dhcp,type=veth"}', u'memory': 1200}) => {"ansible_loop_var": "item", "changed": false, "item": {"hostname": "radegastjn2", "id": 110, "memory": 1200, "netif": "{\"net0\":\"name=eth0,bridge=vmbr0,firewall=1,hwaddr=XXX,ip=dhcp,ip6=dhcp,type=veth\"}"}, "msg": "authorization on proxmox cluster failed with exception: invalid literal for float(): 6.0-4"}
