### PR TITLE
Add `no_overwrite` option to `k8s` module.

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -84,6 +84,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         argument_spec['validate'] = dict(type='dict', default=None, options=self.validate_spec)
         argument_spec['append_hash'] = dict(type='bool', default=False)
         argument_spec['apply'] = dict(type='bool')
+        argument_spec['no_overwrite'] = dict(type='bool', default=False)
         return argument_spec
 
     def __init__(self, k8s_kind=None, *args, **kwargs):
@@ -103,6 +104,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         self.api_version = self.params.get('api_version')
         self.name = self.params.get('name')
         self.namespace = self.params.get('namespace')
+        self.no_overwrite = self.params.get('no_overwrite')
         resource_definition = self.params.get('resource_definition')
         validate = self.params.get('validate')
         if validate:
@@ -282,6 +284,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
                             self.fail_json(msg="Resource deletion timed out", **result)
                 return result
         else:
+            if existing and self.no_overwrite:
+                return result
+
             if self.apply:
                 if self.check_mode:
                     k8s_obj = definition

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -146,6 +146,13 @@ options:
     - mutually exclusive with C(merge_type)
     type: bool
     version_added: "2.9"
+  no_overwrite:
+    description:
+    - C(no_overwrite) will not modify existing resources and simply return 'OK' while leaving the k8s object unchanged
+    type: bool
+    default: no
+    version_added: "2.9"
+
 
 requirements:
   - "python >= 2.7"

--- a/test/integration/targets/k8s/tasks/no_overwrite.yml
+++ b/test/integration/targets/k8s/tasks/no_overwrite.yml
@@ -1,0 +1,42 @@
+---
+- name: Ensure testing1 namespace exists
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: testing1
+
+- name: Create a ConfigMap
+  k8s:
+    api_version: v1
+    kind: ConfigMap
+    resource_definition:
+      metadata:
+        name: test
+        namespace: testing1
+      data:
+        key1: value1
+        key2: value2
+
+- name: Create a new ConfigMap, but only if the first doesn't exist
+  k8s:
+    no_overwrite: yes
+    api_version: v1
+    kind: ConfigMap
+    resource_definition:
+      metadata:
+        name: test
+        namespace: testing1
+      data:
+        key1: valueA
+        key2: valueB
+
+- name: Get the ConfigMap
+  set_fact:
+    test_data: "{{ lookup('k8s', kind='ConfigMap', namespace='testing1', resource_name='test') }}"
+
+- name: Check that the values are from the first ConfigMap
+  assert:
+    that:
+    - test_data['data']['key1'] == 'value1'
+    - test_data['data']['key2'] == 'value2'
+  


### PR DESCRIPTION


##### SUMMARY
I occasionally want to create a ConfigMap or a Secret if it is not there, but do not want it to replace the object if it already exists.

For example, I generate some random data and place it into a secret, which is then exposed to certain pods.  On the next run, I do not need to change the random information, as this would involve re-keying running pods.

This option makes this (and other similar scenarios) extremely simple.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Add `no_overwrite` option to `k8s` module.

##### ADDITIONAL INFORMATION
Example usage:
```yaml
- name: Create a Secret if one doesn't already exist
  k8s:
    no_overwrite: yes
    api_version: v1
    kind: Secret
    resource_definition:
      metadata:
        name: test
        namespace: testing1
      data:
        password: "{{ random_string | b64encode }}"
```