### PR TITLE
Suppress warning TRANSFORM_INVALID_GROUP_CHARS set to 'never'

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1420,14 +1420,15 @@ TRANSFORM_INVALID_GROUP_CHARS:
   default: 'never'
   description:
     - Make ansible transform invalid characters in group names supplied by inventory sources.
-    - If 'never' it will allow for the group name but warn about the issue.
-    - When 'always' it will replace any invalid charachters with '_' (underscore) and warn the user
+    - If 'never', it will allow for the group name but warn about the issue.
+    - When 'ignore', it does the same as 'never' sans the warningss.
+    - If 'always', it will replace any invalid charachters with '_' (underscore) and warn the user.
     - When 'silently', it does the same as 'always' sans the warnings.
   env: [{name: ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS}]
   ini:
   - {key: force_valid_group_names, section: defaults}
   type: string
-  choices: ['always', 'never', 'silently']
+  choices: ['never', 'ignore', 'always', 'silently']
   version_added: '2.8'
 INVALID_TASK_ATTRIBUTE_FAILED:
   name: Controls whether invalid attributes for a task result in errors instead of warnings

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -45,7 +45,6 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
             else:
                 if C.TRANSFORM_INVALID_GROUP_CHARS == 'never':
                     display.vvvv('Not replacing %s' % msg)
-                    warn = True
                     warn = 'Invalid characters were found in group names but not replaced, use -vvvv to see details'
 
                 # remove this message after 2.10 AND changing the default to 'always'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If users set `TRANSFORM_INVALID_GROUP_CHARS` to `never` explictly, then they know what they are doing, and the warning message become nuisance and should be suppressed as well as the deprecation warning.

Related: https://github.com/ansible/ansible-documentation/issues/89

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory/group