### PR TITLE
WIP: Allow loading of role/tasks/main.yaml for collections

### DIFF
--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -289,7 +289,7 @@ def get_collection_role_path(role_name, collection_list=None):
             pkg = import_module(role_package + u'.tasks')
 
             # get_data input must be a native string
-            tasks_file = pkgutil.get_data(to_native(role_package) + '.tasks', 'main.yml')
+            tasks_file = pkgutil.get_data(to_native(role_package) + '.tasks', 'main.yaml')
 
             if tasks_file is not None:
                 # the package is now loaded, get the collection's package and ask where it lives


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow users to create a collection role using tasks/main.yaml

Note, before merging this we need to write tests.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible_collections

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```