### PR TITLE
Change dummy package name in yum/dnf integration test to not collide with an actual package

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -299,10 +299,10 @@
     state: present
   register: dnf_result
 
-- name: check foo with rpm
-  command: rpm -q foo
+- name: check dinginessentail with rpm
+  command: rpm -q dinginessentail
   failed_when: False
-  register: foo_result
+  register: dinginessentail_result
 
 - name: verify installation of the group
   assert:
@@ -310,7 +310,7 @@
     - not dnf_result is failed
     - dnf_result is changed
     - "'results' in dnf_result"
-    - foo_result.rc == 0
+    - dinginessentail_result.rc == 0
 
 - name: install the group again
   dnf:
@@ -324,30 +324,30 @@
     - not dnf_result is changed
     - "'msg' in dnf_result"
 
-- name: verify that bar is not installed
+- name: verify that landsidescalping is not installed
   dnf:
-    name: bar
+    name: landsidescalping
     state: absent
 
 - name: install the group again but also with a package that is not yet installed
   dnf:
     name:
       - "@Custom Group"
-      - bar
+      - landsidescalping
     state: present
   register: dnf_result
 
-- name: check bar with rpm
-  command: rpm -q bar
+- name: check landsidescalping with rpm
+  command: rpm -q landsidescalping
   failed_when: False
-  register: bar_result
+  register: landsidescalping_result
 
-- name: verify bar is installed
+- name: verify landsidescalping is installed
   assert:
     that:
     - dnf_result is changed
     - "'results' in dnf_result"
-    - bar_result.rc == 0
+    - landsidescalping_result.rc == 0
 
 - name: try to install the group again, with --check to check 'changed'
   dnf:
@@ -362,9 +362,9 @@
     - not dnf_result is changed
     - "'msg' in dnf_result"
 
-- name: remove bar after test
+- name: remove landsidescalping after test
   dnf:
-    name: bar
+    name: landsidescalping
     state: absent
 
 # cleanup until https://github.com/ansible/ansible/issues/27377 is resolved
@@ -455,9 +455,9 @@
     state: latest
   register: dnf_result
 
-- name: check bar with rpm
-  command: rpm -q bar
-  register: bar_result
+- name: check landsidescalping with rpm
+  command: rpm -q landsidescalping
+  register: landsidescalping_result
 
 - name: verify installation of the environment
   assert:
@@ -465,12 +465,12 @@
     - not dnf_result is failed
     - dnf_result is changed
     - "'results' in dnf_result"
-    - bar_result.rc == 0
+    - landsidescalping_result.rc == 0
 
 # Fedora 28 (DNF 2) does not support this, just remove the package itself
-- name: remove bar package on Fedora 28
+- name: remove landsidescalping package on Fedora 28
   dnf:
-    name: bar
+    name: landsidescalping
     state: absent
   when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int <= 28
 

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -1,203 +1,203 @@
 - block:
-    - name: Install foo-1.0-1
+    - name: Install dinginessentail-1.0-1
       dnf:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
     # ============================================================================
-    - name: Install foo-1.0-1 again
+    - name: Install dinginessentail-1.0-1 again
       dnf:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'msg' in dnf_result"
     # ============================================================================
-    - name: Install foo-1:1.0-2
+    - name: Install dinginessentail-1:1.0-2
       dnf:
-        name: "foo-1:1.0-2.{{ ansible_architecture }}"
+        name: "dinginessentail-1:1.0-2.{{ ansible_architecture }}"
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
     # ============================================================================
-    - name: Update to the latest foo
+    - name: Update to the latest dinginessentail
       dnf:
-        name: foo
+        name: dinginessentail
         state: latest
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1-1')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
     # ============================================================================
-    - name: Install foo-1.0-1 from a file (downgrade)
+    - name: Install dinginessentail-1.0-1 from a file (downgrade)
       dnf:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
         allow_downgrade: True
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
 
-    - name: Remove foo
+    - name: Remove dinginessentail
       dnf:
-        name: foo
+        name: dinginessentail
         state: absent
     # ============================================================================
