### PR TITLE
New module: aix_chsec

### DIFF
--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -43,8 +43,9 @@ attrs:
      aliases: [ options ]
   state:
      description:
-     - If set to C(absent) the whole stanza incl. all given attrs will be removed.
-     - If set to C(present) stanza incl.attrs will be added.
+     - If set to C(present) all given attrs values will be set.
+     - If set to C(absent) all attrs provided will be un-set, regardless of value provided.
+       - NB: This does not remove the entire stanza, only the provided attrs will be removed.
      - To remove an attribute from the stanza set to C(present) and set key to an empty value (key=).
      - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
      type: str
@@ -53,9 +54,13 @@ attrs:
 seealso:
 - name: The chsec manual page from the IBM Knowledge Center
   description: Changes the attributes in the security stanza files.
-  link: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds1/chsec.htm
+  link: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/c_commands/chsec.html
+- name: The lssec manual page from the IBM Knowledge Center
+  description: Lists attributes in the security stanza files.
+  link: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/l_commands/lssec.html
 author:
 - Christian Tremel (@flynn1973)
+- David Little (@d-little)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -72,7 +72,6 @@ EXAMPLES = r'''
       SYSTEM: LDAP
       registry: LDAP
     state: present
-    mode: '0644'
 
 - name: Change login times for user
   aix_chsec:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -27,7 +27,7 @@ description:
 attrs:
   path:
     description:
-    - Path to the stanza file.
+      - Path to the stanza file.
     type: path
     required: true
     aliases: [ dest ]
@@ -37,20 +37,20 @@ attrs:
     type: str
     required: true
   attrs:
-     description:
+    description:
     - A list of key/value pairs
-     type: list
-     aliases: [ options ]
+    type: list
+    aliases: [ options ]
   state:
-     description:
-     - If set to C(present) all given attrs values will be set.
-     - If set to C(absent) all attrs provided will be un-set, regardless of value provided.
-       - NB: This does not remove the entire stanza, only the provided attrs will be removed.
-     - To remove an attribute from the stanza set to C(present) and set key to an empty value (key=).
-     - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
-     type: str
-     choices: [ absent, present ]
-     default: present
+    description:
+    - If set to C(present) all given attrs values will be set.
+    - If set to C(absent) all attrs provided will be un-set, regardless of value provided.
+    - NB: This does not remove the entire stanza, only the provided attrs will be removed.
+    - To remove an attribute from the stanza set to C(present) and set key to an empty value (key=).
+    - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
+    type: str
+    choices: [ absent, present ]
+    default: present
 seealso:
 - name: The chsec manual page from the IBM Knowledge Center
   description: Changes the attributes in the security stanza files.
@@ -107,13 +107,13 @@ def attrs2dict(attrs):
         { 'SYSTEM': 'LDAP', 'registry': 'LDAP' }
     """
     return_dict = {}
-    if type(attrs) == str:
+    if isinstance(attrs, str):
         # Assume we have this:
         #   "SYSTEM=LDAP,registry=LDAP"
         # Split it into a list of strings, like this:
         #   [ "SYSTEM=LDAP", "registry=LDAP" ]
         attrs = [x.strip() for x in attrs.split(',')]
-    if type(attrs) == list:
+    if isinstance(attrs, list):
         # Assume it's a list of key=values, so
         #   [ "SYSTEM=LDAP", "registry=LDAP" ]
         # Take each attr and split it into a key:value dict and update return_dict
@@ -121,7 +121,7 @@ def attrs2dict(attrs):
         for element in attrs:
             k, v = element.split('=')
             return_dict.update({k: v})
-    if type(attrs) == dict:
+    if isinstance(attrs, dict):
         return_dict.update(attrs)
     return return_dict
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -24,7 +24,7 @@ short_description: Modify AIX stanza files
 version_added: '2.8'
 description:
 - Modify stanzas to AIX config files using the C(chsec) command.
-options:
+attrs:
   path:
     description:
     - Path to the stanza file.
@@ -36,15 +36,15 @@ options:
     - Name of stanza.
     type: str
     required: true
-  options:
+  attrs:
      description:
-     - A list of key/value pairs, e.g. C(key=val,key=val).
+     - A list of key/value pairs, e.g. C(key: val,key: val).
      type: list
   state:
      description:
-     - If set to C(absent) the whole stanza incl. all given options will be removed.
-     - If set to C(present) stanza incl.options will be added.
-     - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
+     - If set to C(absent) the whole stanza incl. all given attrs will be removed.
+     - If set to C(present) stanza incl.attrs will be added.
+     - To remove an attribute from the stanza set to C(present) and set key to an empty value (key=).
      - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
      type: str
      choices: [ absent, present ]
@@ -166,7 +166,7 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['dest']),
             stanza=dict(type='str', required=True),
-            options=dict(type='list', required=True),
+            attrs=dict(type='raw', required=True),
             state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=False,

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -4,6 +4,10 @@
 # Copyright: (c) 2018, Christian Tremel (@flynn1973)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+# AIX 7.1: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_71/c_commands/chsec.html
+# AIX 7.2: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/c_commands/chsec.html
+# AIX 6.1 PDF: https://public.dhe.ibm.com/systems/power/docs/aix/61/aixcmds1_pdf.pdf
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -73,7 +73,7 @@ EXAMPLES = r'''
     path: /etc/security/user
     stanza: ldapuser
     attrs: 
