### PR TITLE
Backport/2.8/57418

### DIFF
--- a/changelogs/fragments/60683-backport-57418.yaml
+++ b/changelogs/fragments/60683-backport-57418.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  Backported to stable-2.8 - Fix #56640 Map k8s ansible keys to api keys (https://github.com/ansible/ansible/pull/57418)

--- a/changelogs/fragments/60683-backport-57418.yaml
+++ b/changelogs/fragments/60683-backport-57418.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  Backported to stable-2.8 - Fix #56640 Map k8s ansible keys to api keys (https://github.com/ansible/ansible/pull/57418)
+  - Backported to stable-2.8 - Fix #56640 Map k8s ansible keys to api keys (https://github.com/ansible/ansible/pull/57418)

--- a/changelogs/fragments/backport-57418.yaml
+++ b/changelogs/fragments/backport-57418.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  Backported to stable-2.8 - Fix #56640 Map k8s ansible keys to api keys (https://github.com/ansible/ansible/pull/57418)

--- a/changelogs/fragments/backport-57418.yaml
+++ b/changelogs/fragments/backport-57418.yaml
@@ -1,2 +1,0 @@
-bugfixes:
-  Backported to stable-2.8 - Fix #56640 Map k8s ansible keys to api keys (https://github.com/ansible/ansible/pull/57418)

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -124,6 +124,21 @@ AUTH_ARG_SPEC = {
     },
 }
 
+# Map kubernetes-client parameters to ansible parameters
+AUTH_ARG_MAP = {
+    'kubeconfig': 'kubeconfig',
+    'context': 'context',
+    'host': 'host',
+    'api_key': 'api_key',
+    'username': 'username',
+    'password': 'password',
+    'verify_ssl': 'validate_certs',
+    'ssl_ca_cert': 'ca_cert',
+    'cert_file': 'client_cert',
+    'key_file': 'client_key',
+    'proxy': 'proxy',
+}
+
 
 class K8sAnsibleMixin(object):
     _argspec_cache = None
@@ -142,19 +157,19 @@ class K8sAnsibleMixin(object):
         return self._argspec_cache
 
     def get_api_client(self, **auth_params):
-        auth_args = AUTH_ARG_SPEC.keys()
-
         auth_params = auth_params or getattr(self, 'params', {})
-        auth = copy.deepcopy(auth_params)
+        auth = {}
 
         # If authorization variables aren't defined, look for them in environment variables
-        for arg in auth_args:
-            if auth_params.get(arg) is None:
-                env_value = os.getenv('K8S_AUTH_{0}'.format(arg.upper()), None)
+        for true_name, arg_name in AUTH_ARG_MAP.items():
+            if auth_params.get(arg_name) is None:
+                env_value = os.getenv('K8S_AUTH_{0}'.format(arg_name.upper()), None) or os.getenv('K8S_AUTH_{0}'.format(true_name.upper()), None)
                 if env_value is not None:
-                    if AUTH_ARG_SPEC[arg].get('type') == 'bool':
+                    if AUTH_ARG_SPEC[arg_name].get('type') == 'bool':
                         env_value = env_value.lower() not in ['0', 'false', 'no']
-                    auth[arg] = env_value
+                    auth[true_name] = env_value
+            else:
+                auth[true_name] = auth_params[arg_name]
 
         def auth_set(*names):
             return all([auth.get(name) for name in names])
@@ -174,7 +189,7 @@ class K8sAnsibleMixin(object):
         # Override any values in the default configuration with Ansible parameters
         configuration = kubernetes.client.Configuration()
         for key, value in iteritems(auth):
-            if key in auth_args and value is not None:
+            if key in AUTH_ARG_MAP.keys() and value is not None:
                 if key == 'api_key':
                     setattr(configuration, key, {'authorization': "Bearer {0}".format(value)})
                 else:

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -136,7 +136,6 @@ AUTH_ARG_MAP = {
     'ssl_ca_cert': 'ca_cert',
     'cert_file': 'client_cert',
     'key_file': 'client_key',
-    'proxy': 'proxy',
 }
 
 

--- a/test/integration/targets/k8s/tasks/full_test.yml
+++ b/test/integration/targets/k8s/tasks/full_test.yml
@@ -17,6 +17,19 @@
       debug:
         var: output
 
+    - name: Setting validate_certs to true causes a failure
+      k8s:
+        name: testing
+        kind: namespace
+        validate_certs: yes
+      ignore_errors: yes
+      register: output
+
+    - name: assert that validate_certs caused a failure (and therefore was correctly translated to verify_ssl)
+      assert:
+        that:
+          - output is failed
+
     - name: k8s_facts works with empty resources
       k8s_facts:
         kind: Deployment


### PR DESCRIPTION
##### SUMMARY
Backport of "Fix #56640: Map k8s ansible keys to api keys" to ansible 2.8

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION
proxy mapping has been removed from AUTH_ARG_MAP since this is added in 2.9