### PR TITLE
fix issue #60237 when non-ascii is returned from the WLC

### DIFF
--- a/lib/ansible/modules/network/aireos/aireos_command.py
+++ b/lib/ansible/modules/network/aireos/aireos_command.py
@@ -120,12 +120,13 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_text
 
 
 def to_lines(stdout):
     for item in stdout:
         if isinstance(item, string_types):
-            item = str(item).split('\n')
+            item = to_text(item, errors='surrogate_then_replace').split('\n')
         yield item
 
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -225,7 +225,6 @@ class Connection(NetworkConnectionBase):
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
-
         self._ssh_shell = None
 
         self._matched_prompt = None
@@ -465,7 +464,7 @@ class Connection(NetworkConnectionBase):
             if sendonly:
                 return
             response = self.receive(command, prompt, answer, newline, prompt_retry_check, check_all)
-            return to_text(response, errors='surrogate_or_strict')
+            return to_text(response, errors='surrogate_then_replace')
         except (socket.timeout, AttributeError):
             self.queue_message('error', traceback.format_exc())
             raise AnsibleConnectionFailure("timeout value %s seconds reached while trying to send command: %s"

--- a/test/units/modules/network/aireos/test_aireos_command.py
+++ b/test/units/modules/network/aireos/test_aireos_command.py
@@ -25,6 +25,7 @@ from units.compat.mock import patch
 from ansible.modules.network.aireos import aireos_command
 from units.modules.utils import set_module_args
 from .aireos_module import TestCiscoWlcModule, load_fixture
+from ansible.module_utils import six 
 
 
 class TestCiscoWlcCommandModule(TestCiscoWlcModule):
@@ -114,7 +115,7 @@ class TestCiscoWlcCommandModule(TestCiscoWlcModule):
         `\xc8\x92\xef\xbf\xbdR\x7f`\xc8\x92\xef\xbf\xbdR\x7f`
         wlan wgb broadcast-tagging disable 1
         '''.strip()
-        test_string = unicode(test_data, 'utf-8')
+        test_string = six.u(test_data)
         test_stdout = [test_string, ]
         result = list(aireos_command.to_lines(test_stdout))
         print(result[0])

--- a/test/units/modules/network/aireos/test_aireos_command.py
+++ b/test/units/modules/network/aireos/test_aireos_command.py
@@ -105,3 +105,17 @@ class TestCiscoWlcCommandModule(TestCiscoWlcModule):
         commands = ['show sysinfo', 'show sysinfo']
         set_module_args(dict(commands=commands, wait_for=wait_for, match='all'))
         self.execute_module(failed=True)
+
+    def test_aireos_command_to_lines_non_ascii(self):
+        ''' Test data is one variation of the result of a `show run-config commands`
+        command on Cisco WLC version 8.8.120.0 '''
+        test_data = '''
+        wlan flexconnect learn-ipaddr 101 enable
+        `\xc8\x92\xef\xbf\xbdR\x7f`\xc8\x92\xef\xbf\xbdR\x7f`
+        wlan wgb broadcast-tagging disable 1
+        '''.strip()
+        test_string = unicode(test_data, 'utf-8')
+        test_stdout = [test_string, ]
+        result = list(aireos_command.to_lines(test_stdout))
+        print(result[0])
+        self.assertEqual(len(result[0]), 3)

--- a/test/units/modules/network/aireos/test_aireos_command.py
+++ b/test/units/modules/network/aireos/test_aireos_command.py
@@ -25,7 +25,7 @@ from units.compat.mock import patch
 from ansible.modules.network.aireos import aireos_command
 from units.modules.utils import set_module_args
 from .aireos_module import TestCiscoWlcModule, load_fixture
-from ansible.module_utils import six 
+from ansible.module_utils import six
 
 
 class TestCiscoWlcCommandModule(TestCiscoWlcModule):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix issue #60237 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aireos_command
network_cli
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Was able to add test for the `to_lines` function of the aireos_command module but have not looked into trying to further test network_cli

I don't know if escaping the binary data returned will cause more impact. In my case it's trading the exception, and failed task execution for some data in the returned output that would need to be cleaned up later.

--- From the linked issue ---

The non-ascii values returned from the controller cause a UnicodeError exception on line 467 in file lib/ansible/plugins/connection/network_cli.pywhen to_text fails to convert the binary data to a string. This then causes the command to be re-sent on line 284 of lib/ansible/plugins/connection/network_cli.py as UnicodeError is a subclass of ValueError.

The command that's resent is actually a string version of the dictionary that represents the command. I'm guessing the exception handling is there to handle the case where the command sent is was just a string and not a dictionary.

When the command is re-sent it triggers a raising of AnsibleConnectionFailure in the function _find_prompt because the text returned from the controller matches the terminal_stdout_re in lib/ansible/plugins/terminal/aireos.py because the controller didn't recognize the command sent (rightfully so).

After that's fixed, there's another problem in the lib/ansible/modules/network/aireos/aireos_command.py file on line 129 in the to_lines function where str is called on the returned output. The type of the item is unicode on my system with Python 2.7, and since the unicode string contains non-ascii characters, a UnicodeDecodeError exception is raised.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
