### PR TITLE
fix misleading example in docker_image doc

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -361,6 +361,8 @@ EXAMPLES = '''
   docker_image:
     name: myimage:7.1.2
     repository: myimage:latest
+    # As 'latest' usually already is present, we need to enable overwriting of existing tags:
+    force_tag: yes
     source: local
 
 - name: Remove image


### PR DESCRIPTION
##### SUMMARY
Using docker_image to tag an image as "latest" only updates an existing
tag when used with "force_tag: yes" option. As "latest" is present in
most cases, the option is added to the example to prevent unexpected
behaviour.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_image