### PR TITLE
ovirt: remove linux boot params 

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_instance_type.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_instance_type.py
@@ -489,7 +489,6 @@ class InstanceTypeModule(BaseModule):
         cpu_mode = getattr(entity.cpu, 'mode')
         it_display = entity.display
         return (
-            not self.param('kernel_params_persist') and
             equal(convert_to_bytes(self.param('memory_guaranteed')), entity.memory_policy.guaranteed) and
             equal(convert_to_bytes(self.param('memory_max')), entity.memory_policy.max) and
             equal(self.param('cpu_cores'), entity.cpu.topology.cores) and


### PR DESCRIPTION
Removed linux boot params including initrd,kernel and kernel params. #60383 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch will remove the unsupported linux boot parameters.
Fixes #60383 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt_vm
ovirt_instance_type
