### PR TITLE
add npipe support to docker_swarm_service

### DIFF
--- a/changelogs/fragments/60073-docker_swarm_service_add_npipe.yml
+++ b/changelogs/fragments/60073-docker_swarm_service_add_npipe.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- docker_swarm_service - Add I(npipe) mount support

--- a/changelogs/fragments/60073-docker_swarm_service_add_npipe.yml
+++ b/changelogs/fragments/60073-docker_swarm_service_add_npipe.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- docker_swarm_service - Add I(npipe) mount support
+- docker_swarm_service - Add ``npipe`` mount support.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -285,12 +285,14 @@ options:
       type:
         description:
           - The mount type.
+          - Note that C(npipe) is only supported by Docker for Windows.
         type: str
         default: bind
         choices:
           - bind
           - volume
           - tmpfs
+          - npipe
       readonly:
         description:
           - Whether the mount should be read-only.
@@ -2535,7 +2537,7 @@ def main():
             type=dict(
                 type='str',
                 default='bind',
-                choices=['bind', 'volume', 'tmpfs'],
+                choices=['bind', 'volume', 'tmpfs', 'npipe'],
             ),
             readonly=dict(type='bool'),
             labels=dict(type='dict'),

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -285,7 +285,7 @@ options:
       type:
         description:
           - The mount type.
-          - Note that C(npipe) is only supported by Docker for Windows.
+          - Note that C(npipe) is only supported by Docker for Windows. Also note that C(npipe) was added in Ansible 2.9.
         type: str
         default: bind
         choices:


### PR DESCRIPTION
##### SUMMARY
Per the following moby/docker merge that was released with docker 19.03.0:
https://github.com/moby/moby/pull/37400


> SWARM
> - Added support for maximum replicas per node. moby/moby#37940
> - Added support for GMSA CredentialSpecs from Swarmkit configs. moby/moby#38632
> - Added support for sysctl options in services. moby/moby#37701
> - Added support for filtering on node labels. moby/moby#37650
> - **_Windows: Support added for named pipe mounts in docker service create + stack yml. moby/moby#37400_**
> - VXLAN UDP Port configuration now supported. moby/moby#38102
> - Now using Service Placement Constraints in Enforcer. docker/swarmkit#2857
> - Increased max recv gRPC message size for nodes and secrets. docker/engine#256
> 

npipe support has been added for swarm service creation. This should just work as-is, but I did not get a chance to fully test.
This should be as simple as the commit looks, just needed to allow that mount type. It will of course only work with windows.
In my case, I have linux (centos) manager nodes with some windows worker nodes, and I create swarm services thru the linux managers. So, I needed a way to allow npipe creation for the windows nodes.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docker_swarm_service

##### ADDITIONAL INFO
Here's an example of where this can be applied:
```
- name: Ensure swarm service portainer agent is applied (windows)
  docker_swarm_service:
    name: portainer-agent-win
    image: "portainer/agent:windows-amd64-1.3.0"
    mode: global
    placement:
        constraints:
            - node.platform.os == windows
    restart_config:
      condition: any
      delay: 5s
      max_attempts: 5
      window: 30s
    networks:
        - portainer-agent
    env:
        AGENT_CLUSTER_ADDR: tasks.portainer-agent
    mounts:
        - source: '\\\\.\\pipe\\docker_engine'
          target: '\\\\.\pipe\\docker_engine'
          type: npipe
```