-    - name: Install foo-1.0-1 from a file
+    - name: Install dinginessentail-1.0-1 from a file
       dnf:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
     # ============================================================================
-    - name: Install foo-1.0-1 from a file again
+    - name: Install dinginessentail-1.0-1 from a file again
       dnf:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
     # ============================================================================
-    - name: Install foo-1.0-2 from a file
+    - name: Install dinginessentail-1.0-2 from a file
       dnf:
-        name: "{{ repodir }}/foo-1.0-2.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-2.{{ ansible_architecture }}.rpm"
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify dnf module outputs
       assert:
         that:
             - "'results' in dnf_result"
     # ============================================================================
-    - name: Install foo-1.0-2 from a file again
+    - name: Install dinginessentail-1.0-2 from a file again
       dnf:
-        name: "{{ repodir }}/foo-1.0-2.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-2.{{ ansible_architecture }}.rpm"
         state: present
       register: dnf_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not dnf_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
     # ============================================================================
-    - name: Remove foo
+    - name: Remove dinginessentail
       dnf:
-        name: foo
+        name: dinginessentail
         state: absent
 
     - name: Try to install incompatible arch
       dnf:
-        name: "{{ repodir_ppc64 }}/foo-1.0-1.ppc64.rpm"
+        name: "{{ repodir_ppc64 }}/dinginessentail-1.0-1.ppc64.rpm"
         state: present
       register: dnf_result
       ignore_errors: yes
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
       ignore_errors: yes
 
@@ -209,18 +209,18 @@
             - "dnf_result is failed"
     # ============================================================================
 
-    # Should install foo-with-weak-dep and foo-weak-dep
+    # Should install dinginessentail-with-weak-dep and dinginessentail-weak-dep
     - name: Install package with defaults
       dnf:
-        name: foo-with-weak-dep
+        name: dinginessentail-with-weak-dep
         state: present
 
-    - name: Check if foo-with-weak-dep is installed
-      shell: rpm -q foo-with-weak-dep
+    - name: Check if dinginessentail-with-weak-dep is installed
+      shell: rpm -q dinginessentail-with-weak-dep
       register: rpm_main_result
 
-    - name: Check if foo-weak-dep is installed
-      shell: rpm -q foo-weak-dep
+    - name: Check if dinginessentail-weak-dep is installed
+      shell: rpm -q dinginessentail-weak-dep
       register: rpm_weak_result
 
     - name: Verify install with weak deps
@@ -229,25 +229,25 @@
         - rpm_main_result.rc == 0
         - rpm_weak_result.rc == 0
 
-    - name: Uninstall foo weak dep packages
+    - name: Uninstall dinginessentail weak dep packages
       dnf:
         name:
-        - foo-with-weak-dep
-        - foo-weak-dep
+        - dinginessentail-with-weak-dep
+        - dinginessentail-weak-dep
         state: absent
 
     - name: Install package with weak deps but skip weak deps
       dnf:
-        name: foo-with-weak-dep
+        name: dinginessentail-with-weak-dep
         install_weak_deps: False
         state: present
 
-    - name: Check if foo-with-weak-dep is installed
-      shell: rpm -q foo-with-weak-dep
+    - name: Check if dinginessentail-with-weak-dep is installed
+      shell: rpm -q dinginessentail-with-weak-dep
       register: rpm_main_result
 
-    - name: Check if foo-weak-dep is installed
-      shell: rpm -q foo-weak-dep
+    - name: Check if dinginessentail-weak-dep is installed
+      shell: rpm -q dinginessentail-weak-dep
       register: rpm_weak_result
       ignore_errors: yes
 
@@ -258,18 +258,18 @@
         - rpm_weak_result.rc == 1  # the weak dependency shouldn't be installed
 
     # https://github.com/ansible/ansible/issues/55938
-    - name: Install foo-*
+    - name: Install dinginessentail-*
       dnf:
-        name: foo-*
+        name: dinginessentail-*
         state: present
 
-    - name: Uninstall foo-*
+    - name: Uninstall dinginessentail-*
       dnf:
