### PR TITLE
Addition of ECS_Certificate Module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -217,7 +217,8 @@ files:
     maintainers: $team_crypto
     supershipit: felixfontein
   $modules/crypto/openssl_certificate.py:
-    maintainers: ctrufan
+    maintainers: ctrufan tylert
+  $modules/crypto/entrust/: ctrufan tylert
   $modules/database/influxdb/: kamsz
   $modules/database/mssql/mssql_db.py: Jmainguy kenichi-ogawa-1988
   $modules/database/mysql/: &mysql
@@ -460,7 +461,7 @@ files:
     notified: jlozadad
   $modules/storage/hpe3par/: farhan7500 gautamphegde
   $modules/storage/infinidat/: GR360RY vmalloc
-  $modules/storage/netapp/: 
+  $modules/storage/netapp/:
     maintainers: $team_netapp
     support: community
   $modules/storage/purestorage/:
@@ -671,7 +672,7 @@ files:
       - aws
       - cloud
   $module_utils/ecs/:
-    maintainers: ctrufan $team_crypto
+    maintainers: ctrufan tylert $team_crypto
   $module_utils/facts:
     support: core
   $module_utils/facts/hardware/aix.py: *aix

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -217,7 +217,7 @@ files:
     maintainers: $team_crypto
     supershipit: felixfontein
   $modules/crypto/openssl_certificate.py:
-    maintainers: ctrufan tylert
+    maintainers: ctrufan
   $modules/crypto/entrust/: ctrufan tylert
   $modules/database/influxdb/: kamsz
   $modules/database/mssql/mssql_db.py: Jmainguy kenichi-ogawa-1988

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -303,7 +303,7 @@ def select_message_digest(digest_string):
     return digest
 
 
-def write_file(module, content, default_mode=None):
+def write_file(module, content, default_mode=None, path=None):
     '''
     Writes content into destination file as securely as possible.
     Uses file arguments from module.
@@ -312,6 +312,9 @@ def write_file(module, content, default_mode=None):
     file_args = module.load_file_common_arguments(module.params)
     if file_args['mode'] is None:
         file_args['mode'] = default_mode
+    # If the path was set to override module path
+    if path is not None:
+        file_args['path'] = path
     # Create tempfile name
     tmp_fd, tmp_name = tempfile.mkstemp(prefix=b'.ansible_tmp')
     try:

--- a/lib/ansible/module_utils/ecs/api.py
+++ b/lib/ansible/module_utils/ecs/api.py
@@ -55,6 +55,16 @@ else:
 valid_file_format = re.compile(r".*(\.)(yml|yaml|json)$")
 
 
+def ecs_client_argument_spec():
+    return dict(
+        entrust_api_user=dict(type='str', required=True),
+        entrust_api_key=dict(type='str', required=True, no_log=True),
+        entrust_api_client_cert_path=dict(type='path', required=True),
+        entrust_api_client_cert_key_path=dict(type='path', required=True, no_log=True),
+        entrust_api_specification_path=dict(type='path', default='https://cloud.entrust.net/EntrustCloud/documentation/cms-api-2.1.0.yaml'),
+    )
+
+
 class SessionConfigurationException(Exception):
     """ Raised if we cannot configure a session with the API """
 

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -1,0 +1,890 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c), Entrust Datacard Corporation, 2019
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ecs_certificate
+author:
+    - Chris Trufan (@ctrufan)
+version_added: 2.9
+short_description: Request SSL/TLS certificates with the Entrust Certificate Services (ECS) API.
+description:
+    - Create, reissue, and renew Certificates with the Entrust Certificate Services (ECS) API.
+    - Requires credentials for the L(https://www.entrustdatacard.com/products/categories/ssl-certificates,Entrust Certificate Services) (ECS) API.
+    - In order to request a certificate, the domain and organization used in the certificate signing request must be already
+      validated in the ECS system. It is I(not) the responsibility of this module to perform those steps.
+notes:
+    - C(path) must be specified as the output location of the certificate.
+requirements:
+    - cryptography >= 1.6
+options:
+    backup:
+        description:
+            - pathination to store a backup of the initial certificate, if I(path) pointed to an existing file certificate.
+        type: bool
+        default: False
+    force:
+        description:
+            - If force is used, a certificate is requested regardless of whether I(path) points to an existing valid certificate.
+            - If C(request_type=RENEW), a forced renew will fail if the certificate being renewed has been issued within the past 30 days.
+        type: bool
+        default: False
+    path:
+        description:
+            - pathination to put the certificate file as a PEM encoded cert
+            - If the certificate at this location is not an Entrust issued certificate, a new certificate will always be requested regardless of validity.
+            - If there is already an Entrust certificate at this location, whether it is replaced is dependent upon the I(remaining_days) calculation.
+            - If an existing certificate is being replaced (see I(remaining_days), I(force), I(tracking_id)), the operation taken to replace it is dependent
+              on I(request_type)
+        type: path
+        required: True
+    chain_path:
+        description:
+            - pathination to put the full certificate chain of the certificate, intermediates, and roots.
+        type: path
+    csr:
+        description:
+            - Base-64 encoded Certificate Signing Request (CSR). I(csr) is accepted with or without PEM formatting around the Base-64 string.
+            - If no I(csr) is provided during a reissue or renew action, the certificate will be generated with the same public key as previous certificate.
+            - If I(subject_alt_name) is specified, it will override the subject alternate names in the CSR.
+            - If I(eku) is specified, it will override the extended key usage in the CSR.
+            - If I(ou) is specified, it will override the organizational units "ou=" present in the subject distinguished name of the CSR, if any.
+            - The organization "O=" field from the CSR will not be used. It will be replaced in the issued certificate by I(org) if present, and if not present,
+              the organization tied to I(client_id).
+        type: str
+    tracking_id:
+        description:
+            - Tracking ID of certificate to reissue or renew.
+            - Parameter is invalid if C(action = NEW)
+            - I(tracking_id) is invalid if C(request_type=NEW).
+            - If there is a certificate present in I(path) and it is an ECS certificate, I(tracking_id) will be ignored.
+            - If there is not a certificate present in I(path) or there is but it is from another provider, the certificate represented by I(tracking_id) will
+              be renewed or reissued and saved to I(path)
+            - If there is not a certificate present in I(path) and the I(force) and I(remaining_days) parameters do not indicate a new certificate is needed,
+              the certificate referenced by I(tracking_id) certificate will be saved to I(path).
+            - This can be used when a known certificate is not currently present on a server, but you want to renew or reissue it to be managed by an ansible
+              playbook. For example, if you specify C(request_type=RENEW), I(tracking_id) of an issued certificate, and I(path) to a file that does not exist,
+              the first run of a task will download the certificate specified by I(tracking_id) (assuming it is still valid), and future runs of the task will
+              (if applicable - see I(force) and I(remaining_days)) renew the certificate now present in I(path).
+        type: int
+    remaining_days:
+        description:
+            - The number of days the certificate must have left being valid. If C(cert_days < remaining_days) then a new certificate will be
+              obtained using I(request_type).
+            - If C(request_type=RENEW), a renew will fail if the certificate being renewed has been issued within the past 30 days, so do not set a
+              I(remaining_days) value that is within 30 days of the full lifetime of the certificate being acted upon. (e.g. if you are requesting Certificates
+              with a 90 day lifetime, do not set remaining_days to a value C(60) or higher).
+            - The I(force) option may be used to ensure that a new certificate is always obtained.
+        type: int
+        default: 30
+    request_type:
+        description:
+            - Operation performed if I(tracking_id) references a valid certificate to reissue, or there is already a certificate present in I(path) but either
+              I(force) is specified or C(cert_days < remaining_days).
+            - Specifying C(request_type=NEW) means a certificate request will always be submitted and a new certificate issued.
+            - Specifying C(request_type=RENEW) means that an existing certificate (specified by I(tracking_id) if present, otherwise I(path)) will be renewed.
+              If there is no certificate to renew, a new certificate is requested.
+            - Specifying C(request_type=REISSUE) means that an existing certificate (specified by I(tracking_id) if present, otherwise I(path)) will be
+              reissued.
+              If there is no certificate to reissue, a new certificate is requested.
+            - If a certificate was issued within the past 30 days, the 'renew' operation is not a valid operation and will fail.
+            - Note that C(reissue) is an operation that will result in the revocation of the certificate that is reissued, be cautious with it's use.
+            - I(check_mode) is only supported if C(request_type=NEW)
+            - For example, setting C(request_type=renew) and C(remaining_days=30) and pointing to the same certificate on multiple playbook runs means that on
+              the first run new certificate will be requested. It will then be left along on future runs until it is within 30 days of expiry, then the
+              ECS "renew" operation will be performed.
+        type: str
+        choices: [ 'NEW', 'RENEW', 'REISSUE']
+        default: NEW
+    cert_type:
+        description:
+            - The type of certificate product to request.
+            - If a certificate is being reissued or renewed, this parameter is ignored, and the C(cert_type) of the initial certificate is used.
+        type: str
+        choices: [ 'STANDARD_SSL', 'ADVANTAGE_SSL', 'UC_SSL', 'EV_SSL', 'WILDCARD_SSL', 'PRIVATE_SSL', 'PD_SSL', 'CODE_SIGNING', 'EV_CODE_SIGNING',
+                   'CDS_INDIVIDUAL', 'CDS_GROUP', 'CDS_ENT_LITE', 'CDS_ENT_PRO', 'SMIME_ENT' ]
+    subject_alt_name:
+        description:
+            - The subject alternative name identifiers, as an array of values (applies to I(cert_type) with a value of C(STANDARD_SSL), C(ADVANTAGE_SSL),
+              C(UC_SSL), C(EV_SSL), C(WILDCARD_SSL), C(PRIVATE_SSL), and C(PD_SSL)).
+            - If you are requesting a new SSL certificate, and you pass a I(subject_alt_name) parameter, any SAN names in the CSR are ignored.
+              If no subjectAltName parameter is passed, the SAN names in the CSR are used.
+            - See I(request_type) to understand more about SANs during reissues and renewals.
+            - In the case of certificates of type C(STANDARD_SSL) certificates, if the CN of the certificate is <domain>.<tld> only the www.<domain>.<tld> value
+              is accepted. If the CN of the certificate is www.<domain>.<tld> only the <domain>.<tld> value is accepted.
+        type: list
+    eku:
+        description:
+            - If specified, overrides the key usage in the I(csr).
+        type: str
+        choices: [ SERVER_AUTH, CLIENT_AUTH, SERVER_AND_CLIENT_AUTH ]
+    ct_log:
+        description:
+            - In compliance with browser requirements, this certificate may be posted to the Certificate Transparency (CT) logs. This is a best practice
+              technique that helps domain owners monitor certificates issued to their domains. Note that not all certificates are eligible for CT logging.
+            - If I(ct_log) is not specified, the certificate uses the account default.
+            - If I(ct_log) is specified and the account settings allow it,    I(ct_log) overrides the account default.
+            - If I(ct_log) is set to C(false), but the account settings are set to "always log", the certificate generation will fail.
+        type: bool
+    client_id:
+        description:
+            - The client ID to submit the Certificate Signing Request under.
+            - If no client ID is specified, the certificate will be submitted under the primary client with ID of 1.
+            - When using a client other than the primary client, the I(org) parameter cannot be specified.
+            - The issued certificate will have an organization value in the subject distinguished name represented by the client.
+        type: int
+        default: 1
+    org:
+        description:
+            - Organization "O=" to include in the certificate.
+            - If I(org) is not specified, the organization from the client represented by I(client_id) is used.
+            - Unless the I(cert_type) is C(PD_SSL), this field may not be specified if the value of I(client_id) is not the primary client of "1". For all
+              non-primary clients, certificates may only be issued with the organization of that client.
+        type: str
+    ou:
+        description:
+            - Organizational unit "OU=" to include in the certificate.
+            - I(ou) behavior is dependent on whether organizational units are enabled for your account. If organizational unit support is disabled for your
+              account, organizational units from the I(csr) and the I(ou) parameter are ignored.
+            - If both I(csr) and I(ou) are specified, the value in I(ou) will override the OU fields present in the subject distinguished name in the I(csr)
+            - If neither I(csr) nor I(ou) are specified for a renew or reissue operation, the OU fields in the initial certificate are reused.
+            - An invalid OU from I(csr) is ignored, but any invalid organizational units in I(ou) will result in an error indicating "Unapproved OU". The I(ou)
+              parameter can be used to force failure if an unapproved organizational unit is provided.
+            - A maximum of one OU may be specified for current products. Multiple OUs are reserved for future products.
+        type: list
+    end_user_key_storage_agreement:
+        description:
+            - The end user of the Code Signing certificate must generate and store the private key for this request on cryptographically secure
+              hardware to be compliant with the Entrust CSP and Subscription agreement. If requesting a certificate of type C(CODE_SIGNING) or
+              C(EV_CODE_SIGNING), you must set I(end_user_key_storage_agreement) to true if and only if you acknowledge that you will inform the user of this
+              requirement.
+            - Applicable only to I(cert_type) of values C(CODE_SIGNING) and C(EV_CODE_SIGNING).
+        type: bool
+    tracking_info:
+        description: Free form tracking information to attach to the record for the certificate
+        type: str
+    requester_name:
+        description: Requester name to associate with certificate tracking information.
+        type: str
+    requester_email:
+        description: Requester email to associate with certificate tracking information and receive delivery and expiry notices for the certificate.
+        type: str
+    requester_phone:
+        description: Requester phone number to associate with certificate tracking information.
+        type: str
+    additional_emails:
+        description: A list of additional email addresses to receive the delivery notice and expiry notification for the certificate
+        type: list
+    custom_fields:
+        description:
+            - Mapping of custom fields to associate with the certificate request and certificate.
+            - Only supported if custom fields are enabled for your account.
+            - Each custom field specified must be a custom field you have defined for your account.
+        type: list
+        suboptions:
+            text1:
+                description: Custom text field of maximum size 500.
+                type: str
+            text2:
+                description: Custom text field of maximum size 500.
+                type: str
+            text3:
+                description: Custom text field of maximum size 500.
+                type: str
+            text4:
+                description: Custom text field of maximum size 500.
+                type: str
+            text5:
+                description: Custom text field of maximum size 500.
+                type: str
+            text6:
+                description: Custom text field of maximum size 500.
+                type: str
+            text7:
+                description: Custom text field of maximum size 500.
+                type: str
+            text8:
+                description: Custom text field of maximum size 500.
+                type: str
+            text9:
+                description: Custom text field of maximum size 500.
+                type: str
+            text10:
+                description: Custom text field of maximum size 500.
+                type: str
+            text11:
+                description: Custom text field of maximum size 500.
+                type: str
+            text12:
+                description: Custom text field of maximum size 500.
+                type: str
+            text13:
+                description: Custom text field of maximum size 500.
+                type: str
+            text14:
+                description: Custom text field of maximum size 500.
+                type: str
+            text15:
+                description: Custom text field of maximum size 500.
+                type: str
+            number1:
+                description: Custom number field.
+                type: float
+            number2:
+                description: Custom number field.
+                type: float
+            number3:
+                description: Custom number field.
+                type: float
+            number4:
+                description: Custom number field.
+                type: float
+            number5:
+                description: Custom number field.
+                type: float
+            date1:
+                description: Custom date field.
+                type: str
+            date2:
+                description: Custom date field.
+                type: str
+            date3:
+                description: Custom date field.
+                type: str
+            date4:
+                description: Custom date field.
+                type: str
+            date5:
+                description: Custom date field.
+                type: str
+            email1:
+                description: Custom email field.
+                type: str
+            email2:
+                description: Custom email field.
+                type: str
+            email3:
+                description: Custom email field.
+                type: str
+            email4:
+                description: Custom email field.
+                type: str
+            email5:
+                description: Custom email field.
+                type: str
+            dropdown1:
+                description: Custom dropdown field.
+                type: str
+            dropdown2:
+                description: Custom dropdown field.
+                type: str
+            dropdown3:
+                description: Custom dropdown field.
+                type: str
+            dropdown4:
+                description: Custom dropdown field.
+                type: str
+            dropdown5:
+                description: Custom dropdown field.
+                type: str
+    cert_expiry:
+        description:
+            - The date the certificate should be set to expire, as an RFC3339 compliant date. For example, C(2020-02-23).
+            - I(cert_expiry) is only supported for requests of C(request_type=NEW) or C(request_type=RENEW). If C(request_type=REISSUE),
+              I(cert_expiry) will be used for the first certificate issuance, but subsequent issuances will have the same expiry as the initial
+              certificate.
+            - A reissued certificate will always have the same expiry as the original certificate.
+            - Note that only the date (day, month, year) is supported for specifying expiry date. If you choose to specify an expiry time with the expiry date,
+              the time will be adjusted to Eastern Standard Time (EST). This could have the unintended effect of moving your expiry date to the previous day.
+            - Applies only to accounts with a pooling inventory model.
+            - Only one of I(cert_expiry) or I(cert_lifetime) may be specified.
+        type: str
+    cert_lifetime:
+        description:
+            - The lifetime of the certificate.
+            - Applies to all certificates for accounts with a non-pooling inventory model.
+            - I(cert_lifetime) is only supported for requests of C(request_type=NEW) or C(request_type=RENEW). If C(request_type=REISSUE), I(cert_lifetime) will
+              be used for the first certificate issuance, but subsequent issuances will have the same expiry as the initial certificate.
+            - Applies to certificates of I(cert_type)=C(CDS_INDIVIDUAL, CDS_GROUP, CDS_ENT_LITE, CDS_ENT_PRO, SMIME_ENT) for accounts with a pooling inventory
+              model.
+            - Only one of I(cert_expiry) or I(cert_lifetime) may be specified.
+        type: str
+        choices: [ P1Y, P2Y, P3Y ]
+seealso:
+    - module: openssl_privatekey
+      description: Can be used to create private keys (both for certificates and accounts).
+    - module: openssl_csr
+      description: Can be used to create a Certificate Signing Request (CSR).
+    - module: certificate_complete_chain
+      description: Allows to find the root certificate for the returned fullchain.
+extends_documentation_fragment:
+    - ecs_credential
+'''
+
+EXAMPLES = r'''
+- name: Request a new certificate from Entrust with bare minimum parameters. Will request a new certificate if current one is valid but within 30 days of
+        expiry. If replacing an existing file in path, will back it up.
+  entrust_certificate:
+    backup: True
+    path: /etc/ssl/crt/ansible.com.crt
+    chain_path: /etc/ssl/crt/ansible.com.chain.crt
+    csr: /etc/ssl/csr/ansible.com.csr
+    cert_type: EV_SSL
+    requester_name: Jo Doe
+    requester_email: jdoe@ansible.com
+    requester_phone: 555-555-5555
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+- name: If there is no certificate present in path, request a new certificate of type EV_SSL. Otherwise, if there is an Entrust managed certificate in path and
+        it is within 63 days of expiration, request a RENEW of that certificate.
+  entrust_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    csr: /etc/ssl/csr/ansible.com.csr
+    cert_type: EV_SSL
+    cert_expiry: 2019-08-20
+    request_type: RENEW
+    remaining_days: 63
+    requester_name: Jo Doe
+    requester_email: jdoe@ansible.com
+    requester_phone: 555-555-5555
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+- name: If there is no certificate present in path, download certificate specified by tracking_id if it is still valid. Otherwise, if the certificate is within
+        79 days of expiration, request a RENEW of that certificate and save it in path. This can be used to "migrate" a certificate to be Ansible managed.
+  entrust_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    csr: /etc/ssl/csr/ansible.com.csr
+    tracking_id: 2378915
+    request_type: RENEW
+    remaining_days: 79
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+- name: Force a reissue of the certificate specified by tracking_id.
+  entrust_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    force: True
+    tracking_id: 2378915
+    request_type: REISSUE
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+- name: Request a new certificate with an alternative client. Note that the issued certificate will have it's Subject Distinguished Name use the organization
+        details associated with that client, rather than what is in the CSR.
+  entrust_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    csr: /etc/ssl/csr/ansible.com.csr
+    client_id: 2
+    requester_name: Jo Doe
+    requester_email: jdoe@ansible.com
+    requester_phone: 555-555-5555
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+- name: Request a new certificate with a number of CSR parameters overridden and tracking information
+  entrust_certificate:
+    path: /etc/ssl/crt/ansible.com.crt
+    chain_path: /etc/ssl/crt/ansible.com.chain.crt
+    csr: /etc/ssl/csr/ansible.com.csr
+    subject_alt_name:
+      - ansible.testcertificates.com
+      - www.testcertificates.com
+    eku: SERVER_AND_CLIENT_AUTH
+    ct_log: True
+    org: Test Organization Inc.
+    ou:
+      - Administration
+    tracking_info: "Submitted via Ansible"
+    additional_emails:
+      - itsupport@testcertificates.com
+      - jsmith@ansible.com
+    custom_fields:
+      text1: Admin
+      text2: Invoice 25
+      number1: 342
+      date1: 2018-01-01
+      email1: sales@ansible.testcertificates.com
+      dropdown1: red
+    cert_expiry: 2020-08-15
+    requester_name: Jo Doe
+    requester_email: jdoe@ansible.com
+    requester_phone: 555-555-5555
+    entrust_api_user: apiusername
+    entrust_api_key: a^lv*32!cd9LnT
+    entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
+    entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
+
+'''
+
+RETURN = '''
+filename:
+    description: Path to the generated Certificate
+    returned: changed or success
+    type: str
+    sample: /etc/ssl/crt/www.ansible.com.crt
+backup_file:
+    description: Name of backup file created.
+    returned: changed and if I(backup) is C(yes)
+    type: str
+    sample: /path/to/www.ansible.com.crt.2019-03-09@11:22~
+tracking_id:
+    description: The tracking ID to reference and track the certificate in ECS.
+    returned: success
+    type: int
+    sample: 380079
+serial_number:
+    description: The serial number of the issued certificate.
+    returned: success
+    type: int
+    sample: 1235262234164342
+cert_days:
+    description: The number of days the certificate remains valid.
+    returned: success
+    type: int
+    sample: 253
+cert_status:
+    description:
+        - The certificate status in ECS.
+        - 'Current possible values (which may be expanded in the future) are: C(ACTIVE), C(APPROVED), C(DEACTIVATED), C(DECLINED), C(EXPIRED), C(NA),
+          C(PENDING), C(PENDING_QUORUM), C(READY), C(REISSUED), C(REISSUING), C(RENEWED), C(RENEWING), C(REVOKED), C(SUSPENDED)'
+    returned: success
+    type: str
+    sample: ACTIVE
+cert_details:
+    description:
+        - The full response JSON from the Get Certificate call of the ECS API.
+        - 'While the response contents are guaranteed to be forwards compatible with new ECS API releases, Entrust recommends that you do not make any
+          playbooks take actions based on the content of this field. However it may be useful for debugging, logging, or auditing purposes.'
+    returned: success
+    type: dict
+
+'''
+
+from ansible.module_utils.ecs.api import (
+    ecs_client_argument_spec,
+    ECSClient,
+    RestOperationException,
+    SessionConfigurationException,
+)
+
+import datetime
+import json
+import os
+import time
+import traceback
+from distutils.version import LooseVersion
+
+from ansible.module_utils import crypto as crypto_utils
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils._text import to_native, to_bytes
+
+CRYPTOGRAPHY_IMP_ERR = None
+try:
+    import cryptography
+    CRYPTOGRAPHY_VERSION = LooseVersion(cryptography.__version__)
+except ImportError:
+    CRYPTOGRAPHY_IMP_ERR = traceback.format_exc()
+    CRYPTOGRAPHY_FOUND = False
+else:
+    CRYPTOGRAPHY_FOUND = True
+
+MINIMAL_CRYPTOGRAPHY_VERSION = '1.6'
+
+
+def calculate_cert_days(expires_after):
+    cert_days = 0
+    if expires_after:
+        expires_after_datetime = datetime.datetime.strptime(expires_after, '%Y-%m-%dT%H:%M:%SZ')
+        cert_days = (expires_after_datetime - datetime.datetime.now()).days
+    return cert_days
+
+
+# Populate the value of body[dict_param_name] with the JSON equivalent of
+# module parameter of param_name if that parameter is present, otherwise leave field
+# out of resulting dict
+def convert_module_param_to_json_bool(module, dict_param_name, param_name):
+    body = {}
+    if module.params.get(param_name, None) is not None:
+        if module.params[param_name]:
+            body[dict_param_name] = 'true'
+        else:
+            body[dict_param_name] = 'false'
+    return body
+
+
+class EcsCertificate(object):
+    '''
+    Entrust Certificate Services certificate class.
+    '''
+
+    def __init__(self, module):
+        self.path = module.params['path']
+        self.filename = None
+        self.chain_path = module.params.get('chain_path')
+        self.force = module.params['force']
+        self.backup = module.params['backup']
+        self.request_type = module.params['request_type']
+        self.backup_file = None
+        self.module = module
+        self.csr = module.params.get('csr')
+        self.tracking_id = None
+        self.serial_number = None
+
+        self.cert = None
+        if self.path and os.path.exists(self.path):
+            try:
+                self.cert = crypto_utils.load_certificate(self.path, backend='cryptography')
+            except Exception as dummy:
+                self.cert = None
+
+        # Instantiate the ECS client and then try a no-op connection to verify credentials are valid
+        try:
+            self.ecs_client = ECSClient(
+                entrust_api_user=module.params.get('entrust_api_user'),
+                entrust_api_key=module.params.get('entrust_api_key'),
+                entrust_api_cert=module.params.get('entrust_api_client_cert_path'),
+                entrust_api_cert_key=module.params.get('entrust_api_client_cert_key_path'),
+                entrust_api_specification_path=module.params.get('entrust_api_specification_path')
+            )
+        except SessionConfigurationException as e:
+            module.fail_json(msg='Failed to initialize Entrust Provider: {0}'.format(to_native(e.message)))
+        try:
+            self.ecs_client.GetAppVersion()
+        except RestOperationException as e:
+            module.fail_json(msg='Please verify credential information. Received exception when testing ECS connection: {0}'.format(to_native(e.message)))
+
+    # Conversion of the fields that go into the 'tracking' parameter of the request object
+    def convert_tracking_params(self, module):
+        body = {}
+        tracking = {}
+        if module.params.get('requester_name'):
+            tracking['requesterName'] = module.params['requester_name']
+        if module.params.get('requester_email'):
+            tracking['requesterEmail'] = module.params['requester_email']
+        if module.params.get('requester_phone'):
+            tracking['requesterPhone'] = module.params['requester_phone']
+        if module.params.get('tracking_info'):
+            tracking['trackingInfo'] = module.params['tracking_info']
+        if(module.params.get('custom_fields')):
+            tracking['customFields'] = module.params['custom_fields']
+        if(module.params.get('additional_emails')):
+            tracking['additionalEmails'] = json.dumps(module.params['additional_emails'])
+        body['tracking'] = tracking
+        return body
+
+    def convert_cert_subject_params(self, module):
+        body = {}
+        if module.params.get('subject_alt_name') and module.params.get('subject_alt_name').len() > 0:
+            body['subjectAltName'] = json.dumps(module.params['subject_alt_name'])
+        if module.params.get('org'):
+            body['org'] = module.params['org']
+        if module.params.get('ou') and module.params.get('ou').len() > 0:
+            body['ou'] = json.dumps(module.params['ou'])
+        return body
+
+    def convert_general_params(self, module):
+        body = {}
+        if module.params.get('eku'):
+            body['eku'] = module.params['eku']
+        if self.request_type == 'NEW':
+            body['certType'] = module.params['cert_type']
+        body['clientId'] = module.params['client_id']
+        body.update(convert_module_param_to_json_bool(module, 'ctLog', 'ct_log'))
+        body.update(convert_module_param_to_json_bool(module, 'endUserKeyStorageAgreement', 'end_user_key_storage_agreement'))
+        return body
+
+    def convert_expiry_params(self, module):
+        body = {}
+        if module.params.get('cert_lifetime'):
+            body['certLifetime'] = module.params['cert_lifetime']
+        elif module.params.get('cert_expiry'):
+            body['certExpiryDate'] = module.params['cert_expiry']
+        # If neither cerTLifetime or certExpiryDate was specified and the request type is new, default to 365 days
+        elif self.request_type == 'NEW':
+            gmt_now = datetime.datetime.fromtimestamp(time.mktime(time.gmtime()))
+            expiry = gmt_now + datetime.timedelta(days=365)
+            body['certExpiryDate'] = expiry.strftime("%Y-%m-%dT%H:%M:%S.00Z")
+        return body
+
+    def set_tracking_id_by_serial_number(self, module):
+        try:
+            # Use serial_number to identify if certificate is an Entrust Certificate
+            # with an associated tracking ID
+            serial_number = "{0:X}".format(self.cert.serial_number)
+            cert_results = self.ecs_client.GetCertificates(serialNumber=serial_number).get('certificates', {})
+            if len(cert_results) == 1:
+                self.tracking_id = cert_results[0].get('trackingId')
+        except RestOperationException as dummy:
+            # If we fail to find a cert by serial number, that's fine, we just don't set self.tracking_id
+            return
+
+    def set_cert_details(self, module):
+        try:
+            self.cert_details = self.ecs_client.GetCertificate(trackingId=self.tracking_id)
+            self.cert_status = self.cert_details.get('status')
+            self.serial_number = self.cert_details.get('serialNumber')
+            self.cert_days = calculate_cert_days(self.cert_details.get('expiresAfter'))
+        except RestOperationException as e:
+            module.fail_json('Failed to get details of certificate with tracking_id="{0}", Error: '.format(self.tracking_id), to_native(e.message))
+
+    def check(self, module):
+        if self.cert:
+            # We will only treat a certificate as valid if it is found as a managed entrust cert.
+            # We will only set updated tracking ID based on certificate in "path" if it is managed by entrust.
+            self.set_tracking_id_by_serial_number(module)
+
+            if module.params.get('tracking_id') and self.tracking_id and module.params['tracking_id'] != self.tracking_id:
+                module.warn('tracking_id parameter of "{0}" provided, but will be ignored. Valid certificate was present in path "{1}" with '
+                            'tracking_id of "{2}".'.format(module.params['tracking_id'], self.path, self.tracking_id))
+
+        # If we did not end up setting tracking_id based on existing cert, get from module params
+        if not self.tracking_id:
+            self.tracking_id = module.params.get('tracking_id')
+
+        if not self.tracking_id:
+            return False
+
+        self.set_cert_details(module)
+
+        if self.cert_status == 'EXPIRED' or self.cert_status == 'SUSPENDED' or self.cert_status == 'REVOKED':
+            return False
+        if self.cert_days < module.params.get('remaining_days'):
+            return False
+
+        return True
+
+    def request_cert(self, module):
+        if not self.check(module) or self.force:
+            # Read the CSR contents
+            body = {}
+            with open(self.csr, 'r') as csr_file:
+                body['csr'] = csr_file.read()
+
+            # Check if the path is already a cert
+            # tracking_id may be set as a parameter or by get_cert_details if an entrust cert is in 'path'. If tracking ID is null
+            # We will be performing a reissue operation.
+            if self.request_type != 'NEW' and not self.tracking_id:
+                module.warn('No existing Entrust certificate found in path={0} and no tracking_id was provided, setting request_type to "NEW" for this task'
+                            'run. Future playbook runs that point to the pathination file in {1} will use request_type={2}'
+                            .format(self.path, self.path, self.request_type))
+                self.request_type = 'NEW'
+            elif self.request_type == 'NEW' and self.tracking_id:
+                module.warn('Existing certificate being acted upon, but request_type is "NEW", so will be a new certificate issuance rather than a'
+                            'REISSUE or RENEW')
+            # Use cases where request type is NEW and no existing certificate, or where request type is REISSUE/RENEW and a valid
+            # existing certificate is found, do not need warnings.
+
+            body.update(self.convert_tracking_params(module))
+            body.update(self.convert_cert_subject_params(module))
+            body.update(self.convert_general_params(module))
+            body.update(self.convert_expiry_params(module))
+
+            if module.check_mode:
+                body['validateOnly'] = 'true'
+                try:
+                    result = self.ecs_client.NewCertRequest(Body=body)
+                    self.changed = True
+                except RestOperationException as e:
+                    module.fail_json(msg='Failed to request new certificate from Entrust (ECS) {0}'.format(e.message))
+            else:
+                try:
+                    if self.request_type == 'NEW':
+                        result = self.ecs_client.NewCertRequest(Body=body)
+                    elif self.request_type == 'RENEW':
+                        result = self.ecs_client.RenewCertRequest(trackingId=self.tracking_id, Body=body)
+                    elif self.request_type == 'REISSUE':
+                        result = self.ecs_client.ReissueCertRequest(trackingId=self.tracking_id, Body=body)
+                    self.tracking_id = result.get('trackingId')
+                    self.set_cert_details(module)
+                except RestOperationException as e:
+                    module.fail_json(msg='Failed to request new certificate from Entrust (ECS) {0}'.format(e.message))
+
+                if self.backup:
+                    self.backup_file = module.backup_local(self.path)
+                crypto_utils.write_file(self.module, to_bytes(self.cert_details.get('endEntityCert')))
+                if self.chain_path:
+                    crypto_utils.write_file(self.module, to_bytes(self.cert_details.get('chainCerts')), path=self.chain_path)
+                self.changed = True
+        # If there is no certificate present in path but a tracking ID was specified, save it to disk
+        elif not os.path.exists(self.path) and self.tracking_id:
+            if not module.check_mode:
+                crypto_utils.write_file(self.module, to_bytes(self.cert_details.get('endEntityCert')))
+                if self.chain_path:
+                    crypto_utils.write_file(self.module, to_bytes(self.cert_details.get('chainCerts')), path=self.chain_path)
+            self.changed = True
+
+    def dump(self):
+        result = {
+            'changed': self.changed,
+            'filename': self.path,
+            'tracking_id': self.tracking_id,
+            'cert_status': self.cert_status,
+            'serial_number': self.serial_number,
+            'cert_days': self.cert_days,
+            'cert_details': self.cert_details,
+        }
+        if self.backup_file:
+            result['backup_file'] = self.backup_file
+        return result
+
+
+def custom_fields_spec():
+    return dict(
+        text1=dict(type='str'),
+        text2=dict(type='str'),
+        text3=dict(type='str'),
+        text4=dict(type='str'),
+        text5=dict(type='str'),
+        text6=dict(type='str'),
+        text7=dict(type='str'),
+        text8=dict(type='str'),
+        text9=dict(type='str'),
+        text10=dict(type='str'),
+        text11=dict(type='str'),
+        text12=dict(type='str'),
+        text13=dict(type='str'),
+        text14=dict(type='str'),
+        text15=dict(type='str'),
+        number1=dict(type='float'),
+        number2=dict(type='float'),
+        number3=dict(type='float'),
+        number4=dict(type='float'),
+        number5=dict(type='float'),
+        date1=dict(type='str'),
+        date2=dict(type='str'),
+        date3=dict(type='str'),
+        date4=dict(type='str'),
+        date5=dict(type='str'),
+        email1=dict(type='str'),
+        email2=dict(type='str'),
+        email3=dict(type='str'),
+        email4=dict(type='str'),
+        email5=dict(type='str'),
+        dropdown1=dict(type='str'),
+        dropdown2=dict(type='str'),
+        dropdown3=dict(type='str'),
+        dropdown4=dict(type='str'),
+        dropdown5=dict(type='str'),
+    )
+
+
+def ecs_certificate_argument_spec():
+    return dict(
+        backup=dict(type='bool', default=False),
+        force=dict(type='bool', default=False),
+        path=dict(type='path', required=True),
+        chain_path=dict(type='path'),
+        tracking_id=dict(type='int'),
+        remaining_days=dict(type='int', default=30),
+        request_type=dict(type='str', default='NEW', choices=['NEW', 'RENEW', 'REISSUE']),
+        cert_type=dict(type='str', choices=['STANDARD_SSL',
+                                            'ADVANTAGE_SSL',
+                                            'UC_SSL',
+                                            'EV_SSL',
+                                            'WILDCARD_SSL',
+                                            'PRIVATE_SSL',
+                                            'PD_SSL',
+                                            'CODE_SIGNING',
+                                            'EV_CODE_SIGNING',
+                                            'CDS_INDIVIDUAL',
+                                            'CDS_GROUP',
+                                            'CDS_ENT_LITE',
+                                            'CDS_ENT_PRO',
+                                            'SMIME_ENT',
+                                            ]),
+        csr=dict(type='str'),
+        subject_alt_name=dict(type='list', elements='str'),
+        eku=dict(type='str', choices=['SERVER_AUTH', 'CLIENT_AUTH', 'SERVER_AND_CLIENT_AUTH']),
+        ct_log=dict(type='bool'),
+        client_id=dict(type='int', default=1),
+        org=dict(type='str'),
+        ou=dict(type='list', elements='str'),
+        end_user_key_storage_agreement=dict(type='bool'),
+        tracking_info=dict(type='str'),
+        requester_name=dict(type='str'),
+        requester_email=dict(type='str'),
+        requester_phone=dict(type='str'),
+        additional_emails=dict(type='list', elements='str'),
+        custom_fields=dict(type='list', elements='dict', options=custom_fields_spec()),
+        cert_expiry=dict(type='str'),
+        cert_lifetime=dict(type='str', choices=['P1Y', 'P2Y', 'P3Y']),
+    )
+
+
+def main():
+    ecs_argument_spec = ecs_client_argument_spec()
+    ecs_argument_spec.update(ecs_certificate_argument_spec())
+    module = AnsibleModule(
+        argument_spec=ecs_argument_spec,
+        required_if=(
+            ['request_type', 'NEW', ['cert_type', 'requester_name', 'requester_email', 'requester_phone']],
+            ['cert_type', 'CODE_SIGNING', ['end_user_key_storage_agreement']],
+            ['cert_type', 'EV_CODE_SIGNING', ['end_user_key_storage_agreement']],
+        ),
+        mutually_exclusive=(
+            ['cert_expiry', 'cert_lifetime'],
+        ),
+        supports_check_mode=True,
+    )
+
+    # Does not yet support pyopenssl as a cryptography provider
+    if (not CRYPTOGRAPHY_FOUND) or CRYPTOGRAPHY_VERSION < LooseVersion(MINIMAL_CRYPTOGRAPHY_VERSION):
+        module.fail_json(msg=missing_required_lib('cryptography >= {0}'.format(MINIMAL_CRYPTOGRAPHY_VERSION)),
+                         exception=CRYPTOGRAPHY_IMP_ERR)
+
+    # A reissued request can not specify an expiration date or lifetime
+    if module.params.get('request_type') == 'REISSUE':
+        if module.params.get('cert_expiry'):
+            module.fail_json(msg='The cert_expiry field is invalid when request_type="REISSUE".')
+        elif module.params.get('cert_lifetime'):
+            module.fail_json(msg='The cert_lifetime field is invalid when request_type="REISSUE".')
+    # Only a reissued request can omit the CSR
+    else:
+        module_params_csr = module.params.get('csr')
+        if module_params_csr is None:
+            module.fail_json(msg='The csr field is required when request_type={0}'.format(module.params['request_type']))
+        elif not os.path.exists(module_params_csr):
+            module.fail_json(msg='The csr field of {0} was not a valid path. csr is required when request_type={1}'.format(
+                module_params_csr, module.params['request_type']))
+
+    if module.params.get('ou') and module.params.get('ou').len() > 1:
+        module.fail_json(msg='Multiple "ou" values are not currently supported.')
+
+    if module.params.get('end_user_key_storage_agreement'):
+        if module.params.get('cert_type') != 'CODE_SIGNING' and module.params.get('cert_type') != 'EV_CODE_SIGNING':
+            module.fail_json(msg='Parameter "end_user_key_storage_agreement" is valid only for cert_types "CODE_SIGNING" and "EV_CODE_SIGNING"')
+
+    if module.params.get('org') and module.params.get('client_id') != 1 and module.params.get('cert_type' != 'PD_SSL'):
+        module.fail_json(msg='The "org" parameter is not supported when client_id parameter is set to a value other than 1, unless cert_type is "PD_SSL".')
+
+    certificate = EcsCertificate(module)
+    certificate.request_cert(module)
+    result = certificate.dump()
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -44,7 +44,7 @@ options:
         default: false
     path:
         description:
