### PR TITLE
ansible-inventory : add an "unmerge" feature to view all variables and overwrites

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -83,6 +83,8 @@ class InventoryCLI(CLI):
         # host
         self.parser.add_argument("--unmerge", action="store_true", default=False,
                                  help='Show all vars before merging, ignored unless used with --host')
+        self.parser.add_argument("--filter", action="store",
+                                 help='Show only vars whose path contains FILTER, ignored unless used with --unmerge')
 
         # graph
         self.parser.add_argument("-y", "--yaml", action="store_true", default=False, dest='yaml',
@@ -301,13 +303,14 @@ class InventoryCLI(CLI):
 
         result = []
         for key, values in sorted(unmerged_vars.items()):
-            if len(values)==1:  # There was no override, just display "[source] path.to.variable : value"
-                result.append('[{}] {} : {}'.format(InventoryCLI._colorize_entity(values[0][0], host, max_width), key, values[0][1]))
-            else:  # There was several candidates, display the winning one first, and all others in order (starting with the winning one) along with their source
-                result.append('[{}] {} : {}'.format('-' * max_width, key, values[0][1]))
-                local_max_width = len(str(max(values, key=lambda v: len(str(v[0])))[0]))  # Longer of all candidates' sources, for alignment
-                for entity, value in values:
-                    result.append('    [{}] : {}'.format(InventoryCLI._colorize_entity(entity, host, max_width), value))
+            if context.CLIARGS['filter'] is None or context.CLIARGS['filter'] in key:  # Apply filter if provided
+                if len(values)==1:  # There was no override, just display "[source] path.to.variable : value"
+                    result.append('[{}] {} : {}'.format(InventoryCLI._colorize_entity(values[0][0], host, max_width), key, values[0][1]))
+                else:  # There was several candidates, display the winning one first, and all others in order (starting with the winning one) along with their source
+                    result.append('[{}] {} : {}'.format('-' * max_width, key, values[0][1]))
+                    local_max_width = len(str(max(values, key=lambda v: len(str(v[0])))[0]))  # Longer of all candidates' sources, for alignment
+                    for entity, value in values:
+                        result.append('    [{}] : {}'.format(InventoryCLI._colorize_entity(entity, host, max_width), value))
         return '\n'.join(result)
 
     @staticmethod

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -141,7 +141,7 @@ class InventoryCLI(CLI):
             hosts = self.inventory.get_hosts(context.CLIARGS['host'])
             if len(hosts) != 1:
                 raise AnsibleOptionsError("You must pass a single valid host to --host parameter")
-            
+
             if context.CLIARGS['unmerge']:
                 myvars = self._get_host_variables_unmerged(host=hosts[0])
 
@@ -282,7 +282,8 @@ class InventoryCLI(CLI):
     @staticmethod
     def _combine_vars_unmerged(results, hash_to_integrate, group, path):
         ''' Recursive function that browses a recursive dict ('hash_to_integrate') to update the 'results' dict.
-            For each leaf encountered (i.e. anything that is not another dict) it creates an entry in 'results' with the path (in a dotted format) as key and a list as value.
+            For each leaf encountered (i.e. anything that is not another dict) it creates an entry in 'results' with the path (in a dotted format) as key and
+            a list as value.
             This list contain the leaf's value, along with the "source" (group name most of the time, or host name) of 'hash_to_integrate'.
             If the key already exists, the list is simply prepended. The first item of said list is considered to be the "winning" value.
         '''
@@ -291,8 +292,8 @@ class InventoryCLI(CLI):
             new_path = path + [key]
             flattened_path = '.'.join(new_path)
             if isinstance(value, MutableMapping):  # We are not at a leaf
-                if flattened_path in results: del results[flattened_path]  # If there was a leaf here previously, delete it as it would have been overwritten by combine_vars
-                                                                           # We should maybe find a way to display that...
+                if flattened_path in results:
+                    del results[flattened_path]  # If there was a leaf here previously, delete it as it would have been overwritten by combine_vars.
                 InventoryCLI._combine_vars_unmerged(results, value, group, new_path)  # We need to go deeper !
             else:
                 if flattened_path in results:
@@ -312,33 +313,35 @@ class InventoryCLI(CLI):
                 elif isinstance(source, Group):
                     source_entities.add(source)  # set.add() only adds if item is not present already
         source_entities = sort_groups(source_entities)  # This is now a list of groups with the less specific ('all' for instance) first
-        if host is not None: source_entities.append(host)
+        if host is not None:
+            source_entities.append(host)
         source_entities.reverse()  # We're done, we have a list of all place where we found variables, from more specific to less specific
 
-        max_width = len(str(max(source_entities, key=lambda v: len(str(v)))))  # The maximum string length of all group names (and the hostname), for display purposes
+        max_width = len(str(max(source_entities, key=lambda v: len(str(v)))))  # The max string length of all group and host names, for display purposes
 
         result = []
         for key, values in sorted(unmerged_vars.items()):
             if context.CLIARGS['filter'] is None or context.CLIARGS['filter'] in key:  # Apply filter if provided
-                if len(values)==1:  # There was no override, just display "[source] path.to.variable : value"
-                    prefix = '[{}] {} : '.format(InventoryCLI._colorize_entity(values[0][0], source_entities, max_width), key)
-                    prefix_nocolor = '[{}] {} : '.format(InventoryCLI._colorize_entity(values[0][0], source_entities, max_width, force_nocolor=True), key)
+                if len(values) == 1:  # There was no override, just display "[source] path.to.variable : value"
+                    prefix = '[{0}] {1} : '.format(InventoryCLI._colorize_entity(values[0][0], source_entities, max_width), key)
+                    prefix_nocolor = '[{0}] {1} : '.format(InventoryCLI._colorize_entity(values[0][0], source_entities, max_width, force_nocolor=True), key)
                     value_pretty = pformat(values[0][1]).split('\n')
 
-                    # Add the prefix to the first line. If the value is complex, pprint.pformat() will output multiple lines : in that case, indent the remaining ones.
+                    # Add the prefix to the first line. If the value is complex, pprint.pformat() will output multiple lines : indent the remaining ones.
                     result.extend([prefix + line if index == 0 else " " * len(prefix_nocolor) + line for index, line in enumerate(value_pretty)])
 
-                else:  # There was several candidates, display the winning one first, and then all of them in order (starting with the winning one) along with their source
-                    prefix = '[{}] {} : '.format('+' * max_width, key)
+                else:  # There was several candidates, display the winning one first, and then all of them in order (starting with the winning one), with source
+                    prefix = '[{0}] {1} : '.format('+' * max_width, key)
                     value_pretty = pformat(values[0][1]).split('\n')
 
-                    # Add the prefix to the first line. If the value is complex, pprint.pformat() will output multiple lines : in that case, indent the remaining ones.
+                    # Add the prefix to the first line. If the value is complex, pprint.pformat() will output multiple lines : indent the remaining ones.
                     result.extend([prefix + line if index == 0 else " " * len(prefix) + line for index, line in enumerate(value_pretty)])
 
                     local_max_width = len(str(max(values, key=lambda v: len(str(v[0])))[0]))  # Longer of all candidates' sources, for alignment
                     for entity, value in values:
-                        prefix = '{}|{} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width))
-                        prefix_nocolor = '{}|{} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width, force_nocolor=True))
+                        prefix = '{0}|{1} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width))
+                        prefix_nocolor = '{0}|{1} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width,
+                                                                                                                  force_nocolor=True))
                         value_pretty = pformat(value).split('\n')
 
                         result.extend([prefix + line if index == 0 else " " * len(prefix_nocolor) + line for index, line in enumerate(value_pretty)])

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -257,13 +257,15 @@ class InventoryCLI(CLI):
         return self._remove_internal(hostvars)
 
     def _get_host_variables_unmerged(self, host):
