### PR TITLE
openssl_certificate: various assertonly bugfixes

### DIFF
--- a/changelogs/fragments/60658-openssl_certificate-assertonly-bugfix.yml
+++ b/changelogs/fragments/60658-openssl_certificate-assertonly-bugfix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "openssl_certificate - relative times did not work for ``pyopenssl`` backend under Python 3, and generally didn't work for ``valid_at`` and ``invalid_at`` for ``pyopenssl`` backend."
+- "openssl_certificate - ``invalid_at`` check was broken."
+- "openssl_certificate - ``key_usage`` check was broken for ``pyopenssl`` backend. Its error message was wrong for the ``cryptography`` backend."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1525,7 +1525,7 @@ class AssertOnlyCertificateCryptography(AssertOnlyCertificateBase):
         return self.cert.not_valid_before, rt, self.cert.not_valid_after
 
     def _validate_invalid_at(self):
-        rt = self.get_relative_time_option(self.valid_at, 'valid_at')
+        rt = self.get_relative_time_option(self.invalid_at, 'invalid_at')
         return self.cert.not_valid_before, rt, self.cert.not_valid_after
 
     def _validate_valid_in(self):
@@ -1689,7 +1689,7 @@ class AssertOnlyCertificate(AssertOnlyCertificateBase):
         return self.cert.get_notBefore(), self.valid_at, self.cert.get_notAfter()
 
     def _validate_invalid_at(self):
-        return self.cert.get_notBefore(), self.valid_at, self.cert.get_notAfter()
+        return self.cert.get_notBefore(), self.invalid_at, self.cert.get_notAfter()
 
     def _validate_valid_in(self):
         valid_in_asn1 = self.get_relative_time_option(self.valid_in, "valid_in")

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1627,10 +1627,9 @@ class AssertOnlyCertificate(AssertOnlyCertificateBase):
             extension = self.cert.get_extension(extension_idx)
             if extension.get_short_name() == b'keyUsage':
                 found = True
-                key_usage = [crypto_utils.pyopenssl_normalize_name(to_text(usage, errors='surrogate_or_strict'))
-                             for usage in self.key_usage]
-                current_ku = [crypto_utils.pyopenssl_normalize_name(usage.strip()) for usage in
-                              to_text(extension, errors='surrogate_or_strict').split(',')]
+                expected_extension = crypto.X509Extension(b"keyUsage", False, b', '.join(self.key_usage))
+                key_usage = [usage.strip() for usage in to_text(expected_extension, errors='surrogate_or_strict').split(',')]
+                current_ku = [usage.strip() for usage in to_text(extension, errors='surrogate_or_strict').split(',')]
                 if not compare_sets(key_usage, current_ku, self.key_usage_strict):
                     return self.key_usage, str(extension).split(', ')
         if not found:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1686,10 +1686,14 @@ class AssertOnlyCertificate(AssertOnlyCertificateBase):
         return self.cert.get_notAfter()
 
     def _validate_valid_at(self):
-        return self.cert.get_notBefore(), self.valid_at, self.cert.get_notAfter()
+        rt = self.get_relative_time_option(self.valid_at, "valid_at")
+        rt = to_bytes(rt, errors='surrogate_or_strict')
+        return self.cert.get_notBefore(), rt, self.cert.get_notAfter()
 
     def _validate_invalid_at(self):
-        return self.cert.get_notBefore(), self.invalid_at, self.cert.get_notAfter()
+        rt = self.get_relative_time_option(self.invalid_at, "invalid_at")
+        rt = to_bytes(rt, errors='surrogate_or_strict')
+        return self.cert.get_notBefore(), rt, self.cert.get_notAfter()
 
     def _validate_valid_in(self):
         valid_in_asn1 = self.get_relative_time_option(self.valid_in, "valid_in")

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1627,9 +1627,10 @@ class AssertOnlyCertificate(AssertOnlyCertificateBase):
             extension = self.cert.get_extension(extension_idx)
             if extension.get_short_name() == b'keyUsage':
                 found = True
-                key_usage = [OpenSSL._util.lib.OBJ_txt2nid(key_usage) for key_usage in self.key_usage]
-                current_ku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in
-                              to_bytes(extension, errors='surrogate_or_strict').split(b',')]
+                key_usage = [crypto_utils.pyopenssl_normalize_name(to_text(usage, errors='surrogate_or_strict'))
+                             for usage in self.key_usage]
+                current_ku = [crypto_utils.pyopenssl_normalize_name(usage.strip()) for usage in
+                              to_text(extension, errors='surrogate_or_strict').split(',')]
                 if not compare_sets(key_usage, current_ku, self.key_usage_strict):
                     return self.key_usage, str(extension).split(', ')
         if not found:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1483,7 +1483,7 @@ class AssertOnlyCertificateCryptography(AssertOnlyCertificateBase):
 
             key_usages = crypto_utils.cryptography_parse_key_usage_params(self.key_usage)
             if not compare_dicts(key_usages, test_key_usage, self.key_usage_strict):
-                return self.key_usage, [x for x in test_key_usage if x is True]
+                return self.key_usage, [k for k, v in test_key_usage.items() if v is True]
 
         except cryptography.x509.ExtensionNotFound:
             # This is only bad if the user specified a non-empty list

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1363,7 +1363,7 @@ class AssertOnlyCertificateBase(Certificate):
 
         if self.invalid_at is not None:
             not_before, invalid_at, not_after = self._validate_invalid_at()
-            if (invalid_at <= not_before) or (invalid_at >= not_after):
+            if not_before <= invalid_at <= not_after:
                 messages.append(
                     'Certificate is not invalid for the specified date (%s) - not_before: %s - not_after: %s' %
                     (self.invalid_at, not_before, not_after)


### PR DESCRIPTION
##### SUMMARY
Fixes various bugs for `assertonly` provider of `openssl_certificate`:
 * `get_relative_time_option` didn't work for byte strings (Python 3 + pyOpenSSL backend);
 * `invalid_at` check was wrong (wrong property was used, comparison was wrong);
 * relative times didn't work for `valid_at` and `invalid_at` (pyOpenSSL backend);
 * key usage check didn't work (pyOpenSSL backend);
 * key usage for certificate was always shown as `[]` in error message when check failed (cryptography backend).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
