### PR TITLE
corrected example

### DIFF
--- a/lib/ansible/modules/windows/win_file.py
+++ b/lib/ansible/modules/windows/win_file.py
@@ -50,21 +50,21 @@ author:
 EXAMPLES = r'''
 - name: Touch a file (creates if not present, updates modification time if present)
   win_file:
-    path: C:\Temp\foo.conf
+    path: C:\\Temp\\foo.conf
     state: touch
 
 - name: Remove a file, if present
   win_file:
-    path: C:\Temp\foo.conf
+    path: C:/Temp/foo.conf
     state: absent
 
 - name: Create directory structure
   win_file:
-    path: C:\Temp\folder\subfolder
+    path: C:\\Temp\\folder\\subfolder
     state: directory
 
 - name: Remove directory structure
   win_file:
-    path: C:\Temp
+    path: c:/Temp
     state: absent
 '''


### PR DESCRIPTION
##### SUMMARY
corrected the path in the example


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`C:\Temp` result in an invalid "C:   \<tab\>  emp" ( where `\t` is converted to a `tab`- sequence)
Followin (case-insensitive) expressions work:
`c:\\Temp` (escaping the backslash)
`c:/Temp` (`/` is converted to the correct `\`)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_file

