### PR TITLE
cg snapshot needs to use vserver

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_cg_snapshot.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_cg_snapshot.py
@@ -133,6 +133,7 @@ class NetAppONTAPCGSnapshot(object):
         snapshot_info_obj = netapp_utils.zapi.NaElement("snapshot-info")
         snapshot_info_obj.add_new_child("name", self.snapshot)
         snapshot_info_obj.add_new_child("volume", volume)
+        snapshot_info_obj.add_new_child("vserver", self.vserver)
         query.add_child_elem(snapshot_info_obj)
         snapshot_obj.add_child_elem(query)
         result = self.server.invoke_successfully(snapshot_obj, True)


### PR DESCRIPTION
##### SUMMARY
cg snapshot needs to use vserver

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_cg_snapshot.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
