### PR TITLE
Fix capitalization of SUSE

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -118,7 +118,7 @@ notes:
     it is much more efficient to pass the list directly to the `name` option.
 # informational: requirements for nodes
 requirements:
-    - "zypper >= 1.0  # included in openSuSE >= 11.1 or SuSE Linux Enterprise Server/Desktop >= 11.0"
+    - "zypper >= 1.0  # included in openSUSE >= 11.1 or SUSE Linux Enterprise Server/Desktop >= 11.0"
     - python-xml
     - rpm
 '''

--- a/lib/ansible/modules/packaging/os/zypper_repository.py
+++ b/lib/ansible/modules/packaging/os/zypper_repository.py
@@ -90,7 +90,7 @@ options:
 
 
 requirements:
-    - "zypper >= 1.0  # included in openSuSE >= 11.1 or SuSE Linux Enterprise Server/Desktop >= 11.0"
+    - "zypper >= 1.0  # included in openSUSE >= 11.1 or SUSE Linux Enterprise Server/Desktop >= 11.0"
     - python-xml
 '''
 

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -64,7 +64,7 @@ Requires: python-setuptools
 Requires: python-six
 %endif
 
-# SuSE/openSuSE
+# SUSE/openSUSE
 %if 0%{?suse_version}
 BuildRequires: python-devel
 BuildRequires: python-setuptools


### PR DESCRIPTION
The openSUSE project was always capitalized openSUSE, and SUSE does not
use the lowercase "u" since over 15 years. Let's update the docs for
this.

##### SUMMARY
SuSE -> SUSE

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zypper
zypper_repository