-        ''' Build a dict of all variables where :
+        ''' Build a dict of all host and group variables where :
             - keys are the "flattened paths" of the variables (similar to the dotted format used in jinja templates)
             - values are lists of 2 elements tuples where :
-                - first element of the tuple is the "source" (group name or host name)
-                - second element of the tuple is the candidate value
+                - first element of the tuple is the "source" (group or host object) where the variable value was found
+                - second element of the tuple is the value we found
                 - first item of the list is the one that would "win" the merging process
-            "Unmerged" because, contrary to 'combine_vars()', we keep values that would be overwritten.
+            "Unmerged" because, contrary to 'combine_vars()', we keep values that would have been overwritten.
+            The result is something like this :
+            {'path.to.variable': [(Host, 123), (Group1, 456), (Group2, 789)]}
         '''
 
         results = {}

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -337,8 +337,8 @@ class InventoryCLI(CLI):
 
                     local_max_width = len(str(max(values, key=lambda v: len(str(v[0])))[0]))  # Longer of all candidates' sources, for alignment
                     for entity, value in values:
-                        prefix = '----[{}] : '.format(InventoryCLI._colorize_entity(entity, source_entities, local_max_width))
-                        prefix_nocolor = '----[{}] : '.format(InventoryCLI._colorize_entity(entity, source_entities, local_max_width, force_nocolor=True))
+                        prefix = '{}|{} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width))
+                        prefix_nocolor = '{}|{} : '.format('-' * (max_width + 3), InventoryCLI._colorize_entity(entity, source_entities, local_max_width, force_nocolor=True))
                         value_pretty = pformat(value).split('\n')
 
                         result.extend([prefix + line if index == 0 else " " * len(prefix_nocolor) + line for index, line in enumerate(value_pretty)])

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -299,14 +299,16 @@ class InventoryCLI(CLI):
     def _format_unmerged_variables(unmerged_vars, max_width):
         ''' Display the unmerged vars in a human readable way '''
 
+        result = []
         for key, values in sorted(unmerged_vars.items()):
             if len(values)==1:  # There was no override, just display "[source] path.to.variable : value"
-                print('[{0:>{x}}] {1} : {2}'.format(str(values[0][0]), key, values[0][1], x=max_width))
+                result.append('[{0:>{x}}] {1} : {2}'.format(str(values[0][0]), key, values[0][1], x=max_width))
             else:  # There was several candidates, display the winning one first, and all others in order (starting with the winning one) along with their source
-                print('[{0:>{x}}] {1} : {2}'.format('-', key, values[0][1], x=max_width))
+                result.append('[{0:>{x}}] {1} : {2}'.format('-', key, values[0][1], x=max_width))
                 local_max_width = len(str(max(values, key=lambda v: len(str(v[0])))[0]))  # Longer of all candidates' sources, for alignment
                 for priority, value in values:
-                    print('    [{0:>{x}}] : {1}'.format(str(priority), value, x=local_max_width))
+                    result.append('    [{0:>{x}}] : {1}'.format(str(priority), value, x=local_max_width))
+        return '\n'.join(result)
 
     def _get_group(self, gname):
         group = self.inventory.groups.get(gname)

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -289,7 +289,7 @@ class InventoryCLI(CLI):
         '''
 
         for key, value in hash_to_integrate.items():
