### PR TITLE
Allow the users to enable or disable the rescue mode on hcloud servers

### DIFF
--- a/changelogs/fragments/58746-hcloud_server_allow_rescue_mode.yml
+++ b/changelogs/fragments/58746-hcloud_server_allow_rescue_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Allow the users to enable or disable the rescue mode on Hetzner cloud servers

--- a/test/integration/targets/hcloud_server/tasks/main.yml
+++ b/test/integration/targets/hcloud_server/tasks/main.yml
@@ -279,7 +279,7 @@
       - ci@ansible.hetzner.cloud
     state: started
   register: main_server
-- name: verify create server
+- name: verify create server with ssh key
   assert:
     that:
       - main_server is changed
@@ -287,6 +287,115 @@
       - main_server.hcloud_server.server_type == "cx11"
       - main_server.hcloud_server.status == "running"
       - main_server.root_password != ""
+
+- name: absent server
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+  register: result
+- name: verify absent server
+  assert:
+    that:
+    - result is success
+
+- name: test create server with rescue_mode
+  hcloud_server:
+    name: "{{ hcloud_server_name}}"
+    server_type: cx11
+    image: "ubuntu-18.04"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    rescue_mode: "linux64"
+    state: started
+  register: main_server
+- name: verify create server with rescue_mode
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.hcloud_server.status == "running"
+      - main_server.root_password != ""
+      - main_server.hcloud_server.rescue_enabled is sameas true
+
+- name: absent server
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    state: absent
+  register: result
+- name: verify absent server
+  assert:
+    that:
+    - result is success
+
+- name: setup server
+  hcloud_server:
+    name: "{{ hcloud_server_name}}"
+    server_type: cx11
+    image: ubuntu-18.04
+    state: started
+  register: main_server
+- name: verify setup server
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.name == "{{ hcloud_server_name }}"
+      - main_server.hcloud_server.server_type == "cx11"
+      - main_server.hcloud_server.status == "running"
+      - main_server.root_password != ""
+
+- name: test activate rescue mode with check_mode
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    rescue_mode: "linux64"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
+  register: main_server
+  check_mode: true
+- name: verify activate rescue mode
+  assert:
+    that:
+      - main_server is changed
+
+- name: test activate rescue mode
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    rescue_mode: "linux64"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
+  register: main_server
+- name: verify activate rescue mode
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.rescue_enabled is sameas true
+
+- name: test disable rescue mode
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    ssh_keys:
+      - ci@ansible.hetzner.cloud
+    state: present
+  register: main_server
+- name: verify activate rescue mode
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.rescue_enabled is sameas false
+
+- name: test activate rescue mode without ssh keys
+  hcloud_server:
+    name: "{{ hcloud_server_name }}"
+    rescue_mode: "linux64"
+    state: present
+  register: main_server
+- name: verify activate rescue mode without ssh keys
+  assert:
+    that:
+      - main_server is changed
+      - main_server.hcloud_server.rescue_enabled is sameas true
 
 - name: cleanup
   hcloud_server:
@@ -335,7 +444,6 @@
       - main_server is changed
       - main_server.hcloud_server.labels.key == "other"
       - main_server.hcloud_server.labels.mylabel == "val123"
-
 
 - name: test update server with labels in other order
   hcloud_server:


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR allows users to en-/disable the rescue mode on Hetzner Cloud Servers. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #58746
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Module Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
hcloud_server
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
