### PR TITLE
[2.8] proxmox_kvm: While a VM is beeing created, vm has no name item

### DIFF
--- a/changelogs/fragments/58194-vm-name-item-not-yet-present-at-creation-time.yaml
+++ b/changelogs/fragments/58194-vm-name-item-not-yet-present-at-creation-time.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_kvm - fixed issue when vm has not yet a name item (https://github.com/ansible/ansible/issues/58194)

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -604,7 +604,7 @@ def get_nextvmid(module, proxmox):
 
 
 def get_vmid(proxmox, name):
-    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == name]
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm.get('name') == name]
 
 
 def get_vm(proxmox, vmid):


### PR DESCRIPTION
##### SUMMARY
Backport of #58196 to stable-2.8.

CC @pguermo @xenlo 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm
