### PR TITLE
VMware: Modify conditional expression for VM existence check processing of folder

### DIFF
--- a/changelogs/fragments/60679-vmware_module_utils_fix.yml
+++ b/changelogs/fragments/60679-vmware_module_utils_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Changed to check if VM in folder are unique.

--- a/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
@@ -13,5 +13,7 @@ virtual_machines:
 virtual_machines_in_cluster:
   - name: DC0_C0_RP0_VM0
     cluster: '{{ ccr1 }}'
+    folder: /F0/DC0/vm/F0
   - name: DC0_C0_RP0_VM1
     cluster: '{{ ccr1 }}'
+    folder: /F0/DC0/vm/F0

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -4,7 +4,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -36,7 +36,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datastore: "{{ rw_datastore }}"
     datacenter: "{{ dc1 }}"
@@ -59,7 +59,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cdrom:
@@ -84,7 +84,7 @@
     template: test_vm1
     datacenter: "{{ dc1 }}"
     state: poweredoff
-    folder: vm
+    folder: "{{ f0 }}"
     convert: thin
 
 - name: Update CDROM to none for the new VM
@@ -93,7 +93,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm2
     datacenter: "{{ dc1 }}"
     cdrom:
@@ -114,7 +114,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm3
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -152,7 +152,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -197,7 +197,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cdrom:

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -10,6 +10,7 @@
     password: "{{ vcenter_password }}"
     name: "{{ virtual_machines[0].name }}"
     datacenter: "{{ dc1 }}"
+    folder: "{{ virtual_machines[0].folder }}"
     state: "{{ item }}"
   with_items:
     - absent
@@ -40,6 +41,7 @@
     password: "{{ vcenter_password }}"
     name: non_existent_vm
     datacenter: "{{ dc1 }}"
+    folder: "{{ virtual_machines[0].folder }}"
     state: "{{ item }}"
   with_items:
     - present

--- a/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
@@ -27,7 +27,7 @@
           start_connected: True
           allow_guest_control: True
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -17,7 +17,7 @@
           type: thin
           datastore: "{{ rw_datastore }}"
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rp_d1_c1_f0
 
 - debug: var=clone_rp_d1_c1_f0
@@ -38,7 +38,7 @@
     #guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     state: absent
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rp_d1_c1_f0_delete
 
 - debug: var=clone_rp_d1_c1_f0_delete
@@ -68,7 +68,7 @@
           type: thin
           datastore: "{{ rw_datastore }}"
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rpc_d1_c1_f0
 
 - debug: var=clone_rpc_d1_c1_f0
@@ -90,7 +90,7 @@
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     state: absent
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rpc_d1_c1_f0_delete
 
 - debug: var=clone_rpc_d1_c1_f0_delete
@@ -121,7 +121,7 @@
           type: thin
           datastore: "{{ rw_datastore }}"
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rpcp_d1_c1_f0
 
 - debug: var=clone_rpcp_d1_c1_f0
@@ -143,7 +143,7 @@
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     state: absent
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rpcp_d1_c1_f0_delete
 
 - debug: var=clone_rpcp_d1_c1_f0_delete
@@ -173,7 +173,7 @@
           type: thin
           datastore: "{{ rw_datastore }}"
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rph_d1_c1_f0
 
 - debug: var=clone_rph_d1_c1_f0
@@ -194,7 +194,7 @@
     #guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     state: absent
-    folder: F0
+    folder: "{{ f0 }}"
   register: clone_rph_d1_c1_f0_delete
 
 - debug: var=clone_rph_d1_c1_f0_delete

--- a/test/integration/targets/vmware_guest/tasks/delete_vm.yml
+++ b/test/integration/targets/vmware_guest/tasks/delete_vm.yml
@@ -10,6 +10,7 @@
     password: "{{ vcenter_password }}"
     name: nothinghere
     datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
     state: absent
   register: delete_vm
   ignore_errors: yes

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -22,7 +22,7 @@
           type: thin
           datastore: "{{ rw_datastore }}"
     state: poweredoff
-    folder: F0
+    folder: "{{ f0 }}"
   register: disk_type_d1_c1_f0
 
 - debug: var=disk_type_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -25,7 +25,7 @@
           gateway: 192.168.10.254
           mac: aa:bb:cc:dd:aa:42
     state: poweredoff
-    folder: vm
+    folder: "{{ f0 }}"
   register: clone_d1_c1_f0
 
 - debug: var=clone_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/multiple_folder.yml
