### PR TITLE
Runas docs

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -693,6 +693,8 @@ Be aware of the following limitations with ``become`` on Windows:
   ``ansible_winrm_transport`` was either ``basic`` or ``credssp``. This
   restriction has been lifted since the 2.4 release of Ansible for all hosts
   except Windows Server 2008 (non R2 version).
+  
+* The Secondary Logon service ``seclogon`` must be running to use ``ansible_become_method: runas``
 
 .. seealso::
 

--- a/lib/ansible/plugins/become/runas.py
+++ b/lib/ansible/plugins/become/runas.py
@@ -55,6 +55,7 @@ DOCUMENTATION = """
     notes:
         - runas is really implemented in the powershell module handler and as such can only be used with winrm connections.
         - This plugin ignores the 'become_exe' setting as it uses an API and not an executable.
+        - The Secondary Logon service (seclogon) must be running to use runas
 """
 
 from ansible.plugins.become import BecomeBase


### PR DESCRIPTION
##### SUMMARY
Updating documentation to reflect the dependency of ``become_method: runas`` on the Windows Secondary Logon service ``seclogon`` .

In some environments this service is disabled due to a [STIG rule](https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_MS_Windows_10_V1R17_STIG-1.zip).  More readable duplicate [here](https://www.stigviewer.com/stig/windows_10/2017-12-01/finding/V-74719).

Having this requirement documented would have made troubleshooting easier, and the change much easier to justify.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
runas plugin
User Guide for become

##### ADDITIONAL INFORMATION
If the service is disabled/offline, you get a cryptic error:
`"internal error: failed to become user 'Administrator': Exception calling "CreateProcessAsUser" with "9" argument(s): "CreateProcessWithTokenW() failed (The service cannot be started, either because it is disabled or because it has no enabled devices associated with it, Win32ErrorCode 1058)""`
