### PR TITLE
Add file locking support for concurrent file access

### DIFF
--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -179,7 +179,7 @@ class FileLock:
                     total_wait += wait_interval
                     continue
             os.close(self.lock_file)
-            raise LockTimeout('Waited {0} seconds for lock on {1}'.format(total_wait, path))
+            raise LockTimeout('Waited {0} seconds for lock on {1}'.format(total_wait, self.path))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """ Remove lock

--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -157,6 +157,7 @@ import tempfile
 from ansible.module_utils.six import b
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.file import FileLock
 
 
 def write_changes(module, contents, path):
@@ -220,120 +221,121 @@ def main():
         module.fail_json(rc=256,
                          msg='Path %s is a directory !' % path)
 
-    path_exists = os.path.exists(path)
-    if not path_exists:
-        if not module.boolean(params['create']):
-            module.fail_json(rc=257,
-                             msg='Path %s does not exist !' % path)
-        destpath = os.path.dirname(path)
-        if not os.path.exists(destpath) and not module.check_mode:
-            try:
-                os.makedirs(destpath)
-            except Exception as e:
-                module.fail_json(msg='Error creating %s Error code: %s Error description: %s' % (destpath, e[0], e[1]))
-        original = None
-        lines = []
-    else:
-        f = open(path, 'rb')
-        original = f.read()
-        f.close()
-        lines = original.splitlines()
-
-    diff = {'before': '',
-            'after': '',
-            'before_header': '%s (content)' % path,
-            'after_header': '%s (content)' % path}
-
-    if module._diff and original:
-        diff['before'] = original
-
-    insertbefore = params['insertbefore']
-    insertafter = params['insertafter']
-    block = to_bytes(params['block'])
-    marker = to_bytes(params['marker'])
-    present = params['state'] == 'present'
-
-    if not present and not path_exists:
-        module.exit_json(changed=False, msg="File %s not present" % path)
-
-    if insertbefore is None and insertafter is None:
-        insertafter = 'EOF'
-
-    if insertafter not in (None, 'EOF'):
-        insertre = re.compile(to_bytes(insertafter, errors='surrogate_or_strict'))
-    elif insertbefore not in (None, 'BOF'):
-        insertre = re.compile(to_bytes(insertbefore, errors='surrogate_or_strict'))
-    else:
-        insertre = None
-
-    marker0 = re.sub(b(r'{mark}'), b(params['marker_begin']), marker)
-    marker1 = re.sub(b(r'{mark}'), b(params['marker_end']), marker)
-    if present and block:
-        # Escape seqeuences like '\n' need to be handled in Ansible 1.x
-        if module.ansible_version.startswith('1.'):
-            block = re.sub('', block, '')
-        blocklines = [marker0] + block.splitlines() + [marker1]
-    else:
-        blocklines = []
-
-    n0 = n1 = None
-    for i, line in enumerate(lines):
-        if line == marker0:
-            n0 = i
-        if line == marker1:
-            n1 = i
-
-    if None in (n0, n1):
-        n0 = None
-        if insertre is not None:
-            for i, line in enumerate(lines):
-                if insertre.search(line):
-                    n0 = i
-            if n0 is None:
-                n0 = len(lines)
-            elif insertafter is not None:
-                n0 += 1
-        elif insertbefore is not None:
-            n0 = 0  # insertbefore=BOF
+    with FileLock(path, check_mode=module.check_mode):
+        path_exists = os.path.exists(path)
+        if not path_exists:
+            if not module.boolean(params['create']):
+                module.fail_json(rc=257,
+                                 msg='Path %s does not exist !' % path)
+            destpath = os.path.dirname(path)
+            if not os.path.exists(destpath) and not module.check_mode:
+                try:
+                    os.makedirs(destpath)
+                except Exception as e:
+                    module.fail_json(msg='Error creating %s Error code: %s Error description: %s' % (destpath, e[0], e[1]))
+            original = None
+            lines = []
         else:
-            n0 = len(lines)  # insertafter=EOF
-    elif n0 < n1:
-        lines[n0:n1 + 1] = []
-    else:
-        lines[n1:n0 + 1] = []
-        n0 = n1
+            f = open(path, 'rb')
+            original = f.read()
+            f.close()
+            lines = original.splitlines()
 
-    lines[n0:n0] = blocklines
+        diff = {'before': '',
+                'after': '',
+                'before_header': '%s (content)' % path,
+                'after_header': '%s (content)' % path}
 
-    if lines:
-        result = b('\n').join(lines)
-        if original is None or original.endswith(b('\n')):
-            result += b('\n')
-    else:
-        result = b''
+        if module._diff and original:
+            diff['before'] = original
 
-    if module._diff:
-        diff['after'] = result
+        insertbefore = params['insertbefore']
+        insertafter = params['insertafter']
+        block = to_bytes(params['block'])
+        marker = to_bytes(params['marker'])
+        present = params['state'] == 'present'
 
-    if original == result:
-        msg = ''
-        changed = False
-    elif original is None:
-        msg = 'File created'
-        changed = True
-    elif not blocklines:
-        msg = 'Block removed'
-        changed = True
-    else:
-        msg = 'Block inserted'
-        changed = True
+        if not present and not path_exists:
+            module.exit_json(changed=False, msg="File %s not present" % path)
 
-    if changed and not module.check_mode:
-        if module.boolean(params['backup']) and path_exists:
-            module.backup_local(path)
-        # We should always follow symlinks so that we change the real file
-        real_path = os.path.realpath(params['path'])
-        write_changes(module, result, real_path)
+        if insertbefore is None and insertafter is None:
+            insertafter = 'EOF'
+
+        if insertafter not in (None, 'EOF'):
+            insertre = re.compile(to_bytes(insertafter, errors='surrogate_or_strict'))
+        elif insertbefore not in (None, 'BOF'):
+            insertre = re.compile(to_bytes(insertbefore, errors='surrogate_or_strict'))
+        else:
+            insertre = None
+
+        marker0 = re.sub(b(r'{mark}'), b(params['marker_begin']), marker)
+        marker1 = re.sub(b(r'{mark}'), b(params['marker_end']), marker)
+        if present and block:
+            # Escape seqeuences like '\n' need to be handled in Ansible 1.x
+            if module.ansible_version.startswith('1.'):
+                block = re.sub('', block, '')
+            blocklines = [marker0] + block.splitlines() + [marker1]
+        else:
+            blocklines = []
+
+        n0 = n1 = None
+        for i, line in enumerate(lines):
+            if line == marker0:
+                n0 = i
+            if line == marker1:
+                n1 = i
+
+        if None in (n0, n1):
+            n0 = None
+            if insertre is not None:
+                for i, line in enumerate(lines):
+                    if insertre.search(line):
+                        n0 = i
+                if n0 is None:
+                    n0 = len(lines)
+                elif insertafter is not None:
+                    n0 += 1
+            elif insertbefore is not None:
+                n0 = 0  # insertbefore=BOF
+            else:
+                n0 = len(lines)  # insertafter=EOF
+        elif n0 < n1:
+            lines[n0:n1 + 1] = []
+        else:
+            lines[n1:n0 + 1] = []
+            n0 = n1
+
+        lines[n0:n0] = blocklines
+
+        if lines:
+            result = b('\n').join(lines)
+            if original is None or original.endswith(b('\n')):
+                result += b('\n')
+        else:
+            result = b''
+
+        if module._diff:
+            diff['after'] = result
+
+        if original == result:
+            msg = ''
+            changed = False
+        elif original is None:
+            msg = 'File created'
+            changed = True
+        elif not blocklines:
+            msg = 'Block removed'
+            changed = True
+        else:
+            msg = 'Block inserted'
+            changed = True
+
+        if changed and not module.check_mode:
+            if module.boolean(params['backup']) and path_exists:
+                module.backup_local(path)
+            # We should always follow symlinks so that we change the real file
+            real_path = os.path.realpath(params['path'])
+            write_changes(module, result, real_path)
 
     if module.check_mode and not path_exists:
         module.exit_json(changed=changed, msg=msg, diff=diff)


### PR DESCRIPTION
##### SUMMARY
This commit implements file locking feature to avoid
race conditions, when multiple ansible processes access
same file. Common scenario is, when we use delegate_to
on task with file manipulation module.

Lock is set on separate .lock files. This avoids loosing lock
when we write content back into original location with (atomic)
move command. Fcntl system's calls are used (in PY fcntl.flock).
This is advisory lock implementation, where locks are set on
inode & PID pair.

.lock files are located in temp directory. That way cleanup
is handled by OS.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
FileLock

##### ADDITIONAL INFORMATION
Replacement of https://github.com/ansible/ansible/pull/52567
For now i will just add test playbook in PR description.
Note: Validate is important parameter when testing, as it increases chances of race conditions.
Although it can be simple sleep command.
```Test playbook
- name: Test race condition
  hosts: all
  gather_facts: no
  vars:
    testfile1: "{{ playbook_dir }}/race.test"
    testfile2: "{{ playbook_dir }}/race2.test"
  tasks:
    - name: Test blockinfile
      blockinfile:
        path: "{{ testfile1 }}"
        state: present
        create: true
        marker: "# {{ inventory_hostname }} {mark}"
        block: "{{ inventory_hostname }}"
        validate: bash -c 'TMP_DIR=`mktemp -d`;
            cp -Tp %s "$TMP_DIR"/race.test &&
            rm -rf $TMP_DIR'
      delegate_to: localhost

    - name: Test lineinfile
      lineinfile:
        path: "{{ testfile2 }}"
        state: present
        create: true
        line: "{{ inventory_hostname }}"
        validate: bash -c 'TMP_DIR=`mktemp -d`;
            cp -Tp %s "$TMP_DIR"/race2.test &&
            rm -rf $TMP_DIR'
      delegate_to: localhost

    - name: Blockinfile expected number of lines
      assert:
        that:
        - "{{ lines }} == ansible_play_hosts|length"
      vars:
        lines: "{{ lookup('file', testfile1).split('\n').__len__() / 3 }}"
      run_once: yes
      delegate_to: localhost

    - name: Lineinfile expected number of lines
      assert:
        that:
        - lines|length == ansible_play_hosts|length
      vars:
        lines: "{{ lookup('file', testfile2).split('\n') }}"
      run_once: yes
      delegate_to: localhost

    - name: Clean up
      file:
        state: absent
        path: "{{ item }}"
      with_items:
        - "{{ testfile1 }}"
        - "{{ testfile2 }}"
      run_once: yes
      delegate_to: localhost
```
