### PR TITLE
VyOS: Set eth0 to dhcp explicitly in prepare_vyos_tests

### DIFF
--- a/test/integration/targets/prepare_vyos_tests/tasks/main.yaml
+++ b/test/integration/targets/prepare_vyos_tests/tasks/main.yaml
@@ -4,7 +4,7 @@
     config: "{{ lines }}"
   vars:
     lines: |
-      set interfaces ethernet eth0
+      set interfaces ethernet eth0 address dhcp
       set interfaces ethernet eth1
       set interfaces ethernet eth2
       set interfaces loopback lo


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Set eth0 to dhcp in running-config explicitly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
prepare_vyos_tests