### PR TITLE
ansible-galaxy - more fixes for verbosity without sub type

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -428,7 +428,6 @@ class GalaxyCLI(CLI):
         Creates the skeleton framework of a role or collection that complies with the Galaxy metadata format.
         Requires a role or collection name. The collection name must be in the format ``<namespace>.<collection>``.
         """
-        raise Exception("abc")
 
         galaxy_type = context.CLIARGS['type']
         init_path = context.CLIARGS['init_path']

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -44,7 +44,9 @@ class GalaxyCLI(CLI):
         # Inject role into sys.argv[1] as a backwards compatibility step
         if len(args) > 1 and args[1] not in ['-h', '--help'] and 'role' not in args and 'collection' not in args:
             # TODO: Should we add a warning here and eventually deprecate the implicit role subcommand choice
-            args.insert(1, 'role')
+            # Remove this in Ansible 2.13 when we also remove -v as an option on the root parser for ansible-galaxy.
+            idx = 2 if args[1].startswith('-v') else 1
+            args.insert(idx, 'role')
 
         self.api = None
         self.galaxy = None
@@ -426,6 +428,7 @@ class GalaxyCLI(CLI):
         Creates the skeleton framework of a role or collection that complies with the Galaxy metadata format.
         Requires a role or collection name. The collection name must be in the format ``<namespace>.<collection>``.
         """
+        raise Exception("abc")
 
         galaxy_type = context.CLIARGS['type']
         init_path = context.CLIARGS['init_path']

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -469,6 +469,8 @@ class TestGalaxyInitSkeleton(unittest.TestCase, ValidRoleTests):
     # deprecated and tests should be removed when the code that handles it is removed
     (['ansible-galaxy', '-vv', 'collection', 'init', 'abc.def', '-v'], 1),
     (['ansible-galaxy', '-vv', 'collection', 'init', 'abc.def', '-vvvv'], 4),
+    (['ansible-galaxy', '-vvv', 'init', 'name'], 3),
+    (['ansible-galaxy', '-vvvvv', 'init', '-v', 'name'], 1),
 ])
 def test_verbosity_arguments(cli_args, expected, monkeypatch):
     # Mock out the functions so we don't actually execute anything


### PR DESCRIPTION
##### SUMMARY
While PR #59202 fixed the issue when `-v` was set straight after `ansible-galaxy` it still did not work if `role` or `collection` was not specified. This PR adds logic to the auto insertion of the `role` sub type for further backwards compatibility.

Fixes comment in https://github.com/ansible/ansible/issues/59202#issuecomment-521369339

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy