### PR TITLE
Fix a number of bugs in pull-based copies.

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -294,10 +294,12 @@ def copy_file_from_remote(module, local, local_file_directory, file_system='boot
     try:
         child = pexpect.spawn('ssh ' + username + '@' + hostname + ' -p' + str(port))
         # response could be unknown host addition or Password
-        index = child.expect(['yes', '(?i)Password', '#'])
+        # The "# " is here so to better avoid catching '#' in a banner.
+        index = child.expect(['yes', '(?i)Password', '# '])
         if index == 0:
             child.sendline('yes')
             child.expect('(?i)Password')
+            index = 1
         if index == 1:
             child.sendline(password)
             child.expect('#')
@@ -341,7 +343,7 @@ def copy_file_from_remote(module, local, local_file_directory, file_system='boot
         # remote file non-existent or success,
         # timeout due to large file transfer or network too slow,
         # success
-        index = child.expect(['No space', 'Permission denied', 'No such file', pexpect.TIMEOUT, '#'], timeout=fpt)
+        index = child.expect(['No space', 'Permission denied', '(?i)No such file', pexpect.TIMEOUT, '#'], timeout=fpt)
         if index == 0:
             module.fail_json(msg='File copy failed due to no space left on the device')
         elif index == 1:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes a number of issues I encountered while trying to use the nxos_file_copy module to pull a file from a remote SCP server.   Specifically:

* Try to be better about avoiding '#' in login banners
* Make sure to send the password after accepting the host key
* Make one pattern check case-insensitive to catch more errors

In terms of design, I tried to make the least amount of change while ensuring the product worked correctly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_file_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