-            - Path to put the certificate file as a PEM encoded cert
+            - Path to put the certificate file as a PEM encoded cert.
             - If the certificate at this location is not an Entrust issued certificate, a new certificate will always be requested regardless of validity.
             - If there is already an Entrust certificate at this location, whether it is replaced is dependent upon the I(remaining_days) calculation.
             - If an existing certificate is being replaced (see I(remaining_days), I(force), I(tracking_id)), the operation taken to replace it is dependent
@@ -72,7 +72,7 @@ options:
             - I(tracking_id) is invalid if C(request_type=new) or C(request_type=validate_only).
             - If there is a certificate present in I(path) and it is an ECS certificate, I(tracking_id) will be ignored.
             - If there is not a certificate present in I(path) or there is but it is from another provider, the certificate represented by I(tracking_id) will
-              be renewed or reissued and saved to I(path)
+              be renewed or reissued and saved to I(path).
             - If there is not a certificate present in I(path) and the I(force) and I(remaining_days) parameters do not indicate a new certificate is needed,
               the certificate referenced by I(tracking_id) certificate will be saved to I(path).
             - This can be used when a known certificate is not currently present on a server, but you want to renew or reissue it to be managed by an ansible
@@ -137,7 +137,7 @@ options:
             - In compliance with browser requirements, this certificate may be posted to the Certificate Transparency (CT) logs. This is a best practice
               technique that helps domain owners monitor certificates issued to their domains. Note that not all certificates are eligible for CT logging.
             - If I(ct_log) is not specified, the certificate uses the account default.
