### PR TITLE
aws-kms-update-policy - allow aws_kms to update existing key policy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -619,6 +619,14 @@ def update_key(connection, module, key):
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Failed to update key description")
 
+    if module.params.get('policy'):
+        policy = module.params['policy']
+        try:
+            connection.put_key_policy(KeyId=key['key_id'], PolicyName='default', Policy=policy, BypassPolicyLockoutSafetyCheck=True)
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to update key policy")
+
     desired_tags = module.params.get('tags')
     to_add, to_remove = compare_aws_tags(key['tags'], desired_tags,
                                          module.params.get('purge_tags'))


### PR DESCRIPTION
##### SUMMARY
The aws_kms.py module allows creation of kms key policy, but does NOT allow subsequent modification of policy.  This violates the idempotency principle of Ansible, and reduces the usefulness of this module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_kms.py, function update_key()

##### ADDITIONAL INFORMATION
Currently using Ansible and Tower 2.8.1.

ansible 2.8.1
  config file = None
  configured module search path = ['/Users/xxxxxxxxxx/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.7.3 (default, Mar 27 2019, 09:23:15) [Clang 10.0.1 (clang-1001.0.46.3)] 

