### PR TITLE
[os_router] handle additional routes

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_routers_info.py
+++ b/lib/ansible/modules/cloud/openstack/os_routers_info.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: os_routers_info
+short_description: Retrieve state about one or more OpenStack routerss.
+version_added: "2.9"
+author: "Julien Girardin (@Zempashi)"
+description:
+    - Retrieve state about one or more routers from OpenStack.
+requirements:
+    - "python >= 2.7"
+    - "sdk"
+options:
+   name:
+     description:
+        - Name or ID of the Router
+     required: false
+     type: str
+   filters:
+     description:
+        - A dictionary of meta data to use for further filtering.  Elements of
+          this dictionary may be additional dictionaries.
+     required: false
+     type: dict
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatibility
+     required: false
+     type: str
+extends_documentation_fragment: openstack
+'''
+
+EXAMPLES = '''
+- name: Gather state about previously created routers
+  os_routers_info:
+    auth:
+      auth_url: https://identity.example.com
+      username: user
+      password: password
+      project_name: someproject
+  register: openstack_routers
+
+- name: Show openstack networks
+  debug:
+    var: openstack_routers
+
+- name: Gather state about a previously created router by name
+  os_router_infos:
+    auth:
+      auth_url: https://identity.example.com
+      username: user
+      password: password
+      project_name: someproject
+    name:  router1
+  register: openstack_routers
+
+- name: Show openstack networks
+  debug:
+    var: openstack_routers
+'''
+
+RETURN = '''
+openstack_routers:
+    description: has all the openstack data about the routers
+    returned: always, but can be null
+    type: complex
+    contains:
+        id:
+            description: Unique UUID.
+            returned: success
+            type: str
+        name:
+            description: Name given to the router.
+            returned: success
+            type: str
+        status:
+            description: Router status.
+            returned: success
+            type: str
+        routes:
+            description: >-
+               Additional route(s) handled by the router.
+               Don't list default route, neither implicit routes for subnet
+            returned: success
+            type: list of dicts
+        tenant_id:
+            description: Tenant id associated with this router.
+            returned: success
+            type: str
+        external_gateway_info:
+            description: Information about external gateway.
+            returned: success
+            type: dict
+        interfaces:
+            description: Informatrion about internal interfaces
+            returned: success
+            type: list of dicts
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=False, default=None),
+        filters=dict(required=False, type='dict', default=None)
+    )
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        routers = cloud.search_routers(module.params['name'],
+                                       module.params['filters'])
+        for router in routers:
+            router['interfaces'] = cloud.list_router_interfaces(router, 'internal')
+        module.exit_json(changed=False, openstack_routers=routers)
+
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Currently os_router handles internal interfaces in a clumsy way: on change delete everything and readd everything. This leads to error such as, when wanting to add interfaces...:

```
FAILED! => {"changed": false, "msg": "Error detaching interface from router e5913403-b3f6-40c2-84a9-e75dc01700c0: Client Error for url: https://redacted.example.com/neutron/v2.0/routers/e5913403-b3f6-40c2-84a9-e75dc01700c0/remove_router_interface.json, Router interface for subnet 559c000f-5d52-473e-811a-503a10093445 on router e5913403-b3f6-40c2-84a9-e75dc01700c0 cannot be deleted, as it is required by one or more floating IPs."}
```

I tried to refactor that to be conservative as much as possible.

The second commit is about routes, that span in two parts: before internal interface update and after.
Editing route at a single point will result in error like:

```
FAILED! => {"changed": false, "msg": "Error detaching interface from router e5913403-b3f6-40c2-84a9-e75dc01700c0: Client Error for url: https://redacted.example.com/neutron/v2.0/routers/e5913403-b3f6-40c2-84a9-e75dc01700c0/remove_router_interface.json, Router interface for subnet f6baab1f-7e63-4450-ae97-196e8ffbb4a2 on router e5913403-b3f6-40c2-84a9-e75dc01700c0 cannot be deleted, as it is required by one or more routes."}
```

I found https://github.com/ansible/ansible/issues/31640, and I decided that the module should manage the entire list of routes (as other parameters of the module act). I provided a third commit (and the 'os_router_info' that is a modified copy paste of os_networks_facts) for getting information about router and easily handling route addition:

```
- os_routers_info:
      name: router1
  register: router1_info

- os_router:
      routes: '{{ router1_info.openstack_router.routes + [{"destination": "8.8.8.8/32", "nexthost": "192.168.0.5"]} }}'
```
The new tasks is already named '_info' to follow https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_checklist.html#other-checklists, but I'm not sure if I should follow specific return structure.

Now about tests, there is none...As previously... I could try to setup thing around https://ask.openstack.org/en/question/28/openstack-api-mocker-or-simulator/ and https://github.com/ewindisch/dockenstack, but that a bit complex and I read something in the developer guide somewhere that test should not pull docker images....
But considering I'm not an openstack expert, this should be tested heavily before merge.
(For exemple I'm not sure to understand the openstack model where a port could have multiple subnets, and I decided to remove port on first mismatch, but I'm not sure if this could lead to inconsistency).
There is a lot of clue that made me believe that the module was badly written originally; but may be I'm totally wrong and my approach can't work in the general case. 

Fixes #31640

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
os_router, os_routers_info