### PR TITLE
Fix ssh example with sshd config

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -119,8 +119,8 @@ EXAMPLES = r'''
 
 - name: Insert/Update configuration using a local file and validate it
   blockinfile:
-    block: "{{ lookup('file', './local/ssh_config') }}"
-    dest: /etc/ssh/ssh_config
+    block: "{{ lookup('file', './local/sshd_config') }}"
+    dest: /etc/ssh/sshd_config
     backup: yes
     validate: /usr/sbin/sshd -T -f %s
 


### PR DESCRIPTION
##### SUMMARY
The current example for a validation command tries to validate a sshd config, but provides sshd (server) a client configuration.
If trying to execute the given validation command on a client file, it doesn't work (e.g. running `/usr/sbin/sshd -T -f /etc/ssh/sshd_config` returns non-zero code)

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
blockinfile

##### ADDITIONAL INFORMATION
