### PR TITLE
apt_facts - Fix cache related performance regression

### DIFF
--- a/changelogs/fragments/package_facts-performace-regression-fix.yaml
+++ b/changelogs/fragments/package_facts-performace-regression-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt_facts - fix performance regression when getting facts about apt packages (https://github.com/ansible/ansible/issues/60450)

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -211,7 +211,7 @@ class APT(LibMgr):
     def list_installed(self):
         # Store the cache to avoid running pkg_cache() for each item in the comprehension, which is very slow
         cache = self.pkg_cache
-        return [pk for pk in self.pkg_cache.keys() if cache[pk].is_installed]
+        return [pk for pk in cache.keys() if cache[pk].is_installed]
 
     def get_package_details(self, package):
         ac_pkg = self.pkg_cache[package].installed

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -192,7 +192,7 @@ class APT(LibMgr):
 
     @property
     def pkg_cache(self):
-        if self._cache:
+        if self._cache is not None:
             return self._cache
 
         self._cache = self._lib.Cache()
@@ -209,7 +209,9 @@ class APT(LibMgr):
         return we_have_lib
 
     def list_installed(self):
-        return [pk for pk in self.pkg_cache.keys() if self.pkg_cache[pk].is_installed]
+        # Store the cache to avoid running pkg_cache() for each item in the comprehension, which is very slow
+        cache = self.pkg_cache
+        return [pk for pk in self.pkg_cache.keys() if cache[pk].is_installed]
 
     def get_package_details(self, package):
         ac_pkg = self.pkg_cache[package].installed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #60450
Related in #56008

Fix a performance regression related to caching data about apt packages by reusing an empty cache object if it exists and also by storing the cache outside of the list comprehension.

In my testing, this takes module execution time down to ~2s from ~106s.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/packaging/os/package_facts.py`