### PR TITLE
Backport/2.8/59690 ce_netstream_template: update to fix a bug. (#59690)

### DIFF
--- a/changelogs/fragments/60033-ce_netstream_template-to-fix-bugs.yml
+++ b/changelogs/fragments/60033-ce_netstream_template-to-fix-bugs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ce_netstream_global - The 'get_config', which is from 'ansible.module_utils.network.cloudengine.ce', try to return the result from cache,however the configure has changed. (https://github.com/ansible/ansible/pull/59690)

--- a/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_template.py
@@ -138,8 +138,41 @@ updates:
 
 import re
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import get_config, load_config
+from ansible.module_utils.network.cloudengine.ce import load_config
+from ansible.module_utils.network.cloudengine.ce import get_connection, rm_config_prefix
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
+
+
+def get_config(module, flags):
+
+    """Retrieves the current config from the device or cache
+    """
+    flags = [] if flags is None else flags
+    if isinstance(flags, str):
+        flags = [flags]
+    elif not isinstance(flags, list):
+        flags = []
+
+    cmd = 'display current-configuration '
+    cmd += ' '.join(flags)
+    cmd = cmd.strip()
+    conn = get_connection(module)
+    rc, out, err = conn.exec_command(cmd)
+    if rc != 0:
+        module.fail_json(msg=err)
+    cfg = str(out).strip()
+    # remove default configuration prefix '~'
+    for flag in flags:
+        if "include-default" in flag:
+            cfg = rm_config_prefix(cfg)
+            break
+    if cfg.startswith('display'):
+        lines = cfg.split('\n')
+        if len(lines) > 1:
+            return '\n'.join(lines[1:])
+        else:
+            return ''
+    return cfg
 
 
 class NetstreamTemplate(object):
@@ -291,6 +324,9 @@ class NetstreamTemplate(object):
                 tmp_value = re.findall(r'collect interface (.*)', self.netstream_cfg)
                 if tmp_value:
                     self.end_state["collect_interface"] = tmp_value
+        if self.end_state == self.existing:
+            self.changed = False
+            self.updates_cmd = list()
 
     def present_netstream(self):
         """ Present netstream configuration """
@@ -309,7 +345,7 @@ class NetstreamTemplate(object):
             need_create_record = True
 
         if self.description:
-            cmd = "description %s" % self.description
+            cmd = "description %s" % self.description.strip()
             if not self.netstream_cfg or cmd not in self.netstream_cfg:
                 cmds.append(cmd)
                 self.updates_cmd.append(cmd)


### PR DESCRIPTION
* update to fix a bug.

* Update ce_netstream_template.py

* Update ce_netstream_template.py

* Update ce_netstream_template.py

(cherry picked from commit adfbd04b3ab611a9807a36c7d4ab648d53a811be)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_netstream_template.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The below method, which is from ‘ansible.module_utils.network.cloudengine.ce’，
try to return the result from cache, if a result with the same flags is existing.
That is not the result we expected when 'get_config' is called at two different moments, such as 'get_existing' and  'get_end_state' 
 which all call the 'get_config' at a different time whenever the configure on device has changed. So refactor it to fix the bug.
```
```paste below
    def get_config(self, flags=None):
        """Retrieves the current config from the device or cache
        """
        flags = [] if flags is None else flags

        cmd = 'display current-configuration '
        cmd += ' '.join(flags)
        cmd = cmd.strip()

        try:
            return self._device_configs[cmd]
        except KeyError:
            rc, out, err = self.exec_command(cmd)
            if rc != 0:
                self._module.fail_json(msg=err)
            cfg = str(out).strip()
            # remove default configuration prefix '~'
            for flag in flags:
                if "include-default" in flag:
                    cfg = rm_config_prefix(cfg)
                    break

            self._device_configs[cmd] = cfg
            return cfg
```
