### PR TITLE
Warn when transforming constructed groups

### DIFF
--- a/changelogs/fragments/60912-constructed-groups-option-sanitization.yaml
+++ b/changelogs/fragments/60912-constructed-groups-option-sanitization.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - constructed - Add a warning for the change in behavior in the sanitization of the groups option.

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -372,7 +372,7 @@ class Constructable(object):
             self.templar.available_variables = variables
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = self._sanitize_group_name(group_name)
+                group_name = original_safe(group_name, force=True)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Fixes #59508

The `keyed_groups` field has used sanitization since 2.6, but `groups` only started doing so in 2.8. I'm not sure how widely that has been used, but it seems like at minimum a warning for the change in behavior should be given, or perhaps the previous lack of forced sanitization + a deprecation warning for that behavior should be reinstated.

Whichever solution, should also be backported to 2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
constructed
