### PR TITLE
vultr: use exponential backoff for api query retries

### DIFF
--- a/changelogs/fragments/60529-vultry_retry_backoff.yml
+++ b/changelogs/fragments/60529-vultry_retry_backoff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vultr - the retry on failure functionality was changed to use an exponential backoff behaviour.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -164,7 +164,7 @@ class Vultr:
                 data = urllib.parse.urlencode(data_encoded) + data_list
 
         retry_max_delay = self.api_config['api_retry_max_delay']
-        randint = random.randint(0, 1000) / 1000.0
+        randomness = random.randint(0, 1000) / 1000.0
 
         for retry in range(0, self.api_config['api_retries']):
             response, info = fetch_url(
@@ -181,9 +181,9 @@ class Vultr:
 
             # Vultr has a rate limiting requests per second, try to be polite
             # Use exponential backoff plus a little bit of randomness
-            delay = 2 ** retry + randint
+            delay = 2 ** retry + randomness
             if delay > retry_max_delay:
-                delay = retry_max_delay + randint
+                delay = retry_max_delay + randomness
             time.sleep(delay)
 
         else:

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -164,7 +164,7 @@ class Vultr:
                 data = urllib.parse.urlencode(data_encoded) + data_list
 
         retry_max_delay = self.api_config['api_retry_max_delay']
-        randint = random.randint(0, 1000) / 1000
+        randint = random.randint(0, 1000) / 1000.0
 
         for retry in range(0, self.api_config['api_retries']):
             response, info = fetch_url(

--- a/lib/ansible/modules/cloud/vultr/_vultr_account_facts.py
+++ b/lib/ansible/modules/cloud/vultr/_vultr_account_facts.py
@@ -58,6 +58,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/_vultr_block_storage_facts.py
+++ b/lib/ansible/modules/cloud/vultr/_vultr_block_storage_facts.py
@@ -57,6 +57,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/_vultr_os_facts.py
+++ b/lib/ansible/modules/cloud/vultr/_vultr_os_facts.py
@@ -58,6 +58,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/_vultr_ssh_key_facts.py
+++ b/lib/ansible/modules/cloud/vultr/_vultr_ssh_key_facts.py
@@ -58,6 +58,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/_vultr_user_facts.py
+++ b/lib/ansible/modules/cloud/vultr/_vultr_user_facts.py
@@ -57,6 +57,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_account_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_account_info.py
@@ -54,6 +54,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_block_storage.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_block_storage.py
@@ -78,6 +78,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_block_storage_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_block_storage_info.py
@@ -57,6 +57,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_dns_domain.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_dns_domain.py
@@ -74,6 +74,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_dns_domain_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_dns_domain_facts.py
@@ -53,6 +53,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_dns_record.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_dns_record.py
@@ -139,6 +139,22 @@ vultr_api:
       returned: success
       type: int
       sample: 60
+    api_retries:
+      description: Amount of max retries for the API requests
+      returned: success
+      type: int
+      sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
+    api_endpoint:
+      description: Endpoint used for the API requests
+      returned: success
+      type: str
+      sample: "https://api.vultr.com"
 vultr_dns_record:
   description: Response from Vultr API
   returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_firewall_group.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_firewall_group.py
@@ -68,6 +68,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_firewall_group_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_firewall_group_facts.py
@@ -53,6 +53,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_firewall_rule.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_firewall_rule.py
@@ -116,6 +116,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_network.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_network.py
@@ -76,6 +76,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_network_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_network_facts.py
@@ -53,6 +53,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_os_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_os_info.py
@@ -57,6 +57,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_plan_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_plan_facts.py
@@ -54,6 +54,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_region_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_region_facts.py
@@ -54,6 +54,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_server.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server.py
@@ -184,6 +184,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_server_facts.py
@@ -54,6 +54,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_ssh_key.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_ssh_key.py
@@ -73,6 +73,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_ssh_key_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_ssh_key_info.py
@@ -58,6 +58,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_startup_script.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_startup_script.py
@@ -86,6 +86,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_startup_script_facts.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_startup_script_facts.py
@@ -54,6 +54,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_user.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_user.py
@@ -113,6 +113,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/modules/cloud/vultr/vultr_user_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_user_info.py
@@ -57,6 +57,12 @@ vultr_api:
       returned: success
       type: int
       sample: 5
+    api_retry_max_delay:
+      description: Exponential backoff delay in seconds between retries up to this max delay value.
+      returned: success
+      type: int
+      sample: 12
+      version_added: '2.9'
     api_endpoint:
       description: Endpoint used for the API requests
       returned: success

--- a/lib/ansible/plugins/doc_fragments/vultr.py
+++ b/lib/ansible/plugins/doc_fragments/vultr.py
@@ -26,6 +26,13 @@ options:
       - The ENV variable C(VULTR_API_RETRIES) is used as default, when defined.
       - Fallback value is 5 retries if not specified.
     type: int
+  api_retry_max_delay:
+    description:
+      - Retry backoff delay in seconds is exponential up to this max. value, in seconds.
+      - The ENV variable C(VULTR_API_RETRY_MAX_DELAY) is used as default, when defined.
+      - Fallback value is 12 seconds.
+    type: int
+    version_added: '2.9'
   api_account:
     description:
       - Name of the ini section in the C(vultr.ini) file.


### PR DESCRIPTION
##### SUMMARY
use exponential backoff for api query retries.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vultr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
