### PR TITLE
 Fix lambda_event AWS account_id query to work with AWS role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda_event.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_event.py
@@ -145,7 +145,7 @@ class AWSConnection:
             if not resources:
                 resources = ['lambda']
 
-            resources.append('iam')
+            resources.append('sts')
 
             for resource in resources:
                 aws_connect_kwargs.update(dict(region=self.region,
@@ -164,7 +164,7 @@ class AWSConnection:
 
         # set account ID
         try:
-            self.account_id = self.resource_client['iam'].get_user()['User']['Arn'].split(':')[4]
+            self.account_id = self.resource_client['sts'].get_caller_identity()['Account']
         except (ClientError, ValueError, KeyError, IndexError):
             self.account_id = ''
 


### PR DESCRIPTION
##### SUMMARY
Fixes lambda_event module to be able query AWS account id when AWS role is used for AWS access keys instead of AWS user.

I ran into an issue where the aws account query against IAM works when AWS credentials are gotten from a user but when I use a role I get error "botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the GetUser operation: Must specify userName when calling with non-User credentials". Looking at the sts docs https://docs.aws.amazon.com/cli/latest/reference/sts/get-caller-identity.html, the get_caller_identity function does not require any specific AWS permissions so I think it is a good alternative.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lambda_event

##### ADDITIONAL INFORMATION
```[bfloyd@xxx ansible]$ source ~/aws_creds_user
[bfloyd@xxx ansible]$ python2.7
Python 2.7.6 (default, Jun 20 2014, 10:16:54)
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
>>> print boto3.client('iam').get_user()
{u'User': {u'UserName': 'bfloyd', u'PasswordLastUsed': datetime.datetime(2018, 1, 9, 16, 51, 36, tzinfo=tzlocal()), u'CreateDate': datetime.datetime(2013, 8, 29, 17, 35, 33, tzinfo=tzlocal()), u'UserId': 'AIDAIO4UAWJTZFYA5GBLE', u'Path': '/', u'Arn': 'arn:aws:iam::230700467799:user/bfloyd'}, 'ResponseMetadata': {'RetryAttempts': 0, 'HTTPStatusCode': 200, 'RequestId': '36c19751-bf70-11e9-b14f-f1ca31a7cdab', 'HTTPHeaders': {'x-amzn-requestid': '36c19751-bf70-11e9-b14f-f1ca31a7cdab', 'date': 'Thu, 15 Aug 2019 15:20:28 GMT', 'content-length': '525', 'content-type': 'text/xml'}}}
>>> exit()
[bfloyd@xxx ansible]$ source ~/aws_creds_role
[bfloyd@xxx ansible]$ python2.7
Python 2.7.6 (default, Jun 20 2014, 10:16:54)
[GCC 4.4.6 20120305 (Red Hat 4.4.6-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
>>> print boto3.client('iam').get_user()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python2.7/site-packages/botocore/client.py", line 661, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the GetUser operation: Must specify userName when calling with non-User credentials
>>> exit()
```
