### PR TITLE
perf: reduce getting handler variables

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -370,6 +370,7 @@ class StrategyBase:
         '''
 
         ret_results = []
+        dummy_templar = Templar(None)
 
         def get_original_host(host_name):
             # FIXME: this should not need x2 _inventory
@@ -385,8 +386,9 @@ class StrategyBase:
                 for handler_task in handler_block.block:
                     if handler_task.name:
                         if not handler_task.cached_name:
-                            templar = self.get_handler_templar(handler_task, iterator)
-                            handler_task.name = templar.template(handler_task.name)
+                            if dummy_templar.is_template(handler_task.name):
+                                templar = self.get_handler_templar(handler_task, iterator)
+                                handler_task.name = templar.template(handler_task.name)
                             handler_task.cached_name = True
 
                         try:
@@ -541,6 +543,8 @@ class StrategyBase:
                                 for listening_handler_block in iterator._play.handlers:
                                     for listening_handler in listening_handler_block.block:
                                         listeners = getattr(listening_handler, 'listen', []) or []
+                                        if not listeners:
+                                            continue
                                         templar = self.get_handler_templar(listening_handler, iterator)
                                         listeners = listening_handler.get_validated_value(
                                             'listen', listening_handler._valid_attrs['listen'], listeners, templar


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See great analysis by @Vladimir-csp in #59017

Based on: https://github.com/ansible/ansible/issues/59017#issuecomment-516812136
Reproducer: https://github.com/ansible/ansible/issues/59017#issuecomment-516883033
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

`ci_complete`'ed

before:
```
real    2m0.019s
user    1m59.329s
sys     0m0.447s
```

after:
```
real    0m14.050s
user    0m13.761s                                                                                                                            
sys     0m0.359s
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`