### PR TITLE
Fix missing variable with nxos_install_os tests

### DIFF
--- a/test/integration/targets/nxos_install_os/defaults/main.yaml
+++ b/test/integration/targets/nxos_install_os/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
-testcase: " {{ testcase }}"
+testcase: ""
+test_items: []


### PR DESCRIPTION
##### SUMMARY
Fix nxos_install_os syntax error

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos