### PR TITLE
Remove old Makefile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@
 #   make deb ------------------ produce a DEB
 #   make docs ----------------- rebuild the manpages (results are checked in)
 #   make tests ---------------- run the tests (see https://docs.ansible.com/ansible/devel/dev_guide/testing_units.html for requirements)
-#   make pyflakes, make pep8 -- source code checks
 
 ########################################################
 # variable section
@@ -171,18 +170,6 @@ authors:
 # recently than %.1. (Implicitly runs the %.1.rst recipe)
 %.1: %.1.rst lib/ansible/release.py
 	$(ASCII2MAN)
-
-.PHONY: loc
-loc:
-	sloccount lib library bin
-
-.PHONY: pep8
-pep8:
-	$(ANSIBLE_TEST) sanity --test pep8 --python $(PYTHON_VERSION) $(TEST_FLAGS)
-
-.PHONY: pyflakes
-pyflakes:
-	pyflakes lib/ansible/*.py lib/ansible/*/*.py bin/*
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
##### SUMMARY
Remove old Makefile targets.

- `pep8` - There is no need to give it more prominent placement than other sanity tests.
- `pyflakes` - The project only makes use of `pylint` and `pycodestyle`. Having the target implies that it should work.
- `loc` - Not used. Easily run manually if needed.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Makefile
