### PR TITLE
Fixes system module group group_exists method

### DIFF
--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -74,6 +74,7 @@ EXAMPLES = '''
     state: present
 '''
 
+import os
 import grp
 
 from ansible.module_utils._text import to_bytes
@@ -167,11 +168,37 @@ class Group(object):
         return self.execute_command(cmd)
 
     def group_exists(self):
-        try:
-            if grp.getgrnam(self.name):
-                return True
-        except KeyError:
-            return False
+        # The grp module does not distinguish between local and directory groups.
+        # It's output cannot be used to determine whether or not an account exists locally.
+        # It returns True if the account exists locally or in the directory, so instead
+        # look in the local GROUP file for an existing group.
+        if self.local:
+            if not os.path.exists(self.GROUPFILE):
+                self.module.fail_json(msg="'local: true' specified but unable to find local group file {0} to parse.".format(self.GROUPFILE))
+
+            exists = False
+            name_test = '{0}:'.format(self.name)
+            with open(self.GROUPFILE, 'rb') as f:
+                reversed_lines = f.readlines()[::-1]
+                for line in reversed_lines:
+                    if line.startswith(to_bytes(name_test)):
+                        exists = True
+                        break
+
+            if not exists:
+                self.module.warn(
+                    "'local: true' specified and group '{name}' was not found in {file}. "
+                    "The local group may already exist if the local account database exists "
+                    "somewhere other than {file}.".format(file=self.GROUPFILE, name=self.name))
+
+            return exists
+
+        else:
+            try:
+                if grp.getgrnam(self.name):
+                    return True
+            except KeyError:
+                return False
 
     def group_info(self):
         if not self.group_exists():


### PR DESCRIPTION
Like in the `user` module, when dealing with local only groups, python `grp` can't be relied on to determine whether or not a group exists locally.
Local group file must be parsed to check for group existence.

##### SUMMARY

When using the `group` module with parameter `local: true`, the existence of the group is checked using python `grp`. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
system `group` module.

##### ADDITIONAL INFORMATION

**Software versions**

* `ansible-playbook 2.9.0.dev0` (`devel` branch)
* `python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]`
* `Linux hostname 4.15.0-55-generic #60-Ubuntu SMP Tue Jul 2 18:22:20 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux`

**How to reproduce**

* in _NIS / LDAP / whatever_, create a group `mygroup`
* then create the following playbook:

```yaml
---
- hosts: all
  become: true
  gather_facts: false

  tasks:
    - name: Create local group to get rid of NIS/LDAP definition
      group:
        state: present
        name: 'mygroup'
        local: true
```

and run it. The output should be:

```
$ ansible-playbook -i myhost, group.yml -v
Using /home/user/ansible/ansible.cfg as config file

PLAY [all] ************************************************************************************************************************************************************************************

TASK [Create local group to get rid of NIS/LDAP definition] ***********************************************************************************************************************************
ok: [myhost] => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "gid": 9986, "name": "mygroup", "state": "present", "system": false}

PLAY RECAP ************************************************************************************************************************************************************************************
myhost                   : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

The current version of the `group` module considers that the group resource exists and does not try to create it locally.