### PR TITLE
win_domain reboot required exception incorrectly reported

### DIFF
--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -127,6 +127,9 @@ if (-not $forest) {
         if ($_.Exception.ExitCode -eq 15) {
             $result.reboot_required = $true
         } else {
+            if ($_.Exception.Message.Contains("A reboot is required.")) {
+                $result.reboot_required = $true
+            }
             Fail-Json -obj $result -message "Failed to install ADDSForest with DCPromo: $($_.Exception.Message)"
         }
     }

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -124,13 +124,10 @@ if (-not $forest) {
     } catch [Microsoft.DirectoryServices.Deployment.DCPromoExecutionException] {
         # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
         # DCPromo exit codes details can be found at https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment
-        if ($_.Exception.ExitCode -eq 15) {
+        if ($_.Exception.ExitCode -in @(15, 19)) {
             $result.reboot_required = $true
         } else {
-            if ($_.Exception.Message.Contains("A reboot is required.")) {
-                $result.reboot_required = $true
-            }
-            Fail-Json -obj $result -message "Failed to install ADDSForest with DCPromo: $($_.Exception.Message)"
+            Fail-Json -obj $result -message "Failed to install ADDSForest, DCPromo exited with $($_.Exception.ExitCode): $($_.Exception.Message)"
         }
     }
 


### PR DESCRIPTION
##### SUMMARY
If the module fails because a reboot is pending it is stated in the exception message, but reboot_required is still false.

Fixes: #60493

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain

##### ADDITIONAL INFORMATION

```
fatal: [****-****]: FAILED! => {
    "changed": true,
    "msg": "Failed to install ADDSForest with DCPromo: Name change pending. A reboot is required.\r\n",
    "reboot_required": false
}
```
