### PR TITLE
Fix firewalld rich_rule example

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -175,7 +175,7 @@ EXAMPLES = r'''
 
 - name: Redirect port 443 to 8443 with Rich Rule
   firewalld:
-    rich_rule: rule forward-port port=443 protocol=tcp to-port=8443
+    rich_rule: rule family=ipv4 forward-port port=443 protocol=tcp to-port=8443
     zone: public
     permanent: yes
     immediate: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
The rich rule example doesn't specify the `family` field, which firewalld will fail on if not provided.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Just fixing the documentation to avoid confusion.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Without this field firewalld will fail with "ERROR: Exception caught: MISSING_FAMILY".

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
fatal: [localhost]: FAILED! => {"changed": false, "msg": "ERROR: Exception caught: MISSING_FAMILY"}
```
