### PR TITLE
VMware: Add writing new tests subsection to vmware_guidelines

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -188,7 +188,7 @@ If you are writing a new collection of integration tests, there are a few VMware
 the standard Ansible :ref:`integration testing<testing_integration>` process.
 
 The test-suite uses a set of common, pre-defined vars located in the :file:`test/integration/targets/prepare_vmware_tests/` role.
-The resources defined there are automatically created by importing that role are the start of your test:
+The resources defined there are automatically created by importing that role at the start of your test:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -181,6 +181,24 @@ Depending upon the functionality provided by ESXi or vCenter, some modules can s
 Functional tests
 ----------------
 
+Writing new tests
+~~~~~~~~~~~~~~~~~
+
+If you are writing a new collection of integration tests, there are a few VMware-specific things to note beyond
+the standard Ansible :ref:`integration testing<testing_integration>` process.
+
+The test-suite uses a set of common, pre-defined vars located in the :file:`test/integration/targets/prepare_vmware_tests/` role.
+The resources defined there are automatically created by importing that role are the start of your test:
+
+.. code-block:: yaml
+
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_datacenter: true
+
+This will give you a ready to use cluster, datacenter, datastores, folder, switch, dvswitch, ESXi hosts, and VMs.
+
 No need to create too much resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Specifically address use of the prepare_vmware_tests role
Point to common vars for use by test writers

##### SUMMARY
Add info about common vars and prepare role to aid test writers

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst

