### PR TITLE
acme_certificate: add select_chain option

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -1099,6 +1099,7 @@ class ACMEClient(object):
                 # Try to select alternate chain depending on criteria
                 if self.module.params['select_alternate_chain']:
                     matching_chain = None
+                    all_chains = [cert] + alternate_chains
                     for criterium_idx, criterium in enumerate(self.module.params['select_alternate_chain']):
                         for v in ('subject_key_identifier', 'authority_key_identifier'):
                             if criterium[v]:
@@ -1108,9 +1109,9 @@ class ACMEClient(object):
                                     self.module.warn('Criterium {0} in select_alternate_chain has invalid {1} value. '
                                                      'Ignoring criterium.'.format(criterium_idx, v))
                                     continue
-                        for alt_chain in alternate_chains:
+                        for alt_chain in all_chains:
                             if self._chain_matches(alt_chain.get('chain', []), criterium):
-                                self.module.debug('Found matching alternative chain for criterium {0}'.format(criterium_idx))
+                                self.module.debug('Found matching chain for criterium {0}'.format(criterium_idx))
                                 matching_chain = alt_chain
                                 break
                         if matching_chain:

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -1004,7 +1004,7 @@ class ACMEClient(object):
             chain = chain[-1:]
         for cert in chain:
             try:
-                x509 = cryptography.x509.load_pem_x509_certificate(cert, cryptography.hazmat.backends.cryptography_backend())
+                x509 = cryptography.x509.load_pem_x509_certificate(to_bytes(cert), cryptography.hazmat.backends.default_backend())
                 matches = True
                 if criterium['subject']:
                     for k, v in crypto_utils.parse_name_field(criterium['subject']):
@@ -1023,7 +1023,7 @@ class ACMEClient(object):
                         oid = crypto_utils.cryptography_name_to_oid(k)
                         value = to_native(v)
                         found = False
-                        for attribute in x509.subject:
+                        for attribute in x509.issuer:
                             if attribute.oid == oid and value == to_native(attribute.value):
                                 found = True
                                 break
@@ -1033,14 +1033,14 @@ class ACMEClient(object):
                 if criterium['subject_key_identifier']:
                     try:
                         ext = x509.extensions.get_extension_for_class(cryptography.x509.SubjectKeyIdentifier)
-                        if criterium['subject_key_identifier'] != ext.digest:
+                        if criterium['subject_key_identifier'] != ext.value.digest:
                             matches = False
                     except cryptography.x509.ExtensionNotFound:
                         matches = False
                 if criterium['authority_key_identifier']:
                     try:
                         ext = x509.extensions.get_extension_for_class(cryptography.x509.AuthorityKeyIdentifier)
-                        if criterium['authority_key_identifier'] != ext.key_identifier:
+                        if criterium['authority_key_identifier'] != ext.value.key_identifier:
                             matches = False
                     except cryptography.x509.ExtensionNotFound:
                         matches = False

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -997,6 +997,9 @@ class ACMEClient(object):
                 self._validate_challenges(identifier_type, identifier, auth)
 
     def _chain_matches(self, chain, criterium):
+        '''
+        Check whether an alternate chain matches the specified criterium.
+        '''
         if criterium['test_certificates'] == 'last':
             chain = chain[-1:]
         for cert in chain:
@@ -1068,6 +1071,7 @@ class ACMEClient(object):
             cert_uri = self._finalize_cert()
             cert = self._download_cert(cert_uri)
             if self.module.params['retrieve_all_alternates'] or self.module.params['select_alternate_chain']:
+                # Retrieve alternate chains
                 alternate_chains = []
                 for alternate in cert['alternates']:
                     try:
@@ -1077,6 +1081,7 @@ class ACMEClient(object):
                         continue
                     alternate_chains.append(alt_cert)
 
+                # Prepare return value for all alternate chains
                 if self.module.params['retrieve_all_alternates']:
                     self.all_chains = []
 
@@ -1091,6 +1096,7 @@ class ACMEClient(object):
                     for alt_chain in alternate_chains:
                         _append_all_chains(alt_chain)
 
