### PR TITLE
Update copy.py

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -168,14 +168,14 @@ EXAMPLES = r'''
   copy:
     src: /mine/sudoers
     dest: /etc/sudoers
-    validate: /usr/sbin/visudo -cf %s
+    validate: /usr/sbin/visudo -csf %s
 
 - name: Copy a "sudoers" file on the remote machine for editing
   copy:
     src: /etc/sudoers
     dest: /etc/sudoers.edit
     remote_src: yes
-    validate: /usr/sbin/visudo -cf %s
+    validate: /usr/sbin/visudo -csf %s
 
 - name: Copy using inline content
   copy:


### PR DESCRIPTION
##### SUMMARY
Minor adjustment to the validate examples for sudoers file validation by adding additional "strict" flag. I was testing the use of this parameter and managed to lock myself out by adding a deliberate typo which, due to lack of "strict" flag caused validation to pass. I prefer the documentation has the strictest type of validation for more safety. Power users can reduce after reading man pages if they so desire.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
