### PR TITLE
Remove description from junos_l3_interfaces

### DIFF
--- a/lib/ansible/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -28,7 +28,6 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
                                              {'address': {'type': 'str'}},
                                              'type': 'list'},
                                     'name': {'required': True, 'type': 'str'},
-                                    'description': {'type': 'str'},
                                     'unit': {'type': 'int', 'default': 0}
                                 },
                                 'type': 'list'},

--- a/lib/ansible/modules/network/junos/junos_l3_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interfaces.py
@@ -59,10 +59,6 @@ options:
           - Full name of interface, e.g. ge-0/0/1
         type: str
         required: True
-      description:
-        description:
-          - Description about the interface, like an alias
-        type: str
       unit:
         description:
           - Logical interface number. Value of C(unit) should be of type integer


### PR DESCRIPTION
##### SUMMARY
Removes interface description from junos_l3_interfaces module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
junos_l3_interface

##### ADDITIONAL INFORMATION
The interface description will be just handled by the junos_interfaces module,
leaving this one with l3 options only.