### PR TITLE
croc cloud - ec2 key patch

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_key.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_key.py
@@ -180,6 +180,8 @@ def find_key_pair(module, ec2_client, name):
         if err.response['Error']['Code'] == "InvalidKeyPair.NotFound":
             return None
         module.fail_json_aws(err, msg="error finding keypair")
+    except IndexError:
+        key = None
     return key
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch fixes "IndexError: list index out of range" error for https://console.cloud.croc.ru.
When key pair is new, croc return dict with an empty list for key KeyPairs that causes ansible to crush.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_key

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: user
<127.0.0.1> EXEC /bin/sh -c 'echo ~user && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607 `" && echo ansible-tmp-1566293632.1787608-45601675593607="` echo /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607 `" ) && sleep 0'
Using module file /home/user/.local/lib/python3.6/site-packages/ansible/modules/cloud/amazon/ec2_key.py
<127.0.0.1> PUT /home/user/.ansible/tmp/ansible-local-31974wpvc25aa/tmpi1h7fvmx TO /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/ /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py", line 114, in <module>
    _ansiballz_main()
  File "/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/usr/lib/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 618, in _exec
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py", line 277, in <module>
  File "/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py", line 273, in main
  File "/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py", line 191, in create_key_pair
  File "/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py", line 181, in find_key_pair
IndexError: list index out of range

fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/user/.ansible/tmp/ansible-tmp-1566293632.1787608-45601675593607/AnsiballZ_ec2_key.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.6/imp.py\", line 235, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.6/imp.py\", line 170, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 618, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py\", line 277, in <module>\n  File \"/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py\", line 273, in main\n  File \"/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py\", line 191, in create_key_pair\n  File \"/tmp/ansible_ec2_key_payload_g82c75ow/__main__.py\", line 181, in find_key_pair\nIndexError: list index out of range\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   



with a breakpoint 
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "",
    "module_stdout": "{'KeyPairs': [], 'ResponseMetadata': {'RequestId': 'af8d02da-855f-43d5-9521-4192a37dda6a', 'HTTPStatusCode': 200, 'HTTPHeaders': {'server': 'nginx', 'date': 'Tue, 20 Aug 2019 09:34:17 GMT', 'content-type': 'text/xml', 'transfer-encoding': 'chunked', 'connection': 'close'}, 'RetryAttempts': 0}}\n",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 0
}


anfter fix

TASK [ec2_key] *********************************************************************************************************************************************************************************************
task path: /home/user/Documents/ansible_tests/croc/test.yml:3
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: user
<127.0.0.1> EXEC /bin/sh -c 'echo ~user && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502 `" && echo ansible-tmp-1566293908.6296523-226074249381502="` echo /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502 `" ) && sleep 0'
Using module file /home/user/.local/lib/python3.6/site-packages/ansible/modules/cloud/amazon/ec2_key.py
<127.0.0.1> PUT /home/user/.ansible/tmp/ansible-local-32412l5m0h6a5/tmp6knlhn03 TO /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502/AnsiballZ_ec2_key.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502/ /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502/AnsiballZ_ec2_key.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502/AnsiballZ_ec2_key.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/user/.ansible/tmp/ansible-tmp-1566293908.6296523-226074249381502/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "debug_botocore_endpoint_logs": false,
            "ec2_url": null,
            "force": true,
            "key_material": null,
            "name": "test",
            "profile": null,
            "region": "bla-bla",
            "security_token": null,
            "state": "present",
            "validate_certs": true,
            "wait": false,
            "wait_timeout": 300
        }
    },
    "key": {
        "fingerprint": "someid",
        "name": "test",
        "private_key": "somedata"
    },
    "msg": "key pair created"
}

TASK [debug] ***********************************************************************************************************************************************************************************************
task path: /home/user/Documents/ansible_tests/croc/test.yml:7
ok: [localhost] => {
    "ec2": {
        "changed": true,
        "failed": false,
        "key": {
            "fingerprint": "someid",
            "name": "test",
            "private_key": "somedata"
        },
        "msg": "key pair created"
    }




```
