### PR TITLE
Provide nice error when the shell plugin is incompatible with the con figured become plugin

### DIFF
--- a/changelogs/fragments/57770-become-shell-compat.yml
+++ b/changelogs/fragments/57770-become-shell-compat.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- become - Provide nice error when the shell plugin is incompatible with the configured become plugin
+  (https://github.com/ansible/ansible/issues/57770)

--- a/lib/ansible/plugins/become/__init__.py
+++ b/lib/ansible/plugins/become/__init__.py
@@ -9,6 +9,7 @@ from random import choice
 from string import ascii_lowercase
 from gettext import dgettext
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes
 from ansible.plugins import AnsiblePlugin

--- a/lib/ansible/plugins/become/__init__.py
+++ b/lib/ansible/plugins/become/__init__.py
@@ -49,7 +49,10 @@ class BecomeBase(AnsiblePlugin):
         if not all((cmd, shell, self.success)):
             return cmd
 
-        cmd = shlex_quote('%s %s %s %s' % (shell.ECHO, self.success, shell.COMMAND_SEP, cmd))
+        try:
+            cmd = shlex_quote('%s %s %s %s' % (shell.ECHO, self.success, shell.COMMAND_SEP, cmd))
+        except AttributeError:
+            raise AnsibleError('The %s shell family is incompatible with the %s become plugin' % (shell.SHELL_FAMILY, self.name))
         exe = getattr(shell, 'executable', None)
         if exe and not noexe:
             cmd = '%s -c %s' % (exe, cmd)

--- a/lib/ansible/plugins/become/__init__.py
+++ b/lib/ansible/plugins/become/__init__.py
@@ -52,6 +52,7 @@ class BecomeBase(AnsiblePlugin):
         try:
             cmd = shlex_quote('%s %s %s %s' % (shell.ECHO, self.success, shell.COMMAND_SEP, cmd))
         except AttributeError:
+            # TODO: This should probably become some more robust functionlity used to detect incompat
             raise AnsibleError('The %s shell family is incompatible with the %s become plugin' % (shell.SHELL_FAMILY, self.name))
         exe = getattr(shell, 'executable', None)
         if exe and not noexe:


### PR DESCRIPTION
##### SUMMARY
Provide nice error when the shell plugin is incompatible with the con figured become plugin. Fixes #57770

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/become/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```