### PR TITLE
Specify the password auth plugin for new versions of mysql/mariadb (mysql_user)

### DIFF
--- a/changelogs/fragments/60681-mysql-user-create-with-native-password.yaml
+++ b/changelogs/fragments/60681-mysql-user-create-with-native-password.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - for newer versions of mysql/mariadb pass the default password plugin when password is encrypted


### PR DESCRIPTION
##### SUMMARY
Starting with MySQL 5.7 / MariaDB 10.2 you can specify the password auth plugin when creating a user. If you try to create a user with MySQL 8.0 without specifying the plugin, you get the following error:

```
"msg": "(1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'PASSWORD '********'' at line 1\")",
```

Fixes #57693

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ADDITIONAL INFORMATION
Expands on the fix introduced in [PR #45355](https://github.com/ansible/ansible/pull/45355)