-            - If I(ct_log) is specified and the account settings allow it,    I(ct_log) overrides the account default.
+            - If I(ct_log) is specified and the account settings allow it, I(ct_log) overrides the account default.
             - If I(ct_log) is set to C(false), but the account settings are set to "always log", the certificate generation will fail.
         type: bool
     client_id:
@@ -175,7 +175,7 @@ options:
             - Applicable only to I(cert_type) of values C(CODE_SIGNING) and C(EV_CODE_SIGNING).
         type: bool
     tracking_info:
-        description: Free form tracking information to attach to the record for the certificate
+        description: Free form tracking information to attach to the record for the certificate.
         type: str
     requester_name:
         description: Requester name to associate with certificate tracking information.
@@ -190,7 +190,7 @@ options:
         type: str
         required: true
     additional_emails:
-        description: A list of additional email addresses to receive the delivery notice and expiry notification for the certificate
+        description: A list of additional email addresses to receive the delivery notice and expiry notification for the certificate.
         type: list
     custom_fields:
         description:
@@ -341,8 +341,9 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Request a new certificate from Entrust with bare minimum parameters. Will request a new certificate if current one is valid but within 30 days of
-        expiry. If replacing an existing file in path, will back it up.
+- name: Request a new certificate from Entrust with bare minimum parameters.
+        Will request a new certificate if current one is valid but within 30
+        days of expiry. If replacing an existing file in path, will back it up.
   ecs_certificate:
     backup: true
     path: /etc/ssl/crt/ansible.com.crt
