### PR TITLE
Fix issues with aws_kms when working cross-account and with IDs

### DIFF
--- a/changelogs/fragments/60805-aws_kms-ID-and-ARN-fixes.yml
+++ b/changelogs/fragments/60805-aws_kms-ID-and-ARN-fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- aws_kms - fix exception when only Key ID is passed
+- aws_kms - Use ARN rather than ID so that cross-account changes function

--- a/test/integration/targets/aws_kms/tasks/main.yml
+++ b/test/integration/targets/aws_kms/tasks/main.yml
@@ -57,7 +57,7 @@
 
     - name: Update Policy on key to match AWS Console generate policy
       aws_kms:
-        key_alias: "alias/{{ resource_prefix }}-kms"
+        key_id: '{{ new_key["keys"][0]["key_id"] }}'
         policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
       register: kms_policy_changed
 
@@ -68,7 +68,7 @@
 
     - name: Attempt to re-assert the same policy
       aws_kms:
-        key_alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ resource_prefix }}-kms"
         policy: "{{ lookup('template', 'console-policy.j2') | to_json }}"
       register: kms_policy_changed
 
@@ -80,7 +80,7 @@
     - name: grant user-style access to production secrets
       aws_kms:
         mode: grant
-        key_alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ resource_prefix }}-kms"
         role_name: "{{ resource_prefix }}-kms-role"
         grant_types: "role,role grant"
 
@@ -93,7 +93,7 @@
     - name: remove access to production secrets from role
       aws_kms:
         mode: deny
-        key_alias: "alias/{{ resource_prefix }}-kms"
+        alias: "alias/{{ resource_prefix }}-kms"
         role_arn: "{{ iam_role_result.iam_role.arn }}"
 
     - name: find facts about the key

--- a/test/integration/targets/aws_kms/tasks/main.yml
+++ b/test/integration/targets/aws_kms/tasks/main.yml
@@ -300,6 +300,18 @@
           - delete_kms.key_state == "PendingDeletion"
           - delete_kms.changed
 
+    - name: re-delete the key
+      aws_kms:
+        alias: "{{ resource_prefix }}-kms"
+        state: absent
+      register: delete_kms
+
+    - name: assert that state is pending deletion
+      assert:
+        that:
+          - delete_kms.key_state == "PendingDeletion"
+          - delete_kms is not changed
+
     - name: undelete and enable the key
       aws_kms:
         alias: "{{ resource_prefix }}-kms"
@@ -312,6 +324,17 @@
         that:
           - undelete_kms.key_state == "Enabled"
           - undelete_kms.changed
+
+    - name: delete a non-existant key
+      aws_kms:
+        key_id: '00000000-0000-0000-0000-000000000000'
+        state: absent
+      register: delete_kms
+
+    - name: assert that state is unchanged
+      assert:
+        that:
+          - delete_kms is not changed
 
   always:
     # ============================================================


### PR DESCRIPTION
##### SUMMARY

- Ensure that we keep passing ARNs around rather than using IDs
- Fix exceptions when passing just an ID rather than an alias

Fixes #60773
Fixes #60744

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_kms.py

##### ADDITIONAL INFORMATION
Tests included
Also results in a significant performance boost by directly querying keys rather than getting *all* keys on an account.

This code is ready for review I've only flagged it as WIP this because it's currently based over the top of #60206 and #60059

CC: @willthames 