### PR TITLE
Update ansible-test --windows inventory creation.

### DIFF
--- a/test/integration/host_vars/windows-2008
+++ b/test/integration/host_vars/windows-2008
@@ -1,4 +1,0 @@
-# force 2008 to use PSRP for the connection plugin
-ansible_connection: psrp
-ansible_psrp_auth: basic
-ansible_psrp_cert_validation: ignore

--- a/test/integration/host_vars/windows-2016
+++ b/test/integration/host_vars/windows-2016
@@ -1,4 +1,0 @@
-# force 2016 to use NTLM + HTTP message encryption
-ansible_winrm_transport: ntlm
-ansible_winrm_scheme: http
-ansible_port: 5985

--- a/test/integration/targets/connection_psrp/inventory.ini
+++ b/test/integration/targets/connection_psrp/inventory.ini
@@ -1,3 +1,0 @@
-[windows:vars]
-ansible_connection=psrp
-ansible_psrp_cert_validation=ignore

--- a/test/integration/targets/connection_psrp/runme.sh
+++ b/test/integration/targets/connection_psrp/runme.sh
@@ -6,7 +6,6 @@ set -eux
 ansible -i ../../inventory.winrm localhost \
     -m template \
     -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
-    -e "test_shell_type=cmd" \
     "$@"
 
 python.py -m pip install pypsrp

--- a/test/integration/targets/connection_psrp/runme.sh
+++ b/test/integration/targets/connection_psrp/runme.sh
@@ -2,12 +2,18 @@
 
 set -eux
 
+# make sure hosts are using psrp connections
+ansible -i ../../inventory.winrm localhost \
+    -m template \
+    -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
+    -e "test_shell_type=cmd" \
+    "$@"
+
 python.py -m pip install pypsrp
 cd ../connection
 
-INVENTORY=../../inventory.winrm ./test.sh \
-    -i ../connection_psrp/inventory.ini \
-    -e target_hosts=winrm \
+INVENTORY="${OUTPUT_DIR}/test_connection.inventory" ./test.sh \
+    -e target_hosts=windows \
     -e action_prefix=win_ \
     -e local_tmp=/tmp/ansible-local \
     -e remote_tmp=c:/windows/temp/ansible-remote \
@@ -15,5 +21,5 @@ INVENTORY=../../inventory.winrm ./test.sh \
 
 cd ../connection_psrp
 
-ansible-playbook -i ../../inventory.winrm -i inventory.ini tests.yml \
+ansible-playbook -i "${OUTPUT_DIR}/test_connection.inventory" tests.yml \
     "$@"

--- a/test/integration/targets/connection_psrp/test_connection.inventory.j2
+++ b/test/integration/targets/connection_psrp/test_connection.inventory.j2
@@ -1,0 +1,9 @@
+[windows]
+{% for host in vars.groups.windows %}
+{{ host }}  ansible_host={{ hostvars[host]['ansible_host'] }} ansible_port={{ hostvars[host]['ansible_port'] }} ansible_user={{ hostvars[host]['ansible_user'] }} ansible_password={{ hostvars[host]['ansible_password'] }}
+{% endfor %}
+
+[windows:vars]
+ansible_connection=psrp
+ansible_psrp_auth=negotiate
+ansible_psrp_cert_validation=ignore

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -1,7 +1,7 @@
 ---
 # these are extra tests for psrp that aren't covered under test/integration/targets/connection/*
 - name: test out psrp specific tests
-  hosts: winrm
+  hosts: windows
   serial: 1
   gather_facts: no
 

--- a/test/integration/targets/connection_windows_ssh/runme.sh
+++ b/test/integration/targets/connection_windows_ssh/runme.sh
@@ -18,7 +18,7 @@ ansible -i ../../inventory.winrm windows \
     "$@"
 
 # Need to flush the connection to ensure we get a new shell for the next tests
-ansible -i "${OUTPUT_DIR}/test_connection.inventory" windows-ssh \
+ansible -i "${OUTPUT_DIR}/test_connection.inventory" windows \
     -m meta -a "reset_connection" \
     "$@"
 
@@ -44,7 +44,7 @@ ansible -i ../../inventory.winrm windows \
     -a "path=HKLM:\\\\SOFTWARE\\\\OpenSSH name=DefaultShell data=C:\\\\Windows\\\\System32\\\\WindowsPowerShell\\\\v1.0\\\\powershell.exe" \
     "$@"
 
-ansible -i "${OUTPUT_DIR}/test_connection.inventory" windows-ssh \
+ansible -i "${OUTPUT_DIR}/test_connection.inventory" windows \
     -m meta -a "reset_connection" \
     "$@"
 

