### PR TITLE
vmware: avoid unnecessary copy() call

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_facts.py
@@ -217,12 +217,10 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
-                tmpobjs = objects.copy()
-                for k, v in objects.items():
+                for k, v in tuple(objects.items()):
                     parent_dc = get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        tmpobjs.pop(k, None)
-                objects = tmpobjs
+                        del objects[k]
             else:
                 # everything else should be a list
                 objects = [x for x in objects if get_parent_datacenter(x).name == self.dc_name]

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -785,12 +785,10 @@ class PyVmomiCache(object):
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
                 # make a copy
-                tmpobjs = objects.copy()
-                for k, v in objects.items():
+                for k, v in tuple(objects.items()):
                     parent_dc = self.get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        tmpobjs.pop(k, None)
-                objects = tmpobjs
+                        del objects[k]
             else:
                 # everything else should be a list
                 objects = [x for x in objects if self.get_parent_datacenter(x).name == self.dc_name]


### PR DESCRIPTION
##### SUMMARY

Two vmware modules uses copy() to duplicate an internal instance of a
pyvmomi object. This to be able to modify the object during an iteration.

See: https://github.com/ansible/ansible/pull/60196/files#r312643761

Fixes #60399

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware