### PR TITLE
Ensure k8s apply works with check mode

### DIFF
--- a/changelogs/fragments/60510-k8s-apply-check-mode.yml
+++ b/changelogs/fragments/60510-k8s-apply-check-mode.yml
@@ -1,2 +1,2 @@
-minor_bugfixes:
+bugfixes:
   - k8s - ensure that apply works with check mode. Bumps minimum openshift version for apply to 0.9.2.

--- a/changelogs/fragments/60510-k8s-apply-check-mode.yml
+++ b/changelogs/fragments/60510-k8s-apply-check-mode.yml
@@ -1,0 +1,2 @@
+minor_bugfixes:
+  - k8s - ensure that apply works with check mode. Bumps minimum openshift version for apply to 0.9.2.

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -288,7 +288,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         else:
             if self.apply:
                 if self.check_mode:
-                    k8s_obj = definition
+                    k8s_obj = dict_merge(existing.to_dict(), definition)
                 else:
                     try:
                         k8s_obj = resource.apply(definition, namespace=namespace).to_dict()

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -53,6 +53,13 @@ except ImportError:
     K8S_CONFIG_HASH_IMP_ERR = traceback.format_exc()
     HAS_K8S_CONFIG_HASH = False
 
+HAS_K8S_APPLY = None
+try:
+    from openshift.dynamic.apply import apply_object
+    HAS_K8S_APPLY = True
+except ImportError:
+    HAS_K8S_APPLY = False
+
 
 class KubernetesRawModule(KubernetesAnsibleModule):
 
@@ -117,11 +124,11 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             if LooseVersion(self.openshift_version) < LooseVersion("0.6.2"):
                 self.fail_json(msg=missing_required_lib("openshift >= 0.6.2", reason="for merge_type"))
         if self.params.get('apply') is not None:
-            if LooseVersion(self.openshift_version) < LooseVersion("0.9.0"):
-                self.fail_json(msg=missing_required_lib("openshift >= 0.9.0", reason="for apply"))
+            if not HAS_K8S_APPLY:
+                self.fail_json(msg=missing_required_lib("openshift >= 0.9.2", reason="for apply"))
             self.apply = self.params['apply']
         else:
-            self.apply = LooseVersion(self.openshift_version) >= LooseVersion("0.9.0")
+            self.apply = HAS_K8S_APPLY
 
         if resource_definition:
             if isinstance(resource_definition, string_types):
@@ -288,7 +295,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         else:
             if self.apply:
                 if self.check_mode:
-                    k8s_obj = dict_merge(existing.to_dict(), definition)
+                    ignored, k8s_obj = apply_object(resource, definition)
                 else:
                     try:
                         k8s_obj = resource.apply(definition, namespace=namespace).to_dict()

--- a/test/integration/targets/k8s/tasks/apply.yml
+++ b/test/integration/targets/k8s/tasks/apply.yml
@@ -55,6 +55,27 @@
         that:
           - k8s_configmap_2 is not changed
 
+    - name: add same configmap again with check mode on
+      k8s:
+        definition:
+          kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: "apply-configmap"
+            namespace: "{{ apply_namespace }}"
+          data:
+            one: "1"
+            two: "2"
+            three: "3"
+        apply: yes
+      check_mode: yes
+      register: k8s_configmap_check
+
+    - name: check nothing changed
+      assert:
+        that:
+          - k8s_configmap_check is not changed
+
     - name: add same configmap again but using name and namespace args
       k8s:
         name: "apply-configmap"

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -25,6 +25,7 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Test validate with kubernetes-validate
 
@@ -45,6 +46,7 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Test graceful failure for older versions of openshift
 
@@ -66,6 +68,7 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Run full test suite
 
@@ -86,3 +89,4 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - pip:
     name:
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -32,7 +32,7 @@
 - pip:
     name:
       - kubernetes-validate==1.12.0
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -74,7 +74,7 @@
 
 - pip:
     name:
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"

--- a/test/integration/targets/k8s/tasks/older_openshift_fail.yml
+++ b/test/integration/targets/k8s/tasks/older_openshift_fail.yml
@@ -66,4 +66,4 @@
       assert:
         that:
           - k8s_apply is failed
-          - "k8s_apply.msg.startswith('Failed to import the required Python library (openshift >= 0.9.0)')"
+          - "k8s_apply.msg.startswith('Failed to import the required Python library (openshift >= 0.9.2)')"


### PR DESCRIPTION
##### SUMMARY

Update the new predicted object with fields from the previous object
before applying in check mode

Don't log output of `file` with `state: absent` on huge virtualenvs!

Fixes #60510

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/k8s/raw.py