### PR TITLE
XenServer: When VM is in powered on state, plug newly added disks (fixes #60693)

### DIFF
--- a/changelogs/fragments/60737-xenserver_guest-vbd-plug-fix.yml
+++ b/changelogs/fragments/60737-xenserver_guest-vbd-plug-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- xenserver_guest - when adding disks to a VM in powered on state, disks are now properly plugged/activated (https://github.com/ansible/ansible/issues/60693).

--- a/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
+++ b/lib/ansible/modules/cloud/xenserver/xenserver_guest.py
@@ -708,7 +708,11 @@ class XenServerVM(XenServerObject):
                             }
 
                             new_disk_vbd['VDI'] = self.xapi_session.xenapi.VDI.create(new_disk_vdi)
-                            self.xapi_session.xenapi.VBD.create(new_disk_vbd)
+                            vbd_ref_new = self.xapi_session.xenapi.VBD.create(new_disk_vbd)
+
+                            if self.vm_params['power_state'].lower() == "running":
+                                self.xapi_session.xenapi.VBD.plug(vbd_ref_new)
+
                     elif change.get('cdrom'):
                         vm_cdrom_params_list = [cdrom_params for cdrom_params in self.vm_params['VBDs'] if cdrom_params['type'] == "CD"]
 


### PR DESCRIPTION
##### SUMMARY
Fixes an issue (#60693) where newly added disk to a VM in powered on state are inaccessible by guest OS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
xenserver_guest

##### ADDITIONAL INFORMATION
If a disk is added to a VM in powered on state, it remains unplugged (seen as not active in XenCenter) until manually plugged (activated). While unplugged, disk remains inaccessible by guest OS.