### PR TITLE
Move windows test to another group

### DIFF
--- a/test/integration/targets/win_user_profile/aliases
+++ b/test/integration/targets/win_user_profile/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group7
+shippable/windows/group5


### PR DESCRIPTION
##### SUMMARY
Further testing on https://github.com/ansible/ansible/pull/59009 has shown group 7 is just reaching capacity. This moves a test from that group to another that is less full.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test