### PR TITLE
Backport: Add exception handling to win_domain_controller (#58234)

### DIFF
--- a/changelogs/fragments/win_domain-exceptions-2.yaml
+++ b/changelogs/fragments/win_domain-exceptions-2.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_controller - Do not fail the play without the user being able to catch dcpromo failing because of a pending reboot within a playbook using ignore_error or retry logic.

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -211,7 +211,20 @@ Try {
                 if ($site_name) {
                     $install_params.SiteName = $site_name
                 }
-                $install_result = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
+                try
+                {
+                    $null = Install-ADDSDomainController -NoRebootOnCompletion -Force @install_params
+                } catch [Microsoft.DirectoryServices.Deployment.DCPromoExecutionException] {
+                    # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
+                    # DCPromo exit codes details can be found at https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment
+                    if ($_.Exception.ExitCode -eq 15) {
+                        $result.reboot_required = $true
+                    } else {
+                        Fail-Json -obj $result -message "Failed to install ADDSDomainController with DCPromo: $($_.Exception.Message)"
+                    }
+                }
+                # If $_.FullyQualifiedErrorId -eq 'Test.VerifyUserCredentialPermissions.DCPromo.General.25,Microsoft.DirectoryServices.Deployment.PowerShell.Commands.InstallADDSDomainControllerCommand'
+                # the module failed to resolve the given dns domain name
 
                 Write-DebugLog "Installation complete, trying to start the Netlogon service"
                 # The Netlogon service is set to auto start but is not started. This is


### PR DESCRIPTION

##### SUMMARY
Add error handling for two exceptions.

Backport: #58234
* Add exception handling to win_domain_controller
* Add changelog
* Fix PSUseDeclaredVarsMoreThanAssignments
* Remove dns domain cannot be resolved error message

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_controller

##### ADDITIONAL INFORMATION

If a user specifies a domain to join that cannot be resolved by dns, the Install-ADDSDomainController command throws an Microsoft.ADRoles.Deployment.Common.Tests.TestFailedException exception.

If the module is either invoked twice without a reboot, or a reboot is pending for another reason the Install-ADDSDomainController command throws an Microsoft.DirectoryServices.Deployment.DCPromoExecutionException exception with Errorcode 15.

I added error handling for both of them, so that a user can handle them from within the playbook.