### PR TITLE
na_ontap_user add cert as authentication_method 

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_user.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_user.py
@@ -58,7 +58,7 @@ options:
     - Password for telnet application.
     - Password, publickey, domain, nsswitch for ssh application.
     required: true
-    choices: ['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm']
+    choices: ['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm', 'cert']
   set_password:
     description:
     - Password for the user account.
@@ -134,9 +134,7 @@ class NetAppOntapUser(object):
                               choices=['console', 'http', 'ontapi', 'rsh', 'snmp',
                                        'sp', 'service-processor', 'ssh', 'telnet'],),
             authentication_method=dict(required=True, type='str',
-                                       choices=['community', 'password',
-                                                'publickey', 'domain',
-                                                'nsswitch', 'usm']),
+                                       choices=['community', 'password', 'publickey', 'domain', 'nsswitch', 'usm', 'cert']),
             set_password=dict(required=False, type='str', no_log=True),
             role_name=dict(required=False, type='str'),
             lock_user=dict(required=False, type='bool'),


### PR DESCRIPTION
##### SUMMARY
na_ontap_user was missing cert as a authentication method 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
- na_ontap_user.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
