### PR TITLE
EC2: Don't count instances in 'shutting-down' as running

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -600,7 +600,7 @@ def find_running_instances_by_count_tag(module, ec2, vpc, count_tag, zone=None):
     for res in reservations:
         if hasattr(res, 'instances'):
             for inst in res.instances:
-                if inst.state == 'terminated':
+                if inst.state == 'terminated' or inst.state == 'shutting-down':
                     continue
                 instances.append(inst)
 


### PR DESCRIPTION
state: shutting-down is a precursor to terminated and should be treated as such for exact_count.
Fixes #55955

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

