### PR TITLE
[stable-2.8] Use new version of default test image that contains Python 3.8.0b3(#60139)

### DIFF
--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.8.2 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:1.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #60139 for Ansible 2.8
(cherry picked from commit a20848bf66)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/runner/completion/docker.txt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Depends on #60442
Depends on #60541