### PR TITLE
Adding overrides for INTERPRETER_PYTHON_{DISTRO_MAP,FALLBACK}

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1407,6 +1407,10 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3
+  env: [{name: INTERPRETER_PYTHON_DISTRO_MAP}]
+  ini:
+  - {key: interpreter_python_distro_map, section: defaults}
+  type: dict
   version_added: "2.8"
   # FUTURE: add inventory override once we're sure it can't be abused by a rogue target
   # FUTURE: add a platform layer to the map so we could use for, eg, freebsd/macos/etc?
@@ -1422,6 +1426,10 @@ INTERPRETER_PYTHON_FALLBACK:
   - /usr/libexec/platform-python
   - /usr/bin/python3
   - python
+  env: [{name: INTERPRETER_PYTHON_FALLBACK}]
+  ini:
+  - {key: interpreter_python_fallback, section: defaults}
+  type: list
   # FUTURE: add inventory override once we're sure it can't be abused by a rogue target
   version_added: "2.8"
 TRANSFORM_INVALID_GROUP_CHARS:


### PR DESCRIPTION
##### SUMMARY
Currently, the defaults for [`INTERPRETER_PYTHON_DISTRO_MAP`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html?highlight=interpreter_python_fallback#interpreter-python-distro-map) and [`INTERPRETER_PYTHON_FALLBACK`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html?highlight=interpreter_python_fallback#interpreter-python-fallback) are hardcoded in the [config/base.yml](https://github.com/ansible/ansible/blob/devel/lib/ansible/config/base.yml#L1397-L1426) file without the possibility to override them via environment variable or via Ansible config file. This PR is adding the possibility to specify overrides via environment variable and Ansible config file. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`interpreter_discovery`

##### ADDITIONAL INFORMATION
I would like to use these overrides to change the precedence of Python interpreter which are discovered on RHEL/CentOS 5. The default Python on these systems is v2.4 (`/usr/bin/python`) but there is also v2.6 (`/usr/bin/python2.6`) which I would like to be used instead. The problem is that `INTERPRETER_PYTHON_FALLBACK = ['/usr/bin/python', 'python3.7', 'python3.6', 'python3.5', 'python2.7', 'python2.6', '/usr/libexec/platform-python', '/usr/bin/python3', 'python']` which makes the `/usr/bin/python` being used. This is why I would like to override the configuration with a list of interpreters where the `/usr/bin/python` will be behind the versioned interpreters (`['python3.7', 'python3.6', 'python3.5', 'python2.7', 'python2.6', '/usr/bin/python', '/usr/libexec/platform-python', '/usr/bin/python3', 'python']`) which makes the `/usr/bin/python2.6` the one being used. Then I also need to override the `INTERPRETER_PYTHON_DISTRO_MAP` to add records for `centos`, `rhel` and `redhat` version 5 to choose `/usr/bin/python2.6` instead of the default `/usr/bin/python`.