### PR TITLE
vmware_drs_group: creates test vm properly

### DIFF
--- a/test/integration/targets/vmware_drs_group/tasks/main.yml
+++ b/test/integration/targets/vmware_drs_group/tasks/main.yml
@@ -7,31 +7,7 @@
   vars:
     setup_attach_host: true
     setup_datastore: true
-
-- name: Create VMs
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    validate_certs: no
-    folder: '{{ f0 }}'
-    name: test_vm1
-    state: poweredoff
-    guest_id: debian8_64Guest
-    disk:
-    - size_gb: 1
-      type: thin
-      datastore: '{{ ds2 }}'
-    hardware:
-      memory_mb: 128
-      num_cpus: 1
-      scsi: paravirtual
-    cdrom:
-      type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
-    networks:
-    - name: VM Network
+    setup_virtualmachines: true
 
 - name: Create DRS VM group
   vmware_drs_group:


### PR DESCRIPTION
##### SUMMARY

Creates the test VMs with `prepare_vmware_test`. Before this commit,
only one VM was created and the next step was failing because this was
not matching the expected list of VMs.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_drs_group
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
