### PR TITLE
Load integration config test vars from content.

### DIFF
--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -1,3 +1,0 @@
----
-win_output_dir: 'C:\ansible_testing'
-output_dir: ~/ansible_testing

--- a/test/lib/ansible_test/_internal/payload.py
+++ b/test/lib/ansible_test/_internal/payload.py
@@ -81,9 +81,7 @@ def create_payload(args, dst_path):  # type: (CommonConfig, str) -> None
 
     # these files need to be migrated to the ansible-test data directory
     hack_files_to_keep = (
-        'test/integration/integration_config.yml',
         'test/integration/inventory',
-        'test/integration/target-prefixes.network',
     )
 
     # temporary solution to include files not yet present in the ansible-test data directory


### PR DESCRIPTION
##### SUMMARY

Load integration config test vars from content.

The `test/integration/integration_config.yml` vars file will now be loaded from the content under test and is now optional.

The `output_dir` and `win_output_dir` vars are now provided by ansible-test.

This is another step towards completion of https://github.com/ansible/ansible/issues/60227

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