-            new_path = path + [key]
+            new_path = path + [str(key)]
             flattened_path = '.'.join(new_path)
             if isinstance(value, MutableMapping):  # We are not at a leaf
                 if flattened_path in results:


### PR DESCRIPTION
##### SUMMARY

I added a feature to `ansible-inventory --host` called "unmerge" where one can see all inventory variables, where they come from (host var, group var and if so which group), and most importantly if there was any overwrite (and which value overwrote which other value).

See https://asciinema.org/a/263397 for a quick overview.

It is inspired from https://github.com/Gandi/hieracles/ (for puppet) which I miss when I use Ansible.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ansible-inventory

##### ADDITIONAL INFORMATION
End result looks like this (with some color) :
```paste below
$ ansible-inventory -i hosts --host webserver-1.example.com --unmerge
[                    all] dns.resolvers : ['192.168.1.1', '192.168.2.1']
[                    all] dns.search : 'example.com'
[webserver-1.example.com] interfaces.eth0.address : '10.0.0.1'
[                servers] interfaces.eth0.gateway : '10.0.0.254'
[+++++++++++++++++++++++] interfaces.eth0.mtu : 1500
--------------------------|webservers : 1500
--------------------------|   servers : 9000
[                servers] interfaces.eth0.netmask : 24
[                servers] interfaces.eth0.subnet : '10.0.0.0'
[                    all] users : [{'hash': '9a266fc8b42966fb624d852bafa241d8fd05b47d36153ff6684ab344bd1ae57bba96a7de8fc12ec0bb016583735d7f5bca6dd7d9bc6482ijustneedsomethinglongc2a3ac6bf6f9thisisnotrealec323f',
                                    'home': '/home/admin',
                                    'shell': 'bash',
                                    'sudoer': True,
                                    'username': 'admin'},
                                   {'hash': 'ee4cb392d97fa38585a433563b8f97a063bb3ec466fcdb1d19e24f73f8de71e3eb5b2526d0d546a94e258cc3c3425e6def6d4f73f8de7a0cd3c5057023c117f5ofcourse5c55ethisisnotarealhash3b55',
                                    'home': '/home/user',
                                    'shell': 'zsh',
                                    'sudoer': False,
                                    'username': 'user'}]

```