@@ -357,8 +358,10 @@ EXAMPLES = r'''
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
-- name: If there is no certificate present in path, request a new certificate of type EV_SSL. Otherwise, if there is an Entrust managed certificate in path and
-        it is within 63 days of expiration, request a renew of that certificate.
+- name: If there is no certificate present in path, request a new certificate
+        of type EV_SSL. Otherwise, if there is an Entrust managed certificate
+        in path and it is within 63 days of expiration, request a renew of that
+        certificate.
   ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
@@ -374,8 +377,11 @@ EXAMPLES = r'''
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
-- name: If there is no certificate present in path, download certificate specified by tracking_id if it is still valid. Otherwise, if the certificate is within
-        79 days of expiration, request a renew of that certificate and save it in path. This can be used to "migrate" a certificate to be Ansible managed.
+- name: If there is no certificate present in path, download certificate
+        specified by tracking_id if it is still valid. Otherwise, if the
+        certificate is within 79 days of expiration, request a renew of that
+        certificate and save it in path. This can be used to "migrate" a
+        certificate to be Ansible managed.
   ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
@@ -398,8 +404,10 @@ EXAMPLES = r'''
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
-- name: Request a new certificate with an alternative client. Note that the issued certificate will have it's Subject Distinguished Name use the organization
-        details associated with that client, rather than what is in the CSR.
+- name: Request a new certificate with an alternative client. Note that the
+        issued certificate will have it's Subject Distinguished Name use the
+        organization details associated with that client, rather than what is
+        in the CSR.
   ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     csr: /etc/ssl/csr/ansible.com.csr
@@ -412,7 +420,8 @@ EXAMPLES = r'''
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
     entrust_api_client_cert_key_path: /etc/ssl/entrust/ecs-client.key
 
