### PR TITLE
Updating intro_inventory.rst

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -356,7 +356,7 @@ Default groups
 
 There are two default groups: ``all`` and ``ungrouped``. ``all`` contains every host.
 ``ungrouped`` contains all hosts that don't have another group aside from ``all``.
-Every host will always belong to at least 2 groups.
+Every host will always belong to at least 2 groups (``all`` and ``ungrouped`` or ``all`` and some other group).
 Though ``all`` and ``ungrouped`` are always present, they can be implicit and not appear in group listings like ``group_names``.
 
 .. _splitting_out_vars:


### PR DESCRIPTION
##### SUMMARY
This PR is amending the documentation describing [default groups in Ansible](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#default-groups). It's adding an explicit information about in which groups every hosts is. When I was reading the documentation, I had to think what the original text actually mean. Although it can be deducted from the text, it's better to explicitly write it down to make the reading of the documentation more fluent.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`intro_inventory.rst`

##### ADDITIONAL INFORMATION
N/A