### PR TITLE
apache2_mod_proxy. Auth arguments added. Fix bug with non-existsing fields of LB members.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
@@ -57,6 +57,12 @@ options:
       - Validate ssl/tls certificates.
     type: bool
     default: 'yes'
+  url_username:
+    description:
+      - Username for Apache
+  url_password:
+    description:
+      - Password for Apache
 '''
 
 EXAMPLES = '''
@@ -354,7 +360,9 @@ def main():
             member_host=dict(type='str'),
             state=dict(type='str'),
             tls=dict(default=False, type='bool'),
-            validate_certs=dict(default=True, type='bool')
+            validate_certs=dict(default=True, type='bool'),
+            url_username=dict(type='str'),
+            url_password=dict(type='str')
         ),
         supports_check_mode=True
     )
@@ -385,11 +393,9 @@ def main():
         for member in mybalancer.members:
             json_output_list.append({
                 "host": member.host,
-                "status": member.status,
                 "protocol": member.protocol,
                 "port": member.port,
                 "path": member.path,
-                "attributes": member.attributes,
                 "management_url": member.management_url,
                 "balancer_url": member.balancer_url
             })


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
apache2_mod_proxy doesn't support any auth method for apache.
Module ansible.module_utils.urls which is used in apache2_mod_proxy has native support of login to the web page.
With url_username and url_password arguments, users may paste login and password for their apache LB

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Remove two unused attributes for Apache Load Balancer members

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apache2_mod_proxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
