### PR TITLE
Clean up ansible-test results path handling.

### DIFF
--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -81,7 +81,7 @@ def ansible_environment(args, color=True, ansible_config=None):
     if args.debug:
         env.update(dict(
             ANSIBLE_DEBUG='true',
-            ANSIBLE_LOG_PATH=os.path.abspath('test/results/logs/debug.log'),
+            ANSIBLE_LOG_PATH=os.path.join(data_context().results, 'logs', 'debug.log'),
         ))
 
     if data_context().content.collection:

--- a/test/lib/ansible_test/_internal/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/cloud/__init__.py
@@ -158,7 +158,8 @@ def cloud_init(args, targets):
         )
 
     if not args.explain and results:
-        results_path = 'test/results/data/%s-%s.json' % (args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0))))
+        results_path = os.path.join(data_context().results, 'data', '%s-%s.json' % (
+            args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0)))))
 
         data = dict(
             clouds=results,

--- a/test/lib/ansible_test/_internal/data.py
+++ b/test/lib/ansible_test/_internal/data.py
@@ -70,6 +70,7 @@ class DataContext:
             content = self.__create_content_layout(layout_providers, source_providers, current_path, True)
 
         self.content = content  # type: ContentLayout
+        self.results = os.path.join(self.content.root, 'test', 'results')
 
     @staticmethod
     def __create_content_layout(layout_providers,  # type: t.List[t.Type[LayoutProvider]]

--- a/test/lib/ansible_test/_internal/env.py
+++ b/test/lib/ansible_test/_internal/env.py
@@ -47,6 +47,10 @@ from .test import (
     TestTimeout,
 )
 
+from .data import (
+    data_context,
+)
+
 
 class EnvConfig(CommonConfig):
     """Configuration for the tools command."""
@@ -105,7 +109,7 @@ def show_dump_env(args):
         show_dict(data, verbose)
 
     if args.dump and not args.explain:
-        with open('test/results/bot/data-environment.json', 'w') as results_fd:
+        with open(os.path.join(data_context().results, 'bot', 'data-environment.json'), 'w') as results_fd:
             results_fd.write(json.dumps(data, sort_keys=True))
 
 

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -194,8 +194,8 @@ def install_command_requirements(args, python_version=None):
     :type python_version: str | None
     """
     if not args.explain:
-        make_dirs('test/results/coverage')
-        make_dirs('test/results/data')
+        make_dirs(os.path.join(data_context().results, 'coverage'))
+        make_dirs(os.path.join(data_context().results, 'data'))
 
     if isinstance(args, ShellConfig):
         if args.raw:
@@ -1001,14 +1001,15 @@ def command_integration_filtered(args, targets, all_targets, inventory_path, pre
         if not args.explain:
             if args.coverage:
                 coverage_temp_path = os.path.join(common_temp_path, COVERAGE_OUTPUT_NAME)
-                coverage_save_path = 'test/results/coverage'
+                coverage_save_path = os.path.join(data_context().results, 'coverage')
 
                 for filename in os.listdir(coverage_temp_path):
                     shutil.copy(os.path.join(coverage_temp_path, filename), os.path.join(coverage_save_path, filename))
 
             remove_tree(common_temp_path)
 
-            results_path = 'test/results/data/%s-%s.json' % (args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0))))
+            results_path = os.path.join(data_context().results, 'data', '%s-%s.json' % (
+                args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0)))))
 
             data = dict(
                 targets=results,
@@ -1199,7 +1200,7 @@ def integration_environment(args, target, test_dir, inventory_path, ansible_conf
     callback_plugins = ['junit'] + (env_config.callback_plugins or [] if env_config else [])
 
     integration = dict(
-        JUNIT_OUTPUT_DIR=os.path.abspath('test/results/junit'),
+        JUNIT_OUTPUT_DIR=os.path.join(data_context().results, 'junit'),
         ANSIBLE_CALLBACK_WHITELIST=','.join(sorted(set(callback_plugins))),
         ANSIBLE_TEST_CI=args.metadata.ci_provider,
         ANSIBLE_TEST_COVERAGE='check' if args.coverage_check else ('yes' if args.coverage else ''),

--- a/test/lib/ansible_test/_internal/sanity/integration_aliases.py
+++ b/test/lib/ansible_test/_internal/sanity/integration_aliases.py
@@ -37,6 +37,10 @@ from ..util import (
     display,
 )
 
+from ..data import (
+    data_context,
+)
+
 
 class IntegrationAliasesTest(SanityVersionNeutral):
     """Sanity test to evaluate integration test aliases."""
@@ -176,7 +180,7 @@ class IntegrationAliasesTest(SanityVersionNeutral):
 
         self.check_changes(args, results)
 
-        with open('test/results/bot/data-sanity-ci.json', 'w') as results_fd:
+        with open(os.path.join(data_context().results, 'bot', 'data-sanity-ci.json'), 'w') as results_fd:
             json.dump(results, results_fd, sort_keys=True, indent=4)
 
         messages = []

--- a/test/lib/ansible_test/_internal/test.py
+++ b/test/lib/ansible_test/_internal/test.py
@@ -18,6 +18,10 @@ from .config import (
     TestConfig,
 )
 
+from .data import (
+    data_context,
+)
+
 
 def calculate_best_confidence(choices, metadata):
     """
@@ -120,7 +124,7 @@ class TestResult:
         :type extension: str
         :rtype: str
         """
-        path = 'test/results/%s/ansible-test-%s' % (directory, self.command)
+        path = os.path.join(data_context().results, directory, 'ansible-test-%s' % self.command)
 
         if self.test:
             path += '-%s' % self.test

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -98,8 +98,7 @@ def command_units(args):
             'yes' if args.color else 'no',
             '-p', 'no:cacheprovider',
             '-c', os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest.ini'),
-            '--junit-xml',
-            'test/results/junit/python%s-units.xml' % version,
+            '--junit-xml', os.path.join(data_context().results, 'junit', 'python%s-units.xml' % version),
         ]
 
         if version != '2.6':

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -24,6 +24,10 @@ from .util import (
     ANSIBLE_TEST_DATA_ROOT,
 )
 
+from .data import (
+    data_context,
+)
+
 
 class CommonConfig:
     """Configuration common to all commands."""
@@ -159,7 +163,7 @@ def get_coverage_environment(args, target_name, version, temp_path, module_cover
         # config is in a temporary directory
         # results are in the source tree
         coverage_config_base_path = args.coverage_config_base_path
-        coverage_output_base_path = os.path.abspath(os.path.join('test/results'))
+        coverage_output_base_path = data_context().results
     else:
         raise Exception('No temp path and no coverage config base path. Check for missing coverage_context usage.')
 


### PR DESCRIPTION
##### SUMMARY

Clean up ansible-test results path handling.

This brings us closer to being able to use `tests/` instead of `test/` in collections.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
