### PR TITLE
gitlab_runner: document minimal dependency version

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -34,7 +34,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab >= 1.5.0
 extends_documentation_fragment:
     - auth_basic
 options:


### PR DESCRIPTION
##### SUMMARY
gitlab_runner module doesn't work with python-gitlab older than 1.5.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
gitlab_runner

