### PR TITLE
Bugfix 60043: turn off the default db warning where it doesn't make sense

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_membership.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_membership.py
@@ -271,7 +271,7 @@ def main():
     fail_on_role = module.params['fail_on_role']
     state = module.params['state']
 
-    conn_params = get_conn_params(module, module.params)
+    conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, autocommit=False)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_ping.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ping.py
@@ -129,7 +129,7 @@ def main():
         server_version=dict(),
     )
 
-    conn_params = get_conn_params(module, module.params)
+    conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, fail_on_conn=False)
 
     if db_connection is not None:

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -231,7 +231,18 @@ def main():
     if immediately_reserve and slot_type == 'logical':
         module.fail_json(msg="Module parameters immediately_reserve and slot_type=logical are mutually exclusive")
 
-    conn_params = get_conn_params(module, module.params)
+    # When slot_type is logical and parameter db is not passed,
+    # the default database will be used to create the slot and
+    # the user should know about this.
+    # When the slot type is physical,
+    # it doesn't matter which database will be used
+    # because physical slots are global objects.
+    if slot_type == 'logical':
+        warn_db_default = True
+    else:
+        warn_db_default = False
+
+    conn_params = get_conn_params(module, module.params, warn_db_default=warn_db_default)
     db_connection = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_tablespace.py
@@ -395,7 +395,7 @@ def main():
         module.fail_json(msg="state=absent is mutually exclusive location, "
                              "owner, rename_to, and set")
 
-    conn_params = get_conn_params(module, module.params)
+    conn_params = get_conn_params(module, module.params, warn_db_default=False)
     db_connection = connect_to_db(module, conn_params, autocommit=True)
     cursor = db_connection.cursor(cursor_factory=DictCursor)
 


### PR DESCRIPTION
##### SUMMARY
Bugfix of #60043: turn off the default db warning where it doesn't make sense

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```
postgresql_slot.py
postgresql_membership.py
postgresql_ping.py
postgresql_tablespace.py
```

