### PR TITLE
Remove Python 2.6 from Windows tests

### DIFF
--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -16,7 +16,6 @@ provider="${P:-default}"
 # python versions to test in order
 # python 2.7 runs full tests while other versions run minimal tests
 python_versions=(
-    2.6
     3.5
     3.6
     3.7


### PR DESCRIPTION
##### SUMMARY
We no longer support Python 2.6 on the controller so testing Python 2.6 against Windows hosts is not needed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test