### PR TITLE
Fix ansible-test bin creation.

### DIFF
--- a/test/lib/ansible_test/_internal/payload.py
+++ b/test/lib/ansible_test/_internal/payload.py
@@ -118,6 +118,6 @@ def create_temporary_bin_files(args):  # type: (CommonConfig) -> t.Tuple[t.Tuple
 
         for name, dest in ANSIBLE_BIN_SYMLINK_MAP.items():
             path = os.path.join(temp_path, name)
-            os.link(dest, path)
+            os.symlink(dest, path)
 
     return tuple((os.path.join(temp_path, name), os.path.join('bin', name)) for name in sorted(ANSIBLE_BIN_SYMLINK_MAP))


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test bin creation.

Use symlink instead of link.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