+                # Try to select alternate chain depending on criteria
                 if self.module.params['select_alternate_chain']:
                     matching_chain = None
                     for criterium_idx, criterium in enumerate(self.module.params['select_alternate_chain']):

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -237,15 +237,15 @@ options:
           - "Allows to specify parts of the issuer of a certificate in the chain must
              have to be selected."
           - "If I(issuer) is empty, any certificate will match."
+          - 'An example value would be C({"commonName": "My Preferred CA Root"}).'
         type: dict
-        sample: '{"commonName": "My Preferred CA Root"}'
       subject:
         description:
           - "Allows to specify parts of the subject of a certificate in the chain must
              have to be selected."
           - "If I(subject) is empty, any certificate will match."
+          - 'An example value would be C({"CN": "My Preferred CA Intermediate"})'
         type: dict
-        sample: '{"commonName": "My Preferred CA Intermediate"}'
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -220,7 +220,7 @@ options:
          to the same certificate in the chain."
       - "This option can only be used with the C(cryptography) backend."
     type: list
-    version_added: "2.9"
+    version_added: "2.10"
     suboptions:
       test_certificates:
         description:

--- a/test/integration/targets/acme_certificate/tasks/impl.yml
+++ b/test/integration/targets/acme_certificate/tasks/impl.yml
@@ -58,9 +58,14 @@
     terms_agreed: yes
     account_email: "example@example.org"
     retrieve_all_alternates: yes
+    acme_expected_root_number: 1
+    select_alternate_chain:
+      - test_certificates: last
+        issuer: "{{ acme_roots[1].subject }}"
 - name: Store obtain results for cert 1
   set_fact:
     cert_1_obtain_results: "{{ certificate_obtain_result }}"
+    cert_1_alternate: "{{ 1 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 2
   include_tasks: obtain-cert.yml
   vars:
@@ -77,9 +82,21 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
+    acme_expected_root_number: 0
+    retrieve_all_alternates: yes
+    select_alternate_chain:
+      # All intermediates have the same subject, so always the first
+      # chain will be found, and we need a second condition to make sure
+      # that the first condition actually works. (The second condition
+      # has been tested above.)
+      - test_certificates: all
+        subject: "{{ acme_intermediates[0].subject }}"
+      - test_certificates: all
+        issuer: "{{ acme_roots[2].subject }}"
 - name: Store obtain results for cert 2
   set_fact:
     cert_2_obtain_results: "{{ certificate_obtain_result }}"
+    cert_2_alternate: "{{ 0 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 3
   include_tasks: obtain-cert.yml
   vars:
@@ -96,6 +113,15 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
+    acme_expected_root_number: 0
+    retrieve_all_alternates: yes
+    select_alternate_chain:
+      - test_certificates: last
+        subject: "{{ acme_roots[1].subject }}"
+- name: Store obtain results for cert 3
+  set_fact:
+    cert_3_obtain_results: "{{ certificate_obtain_result }}"
+    cert_3_alternate: "{{ 0 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 4
   include_tasks: obtain-cert.yml
   vars:
@@ -113,6 +139,16 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
+    acme_expected_root_number: 2
+    select_alternate_chain:
+      - test_certificates: last
+        issuer: "{{ acme_roots[2].subject }}"
+      - test_certificates: last
+        issuer: "{{ acme_roots[1].subject }}"
+- name: Store obtain results for cert 4
+  set_fact:
+    cert_4_obtain_results: "{{ certificate_obtain_result }}"
+    cert_4_alternate: "{{ 2 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 5
   include_tasks: obtain-cert.yml
   vars:
@@ -129,6 +165,10 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
+- name: Store obtain results for cert 5a
+  set_fact:
+    cert_5a_obtain_results: "{{ certificate_obtain_result }}"
+    cert_5_alternate: "{{ 0 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 5 (should not, since already there and valid for more than 10 days)
   include_tasks: obtain-cert.yml
   vars:
