### PR TITLE
for capability/exchange/1.0

### DIFF
--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -367,8 +367,6 @@ def get_nc_next(module, xml_str):
                 break
     return result
 
-    return to_string(to_xml(response))
-
 
 def get_nc_config(module, xml_str):
     """ get_config """

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -42,11 +42,16 @@ from ansible.module_utils.network.common.netconf import NetconfConnection
 
 
 try:
-    from ncclient.xml_ import to_xml
+    from ncclient.xml_ import to_xml, new_ele_ns
     HAS_NCCLIENT = True
 except ImportError:
     HAS_NCCLIENT = False
 
+
+try:
+    from lxml import etree
+except ImportError:
+    from xml.etree import ElementTree as etree
 
 _DEVICE_CLI_CONNECTION = None
 _DEVICE_NC_CONNECTION = None

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -362,7 +362,7 @@ def get_nc_next(module, xml_str):
             try:
                 next = conn.dispatch(etree.tostring(fetch_node))
                 if next is not None:
-                    result.extend(next.find('./*'))
+                    result.extend(next)
             except ConnectionError:
                 break
     return result

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -365,6 +365,8 @@ def get_nc_next(module, xml_str):
                     result.extend(next)
             except ConnectionError:
                 break
+    if result is not None:
+        return etree.tostring(result)
     return result
 
 

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -35,7 +35,7 @@ import traceback
 
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.connection import exec_command
+from ansible.module_utils.connection import exec_command, ConnectionError
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
 from ansible.module_utils.network.common.netconf import NetconfConnection
@@ -341,6 +341,28 @@ def set_nc_config(module, xml_str):
         # conn.unlock(target = 'candidate')
         pass
     return to_string(to_xml(out))
+
+
+def get_nc_next(module, xml_str):
+    """ get_nc_next for exchange capability """
+
+    conn = get_nc_connection(module)
+    result = None
+    if xml_str is not None:
+        response = conn.get(xml_str, if_rpc_reply=True)
+        result = response.find('./*')
+        set_id = response.get('set-id')
+        fetch_node = new_ele_ns('get-next', 'http://www.huawei.com/netconf/capability/base/1.0', {'set-id': set_id})
+        while True:
+            try:
+                next = conn.dispatch(etree.tostring(fetch_node))
+                if next is not None:
+                    result.extend(next.find('./*'))
+            except ConnectionError:
+                break
+    return result
+
+    return to_string(to_xml(response))
 
 
 def get_nc_config(module, xml_str):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/network/cloudengine/ce.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The NETCONF client can interact with the device using the <get-next> action.

For example, when a user queries a large amount of running data using operations such as <get>, <get-config>, the device needs to return data for packet processing. After returning the first data packet, the client needs to use the <get-nex> operation to interact with the device, requesting the device to continue to send the next data packet, or terminate the data query in advance.

An example of the client sending an RPC request query interface information.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
• RPC request
<rpc message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <get>
    <filter type="subtree">
      <ifm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
        <interfaces>
           <interface>
           </interface>
        </interfaces>
      </ifm>
    </filter>
  </get>
</rpc>

 • RPC response

<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" set-id="989">
  <data>
    <ifm xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
      <interfaces>
        <interface>
          <ifIndex>2</ifIndex>
          <ifName>Virtual-Template0</ifName>
          <ifPhyType>Virtual-Template</ifPhyType>
     <!-- additional <user> elements appear here... -->
        </interface>
      </interfaces>
    </ifm>
  </data>
</rpc-reply> The client needs to get the next data packet.

• RPC request

<rpc message-id="103" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <get-next xmlns="http://www.huawei.com/netconf/capability/base/1.0" set-id="1">
  </get-next>
</rpc>

•RPC response
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" set-id="989">
  <data>
    <ifm xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
      <interfaces>
        <interface>
          <ifIndex>3</ifIndex>
          <ifName>Virtual-Template1</ifName>
          <ifPhyType>Virtual-Template</ifPhyType>
     <!-- additional <user> elements appear here... -->
        </interface>
      </interfaces>
    </ifm>
  </data>
</rpc-reply>
```
