### PR TITLE
Fix for redhat_subscription: don't discard vars with key

### DIFF
--- a/changelogs/fragments/redhat_subscribtion.yml
+++ b/changelogs/fragments/redhat_subscribtion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - do not ignore consumer_name and other variables if activationkey is specified (https://github.com/ansible/ansible/pull/60266)

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -414,23 +414,28 @@ class Rhsm(RegistrationBase):
         if server_proxy_password:
             args.extend(['--proxypassword', server_proxy_password])
 
+        if auto_attach:
+            args.append('--auto-attach')
+
+        if consumer_type:
+            args.extend(['--type', consumer_type])
+
+        if consumer_name:
+            args.extend(['--name', consumer_name])
+
+        if consumer_id:
+            args.extend(['--consumerid', consumer_id])
+
+        if environment:
+            args.extend(['--environment', environment])
+
         if activationkey:
             args.extend(['--activationkey', activationkey])
         else:
-            if auto_attach:
-                args.append('--auto-attach')
             if username:
                 args.extend(['--username', username])
             if password:
                 args.extend(['--password', password])
-            if consumer_type:
-                args.extend(['--type', consumer_type])
-            if consumer_name:
-                args.extend(['--name', consumer_name])
-            if consumer_id:
-                args.extend(['--consumerid', consumer_id])
-            if environment:
-                args.extend(['--environment', environment])
 
         if release:
             args.extend(['--release', release])


### PR DESCRIPTION
##### SUMMARY
Fixes #50502. 

From the man-pages of subscription-manager, none of the parameters used is tied to `activationkey` except the two that remain in its else-clause.

Per the documentation, none of these should be tied to `activationkey`, and as such, no correct usage of the module per its documentation should be affected in a negative way.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`redhat_subscription`

##### ADDITIONAL INFORMATION
Note that `type` is not mentioned in the man-pages on 7.6 (at least), but is still present and available.
