### PR TITLE
WIP: Add PolicyArns parameters to sts_assume_role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sts_assume_role.py
+++ b/lib/ansible/modules/cloud/amazon/sts_assume_role.py
@@ -34,6 +34,12 @@ options:
   policy:
     description:
       - Supplemental policy to use in addition to assumed role's policies.
+  policy_arns:
+    description:
+      - The ARN of the IAM managed policies that you want to use as managed session policies.
+        The policies must exist in the same account as the role.
+        You can provide up to 10 managed policy ARNs.
+        However, the plain text that you use for both inline and  managed  session  policies  shouldn't  exceed 2048 characters.
   duration_seconds:
     description:
       - The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) to 43200 seconds (12 hours).
@@ -101,6 +107,13 @@ ec2_tag:
   tags:
     MyNewTag: value
 
+# Get an STS token limited to the policy policyS3ReadOnly
+sts_assume_role:
+  role_arn: "arn:aws:iam::123456789012:role/someRole"
+  role_session_name: "someRoleSession"
+  policy_arns:
+    - arn: "arn:aws:iam::123456789012:role/policyS3ReadOnly"
+register: assumed_role
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -133,6 +146,7 @@ def assume_role_policy(connection, module):
         'RoleArn': module.params.get('role_arn'),
         'RoleSessionName': module.params.get('role_session_name'),
         'Policy': module.params.get('policy'),
+        'PolicyArns': module.params.get('policy_arns'),
         'DurationSeconds': module.params.get('duration_seconds'),
         'ExternalId': module.params.get('external_id'),
         'SerialNumber': module.params.get('mfa_serial_number'),
@@ -161,6 +175,7 @@ def main():
             duration_seconds=dict(required=False, default=None, type='int'),
             external_id=dict(required=False, default=None),
             policy=dict(required=False, default=None),
+            policy_arns=dict(type='list',required=False, default=None),
             mfa_serial_number=dict(required=False, default=None),
             mfa_token=dict(required=False, default=None)
         )

--- a/lib/ansible/modules/cloud/amazon/sts_assume_role.py
+++ b/lib/ansible/modules/cloud/amazon/sts_assume_role.py
@@ -40,6 +40,7 @@ options:
         The policies must exist in the same account as the role.
         You can provide up to 10 managed policy ARNs.
         However, the plain text that you use for both inline and  managed  session  policies  shouldn't  exceed 2048 characters.
+    version_added: 2.9
   duration_seconds:
     description:
       - The duration, in seconds, of the role session. The value can range from 900 seconds (15 minutes) to 43200 seconds (12 hours).
@@ -92,28 +93,28 @@ EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Assume an existing role (more details: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
-sts_assume_role:
-  role_arn: "arn:aws:iam::123456789012:role/someRole"
-  role_session_name: "someRoleSession"
-register: assumed_role
+- sts_assume_role:
+    role_arn: "arn:aws:iam::123456789012:role/someRole"
+    role_session_name: "someRoleSession"
+  register: assumed_role
 
 # Use the assumed role above to tag an instance in account 123456789012
-ec2_tag:
-  aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
-  aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
-  security_token: "{{ assumed_role.sts_creds.session_token }}"
-  resource: i-xyzxyz01
-  state: present
-  tags:
-    MyNewTag: value
+- ec2_tag:
+    aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
+    aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
+    security_token: "{{ assumed_role.sts_creds.session_token }}"
+    resource: i-xyzxyz01
+    state: present
+    tags:
+      MyNewTag: value
 
 # Get an STS token limited to the policy policyS3ReadOnly
-sts_assume_role:
-  role_arn: "arn:aws:iam::123456789012:role/someRole"
-  role_session_name: "someRoleSession"
-  policy_arns:
-    - arn: "arn:aws:iam::123456789012:role/policyS3ReadOnly"
-register: assumed_role
+- sts_assume_role:
+    role_arn: "arn:aws:iam::123456789012:role/someRole"
+    role_session_name: "someRoleSession"
+    policy_arns:
+      - arn: "arn:aws:iam::123456789012:role/policyS3ReadOnly"
+  register: assumed_role
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -175,7 +176,7 @@ def main():
             duration_seconds=dict(required=False, default=None, type='int'),
             external_id=dict(required=False, default=None),
             policy=dict(required=False, default=None),
-            policy_arns=dict(type='list',required=False, default=None),
+            policy_arns=dict(type='list', required=False, default=None),
             mfa_serial_number=dict(required=False, default=None),
             mfa_token=dict(required=False, default=None)
         )

