### PR TITLE
Fortinet's new module for fortios_system_fortiguard

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_system_fortiguard.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_fortiguard.py
@@ -1,0 +1,516 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_fortiguard
+short_description: Configure FortiGuard services in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and fortiguard category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_fortiguard:
+        description:
+            - Configure FortiGuard services.
+        default: null
+        type: dict
+        suboptions:
+            antispam_cache:
+                description:
+                    - Enable/disable FortiGuard antispam request caching. Uses a small amount of memory but improves performance.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            antispam_cache_mpercent:
+                description:
+                    - Maximum percent of FortiGate memory the antispam cache is allowed to use (1 - 15%).
+                type: int
+            antispam_cache_ttl:
+                description:
+                    - Time-to-live for antispam cache entries in seconds (300 - 86400). Lower times reduce the cache size. Higher times may improve
+                       performance since the cache will have more entries.
+                type: int
+            antispam_expiration:
+                description:
+                    - Expiration date of the FortiGuard antispam contract.
+                type: int
+            antispam_force_off:
+                description:
+                    - Enable/disable turning off the FortiGuard antispam service.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            antispam_license:
+                description:
+                    - Interval of time between license checks for the FortiGuard antispam contract.
+                type: int
+            antispam_timeout:
+                description:
+                    - Antispam query time out (1 - 30 sec, default = 7).
+                type: int
+            auto_join_forticloud:
+                description:
+                    - Automatically connect to and login to FortiCloud.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            ddns_server_ip:
+                description:
+                    - IP address of the FortiDDNS server.
+                type: str
+            ddns_server_port:
+                description:
+                    - Port used to communicate with FortiDDNS servers.
+                type: int
+            load_balance_servers:
+                description:
+                    - Number of servers to alternate between as first FortiGuard option.
+                type: int
+            outbreak_prevention_cache:
+                description:
+                    - Enable/disable FortiGuard Virus Outbreak Prevention cache.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            outbreak_prevention_cache_mpercent:
+                description:
+                    - Maximum percent of memory FortiGuard Virus Outbreak Prevention cache can use (1 - 15%, default = 2).
+                type: int
+            outbreak_prevention_cache_ttl:
+                description:
+                    - Time-to-live for FortiGuard Virus Outbreak Prevention cache entries (300 - 86400 sec, default = 300).
+                type: int
+            outbreak_prevention_expiration:
+                description:
+                    - Expiration date of FortiGuard Virus Outbreak Prevention contract.
+                type: int
+            outbreak_prevention_force_off:
+                description:
+                    - Turn off FortiGuard Virus Outbreak Prevention service.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            outbreak_prevention_license:
+                description:
+                    - Interval of time between license checks for FortiGuard Virus Outbreak Prevention contract.
+                type: int
+            outbreak_prevention_timeout:
+                description:
+                    - FortiGuard Virus Outbreak Prevention time out (1 - 30 sec, default = 7).
+                type: int
+            port:
+                description:
+                    - Port used to communicate with the FortiGuard servers.
+                type: str
+                choices:
+                    - 53
+                    - 8888
+                    - 80
+            sdns_server_ip:
+                description:
+                    - IP address of the FortiDNS server.
+                type: str
+            sdns_server_port:
+                description:
+                    - Port used to communicate with FortiDNS servers.
+                type: int
+            service_account_id:
+                description:
+                    - Service account ID.
+                type: str
+            source_ip:
+                description:
+                    - Source IPv4 address used to communicate with FortiGuard.
+                type: str
+            source_ip6:
+                description:
+                    - Source IPv6 address used to communicate with FortiGuard.
+                type: str
+            update_server_location:
+                description:
+                    - Signature update server location.
+                type: str
+                choices:
+                    - usa
+                    - any
+            webfilter_cache:
+                description:
+                    - Enable/disable FortiGuard web filter caching.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            webfilter_cache_ttl:
+                description:
+                    - Time-to-live for web filter cache entries in seconds (300 - 86400).
+                type: int
+            webfilter_expiration:
+                description:
+                    - Expiration date of the FortiGuard web filter contract.
+                type: int
+            webfilter_force_off:
+                description:
+                    - Enable/disable turning off the FortiGuard web filtering service.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            webfilter_license:
+                description:
+                    - Interval of time between license checks for the FortiGuard web filter contract.
+                type: int
+            webfilter_timeout:
+                description:
+                    - Web filter query time out (1 - 30 sec, default = 7).
+                type: int
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure FortiGuard services.
+    fortios_system_fortiguard:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_fortiguard:
+        antispam_cache: "enable"
+        antispam_cache_mpercent: "4"
+        antispam_cache_ttl: "5"
+        antispam_expiration: "6"
+        antispam_force_off: "enable"
+        antispam_license: "8"
+        antispam_timeout: "9"
+        auto_join_forticloud: "enable"
+        ddns_server_ip: "<your_own_value>"
+        ddns_server_port: "12"
+        load_balance_servers: "13"
+        outbreak_prevention_cache: "enable"
+        outbreak_prevention_cache_mpercent: "15"
+        outbreak_prevention_cache_ttl: "16"
+        outbreak_prevention_expiration: "17"
+        outbreak_prevention_force_off: "enable"
+        outbreak_prevention_license: "19"
+        outbreak_prevention_timeout: "20"
+        port: "53"
+        sdns_server_ip: "<your_own_value>"
+        sdns_server_port: "23"
+        service_account_id: "<your_own_value>"
+        source_ip: "84.230.14.43"
+        source_ip6: "<your_own_value>"
+        update_server_location: "usa"
+        webfilter_cache: "enable"
+        webfilter_cache_ttl: "29"
+        webfilter_expiration: "30"
+        webfilter_force_off: "enable"
+        webfilter_license: "32"
+        webfilter_timeout: "33"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_fortiguard_data(json):
+    option_list = ['antispam_cache', 'antispam_cache_mpercent', 'antispam_cache_ttl',
+                   'antispam_expiration', 'antispam_force_off', 'antispam_license',
+                   'antispam_timeout', 'auto_join_forticloud', 'ddns_server_ip',
+                   'ddns_server_port', 'load_balance_servers', 'outbreak_prevention_cache',
+                   'outbreak_prevention_cache_mpercent', 'outbreak_prevention_cache_ttl', 'outbreak_prevention_expiration',
+                   'outbreak_prevention_force_off', 'outbreak_prevention_license', 'outbreak_prevention_timeout',
+                   'port', 'sdns_server_ip', 'sdns_server_port',
+                   'service_account_id', 'source_ip', 'source_ip6',
+                   'update_server_location', 'webfilter_cache', 'webfilter_cache_ttl',
+                   'webfilter_expiration', 'webfilter_force_off', 'webfilter_license',
+                   'webfilter_timeout']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_fortiguard(data, fos):
+    vdom = data['vdom']
+    system_fortiguard_data = data['system_fortiguard']
+    filtered_data = underscore_to_hyphen(filter_system_fortiguard_data(system_fortiguard_data))
+
+    return fos.set('system',
+                   'fortiguard',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_fortiguard']:
+        resp = system_fortiguard(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_fortiguard": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "antispam_cache": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "antispam_cache_mpercent": {"required": False, "type": "int"},
+                "antispam_cache_ttl": {"required": False, "type": "int"},
+                "antispam_expiration": {"required": False, "type": "int"},
+                "antispam_force_off": {"required": False, "type": "str",
+                                       "choices": ["enable", "disable"]},
+                "antispam_license": {"required": False, "type": "int"},
+                "antispam_timeout": {"required": False, "type": "int"},
+                "auto_join_forticloud": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "ddns_server_ip": {"required": False, "type": "str"},
+                "ddns_server_port": {"required": False, "type": "int"},
+                "load_balance_servers": {"required": False, "type": "int"},
+                "outbreak_prevention_cache": {"required": False, "type": "str",
+                                              "choices": ["enable", "disable"]},
+                "outbreak_prevention_cache_mpercent": {"required": False, "type": "int"},
+                "outbreak_prevention_cache_ttl": {"required": False, "type": "int"},
+                "outbreak_prevention_expiration": {"required": False, "type": "int"},
+                "outbreak_prevention_force_off": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                "outbreak_prevention_license": {"required": False, "type": "int"},
+                "outbreak_prevention_timeout": {"required": False, "type": "int"},
+                "port": {"required": False, "type": "str",
+                         "choices": ["53", "8888", "80"]},
+                "sdns_server_ip": {"required": False, "type": "str"},
+                "sdns_server_port": {"required": False, "type": "int"},
+                "service_account_id": {"required": False, "type": "str"},
+                "source_ip": {"required": False, "type": "str"},
+                "source_ip6": {"required": False, "type": "str"},
+                "update_server_location": {"required": False, "type": "str",
+                                           "choices": ["usa", "any"]},
+                "webfilter_cache": {"required": False, "type": "str",
+                                    "choices": ["enable", "disable"]},
+                "webfilter_cache_ttl": {"required": False, "type": "int"},
+                "webfilter_expiration": {"required": False, "type": "int"},
+                "webfilter_force_off": {"required": False, "type": "str",
+                                        "choices": ["enable", "disable"]},
+                "webfilter_license": {"required": False, "type": "int"},
+                "webfilter_timeout": {"required": False, "type": "int"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/fortios/test_fortios_system_fortiguard.py
+++ b/test/units/modules/network/fortios/test_fortios_system_fortiguard.py
@@ -1,0 +1,391 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_fortiguard
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_fortiguard.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_fortiguard_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_fortiguard': {
+            'antispam_cache': 'enable',
+            'antispam_cache_mpercent': '4',
+            'antispam_cache_ttl': '5',
+            'antispam_expiration': '6',
+            'antispam_force_off': 'enable',
+            'antispam_license': '8',
+            'antispam_timeout': '9',
+            'auto_join_forticloud': 'enable',
+            'ddns_server_ip': 'test_value_11',
+            'ddns_server_port': '12',
+            'load_balance_servers': '13',
+            'outbreak_prevention_cache': 'enable',
+            'outbreak_prevention_cache_mpercent': '15',
+            'outbreak_prevention_cache_ttl': '16',
+            'outbreak_prevention_expiration': '17',
+            'outbreak_prevention_force_off': 'enable',
+            'outbreak_prevention_license': '19',
+            'outbreak_prevention_timeout': '20',
+            'port': '53',
+            'sdns_server_ip': 'test_value_22',
+            'sdns_server_port': '23',
+            'service_account_id': 'test_value_24',
+            'source_ip': '84.230.14.25',
+            'source_ip6': 'test_value_26',
+            'update_server_location': 'usa',
+            'webfilter_cache': 'enable',
+            'webfilter_cache_ttl': '29',
+            'webfilter_expiration': '30',
+            'webfilter_force_off': 'enable',
+            'webfilter_license': '32',
+            'webfilter_timeout': '33'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_fortiguard.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'antispam-cache': 'enable',
+        'antispam-cache-mpercent': '4',
+        'antispam-cache-ttl': '5',
+        'antispam-expiration': '6',
+        'antispam-force-off': 'enable',
+        'antispam-license': '8',
+        'antispam-timeout': '9',
+        'auto-join-forticloud': 'enable',
+        'ddns-server-ip': 'test_value_11',
+        'ddns-server-port': '12',
+        'load-balance-servers': '13',
+        'outbreak-prevention-cache': 'enable',
+        'outbreak-prevention-cache-mpercent': '15',
+        'outbreak-prevention-cache-ttl': '16',
+        'outbreak-prevention-expiration': '17',
+        'outbreak-prevention-force-off': 'enable',
+        'outbreak-prevention-license': '19',
+        'outbreak-prevention-timeout': '20',
+        'port': '53',
+                'sdns-server-ip': 'test_value_22',
+                'sdns-server-port': '23',
+                'service-account-id': 'test_value_24',
+                'source-ip': '84.230.14.25',
+                'source-ip6': 'test_value_26',
+                'update-server-location': 'usa',
+                'webfilter-cache': 'enable',
+                'webfilter-cache-ttl': '29',
+                'webfilter-expiration': '30',
+                'webfilter-force-off': 'enable',
+                'webfilter-license': '32',
+                'webfilter-timeout': '33'
+    }
+
+    set_method_mock.assert_called_with('system', 'fortiguard', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_fortiguard_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_fortiguard': {
+            'antispam_cache': 'enable',
+            'antispam_cache_mpercent': '4',
+            'antispam_cache_ttl': '5',
+            'antispam_expiration': '6',
+            'antispam_force_off': 'enable',
+            'antispam_license': '8',
+            'antispam_timeout': '9',
+            'auto_join_forticloud': 'enable',
+            'ddns_server_ip': 'test_value_11',
+            'ddns_server_port': '12',
+            'load_balance_servers': '13',
+            'outbreak_prevention_cache': 'enable',
+            'outbreak_prevention_cache_mpercent': '15',
+            'outbreak_prevention_cache_ttl': '16',
+            'outbreak_prevention_expiration': '17',
+            'outbreak_prevention_force_off': 'enable',
+            'outbreak_prevention_license': '19',
+            'outbreak_prevention_timeout': '20',
+            'port': '53',
+            'sdns_server_ip': 'test_value_22',
+            'sdns_server_port': '23',
+            'service_account_id': 'test_value_24',
+            'source_ip': '84.230.14.25',
+            'source_ip6': 'test_value_26',
+            'update_server_location': 'usa',
+            'webfilter_cache': 'enable',
+            'webfilter_cache_ttl': '29',
+            'webfilter_expiration': '30',
+            'webfilter_force_off': 'enable',
+            'webfilter_license': '32',
+            'webfilter_timeout': '33'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_fortiguard.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'antispam-cache': 'enable',
+        'antispam-cache-mpercent': '4',
+        'antispam-cache-ttl': '5',
+        'antispam-expiration': '6',
+        'antispam-force-off': 'enable',
+        'antispam-license': '8',
+        'antispam-timeout': '9',
+        'auto-join-forticloud': 'enable',
+        'ddns-server-ip': 'test_value_11',
+        'ddns-server-port': '12',
+        'load-balance-servers': '13',
+        'outbreak-prevention-cache': 'enable',
+        'outbreak-prevention-cache-mpercent': '15',
+        'outbreak-prevention-cache-ttl': '16',
+        'outbreak-prevention-expiration': '17',
+        'outbreak-prevention-force-off': 'enable',
+        'outbreak-prevention-license': '19',
+        'outbreak-prevention-timeout': '20',
+        'port': '53',
+                'sdns-server-ip': 'test_value_22',
+                'sdns-server-port': '23',
+                'service-account-id': 'test_value_24',
+                'source-ip': '84.230.14.25',
+                'source-ip6': 'test_value_26',
+                'update-server-location': 'usa',
+                'webfilter-cache': 'enable',
+                'webfilter-cache-ttl': '29',
+                'webfilter-expiration': '30',
+                'webfilter-force-off': 'enable',
+                'webfilter-license': '32',
+                'webfilter-timeout': '33'
+    }
+
+    set_method_mock.assert_called_with('system', 'fortiguard', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_fortiguard_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_fortiguard': {
+            'antispam_cache': 'enable',
+            'antispam_cache_mpercent': '4',
+            'antispam_cache_ttl': '5',
+            'antispam_expiration': '6',
+            'antispam_force_off': 'enable',
+            'antispam_license': '8',
+            'antispam_timeout': '9',
+            'auto_join_forticloud': 'enable',
+            'ddns_server_ip': 'test_value_11',
+            'ddns_server_port': '12',
+            'load_balance_servers': '13',
+            'outbreak_prevention_cache': 'enable',
+            'outbreak_prevention_cache_mpercent': '15',
+            'outbreak_prevention_cache_ttl': '16',
+            'outbreak_prevention_expiration': '17',
+            'outbreak_prevention_force_off': 'enable',
+            'outbreak_prevention_license': '19',
+            'outbreak_prevention_timeout': '20',
+            'port': '53',
+            'sdns_server_ip': 'test_value_22',
+            'sdns_server_port': '23',
+            'service_account_id': 'test_value_24',
+            'source_ip': '84.230.14.25',
+            'source_ip6': 'test_value_26',
+            'update_server_location': 'usa',
+            'webfilter_cache': 'enable',
+            'webfilter_cache_ttl': '29',
+            'webfilter_expiration': '30',
+            'webfilter_force_off': 'enable',
+            'webfilter_license': '32',
+            'webfilter_timeout': '33'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_fortiguard.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'antispam-cache': 'enable',
+        'antispam-cache-mpercent': '4',
+        'antispam-cache-ttl': '5',
+        'antispam-expiration': '6',
+        'antispam-force-off': 'enable',
+        'antispam-license': '8',
+        'antispam-timeout': '9',
+        'auto-join-forticloud': 'enable',
+        'ddns-server-ip': 'test_value_11',
+        'ddns-server-port': '12',
+        'load-balance-servers': '13',
+        'outbreak-prevention-cache': 'enable',
+        'outbreak-prevention-cache-mpercent': '15',
+        'outbreak-prevention-cache-ttl': '16',
+        'outbreak-prevention-expiration': '17',
+        'outbreak-prevention-force-off': 'enable',
+        'outbreak-prevention-license': '19',
+        'outbreak-prevention-timeout': '20',
+        'port': '53',
+                'sdns-server-ip': 'test_value_22',
+                'sdns-server-port': '23',
+                'service-account-id': 'test_value_24',
+                'source-ip': '84.230.14.25',
+                'source-ip6': 'test_value_26',
+                'update-server-location': 'usa',
+                'webfilter-cache': 'enable',
+                'webfilter-cache-ttl': '29',
+                'webfilter-expiration': '30',
+                'webfilter-force-off': 'enable',
+                'webfilter-license': '32',
+                'webfilter-timeout': '33'
+    }
+
+    set_method_mock.assert_called_with('system', 'fortiguard', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_fortiguard_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_fortiguard': {
+            'random_attribute_not_valid': 'tag',
+            'antispam_cache': 'enable',
+            'antispam_cache_mpercent': '4',
+            'antispam_cache_ttl': '5',
+            'antispam_expiration': '6',
+            'antispam_force_off': 'enable',
+            'antispam_license': '8',
+            'antispam_timeout': '9',
+            'auto_join_forticloud': 'enable',
+            'ddns_server_ip': 'test_value_11',
+            'ddns_server_port': '12',
+            'load_balance_servers': '13',
+            'outbreak_prevention_cache': 'enable',
+            'outbreak_prevention_cache_mpercent': '15',
+            'outbreak_prevention_cache_ttl': '16',
+            'outbreak_prevention_expiration': '17',
+            'outbreak_prevention_force_off': 'enable',
+            'outbreak_prevention_license': '19',
+            'outbreak_prevention_timeout': '20',
+            'port': '53',
+            'sdns_server_ip': 'test_value_22',
+            'sdns_server_port': '23',
+            'service_account_id': 'test_value_24',
+            'source_ip': '84.230.14.25',
+            'source_ip6': 'test_value_26',
+            'update_server_location': 'usa',
+            'webfilter_cache': 'enable',
+            'webfilter_cache_ttl': '29',
+            'webfilter_expiration': '30',
+            'webfilter_force_off': 'enable',
+            'webfilter_license': '32',
+            'webfilter_timeout': '33'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_fortiguard.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'antispam-cache': 'enable',
+        'antispam-cache-mpercent': '4',
+        'antispam-cache-ttl': '5',
+        'antispam-expiration': '6',
+        'antispam-force-off': 'enable',
+        'antispam-license': '8',
+        'antispam-timeout': '9',
+        'auto-join-forticloud': 'enable',
+        'ddns-server-ip': 'test_value_11',
+        'ddns-server-port': '12',
+        'load-balance-servers': '13',
+        'outbreak-prevention-cache': 'enable',
+        'outbreak-prevention-cache-mpercent': '15',
+        'outbreak-prevention-cache-ttl': '16',
+        'outbreak-prevention-expiration': '17',
+        'outbreak-prevention-force-off': 'enable',
+        'outbreak-prevention-license': '19',
+        'outbreak-prevention-timeout': '20',
+        'port': '53',
+                'sdns-server-ip': 'test_value_22',
+                'sdns-server-port': '23',
+                'service-account-id': 'test_value_24',
+                'source-ip': '84.230.14.25',
+                'source-ip6': 'test_value_26',
+                'update-server-location': 'usa',
+                'webfilter-cache': 'enable',
+                'webfilter-cache-ttl': '29',
+                'webfilter-expiration': '30',
+                'webfilter-force-off': 'enable',
+                'webfilter-license': '32',
+                'webfilter-timeout': '33'
+    }
+
+    set_method_mock.assert_called_with('system', 'fortiguard', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200


### PR DESCRIPTION
##### SUMMARY
 
Fortinet is adding Ansible support for FortiOS and FortiGate products. This module follows the same structure, guidelines and ideas given in previous approved module for a parallel feature of FortiGate (user device): https://github.com/ansible/ansible/pull/56447
In this case we are providing a different functionality: "Fortios System FortiGuard".
 
Please note that this will be part of other modules to come for FortiGate, including different functionalities: system, wireless-controller, firewall, webfilter, ips, web-proxy, wanopt, application, dlp spamfilter, log, vpn, certificate, user, dnsfilter, antivirus, report, waf, authentication, switch controller, endpoint-control and router. We plan to follow the same style, structure and usage as in the previous module in order to make it easier to comply with Ansible guidelines.
 
This PR has been updated according to suggestions and code reviews given in previous submissions of Fortinet modules.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

fortios_system_fortiguard

##### ANSIBLE VERSION

```
ansible 2.8.2
python version = 3.7.3 (default, Apr  3 2019, 05:39:12) [GCC 8.3.0]
```