### PR TITLE
Avoid pylint error on Python 3.7.

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/main.py
@@ -1742,8 +1742,8 @@ def main():
             if ModuleValidator.is_blacklisted(path):
                 continue
             with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
-                                 base_branch=args.base_branch, git_cache=git_cache, reporter=reporter) as mv:
-                mv.validate()
+                                 base_branch=args.base_branch, git_cache=git_cache, reporter=reporter) as mv1:
+                mv1.validate()
                 check_dirs.add(os.path.dirname(path))
 
         for root, dirs, files in os.walk(module):
@@ -1765,8 +1765,8 @@ def main():
                 if ModuleValidator.is_blacklisted(path):
                     continue
                 with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
-                                     base_branch=args.base_branch, git_cache=git_cache, reporter=reporter) as mv:
-                    mv.validate()
+                                     base_branch=args.base_branch, git_cache=git_cache, reporter=reporter) as mv2:
+                    mv2.validate()
 
     for path in sorted(check_dirs):
         pv = PythonPackageValidator(path, reporter=reporter)


### PR DESCRIPTION
##### SUMMARY

Avoid pylint error on Python 3.7.

Without this, running pylint on the module validator on Python 3.7 results in an error:

```
ansible-test sanity --test pylint test/lib/ansible_test/_data/sanity/validate-modules/ -v --python 3.7
```

```
internal error with sending report for module ['test/lib/ansible_test/_data/sanity/validate-modules/main.py']
generator raised StopIteration
```

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules
