### PR TITLE
no logging for service account contents

### DIFF
--- a/changelogs/fragments/gcp_fixes.yml
+++ b/changelogs/fragments/gcp_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add no_log to credentials field to avoid disclosures, also switch type to jsonarg to avoid having users responsible for transformations.

--- a/changelogs/fragments/gcp_fixes.yml
+++ b/changelogs/fragments/gcp_fixes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Add no_log to credentials field to avoid disclosures
+  - Add no_log to credentials field to avoid disclosures (CVE-2019-10217)

--- a/changelogs/fragments/gcp_fixes.yml
+++ b/changelogs/fragments/gcp_fixes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Add no_log to credentials field to avoid disclosures, also switch type to jsonarg to avoid having users responsible for transformations.
+  - Add no_log to credentials field to avoid disclosures

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -200,7 +200,8 @@ class GcpModule(AnsibleModule):
                 service_account_contents=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SERVICE_ACCOUNT_CONTENTS']),
-                    type='str'),
+                    no_log=True,
+                    type='jsonarg'),
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),

--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -200,8 +200,8 @@ class GcpModule(AnsibleModule):
                 service_account_contents=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SERVICE_ACCOUNT_CONTENTS']),
-                    no_log=True,
-                    type='jsonarg'),
+                    type='str',
+                    no_log=True),
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),

--- a/lib/ansible/plugins/doc_fragments/gcp.py
+++ b/lib/ansible/plugins/doc_fragments/gcp.py
@@ -20,10 +20,8 @@ options:
         choices: [ application, machineaccount, serviceaccount ]
     service_account_contents:
         description:
-            - A string representing the contents of a Service Account JSON file.
-            - This should not be passed in as a dictionary, but a string
-              that has the exact contents of a service account json file (valid JSON)
-        type: str
+            - The contents of a Service Account JSON file, either in a dictionary or as a JSON string that represents it.
+        type: jsonarg
     service_account_file:
         description:
             - The path of a Service Account JSON file if serviceaccount is selected as type.

--- a/lib/ansible/plugins/doc_fragments/gcp.py
+++ b/lib/ansible/plugins/doc_fragments/gcp.py
@@ -20,7 +20,9 @@ options:
         choices: [ application, machineaccount, serviceaccount ]
     service_account_contents:
         description:
-            - The contents of a Service Account JSON file, either in a dictionary or as a JSON string that represents it.
+            - A string representing the contents of a Service Account JSON file.
+            - This should not be passed in as a dictionary, but a string
+              that has the exact contents of a service account json file (valid JSON)
         type: str
     service_account_file:
         description:

--- a/lib/ansible/plugins/doc_fragments/gcp.py
+++ b/lib/ansible/plugins/doc_fragments/gcp.py
@@ -21,7 +21,7 @@ options:
     service_account_contents:
         description:
             - The contents of a Service Account JSON file, either in a dictionary or as a JSON string that represents it.
-        type: jsonarg
+        type: str
     service_account_file:
         description:
             - The path of a Service Account JSON file if serviceaccount is selected as type.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Turning off logging on service_accounts_contents on GCP modules. This is a backport of https://github.com/ansible/ansible/pull/60149

This PR *does not* change the type (like #60149) since that kind of breaking change doesn't seem right for a backport

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
