### PR TITLE
VyOS: Add eth0 in prepare_vyos_tests

### DIFF
--- a/test/integration/targets/prepare_vyos_tests/tasks/main.yaml
+++ b/test/integration/targets/prepare_vyos_tests/tasks/main.yaml
@@ -4,6 +4,7 @@
     config: "{{ lines }}"
   vars:
     lines: |
+      set interfaces ethernet eth0
       set interfaces ethernet eth1
       set interfaces ethernet eth2
       set interfaces loopback lo


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Add eth0 in running-config to avoid race conditions and have more stable before/after assertions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
prepare_vyos_tests
