### PR TITLE
Backport/2.8/60075 ce_rollback: set mmi-mode enable to run commands and unset after running. (#60075)

### DIFF
--- a/changelogs/fragments/60084-ce_ce_rollback_set_mmi-mode-enable.yaml
+++ b/changelogs/fragments/60084-ce_ce_rollback_set_mmi-mode-enable.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ce_rollback - set mmi-mode enable to run commands and unset after running(https://github.com/ansible/ansible/pull/60075).

--- a/lib/ansible/modules/network/cloudengine/ce_rollback.py
+++ b/lib/ansible/modules/network/cloudengine/ce_rollback.py
@@ -170,6 +170,7 @@ class RollBack(object):
     def cli_add_command(self, command, undo=False):
         """add command to self.update_cmd and self.commands"""
         self.commands.append("return")
+        self.commands.append("mmi-mode enable")
 
         if self.action == "commit":
             self.commands.append("sys")
@@ -246,19 +247,15 @@ class RollBack(object):
         if self.action == "rollback":
             if self.commit_id:
                 cmd = "rollback configuration to commit-id %s" % self.commit_id
-                cmd = {"command": cmd, "prompt": r"[Y/N]", "answer": "Y"}
                 self.cli_add_command(cmd)
             if self.label:
                 cmd = "rollback configuration to label %s" % self.label
-                cmd = {"command": cmd, "prompt": r"[Y/N]", "answer": "Y"}
                 self.cli_add_command(cmd)
             if self.filename:
                 cmd = "rollback configuration to file %s" % self.filename
-                cmd = {"command": cmd, "prompt": r"[Y/N]", "answer": "Y"}
                 self.cli_add_command(cmd)
             if self.last:
                 cmd = "rollback configuration last %s" % self.last
-                cmd = {"command": cmd, "prompt": r"[Y/N]", "answer": "Y"}
                 self.cli_add_command(cmd)
         elif self.action == "set":
             if self.commit_id and self.label:
@@ -270,7 +267,6 @@ class RollBack(object):
                 self.cli_add_command(cmd)
             if self.oldest:
                 cmd = "clear configuration commit oldest %s" % self.oldest
-                cmd = {"command": cmd, "prompt": r"[Y/N]", "answer": "Y"}
                 self.cli_add_command(cmd)
         elif self.action == "commit":
             if self.label:
@@ -280,6 +276,8 @@ class RollBack(object):
         elif self.action == "display":
             self.rollback_info = self.get_rollback_dict()
         if self.commands:
+            self.commands.append('return')
+            self.commands.append('undo mmi-mode enable')
             self.cli_load_config(self.commands)
             self.changed = True
 


### PR DESCRIPTION
(cherry picked from commit 16e237e095f44729082aa78b81d3545dbe93cc70)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the title wrote, set mmi-mode enable to run commands and unset after running.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_rollback.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
