### PR TITLE
Clean up unused config usage in integration tests.

### DIFF
--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
 set -ux
-ansible-playbook -i inventory -e @../../integration_config.yml "$@" play_level.yml| tee out.txt | grep 'any_errors_fatal_play_level_post_fail'
+ansible-playbook -i inventory "$@" play_level.yml| tee out.txt | grep 'any_errors_fatal_play_level_post_fail'
 res=$?
 cat out.txt
 if [ "${res}" -eq 0 ] ; then
 	exit 1
 fi
 
-ansible-playbook -i inventory -e @../../integration_config.yml "$@" on_includes.yml | tee out.txt | grep 'any_errors_fatal_this_should_never_be_reached'
+ansible-playbook -i inventory "$@" on_includes.yml | tee out.txt | grep 'any_errors_fatal_this_should_never_be_reached'
 res=$?
 cat out.txt
 if [ "${res}" -eq 0 ] ; then
@@ -17,7 +17,7 @@ fi
 
 set -ux
 
-ansible-playbook -i inventory -e @../../integration_config.yml "$@" always_block.yml | tee out.txt | grep 'any_errors_fatal_always_block_start'
+ansible-playbook -i inventory "$@" always_block.yml | tee out.txt | grep 'any_errors_fatal_always_block_start'
 res=$?
 cat out.txt
 exit $res

--- a/test/integration/targets/cloudformation_stack_set/runme.sh
+++ b/test/integration/targets/cloudformation_stack_set/runme.sh
@@ -5,4 +5,4 @@ set -eux
 # Run full test suite
 source virtualenv.sh
 pip install 'botocore>1.10.26' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/ec2_launch_template/runme.sh
+++ b/test/integration/targets/ec2_launch_template/runme.sh
@@ -7,9 +7,9 @@ export ANSIBLE_ROLES_PATH=../
 # Test graceful failure for older versions of botocore
 source virtualenv.sh
 pip install 'boto3<1.6.0'
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
 source virtualenv.sh
 pip install 'boto3>1.6.0'
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/efs/runme.sh
+++ b/test/integration/targets/efs/runme.sh
@@ -7,9 +7,9 @@ export ANSIBLE_ROLES_PATH=../
 # Test graceful failure for older versions of botocore
 source virtualenv.sh
 pip install 'botocore<1.10.57' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
 source virtualenv.sh
 pip install 'botocore>=1.10.57' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/elb_target/runme.sh
+++ b/test/integration/targets/elb_target/runme.sh
@@ -5,9 +5,9 @@ set -eux
 # Test graceful failure for older versions of botocore
 source virtualenv.sh
 pip install 'botocore<=1.7.1' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/version_fail.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/version_fail.yml "$@"
 
 # Run full test suite
 source virtualenv.sh
 pip install 'botocore>=1.8.0' boto3
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/elb_target_info/runme.sh
+++ b/test/integration/targets/elb_target_info/runme.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# We don't set -u here, due to pypa/virtualenv#150
-set -ex
+set -eux
 
-ansible-playbook -i ../../inventory -e @../../integration_config.yml -v playbooks/full_test.yml "$@"
+ansible-playbook -i ../../inventory -v playbooks/full_test.yml "$@"

--- a/test/integration/targets/inventory_aws_ec2/runme.sh
+++ b/test/integration/targets/inventory_aws_ec2/runme.sh
@@ -16,20 +16,20 @@ export ANSIBLE_INVENTORY=test.aws_ec2.yml
 ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@"
-ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml "$@"
+ansible-playbook playbooks/test_populating_inventory.yml "$@"
 
 # generate inventory config with caching and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml'" "$@"
+ansible-playbook playbooks/populate_cache.yml "$@"
 ansible-playbook playbooks/test_inventory_cache.yml "$@"
 
 # remove inventory cache
 rm -r aws_ec2_cache_dir/
 
 # generate inventory config with constructed features and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml'" "$@"
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/test/integration/targets/inventory_aws_rds/runme.sh
+++ b/test/integration/targets/inventory_aws_rds/runme.sh
@@ -16,20 +16,20 @@ export ANSIBLE_INVENTORY=test.aws_rds.yml
 ansible-playbook playbooks/test_invalid_aws_rds_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e @../../integration_config.yml "$@"
-ansible-playbook playbooks/test_populating_inventory.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml "$@"
+ansible-playbook playbooks/test_populating_inventory.yml "$@"
 
 # generate inventory config with caching and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/populate_cache.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml'" "$@"
+ansible-playbook playbooks/populate_cache.yml "$@"
 ansible-playbook playbooks/test_inventory_cache.yml "$@"
 
 # remove inventory cache
 rm -r aws_rds_cache_dir/
 
 # generate inventory config with constructed features and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml' @../../integration_config.yml" "$@"
-ansible-playbook playbooks/test_populating_inventory_with_constructed.yml -e @../../integration_config.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml'" "$@"
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/test/integration/targets/lookup_hashi_vault/runme.sh
+++ b/test/integration/targets/lookup_hashi_vault/runme.sh
@@ -17,7 +17,7 @@ set -eux
 #   fatal: [testhost]: FAILED! => { "msg": "An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'requests.exceptions.SSLError'>, original message: HTTPSConnectionPool(host='localhost', port=8201): Max retries exceeded with url: /v1/auth/token/lookup-self (Caused by SSLError(SSLError(\"bad handshake: Error([('SSL routines', 'ssl3_get_server_certificate', 'certificate verify failed')],)\",),))"}
 
 ANSIBLE_ROLES_PATH=../ \
-    ansible-playbook -e@../../integration_config.yml playbooks/install_dependencies.yml -v "$@"
+    ansible-playbook playbooks/install_dependencies.yml -v "$@"
 
 ANSIBLE_ROLES_PATH=../ \
-    ansible-playbook -e@../../integration_config.yml playbooks/test_lookup_hashi_vault.yml -v "$@"
+    ansible-playbook playbooks/test_lookup_hashi_vault.yml -v "$@"


### PR DESCRIPTION
##### SUMMARY

Clean up unused config usage in integration tests.

Remove references to `@../../integration_config.yml` in script based integration tests that do not use the the `output_dir` variable defined in that file.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests
