### PR TITLE
Deprecates Digital Ocean sshkey_facts in favor of new module sshkey_info

### DIFF
--- a/changelogs/fragments/60530-facts-info-rename.yaml
+++ b/changelogs/fragments/60530-facts-info-rename.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- The ``digital_ocean_sshkey_facts`` module has been deprecated. Use ``digital_ocean_sshkey_info`` instead.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -62,6 +62,8 @@ Deprecation notices
 
 The following modules will be removed in Ansible 2.13. Please update update your playbooks accordingly.
 
+* digital_ocean_sshkey_facts use :ref:`digital_ocean_sshkey_info <digital_ocean_sshkey_info_module>` instead.
+
 * junos_interface use :ref:`junos_interfaces <junos_interfaces_module>` instead.
 
 * junos_l2_interface use :ref:`junos_l2_interfaces <junos_l2_interfaces_module>` instead.

--- a/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
@@ -17,6 +17,10 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: digital_ocean_sshkey_facts
+deprecated:
+  removed_in: '2.13'
+  why: Deprecated in favour of C(_info) module.
+  alternative: Use M(digital_ocean_sshkey_info) instead.
 short_description: DigitalOcean SSH keys facts
 description:
      - Fetch DigitalOcean SSH keys facts.
@@ -90,6 +94,8 @@ def main():
         argument_spec=DigitalOceanHelper.digital_ocean_argument_spec(),
         supports_check_mode=False,
     )
+
+    module.deprecate("The 'digital_ocean_sshkey_facts' module has been renamed to 'digital_ocean_sshkey_info'", version='2.13')
 
     core(module)
 

--- a/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
@@ -95,7 +95,7 @@ def main():
         supports_check_mode=False,
     )
 
-    module.deprecate("The 'digital_ocean_sshkey_facts' module has been deprecated, use the new 'digital_ocean_sshkey_info'", version='2.13')
+    module.deprecate("The 'digital_ocean_sshkey_facts' module has been deprecated, use the new 'digital_ocean_sshkey_info' module", version='2.13')
 
     core(module)
 

--- a/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'status': ['preview'],
+ANSIBLE_METADATA = {'status': ['deprecated'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
 

--- a/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
+++ b/lib/ansible/modules/cloud/digital_ocean/_digital_ocean_sshkey_facts.py
@@ -95,7 +95,7 @@ def main():
         supports_check_mode=False,
     )
 
-    module.deprecate("The 'digital_ocean_sshkey_facts' module has been renamed to 'digital_ocean_sshkey_info'", version='2.13')
+    module.deprecate("The 'digital_ocean_sshkey_facts' module has been deprecated, use the new 'digital_ocean_sshkey_info'", version='2.13')
 
     core(module)
 

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
@@ -21,7 +21,7 @@ short_description: Gather information about DigitalOcean SSH keys
 description:
   - This module can be used to gather information about DigitalOcean SSH keys.
   - This module replaces the C(digital_ocean_sshkey_facts) module.
-version_added: "2.5"
+version_added: "2.9"
 author: "Patrick Marques (@pmarques)"
 extends_documentation_fragment: digital_ocean.documentation
 notes:

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
@@ -20,7 +20,7 @@ module: digital_ocean_sshkey_info
 short_description: Gather information about DigitalOcean SSH keys
 description:
   - This module can be used to gather information about DigitalOcean SSH keys.
-  - This module was called C(digital_ocean_sshkey_facts) before Ansible 2.9. The usage did not change.
+  - This module replaces the C(digital_ocean_sshkey_facts) module.
 version_added: "2.5"
 author: "Patrick Marques (@pmarques)"
 extends_documentation_fragment: digital_ocean.documentation

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+
+DOCUMENTATION = '''
+---
+module: digital_ocean_sshkey_info
+short_description: Gather information about DigitalOcean SSH keys
+description:
+  - This module can be used to gather information about DigitalOcean SSH keys.
+  - This module was called C(digital_ocean_sshkey_facts) before Ansible 2.9. The usage did not change.
+version_added: "2.5"
+author: "Patrick Marques (@pmarques)"
+extends_documentation_fragment: digital_ocean.documentation
+notes:
+  - Version 2 of DigitalOcean API is used.
+requirements:
+  - "python >= 2.6"
+'''
+
+
+EXAMPLES = '''
+- digital_ocean_sshkey_info:
+    oauth_token: "{{ my_do_key }}"
+  register: ssh_keys
+
+- set_fact:
+    pubkey: "{{ item.public_key }}"
+  loop: "{{ ssh_keys.data|json_query(ssh_pubkey) }}"
+  vars:
+    ssh_pubkey: "[?name=='ansible_ctrl']"
+
+- debug:
+    msg: "{{ pubkey }}"
+'''
+
+
+RETURN = '''
+# Digital Ocean API info https://developers.digitalocean.com/documentation/v2/#list-all-keys
+data:
+    description: List of SSH keys on DigitalOcean
+    returned: success and no resource constraint
+    type: dict
+    sample: [
+      {
+        "id": 512189,
+        "fingerprint": "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
+        "public_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
+        "name": "My SSH Public Key"
+      }
+    ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.digital_ocean import DigitalOceanHelper
+
+
+def core(module):
+    rest = DigitalOceanHelper(module)
+
+    response = rest.get("account/keys")
+    status_code = response.status_code
+    json = response.json
+    if status_code == 200:
+        module.exit_json(changed=False, data=json['ssh_keys'])
+    else:
+        module.fail_json(msg='Error fetching SSH Key information [{0}: {1}]'.format(
+            status_code, response.json['message']))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=DigitalOceanHelper.digital_ocean_argument_spec(),
+        supports_check_mode=False,
+    )
+
+    core(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey_info.py
@@ -83,7 +83,7 @@ def core(module):
 def main():
     module = AnsibleModule(
         argument_spec=DigitalOceanHelper.digital_ocean_argument_spec(),
-        supports_check_mode=False,
+        supports_check_mode=True,
     )
 
     core(module)


### PR DESCRIPTION
##### SUMMARY

Deprecate Digital Ocean _facts module in favor of module _info.
Continues #56822, #54280
Fixes #60530

This also enables Check Mode for the new module _info.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

digital_ocean_sshkey_facts