### PR TITLE
acme_certificate: make compatible to Buypass' ACME v2 testing endpoint

### DIFF
--- a/changelogs/fragments/60727-acme_certificate-acme-compatibility.yml
+++ b/changelogs/fragments/60727-acme_certificate-acme-compatibility.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - improve compatibility when finalizing ACME v2 orders. Fixes problem with Buypass' ACME v2 testing endpoint."

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -668,12 +668,10 @@ class ACMEClient(object):
         if info['status'] not in [200]:
             raise ModuleFailException("Error new cert: CODE: {0} RESULT: {1}".format(info['status'], result))
 
-        order = info['location']
-
         status = result['status']
         while status not in ['valid', 'invalid']:
             time.sleep(2)
-            result, dummy = self.account.get_request(order)
+            result, dummy = self.account.get_request(self.order_uri)
             status = result['status']
 
         if status != 'valid':


### PR DESCRIPTION
##### SUMMARY
While trying the [Buypass ACME v2 testing endpoint](https://api.test4.buypass.no/acme/directory) ([see also](https://community.buypass.com/t/63d4ay/buypass-go-ssl-endpoints)), I found a problem where Boulder and Pebble behave differently than Buypass. When finalizing an order, Boulder and Pebble return a `Location` header with the order URI, while Buypass does not. If I understand RFC8555 correctly, this header does not need to be returned; in any case, there should be no need for it since we already know the order URI.

Note that the Buypass [ACME v1 endpoint](https://api.buypass.com/acme/directory) doesn't seem to work with `acme_certificate`. If anyone wants to debug this, feel free :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
