### PR TITLE
Fix documentation for collection build code example

### DIFF
--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -199,7 +199,7 @@ To build a collection, run ``ansible-galaxy collection build`` from inside the r
 
 .. code-block:: bash
 
-    collection_dir#> ansible-galaxy collection build my_namespace.my_collection
+    collection_dir#> ansible-galaxy collection build
 
 This creates
 a tarball of the built collection in the current directory which can be uploaded to Galaxy.::


### PR DESCRIPTION
##### SUMMARY
I was running through the Collections guide on the devel docs site, and when I ran the command it gave an error because you're not supposed to specify a path to the collection for building if you're in the collection's root directory (since that's the default).

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Collections

##### ADDITIONAL INFORMATION

Using the code currently in devel:

```
$ ansible-galaxy collection build geerlingguy.php
ERROR! The collection galaxy.yml path '!/collections/geerlingguy.php/geerlingguy.php/galaxy.yml' does not exist.
```

Using the new command as written in this PR:

```
$ ansible-galaxy collection build
Created collection for geerlingguy.php at ~/VMs/collections/geerlingguy.php/geerlingguy-php-0.9.0.tar.gz
```