### PR TITLE
Fix for shared snapshot parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
@@ -338,7 +338,7 @@ def cluster_snapshot_info(module, conn):
     if snapshot_type:
         params['SnapshotType'] = snapshot_type
         if snapshot_type == 'public':
-            params['IsPublic'] = True
+            params['IncludePublic'] = True
         elif snapshot_type == 'shared':
             params['IncludeShared'] = True
 
@@ -358,7 +358,7 @@ def standalone_snapshot_info(module, conn):
     if snapshot_type:
         params['SnapshotType'] = snapshot_type
         if snapshot_type == 'public':
-            params['IsPublic'] = True
+            params['IncludePublic'] = True
         elif snapshot_type == 'shared':
             params['IncludeShared'] = True
 

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
@@ -318,7 +318,7 @@ def common_snapshot_info(module, conn, method, prefix, params):
         try:
             if snapshot['SnapshotType'] != 'shared':
                 snapshot['Tags'] = boto3_tag_list_to_ansible_dict(conn.list_tags_for_resource(ResourceName=snapshot['%sArn' % prefix],
-                                                                                          aws_retry=True)['TagList'])
+                                                                                              aws_retry=True)['TagList'])
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, "Couldn't get tags for snapshot %s" % snapshot['%sIdentifier' % prefix])
 

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
@@ -179,7 +179,7 @@ snapshots:
       sample: gp2
     tags:
       description: Snapshot tags
-      returned: always
+      returned: when snapshot is not shared
       type: complex
       contains: {}
     vpc_id:
@@ -286,7 +286,7 @@ cluster_snapshots:
       sample: true
     tags:
       description: Tags of the snapshot
-      returned: always
+      returned: when snapshot is not shared
       type: complex
       contains: {}
     vpc_id:
@@ -316,7 +316,8 @@ def common_snapshot_info(module, conn, method, prefix, params):
 
     for snapshot in results:
         try:
