### PR TITLE
BOTMETA: Add dcermak to team_suse

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1625,7 +1625,7 @@ macros:
   team_rhn: alikins barnabycourt FlossWare vritant
   team_scaleway: remyleone abarbare DenBeke jerome-quere kindermoumoute QuentinBrosse
   team_solaris: bcoca dagwieers danowar2k fishman jpdasma jasperla mator scathatheworm troy2914 xen0l
-  team_suse: evrardjp toabctl
+  team_suse: evrardjp toabctl dcermak
   team_tower: ghjm matburt ryanpetrello rooftopcellist AlanCoding jladdjr kdelee chrismeyersfsu
   team_ucs: dsoper2 movinalot SDBrett vallard vvb
   team_vmware: Akasurde warthog9 Tomorrow9 goneri pgbidkar


### PR DESCRIPTION
##### SUMMARY
Add myself to `team_suse` to help maintaining the zypper modules. 

CC @toabctl @evrardjp