### PR TITLE
Fix ec2_vpc_vgw broken tests

### DIFF
--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -162,11 +162,6 @@ ec2_data = {
                     "argument": "VpnGateways[0].State == 'available'",
                     "state": "success"
                 },
-                {
-                    "matcher": "error",
-                    "expected": False,
-                    "state": "retry"
-                },
             ]
         },
     }

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -151,6 +151,24 @@ ec2_data = {
                 },
             ]
         },
+        "VpnGatewayDetached": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeVpnGateways",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "VpnGateways[0].State == 'available'",
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": False,
+                    "state": "retry"
+                },
+            ]
+        },
     }
 }
 
@@ -314,6 +332,12 @@ waiters_by_name = {
     ('EC2', 'vpn_gateway_exists'): lambda ec2: core_waiter.Waiter(
         'vpn_gateway_exists',
         ec2_model('VpnGatewayExists'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_vpn_gateways
+        )),
+    ('EC2', 'vgw_detached'): lambda ec2: core_waiter.Waiter(
+        'vgw_detached',
+        ec2_model('VpnGatewayDetached'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_vpn_gateways
         )),

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -330,8 +330,8 @@ waiters_by_name = {
         core_waiter.NormalizedOperationMethod(
             ec2.describe_vpn_gateways
         )),
-    ('EC2', 'vgw_detached'): lambda ec2: core_waiter.Waiter(
-        'vgw_detached',
+    ('EC2', 'vpn_gateway_detached'): lambda ec2: core_waiter.Waiter(
+        'vpn_gateway_detached',
         ec2_model('VpnGatewayDetached'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_vpn_gateways

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -171,7 +171,13 @@ def attach_vgw(client, module, vpn_gateway_id):
     params['VpcId'] = module.params.get('vpc_id')
 
     try:
-        response = AWSRetry.jittered_backoff()(client.attach_vpn_gateway)(VpnGatewayId=vpn_gateway_id, VpcId=params['VpcId'])
+        # Immediately after a detachment, the EC2 API sometimes will report the VpnGateways[0].State
+        # as available several seconds before actually permitting a new attachment.
+        # So we catch and retry that error.  See https://github.com/ansible/ansible/issues/53185
+        response = AWSRetry.jittered_backoff(retries=5,
+                                             catch_extra_error_codes=['InvalidParameterValue']
+                                             )(client.attach_vpn_gateway)(VpnGatewayId=vpn_gateway_id,
+                                                                          VpcId=params['VpcId'])
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
@@ -400,7 +406,7 @@ def ensure_vgw_present(client, module):
                     # detach the existing vpc from the virtual gateway
                     vpc_to_detach = current_vpc_attachments[0]['VpcId']
                     detach_vgw(client, module, vpn_gateway_id, vpc_to_detach)
-                    time.sleep(5)
+                    get_waiter(client, 'vgw_detached').wait(VpnGatewayIds=[vpn_gateway_id])
                     attached_vgw = attach_vgw(client, module, vpn_gateway_id)
                     changed = True
             else:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
@@ -406,7 +406,7 @@ def ensure_vgw_present(client, module):
                     # detach the existing vpc from the virtual gateway
                     vpc_to_detach = current_vpc_attachments[0]['VpcId']
                     detach_vgw(client, module, vpn_gateway_id, vpc_to_detach)
-                    get_waiter(client, 'vgw_detached').wait(VpnGatewayIds=[vpn_gateway_id])
+                    get_waiter(client, 'vpn_gateway_detached').wait(VpnGatewayIds=[vpn_gateway_id])
                     attached_vgw = attach_vgw(client, module, vpn_gateway_id)
                     changed = True
             else:

--- a/test/integration/targets/ec2_vpc_vgw/aliases
+++ b/test/integration/targets/ec2_vpc_vgw/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group2
-disabled


### PR DESCRIPTION
##### SUMMARY
Add waiter function to wait for API to report detached vgw is available.
Also catch extra error code in attach retry as EC2 sometimes reports that the vgw is available several seconds before permitting the attachment.
    
Fixes: #53185

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py

##### ADDITIONAL INFORMATION
Run 100x locally with no failures seen.