+++ b/test/integration/targets/vmware_guest/tasks/multiple_folder.yml
@@ -1,0 +1,95 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt) 
+
+- name: Create multiple folders
+  vcenter_folder:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+    folder_name: "test{{ item }}"
+    folder_type: vm
+    state: present
+  register: all_folder_results
+  with_items:
+    - 0
+    - 1
+    - 2
+    - 3
+
+- name: Create new VM in test0 folder
+  vmware_guest:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    guest_id: centos64Guest
+    datacenter: "{{ dc1 }}"
+    hardware:
+      num_cpus: 4
+      memory_mb: 512
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+    folder: "/vm/test0"
+  register: vm
+
+- name: Check if VM already existing.
+  vmware_guest_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+    folder: "{{ item }}"
+    name: test_vm1
+  register: test
+  failed_when: False
+  delegate_to: localhost
+  loop:
+    - "/vm/test0/"
+    - "/vm/test1/"
+    - "/vm/test2/"
+    - "/vm/test3/"
+
+- name: Check if VM found in test0 only
+  assert:
+    that:
+      - item.instance.hw_folder
+  with_items:
+    - "{{ test.results | json_query(query) }}"
+  vars:
+    query: "[?instance.hw_name=='test_vm1']"
+
+- name: Check if VM not found for other folder except test0
+  assert:
+    that:
+      - not item.instance is defined
+  with_items:
+    - "{{ test.results | json_query(query) }}"
+  vars:
+    query: "[?instance.hw_name!='test_vm1']"
+
+- name: Remove VM
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+    folder: "/vm/test0"
+    name: test_vm1
+    force: yes
+    state: absent
+  register: multiple_folder_delete_vm
+  ignore_errors: yes
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "multiple_folder_delete_vm.changed"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f0.yml
@@ -8,6 +8,8 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    folder: "{{ item.folder }}"
     name: "{{ item.name }}"
     state: poweredoff
   with_items: "{{ virtual_machines }}"

--- a/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
+++ b/test/integration/targets/vmware_guest/tasks/poweroff_d1_c1_f1.yml
@@ -14,6 +14,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     name: "{{ item.name }}"
     state: poweredoff
     folder: "{{ item.folder }}"

--- a/test/integration/targets/vmware_guest/tasks/run_test_playbook.yml
+++ b/test/integration/targets/vmware_guest/tasks/run_test_playbook.yml
@@ -7,6 +7,8 @@
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: no
+        datacenter: "{{ dc1 }}"
+        folder: "{{ f0 }}"
 #        cluster: "{{ ccr1 }}"
         name: '{{ item }}'
         force: yes

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -10,7 +10,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
@@ -66,7 +66,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "vm"
+    folder: "{{ f0 }}"
     name: test_vm1
     datacenter: "{{ dc1 }}"
     vapp_properties:

--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -27,6 +27,7 @@
     password: '{{ vcenter_password }}'
     name: "{{ virtual_machines[0].name }}"
     datacenter: '{{ dc1 }}'
+    folder: "{{ f0 }}"
   register: disk_facts
 
 - debug:


### PR DESCRIPTION
##### SUMMARY
Running a VM clone with `vmware_guest` failed under the following conditions:.

**conditions**

For example, create it in the `TENANT-B` folder with the same name as the VM name in the `TENANT-A` folder.

![スクリーンショット 2019-08-16 19 11 06](https://user-images.githubusercontent.com/19516126/63161111-43e23a80-c05a-11e9-9654-8cb60c551443.png)

**playbook**

```yaml
---
- name: VMware VM clone operation
  hosts: localhost
  gather_facts: no
  vars_files:
    - vars/auth.yml
    - vars/vm.yml
  tasks:
    - name: Clone vm from template.
      vmware_guest:
        hostname: "{{ hostname }}"
        username: "{{ username }}"
        password: "{{ password }}"
        validate_certs: no
        datacenter: "{{ datacenter }}"
        folder: "{{ folder }}"
        esxi_hostname: "{{ esxi }}"
        template: "{{ template }}"
        name: "{{ name }}"
        hardware: "{{ hardware }}"
        networks: "{{ vm_networks }}"
        datastore: "{{ datastore }}"
        state: "{{ state }}"
```

**vm.yml**

```yaml
# VM valiables.
datacenter: DC
folder: "/{{ datacenter }}/vm/TENANT-B"
datastore: VM

name: TENANT-VM
template: CentOS7_TMP
esxi: esxi-12.local
hardware:
  num_cpus: 2
  num_cpu_cores_per_socket: 1
  memory_mb: 2048
vm_networks:
  - name: VM Network
state: poweredon
```

**running playbook**

```
(venv) [root@3600ad0bdbd6 vmware]# ansible-playbook main.yml
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

 [WARNING]: Found variable using reserved name: name


PLAY [VMware VM clone operation] *******************************************************************************************************************************************

TASK [Clone vm from template.] *********************************************************************************************************************************************
ok: [localhost]

PLAY RECAP *****************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Clone is not executed because it is determined that the VM already exists.

**Cause**

This is due to a problem with the vmware conditional expression at `module_utils`.

https://github.com/ansible/ansible/blob/c5c270d9f74294888e42e98522eaf360fe10c719/lib/ansible/module_utils/vmware.py#L936

If exists vm one or more, i think we should run the processing of finding VM from folder.
After modifying the code as follows, the clone was executed.

```diff
--- before/vmware.py  2019-08-16 10:27:54.930884918 +0000
+++ after/vmware.py 2019-08-16 10:28:08.866842735 +0000
@@ -904,7 +904,7 @@

             # get_managed_objects_properties may return multiple virtual machine,
             # following code tries to find user desired one depending upon the folder specified.
-            if len(vms) > 1:
+            if len(vms) >= 1:
                 # We have found multiple virtual machines, decide depending upon folder value
                 if self.params['folder'] is None:
                     self.module.fail_json(msg="Multiple virtual machines with same name [%s] found, "
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module_uitls/vmware.py