### PR TITLE
Fix bug in purefa_facts : remote pgroup without a schedule is skipped

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_facts.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_facts.py
@@ -637,19 +637,19 @@ def generate_pgroups_dict(array):
             pgroups_facts[protgroup]['days'] = prot_reten['days']
             pgroups_facts[protgroup]['all_for'] = prot_reten['all_for']
             pgroups_facts[protgroup]['target_all_for'] = prot_reten['target_all_for']
-            if ":" in protgroup:
-                snap_transfers = array.get_pgroup(protgroup, snap=True, transfer=True)
-                pgroups_facts[protgroup]['snaps'] = {}
-                for snap_transfer in range(0, len(snap_transfers)):
-                    snap = snap_transfers[snap_transfer]['name']
-                    pgroups_facts[protgroup]['snaps'][snap] = {
-                        'created': snap_transfers[snap_transfer]['created'],
-                        'started': snap_transfers[snap_transfer]['started'],
-                        'completed': snap_transfers[snap_transfer]['completed'],
-                        'physical_bytes_written': snap_transfers[snap_transfer]['physical_bytes_written'],
-                        'data_transferred': snap_transfers[snap_transfer]['data_transferred'],
-                        'progress': snap_transfers[snap_transfer]['progress'],
-                    }
+        if ":" in protgroup:
+            snap_transfers = array.get_pgroup(protgroup, snap=True, transfer=True)
+            pgroups_facts[protgroup]['snaps'] = {}
+            for snap_transfer in range(0, len(snap_transfers)):
+                snap = snap_transfers[snap_transfer]['name']
+                pgroups_facts[protgroup]['snaps'][snap] = {
+                    'created': snap_transfers[snap_transfer]['created'],
+                    'started': snap_transfers[snap_transfer]['started'],
+                    'completed': snap_transfers[snap_transfer]['completed'],
+                    'physical_bytes_written': snap_transfers[snap_transfer]['physical_bytes_written'],
+                    'data_transferred': snap_transfers[snap_transfer]['data_transferred'],
+                    'progress': snap_transfers[snap_transfer]['progress'],
+                }
     return pgroups_facts
 
 


### PR DESCRIPTION
##### SUMMARY
In the scenario where a remote protection group exists without a schedule (a possible edge case) then this pgroup is skipped and no transfer information is reported by purefa_facts

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_facts.py

##### ADDITIONAL INFORMATION
No changelog fragment required as this impacts a new section of code that is not available in 2.8.x as this is new for 2.9