### PR TITLE
Fix naming discrepancy in zip filter example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -292,10 +292,10 @@ Similarly to the output of the ``items2dict`` filter mentioned above, these filt
 
 Which turns::
 
-    list_one:
+    keys_list:
       - one
       - two
-    list_two:
+    values_list:
       - apple
       - orange
 


### PR DESCRIPTION
##### SUMMARY
Fix naming discrepancies in filter example

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