-      logintimes: 0800-1700
+      logintimes: :0800-1700
     state: present
 
 - name: Remove registry attribute from stanza

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -23,7 +23,7 @@ module: aix_chsec
 short_description: Modify AIX stanza files
 version_added: '2.8'
 description:
-- Modify stanzas to AIX config files using the C(chsec) command.
+- Modify stanza attributes to AIX config files using the C(chsec) command.
 attrs:
   path:
     description:
@@ -40,6 +40,7 @@ attrs:
      description:
      - A list of key/value pairs, e.g. C(key: val,key: val).
      type: list
+     aliases: [ options ]
   state:
      description:
      - If set to C(absent) the whole stanza incl. all given attrs will be removed.
@@ -166,7 +167,7 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['dest']),
             stanza=dict(type='str', required=True),
-            attrs=dict(type='raw', required=True),
+            attrs=dict(type='raw', required=True, aliases=['options']),
             state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=False,

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -150,7 +150,7 @@ def get_current_attr_value(module, filename, stanza, attr):
     return lssec_out
 
 
-def do_stanza(module, filename, stanza, attrs, state='present'):
+def do_stanza(module, filename, stanza, attrs, state):
     ''' Returns (bool(changed), dict(msg)) '''
     attrs = attrs2dict(attrs)
     return_msg = {}

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -62,7 +62,9 @@ EXAMPLES = r'''
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
-    options: SYSTEM=LDAP,registry=LDAP
+    attrs:
+      SYSTEM: LDAP
+      registry: LDAP
     state: present
     mode: '0644'
 
@@ -70,16 +72,17 @@ EXAMPLES = r'''
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
-    options: logintimes=:0800-1700
+    attrs: 
+      logintimes: 0800-1700
     state: present
 
