### PR TITLE
Fix documentation to reflect CLI usage for collections-path

### DIFF
--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -271,20 +271,20 @@ will be the version displayed everywhere in Galaxy; however, users will still be
 Installing collections
 ----------------------
 
-You can use the ``ansible-galaxy collection install`` command to install a collection on your system. The collection by default is installed at ``/path/ansible_collections/my_namespace/my_collection``. You can optionally add the ``-p`` option to specify an alternate location.
+You can use the ``ansible-galaxy collection install`` command to install a collection on your system. You must specify an installation location using the ``-p`` option.
 
 To install a collection hosted in Galaxy:
 
 .. code-block:: bash
 
-   ansible-galaxy collection install my_namespace.my_collection -p /path
+   ansible-galaxy collection install my_namespace.my_collection -p /collections
 
 
 You can also directly use the tarball from your build:
 
 .. code-block:: bash
 
-   ansible-galaxy collection install my_namespace-my_collection-1.0.0.tar.gz -p ./collections/ansible_collections
+   ansible-galaxy collection install my_namespace-my_collection-1.0.0.tar.gz -p ./collections
 
 .. note::
     The install command automatically appends the path ``ansible_collections`` to the one specified  with the ``-p`` option unless the


### PR DESCRIPTION
##### SUMMARY

The documentation suggests that if you leave off the `-p` option, collections are installed in some sort of global path (like `/path/collections...`), but if I don't explicitly add the `-p` option every time I run `ansible-galaxy collection install` then I get the following error:

```
$ ansible-galaxy collection install geerlingguy.php_roles
usage: ansible-galaxy collection install [-h] [-f] [-s API_SERVER] [-c] [-v]
                                         -p COLLECTIONS_PATH [-i]
                                         [-r REQUIREMENTS]
                                         [-n | --force-with-deps]
                                         [collection_name [collection_name ...]]
ansible-galaxy collection install: error: argument -p/--collections-path is required
```

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ansible-galaxy collection install

##### ADDITIONAL INFORMATION

N/A