### PR TITLE
Fix the problem that packages can't be installed when snap has no installed packages.

### DIFF
--- a/changelogs/fragments/60743-snap-not-installed-packages.yaml
+++ b/changelogs/fragments/60743-snap-not-installed-packages.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "snap - fix the problem that packages can't be installed when snap has no installed packages."

--- a/lib/ansible/modules/packaging/os/snap.py
+++ b/lib/ansible/modules/packaging/os/snap.py
@@ -137,7 +137,8 @@ def is_snap_installed(module, snap_name):
     cmd = ' '.join(cmd_parts)
     rc, out, err = module.run_command(cmd, check_rc=False)
 
-    return rc == 0
+    # https://github.com/ansible/ansible/issues/59868
+    return rc == 0 and 'No snaps are installed yet' not in err
 
 
 def get_snap_for_action(module):


### PR DESCRIPTION
##### SUMMARY

Fixes #59868

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- snap

##### ADDITIONAL INFORMATION

On debian 9(maybe older versions), `snap list <package>`, which command is used to check whether `<package>` is installed, returns status 0 when snap has no installed packages.

```bash
root@stretch:~# cat /etc/debian_version
9.9

root@stretch:~# snap list hello-world > /dev/null
No snaps are installed yet. Try "snap install hello-world".
root@stretch:~# snap list hello-world 2> /dev/null

root@stretch:~# snap list hello-world
No snaps are installed yet. Try "snap install hello-world".
root@stretch:~# echo $?
0
```

On debian 10, this problem isn't reproduced because `snap list <package>` returns status 1 even if 
snap has no installed packages.

```bash
root@buster:~# cat /etc/debian_version
10.0

root@buster:~# snap list hello-world > /dev/null
error: no matching snaps installed
root@buster:~# snap list hello-world 2> /dev/null

root@buster:~# snap list hello-world
error: no matching snaps installed
root@buster:~# echo $?
1
```