@@ -145,7 +185,8 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
-- set_fact:
+- name: Store obtain results for cert 5b
+  set_fact:
     cert_5_recreate_1: "{{ challenge_data is changed }}"
 - name: Obtain cert 5 (should again by less days)
   include_tasks: obtain-cert.yml
@@ -163,8 +204,10 @@
     remaining_days: 1000
     terms_agreed: no
     account_email: ""
-- set_fact:
+- name: Store obtain results for cert 5c
+  set_fact:
     cert_5_recreate_2: "{{ challenge_data is changed }}"
+    cert_5c_obtain_results: "{{ certificate_obtain_result }}"
 - name: Obtain cert 5 (should again by force)
   include_tasks: obtain-cert.yml
   vars:
@@ -181,8 +224,10 @@
     remaining_days: 10
     terms_agreed: no
     account_email: ""
-- set_fact:
+- name: Store obtain results for cert 5d
+  set_fact:
     cert_5_recreate_3: "{{ challenge_data is changed }}"
+    cert_5d_obtain_results: "{{ certificate_obtain_result }}"
 - name: Obtain cert 6
   include_tasks: obtain-cert.yml
   vars:
@@ -200,6 +245,20 @@
     remaining_days: 10
     terms_agreed: yes
     account_email: "example@example.org"
+    acme_expected_root_number: 0
+    select_alternate_chain:
+      # All intermediates have the same subject key identifier, so always
+      # the first chain will be found, and we need a second condition to
+      # make sure that the first condition actually works. (The second
+      # condition has been tested above.)
+      - test_certificates: last
+        subject_key_identifier: "{{ acme_intermediates[0].subject_key_identifier }}"
+      - test_certificates: last
+        issuer: "{{ acme_roots[1].subject }}"
+- name: Store obtain results for cert 6
+  set_fact:
+    cert_6_obtain_results: "{{ certificate_obtain_result }}"
+    cert_6_alternate: "{{ 0 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 7
   include_tasks: obtain-cert.yml
   vars:
@@ -219,6 +278,14 @@
     remaining_days: 10
     terms_agreed: yes
     account_email: "example@example.org"
+    acme_expected_root_number: 2
+    select_alternate_chain:
+      - test_certificates: last
+        authority_key_identifier: "{{ acme_roots[2].subject_key_identifier }}"
+- name: Store obtain results for cert 7
+  set_fact:
+    cert_7_obtain_results: "{{ certificate_obtain_result }}"
+    cert_7_alternate: "{{ 2 if select_crypto_backend == 'cryptography' else 0 }}"
 - name: Obtain cert 8
   include_tasks: obtain-cert.yml
   vars:
@@ -240,6 +307,10 @@
     remaining_days: 10
     terms_agreed: yes
     account_email: "example@example.org"
+- name: Store obtain results for cert 8
+  set_fact:
+    cert_8_obtain_results: "{{ certificate_obtain_result }}"
+    cert_8_alternate: "{{ 0 if select_crypto_backend == 'cryptography' else 0 }}"
 ## DISSECT CERTIFICATES #######################################################################
 # Make sure certificates are valid. Root certificate for Pebble equals the chain certificate.
 - name: Verifying cert 1
@@ -299,6 +370,39 @@
 - name: Dumping cert 8
   command: openssl x509 -in "{{ output_dir }}/cert-8.pem" -noout -text
   register: cert_8_text
+# Dump certificate info
+- name: Dumping cert 1
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-1.pem"
+  register: cert_1_info
+- name: Dumping cert 2
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-2.pem"
+  register: cert_2_info
+- name: Dumping cert 3
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-3.pem"
+  register: cert_3_info
+- name: Dumping cert 4
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-4.pem"
+  register: cert_4_info
+- name: Dumping cert 5
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-5.pem"
+  register: cert_5_info
+- name: Dumping cert 6
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-6.pem"
+  register: cert_6_info
+- name: Dumping cert 7
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-7.pem"
+  register: cert_7_info
+- name: Dumping cert 8
+  openssl_certificate_info:
+    path: "{{ output_dir }}/cert-8.pem"
+  register: cert_8_info
 ## GET ACCOUNT ORDERS #########################################################################
 - name: Don't retrieve orders
   acme_account_info:

