### PR TITLE
VMware: vmware_export_ovf module fix Python3 compatibility issue

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
@@ -112,7 +112,7 @@ from time import sleep
 from threading import Thread
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
 try:
     from pyVmomi import vim
@@ -303,7 +303,7 @@ class VMwareExportVmOvf(PyVmomi):
                 with open(self.mf_file, 'a') as mf_handle:
                     with open(ovf_descriptor_path, 'w') as handle:
                         handle.write(vm_descriptor)
-                        sha256_hash.update(vm_descriptor.encode('utf-8'))
+                        sha256_hash.update(to_bytes(vm_descriptor))
                     mf_handle.write('SHA256(' + os.path.basename(ovf_descriptor_path) + ')= ' + sha256_hash.hexdigest() + '\n')
                 http_nfc_lease.HttpNfcLeaseProgress(100)
                 # self.facts = http_nfc_lease.HttpNfcLeaseGetManifest()

--- a/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
@@ -179,6 +179,7 @@ class VMwareExportVmOvf(PyVmomi):
                               total_bytes_to_write):
         mf_content = 'SHA256(' + os.path.basename(temp_target_disk) + ')= '
         sha256_hash = hashlib.sha256()
+        response = None
 
         with open(self.mf_file, 'a') as mf_handle:
             with open(temp_target_disk, 'wb') as handle:
@@ -300,9 +301,9 @@ class VMwareExportVmOvf(PyVmomi):
                 ovf_descriptor_path = os.path.join(self.ovf_dir, ovf_descriptor_name + '.ovf')
                 sha256_hash = hashlib.sha256()
                 with open(self.mf_file, 'a') as mf_handle:
-                    with open(ovf_descriptor_path, 'wb') as handle:
+                    with open(ovf_descriptor_path, 'w') as handle:
                         handle.write(vm_descriptor)
-                        sha256_hash.update(vm_descriptor)
+                        sha256_hash.update(vm_descriptor.encode('utf-8'))
                     mf_handle.write('SHA256(' + os.path.basename(ovf_descriptor_path) + ')= ' + sha256_hash.hexdigest() + '\n')
                 http_nfc_lease.HttpNfcLeaseProgress(100)
                 # self.facts = http_nfc_lease.HttpNfcLeaseGetManifest()
@@ -313,7 +314,7 @@ class VMwareExportVmOvf(PyVmomi):
             kwargs = {
                 'changed': False,
                 'failed': True,
-                'msg': to_text(err),
+                'msg': "get exception: %s" % to_text(err),
             }
             http_nfc_lease.HttpNfcLeaseAbort()
             lease_updater.stop()
@@ -348,9 +349,9 @@ def main():
         if vm_power_state != 'poweredoff':
             module.fail_json(msg='VM state should be poweredoff to export')
         results = pyv.export_to_ovf_files(vm_obj=vm)
+        module.exit_json(**results)
     else:
         module.fail_json(msg='The specified virtual machine not found')
-    module.exit_json(**results)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/vmware_export_ovf/aliases
+++ b/test/integration/targets/vmware_export_ovf/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_export_ovf/tasks/main.yml
+++ b/test/integration/targets/vmware_export_ovf/tasks/main.yml
@@ -1,0 +1,56 @@
+# Test code for the vmware_export_ovf module
+# Copyright: (c) 2019, Diane Wang (Tomorrow9) <dianew@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+      setup_virtualmachines: true
+
+  - name: set state to poweroff on the tested VM
+    vmware_guest:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      state: poweredoff
+
+  - name: export VM to ovf template
+    vmware_export_ovf:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      datacenter: "{{ dc1 }}"
+      export_dir: "~/test_export/"
+    register: ovf_template
+  - debug: var=ovf_template
+  - name: assert the ovf template exported
+    assert:
+      that:
+        - "ovf_template.changed == true"
+        - "ovf_template.instance.device_files | length >= 1"
+
+  - name: export VM to ovf template with timeout set
+    vmware_export_ovf:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      datacenter: "{{ dc1 }}"
+      export_dir: "/tmp/"
+      download_timeout: 30
+    register: ovf_template
+  - debug: var=ovf_template
+  - name: assert the ovf template exported
+    assert:
+      that:
+        - "ovf_template.changed == true"
+        - "ovf_template.instance.device_files | length >= 1"

--- a/test/integration/targets/vmware_export_ovf/tasks/main.yml
+++ b/test/integration/targets/vmware_export_ovf/tasks/main.yml
@@ -4,6 +4,13 @@
 
 - when: vcsim is not defined
   block:
+  - name: create temporary build directory
+    tempfile:
+      state: directory
+      suffix: build
+    register: temp_dir
+  - debug: var=temp_dir
+
   - import_role:
       name: prepare_vmware_tests
     vars:
@@ -28,7 +35,7 @@
       password: "{{ vcenter_password }}"
       name: "{{ virtual_machines_in_cluster[0].name }}"
       datacenter: "{{ dc1 }}"
-      export_dir: "~/test_export/"
+      export_dir: "{{ temp_dir.path }}"
     register: ovf_template
   - debug: var=ovf_template
   - name: assert the ovf template exported
@@ -45,7 +52,7 @@
       password: "{{ vcenter_password }}"
       name: "{{ virtual_machines_in_cluster[0].name }}"
       datacenter: "{{ dc1 }}"
-      export_dir: "/tmp/"
+      export_dir: "{{ temp_dir.path }}"
       download_timeout: 30
     register: ovf_template
   - debug: var=ovf_template
@@ -54,3 +61,9 @@
       that:
         - "ovf_template.changed == true"
         - "ovf_template.instance.device_files | length >= 1"
+  rescue:
+  - name: Clean up the temporary dir
+    file:
+      path: "{{ temp_dir.path }}"
+      state: absent
+    when: temp_dir.path is defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When use this module in Python3, there is always "a bytes-like object is required, not 'str'" error returned. This is an opened file in binary mode while writing string directly issue. Fixed it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_export_ovf
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