-            snapshot['Tags'] = boto3_tag_list_to_ansible_dict(conn.list_tags_for_resource(ResourceName=snapshot['%sArn' % prefix],
+            if snapshot['SnapshotType'] != 'shared':
+                snapshot['Tags'] = boto3_tag_list_to_ansible_dict(conn.list_tags_for_resource(ResourceName=snapshot['%sArn' % prefix],
                                                                                           aws_retry=True)['TagList'])
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, "Couldn't get tags for snapshot %s" % snapshot['%sIdentifier' % prefix])

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
@@ -339,7 +339,7 @@ def cluster_snapshot_info(module, conn):
         if snapshot_type == 'public':
             params['IsPublic'] = True
         elif snapshot_type == 'shared':
-            params['IsShared'] = True
+            params['IncludeShared'] = True
 
     return common_snapshot_info(module, conn, 'describe_db_cluster_snapshots', 'DBClusterSnapshot', params)
 
@@ -359,7 +359,7 @@ def standalone_snapshot_info(module, conn):
         if snapshot_type == 'public':
             params['IsPublic'] = True
         elif snapshot_type == 'shared':
-            params['IsShared'] = True
+            params['IncludeShared'] = True
 
     return common_snapshot_info(module, conn, 'describe_db_snapshots', 'DBSnapshot', params)
 

--- a/test/integration/targets/rds_instance/tasks/main.yml
+++ b/test/integration/targets/rds_instance/tasks/main.yml
@@ -23,5 +23,7 @@
       tags: vpc_security_groups
     - include: ./test_restore_instance.yml  # TODO: snapshot, s3
       tags: restore
+    - include: ./test_snapshot.yml
+      tags: snapshot
     # TODO: uncomment after adding rds_cluster module
     #- include: ./test_aurora.yml

--- a/test/integration/targets/rds_instance/tasks/test_snapshot.yml
+++ b/test/integration/targets/rds_instance/tasks/test_snapshot.yml
@@ -21,4 +21,65 @@
             - result.cluster_snapshots is defined
             - result.snapshots is defined
 
+      - name: Ensure the resource doesn't exist
+        rds_instance:
+          db_instance_identifier: "{{ instance_id }}"
+          state: absent
+          skip_final_snapshot: True
+          <<: *aws_connection_info
+        register: result
+
+      - assert:
+          that:
+            - not result.changed
+        ignore_errors: yes
+
+      - name: Create a mariadb instance
+        rds_instance:
+          db_instance_identifier: "{{ instance_id }}"
+          state: present
+          engine: mariadb
+          username: "{{ username }}"
+          password: "{{ password }}"
+          db_instance_class: "{{ db_instance_class }}"
+          allocated_storage: "{{ allocated_storage }}"
+          tags:
+            Name: "{{ instance_id }}"
+            Created_by: Ansible rds_instance tests
+          <<: *aws_connection_info
+        register: result
+
+      - assert:
+          that:
+            - result.changed
+            - "result.db_instance_identifier == '{{ instance_id }}'"
+            - "result.tags | length == 2"
+            - "result.tags.Name == '{{ instance_id }}'"
+            - "result.tags.Created_by == 'Ansible rds_instance tests'"
+
+      - name: Getting public snapshots
+        rds_snapshot_info:
+          db_instance_identifier: "{{ instance_id }}"
+          snapshot_type: "public"
+          <<: *aws_connection_info
+        register: result
+
+      - assert:
+          that:
+            - not result.changed
+            - result.cluster_snapshots is not defined
+            - result.snapshots is defined
+
+      - name: Ensure the resource doesn't exist
+        rds_instance:
+          db_instance_identifier: "{{ instance_id }}"
+          state: absent
+          skip_final_snapshot: True
+          <<: *aws_connection_info
+        register: result
+
+      - assert:
+          that:
+            - result.changed
+
       # TODO ideally we test with an actual shared snapshot - but we'd need a second account - making tests fairly complicated?

--- a/test/integration/targets/rds_instance/tasks/test_snapshot.yml
+++ b/test/integration/targets/rds_instance/tasks/test_snapshot.yml
@@ -1,0 +1,24 @@
+---
+  - block:
+      - name: set up aws connection info
+        set_fact:
+          aws_connection_info: &aws_connection_info
+            aws_access_key: "{{ aws_access_key }}"
+            aws_secret_key: "{{ aws_secret_key }}"
+            security_token: "{{ security_token }}"
+            region: "{{ aws_region }}"
+        no_log: yes
+
+      - name: Getting shared snapshots
+        rds_snapshot_info:
+          snapshot_type: "shared"
+          <<: *aws_connection_info
+        register: result
+
+      - assert:
+          that:
+            - not result.changed
+            - result.cluster_snapshots is defined
+            - result.snapshots is defined
+
+      # TODO ideally we test with an actual shared snapshot - but we'd need a second account - making tests fairly complicated?


### PR DESCRIPTION
##### SUMMARY
Fixing this bug by correcting parameter from `IsShared` to `IncludeShared`, and excluding tags from shared snapshots as these can't be retrieved.

`Unknown parameter in input: "IsShared", must be one of: DBInstanceIdentifier, DBSnapshotIdentifier, SnapshotType, Filters, MaxRecords, Marker, IncludeShared, IncludePublic, DbiResourceId`

`Couldn't get tags for snapshot arn:aws:rds:..:..:cluster-snapshot:..: An error occurred (InvalidParameterValue) when calling the ListTagsForResource operation: The specified resource name does not match an RDS resource in this region.`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rds_snapshot_info

##### ADDITIONAL INFORMATION
before:
```
Unknown parameter in input: "IsShared", must be one of: DBInstanceIdentifier, DBSnapshotIdentifier, SnapshotType, Filters, MaxRecords, Marker, IncludeShared, IncludePublic, DbiResourceId
```
before:
```
Couldn't get tags for snapshot arn:aws:rds:..:..:cluster-snapshot:..: An error occurred (InvalidParameterValue) when calling the ListTagsForResource operation: The specified resource name does not match an RDS resource in this region.
```

after:
expected list of snapshots