### PR TITLE
[stable-2.7] Wait for Ansible Tower instance to be ready

### DIFF
--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -101,6 +101,7 @@ class TowerCloudProvider(CloudProvider):
 
         aci = get_tower_aci(self.args, self.version)
         aci.start()
+        aci.wait()
 
         connection = aci.get()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #59938 for Ansible 2.7
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/runner/lib/cloud/tower.py`