### PR TITLE
Update default test container to use Python 3.8.0b3

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.8.2 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:1.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7


### PR DESCRIPTION
##### SUMMARY
Update default test container which has Python 3.8.0b3 and updates to various libraries.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/runner/completion/docker.txt`