### PR TITLE
[stable-2.8] Fix hcloud tests

### DIFF
--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_server/tasks/main.yml
+++ b/test/integration/targets/hcloud_server/tasks/main.yml
@@ -307,7 +307,7 @@
       - ci@ansible.hetzner.cloud
     labels:
       key: value
-      mylabel: 123
+      mylabel: "val123"
     state: started
   register: main_server
 - name: verify create server with labels
@@ -315,7 +315,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.labels.key == "value"
-      - main_server.hcloud_server.labels.mylabel == 123
+      - main_server.hcloud_server.labels.mylabel == "val123"
 
 - name: test update server with labels
   hcloud_server:
@@ -326,7 +326,7 @@
       - ci@ansible.hetzner.cloud
     labels:
       key: other
-      mylabel: 123
+      mylabel: "val123"
     state: started
   register: main_server
 - name: verify update server with labels
@@ -334,7 +334,7 @@
     that:
       - main_server is changed
       - main_server.hcloud_server.labels.key == "other"
-      - main_server.hcloud_server.labels.mylabel == 123
+      - main_server.hcloud_server.labels.mylabel == "val123"
 
 
 - name: test update server with labels in other order
@@ -345,7 +345,7 @@
     ssh_keys:
       - ci@ansible.hetzner.cloud
     labels:
-      mylabel: 123
+      mylabel: "val123"
       key: other
     state: started
   register: main_server

--- a/test/integration/targets/hcloud_ssh_key/aliases
+++ b/test/integration/targets/hcloud_ssh_key/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_ssh_key/tasks/main.yml
+++ b/test/integration/targets/hcloud_ssh_key/tasks/main.yml
@@ -91,7 +91,7 @@
     name: "changed-{{ hcloud_ssh_key_name }}"
     labels:
       key: value
-      test: 123
+      test: "val123"
   register: result
 - name: test update ssh key  with other labels
   assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #56409 for Ansible 2.8

(cherry picked from commit 6c1a255d98)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/hcloud_server/aliases`
`test/integration/targets/hcloud_ssh_key/aliases`
