### PR TITLE
openssl_certificate/csr_info: add ordered issuer/subject return value

### DIFF
--- a/changelogs/fragments/60708-openssl_certificate_csr_info-ordered-issuer-subject.yml
+++ b/changelogs/fragments/60708-openssl_certificate_csr_info-ordered-issuer-subject.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "openssl_certificate_info - added ``issuer_ordered`` and ``subject_ordered`` return values."
+- "openssl_csr_info - added ``subject_ordered`` return value."

--- a/test/integration/targets/openssl_certificate_info/tasks/impl.yml
+++ b/test/integration/targets/openssl_certificate_info/tasks/impl.yml
@@ -8,6 +8,16 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: result
 
+- name: Check whether issuer and subject behave as expected
+  assert:
+    that:
+      - result.issuer.organizationalUnitName == 'ACME Department'
+      - "['organizationalUnitName', 'Crypto Department'] in result.issuer_ordered"
+      - "['organizationalUnitName', 'ACME Department'] in result.issuer_ordered"
+      - result.subject.organizationalUnitName == 'ACME Department'
+      - "['organizationalUnitName', 'Crypto Department'] in result.subject_ordered"
+      - "['organizationalUnitName', 'ACME Department'] in result.subject_ordered"
+
 - name: Update result list
   set_fact:
     info_results: "{{ info_results + [result] }}"

--- a/test/integration/targets/openssl_certificate_info/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate_info/tasks/main.yml
@@ -21,7 +21,9 @@
       ST: Zurich
       streetAddress: Welcome Street
       O: Ansible
-      organizationalUnitName: Crypto Department
+      organizationalUnitName:
+        - Crypto Department
+        - ACME Department
       serialNumber: "1234"
       SN: Last Name
       GN: First Name

--- a/test/integration/targets/openssl_csr_info/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr_info/tasks/impl.yml
@@ -8,6 +8,13 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: result
 
+- name: Check whether subject behaves as expected
+  assert:
+    that:
+      - result.subject.organizationalUnitName == 'ACME Department'
+      - "['organizationalUnitName', 'Crypto Department'] in result.subject_ordered"
+      - "['organizationalUnitName', 'ACME Department'] in result.subject_ordered"
+
 - name: Update result list
   set_fact:
     info_results: "{{ info_results + [result] }}"

--- a/test/integration/targets/openssl_csr_info/tasks/main.yml
+++ b/test/integration/targets/openssl_csr_info/tasks/main.yml
@@ -21,7 +21,9 @@
       ST: Zurich
       streetAddress: Welcome Street
       O: Ansible
-      organizationalUnitName: Crypto Department
+      organizationalUnitName:
+        - Crypto Department
+        - ACME Department
       serialNumber: "1234"
       SN: Last Name
       GN: First Name


### PR DESCRIPTION
##### SUMMARY
As pointed out by @ctrufan [here](https://github.com/ansible/ansible/pull/60599#pullrequestreview-275948895), subject and issuer of a certificate can have duplicate OIDs, and potentially the order is important.

This PR adds `subject_ordered` and `issuer_ordered` (`openssl_certificate_info` only) return values to the `_info` modules, which return lists of `(name, value)` tuples as well.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
openssl_certificate_info
openssl_csr_info
