### PR TITLE
win_user - use proper error code in validate error message

### DIFF
--- a/changelogs/fragments/win_user-logon-err.yaml
+++ b/changelogs/fragments/win_user-logon-err.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_user - Get proper error code when failing to validate the user's credentials

--- a/lib/ansible/modules/windows/win_user.ps1
+++ b/lib/ansible/modules/windows/win_user.ps1
@@ -73,14 +73,19 @@ namespace Ansible
     $env:TMP = $original_tmp
 
     $handle = [IntPtr]::Zero
-    $logon_res = [Ansible.WinUserPInvoke]::LogonUser($Username, $null, $Password,
-        $LOGON32_LOGON_NETWORK, $LOGON32_PROVIDER_DEFAULT, [Ref]$handle)
+    $logon_res = [Ansible.WinUserPInvoke]::LogonUser(
+        $Username,
+        $null,
+        $Password,
+        $LOGON32_LOGON_NETWORK,
+        $LOGON32_PROVIDER_DEFAULT,
+        [Ref]$handle
+    ); $err_code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
 
     if ($logon_res) {
         $valid_credentials = $true
         [Ansible.WinUserPInvoke]::CloseHandle($handle) > $null
     } else {
-        $err_code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
         # following errors indicate the creds are correct but the user was
         # unable to log on for other reasons, which we don't care about
         $success_codes = @(


### PR DESCRIPTION
##### SUMMARY
When we call `[System.Runtime.InteropServices.Marshal]::GetLastWin32Error()` the value has already changed as we've executed other PowerShell code. This makes sure we get the error code as soon as the call to `LogonUser` is done even before we check whether it succeeded or not.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_user