### PR TITLE
apt: use exponential backoff for apt update cache retries

### DIFF
--- a/changelogs/fragments/60527-apt_exponential_backoff_cache_update_retry.yml
+++ b/changelogs/fragments/60527-apt_exponential_backoff_cache_update_retry.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apt - Implemented an exponential backoff behaviour when retrying to update the cache.
+  - apt - Implemented an exponential backoff behaviour when retrying to update the cache with new params ``update_cache_retry_max_delay`` and ``update_cache_retries`` to control the behavior.

--- a/changelogs/fragments/60527-apt_exponential_backoff_cache_update_retry.yml
+++ b/changelogs/fragments/60527-apt_exponential_backoff_cache_update_retry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - Implemented an exponential backoff behaviour when retrying to update the cache.

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -43,13 +43,13 @@ options:
       - Amount of retries if the cache update fails. Also see I(update_cache_retry_max_delay).
     type: int
     default: 5
-    version_added: '2.9'
+    version_added: '2.10'
   update_cache_retry_max_delay:
     description:
-      - Use an exponential backoff delay for each retry (see I(update_cache_retries)) up to this max. delay in seconds.
+      - Use an exponential backoff delay for each retry (see I(update_cache_retries)) up to this max delay in seconds.
     type: int
     default: 12
-    version_added: '2.9'
+    version_added: '2.10'
   cache_valid_time:
     description:
       - Update the apt cache if its older than the I(cache_valid_time). This option is set in seconds.

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1017,6 +1017,8 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'build-dep', 'fixed', 'latest', 'present']),
             update_cache=dict(type='bool', aliases=['update-cache']),
+            update_cache_retries=dict(type='int', default=5),
+            update_cache_max_retry_delay=dict(type='int', default=12),
             cache_valid_time=dict(type='int', default=0),
             purge=dict(type='bool', default=False),
             package=dict(type='list', aliases=['pkg', 'name']),

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -46,7 +46,7 @@ options:
     version_added: '2.9'
   update_cache_retry_max_delay:
     description:
-      - Use an exponential backoff delay for each retry (See I(update_cache_retries)) up to this max. delay in seconds.
+      - Use an exponential backoff delay for each retry (see I(update_cache_retries)) up to this max. delay in seconds.
     type: int
     default: 12
     version_added: '2.9'

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1119,7 +1119,7 @@ def main():
                         delay = update_cache_retry_max_delay + randomize
                     time.sleep(delay)
                 else:
-                    module.fail_json(msg='Failed to update apt cache: %s' % err if err else 'unknown reason')
+                    module.fail_json(msg='Failed to update apt cache: %s' % (err if err else 'unknown reason'))
 
                 cache.open(progress=None)
                 mtimestamp, post_cache_update_time = get_updated_cache_time()

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1018,7 +1018,7 @@ def main():
             state=dict(type='str', default='present', choices=['absent', 'build-dep', 'fixed', 'latest', 'present']),
             update_cache=dict(type='bool', aliases=['update-cache']),
             update_cache_retries=dict(type='int', default=5),
-            update_cache_max_retry_delay=dict(type='int', default=12),
+            update_cache_retry_max_delay=dict(type='int', default=12),
             cache_valid_time=dict(type='int', default=0),
             purge=dict(type='bool', default=False),
             package=dict(type='list', aliases=['pkg', 'name']),


### PR DESCRIPTION
##### SUMMARY
As discussed in the core meeting of today use similar exponential backoff logic as suggested for apt_repository PR #57266 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