-- name: Request a new certificate with a number of CSR parameters overridden and tracking information
+- name: Request a new certificate with a number of CSR parameters overridden
+        and tracking information
   ecs_certificate:
     path: /etc/ssl/crt/ansible.com.crt
     full_chain_path: /etc/ssl/crt/ansible.com.chain.crt

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -458,7 +458,7 @@ EXAMPLES = r'''
 
 RETURN = '''
 filename:
-    description: Path to the generated Certificate
+    description: Path to the generated Certificate.
     returned: changed or success
     type: str
     sample: /etc/ssl/crt/www.ansible.com.crt

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -482,7 +482,7 @@ cert_status:
     description:
         - The certificate status in ECS.
         - 'Current possible values (which may be expanded in the future) are: C(ACTIVE), C(APPROVED), C(DEACTIVATED), C(DECLINED), C(EXPIRED), C(NA),
-          C(PENDING), C(PENDING_QUORUM), C(READY), C(reissueD), C(REISSUING), C(renewED), C(renewING), C(REVOKED), C(SUSPENDED)'
+          C(PENDING), C(PENDING_QUORUM), C(READY), C(REISSUED), C(REISSUING), C(RENEWED), C(RENEWING), C(REVOKED), C(SUSPENDED)'
     returned: success
     type: str
     sample: ACTIVE

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -529,9 +529,9 @@ MINIMAL_CRYPTOGRAPHY_VERSION = '1.6'
 
 
 def validate_cert_expiry(cert_expiry):
-    search_string_partial = re.compile('^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\Z')
-    search_string_full = re.compile('^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):'
-                                    '([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))\Z')
+    search_string_partial = re.compile(r'^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\Z')
+    search_string_full = re.compile(r'^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):'
+                                    r'([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))\Z')
     if search_string_partial.match(cert_expiry) or search_string_full.match(cert_expiry):
         return True
     return False

--- a/lib/ansible/plugins/doc_fragments/ecs_credential.py
+++ b/lib/ansible/plugins/doc_fragments/ecs_credential.py
@@ -15,36 +15,27 @@ options:
     entrust_api_user:
         description:
             - The username for authentication to the Entrust Certificate Services (ECS) API.
-            - This is only used by the C(entrust) provider.
-            - This is required if the provider is C(entrust)
         type: str
         required: true
     entrust_api_key:
         description:
             - The key (password) for authentication to the Entrust Certificate Services (ECS) API.
-            - This is only used by the C(entrust) provider.
-            - This is required if the provider is C(entrust)
         type: str
         required: true
     entrust_api_client_cert_path:
         description:
             - The path of the client certificate used to authenticate to the Entrust Certificate Services (ECS) API.
-            - This is only used by the C(entrust) provider.
-            - This is required if the provider is C(entrust)
         type: path
         required: true
     entrust_api_client_cert_key_path:
         description:
-            - The path of the key for the client certificate used to authenticate to the Entrust Certificate Services (ECS) API
-            - This is only used by the C(entrust) provider.
-            - This is required if the provider is C(entrust)
+            - The path of the key for the client certificate used to authenticate to the Entrust Certificate Services (ECS) API.
         type: path
         required: true
     entrust_api_specification_path:
         description:
             - Path to the specification file defining the Entrust Certificate Services (ECS) API.
             - Can be used to keep a local copy of the specification to avoid downloading it every time the module is used.
-            - This is only used by the C(entrust) provider.
         type: path
         default: https://cloud.entrust.net/EntrustCloud/documentation/cms-api-2.1.0.yaml
 requirements:

--- a/lib/ansible/plugins/doc_fragments/ecs_credential.py
+++ b/lib/ansible/plugins/doc_fragments/ecs_credential.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c), Entrust Datacard Corporation, 2019
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Plugin options for Entrust Certificate Services (ECS) credentials
+    DOCUMENTATION = r'''
+options:
+    entrust_api_user:
+        description:
+            - The username for authentication to the Entrust Certificate Services (ECS) API.
+            - This is only used by the C(entrust) provider.
+            - This is required if the provider is C(entrust)
+        type: str
+        required: true
+    entrust_api_key:
+        description:
+            - The key (password) for authentication to the Entrust Certificate Services (ECS) API.
+            - This is only used by the C(entrust) provider.
+            - This is required if the provider is C(entrust)
+        type: str
+        required: true
+    entrust_api_client_cert_path:
+        description:
+            - The path of the client certificate used to authenticate to the Entrust Certificate Services (ECS) API.
+            - This is only used by the C(entrust) provider.
+            - This is required if the provider is C(entrust)
+        type: path
+        required: true
+    entrust_api_client_cert_key_path:
+        description:
+            - The path of the key for the client certificate used to authenticate to the Entrust Certificate Services (ECS) API
+            - This is only used by the C(entrust) provider.
+            - This is required if the provider is C(entrust)
+        type: path
+        required: true
+    entrust_api_specification_path:
+        description:
+            - Path to the specification file defining the Entrust Certificate Services (ECS) API.
+            - Can be used to keep a local copy of the specification to avoid downloading it every time the module is used.
+            - This is only used by the C(entrust) provider.
+        type: path
+        default: https://cloud.entrust.net/EntrustCloud/documentation/cms-api-2.1.0.yaml
+requirements:
+    - "PyYAML >= 3.11"
+'''

--- a/test/integration/targets/ecs_certificate/aliases
+++ b/test/integration/targets/ecs_certificate/aliases
@@ -1,8 +1,8 @@
 # Not enabled due to lack of access to test environments. May be enabled using custom integration_config.yml
 # Example integation_config.yml
 # ---
-# entrust_api_user: apiuser-99543
-# entrust_api_key: apipassword
+# entrust_api_user:
+# entrust_api_key:
 # entrust_api_client_cert_path: /var/integration-testing/publicCert.pem
 # entrust_api_client_cert_key_path: /var/integration-testing/privateKey.pem
 # entrust_api_ip_address: 127.0.0.1

--- a/test/integration/targets/ecs_certificate/aliases
+++ b/test/integration/targets/ecs_certificate/aliases
@@ -1,0 +1,15 @@
+# Not enabled due to lack of access to test environments. May be enabled using custom integration_config.yml
+# Example integation_config.yml
+# ---
+# entrust_api_user: apiuser-99543
+# entrust_api_key: apipassword
+# entrust_api_client_cert_path: /var/integration-testing/publicCert.pem
+# entrust_api_client_cert_key_path: /var/integration-testing/privateKey.pem
+# entrust_api_ip_address: 127.0.0.1
+# entrust_cloud_ip_address: 127.0.0.1
+# # Used for certificate path validation of QA environments - we chose not to support disabling path validation ever.
+# cacerts_bundle_path_local: /var/integration-testing/cacerts
+
+### WARNING: This test will update HOSTS file and CERTIFICATE STORE of target host, in order to be able to validate
+# to a QA environment. ###
+unsupported

--- a/test/integration/targets/ecs_certificate/defaults/main.yml
+++ b/test/integration/targets/ecs_certificate/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for test_ecs_certificate

--- a/test/integration/targets/ecs_certificate/meta/main.yml
+++ b/test/integration/targets/ecs_certificate/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/ecs_certificate/meta/main.yml
+++ b/test/integration/targets/ecs_certificate/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_openssl

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -1,40 +1,15 @@
 ---
 ## Verify that integration_config was specified
 - block:
