### PR TITLE
Do not install requests[security] for MongoDB tests

### DIFF
--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -4,4 +4,3 @@ skip/osx
 skip/freebsd
 skip/rhel
 needs/root
-disabled

--- a/test/integration/targets/mongodb_shard/aliases
+++ b/test/integration/targets/mongodb_shard/aliases
@@ -4,4 +4,3 @@ skip/osx
 skip/freebsd
 skip/rhel
 needs/root
-disabled

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -46,5 +46,4 @@ redhat_packages_py3:
 
 pip_packages:
   - psutil
-  - requests[security]
   - pymongo

--- a/test/integration/targets/setup_mongodb/handlers/main.yml
+++ b/test/integration/targets/setup_mongodb/handlers/main.yml
@@ -17,3 +17,8 @@
   yum:
     name: "{{ redhat_packages_py36 }}"
     state: absent
+
+- name: remove mongodb pip packages
+  pip:
+    name: "{{ pip_packages }}"
+    state: absent

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -184,3 +184,4 @@
   pip:
     name: "{{ pip_packages }}"
     state: present
+  notify: remove mongodb pip packages


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add handler to cleanup packages installed via pip for MongoDB tests.

Fixes #59918
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/mongodb_replicaset/`
`test/integration/targets/mongodb_shard/`
`test/integration/targets/setup_mongodb/`