### PR TITLE
Correct module name in changelog fragment

### DIFF
--- a/changelogs/fragments/docker_compose-fix-error-message-variable.yaml
+++ b/changelogs/fragments/docker_compose-fix-error-message-variable.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  - docker_compose - correct variable used in warning message about default IP

--- a/changelogs/fragments/docker_container-fix-error-message-variable.yaml
+++ b/changelogs/fragments/docker_container-fix-error-message-variable.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_container - correct variable used in warning message about default IP


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I put the incorrect module name in the changelog fragment in #60020.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/docker/docker_container.py`
