### PR TITLE
[stable-2.8] Move plugin loader playbook dir additions back to Playbook instead of PlaybookCLI (#59557)

### DIFF
--- a/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
+++ b/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- plugin loader - Move plugin loader playbook dir additions back to ``Playbook`` instead of ``PlaybookCLI``
+  to solve sub directory playbook relative plugins to be located
+  (https://github.com/ansible/ansible/issues/59548)

--- a/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
+++ b/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
@@ -1,4 +1,4 @@
 bugfixes:
-- plugin loader - Move plugin loader playbook dir additions back to ``Playbook`` instead of ``PlaybookCLI``
-  to solve sub directory playbook relative plugins to be located
-  (https://github.com/ansible/ansible/issues/59548)
+- plugin loader - Restore adding plugin loader playbook dir to ``Playbook`` in
+  addition to ``PlaybookCLI`` to solve sub directory playbook relative plugins
+  to be located (https://github.com/ansible/ansible/issues/59548)

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -26,6 +26,7 @@ from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.play import Play
 from ansible.playbook.playbook_include import PlaybookInclude
+from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.utils.display import Display
 
 display = Display()
@@ -60,6 +61,8 @@ class Playbook:
         # set the loaders basedir
         cur_basedir = self._loader.get_basedir()
         self._loader.set_basedir(self._basedir)
+
+        add_all_plugin_dirs(self._basedir)
 
         self._file_name = file_name
 

--- a/test/integration/targets/include_import/playbook/sub_playbook/library/helloworld.py
+++ b/test/integration/targets/include_import/playbook/sub_playbook/library/helloworld.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(argument_spec={})
+
+    module.exit_json(msg='Hello, World!')
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/include_import/playbook/sub_playbook/sub_playbook.yml
+++ b/test/integration/targets/include_import/playbook/sub_playbook/sub_playbook.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - helloworld:

--- a/test/integration/targets/include_import/playbook/test_import_playbook.yml
+++ b/test/integration/targets/include_import/playbook/test_import_playbook.yml
@@ -18,3 +18,6 @@
 - import_playbook: playbook_needing_vars.yml
   vars:
     import_playbook_role_name: import_playbook_role
+
+# https://github.com/ansible/ansible/issues/59548
+- import_playbook: sub_playbook/sub_playbook.yml


### PR DESCRIPTION
* Move plugin loader playbook dir additions back to Playbook instead of PlaybookCLI. Fixes #59548

* Restore cli additions
(cherry picked from commit 923e218)


Co-authored-by: Matt Martz <matt@sivel.net>