### PR TITLE
Add advice how to prevent jinja2 warning

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -87,7 +87,7 @@ This test also accepts a 3rd parameter, ``strict`` which defines if strict versi
 
     {{ sample_version_var is version('1.0', operator='lt', strict=True) }}
 
-Use the bare variable names in a 'when' statement to prevent warnings on included jinja2::
+When using ``version`` in a playbook or role, don't use ``{{ }}`` as described in the `FAQ <https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#when-should-i-use-also-how-to-interpolate-variables-or-dynamic-variable-names>`_::
 
     vars:
         my_version: 1.2.3

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -87,7 +87,16 @@ This test also accepts a 3rd parameter, ``strict`` which defines if strict versi
 
     {{ sample_version_var is version('1.0', operator='lt', strict=True) }}
 
+Use the bare variable names in a when statement to prevent warnings on included jinja2:
 
+    vars:
+        my_version: 1.2.3
+
+    tasks:
+        - debug:
+            msg: "my_version is higher than 1.0.0"
+          when: my_version is version('1.0.0', '>')
+ 
 .. _math_tests:
 
 Set theory tests

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -87,7 +87,7 @@ This test also accepts a 3rd parameter, ``strict`` which defines if strict versi
 
     {{ sample_version_var is version('1.0', operator='lt', strict=True) }}
 
-Use the bare variable names in a when statement to prevent warnings on included jinja2:
+Use the bare variable names in a 'when' statement to prevent warnings on included jinja2::
 
     vars:
         my_version: 1.2.3


### PR DESCRIPTION
##### SUMMARY
This addition helps users to demonstrate how to prevent `[WARNING]: when statements should not include jinja2 templating delimiters`.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
I ran into an warning, where to documentation was not sufficient to solve it. See https://github.com/ansible/ansible/issues/60554

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
documentation

##### ADDITIONAL INFORMATION
none