### PR TITLE
[2.8] Warn when transforming constructed groups (#60912)

### DIFF
--- a/changelogs/fragments/60912-constructed-groups-option-sanitization.yaml
+++ b/changelogs/fragments/60912-constructed-groups-option-sanitization.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - constructed - Add a warning for the change in behavior in the sanitization of the groups option.

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -372,7 +372,7 @@ class Constructable(object):
             self.templar.set_available_variables(variables)
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = self._sanitize_group_name(group_name)
+                group_name = original_safe(group_name, force=True)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:


### PR DESCRIPTION
##### SUMMARY

Backport of #60912

* Warn when transforming constructed groups

The `keyed_groups` field has used sanitization since 2.6, but `groups` only started doing so in 2.8.
This adds a warning for the change in behavior.

* changelog

(cherry picked from commit 3247626ac7a3e22739e4e343ebf5919b33784c8e)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
constructed
