### PR TITLE
Add adminEnabled flag to gcp_compute_interconnect_attachment

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment.py
@@ -126,6 +126,8 @@ options:
     description:
     - Whether the VLAN attachment is enabled or disabled.  When using PARTNER type
       this will Pre-Activate the interconnect attachment.
+    required: false
+    type: bool
 extends_documentation_fragment: gcp
 '''
 
@@ -268,6 +270,8 @@ vlanTag8021q:
 adminEnabled:
   description:
   - Whether the VLAN attachment is enabled or disabled.
+  returned: success
+  type: bool
 region:
   description:
   - Region where the regional interconnect attachment resides.

--- a/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment.py
@@ -122,6 +122,10 @@ options:
     - Region where the regional interconnect attachment resides.
     required: true
     type: str
+  admin_enabled:
+    description:
+    - Whether the VLAN attachment is enabled or disabled.  When using PARTNER type
+      this will Pre-Activate the interconnect attachment.
 extends_documentation_fragment: gcp
 '''
 
@@ -261,6 +265,9 @@ vlanTag8021q:
     PARTNER type this will be managed upstream.
   returned: success
   type: int
+adminEnabled:
+  description:
+  - Whether the VLAN attachment is enabled or disabled.
 region:
   description:
   - Region where the regional interconnect attachment resides.
@@ -297,6 +304,7 @@ def main():
             candidate_subnets=dict(type='list', elements='str'),
             vlan_tag8021q=dict(type='int'),
             region=dict(required=True, type='str'),
+            admin_enabled=dict(type='bool', default=False)
         )
     )
 
@@ -357,6 +365,7 @@ def resource_to_request(module):
         u'name': module.params.get('name'),
         u'candidateSubnets': module.params.get('candidate_subnets'),
         u'vlanTag8021q': module.params.get('vlan_tag8021q'),
+        u'adminEnabled': module.params.get('admin_enabled'),
     }
     return_vals = {}
     for k, v in request.items():
@@ -439,6 +448,7 @@ def response_to_hash(module, response):
         u'name': response.get(u'name'),
         u'candidateSubnets': response.get(u'candidateSubnets'),
         u'vlanTag8021q': response.get(u'vlanTag8021q'),
+        u'adminEnabled': response.get(u'adminEnabled')
     }
 
 


### PR DESCRIPTION
##### SUMMARY
Google Cloud interconnect attachments have an `adminEnabled` flag that can be set on creating/updating an Interconnect Attachment.  For `PARTNER` type interconnect attachments, this allows you "Pre-Activate" the interconnect attachment which saves the user from having to navigate to the Google Cloud UI and doing the same thing (or using the gcloud CLI).

By default, Google assumes the value is `false`, and in the sake of backwards compatibility, this module parameter is also defaulted to `false`.

Documentation for `adminEnabled` can be found here:
https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments
https://cloud.google.com/interconnect/docs/how-to/partner/activating-connections

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/modules/cloud/google/gcp_compute_interconnect_attachment.py

##### ADDITIONAL INFORMATION