-        name: foo-*
+        name: dinginessentail-*
         state: absent
 
-    - name: Check if all foo packages are removed
-      shell: rpm -qa foo-* | wc -l
+    - name: Check if all dinginessentail packages are removed
+      shell: rpm -qa dinginessentail-* | wc -l
       register: rpm_result
 
     - name: Verify rpm result
@@ -280,7 +280,7 @@
     - name: Clean up
       dnf:
         name:
-        - foo
-        - foo-with-weak-dep
-        - foo-weak-dep
+        - dinginessentail
+        - dinginessentail-with-weak-dep
+        - dinginessentail-weak-dep
         state: absent

--- a/test/integration/targets/setup_rpm_repo/files/comps.xml
+++ b/test/integration/targets/setup_rpm_repo/files/comps.xml
@@ -8,7 +8,7 @@
     <uservisible>true</uservisible>
     <display_order>1024</display_order>
     <packagelist>
-      <packagereq type="mandatory">foo</packagereq>
+      <packagereq type="mandatory">dinginessentail</packagereq>
     </packagelist>
   </group>
 
@@ -20,7 +20,7 @@
     <uservisible>false</uservisible>
     <display_order>1024</display_order>
     <packagelist>
-      <packagereq type="mandatory">bar</packagereq>
+      <packagereq type="mandatory">landsidescalping</packagereq>
     </packagelist>
   </group>
 

--- a/test/integration/targets/setup_rpm_repo/files/create-repo.py
+++ b/test/integration/targets/setup_rpm_repo/files/create-repo.py
@@ -10,15 +10,15 @@ RPM = namedtuple('RPM', ['name', 'version', 'release', 'epoch', 'recommends'])
 
 
 SPECS = [
-    RPM('foo', '1.0', '1', None, None),
-    RPM('foo', '1.0', '2', '1', None),
-    RPM('foo', '1.1', '1', '1', None),
-    RPM('foo-bar', '1.0', '1', None, None),
-    RPM('foo-bar', '1.1', '1', None, None),
-    RPM('bar', '1.0', '1', None, None),
-    RPM('bar', '1.1', '1', None, None),
-    RPM('foo-with-weak-dep', '1.0', '1', None, ['foo-weak-dep']),
-    RPM('foo-weak-dep', '1.0', '1', None, None),
+    RPM('dinginessentail', '1.0', '1', None, None),
+    RPM('dinginessentail', '1.0', '2', '1', None),
+    RPM('dinginessentail', '1.1', '1', '1', None),
+    RPM('dinginessentail-olive', '1.0', '1', None, None),
+    RPM('dinginessentail-olive', '1.1', '1', None, None),
+    RPM('landsidescalping', '1.0', '1', None, None),
+    RPM('landsidescalping', '1.1', '1', None, None),
+    RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep']),
+    RPM('dinginessentail-weak-dep', '1.0', '1', None, None),
 ]
 
 

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -22,7 +22,7 @@
 
     - name: On Fedora 28 the above won't remove the group which results in a failure in repo.yml below
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
       when:
         - ansible_distribution in ['Fedora']

--- a/test/integration/targets/yum/tasks/repo.yml
+++ b/test/integration/targets/yum/tasks/repo.yml
@@ -1,19 +1,19 @@
 - block:
-    - name: Install foo-1.0-1
+    - name: Install dinginessentail-1.0-1
       yum:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -22,21 +22,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1.0-1 again
+    - name: Install dinginessentail-1.0-1 again
       yum:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -45,21 +45,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1:1.0-2
+    - name: Install dinginessentail-1:1.0-2
       yum:
-        name: "foo-1:1.0-2.{{ ansible_architecture }}"
+        name: "dinginessentail-1:1.0-2.{{ ansible_architecture }}"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -68,27 +68,27 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
 
-    - name: Remove foo
+    - name: Remove dinginessentail
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
     # ============================================================================
-    - name: Downgrade foo
+    - name: Downgrade dinginessentail
       yum:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
         allow_downgrade: yes
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -97,21 +97,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Update to the latest foo
+    - name: Update to the latest dinginessentail
       yum:
