### PR TITLE
Improving na_ontap_command module

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_command.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_command.py
@@ -132,7 +132,7 @@ class NetAppONTAPCommand(object):
             output = self.server.invoke_successfully(command_obj, True)
             if self.return_dict:
                 # Parseable dict output
-                retval = self.parse_xml_to_dict(output.to_string())                    
+                retval = self.parse_xml_to_dict(output.to_string())
             else:
                 # Raw XML output
                 retval = output.to_string()
@@ -175,11 +175,10 @@ class NetAppONTAPCommand(object):
             except xml.parsers.expat.ExpatError as errcode:
                 self.result_dict['status'] = "XML parser: " + str(errcode)
 
-            
         except ImportError:
             self.result_dict['stdout'] = "XML parsing failed. Cannot import xml.parsers.expat!"
-        
-        return self.result_dict 
+
+        return self.result_dict
 
     def _start_element(self, name, attrs):
         ''' Start XML element '''

--- a/lib/ansible/modules/storage/netapp/na_ontap_command.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_command.py
@@ -35,7 +35,7 @@ options:
         description:
         - returns a parsesable dictonary instead of raw XML output
         choices: ['true', 'false']
-        default: true
+        default: false
         version_added: "2.9"
 '''
 

--- a/lib/ansible/modules/storage/netapp/na_ontap_command.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_command.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
-
+'''
 # (c) 2018, NetApp, Inc
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+'''
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -30,6 +31,12 @@ options:
         choices: ['admin', 'advanced']
         default: admin
         version_added: "2.8"
+    return_dict:
+        description:
+        - returns a parsesable dictonary instead of raw XML output
+        choices: ['true', 'false']
+        default: true
+        version_added: "2.9"
 '''
 
 EXAMPLES = """
@@ -47,12 +54,14 @@ EXAMPLES = """
         password: "{{ admin password }}"
         command: ['network', 'interface', 'show']
         privilege: 'admin'
