### PR TITLE
[stable-2.8] fixes issue with recieve parameter idempotency (#59999)

### DIFF
--- a/changelogs/fragments/bigip-monitor-http-receive-parameter.yaml
+++ b/changelogs/fragments/bigip-monitor-http-receive-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - bigip_monitor_http - fix issue with receive parameter idempotency (https://github.com/ansible/ansible/pull/59999)

--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -482,6 +482,10 @@ class Difference(object):
         return cmp_str_with_none(self.want.description, self.have.description)
 
     @property
+    def receive(self):
+        return cmp_str_with_none(self.want.receive, self.have.receive)
+
+    @property
     def receive_disable(self):
         return cmp_str_with_none(self.want.receive_disable, self.have.receive_disable)
 

--- a/lib/ansible/modules/network/f5/bigip_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_https.py
@@ -486,6 +486,10 @@ class Difference(object):
         return cmp_str_with_none(self.want.description, self.have.description)
 
     @property
+    def receive(self):
+        return cmp_str_with_none(self.want.receive, self.have.receive)
+
+    @property
     def receive_disable(self):
         return cmp_str_with_none(self.want.receive_disable, self.have.receive_disable)
 

--- a/test/units/modules/network/f5/test_bigip_device_connectivity.py
+++ b/test/units/modules/network/f5/test_bigip_device_connectivity.py
@@ -292,7 +292,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert 'must be between' in str(ex)
+        assert 'must be between' in str(ex.value)
 
     def test_set_multicast_address(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -120,7 +120,7 @@ class TestParameters(unittest.TestCase):
         with pytest.raises(F5ModuleError) as excinfo:
             p = ModuleParameters(params=args)
             assert p.name == 'foo'
-        assert 'The provided name must be a valid FQDN' in str(excinfo)
+        assert 'The provided name must be a valid FQDN' in str(excinfo.value)
 
 
 class TestUntypedManager(unittest.TestCase):

--- a/test/units/modules/network/f5/test_bigip_monitor_http.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_http.py
@@ -305,7 +305,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -335,7 +335,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_send(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_monitor_https.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_https.py
@@ -305,7 +305,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -335,7 +335,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_send(self, *args):
         set_module_args(dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #59999 for Ansible 2.8
(cherry picked from commit c9a9621a022fb6af476a3a4e3353f188c367e047)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/network/f5/bigip_monitor_http.py`