### PR TITLE
vmware_guest_screenshot: fix the functional test

### DIFF
--- a/test/integration/targets/vmware_guest_screenshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_screenshot/tasks/main.yml
@@ -11,13 +11,24 @@
       setup_datastore: true
       setup_virtualmachines: true
 
+  - name: set state to poweroff on all VMs
+    vmware_guest:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      state: poweredon
+
   - name: take screenshot of virtual machine's console
     vmware_guest_screenshot:
       validate_certs: False
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      # Note: set the datacenter key because of https://github.com/ansible/ansible/issues/60565
+      datacenter: "{{ dc1 }}"
     register: take_screenshot
   - debug: var=take_screenshot
   - name: assert the screenshot captured
@@ -31,8 +42,10 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ infra.vm_list[0] }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
       local_path: "/tmp/screenshot_test.png"
+      # Note: set the datacenter key because of https://github.com/ansible/ansible/issues/60565
+      datacenter: "{{ dc1 }}"
     register: take_screenshot
   - debug: var=take_screenshot
   - name: assert the screenshot captured


### PR DESCRIPTION
##### SUMMARY

- VM are off my default since 964783fbd2f738e938deedf338d8a36c1b54ccd6
- `infra.vm_list[0]` → `virtual_machines_in_cluster[0].name`
- `datacenter` key is currently mandatory, see: https://github.com/ansible/ansible/issues/60565

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_screenshot