-- name: Remove registry option from stanza
+- name: Remove registry attribute from stanza
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
-    options:
-    - SYSTEM=LDAP
-    - registry=
+    attrs:
+      SYSTEM: LDAP
+      registry: null
     state: present
 '''
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -145,7 +145,7 @@ def get_current_attr_value(module, filename, stanza, attr):
         module.fail_json(msg=msg, rc=rc, stdout=stdout, stderr=stderr)
     # Strip off whitespace and double-quotation marks that are sometimes added
     lssec_out = stdout.splitlines()[1].split(':')[1].strip('\\\"\n ')
-    return lssec_out
+    return str(lssec_out)
 
 
 def do_stanza(module, filename, stanza, attrs, state):
@@ -155,6 +155,7 @@ def do_stanza(module, filename, stanza, attrs, state):
     changed = 0
 
     for attr, tgt_value in attrs.items():
+        tgt_value = str(tgt_value)  # tgt_value needs to be a string for comparisons later
         if state == 'absent':
             # 'absent' sets all of the given attrs to None, regardless of given value
             tgt_value = ''

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -38,7 +38,7 @@ attrs:
     required: true
   attrs:
      description:
-     - A list of key/value pairs, e.g. C(key: val,key: val).
+    - A list of key/value pairs
      type: list
      aliases: [ options ]
   state:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -172,18 +172,18 @@ def main():
         supports_check_mode=False,
     )
 
-    path = module.params['path']
-    stanza = module.params['stanza']
-    options = module.params['options']
-    state = module.params['state']
-
     result = dict(
         changed=False,
+        msg={},
     )
 
-    result['changed'], result['msg'] = do_stanza(module, path, stanza, options, state)
+    path = module.params['path']
+    stanza = module.params['stanza']
+    attrs = module.params['attrs']
+    state = module.params['state']
 
-    # Mission complete
+    result['changed'], result['msg'] = do_stanza(module, path, stanza, attrs, state)
+
     module.exit_json(**result)
 
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -91,11 +91,7 @@ EXAMPLES = r'''
     state: present
 '''
 
-RETURN = r'''
-tbd:
-    fill: this
-    out: please.
-'''
+RETURN = r''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -161,29 +157,29 @@ def do_stanza(module, filename, stanza, attrs, state='present'):
     changed = 0
 
     for attr, tgt_value in attrs.items():
-    if state == 'absent':
+        if state == 'absent':
             # 'absent' sets all of the given attrs to None, regardless of given value
             tgt_value = ''
-            # Start our msg dict for this key+value
-            msg = {
+        # Start our msg dict for this key+value
+        msg = {
             'desired_value': tgt_value,
-                'status': 'unchanged',
-            }
+            'status': 'unchanged',
+        }
         curr_value = get_current_attr_value(module, filename, stanza, attr)
-            msg.update({
+        msg.update({
             'existing_value': curr_value,
-            })
+        })
         if curr_value != tgt_value:
-                # Change the value of the attr
-                if module.check_mode:
-                    msg.update({"check_mode": True})
-                else:
+            # Change the value of the attr
+            if module.check_mode:
+                msg.update({"check_mode": True})
+            else:
                 set_attr_value(module, filename, stanza, attr, tgt_value)
-                msg.update({
+            msg.update({
                 # 'outgoing_value': tgt_value,
-                    'status': 'changed',
-                })
-                changed += 1
+                'status': 'changed',
+            })
+            changed += 1
         return_msg[attr] = msg
     return (bool(changed), return_msg)
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -39,13 +39,13 @@ options:
   attrs:
     description:
     - A list of key/value pairs
-    type: list
+    type: raw
     aliases: [ options ]
   state:
     description:
     - If set to C(present) all given attrs values will be set.
     - If set to C(absent) all attrs provided will be un-set, regardless of value provided.
-    - NB: This does not remove the entire stanza, only the provided attrs will be removed.
+    - NB, this does not remove the entire stanza, only the provided attrs will be removed.
     - To remove a single attribute from the stanza set to C(present) and set key to an empty value (key=).
     - All rules, allowed file-stanza combos, and allowed files for the AIX C(chsec) command apply here.
     type: str

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -21,10 +21,10 @@ DOCUMENTATION = r'''
 ---
 module: aix_chsec
 short_description: Modify AIX stanza files
-version_added: '2.8'
+version_added: '2.9'
 description:
 - Modify stanza attributes to AIX config files using the C(chsec) command.
-attrs:
+options:
   path:
     description:
       - Path to the stanza file.
@@ -46,8 +46,8 @@ attrs:
     - If set to C(present) all given attrs values will be set.
     - If set to C(absent) all attrs provided will be un-set, regardless of value provided.
     - NB: This does not remove the entire stanza, only the provided attrs will be removed.
-    - To remove an attribute from the stanza set to C(present) and set key to an empty value (key=).
-    - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
+    - To remove a single attribute from the stanza set to C(present) and set key to an empty value (key=).
+    - All rules, allowed file-stanza combos, and allowed files for the AIX C(chsec) command apply here.
     type: str
     choices: [ absent, present ]
     default: present

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -143,8 +143,8 @@ def get_current_attr_value(module, filename, stanza, attr):
     if rc != 0:
         msg = 'Failed to run lssec command: ' + ' '.join(cmd)
         module.fail_json(msg=msg, rc=rc, stdout=stdout, stderr=stderr)
