### PR TITLE
Vmware: Optional delay for vmware_guest_tools_wait

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -72,6 +72,12 @@ options:
      default: no
      type: bool
      version_added: '2.8'
+   delay:
+     description:
+     - Number of seconds to wait before starting to poll.
+     default: 0
+     type: int
+     version_added: '2.9'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -170,6 +176,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         name_match=dict(type='str', default='first', choices=['first', 'last']),
+        delay=dict(type='int', default=0),
         folder=dict(type='str'),
         uuid=dict(type='str'),
         moid=dict(type='str'),
@@ -197,6 +204,8 @@ def main():
 
     result = dict(changed=False)
     try:
+        if module.params['delay']:
+            time.sleep(module.params['delay'])
         result = pyv.wait_for_tools(vm)
     except Exception as e:
         module.fail_json(msg="Waiting for VMware tools failed with"

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -77,7 +77,7 @@ options:
      - Number of seconds to wait before starting to poll.
      default: 0
      type: int
-     version_added: '2.9'
+     version_added: '2.10'
 extends_documentation_fragment: vmware.documentation
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added an optional parameter to vmware_guest_tools_wait so one can delay the polling.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_tools_wait

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Under certain circumstances the vmware agent can give an OK while the VM is shutting down /rebooting and thus make the following tasks fail. While this does not occur at every opportunity when VM is shutting down/rebooting it happens enough to make the module unreliable in its current state in these situations.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
