### PR TITLE
Meraki - Update host parameter notes to include China.

### DIFF
--- a/lib/ansible/plugins/doc_fragments/meraki.py
+++ b/lib/ansible/plugins/doc_fragments/meraki.py
@@ -21,7 +21,7 @@ options:
     host:
         description:
         - Hostname for Meraki dashboard.
-        - Only useful for internal Meraki developers.
+        - Can be used to access regional Meraki environments, such as China.
         type: str
         default: api.meraki.com
     use_proxy:


### PR DESCRIPTION
##### SUMMARY
Meraki has multiple environments, some of which are used in regions, such as China. I updated documentation for the `host` parameter to mention this fact.

Fixes #60750

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meraki
