### PR TITLE
Fix changelog entry for playbook_dir fix

### DIFF
--- a/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
+++ b/changelogs/fragments/59548-import-playbook-plugin-dirs.yml
@@ -1,4 +1,4 @@
 bugfixes:
-- plugin loader - Move plugin loader playbook dir additions back to ``Playbook`` instead of ``PlaybookCLI``
-  to solve sub directory playbook relative plugins to be located
-  (https://github.com/ansible/ansible/issues/59548)
+- plugin loader - Restore adding plugin loader playbook dir to ``Playbook`` in
+  addition to ``PlaybookCLI`` to solve sub directory playbook relative plugins
+  to be located (https://github.com/ansible/ansible/issues/59548)


### PR DESCRIPTION
The final version of the fix makes the addition in two places instead of
moving the single addition from one place to another

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
