### PR TITLE
Fix user: createhome=no home=/no/such/dir

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2901,7 +2901,7 @@ def main():
             # that do not exist.
             path_needs_parents = False
             if user.home:
-                parent = os.path.basename(user.home)
+                parent = os.path.dirname(user.home)
                 if not os.path.isdir(parent):
                     path_needs_parents = True
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -197,6 +197,22 @@
     state: absent
 
 
+# https://github.com/ansible/ansible/issues/60307
+# Make sure we can create a user when the home directory is missing
+- name: Create user with home path that does not exist
+  user:
+    name: ansibulluser3
+    state: present
+    home: "{{ user_home_prefix[ansible_facts.system] }}/nosuchdir"
+    createhome: no
+
+- name: Cleanup test account
+  user:
+    name: ansibulluser3
+    state: absent
+    remove: yes
+
+
 ## user check
 
 - name: run existing user check tests


### PR DESCRIPTION
##### SUMMARY

Fixes #60307.

This bug was introduced in commit d2edf1d43531f938ccbdef79c927141ba193b96d ("User - Create parent directories if they do not exist in the specified home path (#51043)") and did not make it into any releases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION

The bug is pretty obvious: os.path.basename() is not the right function to call to compute the parent directory.