-        name: foo
+        name: dinginessentail
         state: latest
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -120,21 +120,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1.0-1 from a file (higher version is already installed)
+    - name: Install dinginessentail-1.0-1 from a file (higher version is already installed)
       yum:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -143,26 +143,26 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
 
-    - name: Remove foo
+    - name: Remove dinginessentail
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
     # ============================================================================
-    - name: Install foo-1.0-1 from a file
+    - name: Install dinginessentail-1.0-1 from a file
       yum:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -171,21 +171,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1.0-1 from a file again
+    - name: Install dinginessentail-1.0-1 from a file again
       yum:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -194,21 +194,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1.0-2 from a file
+    - name: Install dinginessentail-1.0-2 from a file
       yum:
-        name: "{{ repodir }}/foo-1.0-2.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-2.{{ ansible_architecture }}.rpm"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -217,21 +217,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Install foo-1.0-2 from a file again
+    - name: Install dinginessentail-1.0-2 from a file again
       yum:
-        name: "{{ repodir }}/foo-1.0-2.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-2.{{ ansible_architecture }}.rpm"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -240,22 +240,22 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Try to downgrade foo without allow_downgrade being set
+    - name: Try to downgrade dinginessentail without allow_downgrade being set
       yum:
-        name: foo-1.0-1
+        name: dinginessentail-1.0-1
         state: present
         allow_downgrade: no
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -264,22 +264,22 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Update foo with update_only set
+    - name: Update dinginessentail with update_only set
       yum:
-        name: foo
+        name: dinginessentail
         state: latest
         update_only: yes
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -288,21 +288,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
 
-    - name: Remove foo
+    - name: Remove dinginessentail
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
     # ============================================================================
-    - name: Try to update foo which is not installed, update_only is set
+    - name: Try to update dinginessentail which is not installed, update_only is set
       yum:
-        name: foo
+        name: dinginessentail
         state: latest
         update_only: yes
       register: yum_result
       ignore_errors: yes
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
       ignore_errors: yes
 
@@ -323,13 +323,13 @@
     # ============================================================================
     - name: Try to install incompatible arch
       yum:
-        name: "{{ repodir_ppc64 }}/foo-1.0-1.ppc64.rpm"
+        name: "{{ repodir_ppc64 }}/dinginessentail-1.0-1.ppc64.rpm"
         state: present
       register: yum_result
       ignore_errors: yes
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
       ignore_errors: yes
 
@@ -348,27 +348,27 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
     # ============================================================================
-    - name: Make sure latest foo is installed
+    - name: Make sure latest dinginessentail is installed
       yum:
-        name: foo
+        name: dinginessentail
         state: latest
 
-    - name: Downgrade foo using rpm file
+    - name: Downgrade dinginessentail using rpm file
       yum:
-        name: "{{ repodir }}/foo-1.0-1.{{ ansible_architecture }}.rpm"
+        name: "{{ repodir }}/dinginessentail-1.0-1.{{ ansible_architecture }}.rpm"
         state: present
         allow_downgrade: yes
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -378,35 +378,35 @@
             - "'results' in yum_result"
     # ============================================================================
     - block:
-      - name: make sure foo is not installed
+      - name: make sure dinginessentail is not installed
         yum:
-          name: foo
+          name: dinginessentail
           state: absent
 
-      - name: install foo both archs
+      - name: install dinginessentail both archs
         yum:
           name: "{{ item }}"
           state: present
         with_items:
-          - "{{ repodir }}/foo-1.1-1.x86_64.rpm"
-          - "{{ repodir_i686 }}/foo-1.1-1.i686.rpm"
+          - "{{ repodir }}/dinginessentail-1.1-1.x86_64.rpm"
+          - "{{ repodir_i686 }}/dinginessentail-1.1-1.i686.rpm"
 
-      - name: try to install lower version of foo from rpm file, without allow_downgrade, just one arch
+      - name: try to install lower version of dinginessentail from rpm file, without allow_downgrade, just one arch
         yum:
