### PR TITLE
Updating intro_inventory.rst

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -433,7 +433,7 @@ Starting in Ansible version 2.4, users can use the group variable ``ansible_grou
     a_group:
         testvar: a
         ansible_group_priority: 10
-    b_group：
+    b_group:
         testvar: b
 
 In this example, if both groups have the same priority, the result would normally have been ``testvar == b``, but since we are giving the ``a_group`` a higher priority the result will be ``testvar == a``.


### PR DESCRIPTION
##### SUMMARY
This PR is fixing a typo in the [intro_inventory.rst](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html). There is an unprintable character instead of a colon.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`intro_inventory.rst`

##### ADDITIONAL INFORMATION
N/A