+        return_dict: true
 """
 
 RETURN = """
 """
 
 import traceback
+import xml.parsers.expat
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 import ansible.module_utils.netapp as netapp_utils
@@ -68,7 +77,9 @@ class NetAppONTAPCommand(object):
         self.argument_spec.update(dict(
             command=dict(required=True, type='list'),
             privilege=dict(required=False, type='str', choices=['admin', 'advanced'],
-                           default='admin')
+                           default='admin'),
+            return_dict=dict(required=False, type='bool', choices=[True, False],
+                             default=False)
         ))
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
@@ -78,6 +89,15 @@ class NetAppONTAPCommand(object):
         # set up state variables
         self.command = parameters['command']
         self.privilege = parameters['privilege']
+        self.return_dict = parameters['return_dict']
+
+        self.result_dict = dict()
+        self.result_dict['status'] = ""
+        self.result_dict['result_value'] = 0
+        self.result_dict['invoked_command'] = " ".join(self.command)
+        self.result_dict['stdout'] = ""
+        self.result_dict['stdout_lines'] = []
+        self.result_dict['xml_dict'] = dict()
 
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
@@ -99,7 +119,13 @@ class NetAppONTAPCommand(object):
         ''' calls the ZAPI '''
         self.asup_log_for_cserver("na_ontap_command: " + str(self.command))
         command_obj = netapp_utils.zapi.NaElement("system-cli")
+
         args_obj = netapp_utils.zapi.NaElement("args")
+        if self.return_dict:
+            args_obj.add_new_child('arg', 'set')
+            args_obj.add_new_child('arg', '-showseparator')
+            args_obj.add_new_child('arg', '"###"')
+            args_obj.add_new_child('arg', ';')
         for arg in self.command:
             args_obj.add_new_child('arg', arg)
         command_obj.add_child_elem(args_obj)
@@ -107,7 +133,14 @@ class NetAppONTAPCommand(object):
 
         try:
             output = self.server.invoke_successfully(command_obj, True)
-            return output.to_string()
+            if self.return_dict:
+                # Parseable dict output
+                retval = self.parse_xml_to_dict(output.to_string())
+            else:
+                # Raw XML output
+                retval = output.to_string()
+
+            return retval
         except netapp_utils.zapi.NaApiError as error:
             self.module.fail_json(msg='Error running command %s: %s' %
                                   (self.command, to_native(error)),
@@ -118,6 +151,60 @@ class NetAppONTAPCommand(object):
         changed = True
         output = self.run_command()
         self.module.exit_json(changed=changed, msg=output)
+
+    def parse_xml_to_dict(self, xmldata):
+        '''Parse raw XML from system-cli and create an Ansible parseable dictonary'''
+
+        xml_str = xmldata.decode('utf-8').replace('\n', '---')
+
+        xml_parser = xml.parsers.expat.ParserCreate()
+        xml_parser.StartElementHandler = self._start_element
+        xml_parser.CharacterDataHandler = self._char_data
+        xml_parser.EndElementHandler = self._end_element
+
+        try:
+            xml_parser.Parse(xml_str)
+            self.result_dict['status'] = self.result_dict['xml_dict']['results']['attrs']['status']
+            stdout_string = self._format_escaped_data(self.result_dict['xml_dict']['cli-output']['data'])
+            self.result_dict['stdout'] = stdout_string
+            for line in stdout_string.split('\n'):
+                stripped_line = line.strip()
+                if len(stripped_line) > 1:
+                    self.result_dict['stdout_lines'].append(stripped_line)
+            self.result_dict['xml_dict']['cli-output']['data'] = stdout_string
+            self.result_dict['result_value'] = int(str(self.result_dict['xml_dict']['cli-result-value']['data']).replace("'", ""))
+
+        except xml.parsers.expat.ExpatError as errcode:
+            self.result_dict['status'] = "XML parser: " + str(errcode)
+
+        return self.result_dict
+
+    def _start_element(self, name, attrs):
+        ''' Start XML element '''
+        self.result_dict['xml_dict'][name] = dict()
+        self.result_dict['xml_dict'][name]['attrs'] = attrs
+        self.result_dict['xml_dict'][name]['data'] = ""
+        self.result_dict['xml_dict']['active_element'] = name
+        self.result_dict['xml_dict']['last_element'] = ""
+
+    def _char_data(self, data):
+        ''' Dump XML elemet data '''
+        self.result_dict['xml_dict'][str(self.result_dict['xml_dict']['active_element'])]['data'] = repr(data)
+
+    def _end_element(self, name):
+        self.result_dict['xml_dict']['last_element'] = name
+        self.result_dict['xml_dict']['active_element'] = ""
+
+    @classmethod
+    def _format_escaped_data(cls, datastring):
+        ''' replace helper escape sequences '''
+        formatted_string = datastring.replace('------', '---').replace('---', '\n').replace("###", "    ").strip()
+        retval_string = ""
+        for line in formatted_string.split('\n'):
+            stripped_line = line.strip()
+            if len(stripped_line) > 1:
+                retval_string += stripped_line + "\n"
+        return retval_string
 
 
 def main():


### PR DESCRIPTION
- new option 'return_dict': true|false
- module returns parseable dictionary data instead of raw XML when return_dict: true

##### SUMMARY
Adding new option to adjust module output.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
na_ontap_command

##### ADDITIONAL INFORMATION
```
ansible-playbook test_command_module.yml  --limit lab.filer

PLAY [all] **************************************************************************************************************************************************************************************************************************************************
# Old behaviour 
TASK [na_ontap_command - standard XML output] ***************************************************************************************************************************************************************************************************************
changed: [lab.filer]

TASK [Results of na_ontap_command - standard XML output] ****************************************************************************************************************************************************************************************************
ok: [lab.filer] => 
  cmd_out_xml:
    changed: true
    failed: false
    msg: |-
      <results xmlns="http://www.netapp.com/filer/admin" status="passed"><cli-output>NetApp Release 9.5P2: Thu Mar 14 13:59:39 UTC 2019
  
      </cli-output><cli-result-value>1</cli-result-value></results>

# New behaviour 
TASK [na_ontap_command - returning parsed dictionary] ********************************************************************************************************************************************************************************************************
changed: [lab.filer]

TASK [Debug - parseable output] *****************************************************************************************************************************************************************************************************************************
ok: [lab.filer] => 
  cmd_out_parsed:
    changed: true
    failed: false
    msg:
      invoked_command: version
      result_value: 1
      status: passed
      stdout: |-
        NetApp Release 9.5P2: Thu Mar 14 13:59:39 UTC 2019
      stdout_lines:
      - 'NetApp Release 9.5P2: Thu Mar 14 13:59:39 UTC 2019'
      xml_dict:
        active_element: ''
        cli-output:
          attrs: {}
          data: |-
            NetApp Release 9.5P2: Thu Mar 14 13:59:39 UTC 2019
        cli-result-value:
          attrs: {}
          data: '''1'''
        last_element: results
        results:
          attrs:
            status: passed
            xmlns: http://www.netapp.com/filer/admin
          data: ''

PLAY RECAP ****************************************************************************************************************************
```

```
# Module usage - new option
    - name:             na_ontap_command - returning parsed dictionary
      na_ontap_command:
        command:        ['version']
        return_dict:    true
```