### PR TITLE
Documented disadvantages of using default zabbix password for all zab…

### DIFF
--- a/lib/ansible/plugins/doc_fragments/zabbix.py
+++ b/lib/ansible/plugins/doc_fragments/zabbix.py
@@ -48,4 +48,7 @@ options:
       type: bool
       default: yes
       version_added: "2.5"
+notes:
+    - If you use I(login_password=zabbix), the word "zabbix" is replaced by "********" in all module output, because I(login_password) uses C(no_log).
+      See L(this FAQ,https://docs.ansible.com/ansible/devel/network/user_guide/faq.html#why-is-my-output-sometimes-replaced-with) for more information.
 '''

--- a/lib/ansible/plugins/doc_fragments/zabbix.py
+++ b/lib/ansible/plugins/doc_fragments/zabbix.py
@@ -50,5 +50,5 @@ options:
       version_added: "2.5"
 notes:
     - If you use I(login_password=zabbix), the word "zabbix" is replaced by "********" in all module output, because I(login_password) uses C(no_log).
-      See L(this FAQ,https://docs.ansible.com/ansible/devel/network/user_guide/faq.html#why-is-my-output-sometimes-replaced-with) for more information.
+      See L(this FAQ,https://docs.ansible.com/ansible/latest/network/user_guide/faq.html#why-is-my-output-sometimes-replaced-with) for more information.
 '''


### PR DESCRIPTION
##### SUMMARY
Using default password `zabbix` will make some content to be hidden in module output. This happens due to `no_log=True` option being enabled on module argument `login_password`. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/zabbix.py

##### ADDITIONAL INFORMATION
Issue described in #39220

```bash
fatal: [zbx-dev-node001]: FAILED! => changed=false
  msg: 'Missing required ********-api module (check docs or install with: pip install ********-api)'
```