--- a/test/integration/targets/acme_certificate/tasks/impl.yml
+++ b/test/integration/targets/acme_certificate/tasks/impl.yml
@@ -59,7 +59,7 @@
     account_email: "example@example.org"
     retrieve_all_alternates: yes
     acme_expected_root_number: 1
-    select_alternate_chain:
+    select_chain:
       - test_certificates: last
         issuer: "{{ acme_roots[1].subject }}"
 - name: Store obtain results for cert 1
@@ -84,7 +84,7 @@
     account_email: ""
     acme_expected_root_number: 0
     retrieve_all_alternates: yes
-    select_alternate_chain:
+    select_chain:
       # All intermediates have the same subject, so always the first
       # chain will be found, and we need a second condition to make sure
       # that the first condition actually works. (The second condition
@@ -115,7 +115,7 @@
     account_email: ""
     acme_expected_root_number: 0
     retrieve_all_alternates: yes
-    select_alternate_chain:
+    select_chain:
       - test_certificates: last
         subject: "{{ acme_roots[1].subject }}"
 - name: Store obtain results for cert 3
@@ -140,7 +140,7 @@
     terms_agreed: no
     account_email: ""
     acme_expected_root_number: 2
-    select_alternate_chain:
+    select_chain:
       - test_certificates: last
         issuer: "{{ acme_roots[2].subject }}"
       - test_certificates: last
@@ -246,7 +246,7 @@
     terms_agreed: yes
     account_email: "example@example.org"
     acme_expected_root_number: 0
-    select_alternate_chain:
+    select_chain:
       # All intermediates have the same subject key identifier, so always
       # the first chain will be found, and we need a second condition to
       # make sure that the first condition actually works. (The second
@@ -279,7 +279,7 @@
     terms_agreed: yes
     account_email: "example@example.org"
     acme_expected_root_number: 2
-    select_alternate_chain:
+    select_chain:
       - test_certificates: last
         authority_key_identifier: "{{ acme_roots[2].subject_key_identifier }}"
 - name: Store obtain results for cert 7

--- a/test/integration/targets/acme_certificate/tasks/main.yml
+++ b/test/integration/targets/acme_certificate/tasks/main.yml
@@ -1,5 +1,76 @@
 ---
 - block:
+  - name: Obtain root and intermediate certificates
+    get_url:
+      url: "http://{{ acme_host }}:5000/{{ item.0 }}-certificate-for-ca/{{ item.1 }}"
+      dest: "{{ output_dir }}/acme-{{ item.0 }}-{{ item.1 }}.pem"
+    loop: "{{ query('nested', types, root_numbers) }}"
+
+  - name: Analyze root certificates
+    openssl_certificate_info:
+      path: "{{ output_dir }}/acme-root-{{ item }}.pem"
+    loop: "{{ root_numbers }}"
+    register: acme_roots
+
+  - name: Analyze intermediate certificates
+    openssl_certificate_info:
+      path: "{{ output_dir }}/acme-intermediate-{{ item }}.pem"
+    loop: "{{ root_numbers }}"
+    register: acme_intermediates
+
+  - set_fact:
+      x__: "{{ item | dict2items | selectattr('key', 'in', interesting_keys) | list | items2dict }}"
+      y__: "{{ lookup('file', output_dir ~ '/acme-root-' ~ item.item ~ '.pem', rstrip=False) }}"
+    loop: "{{ acme_roots.results }}"
+    register: acme_roots_tmp
+
+  - set_fact:
+      x__: "{{ item | dict2items | selectattr('key', 'in', interesting_keys) | list | items2dict }}"
+      y__: "{{ lookup('file', output_dir ~ '/acme-intermediate-' ~ item.item ~ '.pem', rstrip=False) }}"
+    loop: "{{ acme_intermediates.results }}"
+    register: acme_intermediates_tmp
+
+  - set_fact:
+      acme_roots: "{{ acme_roots_tmp.results | map(attribute='ansible_facts.x__') | list }}"
+      acme_root_certs: "{{ acme_roots_tmp.results | map(attribute='ansible_facts.y__') | list }}"
+      acme_intermediates: "{{ acme_intermediates_tmp.results | map(attribute='ansible_facts.x__') | list }}"
+      acme_intermediate_certs: "{{ acme_intermediates_tmp.results | map(attribute='ansible_facts.y__') | list }}"
+
+  vars:
+    types:
+      - root
+      - intermediate
+    root_numbers:
+      # The number 3 comes from here: https://github.com/ansible/acme-test-container/blob/master/run.sh#L12
+      - 0
+      - 1
+      - 2
+      - 3
+    interesting_keys:
+      - authority_key_identifier
+      - subject_key_identifier
+      - issuer
+      - subject
+      #- serial_number
+      #- public_key_fingerprints
+
+- name: ACME root certificate info
+  debug:
+    var: acme_roots
+
+#- name: ACME root certificates as PEM
+#  debug:
+#    var: acme_root_certs
+
+- name: ACME intermediate certificate info
+  debug:
+    var: acme_intermediates
+
+#- name: ACME intermediate certificates as PEM
+#  debug:
+#    var: acme_intermediate_certs
+
+- block:
   - name: Running tests with OpenSSL backend
     include_tasks: impl.yml
     vars:

