### PR TITLE
Add network and vpc to args

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
@@ -104,6 +104,14 @@ options:
       - "To delete all tags, set a empty list e.g. I(tags: [])."
     type: list
     aliases: [ tag ]
+  network:
+    description:
+      - Name of the network.
+    type: str
+  vpc:
+    description:
+      - Name of the VPC.
+    type: str
 extends_documentation_fragment: cloudstack
 '''
 
@@ -282,6 +290,7 @@ class AnsibleCloudStackLBRule(AnsibleCloudStack):
                 'cidrlist': self.module.params.get('cidr'),
                 'description': self.module.params.get('description'),
                 'protocol': self.module.params.get('protocol'),
+                'networkid': self.get_network(key='id'),
             })
             res = self.query_api('createLoadBalancerRule', **args)
 
@@ -338,6 +347,8 @@ def main():
         zone=dict(),
         domain=dict(),
         account=dict(),
+        vpc=dict(),
+        network=dict(),
         poll_async=dict(type='bool', default=True),
     ))
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
@@ -108,10 +108,12 @@ options:
     description:
       - Name of the network.
     type: str
+    version_added: '2.9'
   vpc:
     description:
       - Name of the VPC.
     type: str
+    version_added: '2.9'
 extends_documentation_fragment: cloudstack
 '''
 


### PR DESCRIPTION
network and vpc are needed when create a loadbalancer in a vpc in a recent adquired public ip

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
added network and vpc to args
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cs_loadbalancer_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When a public ip is adquired in a vpc, there is no network related, and cloudstack return error.
The fisrt time a loadbalancer rule is created in this public ip, cloudstack requires vpc and network args.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
