### PR TITLE
Remove Python 2.6 from Windows tests (#60235) - 2.8

### DIFF
--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -16,7 +16,6 @@ provider="${P:-default}"
 # python versions to test in order
 # python 2.7 runs full tests while other versions run minimal tests
 python_versions=(
-    2.6
     3.5
     3.6
     3.7


### PR DESCRIPTION
(cherry picked from commit 3a3727d20039cef446518097a3a8e5c1f251e1b8)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/60235

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test