--- a/test/integration/targets/acme_certificate/tests/validate.yml
+++ b/test/integration/targets/acme_certificate/tests/validate.yml
@@ -11,10 +11,13 @@
   assert:
     that:
       - "'all_chains' in cert_1_obtain_results"
-      - "'chain' in cert_1_obtain_results.all_chains[0]"
-      - "'full_chain' in cert_1_obtain_results.all_chains[0]"
-      - "lookup('file', output_dir ~ '/cert-1-chain.pem', rstrip=False) == cert_1_obtain_results.all_chains[0].chain"
-      - "lookup('file', output_dir ~ '/cert-1-fullchain.pem', rstrip=False) == cert_1_obtain_results.all_chains[0].full_chain"
+      - "cert_1_obtain_results.all_chains | length > 1"
+      - "'cert' in cert_1_obtain_results.all_chains[cert_1_alternate | int]"
+      - "'chain' in cert_1_obtain_results.all_chains[cert_1_alternate | int]"
+      - "'full_chain' in cert_1_obtain_results.all_chains[cert_1_alternate | int]"
+      - "lookup('file', output_dir ~ '/cert-1.pem', rstrip=False) == cert_1_obtain_results.all_chains[cert_1_alternate | int].cert"
+      - "lookup('file', output_dir ~ '/cert-1-chain.pem', rstrip=False) == cert_1_obtain_results.all_chains[cert_1_alternate | int].chain"
+      - "lookup('file', output_dir ~ '/cert-1-fullchain.pem', rstrip=False) == cert_1_obtain_results.all_chains[cert_1_alternate | int].full_chain"
 
 - name: Check that certificate 2 is valid
   assert:
@@ -25,10 +28,17 @@
     that:
       - "'DNS:*.example.com' in cert_2_text.stdout"
       - "'DNS:example.com' in cert_2_text.stdout"
-- name: Check that certificate 2 retrieval did not get all chains
+- name: Check that certificate 1 retrieval got all chains
   assert:
     that:
-      - "'all_chains' not in cert_2_obtain_results"
+      - "'all_chains' in cert_2_obtain_results"
+      - "cert_2_obtain_results.all_chains | length > 1"
+      - "'cert' in cert_2_obtain_results.all_chains[cert_2_alternate | int]"
+      - "'chain' in cert_2_obtain_results.all_chains[cert_2_alternate | int]"
+      - "'full_chain' in cert_2_obtain_results.all_chains[cert_2_alternate | int]"
+      - "lookup('file', output_dir ~ '/cert-2.pem', rstrip=False) == cert_2_obtain_results.all_chains[cert_2_alternate | int].cert"
+      - "lookup('file', output_dir ~ '/cert-2-chain.pem', rstrip=False) == cert_2_obtain_results.all_chains[cert_2_alternate | int].chain"
+      - "lookup('file', output_dir ~ '/cert-2-fullchain.pem', rstrip=False) == cert_2_obtain_results.all_chains[cert_2_alternate | int].full_chain"
 
 - name: Check that certificate 3 is valid
   assert:
