### PR TITLE
Terminal prompt Regex update for VPEX mode

### DIFF
--- a/lib/ansible/plugins/terminal/exos.py
+++ b/lib/ansible/plugins/terminal/exos.py
@@ -28,7 +28,7 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n](?:! )?(?:\* )?(?:\(.*\) )?(?:Slot-\d+ )?\S+\.\d+ (?:[>#]) ?$")
+        re.compile(br"[\r\n](?:! )?(?:\* )?(?:\(.*\) )?(?:Slot-\d+ )?(?:VPEX )?\S+\.\d+ (?:[>#]) ?$")
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add capability to communicate with EXOS switch in VPEX mode which has a slightly different terminal prompt.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
 lib/ansible/plugins/terminal/exos.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