--- a/test/integration/targets/connection_windows_ssh/test_connection.inventory.j2
+++ b/test/integration/targets/connection_windows_ssh/test_connection.inventory.j2
@@ -1,9 +1,9 @@
-[windows-ssh]
-{% for host in vars.groups.winrm %}
+[windows]
+{% for host in vars.groups.windows %}
 {{ host }}  ansible_host={{ hostvars[host]['ansible_host'] }} ansible_user={{ hostvars[host]['ansible_user'] }}{{ ' ansible_ssh_private_key_file=' ~ hostvars[host]['ansible_ssh_private_key_file'] if (hostvars[host]['ansible_ssh_private_key_file']|default()) else '' }}
 {% endfor %}
 
-[windows-ssh:vars]
+[windows:vars]
 ansible_shell_type={{ test_shell_type }}
 ansible_connection=ssh
 ansible_port=22

--- a/test/integration/targets/connection_windows_ssh/tests.yml
+++ b/test/integration/targets/connection_windows_ssh/tests.yml
@@ -1,6 +1,6 @@
 ---
 - name: test out Windows SSH specific tests
-  hosts: windows-ssh
+  hosts: windows
   serial: 1
   gather_facts: no
 

--- a/test/integration/targets/connection_windows_ssh/tests_fetch.yml
+++ b/test/integration/targets/connection_windows_ssh/tests_fetch.yml
@@ -3,7 +3,7 @@
 # documented, it isn't actually used hence the separate invocation
 ---
 - name: further fetch tests with metachar characters in filename
-  hosts: windows-ssh
+  hosts: windows
   force_handlers: yes
   serial: 1
   gather_facts: no

--- a/test/integration/targets/connection_windows_ssh/windows.sh
+++ b/test/integration/targets/connection_windows_ssh/windows.sh
@@ -11,7 +11,7 @@ cd ../connection
 # https://unix.stackexchange.com/questions/499958/why-does-scps-strict-filename-checking-reject-quoted-last-component-but-not-oth
 # https://github.com/openssh/openssh-portable/commit/391ffc4b9d31fa1f4ad566499fef9176ff8a07dc
 INVENTORY="${OUTPUT_DIR}/test_connection.inventory" ./test.sh \
-    -e target_hosts=windows-ssh \
+    -e target_hosts=windows \
     -e action_prefix=win_ \
     -e local_tmp=/tmp/ansible-local \
     -e remote_tmp=c:/windows/temp/ansible-remote \

--- a/test/integration/targets/connection_winrm/runme.sh
+++ b/test/integration/targets/connection_winrm/runme.sh
@@ -6,7 +6,6 @@ set -eux
 ansible -i ../../inventory.winrm localhost \
     -m template \
     -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
-    -e "test_shell_type=cmd" \
     "$@"
 
 cd ../connection

--- a/test/integration/targets/connection_winrm/runme.sh
+++ b/test/integration/targets/connection_winrm/runme.sh
@@ -2,10 +2,17 @@
 
 set -eux
 
+# make sure hosts are using winrm connections
+ansible -i ../../inventory.winrm localhost \
+    -m template \
+    -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
+    -e "test_shell_type=cmd" \
+    "$@"
+
 cd ../connection
 
-INVENTORY=../../inventory.winrm ./test.sh \
-    -e target_hosts=winrm \
+INVENTORY="${OUTPUT_DIR}/test_connection.inventory" ./test.sh \
+    -e target_hosts=windows \
     -e action_prefix=win_ \
     -e local_tmp=/tmp/ansible-local \
     -e remote_tmp=c:/windows/temp/ansible-remote \

--- a/test/integration/targets/connection_winrm/test_connection.inventory.j2
+++ b/test/integration/targets/connection_winrm/test_connection.inventory.j2
@@ -1,0 +1,10 @@
+[windows]
+{% for host in vars.groups.windows %}
+{{ host }}  ansible_host={{ hostvars[host]['ansible_host'] }} ansible_port={{ hostvars[host]['ansible_port'] }} ansible_user={{ hostvars[host]['ansible_user'] }} ansible_password={{ hostvars[host]['ansible_password'] }}
+{% endfor %}
+
+[windows:vars]
+ansible_connection=winrm
+# we don't know if we're using an encrypted connection or not, so we'll use message encryption
+ansible_winrm_transport=ntlm
+ansible_winrm_server_cert_validation=ignore


### PR DESCRIPTION
##### SUMMARY

Update ansible-test --windows inventory creation.

Host specific settings are created as part of the generated inventory instead of using a host_vars directory.

Also update connection tests to work properly with the generated inventory changes.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
