### PR TITLE
Add example of "parent_group" usage in aws_ec2.py

### DIFF
--- a/lib/ansible/plugins/inventory/aws_ec2.py
+++ b/lib/ansible/plugins/inventory/aws_ec2.py
@@ -138,6 +138,10 @@ keyed_groups:
   # Create a group per region e.g. aws_region_us_east_2
   - key: placement.region
     prefix: aws_region
+  # Create a group (or groups) based on the value of a custom tag "Role" and add them to a metagroup called "project"
+  - key: tags['Role']
+    prefix: foo
+    parent_group: "project"
 # Set individual variables with compose
 compose:
   # Use the private IP address to connect to the host


### PR DESCRIPTION
##### SUMMARY
Looks like the "parent_group" option in "keyed_groups" is a very recent feature that is not being documented. This pull request just adds a simple example of the usage of this useful option.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
aws_ec2.py
