### PR TITLE
Undeprecated the skip argument for first_found

### DIFF
--- a/changelogs/fragments/59949-undeprecate-first-found-skip.yml
+++ b/changelogs/fragments/59949-undeprecate-first-found-skip.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- first_found - Un-deprecate ``skip``, as the alternative of ``errors`` does
+  not work with ``with_first_found`` and only use of ``lookup``
+  (https://github.com/ansible/ansible/issues/58942)

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -29,10 +29,6 @@ DOCUMENTATION = """
         type: boolean
         default: False
         description: Return an empty list if no file is found, instead of an error.
-        deprecated:
-            why: A generic that applies to all errors exists for all lookups.
-            version: "2.8"
-            alternative: The generic ``errors=ignore``
 """
 
 EXAMPLES = """
@@ -129,9 +125,6 @@ class LookupModule(LookupBase):
         if anydict:
             for term in terms:
                 if isinstance(term, dict):
-
-                    if 'skip' in term:
-                        self._display.deprecated('Use errors="ignore" instead of skip', version='2.12')
 
                     files = term.get('files', [])
                     paths = term.get('paths', [])


### PR DESCRIPTION
##### SUMMARY
Undeprecated the skip argument for first_found. Fixes #58942. Fixes #59949.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/first_found.py

##### ADDITIONAL INFORMATION
Un-deprecate ``skip``, as the alternative of ``errors`` does
not work with ``with_first_found`` and only use of ``lookup``
(https://github.com/ansible/ansible/issues/58942)
