### PR TITLE
systemd module will now wait on deactivating state (#59471)

### DIFF
--- a/changelogs/fragments/59471-systemd-wait-while-deactivating.yaml
+++ b/changelogs/fragments/59471-systemd-wait-while-deactivating.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - systemd - wait for a service which is in deactivating state when using ``state=stopped`` (https://github.com/ansible/ansible/pull/59471)

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -269,7 +269,11 @@ from ansible.module_utils._text import to_native
 
 
 def is_running_service(service_status):
-    return service_status['ActiveState'] in set(['active', 'activating'])
+    return service_status['ActiveState'] in set(['active', 'activating', 'deactivating'])
+
+
+def is_deactivating_service(service_status):
+    return service_status['ActiveState'] in set(['deactivating'])
 
 
 def request_was_ignored(out):
@@ -492,7 +496,7 @@ def main():
                     if not is_running_service(result['status']):
                         action = 'start'
                 elif module.params['state'] == 'stopped':
-                    if is_running_service(result['status']):
+                    if is_running_service(result['status']) or is_deactivating_service(result['status']):
                         action = 'stop'
                 else:
                     if not is_running_service(result['status']):

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -269,7 +269,7 @@ from ansible.module_utils._text import to_native
 
 
 def is_running_service(service_status):
-    return service_status['ActiveState'] in set(['active', 'activating', 'deactivating'])
+    return service_status['ActiveState'] in set(['active', 'activating'])
 
 
 def is_deactivating_service(service_status):


### PR DESCRIPTION
If a service is in the 'deactivating' state running systemctl stop foo,
would wait for the foo service to actually stop before it exits. The
module didn't behave like that and it considered the deactivating state
as if the service wasn't running. This change will align the module with
the systemctl behaviour.

(cherry picked from commit 54d9d7805dc0a905fb9b2ad11746cfdc7ac03a53)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemd