### PR TITLE
VMware: vmware_export_ovf fix timeout and export path issue

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
@@ -70,7 +70,7 @@ options:
     - Absolute path to place the exported files on the server running this task, must have write permission.
     - If folder not exist will create it, also create a folder under this path named with VM name.
     required: yes
-    type: str
+    type: path
   export_with_images:
     default: false
     description:
@@ -82,6 +82,7 @@ options:
     - If the vmdk file is too large to export in 10 minutes, specify the value larger than 10, the maximum value is 60.
     default: 10
     type: int
+    version_added: '2.9'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -165,7 +166,7 @@ class VMwareExportVmOvf(PyVmomi):
         self.download_timeout = 10
 
     def create_export_dir(self, vm_obj):
-        self.ovf_dir = os.path.join(os.path.expanduser(self.params['export_dir']), vm_obj.name)
+        self.ovf_dir = os.path.join(self.params['export_dir'], vm_obj.name)
         if not os.path.exists(self.ovf_dir):
             try:
                 os.makedirs(self.ovf_dir)
@@ -328,7 +329,7 @@ def main():
         moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', default='ha-datacenter'),
-        export_dir=dict(type='str', required=True),
+        export_dir=dict(type='path', required=True),
         export_with_images=dict(type='bool', default=False),
         download_timeout=dict(type='int', default=10),
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #59361
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_export_ovf
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
(1) first issue is when exporting large vmdk files, and the default timeout 10 minutes will be exceed, so add a new parameter to let user set the timeout value according to the specific scenario.
(2) the second one is if there is "~" in destination path, the behavior is not expected, fix this in the PR.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
