### PR TITLE
Fix naming in example code documentation section …

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_codebuild.py
+++ b/lib/ansible/modules/cloud/amazon/aws_codebuild.py
@@ -163,7 +163,7 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
-- code_build:
+- aws_codebuild:
     name: my_project
     description: My nice little project
     service_role: "arn:aws:iam::123123:role/service-role/code-build-service-role"

--- a/lib/ansible/modules/cloud/amazon/aws_codepipeline.py
+++ b/lib/ansible/modules/cloud/amazon/aws_codepipeline.py
@@ -72,7 +72,7 @@ EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Example for creating a pipeline for continuous deploy of Github code to an ECS cluster (container)
-- code_pipeline:
+- aws_codepipeline:
     name: my_deploy_pipeline
     role_arn: arn:aws:iam::123456:role/AWS-CodePipeline-Service
     artifact_store:


### PR DESCRIPTION
…for aws_codebuild and aws_codepipeline modules

##### SUMMARY
Documentation fix for both modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- aws_codebuild
- aws_codepipeline

##### ADDITIONAL INFORMATION
Make documentation match the module names.
