### PR TITLE
Check for correct version of systemd Python library

### DIFF
--- a/changelogs/fragments/60595-systemd_import.yml
+++ b/changelogs/fragments/60595-systemd_import.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add an additional check for importing journal from systemd-python module (https://github.com/ansible/ansible/issues/60595).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -65,7 +65,9 @@ except ImportError:
 
 try:
     from systemd import journal
-    has_journal = True
+    # Makes sure that systemd.journal has method sendv()
+    # Double check that journal has method sendv (some packages don't)
+    has_journal = hasattr(journal, 'sendv')
 except ImportError:
     has_journal = False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #60595
Ansible failed when trying to run `journal.sendv` if the wrong version of `systemd` was installed. This change makes sure that `journal.sendv` exists before setting `has_journal = True`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible/module_utils/basic.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```paste below
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 114, in <module>
  File "<stdin>", line 106, in _ansiballz_main
  File "<stdin>", line 49, in invoke_module
  File "/usr/lib/python3.5/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.5/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 626, in _exec
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/tmp/ansible_command_payload_afjk26dr/__main__.py", line 327, in <module>
  File "/tmp/ansible_command_payload_afjk26dr/__main__.py", line 228, in main
  File "/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py", line 691, in __init__
  File "/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py", line 1940, in _log_invocation
  File "/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py", line 1898, in log
  File "systemd/_journal.pyx", line 68, in systemd._journal.send
  File "systemd/_journal.pyx", line 32, in systemd._journal._send
ValueError: Key name may not begin with an underscore

fatal: [pi]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 114, in <module>\n  File \"<stdin>\", line 106, in _ansiballz_main\n  File \"<stdin>\", line 49, in invoke_module\n  File \"/usr/lib/python3.5/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.5/imp.py\", line 170, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 626, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 673, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 222, in _call_with_frames_removed\n  File \"/tmp/ansible_command_payload_afjk26dr/__main__.py\", line 327, in <module>\n  File \"/tmp/ansible_command_payload_afjk26dr/__main__.py\", line 228, in main\n  File \"/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py\", line 691, in __init__\n  File \"/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py\", line 1940, in _log_invocation\n  File \"/tmp/ansible_command_payload_afjk26dr/ansible_command_payload.zip/ansible/module_utils/basic.py\", line 1898, in log\n  File \"systemd/_journal.pyx\", line 68, in systemd._journal.send\n  File \"systemd/_journal.pyx\", line 32, in systemd._journal._send\nValueError: Key name may not begin with an underscore\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

After:

```paste below
changed: [pi]
```