-    # Strip off whitespace and double-quotation marks that are sometimes added
-    lssec_out = stdout.splitlines()[1].split(':')[1].strip('\\\"\n ')
+    # Strip newline and double-quotation marks that are sometimes added
+    lssec_out = stdout.splitlines()[1].split(':', 1)[1].strip('\\\"\n')
     return str(lssec_out)
 
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -21,7 +21,7 @@ DOCUMENTATION = r'''
 ---
 module: aix_chsec
 short_description: Modify AIX stanza files
-version_added: '2.9'
+version_added: '2.10'
 description:
 - Modify stanza attributes to AIX config files using the C(chsec) command.
 options:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: aix_chsec
+
+short_description: modify aix stanza files
+
+version_added: "0.1"
+
+description:
+    - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"
+
+options:
+    path:
+        description:
+            - Path to the stanza file
+        required: true
+    stanza:
+        description:
+            - name of stanza
+        required: true
+    options:
+         description:
+             - comman separated key/value pairs eg. key=val,key=val
+    state:
+         description:
+            - If set to C(absent) the whole stanza incl. all given options will be removed.
+            - If set to C(present) stanza incl.options will be added.
+            - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
+            - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
+         choices: [ absent, present ]
+         default: present
+
+extends_documentation_fragment:
+    - files
+
+author:
+    - Christian Tremel (@flynn1973)
+'''
+
+EXAMPLES = '''
+- name: add ldap user stanza
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: SYSTEM=LDAP,registry=LDAP
+    state: present
+    mode: 0644
+
+- name: change login times for user
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: logintimes=:0800-1700
+    state: present
+
+- name: remove registry option from stanza 
+  aix_chsec:
+    path: /etc/security/user
+    stanza: ldapuser
+    options: SYSTEM=LDAP,registry=
+    state: present
+'''
+
+
+from ansible.module_utils.basic import *
+
+
+
+def do_stanza(module, filename, stanza, options, state='present'):
+
+    chsec_command = module.get_bin_path('chsec', True)
+
+    def arguments_generator(options):
+        for element in options:
+                yield '-a'
+                yield element
+
+    command = [chsec_command, '-f', filename, '-s', '%s' % stanza]
+    options = list(arguments_generator(options))
+
+    if state == 'present':
+        command += options
+        rc, package_result, err = module.run_command(command)
+        if rc != 0:
+            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, err=err)
+        else:
+            msg='stanza added'
+            changed=True
+    elif state == 'absent':
+        # remove values from keys to enable chsec delete mode 
+        command += [s[:1+s.find('=')] or s for s in options]
+        rc, package_result, err = module.run_command(command)
+        if rc != 0:
+             module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, err=err)
+        else:
+             msg='stanza removed'
+             changed=True
+
+    return (changed, msg)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            path=dict(type='path', required=True, aliases=['dest']),
+            stanza=dict(type='str', required=True),
+            options=dict(type='list', required=True),
+            state=dict(type='str', default='present', choices=['absent', 'present'])
+        ),
+        supports_check_mode=False,
+    )
+
+    path = module.params['path']
+    stanza = module.params['stanza']
+    options = module.params['options']
+    state = module.params['state']
+
+    (changed, msg) = do_stanza(module, path, stanza, options, state)
+
+
+    results = dict(
+        changed=changed,
+        msg=msg,
+        path=path
+    )
+
+    # Mission complete
+    module.exit_json(**results)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -30,7 +30,7 @@ options:
         required: true
     stanza:
         description:
-            - name of stanza
+            - Name of stanza.
         required: true
     options:
          description:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -59,7 +59,7 @@ EXAMPLES = '''
     stanza: ldapuser
     options: SYSTEM=LDAP,registry=LDAP
     state: present
-    mode: 0644
+    mode: '0644'
 
 - name: Change login times for user
   aix_chsec:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -20,7 +20,9 @@ short_description: Modify AIX stanza files
 version_added: '2.8'
 
 description:
-    - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"
+    - Modify stanzas to AIX config files using the chsec command.
+notes:
+    - See `man chsec` for additional information.
 
 options:
     path:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -52,7 +52,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: add ldap user stanza
+- name: Add an LDAP user stanza
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -25,7 +25,8 @@ description:
 options:
     path:
         description:
-            - Path to the stanza file
+            - Path to the stanza file.
+        type: path
         required: true
     stanza:
         description:

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2018, Christian Tremel (@flynn1973)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -11,49 +13,47 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: aix_chsec
-
 short_description: Modify AIX stanza files
-
 version_added: '2.8'
-
 description:
-    - Modify stanzas to AIX config files using the chsec command.
-notes:
-    - See `man chsec` for additional information.
-
+- Modify stanzas to AIX config files using the C(chsec) command.
 options:
-    path:
-        description:
-            - Path to the stanza file.
-        type: path
-        required: true
-    stanza:
-        description:
-            - Name of stanza.
-        required: true
-    options:
-         description:
-             - A list of key/value pairs, e.g. `key=val,key=val`
-         type: list
-    state:
-         description:
-            - If set to C(absent) the whole stanza incl. all given options will be removed.
-            - If set to C(present) stanza incl.options will be added.
-            - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
-            - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
-         type: str
-         choices: [ absent, present ]
-         default: present
-
-
+  path:
+    description:
+    - Path to the stanza file.
+    type: path
+    required: true
+    aliases: [ dest ]
+  stanza:
+    description:
+    - Name of stanza.
+    type: str
+    required: true
+  options:
+     description:
+     - A list of key/value pairs, e.g. C(key=val,key=val).
+     type: list
+  state:
+     description:
+     - If set to C(absent) the whole stanza incl. all given options will be removed.
+     - If set to C(present) stanza incl.options will be added.
+     - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
+     - All rules, allowed file-stanza combos or allowed files for the C(chsec) command also applies here.
+     type: str
+     choices: [ absent, present ]
+     default: present
+seealso:
+- name: The chsec manual page from the IBM Knowledge Center
+  description: Changes the attributes in the security stanza files.
+  link: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds1/chsec.htm
 author:
-    - Christian Tremel (@flynn1973)
+- Christian Tremel (@flynn1973)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add an LDAP user stanza
   aix_chsec:
     path: /etc/security/user
@@ -69,7 +69,7 @@ EXAMPLES = '''
     options: logintimes=:0800-1700
     state: present
 
