### PR TITLE
no logging for service account contents

### DIFF
--- a/changelogs/fragments/gcp_fixes.yml
+++ b/changelogs/fragments/gcp_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add no_log to credentials field to avoid disclosures, also switch type to jsonarg to avoid having users responsible for transformations.

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -215,7 +215,7 @@ class GcpModule(AnsibleModule):
                     required=False,
                     fallback=(env_fallback, ['GCP_SERVICE_ACCOUNT_CONTENTS']),
                     no_log=True,
-                    type='jsonarg')
+                    type='jsonarg'),
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -214,7 +214,8 @@ class GcpModule(AnsibleModule):
                 service_account_contents=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SERVICE_ACCOUNT_CONTENTS']),
-                    type='str'),
+                    no_log=True,
+                    type='jsonarg')
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),

--- a/lib/ansible/plugins/doc_fragments/gcp.py
+++ b/lib/ansible/plugins/doc_fragments/gcp.py
@@ -20,10 +20,8 @@ options:
         choices: [ application, machineaccount, serviceaccount ]
     service_account_contents:
         description:
-            - A string representing the contents of a Service Account JSON file.
-            - This should not be passed in as a dictionary, but a string
-              that has the exact contents of a service account json file (valid JSON)
-        type: str
+            - The contents of a Service Account JSON file, either in a dictionary or as a JSON string that represents it.
+        type: jsonarg
     service_account_file:
         description:
             - The path of a Service Account JSON file if serviceaccount is selected as type.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Service Account Contents should not be logged.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
