### PR TITLE
Backport of 60648: Fix mispelling in postgresql_query docs

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -19,7 +19,7 @@ DOCUMENTATION = r'''
 module: postgresql_query
 short_description: Run PostgreSQL queries
 description:
-- Runs arbitraty PostgreSQL queries.
+- Runs arbitrary PostgreSQL queries.
 - Can run queries from SQL script files.
 version_added: '2.8'
 options:


### PR DESCRIPTION
##### SUMMARY
backport of https://github.com/ansible/ansible/pull/60648
fix typo in postgresql_query module's documentation

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
postgresql_query
