### PR TITLE
Link to the GitHub Web UI for the example file instead of to raw file.

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -30,7 +30,7 @@ as a ``.rpmnew`` file (or other) as appropriate in the case of updates.
 If you installed Ansible from pip or from source, you may want to create this file in order to override
 default settings in Ansible.
 
-An `example file is available on GitHub <https://raw.githubusercontent.com/ansible/ansible/devel/examples/ansible.cfg>`_.
+An `example file is available on GitHub <https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg>`_.
 
 For more details and a full listing of available configurations go to :ref:`configuration_settings<ansible_configuration_settings>`. Starting with Ansible version 2.4, you can use the :ref:`ansible-config` command line utility to list your available options and inspect the current values.
 


### PR DESCRIPTION
##### SUMMARY

In the Ansible Config docs, the link to the example `ansible.cfg` file goes to the raw download.

Sometimes users might want to link to an exact line of that file, or see other files in the repo, so the GitHub web user interface link is more helpful.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
