### PR TITLE
Add sanity test for obsolete files.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/obsolete-files.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/obsolete-files.rst
@@ -1,0 +1,14 @@
+obsolete-files
+==============
+
+Directories in the Ansible source tree are sometimes made obsolete.
+Files should not exist in these directories.
+The new location (if any) is dependent on which directory has been made obsolete.
+
+Below are some of the obsolete directories and their new locations:
+
+- All of ``test/runner/`` is now under ``test/lib/ansible_test/`` instead. The organization of files in the new directory has changed.
+- Most subdirectories of ``test/sanity/`` (with some exceptions) are now under ``test/lib/ansible_test/_data/sanity/`` instead.
+
+This error occurs most frequently for open pull requests which add or modify files in directories which are now obsolete.
+Make sure the branch you are working from is current so that changes can be made in the correct location.

--- a/test/sanity/code-smell/obsolete-files.json
+++ b/test/sanity/code-smell/obsolete-files.json
@@ -1,0 +1,16 @@
+{
+    "prefixes": [
+        "test/runner/",
+        "test/sanity/ansible-doc/",
+        "test/sanity/compile/",
+        "test/sanity/import/",
+        "test/sanity/pep8/",
+        "test/sanity/pslint/",
+        "test/sanity/pylint/",
+        "test/sanity/rstcheck/",
+        "test/sanity/shellcheck/",
+        "test/sanity/validate-modules/",
+        "test/sanity/yamllint/"
+    ],
+    "output": "path-message"
+}

--- a/test/sanity/code-smell/obsolete-files.py
+++ b/test/sanity/code-smell/obsolete-files.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+"""Prevent files from being added to directories that are now obsolete."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+
+
+def main():
+    """Main entry point."""
+    paths = sys.argv[1:] or sys.stdin.read().splitlines()
+
+    for path in paths:
+        print('%s: directory "%s/" is obsolete and should not contain any files' % (path, os.path.dirname(path)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Add sanity test for obsolete files.

This will help prevent accidental merging of content to recently obsoleted directories when adding new files.

It may also help contributors who have modified obsolete files understand where their changes should now be made.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
