### PR TITLE
Add auth and fix bug in apache2_mod_proxy module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
@@ -57,6 +57,12 @@ options:
       - Validate ssl/tls certificates.
     type: bool
     default: 'yes'
+  url_username:
+    description:
+      - Username for Apache auth
+  url_password:
+    description:
+      - Password for Apache auth
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
@@ -354,7 +354,9 @@ def main():
             member_host=dict(type='str'),
             state=dict(type='str'),
             tls=dict(default=False, type='bool'),
-            validate_certs=dict(default=True, type='bool')
+            validate_certs=dict(default=True, type='bool'),
+            url_username=dict(type='str'),
+            url_password=dict(type='str')
         ),
         supports_check_mode=True
     )
@@ -385,11 +387,9 @@ def main():
         for member in mybalancer.members:
             json_output_list.append({
                 "host": member.host,
-                "status": member.status,
                 "protocol": member.protocol,
                 "port": member.port,
                 "path": member.path,
-                "attributes": member.attributes,
                 "management_url": member.management_url,
                 "balancer_url": member.balancer_url
             })


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
apache2_mod_proxy doesn't support any auth method for apache.
Module ansible.module_utils.urls which is used in apache2_mod_proxy has native support of login to the web page.
With url_username and url_password arguments, users may paste login and password for their apache LB

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Remove two unused attributes for Apache Load Balancer members

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apache2_mod_proxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When you try to get all a list of current balancer members, you will receive such output:
```
Traceback (most recent call last):
  File "<stdin>", line 114, in <module>
  File "<stdin>", line 106, in _ansiballz_main
  File "<stdin>", line 49, in invoke_module
  File "/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py", line 446, in <module>
  File "/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py", line 390, in main
  File "/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py", line 271, in get_member_status
  File "/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py", line 260, in get_member_attributes
  File "/Users/dzuba/github/ansible/ansible-install/ENV-2.8.1-1/lib/python2.7/re.py", line 146, in search
    return _compile(pattern, flags).search(string)
  File "/Users/dzuba/github/ansible/ansible-install/ENV-2.8.1-1/lib/python2.7/re.py", line 247, in _compile
    raise TypeError, "first argument must be string or compiled pattern"
TypeError: first argument must be string or compiled pattern

fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 114, in <module>\n  File \"<stdin>\", line 106, in _ansiballz_main\n  File \"<stdin>\", line 49, in invoke_module\n  File \"/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py\", line 446, in <module>\n  File \"/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py\", line 390, in main\n  File \"/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py\", line 271, in get_member_status\n  File \"/var/folders/km/5wfkl2k135l4g4_s7ddhd5x00000gn/T/ansible_apache2_mod_proxy_auth_payload_cTBVRS/__main__.py\", line 260, in get_member_attributes\n  File \"/Users/dzuba/github/ansible/ansible-install/ENV-2.8.1-1/lib/python2.7/re.py\", line 146, in search\n    return _compile(pattern, flags).search(string)\n  File \"/Users/dzuba/github/ansible/ansible-install/ENV-2.8.1-1/lib/python2.7/re.py\", line 247, in _compile\n    raise TypeError, \"first argument must be string or compiled pattern\"\nTypeError: first argument must be string or compiled pattern\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```



<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