-  - name: Test API User is provided.
-    fail:
-      msg: entrust_api_user should be defined in integration_config.yml
-    when: entrust_api_user is not defined
-
-  - name: Test API Key is provided.
-    fail:
-      msg: entrust_api_key should be defined in integration_config.yml
-    when: entrust_api_key is not defined
-
-  - name: Test API IP address is provided
-    fail:
-      msg: entrust_api_ip_address should be defined in integration_config.yml
-    when: entrust_api_ip_address is not defined
-
-  - name: Test Cloud IP address is provided
-    fail:
-      msg: entrust_cloud_ip_address should be defined in integration_config.yml
-    when: entrust_cloud_ip_address is not defined
-
-  - name: Test Entrust Client Cert path is provided
-    fail:
-      msg: entrust_api_client_cert_path should be defined in integration_config.yml
-    when: entrust_api_client_cert_path is not defined
-
-  - name: Test Entrust Client Key path is provided
-    fail:
-      msg: entrust_api_client_cert_key_path should be defined in integration_config.yml
-    when: entrust_api_client_cert_key_path is not defined
-
-  - name: Test cacerts local path is provided
-    fail:
-      msg: cacerts_bundle_path_local should be defined in integration_config.yml
-    when: cacerts_bundle_path_local is not defined
+  - assert:
+      that:
+        - entrust_api_user is defined
+        - entrust_api_key is defined
+        - entrust_api_ip_address is defined
+        - entrust_cloud_ip_address is defined
+        - entrust_api_client_cert_path is defined or entrust_api_client_cert_contents is defined
+        - entrust_api_client_cert_key_path is defined or entrust_api_client_cert_key_contents
+        - cacerts_bundle_path_local is defined
 
 ## SET UP TEST ENVIRONMENT ########################################################################
 - name: copy the files needed for verifying test server certificate to the host
@@ -126,9 +101,8 @@
 
   # Internal CA refuses to issue certificates with the same DN in a short time frame
   - name: Sleep for 5 seconds so we don't run into duplicate-request errors
-    wait_for:
-      timeout: 5
-    delegate_to: localhost
+    pause:
+      seconds: 5
 
   - name: Attempt to have ECS generate a signed certificate, but existing one is valid
     ecs_certificate:
@@ -155,12 +129,10 @@
         - example2_result.serial_number == example1_result.serial_number
         - example2_result.tracking_id == example1_result.tracking_id
 
-
   # Internal CA refuses to issue certificates with the same DN in a short time frame
   - name: Sleep for 5 seconds so we don't run into duplicate-request errors
-    wait_for:
-      timeout: 5
-    delegate_to: localhost
+    pause:
+      seconds: 5
 
   - name: Force a reissue with no CSR, verify that contents changed
     ecs_certificate:
@@ -188,6 +160,11 @@
         - example3_result.tracking_id > 0
         - example3_result.tracking_id != example1_result.tracking_id
         - example3_result.serial_number != example1_result.serial_number
+
+  # Internal CA refuses to issue certificates with the same DN in a short time frame
+  - name: Sleep for 5 seconds so we don't run into duplicate-request errors
+    pause:
+      seconds: 5
 
   - name: Test a request with all of the various optional possible fields populated
     ecs_certificate:

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -121,6 +121,8 @@
       that:
         - example1_result is not failed
         - example1_result.changed
+        - example1_result.tracking_id > 0
+        - example1_result.serial_number is string
 
   # Internal CA refuses to issue certificates with the same DN in a short time frame
   - name: Sleep for 5 seconds so we don't run into duplicate-request errors
@@ -150,6 +152,9 @@
         - not example2_result.changed
         - example2_result.backup_file is undefined
         - example2_result.backup_full_chain_file is undefined
+        - example2_result.serial_number == example1_result.serial_number
+        - example2_result.tracking_id == example1_result.tracking_id
+
 
   # Internal CA refuses to issue certificates with the same DN in a short time frame
   - name: Sleep for 5 seconds so we don't run into duplicate-request errors
@@ -180,14 +185,15 @@
         - example3_result.changed
         - example3_result.backup_file is string
         - example3_result.backup_full_chain_file is string
+        - example3_result.tracking_id > 0
         - example3_result.tracking_id != example1_result.tracking_id
         - example3_result.serial_number != example1_result.serial_number
 
   - name: Test a request with all of the various optional possible fields populated
     ecs_certificate:
-      path: '{{ example4_full_request }}'
+      path: '{{ example4_cert_path }}'
       csr: '{{ csr_path }}'
-      subject_alt_name: {{ example4_subject_alt_name }}
+      subject_alt_name: '{{ example4_subject_alt_name }}'
       eku: '{{ example4_eku }}'
       ct_log: True
       cert_type: '{{ example4_cert_type }}'
@@ -212,7 +218,7 @@
         - example4_result.changed
         - example4_result.backup_file is undefined
         - example4_result.backup_full_chain_file is undefined
-        - example4_result.tracking_id is int
+        - example4_result.tracking_id > 0
         - example4_result.serial_number is string
 
   always:

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -1,0 +1,222 @@
+---
+## Verify that integration_config was specified
+- block:
+  - name: Test API User is provided.
+    fail:
+      msg: entrust_api_user should be defined in integration_config.yml
+    when: entrust_api_user is not defined
+
+  - name: Test API Key is provided.
+    fail:
+      msg: entrust_api_key should be defined in integration_config.yml
+    when: entrust_api_key is not defined
+
+  - name: Test API IP address is provided
+    fail:
+      msg: entrust_api_ip_address should be defined in integration_config.yml
+    when: entrust_api_ip_address is not defined
+
+  - name: Test Cloud IP address is provided
+    fail:
+      msg: entrust_cloud_ip_address should be defined in integration_config.yml
+    when: entrust_cloud_ip_address is not defined
+
+  - name: Test Entrust Client Cert path is provided
+    fail:
+      msg: entrust_api_client_cert_path should be defined in integration_config.yml
+    when: entrust_api_client_cert_path is not defined
+
+  - name: Test Entrust Client Key path is provided
+    fail:
+      msg: entrust_api_client_cert_key_path should be defined in integration_config.yml
+    when: entrust_api_client_cert_key_path is not defined
+
+  - name: Test cacerts local path is provided
+    fail:
+      msg: cacerts_bundle_path_local should be defined in integration_config.yml
+    when: cacerts_bundle_path_local is not defined
+
+## SET UP TEST ENVIRONMENT ########################################################################
+- name: copy the files needed for verifying test server certificate to the host
+  copy:
+    src: '{{ cacerts_bundle_path_local }}/'
+    dest: '{{ cacerts_bundle_path }}'
+
+- name: Update the CA certificates for our QA certs (collection may need updating if new QA environments used)
+  command: c_rehash {{ cacerts_bundle_path }}
+
+- name: Update hosts file
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    regexp: 'api.entrust.net$'
+    line: '{{ entrust_api_ip_address }} api.entrust.net'
+
+- name: Update hosts file
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    regexp: 'cloud.entrust.net$'
+    line: '{{ entrust_cloud_ip_address }} cloud.entrust.net'
+
+- name: Clear out the temporary directory for storing the API connection information
+  file:
+    path: '{{ tmpdir_path }}'
+    state: absent
+
+- name: Create a directory for storing the API connection Information
+  file:
+    path: '{{ tmpdir_path }}'
+    state: directory
+
+- name: Copy the files needed for the connection to entrust API to the host
+  copy:
+    src: '{{ entrust_api_client_cert_path }}'
+    dest: '{{ entrust_api_cert }}'
+
+- name: Copy the files needed for the connection to entrust API to the host
+  copy:
+    src: '{{ entrust_api_client_cert_key_path }}'
+    dest: '{{ entrust_api_cert_key }}'
+
+## SETUP CSR TO REQUEST
+- name: Generate a 2048 bit RSA private key
+  openssl_privatekey:
+    path: '{{ privatekey_path }}'
+    passphrase: '{{ privatekey_passphrase }}'
+    cipher: auto
+    type: RSA
+    size: 2048
+
+- name: Generate a certificate signing request using the generated key
+  openssl_csr:
+    path: '{{ csr_path }}'
+    privatekey_path: '{{ privatekey_path }}'
+    privatekey_passphrase: '{{ privatekey_passphrase }}'
+    common_name: '{{ common_name }}'
+    organization_name: '{{ organization_name | default(omit) }}'
+    organizational_unit_name: '{{ organizational_unit_name | default(omit) }}'
+    country_name: '{{ country_name | default(omit) }}'
+    state_or_province_name: '{{ state_or_province_name | default(omit) }}'
+    digest: sha256
+
+- block:
+  - name: Have ECS generate a signed certificate
+    ecs_certificate:
+      backup: True
+      path: '{{ example1_cert_path }}'
+      full_chain_path: '{{ example1_chain_path }}'
+      csr: '{{ csr_path }}'
+      cert_type: '{{ example1_cert_type }}'
+      requester_name: '{{ entrust_requester_name }}'
+      requester_email: '{{ entrust_requester_email }}'
+      requester_phone: '{{ entrust_requester_phone }}'
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: example1_result
+
+  - assert:
+      that:
+        - example1_result is not failed
+        - example1_result.changed
+
+  # Internal CA refuses to issue certificates with the same DN in a short time frame
+  - name: Sleep for 5 seconds so we don't run into duplicate-request errors
+    wait_for:
+      timeout: 5
+    delegate_to: localhost
+
+  - name: Attempt to have ECS generate a signed certificate, but existing one is valid
+    ecs_certificate:
+      backup: True
+      path: '{{ example1_cert_path }}'
+      full_chain_path: '{{ example1_chain_path }}'
+      csr: '{{ csr_path }}'
+      cert_type: '{{ example1_cert_type }}'
+      requester_name: '{{ entrust_requester_name }}'
+      requester_email: '{{ entrust_requester_email }}'
+      requester_phone: '{{ entrust_requester_phone }}'
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: example2_result
+
+  - assert:
+      that:
+        - example2_result is not failed
+        - not example2_result.changed
+        - example2_result.backup_file is undefined
+        - example2_result.backup_full_chain_file is undefined
+
+  # Internal CA refuses to issue certificates with the same DN in a short time frame
+  - name: Sleep for 5 seconds so we don't run into duplicate-request errors
+    wait_for:
+      timeout: 5
+    delegate_to: localhost
+
+  - name: Force a reissue with no CSR, verify that contents changed
+    ecs_certificate:
+      backup: True
+      force: True
+      path: '{{ example1_cert_path }}'
+      full_chain_path: '{{ example1_chain_path }}'
+      cert_type: '{{ example1_cert_type }}'
+      request_type: reissue
+      requester_name: '{{ entrust_requester_name }}'
+      requester_email: '{{ entrust_requester_email }}'
+      requester_phone: '{{ entrust_requester_phone }}'
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: example3_result
+
+  - assert:
+      that:
+        - example3_result is not failed
+        - example3_result.changed
+        - example3_result.backup_file is string
+        - example3_result.backup_full_chain_file is string
+        - example3_result.tracking_id != example1_result.tracking_id
+        - example3_result.serial_number != example1_result.serial_number
+
+  - name: Test a request with all of the various optional possible fields populated
+    ecs_certificate:
+      path: '{{ example4_full_request }}'
+      csr: '{{ csr_path }}'
+      subject_alt_name: {{ example4_subject_alt_name }}
+      eku: '{{ example4_eku }}'
+      ct_log: True
+      cert_type: '{{ example4_cert_type }}'
+      org: '{{ example4_org }}'
+      ou: '{{ example4_ou }}'
+      tracking_info: '{{ example4_tracking_info }}'
+      additional_emails: '{{ example4_additional_emails }}'
+      custom_fields: '{{ example4_custom_fields }}'
+      cert_expiry: '{{ example4_cert_expiry }}'
+      requester_name: '{{ entrust_requester_name }}'
+      requester_email: '{{ entrust_requester_email }}'
+      requester_phone: '{{ entrust_requester_phone }}'
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: example4_result
+
+  - assert:
+      that:
+        - example4_result is not failed
+        - example4_result.changed
+        - example4_result.backup_file is undefined
+        - example4_result.backup_full_chain_file is undefined
+        - example4_result.tracking_id is int
+        - example4_result.serial_number is string
+
+  always:
+    - name: clean-up temporary folder
+      file:
+        path: '{{ tmpdir_path }}'
+        state: absent

