### PR TITLE
closely match glibc behavior for mntent escaping

### DIFF
--- a/changelogs/fragments/mount_escape_newline_tab.yaml
+++ b/changelogs/fragments/mount_escape_newline_tab.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- mount - properly escape paths with newlines or tabs for fstab

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -172,6 +172,8 @@ def write_fstab(module, lines, path):
 def _escape_fstab(v):
     """Escape invalid characters in fstab fields.
 
+    tab (011)
+    newline (012)
     space (040)
     ampersand (046)
     backslash (134)
@@ -183,6 +185,8 @@ def _escape_fstab(v):
         return(
             v.
             replace('\\', '\\134').
+            replace('\t', '\\011').
+            replace('\n', '\\012').
             replace(' ', '\\040').
             replace('&', '\\046'))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
mntent escaping did not match that in glibc
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
arguably ampersand shouldn't be included in this set; I don't know enough to know if it's safe to remove.  glibc does not translate that option.

For completeness, I've found the glibc code that does the decoding. It decodes exactly 4 characters: space, tab, newline, and 2 encodings of backslash: https://github.com/bminor/glibc/blob/98013846ecc3fd195c19248ec1447d1d9a37654a/misc/mntent_r.c#L67-L113

The encoding function is similarly here: https://github.com/bminor/glibc/blob/98013846ecc3fd195c19248ec1447d1d9a37654a/misc/mntent_r.c#L192-L246

surprisingly (to me), this exactly matches what the manpage describes: http://man7.org/linux/man-pages/man3/getmntent.3.html
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
