### PR TITLE
vmware_datastore_facts: don't modify dict in iter

### DIFF
--- a/changelogs/fragments/vmware_datastore_facts_dict_iter.yml
+++ b/changelogs/fragments/vmware_datastore_facts_dict_iter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - With Python3, we cannot iterate on a dict and modify it at the same time (https://github.com/ansible/ansible/issues/54869).

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -214,10 +214,12 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
+                tmpobjs = objects.copy()
                 for k, v in objects.items():
                     parent_dc = get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        objects.pop(k, None)
+                        tmpobjs.pop(k, None)
+                objects = tmpobjs
             else:
                 # everything else should be a list
                 objects = [x for x in objects if get_parent_datacenter(x).name == self.dc_name]


### PR DESCRIPTION
##### SUMMARY
With Python3, we cannot iterate on a dict and modify it at the same time.

Fixes #54869

(cherry picked from commit 339a0f4a8c4291e71c5b86158dc47ba4f3a7cf51)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_datastore_facts_dict_iter.yml
lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py