-- name: Remove registry option from stanza 
+- name: Remove registry option from stanza
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
@@ -79,9 +79,10 @@ EXAMPLES = '''
     state: present
 '''
 
+RETURN = r'''
+'''
 
 from ansible.module_utils.basic import AnsibleModule
-
 
 
 def do_stanza(module, filename, stanza, options, state='present'):
@@ -90,31 +91,31 @@ def do_stanza(module, filename, stanza, options, state='present'):
 
     def arguments_generator(options):
         for element in options:
-                yield '-a'
-                yield element
+            yield '-a'
+            yield element
 
     command = [chsec_command, '-f', filename, '-s', '%s' % stanza]
     options = list(arguments_generator(options))
 
     if state == 'present':
         command += options
-        rc, package_result, err = module.run_command(command)
+        rc, stdout, stderr = module.run_command(command)
         if rc != 0:
-            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, err=err)
+            module.fail_json(msg='Failed to run chsec command (present).', rc=rc, stdout=stdout, stderr=stderr)
         else:
-            msg='stanza added'
-            changed=True
+            msg = 'stanza added'
+            changed = True
     elif state == 'absent':
-        # remove values from keys to enable chsec delete mode 
-        command += [s[:1+s.find('=')] or s for s in options]
-        rc, package_result, err = module.run_command(command)
+        # remove values from keys to enable chsec delete mode
+        command += [s[:1 + s.find('=')] or s for s in options]
+        rc, stdout, stderr = module.run_command(command)
         if rc != 0:
-             module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, err=err)
+            module.fail_json(msg='Failed to run chsec command (absent).', rc=rc, stdout=stdout, stderr=stderr)
         else:
-             msg='stanza removed'
-             changed=True
+            msg = 'stanza removed'
+            changed = True
 
-    return (changed, msg)
+    return changed, msg
 
 
 def main():
@@ -124,7 +125,7 @@ def main():
             path=dict(type='path', required=True, aliases=['dest']),
             stanza=dict(type='str', required=True),
             options=dict(type='list', required=True),
-            state=dict(type='str', default='present', choices=['absent', 'present'])
+            state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=False,
     )
@@ -134,17 +135,15 @@ def main():
     options = module.params['options']
     state = module.params['state']
 
-    (changed, msg) = do_stanza(module, path, stanza, options, state)
-
-
     result = dict(
-        changed=changed,
-        msg=msg,
-        path=path,
+        changed=False,
     )
+
+    result['changed'], result['msg'] = do_stanza(module, path, stanza, options, state)
 
     # Mission complete
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
     options: logintimes=:0800-1700
     state: present
 
-- name: remove registry option from stanza 
+- name: Remove registry option from stanza 
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -72,7 +72,9 @@ EXAMPLES = '''
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser
-    options: SYSTEM=LDAP,registry=
+    options:
+    - SYSTEM=LDAP
+    - registry=
     state: present
 '''
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -143,7 +143,7 @@ def main():
     )
 
     # Mission complete
-    module.exit_json(**results)
+    module.exit_json(**result)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -44,7 +44,6 @@ options:
          default: present
 
 extends_documentation_fragment:
