### PR TITLE
[docs] Fix subversion.py export example

### DIFF
--- a/lib/ansible/modules/source_control/subversion.py
+++ b/lib/ansible/modules/source_control/subversion.py
@@ -98,6 +98,7 @@ EXAMPLES = '''
   subversion:
     repo: svn+ssh://an.example.org/path/to/repo
     dest: /src/export
+    export: yes
 
 - name: Get information about the repository whether or not it has already been cloned locally
 - subversion:


### PR DESCRIPTION
##### SUMMARY
The svn export example was missing the `export: yes` parameter. It was accidentally omitted when the syntax was changed in ad6999e2ebd65a322ac7f1e5bde84a3b12a8b91d.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
subversion
