### PR TITLE
comments parsed with escape sequence

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -230,6 +230,10 @@ class NetworkConfig(object):
             if not text or ignore_line(text, comment_tokens):
                 continue
 
+            # comment with escape sequence
+            if text.startswith("\\"):
+                cfg.text = cfg.text.strip("\\")
+
             # handle top level commands
             if toplevel.match(line):
                 ancestors = [cfg]


### PR DESCRIPTION
Signed-off-by: rohitthakur2590 <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- related to #57130 
- When pushing a prefix-set to an ASR9K router, it appears Ansible is filtering out "#remarks".
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/network/common/config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
