### PR TITLE
vmware_guest_network: disable 'ifce disconnect' test

### DIFF
--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -73,26 +73,27 @@
         - "del_netadapter.changed == true"
         - "{{ del_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
 
-  - name: disconnect one specified network adapter
-    vmware_guest_network:
-      validate_certs: False
-      hostname: "{{ vcenter_hostname }}"
-      username: "{{ vcenter_username }}"
-      password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines[0].name }}"
-      networks:
-        - state: present
-          mac: "00:50:56:58:59:61"
-          connected: false
-    register: disc_netadapter
-
-  - debug: var=disc_netadapter
-
-  - name: assert the network adapter was disconnected
-    assert:
-      that:
-        - "disc_netadapter.changed == true"
-        - "{{ disc_netadapter.network_data[netadapter_num]['connected'] }} == false"
+# Disabled, see: https://github.com/ansible/ansible/issues/60479
+#  - name: disconnect one specified network adapter
+#    vmware_guest_network:
+#      validate_certs: False
+#      hostname: "{{ vcenter_hostname }}"
+#      username: "{{ vcenter_username }}"
+#      password: "{{ vcenter_password }}"
+#      name: "{{ virtual_machines[0].name }}"
+#      networks:
+#        - state: present
+#          mac: "00:50:56:58:59:61"
+#          connected: false
+#    register: disc_netadapter
+#
+#  - debug: var=disc_netadapter
+#
+#  - name: assert the network adapter was disconnected
+#    assert:
+#      that:
+#        - "disc_netadapter.changed == true"
+#        - "{{ disc_netadapter.network_data[netadapter_num]['connected'] }} == false"
 
   - name: Check if network does not exists
     vmware_guest_network:


### PR DESCRIPTION
##### SUMMARY

Temporary disable the `disconnect one specified network adapter` test, this
until https://github.com/ansible/ansible/issues/60479 is fixed.
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
