### PR TITLE
Add aci_vmm_credential.py

### DIFF
--- a/lib/ansible/modules/network/aci/aci_vmm_credential.py
+++ b/lib/ansible/modules/network/aci/aci_vmm_credential.py
@@ -18,7 +18,7 @@ description:
 - Manage virtual domain credential profiles on Cisco ACI fabrics.
 version_added: '2.8'
 options:
-  credential:
+  name:
     description:
     - Name of the credential profile.
     type: str
@@ -78,7 +78,7 @@ EXAMPLES = r'''
     password: SomeSecretPassword
     domain: vmware_dom
     description: secure credential
-    credential: vCenterCredential
+    name: vCenterCredential
     credential_username: vCenterUsername
     credential_password: vCenterPassword
     vm_provider: vmware
@@ -90,7 +90,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     domain: vmware_dom
-    credential: myCredential
+    name: myCredential
     vm_provider: vmware
     state: absent
 
@@ -100,7 +100,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     domain: vmware_dom
-    credential: vCenterCredential
+    name: vCenterCredential
     vm_provider: vmware
     state: query
   delegate_to: localhost
@@ -240,11 +240,11 @@ VM_PROVIDER_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
-        credential=dict(type='str', aliases=['credential_name', 'credential_profile']),
+        name=dict(type='str', aliases=['credential_name', 'credential_profile']),
         credential_password=dict(type='str'),
         credential_username=dict(type='str'),
         description=dict(type='str', aliases=['descr']),
-        domain=dict(type='str', aliases=['domain_name', 'domain_profile', 'name']),
+        domain=dict(type='str', aliases=['domain_name', 'domain_profile']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         vm_provider=dict(type='str', choices=['cloudfoundry', 'kubernetes', 'microsoft', 'openshift', 'openstack', 'redhat', 'vmware'])
     )
@@ -258,7 +258,7 @@ def main():
         ],
     )
 
-    credential = module.params['credential']
+    name = module.params['name']
     credential_password = module.params['credential_password']
     credential_username = module.params['credential_username']
     description = module.params['description']
@@ -267,11 +267,11 @@ def main():
     vm_provider = module.params['vm_provider']
 
     credential_class = 'vmmUsrAccP'
-    usracc_mo = 'uni/vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, credential)
-    usracc_rn = 'vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, credential)
+    usracc_mo = 'uni/vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, name)
+    usracc_rn = 'vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, name)
 
     # Ensure that querying all objects works when only domain is provided
-    if credential is None:
+    if name is None:
         usracc_mo = None
 
     aci = ACIModule(module)
@@ -280,7 +280,7 @@ def main():
             aci_class=credential_class,
             aci_rn=usracc_rn,
             module_object=usracc_mo,
-            target_filter={'name': domain, 'usracc': credential},
+            target_filter={'name': domain, 'usracc': name},
         ),
     )
 
@@ -291,7 +291,7 @@ def main():
             aci_class=credential_class,
             class_config=dict(
                 descr=description,
-                name=credential,
+                name=name,
                 pwd=credential_password,
                 usr=credential_username
             ),

--- a/lib/ansible/modules/network/aci/aci_vmm_credential.py
+++ b/lib/ansible/modules/network/aci/aci_vmm_credential.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_vmm_credential
+short_description: Manage virtual domain credential profiles (vmm:UsrAccP)
+description:
+- Manage virtual domain credential profiles on Cisco ACI fabrics.
+version_added: '2.8'
+options:
+  credential:
+    description:
+    - Name of the credential profile.
+    type: str
+    aliases: [ credential_name, credential_profile ]
+  credential_password:
+    description:
+    - VMM controller password.
+    type: str
+    aliases: []
+  credential_username:
+    description:
+    - VMM controller username.
+    type: str
+    aliases: []
+  description:
+    description:
+    - Description for the tenant.
+    type: str
+    aliases: [ descr ]
+  domain:
+    description:
+    - Name of the virtual domain profile.
+    type: str
+    aliases: [ domain_name, domain_profile, name ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+  vm_provider:
+    description:
+    - The VM platform for VMM Domains.
+    - Support for Kubernetes was added in ACI v3.0.
+    - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
+    choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
+extends_documentation_fragment: aci
+seealso:
+- module: aci_domain
+- module: aci_aep_to_domain
+- module: aci_domain_to_encap_pool
+- module: aci_domain_to_vlan_pool
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(vmm:DomP)
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Jason Juenger (@jasonjuenger)
+'''
+
+EXAMPLES = r'''
+- name: Add credential to VMware VMM domain
+  aci_vmm_credential:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    description: secure credential
+    credential: vCenterCredential
+    credential_username: vCenterUsername
+    credential_password: vCenterPassword
+    vm_provider: vmware
+    state: present
+
+- name: Remove credential from VMware VMM domain
+  aci_vmm_credential:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    credential: myCredential
+    vm_provider: vmware
+    state: absent
+
+- name: Query a specific VMware VMM credential
+  aci_vmm_credential:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    credential: vCenterCredential
+    vm_provider: vmware
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all VMware VMM credentials
+  aci_vmm_credential:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    vm_provider: vmware
+    state: query
+  delegate_to: localhost
+  register: query_result
+'''
+
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
+
+VM_PROVIDER_MAPPING = dict(
+    cloudfoundry='CloudFoundry',
+    kubernetes='Kubernetes',
+    microsoft='Microsoft',
+    openshift='OpenShift',
+    openstack='OpenStack',
+    redhat='Redhat',
+    vmware='VMware',
+)
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(
+        credential=dict(type='str', aliases=['credential_name', 'credential_profile']),
+        credential_password=dict(type='str'),
+        credential_username=dict(type='str'),
+        description=dict(type='str', aliases=['descr']),
+        domain=dict(type='str', aliases=['domain_name', 'domain_profile', 'name']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        vm_provider=dict(type='str', choices=['cloudfoundry', 'kubernetes', 'microsoft', 'openshift', 'openstack', 'redhat', 'vmware'])
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'absent', ['domain']],
+            ['state', 'present', ['domain']],
+        ],
+    )
+
+    credential = module.params['credential']
+    credential_password = module.params['credential_password']
+    credential_username = module.params['credential_username']
+    description = module.params['description']
+    domain = module.params['domain']
+    state = module.params['state']
+    vm_provider = module.params['vm_provider']
+
+    credential_class = 'vmmUsrAccP'
+    usracc_mo = 'uni/vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, credential)
+    usracc_rn = 'vmmp-{0}/dom-{1}/usracc-{2}'.format(VM_PROVIDER_MAPPING[vm_provider], domain, credential)
+
+    # Ensure that querying all objects works when only domain is provided
+    if credential is None:
+        usracc_mo = None
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class=dict(
+            aci_class=credential_class,
+            aci_rn=usracc_rn,
+            module_object=usracc_mo,
+            target_filter={'name': domain, 'usracc': credential},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == 'present':
+        aci.payload(
+            aci_class=credential_class,
+            class_config=dict(
+                descr=description,
+                name=credential,
+                pwd=credential_password,
+                usr=credential_username
+            ),
+        )
+
+        aci.get_diff(aci_class=credential_class)
+
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/network/aci/aci_vmm_credential.py
+++ b/lib/ansible/modules/network/aci/aci_vmm_credential.py
@@ -16,7 +16,7 @@ module: aci_vmm_credential
 short_description: Manage virtual domain credential profiles (vmm:UsrAccP)
 description:
 - Manage virtual domain credential profiles on Cisco ACI fabrics.
-version_added: '2.8'
+version_added: '2.9'
 options:
   name:
     description:
@@ -60,9 +60,6 @@ options:
 extends_documentation_fragment: aci
 seealso:
 - module: aci_domain
-- module: aci_aep_to_domain
-- module: aci_domain_to_encap_pool
-- module: aci_domain_to_vlan_pool
 - name: APIC Management Information Model reference
   description: More information about the internal APIC classes B(vmm:DomP)
   link: https://developer.cisco.com/docs/apic-mim-ref/

--- a/lib/ansible/modules/network/aci/aci_vmm_credential.py
+++ b/lib/ansible/modules/network/aci/aci_vmm_credential.py
@@ -243,7 +243,7 @@ def main():
         description=dict(type='str', aliases=['descr']),
         domain=dict(type='str', aliases=['domain_name', 'domain_profile']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
-        vm_provider=dict(type='str', choices=['cloudfoundry', 'kubernetes', 'microsoft', 'openshift', 'openstack', 'redhat', 'vmware'])
+        vm_provider=dict(type='str', choices=VM_PROVIDER_MAPPING.keys())
     )
 
     module = AnsibleModule(

--- a/test/integration/targets/aci_vmm_credential/aliases
+++ b/test/integration/targets/aci_vmm_credential/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+unsupported

--- a/test/integration/targets/aci_vmm_credential/tasks/main.yml
+++ b/test/integration/targets/aci_vmm_credential/tasks/main.yml
@@ -1,5 +1,5 @@
 # Test code for the ACI modules
-# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+# Copyright: (c) 2018, Dag Wieers (@dagwieers) <dag@wieers.com>
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -8,42 +8,5 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
-# REMOVE credential
-- name: Remove credential (check_mode)
-  aci_vmm_credential: &credential_absent
-    host: '{{ aci_hostname }}'
-    username: '{{ aci_username }}'
-    password: '{{ aci_password }}'
-    validate_certs: '{{ aci_validate_certs | default(false) }}'
-    use_ssl: '{{ aci_use_ssl | default(true) }}'
-    use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: '{{ aci_output_level | default("info") }}'
-    domain: ansible_test
-    credential: ansible_test
-    description: ansible_test
-    credential_username: ansible_test
-    credential_password: ansible_test
-    vm_provider: vmware
-    state: absent
-  check_mode: yes
-  register: cm_remove_credential
-
-# ADD credential
-- name: Add credential (check_mode)
-  aci_vmm_credential: &credential_present
-    host: '{{ aci_hostname }}'
-    username: '{{ aci_username }}'
-    password: '{{ aci_password }}'
-    validate_certs: '{{ aci_validate_certs | default(false) }}'
-    use_ssl: '{{ aci_use_ssl | default(true) }}'
-    use_proxy: '{{ aci_use_proxy | default(true) }}'
-    output_level: '{{ aci_output_level | default("info") }}'
-    domain: ansible_test
-    credential: ansible_test
-    description: ansible_test
-    credential_username: ansible_test
-    credential_password: ansible_test
-    vm_provider: vmware
-    state: present
-  check_mode: yes
-  register: cm_add_credential
+- include_tasks: vmware.yml
+  when: vmware is not defined or vmware

--- a/test/integration/targets/aci_vmm_credential/tasks/main.yml
+++ b/test/integration/targets/aci_vmm_credential/tasks/main.yml
@@ -1,0 +1,49 @@
+# Test code for the ACI modules
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+# REMOVE credential
+- name: Remove credential (check_mode)
+  aci_vmm_credential: &credential_absent
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    domain: ansible_test
+    credential: ansible_test
+    description: ansible_test
+    credential_username: ansible_test
+    credential_password: ansible_test
+    vm_provider: vmware
+    state: absent
+  check_mode: yes
+  register: cm_remove_credential
+
+# ADD credential
+- name: Add credential (check_mode)
+  aci_vmm_credential: &credential_present
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    domain: ansible_test
+    credential: ansible_test
+    description: ansible_test
+    credential_username: ansible_test
+    credential_password: ansible_test
+    vm_provider: vmware
+    state: present
+  check_mode: yes
+  register: cm_add_credential

--- a/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
+++ b/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
@@ -210,8 +210,8 @@
     - cm_query_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
     - nm_query_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
     - nm_query_fake_credential.current == []
-    - cm_query_all_credential.current.8.vmmUsrAccP.attributes.name == 'vmm_cred'
-    - nm_query_all_credential.current.8.vmmUsrAccP.attributes.name == 'vmm_cred'
+    - cm_query_all_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
+    - nm_query_all_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
 
 - name: Remove credential (check_mode)
   aci_vmm_credential: *credential_absent

--- a/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
+++ b/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
@@ -1,0 +1,149 @@
+# Test code for the ACI modules
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Remove VMM domain
+- name: Remove VMM domain (normal_mode)
+  aci_domain: &domain_absent
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    domain: vmm_dom
+    domain_type: vmm
+    vm_provider: vmware
+    state: absent
+  register: nm_remove_domain
+
+# ADD VMM domain for testing
+- name: Add VMM domain (normal_mode)
+  aci_domain: &domain_present
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    domain: vmm_dom
+    domain_type: vmm
+    vm_provider: vmware
+    state: present
+  register: nm_add_domain
+
+- name: Verify add_domain
+  assert:
+    that:
+    - nm_add_domain is changed
+
+# REMOVE credential
+- name: Remove credential (check_mode)
+  aci_vmm_credential: &credential_absent
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    name: vmm_cred
+    description: my_new_cred
+    domain: vmm_dom
+    credential_username: myUsername
+    credential_password: mySecretPassword
+    vm_provider: vmware
+    state: absent
+  check_mode: yes
+  register: cm_remove_credential
+
+# ADD credential
+- name: Add vmware VMM credential (check_mode)
+  aci_vmm_credential: &credential_present
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    name: vmm_cred
+    description: my_new_cred
+    domain: vmm_dom
+    credential_username: myUsername
+    credential_password: mySecretPassword
+    vm_provider: vmware
+    state: present
+  check_mode: yes
+  register: cm_add_credential
+
+# NOTE: Setting password is not idempotent
+- name: Add vmware VMM credential (normal mode)
+  aci_vmm_credential: *credential_present
+  register: nm_add_credential
+
+# NOTE: Setting password is not idempotent
+- name: Add vmware VMM credential again (check mode)
+  aci_vmm_credential: *credential_present
+  check_mode: yes
+  register: cm_add_credential_again
+
+- name: Verify add_credential
+  assert:
+    that:
+    - cm_add_credential is changed
+    - nm_add_credential is changed
+    - 'cm_add_credential.sent == nm_add_credential.sent == {"vmmUsrAccP": {"attributes": {"descr": "my_new_cred", "name": "vmm_cred", "pwd": "mySecretPassword", "usr": "myUsername"}}}'
+    - 'cm_add_credential.proposed == nm_add_credential.proposed == {"vmmUsrAccP": {"attributes": {"descr": "my_new_cred", "name": "vmm_cred", "pwd": "mySecretPassword", "usr": "myUsername"}}}'
+    - cm_add_credential.current == cm_add_credential.previous == nm_add_credential.previous == []
+    - nm_add_credential.current.0.vmmUsrAccP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/usracc-vmm_cred'
+    - nm_add_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
+
+
+# MODIFY credential
+- name: Modify vmware VMM credential (check_mode)
+  aci_vmm_credential: &credential_mod
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    name: vmm_cred
+    description: my_updated_descr
+    domain: vmm_dom
+    credential_username: myNewUsername
+    credential_password: myNewSecretPassword
+    vm_provider: vmware
+    state: present
+  check_mode: yes
+  register: cm_mod_credential
+
+# NOTE: Setting password is not idempotent
+- name: Modify vmware VMM credential (normal mode)
+  aci_vmm_credential: *credential_mod
+  register: nm_mod_credential
+
+- name: Verify mod_credential
+  assert:
+    that:
+    - cm_mod_credential is changed
+    - nm_mod_credential is changed
+    - 'cm_mod_credential.sent == nm_mod_credential.sent == {"vmmUsrAccP": {"attributes": {"descr": "my_updated_descr", "pwd": "myNewSecretPassword", "usr": "myNewUsername"}}}'
+    - 'cm_mod_credential.proposed == nm_mod_credential.proposed == {"vmmUsrAccP": {"attributes": {"descr": "my_updated_descr", "name": "vmm_cred", "pwd": "myNewSecretPassword", "usr": "myNewUsername"}}}'
+    - nm_mod_credential.current.0.vmmUsrAccP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/usracc-vmm_cred'
+    - nm_mod_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
+
+# REMOVE credential after testing
+- name: Remove credential (normal_mode)
+  aci_vmm_credential: *credential_absent
+  register: nm_remove_credential_final
+
+# Remove VMM domain after testing
+- name: Remove VMM domain (normal_mode)
+  aci_domain: *domain_absent
+  register: nm_remove_domain_again

--- a/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
+++ b/test/integration/targets/aci_vmm_credential/tasks/vmware.yml
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Remove VMM domain
-- name: Remove VMM domain (normal_mode)
+- name: Remove VMM domain (normal mode)
   aci_domain: &domain_absent
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -20,7 +20,7 @@
   register: nm_remove_domain
 
 # ADD VMM domain for testing
-- name: Add VMM domain (normal_mode)
+- name: Add VMM domain (normal mode)
   aci_domain: &domain_present
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -41,7 +41,7 @@
     - nm_add_domain is changed
 
 # REMOVE credential
-- name: Remove credential (check_mode)
+- name: Remove credential (check mode)
   aci_vmm_credential: &credential_absent
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -60,8 +60,18 @@
   check_mode: yes
   register: cm_remove_credential
 
+- name: Remove vmware VMM credential (normal mode)
+  aci_vmm_credential: *credential_absent
+  register: nm_remove_credential
+
+- name: Verify remove_credential
+  assert:
+    that:
+    - cm_remove_credential is not changed
+    - nm_remove_credential is not changed
+
 # ADD credential
-- name: Add vmware VMM credential (check_mode)
+- name: Add vmware VMM credential (check mode)
   aci_vmm_credential: &credential_present
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -102,9 +112,8 @@
     - nm_add_credential.current.0.vmmUsrAccP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/usracc-vmm_cred'
     - nm_add_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
 
-
 # MODIFY credential
-- name: Modify vmware VMM credential (check_mode)
+- name: Modify vmware VMM credential (check mode)
   aci_vmm_credential: &credential_mod
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -123,7 +132,6 @@
   check_mode: yes
   register: cm_mod_credential
 
-# NOTE: Setting password is not idempotent
 - name: Modify vmware VMM credential (normal mode)
   aci_vmm_credential: *credential_mod
   register: nm_mod_credential
@@ -138,10 +146,92 @@
     - nm_mod_credential.current.0.vmmUsrAccP.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/usracc-vmm_cred'
     - nm_mod_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
 
-# REMOVE credential after testing
+- name: Query existing vmware VMM credential (check mode)
+  aci_vmm_credential: &query_existing_cred
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    name: vmm_cred
+    domain: vmm_dom
+    vm_provider: vmware
+    state: query
+  check_mode: yes
+  register: cm_query_credential
+
+- name: Query existing vmware VMM credential (normal mode)
+  aci_vmm_credential: *query_existing_cred
+  register: nm_query_credential
+
+- name: Query non-existent vmware VMM credential
+  aci_vmm_credential:
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    name: vmm_fake_cred
+    domain: vmm_dom
+    vm_provider: vmware
+    state: query
+  register: nm_query_fake_credential
+
+- name: Query all vmware VMM credentials (check mode)
+  aci_vmm_credential: &query_all_creds
+    host: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: '{{ aci_output_level | default("info") }}'
+    vm_provider: vmware
+    state: query
+  check_mode: yes
+  register: cm_query_all_credential
+
+- name: Query all vmware VMM credentials (normal mode)
+  aci_vmm_credential: *query_all_creds
+  register: nm_query_all_credential
+
+- name: Verify query_credential
+  assert:
+    that:
+    - cm_query_credential is not changed
+    - nm_query_credential is not changed
+    - nm_query_fake_credential is not changed
+    - cm_query_all_credential is not changed
+    - nm_query_all_credential is not changed
+    - cm_query_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
+    - nm_query_credential.current.0.vmmUsrAccP.attributes.name == 'vmm_cred'
+    - nm_query_fake_credential.current == []
+    - cm_query_all_credential.current.8.vmmUsrAccP.attributes.name == 'vmm_cred'
+    - nm_query_all_credential.current.8.vmmUsrAccP.attributes.name == 'vmm_cred'
+
+- name: Remove credential (check_mode)
+  aci_vmm_credential: *credential_absent
+  check_mode: yes
+  register: cm_remove_credential_again
+
+- name: Remove credential (normal_mode)
+  aci_vmm_credential: *credential_absent
+  register: nm_remove_credential_again
+
 - name: Remove credential (normal_mode)
   aci_vmm_credential: *credential_absent
   register: nm_remove_credential_final
+
+- name: Verify remove_credential
+  assert:
+    that:
+    - cm_remove_credential_again is changed
+    - nm_remove_credential_again is changed
+    - nm_remove_credential_final is not changed
 
 # Remove VMM domain after testing
 - name: Remove VMM domain (normal_mode)


### PR DESCRIPTION
##### SUMMARY
Adds a new network module, aci_vmm_credential, to create credential objects for VMM integrations. This module partially fulfills feature request #34885.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
aci_vmm_credential.py

##### ADDITIONAL INFORMATION