-          name: "{{ repodir_i686 }}/foo-1.0-1.i686.rpm"
+          name: "{{ repodir_i686 }}/dinginessentail-1.0-1.i686.rpm"
           state: present
         register: yum_result
 
-      - name: check foo with rpm
-        shell: rpm -q foo
+      - name: check dinginessentail with rpm
+        shell: rpm -q dinginessentail
         register: rpm_result
 
       - name: verify installation
         assert:
           that:
               - "not yum_result.changed"
-              - "rpm_result.stdout_lines[0].startswith('foo-1.1-1')"
-              - "rpm_result.stdout_lines[1].startswith('foo-1.1-1')"
+              - "rpm_result.stdout_lines[0].startswith('dinginessentail-1.1-1')"
+              - "rpm_result.stdout_lines[1].startswith('dinginessentail-1.1-1')"
 
       - name: verify yum module outputs
         assert:
@@ -417,35 +417,35 @@
       when: ansible_architecture == "x86_64"
     # ============================================================================
     - block:
-      - name: make sure foo is not installed
+      - name: make sure dinginessentail is not installed
         yum:
-          name: foo
+          name: dinginessentail
           state: absent
 
-      - name: install foo both archs
+      - name: install dinginessentail both archs
         yum:
           name: "{{ item }}"
           state: present
         with_items:
-          - "{{ repodir }}/foo-1.0-1.x86_64.rpm"
-          - "{{ repodir_i686 }}/foo-1.0-1.i686.rpm"
+          - "{{ repodir }}/dinginessentail-1.0-1.x86_64.rpm"
+          - "{{ repodir_i686 }}/dinginessentail-1.0-1.i686.rpm"
 
       - name: Update both arch in one task using rpm files
         yum:
-          name: "{{ repodir }}/foo-1.1-1.x86_64.rpm,{{ repodir_i686 }}/foo-1.1-1.i686.rpm"
+          name: "{{ repodir }}/dinginessentail-1.1-1.x86_64.rpm,{{ repodir_i686 }}/dinginessentail-1.1-1.i686.rpm"
           state: present
         register: yum_result
 
-      - name: check foo with rpm
-        shell: rpm -q foo
+      - name: check dinginessentail with rpm
+        shell: rpm -q dinginessentail
         register: rpm_result
 
       - name: verify installation
         assert:
           that:
               - "yum_result.changed"
-              - "rpm_result.stdout_lines[0].startswith('foo-1.1-1')"
-              - "rpm_result.stdout_lines[1].startswith('foo-1.1-1')"
+              - "rpm_result.stdout_lines[0].startswith('dinginessentail-1.1-1')"
+              - "rpm_result.stdout_lines[1].startswith('dinginessentail-1.1-1')"
 
       - name: verify yum module outputs
         assert:
@@ -458,28 +458,28 @@
   always:
     - name: Clean up
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
 
 # FIXME: dnf currently doesn't support epoch as part of it's pkg_spec for
 #        finding install candidates
 #         https://bugzilla.redhat.com/show_bug.cgi?id=1619687
 - block:
-    - name: Install 1:foo-1.0-2
+    - name: Install 1:dinginessentail-1.0-2
       yum:
-        name: "1:foo-1.0-2.{{ ansible_architecture }}"
+        name: "1:dinginessentail-1.0-2.{{ ansible_architecture }}"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -490,7 +490,7 @@
   always:
     - name: Clean up
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
 
   when: ansible_pkg_mgr == 'yum'
@@ -505,21 +505,21 @@
 #       upstreams
 - block:
     # ============================================================================
-    - name: Install foo-1.0-2
+    - name: Install dinginessentail-1.0-2
       yum:
-        name: "foo-1.0-2.{{ ansible_architecture }}"
+        name: "dinginessentail-1.0-2.{{ ansible_architecture }}"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -528,21 +528,21 @@
             - "'rc' in yum_result"
             - "'results' in yum_result"
 
-    - name: Install foo-1.0-2 again
+    - name: Install dinginessentail-1.0-2 again
       yum:
