### PR TITLE
Add support for multiple manager attributes configuration

### DIFF
--- a/changelogs/fragments/60201-idrac-redfish-config-attributes-support.yml
+++ b/changelogs/fragments/60201-idrac-redfish-config-attributes-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - idrac_redfish_config - Support for multiple manager attributes configuration

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -230,7 +230,7 @@ class IdracRedfishUtils(RedfishUtils):
         if response['ret'] is False:
             return response
         return {'ret': True, 'changed': True,
-                'msg': "%s: Modified Manager attributes %s" % (comman, attrs_to_patch)}
+                'msg': "%s: Modified Manager attributes %s" % (command, attrs_to_patch)}
 
 
 CATEGORY_COMMANDS_ALL = {

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: idrac_redfish_config
-version_added: '2.8'
+version_added: '2.10'
 short_description: Manages servers through iDRAC using Dell Redfish APIs
 description:
   - For use with Dell iDRAC operations that require Redfish OEM extensions

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -132,6 +132,7 @@ EXAMPLES = '''
     idrac_redfish_config:
       category: Manager
       command: SetLifecycleControllerAttributes
+      resource_id: iDRAC.Embedded.1
       manager_attributes:
         LCAttributes.1.CollectSystemInventoryOnRestart: "Enabled"
       baseuri: "{{ baseuri }}"
@@ -142,6 +143,7 @@ EXAMPLES = '''
     idrac_redfish_config:
       category: Manager
       command: SetSystemAttributes
+      resource_id: iDRAC.Embedded.1
       manager_attributes:
         ServerPwr.1.PSRedPolicy: "A/B Grid Redundant"
       baseuri: "{{ baseuri }}"
@@ -295,7 +297,7 @@ def main():
     try:
         # check_mutually_exclusive accepts a single list or list of lists that
         # are groups of terms that should be mutually exclusive with one another
-        # and checks that against a dictionary 
+        # and checks that against a dictionary
         check_mutually_exclusive(CATEGORY_COMMANDS_MUTUALLY_EXCLUSIVE[category],
                                  dict.fromkeys(command_list, True))
 

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -229,7 +229,8 @@ class IdracRedfishUtils(RedfishUtils):
         response = self.patch_request(self.root_uri + manager_uri + "/" + key, payload)
         if response['ret'] is False:
             return response
-        return {'ret': True, 'changed': True, 'msg': "Modified Manager attributes %s" % attrs_to_patch}
+        return {'ret': True, 'changed': True,
+                'msg': "%s: Modified Manager attributes %s" % (comman, attrs_to_patch)}
 
 
 CATEGORY_COMMANDS_ALL = {
@@ -322,8 +323,7 @@ def main():
 
     # Return data back or fail with proper message
     if result['ret'] is True:
-        module.exit_json(changed=result['changed'],
-                         msg=to_native(result['msg']))
+        module.exit_json(changed=result['changed'], msg=to_native(result['msg']))
     else:
         module.fail_json(msg=to_native(result['msg']))
 

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -53,16 +53,12 @@ options:
     required: false
     description:
       - (deprecated) name of iDRAC attribute to update
-    default: None
     type: str
-    version_added: "2.8"
   manager_attribute_value:
     required: false
     description:
       - (deprecated) value of iDRAC attribute to update
-    default: None
     type: str
-    version_added: "2.8"
   manager_attributes:
     required: false
     description:
@@ -184,10 +180,10 @@ class IdracRedfishUtils(RedfishUtils):
 
         key = "Attributes"
         command_manager_attributes_uri_map = {
-                "SetManagerAttributes": self.manager_uri,
-                "SetLifecycleControllerAttributes": "/redfish/v1/Managers/LifecycleController.Embedded.1",
-                "SetSystemAttributes": "/redfish/v1/Managers/System.Embedded.1"
-                }
+            "SetManagerAttributes": self.manager_uri,
+            "SetLifecycleControllerAttributes": "/redfish/v1/Managers/LifecycleController.Embedded.1",
+            "SetSystemAttributes": "/redfish/v1/Managers/System.Embedded.1"
+        }
         manager_uri = command_manager_attributes_uri_map.get(command, self.manager_uri)
 
         attributes = self.module.params['manager_attributes']
@@ -243,9 +239,10 @@ CATEGORY_COMMANDS_ALL = {
 
 # list of mutually exclusive commands for a category
 CATEGORY_COMMANDS_MUTUALLY_EXCLUSIVE = {
-    "Manager": [ ["SetManagerAttributes", "SetLifecycleControllerAttributes",
-                "SetSystemAttributes"] ]
+    "Manager": [["SetManagerAttributes", "SetLifecycleControllerAttributes",
+                 "SetSystemAttributes"]]
 }
+
 
 def main():
     result = {}


### PR DESCRIPTION
##### SUMMARY
Added support for configuring multiple iDRAC manager attributes in a single task.
The current module design accepts only a single manager attribute name and value pair. So you will have to add as many number of tasks in your playbook as the number of manager attributes that you want to configure. This also results in additional REST API calls that can be avoided by passing in  all the attribute names and value pairs in a single REST API call to iDRAC. This PR adds support for passing in a dictionary of manager attributes name and value pairs, allowing multiple attributes configuration in a single task.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
idrac_redfish_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
***Before the change***
```
  tasks:
  - name: Set manager attributes
    idrac_redfish_config:
      baseuri: "{{ inventory_hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      category: "Manager"
      command: "SetManagerAttributes"
      manager_attribute_name: "SysLog.1.SysLogEnable"
      manager_attribute_value: "Enabled"

  - name: Set manager attributes
    idrac_redfish_config:
      baseuri: "{{ inventory_hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      category: "Manager"
      command: "SetManagerAttributes"
      manager_attribute_name: "SysLog.1.Server1"
      manager_attribute_value: "192.168.1.1"

  - name: Set manager attributes
    idrac_redfish_config:
      baseuri: "{{ inventory_hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      category: "Manager"
      command: "SetManagerAttributes"
      manager_attribute_name: "SysLog.1.Server2"
      manager_attribute_value: "192.168.1.2"

$ ansible-playbook -vv manager_attr.yml -i ../hosts 
PLAYBOOK: manager_attr.yml ************************************************
1 plays in manager_attr.yml

PLAY [poweredge] ***************************************************************
META: ran handlers

TASK [Set manager attributes] **************************************************
task path: /home/anupam/workspace/virtualenvs/ansible_redfish/playbooks/manager_attr.yml:18
ok: [192.168.10.11] => {"changed": false, "msg": "Manager attribute already set"}

TASK [Set manager attributes] **************************************************
task path: /home/anupam/workspace/virtualenvs/ansible_redfish/playbooks/manager_attr.yml:30
changed: [192.168.10.11] => {"changed": true, "msg": "Modified Manager attribute SysLog.1.Server1"}

TASK [Set manager attributes] **************************************************
task path: /home/anupam/workspace/virtualenvs/ansible_redfish/playbooks/manager_attr.yml:42
changed: [192.168.10.11] => {"changed": true, "msg": "Modified Manager attribute SysLog.1.Server2"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
192.168.10.11             : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```

***After the change***
```paste below
  tasks:
  - name: Set manager attributes
    idrac_redfish_config:
      baseuri: "{{ inventory_hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      category: "Manager"
      command: "SetManagerAttributes"
      manager_attributes:
        SysLog.1.SysLogEnable: "Enabled"
        SysLog.1.Server1: "192.168.1.1"
        SysLog.1.Server2: "192.168.1.2"


$ ansible-playbook -vv manager_attr.yml -i ../hosts 

PLAYBOOK: manager_attr.yml *****************************************************
1 plays in manager_attr.yml

PLAY [poweredge] ***************************************************************
META: ran handlers

TASK [Set manager attributes] **************************************************
task path: /home/anupam/workspace/virtualenvs/ansible_redfish/playbooks/manager_attr.yml:18
changed: [192.168.10.11] => {"changed": true, "msg": "Modified Manager attributes {'SysLog.1.Server2': '192.168.1.2', 'SysLog.1.Server1': '192.168.1.1'}"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
192.168.10.11             : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
