### PR TITLE
set node position for vault encrypted objects

### DIFF
--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -109,6 +109,7 @@ class AnsibleConstructor(SafeConstructor):
                                    note=None)
         ret = AnsibleVaultEncryptedUnicode(b_ciphertext_data)
         ret.vault = vault
+        ret.ansible_pos = self._node_position_info(node)
         return ret
 
     def construct_yaml_seq(self, node):


### PR DESCRIPTION
##### SUMMARY
The change sets the node position for vault encrypted YAML objects, just like it does for other objects types like strings, mappings and sequences. This allows third-party scripts to retrieve the source position of a specific variable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Core YAML Parsing

##### ADDITIONAL INFORMATION
I recently wrote a script that utilises Ansible's Variable Manager to query specific variables out of a set of inventory variable files. For informational reasons, it is supposed to gather the source file and line number of a variable. This works just fine for strings, sequences and mappings - but won't work for vault encrypted unicode objects, because it doesn't set the ansible_pos property like it does for the other type objects.

The change will align the same standard for vault encrypted unicode objects as it does for strings, sequences, etc.