### PR TITLE
openssh_keypair: forgot version_added in #59268.

### DIFF
--- a/lib/ansible/modules/crypto/openssh_keypair.py
+++ b/lib/ansible/modules/crypto/openssh_keypair.py
@@ -62,6 +62,7 @@ options:
         description:
             - Provides a new comment to the public key. When checking if the key is in the correct state this will be ignored.
         type: str
+        version_added: "2.9"
 
 extends_documentation_fragment: files
 '''


### PR DESCRIPTION
##### SUMMARY
#59268 should have had a `version_added: "2.9"` for the new `comment` return value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_keypair