--- a/test/integration/targets/ecs_certificate/vars/main.yml
+++ b/test/integration/targets/ecs_certificate/vars/main.yml
@@ -1,0 +1,51 @@
+---
+# vars file for test_ecs_certificate
+
+# Path on various hosts that cacerts need to be put as a prerequisite to API server cert validation.
+# May need to be customized for some environments based on SSL implementations
+# that ansible "urls" module utility is using as a backing.
+cacerts_bundle_path: /etc/pki/tls/certs
+
+common_name: '{{ ansible_date_time.epoch }}.ansint.testcertificates.com'
+organization_name: CMS API, Inc.
+organizational_unit_name: RSA
+country_name: US
+state_or_province_name: MA
+privatekey_passphrase: Passphrase452!
+tmpdir_path: /tmp/ecs_cert_test/{{ ansible_date_time.epoch }}
+privatekey_path: '{{ tmpdir_path }}/testcertificates.key'
+entrust_api_cert: '{{ tmpdir_path }}/authcert.cer'
+entrust_api_cert_key: '{{ tmpdir_path }}/authkey.cer'
+csr_path: '{{ tmpdir_path }}/request.csr'
+
+entrust_requester_name: C Trufan
+entrust_requester_email: CTIntegrationTests@entrustdatacard.com
+entrust_requester_phone: 1-555-555-5555  # e.g. 15555555555
+
+# TEST 1
+example1_cert_path: '{{ tmpdir_path }}/issuedcert_1.pem'
+example1_chain_path: '{{ tmpdir_path }}/issuedcert_1_chain.pem'
+example1_cert_type: EV_SSL
+
+example4_cert_path: '{{ tmpdir_path }}/issuedcert_2.pem'
+example4_subject_alt_name:
+  - ansible.testcertificates.com
+  - www.testcertificates.com
+example4_eku: SERVER_AND_CLIENT_AUTH
+example4_cert_type: UC_SSL
+# Test a secondary org and special characters
+example4_org: Cañon City, Inc.
+example4_ou:
+  - StringrsaString
+example4_tracking_info: Submitted via Ansible Integration
+example4_additional_emails:
+  - itsupport@testcertificates.com
+  - jsmith@ansible.com
+example4_custom_fields:
+  text1: Admin
+  text2: Invoice 25
+  number1: 342
+  date3: '2018-01-01'
+  email2: sales@ansible.testcertificates.com
+  dropdown2: Dropdown 2 Value 1
+example4_cert_expiry: 2020-08-15


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addition of a module to submit certificate requests to the Entrust Certificate Services API.

Supports various entrust specific parameters, such as specifying client ID or tracking information such as additional emails or custom fields.

If the certificate in 'path' is present but not an entrust certificate, it will be treated as not valid - expectation is that this allows for transitioning from self-signed/etc to Entrust issued certificates.

If the certificate present in path but *is* an Entrust certificate, whether or not a new one is requested is based on the days remaining and the value of 'force', similarly to how both openssl_certificate and acme_certificate behave.

The "tracking_id" parameter is the value to uniquely identify certificates in the ECS system, and is something customers would be familiar with if they needed to use it.

The ECS API supports two operations on existing certificates, 'RENEW' and 'REISSUE'. If the tracking_id parameter is used, this module can be used to 'adopt' an existing ECS certificate for management under Ansible - specifying a tracking_id means that it will download that certificate to path if it is a valid certificate, and if it is within remaining_days of expiration or the 'force' command is used, it can be reissued or renewed. This design decision was made to make it easier to migrate existing infrastructure to ansible, as many customers have internal setups that already keep track of the tracking_id of existing certificates that they could pass to an ansible playbook.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
crypto
ecs_certificate
entrust/api

##### ADDITIONAL INFORMATION

**Integration Tests**

Tests run against VMs set up with Python 2.7 and Python 3.6. The reason the attached playbook doesn't run as 'localhost' was specifically to test behavior on different endpoint environments.

Attached are the results of the following integration tests running against our QA environment. Once merged these tests will run nightly against both ansible/devel and any baseline releases that include this module, against both our "next release" of ECS and the "current release". If needed I can try to adapt them (e.g. remove any sensitive values) for inclusion in ansible code base, though I'll note that customers and other ansible developers cannot access our internal QA environment, they can only submit against our actual CA, so testing would need to involve owned domains and actual ECS accounts, and unless the account was configured otherwise, would issue genuine publicly trusted certificates.

I am going to clean up the integration tests additionally (migrate the 'fail' calls into distinct pytest methods that check data against our database as well).

Integration Tests:
- Have ECS generate a signed certificate for us using a local file path for the specification
- Verify that ECS will not mark 'changed' if calling a still valid file
- Verify that ECS will force a new request even if current is still valid, and REISSUE works with no CSR.
- Test that ECS will download an existing older cert if tracking_id specified, but will not perform action if still valid.
- Perform an actual renew based on tracking ID.
- Request a certificate with all various parameters
- Request a certificate with client ID other than 1
[ecs_certificate_playbook.txt](https://github.com/ansible/ansible/files/3530888/ecs_certificate_playbook.txt)
[ecs_certificate_output.txt](https://github.com/ansible/ansible/files/3530889/ecs_certificate_output.txt)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
