### PR TITLE
igroup has to use vserver

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_igroup.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_igroup.py
@@ -195,7 +195,8 @@ class NetAppOntapIgroup(object):
         :rtype: dict
         """
         igroup_info = netapp_utils.zapi.NaElement('igroup-get-iter')
-        attributes = dict(query={'initiator-group-info': {'initiator-group-name': name}})
+        attributes = dict(query={'initiator-group-info': {'initiator-group-name': name,
+                                                          'vserver': self.parameters['vserver']}})
         igroup_info.translate_struct(attributes)
         result, current = None, None
 


### PR DESCRIPTION
##### SUMMARY
igroup has to use vserver

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- na_ontap_igroup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
