### PR TITLE
Remove automatic default group assignment in netapp_e_host module

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_host.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_host.py
@@ -439,8 +439,6 @@ class Host(object):
 
         if self.group:
             self.post_body['groupId'] = self.group_id()
-        else:
-            self.post_body['groupId'] = "0000000000000000000000000000000000000000"
 
         self.post_body['hostType'] = dict(index=self.host_type_index)
 


### PR DESCRIPTION
##### SUMMARY
Host will be removed from the hostgroup when group is not specified in the options.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_host

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
```
