### PR TITLE
bug fix, was not checking vserver

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_cifs_server.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cifs_server.py
@@ -170,6 +170,7 @@ class NetAppOntapcifsServer(object):
         cifs_server_info = netapp_utils.zapi.NaElement('cifs-server-get-iter')
         cifs_server_attributes = netapp_utils.zapi.NaElement('cifs-server-config')
         cifs_server_attributes.add_new_child('cifs-server', self.cifs_server_name)
+        cifs_server_attributes.add_new_child('vserver', self.vserver)
         query = netapp_utils.zapi.NaElement('query')
         query.add_child_elem(cifs_server_attributes)
         cifs_server_info.add_child_elem(query)


### PR DESCRIPTION
##### SUMMARY
Was not searching by Vserver (if same name was on 2 vserver we would return error) this fixes that

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_cifs_server.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
