### PR TITLE
Cast booleans to strings.

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_snapshot.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_snapshot.py
@@ -199,7 +199,7 @@ class NetAppOntapSnapshot(object):
         snapshot_obj.add_new_child("volume", self.parameters['volume'])
         # Set up optional variables to create a snapshot
         if self.parameters.get('async_bool'):
-            snapshot_obj.add_new_child("async", self.parameters['async_bool'])
+            snapshot_obj.add_new_child("async", str(self.parameters['async_bool']))
         if self.parameters.get('comment'):
             snapshot_obj.add_new_child("comment", self.parameters['comment'])
         if self.parameters.get('snapmirror_label'):
@@ -223,7 +223,7 @@ class NetAppOntapSnapshot(object):
         snapshot_obj.add_new_child("volume", self.parameters['volume'])
         # set up optional variables to delete a snapshot
         if self.parameters.get('ignore_owners'):
-            snapshot_obj.add_new_child("ignore-owners", self.parameters['ignore_owners'])
+            snapshot_obj.add_new_child("ignore-owners", str(self.parameters['ignore_owners']))
         if self.parameters.get('snapshot_instance_uuid'):
             snapshot_obj.add_new_child("snapshot-instance-uuid", self.parameters['snapshot_instance_uuid'])
         try:


### PR DESCRIPTION
This avoids an error when building the API request:

TypeError: Argument must be bytes or unicode, got 'bool'

This would occur when one explicitly sets async_bool or ignore_owners in
a playbook/role.

##### SUMMARY
This avoids an error when building the API request:

TypeError: Argument must be bytes or unicode, got 'bool'

This would occur when one explicitly sets async_bool or ignore_owners in
a playbook/role.

Full stack trace:

```
/root/.ansible/tmp/ansible-tmp-1565708870.4482722-177223224722115/AnsiballZ_na_ontap_snapshot.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1565708870.4482722-177223224722115/AnsiballZ_na_ontap_snapshot.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1565708870.4482722-177223224722115/AnsiballZ_na_ontap_snapshot.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1565708870.4482722-177223224722115/AnsiballZ_na_ontap_snapshot.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/local/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/local/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_na_ontap_snapshot_payload_x0vol0hl/__main__.py\", line 323, in <module>\n  File \"/tmp/ansible_na_ontap_snapshot_payload_x0vol0hl/__main__.py\", line 319, in main\n  File \"/tmp/ansible_na_ontap_snapshot_payload_x0vol0hl/__main__.py\", line 308, in apply\n  File \"/tmp/ansible_na_ontap_snapshot_payload_x0vol0hl/__main__.py\", line 226, in delete_snapshot\n  File \"/usr/local/lib/python3.7/site-packages/netapp_lib/api/zapi/zapi.py\", line 445, in add_new_child\n    child.set_content(content)\n  File \"/usr/local/lib/python3.7/site-packages/netapp_lib/api/zapi/zapi.py\", line 382, in set_content\n    self._element.text = text\n  File \"src/lxml/etree.pyx\", line 1023, in lxml.etree._Element.text.__set__\n  File \"src/lxml/apihelpers.pxi\", line 734, in lxml.etree._setNodeText\n  File \"src/lxml/apihelpers.pxi\", line 722, in lxml.etree._createTextNode\n  File \"src/lxml/apihelpers.pxi\", line 1525, in lxml.etree._utf8\nTypeError: Argument must be bytes or unicode, got 'bool'\n"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_ontap_snapshot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Below would trigger the error.

```paste below

- name: Create snapshot
  na_ontap_snapshot:
    async_bool: no
   ...

```
