### PR TITLE
[stable-2.8] Fix unit tests to work with pytest >= 5.0 (#60246)

### DIFF
--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -134,14 +134,14 @@ class TestRecursiveFinder(object):
         data = b'#!/usr/bin/python\ndef something(:\n   pass\n'
         with pytest.raises(ansible.errors.AnsibleError) as exec_info:
             recursive_finder(name, data, *finder_containers)
-        assert 'Unable to import fake_module due to invalid syntax' in str(exec_info)
+        assert 'Unable to import fake_module due to invalid syntax' in str(exec_info.value)
 
     def test_module_utils_with_identation_error(self, finder_containers):
         name = 'fake_module'
         data = b'#!/usr/bin/python\n    def something():\n    pass\n'
         with pytest.raises(ansible.errors.AnsibleError) as exec_info:
             recursive_finder(name, data, *finder_containers)
-        assert 'Unable to import fake_module due to unexpected indent' in str(exec_info)
+        assert 'Unable to import fake_module due to unexpected indent' in str(exec_info.value)
 
     def test_from_import_toplevel_package(self, finder_containers, mocker):
         if PY2:

--- a/test/units/module_utils/common/validation/test_check_type_int.py
+++ b/test/units/module_utils/common/validation/test_check_type_int.py
@@ -31,4 +31,4 @@ def test_check_type_int_fail():
     for case in test_cases:
         with pytest.raises(TypeError) as e:
             check_type_int(case)
-        assert 'cannot be converted to an int' in to_native(e)
+        assert 'cannot be converted to an int' in to_native(e.value)

--- a/test/units/modules/network/ftd/test_ftd_file_download.py
+++ b/test/units/modules/network/ftd/test_ftd_file_download.py
@@ -48,7 +48,7 @@ class TestFtdFileDownload(object):
         with pytest.raises(AnsibleFailJson) as ex:
             self.module.main()
 
-        assert 'missing required arguments: %s' % missing_arg in str(ex)
+        assert 'missing required arguments: %s' % missing_arg in str(ex.value)
 
     def test_module_should_fail_when_no_operation_spec_found(self, connection_mock):
         connection_mock.get_operation_spec.return_value = None

--- a/test/units/modules/network/ftd/test_ftd_file_upload.py
+++ b/test/units/modules/network/ftd/test_ftd_file_upload.py
@@ -30,7 +30,7 @@ class TestFtdFileUpload(object):
         with pytest.raises(AnsibleFailJson) as ex:
             self.module.main()
 
-        assert 'missing required arguments: %s' % missing_arg in str(ex)
+        assert 'missing required arguments: %s' % missing_arg in str(ex.value)
 
     def test_module_should_fail_when_no_operation_spec_found(self, connection_mock):
         connection_mock.get_operation_spec.return_value = None

--- a/test/units/plugins/terminal/test_junos.py
+++ b/test/units/plugins/terminal/test_junos.py
@@ -52,4 +52,4 @@ def test_on_open_shell_raises_problem_setting_terminal_config(junos_terminal):
     with pytest.raises(AnsibleConnectionFailure) as exc:
         junos_terminal.on_open_shell()
 
-    assert 'unable to set terminal parameters' in str(exc)
+    assert 'unable to set terminal parameters' in str(exc.value)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #60246 for Ansible 2.8

(cherry picked from commit 2d266fbc87c6e1f2bd7bb887e254938278b8d2cc)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/units/executor/module_common/test_recursive_finder.py`
`test/units/module_utils/common/validation/test_check_type_int.py`
`test/units/modules/network/ftd/test_ftd_file_download.py`
`test/units/modules/network/ftd/test_ftd_file_upload.py`
`test/units/plugins/terminal/test_junos.py`