### PR TITLE
[stable-2.7] Start dbus when setting up postgresql tests

### DIFF
--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -17,6 +17,12 @@
         - 'default{{ python_suffix }}.yml'
       paths: '../vars'
 
+- name: make sure the dbus service is started under systemd
+  systemd:
+    name: dbus
+    state: started
+  when: ansible_service_mgr == 'systemd' and ansible_distribution == 'Fedora'
+
 # Make sure we start fresh
 - name: stop postgresql service
   service: name={{ postgresql_service }} state=stopped


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #54934 for Ansible 2.7
(cherry picked from commit c309570540)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_postgresql_db/tasks/main.yml`