### PR TITLE
VMware: Cross-verify unique VM with folder param

### DIFF
--- a/changelogs/fragments/60199_vmware_guest_get_vm_fix.yml
+++ b/changelogs/fragments/60199_vmware_guest_get_vm_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Cross check VM with folder parameter when we have unique VM (https://github.com/ansible/ansible/issues/60199).

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -984,7 +984,12 @@ class PyVmomi(object):
                         break
             elif vms:
                 # Unique virtual machine found.
-                vm_obj = vms[0]
+                if 'folder' in self.params and self.params['folder']:
+                    # Make sure VM found is unique by folder value
+                    # https://github.com/ansible/ansible/issues/60199
+                    actual_vm_folder_path = self.get_vm_path(content=self.content, vm_name=vms[0])
+                    if actual_vm_folder_path.endswith(self.params['folder']):
+                        vm_obj = vms[0]
         elif 'moid' in self.params and self.params['moid']:
             vm_obj = VmomiSupport.templateOf('VirtualMachine')(self.params['moid'], self.si._stub)
 

--- a/test/integration/targets/prepare_vmware_tests/tasks/init_vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/init_vcsim.yml
@@ -43,6 +43,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ item.name }}"
+    folder: "{{ item.folder }}"
     state: poweredoff
   with_items: "{{ virtual_machines + virtual_machines_in_cluster }}"
   register: poweroff_d1_c1_f0

--- a/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
@@ -11,5 +11,7 @@ virtual_machines:
 virtual_machines_in_cluster:
   - name: DC0_C0_RP0_VM0
     cluster: '{{ ccr1 }}'
+    folder: /F0/DC0/vm/F0
   - name: DC0_C0_RP0_VM1
     cluster: '{{ ccr1 }}'
+    folder: /F0/DC0/vm/F0

--- a/test/integration/targets/vmware_guest/defaults/main.yml
+++ b/test/integration/targets/vmware_guest/defaults/main.yml
@@ -1,6 +1,5 @@
 vmware_guest_test_playbooks:
   - boot_firmware_d1_c1_f0.yml
-  - boot_firmware_d1_c1_f0.yml
   - cdrom_d1_c1_f0.yml
   - check_mode.yml
   - clone_customize_guest_test.yml
@@ -26,6 +25,7 @@ vmware_guest_test_playbooks:
 #  - network_with_portgroup.yml
   - non_existent_vm_ops.yml
   - poweroff_d1_c1_f0.yml
-  - poweroff_d1_c1_f1.yml
+#  - poweroff_d1_c1_f1.yml
 #  - template_d1_c1_f0.yml
   - vapp_d1_c1_f0.yml
+  - multiple_folder.yml

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -4,7 +4,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -37,7 +37,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datastore: "{{ ds2 }}"
     datacenter: "{{ dc1 }}"
@@ -61,7 +61,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cdrom:
@@ -87,7 +87,7 @@
     template: test_vm1
     datacenter: "{{ dc1 }}"
     state: poweredoff
-    folder: vm
+    folder: "{{ f0 }}"
     convert: thin
 
 - name: Update CDROM to none for the new VM
@@ -96,7 +96,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cdrom:
@@ -118,7 +118,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm3
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -9,6 +9,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ virtual_machines[0].name }}"
+    folder: "{{ virtual_machines[0].folder }}"
     datacenter: "{{ dc1 }}"
     state: "{{ item }}"
   with_items:

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -25,7 +25,7 @@
           gateway: 192.168.10.254
           mac: aa:bb:cc:dd:aa:42
     state: poweredoff
-    folder: vm
+    folder: "{{ f0 }}"
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/multiple_folder.yml
+++ b/test/integration/targets/vmware_guest/tasks/multiple_folder.yml
@@ -1,0 +1,76 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt) 
+
+- name: Create multiple folders
+  vcenter_folder:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+    folder_name: "test{{ item }}"
+    folder_type: vm
+    state: present
+  register: all_folder_results
+  with_items:
+    - 0
+    - 1
+    - 2
+    - 3
+
+- name: Create new VM in test0 folder
+  vmware_guest:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    guest_id: centos64Guest
+    datacenter: "{{ dc1 }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: test0
+  register: vm
+
+- name: Check if VM already existing.
+  vmware_guest_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+    folder: "{{ item }}"
+    name: test_vm1
+  register: test
+  failed_when: False
+  delegate_to: localhost
+  loop:
+    - "/test0/"
+    - "/test1/"
+    - "/test2/"
+    - "/test3/"
+
+- name: Check if VM found in test0 only
+  assert:
+    that:
+      - item.instance.hw_folder
+  with_items:
+    - "{{ test.results | json_query(query) }}"
+  vars:
+    query: "[?instance.hw_name=='test_vm1']"
+
+- name: Check if VM not found for other folder except test0
+  assert:
+    that:
+      - not item.instance is defined
+  with_items:
+    - "{{ test.results | json_query(query) }}"
+  vars:
+    query: "[?instance.hw_name!='test_vm1']"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -9,6 +9,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ item.name }}"
+    folder: "{{ f0 }}"
     state: poweredoff
   with_items: "{{ virtual_machines }}"
   register: poweroff_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/run_test_playbook.yml
+++ b/test/integration/targets/vmware_guest/tasks/run_test_playbook.yml
@@ -8,6 +8,7 @@
         password: "{{ vcenter_password }}"
         validate_certs: no
 #        cluster: "{{ ccr1 }}"
+        folder: "{{ f0 }}"
         name: '{{ item }}'
         force: yes
         state: absent

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -10,7 +10,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -66,7 +66,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     vapp_properties:

--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -17,6 +17,7 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     name: "{{ virtual_machines[0].name }}"
+    folder: "{{ virtual_machines[0].folder }}"
     datacenter: '{{ dc1 }}'
   register: disk_facts
 


### PR DESCRIPTION
##### SUMMARY
When there is single unique named VM then consider folder parameter to
verify its uniqueness.

Fixes: #60199

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/60199_vmware_guest_get_vm_fix.yml
lib/ansible/module_utils/vmware.py
test/integration/targets/vmware_guest/defaults/main.yml
test/integration/targets/vmware_guest/tasks/multiple_folder.yml