### PR TITLE
Fix typo and uses more common role syntax in usage examples

### DIFF
--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -384,14 +384,14 @@ This works for roles or any type of plugin distributed within the collection:
 
      - hosts: all
        tasks:
+         - import_role:
+	         name: my_namespace.my_collection.role1
+
          - my_namespace.mycollection.mymodule:
              option1: value
 
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
-
-       roles:
-         - my_namespace.my_collection.role1
 
 
 To avoid a lot of typing, you can use the ``collections`` keyword added in Ansible 2.8:
@@ -403,14 +403,14 @@ To avoid a lot of typing, you can use the ``collections`` keyword added in Ansib
        collections:
         - my_namespace.my_collection
        tasks:
+         - import_role:
+             name: role1
+
          - mymodule:
              option1: value
 
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
-
-       roles:
-         - role1
 
 This keyword creates a 'search path' for non namespaced plugin references. It does not import roles or anything else.
 Notice that you still need the FQCN for non-action or module plugins.

--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -385,7 +385,7 @@ This works for roles or any type of plugin distributed within the collection:
      - hosts: all
        tasks:
          - import_role:
-	         name: my_namespace.my_collection.role1
+             name: my_namespace.my_collection.role1
 
          - my_namespace.mycollection.mymodule:
              option1: value

--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -384,16 +384,17 @@ This works for roles or any type of plugin distributed within the collection:
 
      - hosts: all
        tasks:
-         - include_role:
-             name : my_namespace.my_collection.role1
          - my_namespace.mycollection.mymodule:
              option1: value
 
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
+       roles:
+         - my_namespace.my_collection.role1
 
-To avoid a lot of typing, you can use the ``collections`` keyword added in Ansbile 2.8:
+
+To avoid a lot of typing, you can use the ``collections`` keyword added in Ansible 2.8:
 
 
 .. code-block:: yaml
@@ -402,13 +403,14 @@ To avoid a lot of typing, you can use the ``collections`` keyword added in Ansbi
        collections:
         - my_namespace.my_collection
        tasks:
-         - include_role:
-             name: role1
          - mymodule:
              option1: value
 
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
+
+       roles:
+         - role1
 
 This keyword creates a 'search path' for non namespaced plugin references. It does not import roles or anything else.
 Notice that you still need the FQCN for non-action or module plugins.


### PR DESCRIPTION
##### SUMMARY

Fixed one typo (spelling of 'Ansible'), and also used more idiomatic example of including a role from a collection using the playbook `roles` section (`include_role` usage seems a lot less prevalent than using top-level `roles`, but I would be fine if this is an incorrect understanding).

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME

Collections

##### ADDITIONAL INFORMATION

N/A