### PR TITLE
Introduce new vars_plugin: recursive_group_vars

### DIFF
--- a/lib/ansible/plugins/vars/recursive_group_vars.py
+++ b/lib/ansible/plugins/vars/recursive_group_vars.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     vars: recursive_group_vars
-    version_added: "?"
+    version_added: "2.9"
     short_description: Loads r_group_vars recursively
     description:
         - In comparison to host_group_vars plugin, this plugin traverses the `r_group_vars` directory

--- a/lib/ansible/plugins/vars/recursive_group_vars.py
+++ b/lib/ansible/plugins/vars/recursive_group_vars.py
@@ -1,0 +1,100 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    vars: recursive_group_vars
+    version_added: "?"
+    short_description: Loads r_group_vars recursively
+    description:
+        - In comparison to host_group_vars plugin, this plugin traverses the `r_group_vars` directory
+          and instead of matching all files and directories within the first matching directory it
+          traverses the directory tree and recursively matches directories and files during directory
+          traversal to groups.
+        - In a directory first matching files are applied and then matching directories traversed.
+          The existing priorities for groups apply for both files and directories.
+        - If several matching directories are found on the same level they are traversed consecutively
+          in a depth-first fashion.
+        - The deepest found matching file is applied last.
+        - Only files that match a group name are applied. Any other files are ignored.
+        - The following points are identical to host_group_vars plugin -
+        - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
+        - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
+        - Only applies to inventory sources that are existing paths.
+    options:
+      _valid_extensions:
+        default: [".yml", ".yaml", ".json"]
+        description:
+          - "Check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of these."
+          - 'This affects vars_files, include_vars, inventory and vars plugins among others.'
+        env:
+          - name: ANSIBLE_YAML_FILENAME_EXT
+        ini:
+          - section: yaml_valid_extensions
+            key: defaults
+        type: list
+'''
+
+import os
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.errors import AnsibleParserError
+from ansible.plugins.vars import BaseVarsPlugin
+from ansible.inventory.group import Group
+from ansible.utils.vars import combine_vars
+
+
+class VarsModule(BaseVarsPlugin):
+
+    FOUND = {}
+
+    def find_vars_recurse(self, loader, groups, path):
+        data = {}
+
+        self._display.debug("recursive_group_vars - Traversing dir : %s with groups : %s" % (path, to_text(groups)))
+
+        # Apply matching files in path
+        for group in groups:
+            found_files = loader.find_vars_files(path, group, allow_dir=False)
+            for found in found_files:
+                self._display.debug("recursive_group_vars - Matched file : %s" % to_text(found))
+                try:
+                    new_data = loader.load_from_file(found, cache=True, unsafe=True)
+                    if new_data:
+                        data = combine_vars(data, new_data)
+                except Exception as e:
+                    raise AnsibleParserError("Failed to apply variable file %s : %s" % (found, to_native(e)))
+
+        # Recurse into directories
+        for group in groups:
+            try:
+                b_opath = os.path.realpath(to_bytes(os.path.join(path, group)))
+                if os.path.exists(b_opath):
+                    if os.path.isdir(b_opath):
+                        data = combine_vars(data, self.find_vars_recurse(loader, groups, to_text(b_opath)))
+            except Exception as e:
+                raise AnsibleParserError("Failure during traversal of group directory '%s' in '%s' : %s" % (group, path, to_native(e)))
+
+        return data
+
+    def get_vars(self, loader, path, entities, cache=True):
+
+        if not isinstance(entities, list):
+            entities = [entities]
+
+        groups = [e.name for e in entities if isinstance(e, Group)]
+
+        if not groups:
+            return {}
+
+        super(VarsModule, self).get_vars(loader, path, entities)
+        b_opath = os.path.realpath(os.path.join(to_bytes(self._basedir), b'r_group_vars'))
+
+        data = {}
+        if os.path.exists(b_opath):
+            key = tuple(groups) + (b_opath,)
+            if cache and key in self.FOUND:
+                data = self.FOUND[key]
+            else:
+                data = self.find_vars_recurse(loader, groups, to_text(b_opath))
+                self.FOUND[key] = data
+
+        return data

--- a/lib/ansible/plugins/vars/recursive_group_vars.py
+++ b/lib/ansible/plugins/vars/recursive_group_vars.py
@@ -8,13 +8,13 @@ DOCUMENTATION = '''
     description:
         - In comparison to host_group_vars plugin, this plugin traverses the `r_group_vars` directory
           and instead of matching all files and directories within the first matching directory it
-          traverses the directory tree and recursively matches directories and files during directory
-          traversal to groups.
-        - In a directory first matching files are applied and then matching directories traversed.
-          The existing priorities for groups apply for both files and directories.
-        - If several matching directories are found on the same level they are traversed consecutively
-          in a depth-first fashion.
-        - The deepest found matching file is applied last.
+          traverses the directory tree and recursively matches directories and files to groups during
+          directory traversal.
+        - During traversal in a directory first matching files are applied and then matching directories
+          traversed. The existing priorities for groups apply for both files and directories,
+          respectively.
+        - If several matching directories are found on the same directory level they are traversed
+          consecutively in a depth-first fashion.
         - Only files that match a group name are applied. Any other files are ignored.
         - The following points are identical to host_group_vars plugin -
         - Files are restricted by extension to one of .yaml, .json, .yml or no extension.