@@ -40,6 +50,17 @@
       - "'DNS:*.example.com' in cert_3_text.stdout"
       - "'DNS:example.org' in cert_3_text.stdout"
       - "'DNS:t1.example.com' in cert_3_text.stdout"
+- name: Check that certificate 1 retrieval got all chains
+  assert:
+    that:
+      - "'all_chains' in cert_3_obtain_results"
+      - "cert_3_obtain_results.all_chains | length > 1"
+      - "'cert' in cert_3_obtain_results.all_chains[cert_3_alternate | int]"
+      - "'chain' in cert_3_obtain_results.all_chains[cert_3_alternate | int]"
+      - "'full_chain' in cert_3_obtain_results.all_chains[cert_3_alternate | int]"
+      - "lookup('file', output_dir ~ '/cert-3.pem', rstrip=False) == cert_3_obtain_results.all_chains[cert_3_alternate | int].cert"
+      - "lookup('file', output_dir ~ '/cert-3-chain.pem', rstrip=False) == cert_3_obtain_results.all_chains[cert_3_alternate | int].chain"
+      - "lookup('file', output_dir ~ '/cert-3-fullchain.pem', rstrip=False) == cert_3_obtain_results.all_chains[cert_3_alternate | int].full_chain"
 
 - name: Check that certificate 4 is valid
   assert:
@@ -53,6 +74,10 @@
       - "'DNS:test.t2.example.com' in cert_4_text.stdout"
       - "'DNS:example.org' in cert_4_text.stdout"
       - "'DNS:test.example.org' in cert_4_text.stdout"
+- name: Check that certificate 4 retrieval did not get all chains
+  assert:
+    that:
+      - "'all_chains' not in cert_4_obtain_results"
 
 - name: Check that certificate 5 is valid
   assert:

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -112,6 +112,7 @@
     account_email: "{{ account_email }}"
     data: "{{ challenge_data }}"
     retrieve_all_alternates: "{{ retrieve_all_alternates | default(omit) }}"
+    select_alternate_chain: "{{ select_alternate_chain | default(omit) if select_crypto_backend == 'cryptography' else omit }}"
   register: certificate_obtain_result
   when: challenge_data is changed
 - name: ({{ certgen_title }}) Deleting HTTP challenges
@@ -134,6 +135,6 @@
   when: "challenge_data is changed and challenge == 'tls-alpn-01'"
 - name: ({{ certgen_title }}) Get root certificate
   get_url:
-    url: "http://{{ acme_host }}:5000/root-certificate-for-ca/0"
+    url: "http://{{ acme_host }}:5000/root-certificate-for-ca/{{ acme_expected_root_number | default(0) if select_crypto_backend == 'cryptography' else 0 }}"
     dest: "{{ output_dir }}/{{ certificate_name }}-root.pem"
 ###############################################################################################

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -112,7 +112,7 @@
     account_email: "{{ account_email }}"
     data: "{{ challenge_data }}"
     retrieve_all_alternates: "{{ retrieve_all_alternates | default(omit) }}"
-    select_alternate_chain: "{{ select_alternate_chain | default(omit) if select_crypto_backend == 'cryptography' else omit }}"
+    select_chain: "{{ select_chain | default(omit) if select_crypto_backend == 'cryptography' else omit }}"
   register: certificate_obtain_result
   when: challenge_data is changed
 - name: ({{ certgen_title }}) Deleting HTTP challenges


### PR DESCRIPTION
##### SUMMARY
This option allows to choose an alternate chain (when provided) depending on some criteria on the certificates in the chain. Can be for example used to select a chain with a more compatible root certificate (i.e. corresponding to the cross-signed intermediates in case of Let's Encrypt), if the CA provides such chains.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
acme_certificate
