### PR TITLE
ce_config: It is necessary to undo mmi-mode enable after running commands.

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -261,7 +261,12 @@ def _load_config(module, config):
                         print_msg = print_msg2
                     module.fail_json(msg=print_msg)
 
-    exec_command(module, 'return')
+    rc, out, err = exec_command(module, 'return')
+    if rc != 0:
+        module.fail_json(msg='unable to return', output=err)
+    rc, out, err = exec_command(module, 'undo mmi-mode enable')
+    if rc != 0:
+        module.fail_json(msg='unable to undo mmi-mode enable', output=err)
 
 
 def conversion_src(module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is necessary to undo mmi-mode enable after running commands.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
