### PR TITLE
Improve performane of UnsafeProxy __new__

### DIFF
--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -75,11 +75,17 @@ class AnsibleUnsafeBytes(binary_type, AnsibleUnsafe):
 
 class UnsafeProxy(object):
     def __new__(cls, obj, *args, **kwargs):
+        if isinstance(obj, AnsibleUnsafe):
+            # Already marked unsafe
+            return obj
+
         # In our usage we should only receive unicode strings.
         # This conditional and conversion exists to sanity check the values
         # we're given but we may want to take it out for testing and sanitize
         # our input instead.
-        if isinstance(obj, string_types) and not isinstance(obj, AnsibleUnsafeBytes):
+        # Note that this does the wrong thing if we're *intentionall* passing a byte string to this
+        # function.
+        if isinstance(obj, string_types):
             obj = AnsibleUnsafeText(to_text(obj, errors='surrogate_or_strict'))
         return obj
 


### PR DESCRIPTION
##### SUMMARY
This adds an early return to the __new__ method of the UnsafeProxy object
which avoids creating the unsafe object if the incoming object is already
unsafe.

Proposed perf fix by @abadger 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
unsafe proxy

##### ADDITIONAL INFORMATION
None