--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -47,6 +47,21 @@
         seconds: 30
 
     # ============================================================
+    - name: create test iam policy
+      iam_managed_policy:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        policy_name: "ansible-test-sts-policy-{{ resource_prefix }}"
+        policy: "{{ lookup('template','policy.json.j2') }}"
+        state: present
+      register: test_policy
+    # ============================================================
+    - name: pause to ensure policy exists before using
+      pause:
+        seconds: 30
+
+    # ============================================================
     - name: test with no parameters
       sts_assume_role:
       register: result
@@ -301,6 +316,34 @@
       when: result.module_stderr is defined
 
     # ============================================================
+    - name: test assume not existing sts policy
+      sts_assume_role:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+        role_arn: "{{ test_role.iam_role.arn }}"
+        policy_arns:
+          - arn: "arn:aws:iam:123456789:policy/non-existing-policy"
+        role_session_name: AnsibleTest
+      register: result
+      ignore_errors: true
+
+    - name: assert assume not existing sts policy
+      assert:
+        that:
+          - 'result.failed'
+          - "'specified ARN in the PolicyArns parameter is not valid' in result.msg"
+      when: result.module_stderr is not defined
+
+    - name: assert assume not existing sts policy
+      assert:
+        that:
+          - 'result.failed'
+          - "'specified ARN in the PolicyArns parameter is not valid' in result.module_stderr"
+      when: result.module_stderr is defined
+
+  # ============================================================
     - name: test assume role
       sts_assume_role:
         aws_access_key: "{{ aws_access_key }}"
@@ -370,7 +413,67 @@
       when: result.module_stderr is defined
 
     # ============================================================
+    - name: test assume role
+      sts_assume_role:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        region: "{{ aws_region }}"
+        role_arn: "{{ test_role.iam_role.arn }}"
+        role_session_name: AnsibleTest
+        policy_arns:
+          - arn: "{{test_policy.policy.arn}}"
+      register: assumed_role
+
+    - name: assert assume role
+      assert:
+        that:
+        - 'not assumed_role.failed'
+        - "'sts_creds' in assumed_role"
+        - "'access_key' in assumed_role.sts_creds"
+        - "'secret_key' in assumed_role.sts_creds"
+        - "'session_token' in assumed_role.sts_creds"
+
+    - name: test that assumed credentials have no access with the policy
+      iam_role:
+        aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
+        aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
+        security_token: "{{ assumed_role.sts_creds.session_token }}"
+        region: "{{ aws_region}}"
+        name: "ansible-test-sts-{{ resource_prefix }}"
+        assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
+        create_instance_profile: False
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: assert assumed role with limited permissions
+      assert:
+        that:
+          - 'result.failed'
+          - "'is not authorized to perform: iam:GetRole' in result.msg"
+      # runs on Python2
+      when: result.module_stderr is not defined
+
+    - name: assert assumed role with limited permissions
+      assert:
+        that:
+          - 'result.failed'
+          - "'is not authorized to perform: iam:GetRole' in result.msg"
+      # runs on Python3
+      when: result.module_stderr is defined
+
+    # ============================================================
   always:
+
+    - name: delete test iam policy
+      iam_managed_policy:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token }}"
+        policy_name: "ansible-test-sts-policy-{{ resource_prefix }}"
+        policy: "{{ lookup('template','policy2.json.j2') }}"
+        state: absent
 
     - name: delete test iam role
       iam_role:

--- a/test/integration/targets/sts_assume_role/templates/policy2.json.j2
+++ b/test/integration/targets/sts_assume_role/templates/policy2.json.j2
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AnsibleUnitTest",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::{{aws_account}}:role/{{ test_role.iam_role.arn }}"
+        }
+    ]
+}


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`sts_assume_role` is calling the `assume_role` function of the  `sts` class in `boto3`
This function supports a new parameter `PolicyArns`. We have updated the module accordingly
This PR implements #60734 request
Requires botocore 1.12.146 or higher
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