-        name: foo-1.0-2
+        name: dinginessentail-1.0-2
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "not yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-2')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-2')"
 
     - name: Verify yum module outputs
       assert:
@@ -553,27 +553,27 @@
   always:
     - name: Clean up
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
   when: not (ansible_distribution == "Fedora" and ansible_distribution_major_version|int < 26)
 
 # https://github.com/ansible/ansible/issues/47689
 - block:
-    - name: Install foo == 1.0
+    - name: Install dinginessentail == 1.0
       yum:
-        name: "foo == 1.0"
+        name: "dinginessentail == 1.0"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -584,7 +584,7 @@
   always:
     - name: Clean up
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
 
   when: ansible_pkg_mgr == 'yum'
@@ -592,37 +592,37 @@
 
 # https://github.com/ansible/ansible/pull/54603
 - block:
-    - name: Install foo < 1.1
+    - name: Install dinginessentail < 1.1
       yum:
-        name: "foo < 1.1"
+        name: "dinginessentail < 1.1"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.0')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.0')"
 
-    - name: Install foo >= 1.1
+    - name: Install dinginessentail >= 1.1
       yum:
-        name: "foo >= 1.1"
+        name: "dinginessentail >= 1.1"
         state: present
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
     - name: Verify installation
       assert:
         that:
             - "yum_result.changed"
-            - "rpm_result.stdout.startswith('foo-1.1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1')"
 
     - name: Verify yum module outputs
       assert:
@@ -634,50 +634,50 @@
   always:
     - name: Clean up
       yum:
-        name: foo
+        name: dinginessentail
         state: absent
 
   when: ansible_pkg_mgr == 'yum'
 
 # https://github.com/ansible/ansible/issues/45250
 - block:
-    - name: Install foo-1.0, foo-bar-1.0, bar-1.0
+    - name: Install dinginessentail-1.0, dinginessentail-olive-1.0, landsidescalping-1.0
       yum:
-        name: "foo-1.0,foo-bar-1.0,bar-1.0"
+        name: "dinginessentail-1.0,dinginessentail-olive-1.0,landsidescalping-1.0"
         state: present
 
-    - name: Upgrade foo*
+    - name: Upgrade dinginessentail*
       yum:
-        name: foo*
+        name: dinginessentail*
         state: latest
       register: yum_result
 
-    - name: Check foo with rpm
-      shell: rpm -q foo
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
       register: rpm_result
 
-    - name: Verify update of foo
+    - name: Verify update of dinginessentail
       assert:
         that:
-            - "rpm_result.stdout.startswith('foo-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-1.1-1')"
 
-    - name: Check foo-bar with rpm
-      shell: rpm -q foo-bar
+    - name: Check dinginessentail-olive with rpm
+      shell: rpm -q dinginessentail-olive
       register: rpm_result
 
-    - name: Verify update of foo-bar
+    - name: Verify update of dinginessentail-olive
       assert:
         that:
-            - "rpm_result.stdout.startswith('foo-bar-1.1-1')"
+            - "rpm_result.stdout.startswith('dinginessentail-olive-1.1-1')"
 
-    - name: Check bar with rpm
-      shell: rpm -q bar
+    - name: Check landsidescalping with rpm
+      shell: rpm -q landsidescalping
       register: rpm_result
 
-    - name: Verify bar did NOT get updated
+    - name: Verify landsidescalping did NOT get updated
       assert:
         that:
-            - "rpm_result.stdout.startswith('bar-1.0-1')"
+            - "rpm_result.stdout.startswith('landsidescalping-1.0-1')"
 
     - name: Verify yum module outputs
       assert:
@@ -689,5 +689,5 @@
   always:
     - name: Clean up
       yum:
-        name: foo,foo-bar,bar
+        name: dinginessentail,dinginessentail-olive,landsidescalping
         state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When targeting `foo*` in tests, it pulled in packages other than the dummy packages in our testing repo that have many dependencies, some of which were causing tests to fail.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_rpm_repo/files/create-repo.py`
`test/integration/targets/yum/`