### PR TITLE
ansible-galaxy: create parent dir for token file

### DIFF
--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
 
         b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible"))
         try:
-            os.mkdir(b_ansible_dir, mode=0o700)
+            os.mkdir(b_ansible_dir, 0o700)
         except OSError as exc:
             if exc.errno != errno.EEXIST:
                 display.warning("Failed to create the directory '%s': %s"

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
             else:
                 raise
 
-        b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible/fake"))
+        b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible"))
         try:
             os.mkdir(b_ansible_dir, mode=0o700)
         except OSError as exc:

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -25,6 +25,7 @@ __metaclass__ = type
 __requires__ = ['ansible']
 
 
+import errno
 import os
 import shutil
 import sys
@@ -100,10 +101,16 @@ if __name__ == '__main__':
             else:
                 raise
 
-        b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible"))
-        if not os.path.exists(b_ansible_dir):
-            display.debug("Creating the ~/.ansible directory")
+        b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible/fake"))
+        try:
             os.mkdir(b_ansible_dir, mode=0o700)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                display.warning("Failed to create the directory '%s': %s"
+                                % (to_text(b_ansible_dir, errors='surrogate_or_replace'),
+                                   to_text(exc, errors='surrogate_or_replace')))
+        else:
+            display.debug("Created the '%s' directory" % to_text(b_ansible_dir, errors='surrogate_or_replace'))
 
         try:
             args = [to_text(a, errors='surrogate_or_strict') for a in sys.argv]

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -100,6 +100,11 @@ if __name__ == '__main__':
             else:
                 raise
 
+        b_ansible_dir = os.path.expanduser(os.path.expandvars(b"~/.ansible"))
+        if not os.path.exists(b_ansible_dir):
+            display.debug("Creating the ~/.ansible directory")
+            os.mkdir(b_ansible_dir, mode=0o700)
+
         try:
             args = [to_text(a, errors='surrogate_or_strict') for a in sys.argv]
         except UnicodeError:

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -47,12 +47,6 @@ class GalaxyToken(object):
         f = None
         action = 'Opened'
         if not os.path.isfile(self.b_file):
-            b_parent_dir = os.path.dirname(self.b_file)
-            if not os.path.exists(b_parent_dir):
-                display.vvv("Parent directory for Galaxy token file doesn't exist, creating '%s'"
-                            % to_text(b_parent_dir))
-                os.makedirs(b_parent_dir, 0o700)
-
             # token file not found, create and chomd u+rw
             f = open(self.b_file, 'w')
             f.close()

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -37,7 +37,7 @@ class GalaxyToken(object):
     ''' Class to storing and retrieving local galaxy token '''
 
     def __init__(self):
-        self.b_file = os.path.expanduser(os.path.expandvars(to_bytes(C.GALAXY_TOKEN_PATH)))
+        self.b_file = to_bytes(C.GALAXY_TOKEN_PATH)
         self.config = yaml.safe_load(self.__open_config_for_read())
         if not self.config:
             self.config = {}

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -37,7 +37,7 @@ class GalaxyToken(object):
     ''' Class to storing and retrieving local galaxy token '''
 
     def __init__(self):
-        self.b_file = to_bytes(C.GALAXY_TOKEN_PATH)
+        self.b_file = os.path.expanduser(os.path.expandvars(to_bytes(C.GALAXY_TOKEN_PATH)))
         self.config = yaml.safe_load(self.__open_config_for_read())
         if not self.config:
             self.config = {}
@@ -47,6 +47,12 @@ class GalaxyToken(object):
         f = None
         action = 'Opened'
         if not os.path.isfile(self.b_file):
+            b_parent_dir = os.path.dirname(self.b_file)
+            if not os.path.exists(b_parent_dir):
+                display.vvv("Parent directory for Galaxy token file doesn't exist, creating '%s'"
+                            % to_text(b_parent_dir))
+                os.makedirs(b_parent_dir, 0o700)
+
             # token file not found, create and chomd u+rw
             f = open(self.b_file, 'w')
             f.close()


### PR DESCRIPTION
##### SUMMARY
~The default path to the galaxy token file is not in a directory and fails if it does not exist. This code creates the parent directory as a check before creating the file.~

A lot of default config paths are files and folders located in `~/.ansible`. This PR will create that directory with a safe mode. This ensures that code which creates files in that directory won't fail on a first run. This was proposed by @abadger instead of the first commit which could create a directory in an unsafe location. With this PR the defaults will run without issue but if a user changes the path it is up to them to ensure it exists and is safe.

Fixes https://github.com/ansible/ansible/issues/60588

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy