### PR TITLE
fix: docker_swarm_service does not publish both tcp and udp ports

### DIFF
--- a/changelogs/fragments/60616-support-multiple-port.yaml
+++ b/changelogs/fragments/60616-support-multiple-port.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - allow the same port to be published both with TCP and UDP."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2028,19 +2028,16 @@ class DockerService(DockerBaseClass):
     def build_endpoint_spec(self):
         endpoint_spec_args = {}
         if self.publish is not None:
-            ports = {}
+            ports = []
             for port in self.publish:
+                port_spec = {
+                  'Protocol' : port['protocol'],
+                  'PublishedPort' : port['published_port'],
+                  'TargetPort' : port['target_port']
+                }
                 if port.get('mode'):
-                    ports[port['published_port']] = (
-                        port['target_port'],
-                        port['protocol'],
-                        port['mode'],
-                    )
-                else:
-                    ports[port['published_port']] = (
-                        port['target_port'],
-                        port['protocol'],
-                    )
+                    port_spec['PublishMode'] = port['mode']
+                ports.append(port_spec)
             endpoint_spec_args['ports'] = ports
         if self.endpoint_mode is not None:
             endpoint_spec_args['mode'] = self.endpoint_mode

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2031,9 +2031,9 @@ class DockerService(DockerBaseClass):
             ports = []
             for port in self.publish:
                 port_spec = {
-                  'Protocol' : port['protocol'],
-                  'PublishedPort' : port['published_port'],
-                  'TargetPort' : port['target_port']
+                    'Protocol': port['protocol'],
+                    'PublishedPort': port['published_port'],
+                    'TargetPort': port['target_port']
                 }
                 if port.get('mode'):
                     port_spec['PublishMode'] = port['mode']

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1590,6 +1590,24 @@
   register: publish_7
   ignore_errors: yes
 
+- name: publish (publishes the same port with both protocols)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    publish:
+      - protocol: udp
+        published_port: 60001
+        target_port: 60001
+        mode: host
+      - protocol: tcp
+        published_port: 60001
+        target_port: 60001
+        mode: host
+  register: publish_8
+  ignore_errors: yes
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -1605,6 +1623,8 @@
       - publish_5 is not changed
       - publish_6 is changed
       - publish_7 is not changed
+      - publish_8 is changed
+      - (publish_8.swarm_service.publish | length) == 2
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('3.0.0', '>=')
 - assert:
     that:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -1607,6 +1607,10 @@
         mode: host
   register: publish_8
   ignore_errors: yes
+- name: gather service info
+  docker_swarm_service_info:
+    name: "{{ service_name }}"
+  register: publish_8_info
 
 - name: cleanup
   docker_swarm_service:
@@ -1624,7 +1628,7 @@
       - publish_6 is changed
       - publish_7 is not changed
       - publish_8 is changed
-      - (publish_8.swarm_service.publish | length) == 2
+      - (publish_8_info.service.Endpoint.Ports | length) == 2
   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('3.0.0', '>=')
 - assert:
     that:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix: docker_swarm_service does not publish both tcp and udp ports for same published port
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service

##### ADDITIONAL INFORMATION
this is fix for the issue
https://github.com/ansible/ansible/issues/60568