### PR TITLE
[backport][2.8] Don't truncate cidr_ipv6 addresses in ec2_group.py (#59106)

### DIFF
--- a/changelogs/fragments/59106-fix-ipv6-truncating-in-ec2_group.yml
+++ b/changelogs/fragments/59106-fix-ipv6-truncating-in-ec2_group.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ec2_group - Don't truncate the host bits off of IPv6 CIDRs.
+    CIDRs will be passed thru to EC2 as-is provided they are valid IPv6
+    representations.  (https://github.com/ansible/ansible/issues/53297)

--- a/test/units/modules/cloud/amazon/test_ec2_group.py
+++ b/test/units/modules/cloud/amazon/test_ec2_group.py
@@ -73,8 +73,8 @@ def test_validate_ip():
     ips = [
         ('1.1.1.1/24', '1.1.1.0/24'),
         ('192.168.56.101/16', '192.168.0.0/16'),
-        # 64 bits make 8 octets, or 4 hextets
-        ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/64', '1203:8fe0:fe80:b897::/64'),
+        # Don't modify IPv6 CIDRs, AWS supports /128 and device ranges
+        ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128', '1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128'),
     ]
 
     for ip, net in ips:


### PR DESCRIPTION
Backport Don't truncate cidr_ipv6 addresses in ec2_group.py (#59106)
cherry-picked from 4308b87

(cherry picked from commit 4308b87d72ad2666c15919949cc66b6eca636cf3)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py