### PR TITLE
openssl_certificate: fix idempotency

### DIFF
--- a/changelogs/fragments/60745-openssl_certificate-idempotency.yml
+++ b/changelogs/fragments/60745-openssl_certificate-idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_certificate - if both private key and CSR were specified, the idempotency check for ``selfsigned`` and ``ownca`` providers ignored the CSR."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -958,7 +958,8 @@ class Certificate(crypto_utils.OpenSSLObject):
                 )
             except crypto_utils.OpenSSLBadPassphraseError as exc:
                 raise CertificateError(exc)
-            return self._validate_privatekey()
+            if not self._validate_privatekey():
+                return False
 
         if self.csr_path:
             self.csr = crypto_utils.load_certificate_request(self.csr_path, backend=self.backend)

--- a/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
@@ -17,6 +17,13 @@
     subject:
       commonName: www.example.com
 
+- name: (Selfsigned, {{select_crypto_backend}}) Generate CSR
+  openssl_csr:
+    path: '{{ output_dir }}/csr_minimal_change.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    subject:
+      commonName: www.example.org
+
 - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate
   openssl_certificate:
     path: '{{ output_dir }}/cert.pem'
@@ -46,6 +53,17 @@
     selfsigned_digest: sha256
     select_crypto_backend: '{{ select_crypto_backend }}'
   check_mode: yes
+
+- name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate (check mode, other CSR)
+  openssl_certificate:
+    path: '{{ output_dir }}/cert.pem'
+    csr_path: '{{ output_dir }}/csr_minimal_change.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  check_mode: yes
+  register: selfsigned_certificate_csr_minimal_change
 
 - name: (Selfsigned, {{select_crypto_backend}}) Check selfsigned certificate
   openssl_certificate:

--- a/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
@@ -30,6 +30,11 @@
       - selfsigned_certificate.notBefore == selfsigned_certificate_idempotence.notBefore
       - selfsigned_certificate.notAfter == selfsigned_certificate_idempotence.notAfter
 
+- name: Make sure that changes in CSR are detected even if private key is specified
+  assert:
+    that:
+      - selfsigned_certificate_csr_minimal_change is changed
+
 - block:
   - name: (Selfsigned validation, {{select_crypto_backend}}) Validate certificate v2 (test - certificate version == 2)
     shell: 'openssl x509 -noout  -in {{ output_dir}}/cert_v2.pem -text | grep "Version" | sed "s/.*: \(.*\) .*/\1/g"'


### PR DESCRIPTION
##### SUMMARY
In case a private key and CSR were specified as arguments for `openssl_certificate`, the provider-generic CSR idempotency check was never executed.

Found this while adding tests for #60741.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