-    - files
 
 author:
     - Christian Tremel (@flynn1973)

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -15,7 +15,7 @@ DOCUMENTATION = '''
 ---
 module: aix_chsec
 
-short_description: modify aix stanza files
+short_description: Modify AIX stanza files
 
 version_added: "0.1"
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -42,6 +42,7 @@ options:
             - If set to C(present) stanza incl.options will be added.
             - To remove an option from the stanza set to C(present) and set key to an empty value (key=).
             - All rules/allowed file-stanza combos/allowed files for the chsec command also applies here, so once again, read "man chsec"!
+         type: str
          choices: [ absent, present ]
          default: present
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -136,7 +136,7 @@ def main():
     (changed, msg) = do_stanza(module, path, stanza, options, state)
 
 
-    results = dict(
+    result = dict(
         changed=changed,
         msg=msg,
         path=path,

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
     state: present
     mode: 0644
 
-- name: change login times for user
+- name: Change login times for user
   aix_chsec:
     path: /etc/security/user
     stanza: ldapuser

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -17,7 +17,7 @@ module: aix_chsec
 
 short_description: Modify AIX stanza files
 
-version_added: "0.1"
+version_added: '2.8'
 
 description:
     - "adds stanzas to aix config files using the chsec command. see "man chsec" for additional infos"

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
 '''
 
 
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 
 
 

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -139,7 +139,7 @@ def main():
     results = dict(
         changed=changed,
         msg=msg,
-        path=path
+        path=path,
     )
 
     # Mission complete

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -34,7 +34,8 @@ options:
         required: true
     options:
          description:
-             - comman separated key/value pairs eg. key=val,key=val
+             - A list of key/value pairs, e.g. `key=val,key=val`
+         type: list
     state:
          description:
             - If set to C(absent) the whole stanza incl. all given options will be removed.

--- a/lib/ansible/modules/system/aix_chsec.py
+++ b/lib/ansible/modules/system/aix_chsec.py
@@ -46,7 +46,6 @@ options:
          choices: [ absent, present ]
          default: present
 
-extends_documentation_fragment:
 
 author:
     - Christian Tremel (@flynn1973)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Updated code from stale PR #49057 : adds stanzas to aix config files using the chsec command.

Features:
- Fully idempotent
- Check mode
- Updated docs

Full details below.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aix_chsec.py

##### ADDITIONAL INFORMATION

##### Idempotency

We make the tool idempotent by first checking the output of [`lssec`](https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds3/lssec.htm) before running `chsec`

##### Using the module

One example implementation with multiple key/value being set within a single file+stanza:

```yaml
- name: Name of Task
  aix_chsec:
    file: filename
    stanza: stanzaname
    attrs:
      key1: value1
      key2: value2
      keyN: valueN
    state: [ present, absent ]
```

NB: _`attr` are changes made one at a time in code_

This would return `Changed` if *any number* of the above key/value pairs were changed.  If *none* were changed status would be `OK`.  Failure to change *any* key:value pair would constitute as a `failure` **at the time of failure** _regardless of how many attributes were successfully set_.

- `attrs` has the alias `options`
- Valid `attrs` formats:
```text
attrs:
  key: value
  key2: value2

[key=value, key=value]

"key=value, key=value"
```

**Real world use:**

- Allow logins from 8:00 a.m. until 5:00 p.m. for all users
- Change the CPU time limit of user joe AND charlie to 1 hour (3600 seconds):

```yaml
---
- hosts: targetserver
  gather_facts: no
  vars:
    example_chsec:
      - file: /etc/security/user
        stanza: default
        attrs:
          logintimes: ":0800-1700"
      - file: /etc/security/limits
        stanza: joe
        attrs: cpu=3600
      - file: /etc/security/limits
        stanza: charlie
        attrs:
          cpu: 3600
  remote_user: deploy
- tasks:
  name: Example chsec
    aix_chsec:
      file: "{{ item.file }}"
      stanza: "{{ item.stanza }}"
      attrs: "{{ item.attrs }}"
    loop:
      - "{{ example_chsec }}"
```

### Future Ideas
##### Backup
Have a flag backup=true to create a backup of the `file` before making changes

##### 'Nested' Stanzas

We could 'nest' stanzas for a single file within a single module call.  This increases the chances of any one attribute failing.  We can keep the `stanza` option available in addition to `stanzas`, mutually exclusive.

```yaml
- name: Name of Task
  aix_chsec:
    file: filename
    stanzas:
      - stanza1:
          key1: value1
          key2: value2
          keyN: valueN
        state: [ present|absent ]
      - stanza2:
          key1: value1
          key2: value2
          keyN: valueN
        state: [ present|absent ]
    backup: bool (default no, timestamped backup before making changes.)
```