### PR TITLE
fix a bug: https://github.com/ansible/ansible/issues/30567

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -555,14 +555,15 @@ class Connection(NetworkConnectionBase):
                 cleaned.append(line)
         return b'\n'.join(cleaned).strip()
 
-        def _find_prompt(self, response, previous_stderr_prompt_matched, previous_errored_response):
-        '''Searches the buffered response for a matching command prompt
-           return list for searching results: 
-           (stdout_prompt_matched, stderr_prompt_macthed, errored_response)
-           stdout_prompt_matched indicates if exepcted command ending prompt is found
-           stderr_prompt_macthed indicates the first error key word is found
-           errored_response stores error command output when stderr_prompt_macthed is True
-           and stores current response when stderr_prompt_macthed is False
+    def _find_prompt(self, response, previous_stderr_prompt_matched, previous_errored_response):
+        '''
+        Searches the buffered response for a matching command prompt
+        return list for searching results:
+        (stdout_prompt_matched, stderr_prompt_macthed, errored_response)
+        stdout_prompt_matched indicates if exepcted command ending prompt is found
+        stderr_prompt_macthed indicates the first error key word is found
+        errored_response stores error command output when stderr_prompt_macthed is True
+        and stores current response when stderr_prompt_macthed is False
         '''
         stderr_prompt_matched = False
         stdout_prompt_matched = False

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -383,6 +383,9 @@ class Connection(NetworkConnectionBase):
         handled = False
         command_prompt_matched = False
         matched_prompt_window = window_count = 0
+        stdout_prompt_matched = False
+        previous_stderr_prompt_matched = False
+        previous_errored_response = ""
 
         cache_socket_timeout = self._ssh_shell.gettimeout()
         command_timeout = self.get_option('persistent_command_timeout')
@@ -439,7 +442,10 @@ class Connection(NetworkConnectionBase):
                 if self._handle_prompt(window, prompts, answer, newline, prompt_retry_check, check_all):
                     raise AnsibleConnectionFailure("For matched prompt '%s', answer is not valid" % self._matched_cmd_prompt)
 
-            if self._find_prompt(window):
+            (stdout_prompt_matched, previous_stderr_prompt_matched, previous_errored_response) = self._find_prompt(window,
+                                                                                                                   previous_stderr_prompt_matched,
+                                                                                                                   previous_errored_response)
+            if stdout_prompt_matched:
                 self._last_response = recv.getvalue()
                 resp = self._strip(self._last_response)
                 self._command_response = self._sanitize(resp, command)
@@ -549,40 +555,47 @@ class Connection(NetworkConnectionBase):
                 cleaned.append(line)
         return b'\n'.join(cleaned).strip()
 
-    def _find_prompt(self, response):
+        def _find_prompt(self, response, previous_stderr_prompt_matched, previous_errored_response):
         '''Searches the buffered response for a matching command prompt
+           return list for searching results: 
+           (stdout_prompt_matched, stderr_prompt_macthed, errored_response)
+           stdout_prompt_matched indicates if exepcted command ending prompt is found
+           stderr_prompt_macthed indicates the first error key word is found
+           errored_response stores error command output when stderr_prompt_macthed is True
+           and stores current response when stderr_prompt_macthed is False
         '''
-        errored_response = None
-        is_error_message = False
-        for regex in self._terminal.terminal_stderr_re:
-            if regex.search(response):
-                is_error_message = True
+        stderr_prompt_matched = False
+        stdout_prompt_matched = False
 
-                # Check if error response ends with command prompt if not
-                # receive it buffered prompt
-                for regex in self._terminal.terminal_stdout_re:
-                    match = regex.search(response)
-                    if match:
-                        errored_response = response
-                        self._matched_pattern = regex.pattern
-                        self._matched_prompt = match.group()
-                        self._log_messages("matched error regex '%s' from response '%s'" % (self._matched_pattern, errored_response))
-                        break
+        if not previous_stderr_prompt_matched:
+            for regex in self._terminal.terminal_stderr_re:
+                if regex.search(response):
+                    is_error_message = True
+                    stderr_prompt_matched = True
+                    break
 
-        if not is_error_message:
-            for regex in self._terminal.terminal_stdout_re:
-                match = regex.search(response)
-                if match:
-                    self._matched_pattern = regex.pattern
-                    self._matched_prompt = match.group()
-                    self._log_messages("matched cli prompt '%s' with regex '%s' from response '%s'" % (self._matched_prompt, self._matched_pattern, response))
-                    if not errored_response:
-                        return True
+        for regex in self._terminal.terminal_stdout_re:
+            match = regex.search(response)
+            if match:
+                self._matched_pattern = regex.pattern
+                self._matched_prompt = match.group()
+                stdout_prompt_matched = True
+                break
 
-        if errored_response:
-            raise AnsibleConnectionFailure(errored_response)
-
-        return False
+        if stdout_prompt_matched:
+            if previous_stderr_prompt_matched:
+                raise AnsibleConnectionFailure(previous_errored_response)
+            elif stderr_prompt_matched:
+                raise AnsibleConnectionFailure(response)
+            else:
+                return True, False, ""
+        else:
+            if previous_stderr_prompt_matched:
+                return False, True, previous_errored_response
+            elif stderr_prompt_matched:
+                return False, True, response
+            else:
+                return False, False, ""
 
     def _validate_timeout_value(self, timeout, timer_name):
         if timeout < 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a command is executed,  Ansible usually  determines whether the result is  correct  or incorrect  based on the  last terminal prompt, but it actually ignores the another failed condition that if  error info is reported in the head or middle of all  terminal prompt.
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
https://github.com/ansible/ansible/issues/30567
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/network_cli.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

refer: https://github.com/ansible/ansible/issues/30567
executing aaa command, error appeared in head of terminal prompt, but the execution result of Ansible is correct. it is a bug obviously!

# aaa
---------------------------^
syntax error: expecting
  archive                - Archive configurations
  autowizard             - Automatically query for mandatory elements
  brm                    - Backup and Restore Management.
  cd                     - Change working directory
  change-password        - Change current login password

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

`result:`

127.0.0.1     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
