### PR TITLE
route53: improve octal encoded characters handling

### DIFF
--- a/changelogs/fragments/60508-route53-improve-octal-characters-handling.yml
+++ b/changelogs/fragments/60508-route53-improve-octal-characters-handling.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+bugfixes:
 - route53 - improve handling of octal encoded characters

--- a/changelogs/fragments/60508-route53-improve-octal-characters-handling.yml
+++ b/changelogs/fragments/60508-route53-improve-octal-characters-handling.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- route53 - improve handling of octal encoded characters


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes octal chars returned by AWS Route53 API

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #30077

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
