### PR TITLE
bfd_global: minor test-only fix

### DIFF
--- a/test/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
@@ -85,6 +85,16 @@
     state: disabled
   ignore_errors: yes
 
+- name: feature bfd init
+  # 'feature bfd' init is slow on some platforms, retry on fail
+  nxos_bfd_global:
+    echo_interface:        "{{ nd_echo }}"
+  delay: 3
+  retries: 1
+  register: result
+  until: result is not failed
+  ignore_errors: yes
+
 - block:
   - name: BFD non defaults
     nxos_bfd_global: &bfd_non_def


### PR DESCRIPTION
##### SUMMARY
This is a sanity test fix only.

`bfd_global` will automatically enable the `bfd` feature if it's currently disabled. Some platforms (e.g. N7K) have a slower startup for `feature bfd` so this change just adds a delay/retry to the setup section of the sanity test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos`, `nxos_bfd_global`

##### ADDITIONAL INFORMATION