### PR DESCRIPTION
##### SUMMARY

This pull request is based on my experience during the integration of Ansible into an existing infrastructure with existing environments with various roles of partly clustered hosts.

It always troubled me to be forced to split up inventories for different environments and use separate group_vars. It conceptually tears apart the infrastructure into smaller infrastructures each with their own sets of variables. But: what if I want to share a variable across environments? What if the separation between environments is not where the separation ends (clusters, host functionalities, ...)? It's not possible to split up the inventory further without serious consequences to the ease of use of Ansible. 

###### Goal

This PR aims at providing a new [vars_plugin](https://docs.ansible.com/ansible/latest/plugins/vars.html) to improve Ansible’s capability of variable assignment by enabling fine-grained control to target specific groups of hosts.

A more detailed description of the current situation follows describing how this PR aims to introduce the new concept of fine-grained control over variable assignment to groups and group combinations through recursive group variables:

###### Parent-Child relation
Ansible works very well when there is a hierarchical structure of parent-child relationships between groups:

![image](https://user-images.githubusercontent.com/6923843/63036461-5d01b480-bebd-11e9-901e-5fc1c5af9d24.png)

In this case, the groups are laid out in a way that the child variables overwrite any parent variables. This means that `webserver-cluster-1` can have different variables than `webserver-cluster-2` by simply writing these into `group_vars/webserver-cluster-1.yaml` and `group_vars/webserver-cluster-2.yaml`.

###### Intersecting groups
Imagine the following scenario:

![image](https://user-images.githubusercontent.com/6923843/63036820-18c2e400-bebe-11e9-9e0d-1c5e42ccd29c.png)

It is no longer possible to set `webserver` as a child of `atlanta` because `webserver` also contains hosts in `boston`. Likewise, `webserver-cluster-1` lists hosts in both `atlanta` and `boston`.

Assuming one would want to assign different variables to all the different clusters in `boston` and `atlanta` it is no longer possible to use parent/child-relationships as a means to prioritize `group_vars`.

Further, it is not possible to use `ansible_group_priority` because `webserver-cluster-X` exists in both `boston` and `atlanta`. Targetting `webserver-cluster-X` would apply to both `atlanta` and `boston` no matter what `ansible_group_priority` is applied.

How to specifically set variables for hosts that exist in `atlanta` and `webserver-cluster-1` and not assign the same variable to the `boston` cluster?

* **The naive solution**: Separate the inventory file into `atlanta/hosts` and `boston/hosts` and use separate group variables (`atlanta/group_vars` and `boston/group_vars`).
  * However, what happens if my `webserver` hosts further separate into `webserver-app` and `webserver-db`? How would I have different variables for e.g. `webserver-cluster-1` -> `webserver-app/db` and `webserver-cluster-2` -> `webserver-app/db`? Again it is not possible to use parent-child relationships since `webserver-app/db` is present in `web-cluster-1` and `web-cluster-2`.
  * Further, splitting up the inventory isolates variables completely. They may not be used in another “isolated” group or environment.
  * It appears that this approach introduces more problems than solutions.

* **Enter recursive group_vars**: What if a `r_group_vars` directory would not only evaluate the first directory-level but traverse further down and match the host's groups along the way? This is what this PR is all about (excerpt from code documentation):
    - In comparison to host_group_vars plugin, this plugin traverses the `r_group_vars` directory
      and instead of matching all files and directories within the first matching directory it
      traverses the directory tree and recursively matches directories to groups during directory
      traversal and applies all files within a matching directory.
    - During traversal in a directory first all files are applied and then matching directories
      traversed. The existing priorities for groups apply during directory traversal.
    - If several matching directories are found on the same directory level they are traversed
      consecutively in a depth-first fashion.
    - The following points are identical to host_group_vars plugin -
    - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
    - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
    - Only applies to inventory sources that are existing paths.



With the recursive group_vars plugin enabled the following directory structure is possible:
```
hosts                   # List of hosts and groups
r_group_vars/
    config.yml             # Applies to all clusters anywhere
    atlanta/
       config.yml        # Applies to all hosts in Atlanta
    boston/
        config.yml         # This one is for Boston
        webserver-cluster-1/
            config.yml             # This applies to all webservers of the first cluster in Boston
            webserver-app/
                config.yml         # This only applies to the app webservers of the first cluster in Boston
```


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
recursive_group_vars

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The plugin complements the `host_group_vars` and should work together.

- [ ] `version_added` must be adjusted in the `DOCUMENTATION` part of the plugin

##### Open Questions
* How would this plugin integrate with `host_group_vars` plugin? Would there be a priority which is loaded first? Can the user define the order in which they are loaded (i.e. which overwrites the other)?