### PR TITLE
Backport: win_domain reboot required exception incorrectly reported (#60496)

### DIFF
--- a/changelogs/fragments/win_domain-exceptions.yaml
+++ b/changelogs/fragments/win_domain-exceptions.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain - Set reboot required dependent on exception and add exception id to error message

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -122,10 +122,10 @@ if (-not $forest) {
     } catch [Microsoft.DirectoryServices.Deployment.DCPromoExecutionException] {
         # ExitCode 15 == 'Role change is in progress or this computer needs to be restarted.'
         # DCPromo exit codes details can be found at https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/deploy/troubleshooting-domain-controller-deployment
-        if ($_.Exception.ExitCode -eq 15) {
+        if ($_.Exception.ExitCode -in @(15, 19)) {
             $result.reboot_required = $true
         } else {
-            Fail-Json -obj $result -message "Failed to install ADDSForest with DCPromo: $($_.Exception.Message)"
+            Fail-Json -obj $result -message "Failed to install ADDSForest, DCPromo exited with $($_.Exception.ExitCode): $($_.Exception.Message)"
         }
     }
 


### PR DESCRIPTION
##### SUMMARY
If the module fails because a reboot is pending it is stated in the exception message, but reboot_required is still false.

Fixes: #60493
Backports: #60496

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain

##### ADDITIONAL INFORMATION

```
fatal: [****-****]: FAILED! => {
    "changed": true,
    "msg": "Failed to install ADDSForest with DCPromo: Name change pending. A reboot is required.\r\n",
    "reboot_required": false
}
```
