### PR TITLE
Update ce_bfd_global to fix bugs

### DIFF
--- a/changelogs/fragments/60412-ce_bfd_global-to-fix-bugs.yml
+++ b/changelogs/fragments/60412-ce_bfd_global-to-fix-bugs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ce_bfd_global - update to fix some bugs - When BFD is unavailable, tosExp and other parameters are sent down to report errors; this error is corrected and the query results are processed again. (https://github.com/ansible/ansible/pull/60412)

--- a/lib/ansible/modules/network/cloudengine/ce_bfd_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_bfd_global.py
@@ -284,7 +284,8 @@ class BfdGlobal(object):
         glb = root.find("bfd/bfdSchGlobal")
         if glb:
             for attr in glb:
-                bfd_dict["global"][attr.tag] = attr.text
+                if attr.text is not None:
+                    bfd_dict["global"][attr.tag] = attr.text
 
         return bfd_dict
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When BFD is unavailable, tosExp and other parameters are sent down to report errors; this error is corrected and the query results are processed again.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/modules/network/cloudengine/ce_bfd_global.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
