### PR TITLE
Support galaxy v3/autohub API in ansible-galaxy

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -66,12 +66,13 @@ class GalaxyAPI(object):
 
     SUPPORTED_VERSIONS = ['v1']
 
-    def __init__(self, galaxy, name, url, username=None, password=None, token=None):
+    def __init__(self, galaxy, name, url, username=None, password=None, token=None, token_type=None):
         self.galaxy = galaxy
         self.name = name
         self.username = username
         self.password = password
         self.token = token
+        self.token_type = token_type or 'Token'
         self.api_server = url
         self.validate_certs = not context.CLIARGS['ignore_certs']
         self.baseurl = None
@@ -81,12 +82,14 @@ class GalaxyAPI(object):
 
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
-    def _auth_header(self, required=True, token_type='Token'):
+    def _auth_header(self, required=True, token_type=None):
         '''Generate the Authorization header.
 
         Valid token_type values are 'Token' (galaxy v2) and 'Bearer' (galaxy v3)'''
         token = self.token.get() if self.token else None
 
+        # 'Token' for v2 api, 'Bearer' for v3
+        token_type = token_type or self.token_type
         if token:
             return {'Authorization': "%s %s" % (token_type, token)}
         elif self.username:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -49,9 +49,7 @@ def g_connect(method):
 
             self.baseurl = _urljoin(self.api_server, "api", server_version)
 
-            available_api_versions = self.get_available_api_versions()
             self.version = server_version  # for future use
-            self.available_api_versions = available_api_versions
 
             display.vvvv("Base API: %s" % self.baseurl)
             self.initialized = True
@@ -129,29 +127,7 @@ class GalaxyAPI(object):
         except Exception as e:
             raise AnsibleError("Could not process data from the API server (%s): %s " % (url, to_native(e)))
 
-        available_versions = data.get('available_versions',
-                                      {'v1': '/api/v1',
-                                       'v2': '/api/v2'})
-
-        return available_versions
-
-    def get_available_api_versions(self):
-        url = _urljoin(self.api_server, "api")
-        try:
-            return_data = open_url(url, validate_certs=self.validate_certs)
-        except Exception as e:
-            raise AnsibleError("Failed to get data from the API server (%s): %s " % (url, to_native(e)))
-
-        try:
-            data = json.loads(to_text(return_data.read(), errors='surrogate_or_strict'))
-        except Exception as e:
-            raise AnsibleError("Could not process data from the API server (%s): %s " % (url, to_native(e)))
-
-        available_versions = data.get('available_versions',
-                                      {'v1': '/api/v1',
-                                       'v2': '/api/v2'})
-
-        return available_versions
+        return data['current_version']
 
     @g_connect
     def authenticate(self, github_token):

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -81,11 +81,14 @@ class GalaxyAPI(object):
 
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
-    def _auth_header(self, required=True):
+    def _auth_header(self, required=True, token_type='Token'):
+        '''Generate the Authorization header.
+
+        Valid token_type values are 'Token' (galaxy v2) and 'Bearer' (galaxy v3)'''
         token = self.token.get() if self.token else None
 
         if token:
-            return {'Authorization': "Token %s" % token}
+            return {'Authorization': "%s %s" % (token_type, token)}
         elif self.username:
             token = "%s:%s" % (to_text(self.username, errors='surrogate_or_strict'),
                                to_text(self.password, errors='surrogate_or_strict', nonstring='passthru') or '')

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -310,12 +310,15 @@ class CollectionRequirement:
 
         for api in apis:
             collection_url_paths = [api.api_server, 'api', 'v2', 'collections', namespace, name, 'versions']
-            headers = api._auth_header(required=False)
 
             available_api_versions = get_available_api_versions(api)
             if 'v3' in available_api_versions:
                 # /api/v3/ exists, use it
                 collection_url_paths[2] = 'v3'
+                # update this v3 GalaxyAPI to use Bearer token from now on
+                api.token_type = 'Bearer'
+
+            headers = api._auth_header(required=False)
 
             is_single = False
             if not (requirement == '*' or requirement.startswith('<') or requirement.startswith('>') or
@@ -464,14 +467,15 @@ def publish_collection(collection_path, api, wait, timeout):
 
     display.display("Publishing collection artifact '%s' to %s %s" % (collection_path, api.name, api.api_server))
 
-    headers = {}
-    headers.update(api._auth_header())
-
     n_url = _urljoin(api.api_server, 'api', 'v2', 'collections')
     available_api_versions = get_available_api_versions(api)
 
     if 'v3' in available_api_versions:
         n_url = _urljoin(api.api_server, 'api', 'v3', 'artifacts', 'collections')
+        api.token_type = 'Bearer'
+
+    headers = {}
+    headers.update(api._auth_header())
 
     data, content_type = _get_mime_data(b_collection_path)
     headers.update({

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -379,9 +379,12 @@ class CollectionRequirement:
 
 
 def get_available_api_versions(galaxy_api):
+    headers = {}
+    headers.update(galaxy_api._auth_header(required=False))
+
     url = _urljoin(galaxy_api.api_server, "api")
     try:
-        return_data = open_url(url, validate_certs=galaxy_api.validate_certs)
+        return_data = open_url(url, headers=headers, validate_certs=galaxy_api.validate_certs)
     except urllib_error.HTTPError as err:
         if err.code != 401:
             _handle_http_error(err, galaxy_api, {},

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -312,6 +312,10 @@ class CollectionRequirement:
             collection_url_paths = [api.api_server, 'api', 'v2', 'collections', namespace, name, 'versions']
             headers = api._auth_header(required=False)
 
+            if 'v3' in api.available_api_versions:
+                # /api/v3/ exists, use it
+                collection_url_paths[2] = 'v3'
+
             is_single = False
             if not (requirement == '*' or requirement.startswith('<') or requirement.startswith('>') or
                     requirement.startswith('!=')):
@@ -325,10 +329,11 @@ class CollectionRequirement:
             try:
                 resp = json.load(open_url(n_collection_url, validate_certs=api.validate_certs, headers=headers))
             except urllib_error.HTTPError as err:
+
                 if err.code == 404:
                     display.vvv("Collection '%s' is not available from server %s %s" % (collection, api.name, api.api_server))
                     continue
-                raise
+                _handle_http_error(err, api, 'Error fetching info for %s from %s (%s)' % (collection, api.name, api.api_server))
 
             if is_single:
                 galaxy_info = resp
@@ -336,13 +341,24 @@ class CollectionRequirement:
                 versions = [resp['version']]
             else:
                 versions = []
+
+                results_key = 'results'
+                if 'v3' in api.available_api_versions:
+                    results_key = 'data'
+
                 while True:
                     # Galaxy supports semver but ansible-galaxy does not. We ignore any versions that don't match
                     # StrictVersion (x.y.z) and only support pre-releases if an explicit version was set (done above).
-                    versions += [v['version'] for v in resp['results'] if StrictVersion.version_re.match(v['version'])]
-                    if resp['next'] is None:
+                    versions += [v['version'] for v in resp[results_key] if StrictVersion.version_re.match(v['version'])]
+
+                    next_link = resp.get('next', None)
+                    if 'v3' in api.available_api_versions:
+                        next_link = resp['links']['next']
+
+                    if next_link is None:
                         break
-                    resp = json.load(open_url(to_native(resp['next'], errors='surrogate_or_strict'),
+
+                    resp = json.load(open_url(to_native(next_link, errors='surrogate_or_strict'),
                                               validate_certs=api.validate_certs, headers=headers))
 
             display.vvv("Collection '%s' obtained from server %s %s" % (collection, api.name, api.api_server))
@@ -409,28 +425,23 @@ def publish_collection(collection_path, api, wait, timeout):
 
     display.display("Publishing collection artifact '%s' to %s %s" % (collection_path, api.name, api.api_server))
 
+    headers = {}
+    headers.update(api._auth_header())
+
     n_url = _urljoin(api.api_server, 'api', 'v2', 'collections')
+    if 'v3' in api.available_api_versions:
+        n_url = _urljoin(api.api_server, 'api', 'v3', 'artifacts', 'collections')
 
     data, content_type = _get_mime_data(b_collection_path)
-    headers = {
+    headers.update({
         'Content-type': content_type,
         'Content-length': len(data),
-    }
-    headers.update(api._auth_header())
+    })
 
     try:
         resp = json.load(open_url(n_url, data=data, headers=headers, method='POST', validate_certs=api.validate_certs))
     except urllib_error.HTTPError as err:
-        try:
-            err_info = json.load(err)
-        except (AttributeError, ValueError):
-            err_info = {}
-
-        code = to_native(err_info.get('code', 'Unknown'))
-        message = to_native(err_info.get('message', 'Unknown error returned by Galaxy server.'))
-
-        raise AnsibleError("Error when publishing collection (HTTP Code: %d, Message: %s Code: %s)"
-                           % (err.code, message, code))
+        _handle_http_error(err, api, "Error when publishing collection to %s (%s)" % (api.name, api.api_server))
 
     import_uri = resp['task']
     if wait:
@@ -1016,3 +1027,33 @@ def _extract_tar_file(tar, filename, b_dest, b_temp_path, expected_hash=None):
             os.makedirs(b_parent_dir)
 
         shutil.move(to_bytes(tmpfile_obj.name, errors='surrogate_or_strict'), b_dest_filepath)
+
+
+def _handle_http_error(http_error, api, context_error_message):
+    try:
+        err_info = json.load(http_error)
+    except (AttributeError, ValueError):
+        err_info = {}
+
+    if 'v3' in api.available_api_versions:
+        message_lines = []
+        errors = err_info.get('errors', None)
+
+        if not errors:
+            errors = [{'detail': 'Unknown error returned by Galaxy server.',
+                       'code': 'Unknown'}]
+
+        for error in errors:
+            error_msg = error.get('detail') or error.get('title') or 'Unknown error returned by Galaxy server.'
+            error_code = error.get('code') or 'Unknown'
+            message_line = "(HTTP Code: %d, Message: %s Code: %s)" % (http_error.code, error_msg, error_code)
+            message_lines.append(message_line)
+
+        full_error_msg = "%s %s" % (context_error_message, ', '.join(message_lines))
+    else:
+        code = to_native(err_info.get('code', 'Unknown'))
+        message = to_native(err_info.get('message', 'Unknown error returned by Galaxy server.'))
+        full_error_msg = "%s (HTTP Code: %d, Message: %s Code: %s)" \
+            % (context_error_message, http_error.code, message, code)
+
+    raise AnsibleError(full_error_msg)

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -54,6 +54,7 @@ def collection_input(tmp_path_factory):
 
     return collection_dir, output_dir
 
+
 @pytest.fixture()
 def galaxy_api_version(monkeypatch):
     mock_avail_ver = MagicMock()

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -507,11 +507,11 @@ def test_publish_failure_with_json_info(galaxy_server, collection_artifact, monk
         collection.publish_collection(artifact_path, galaxy_server, True, 0)
 
 
-@pytest.mark.parametrize("api_version", [
-    ('v2',),
-    ('v3',)
+@pytest.mark.parametrize("api_version,token_type", [
+    ('v2', 'Token'),
+    ('v3', 'Bearer')
 ])
-def test_publish_with_wait(api_version, galaxy_server, collection_artifact, monkeypatch):
+def test_publish_with_wait(api_version, token_type, galaxy_server, collection_artifact, monkeypatch):
     mock_avail_ver = MagicMock()
     mock_avail_ver.return_value = {api_version: '/api/%s' % api_version}
     monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
@@ -532,7 +532,7 @@ def test_publish_with_wait(api_version, galaxy_server, collection_artifact, monk
 
     assert mock_open.call_count == 2
     assert mock_open.mock_calls[1][1][0] == fake_import_uri
-    assert mock_open.mock_calls[1][2]['headers']['Authorization'] == 'Token key'
+    assert mock_open.mock_calls[1][2]['headers']['Authorization'] == '%s key' % token_type
     assert mock_open.mock_calls[1][2]['validate_certs'] is True
     assert mock_open.mock_calls[1][2]['method'] == 'GET'
 
@@ -546,11 +546,11 @@ def test_publish_with_wait(api_version, galaxy_server, collection_artifact, monk
                                                'Galaxy server %s %s' % (galaxy_server.name, galaxy_server.api_server)
 
 
-@pytest.mark.parametrize("api_version,exp_api_url", [
-    ('v2', '/api/v2/collections/'),
-    ('v3', '/api/v3/artifacts/collections/')
+@pytest.mark.parametrize("api_version,exp_api_url,token_type", [
+    ('v2', '/api/v2/collections/', 'Token'),
+    ('v3', '/api/v3/artifacts/collections/', 'Bearer')
 ])
-def test_publish_with_wait_timeout(api_version, exp_api_url, galaxy_server, collection_artifact, monkeypatch):
+def test_publish_with_wait_timeout(api_version, exp_api_url, token_type, galaxy_server, collection_artifact, monkeypatch):
     mock_avail_ver = MagicMock()
     mock_avail_ver.return_value = {api_version: '/api/%s' % api_version}
     monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
@@ -574,11 +574,11 @@ def test_publish_with_wait_timeout(api_version, exp_api_url, galaxy_server, coll
 
     assert mock_open.call_count == 3
     assert mock_open.mock_calls[1][1][0] == fake_import_uri
-    assert mock_open.mock_calls[1][2]['headers']['Authorization'] == 'Token key'
+    assert mock_open.mock_calls[1][2]['headers']['Authorization'] == '%s key' % token_type
     assert mock_open.mock_calls[1][2]['validate_certs'] is True
     assert mock_open.mock_calls[1][2]['method'] == 'GET'
     assert mock_open.mock_calls[2][1][0] == fake_import_uri
-    assert mock_open.mock_calls[2][2]['headers']['Authorization'] == 'Token key'
+    assert mock_open.mock_calls[2][2]['headers']['Authorization'] == '%s key' % token_type
     assert mock_open.mock_calls[2][2]['validate_certs'] is True
     assert mock_open.mock_calls[2][2]['method'] == 'GET'
 

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -421,6 +421,10 @@ def test_publish_not_a_tarball():
 
 
 def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)
 
@@ -449,7 +453,11 @@ def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):
         "being set. Import task results can be found at %s" % (galaxy_server.name, galaxy_server.api_server, fake_import_uri)
 
 
-def test_publish_dont_validate_cert(galaxy_server, collection_artifact):
+def test_publish_dont_validate_cert(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     galaxy_server.validate_certs = False
     artifact_path, mock_open = collection_artifact
 
@@ -461,7 +469,11 @@ def test_publish_dont_validate_cert(galaxy_server, collection_artifact):
     assert mock_open.mock_calls[0][2]['validate_certs'] is False
 
 
-def test_publish_failure(galaxy_server, collection_artifact):
+def test_publish_failure(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     artifact_path, mock_open = collection_artifact
 
     mock_open.side_effect = urllib_error.HTTPError('https://galaxy.server.com', 500, 'msg', {}, StringIO())
@@ -473,7 +485,11 @@ def test_publish_failure(galaxy_server, collection_artifact):
         collection.publish_collection(artifact_path, galaxy_server, True, 0)
 
 
-def test_publish_failure_with_json_info(galaxy_server, collection_artifact):
+def test_publish_failure_with_json_info(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     artifact_path, mock_open = collection_artifact
 
     return_content = StringIO(u'{"message":"Galaxy error message","code":"GWE002"}')
@@ -490,7 +506,9 @@ def test_publish_failure_with_json_info(galaxy_server, collection_artifact):
     ('v3',)
 ])
 def test_publish_with_wait(api_version, galaxy_server, collection_artifact, monkeypatch):
-    galaxy_server.available_api_versions = {api_version: ''}
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {api_version: '/api/%s' % api_version}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
 
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)
@@ -527,7 +545,10 @@ def test_publish_with_wait(api_version, galaxy_server, collection_artifact, monk
     ('v3', '/api/v3/artifacts/collections/')
 ])
 def test_publish_with_wait_timeout(api_version, exp_api_url, galaxy_server, collection_artifact, monkeypatch):
-    galaxy_server.available_api_versions = {api_version: ''}
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {api_version: '/api/%s' % api_version}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     monkeypatch.setattr(time, 'sleep', MagicMock())
 
     mock_vvv = MagicMock()
@@ -561,6 +582,10 @@ def test_publish_with_wait_timeout(api_version, exp_api_url, galaxy_server, coll
 
 
 def test_publish_with_wait_timeout_failure(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     monkeypatch.setattr(time, 'sleep', MagicMock())
 
     mock_vvv = MagicMock()
@@ -600,6 +625,10 @@ def test_publish_with_wait_timeout_failure(galaxy_server, collection_artifact, m
 
 
 def test_publish_with_wait_and_failure(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)
 
@@ -673,6 +702,10 @@ def test_publish_with_wait_and_failure(galaxy_server, collection_artifact, monke
 
 
 def test_publish_with_wait_and_failure_and_no_error(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v2': '/api/v2'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)
 
@@ -741,8 +774,11 @@ def test_publish_with_wait_and_failure_and_no_error(galaxy_server, collection_ar
     assert mock_err.mock_calls[0][1][0] == 'Galaxy import error message: Some error'
 
 
-def test_publish_failure_v3_with_json_info_409_conflict(galaxy_server, collection_artifact):
-    galaxy_server.available_api_versions = {'v3': ''}
+def test_publish_failure_v3_with_json_info_409_conflict(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v3': '/api/v3'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     artifact_path, mock_open = collection_artifact
 
     error_response = {
@@ -766,8 +802,11 @@ def test_publish_failure_v3_with_json_info_409_conflict(galaxy_server, collectio
         collection.publish_collection(artifact_path, galaxy_server, True, 0)
 
 
-def test_publish_failure_v3_with_json_info_multiple_errors(galaxy_server, collection_artifact):
-    galaxy_server.available_api_versions = {'v3': ''}
+def test_publish_failure_v3_with_json_info_multiple_errors(galaxy_server, collection_artifact, monkeypatch):
+    mock_avail_ver = MagicMock()
+    mock_avail_ver.return_value = {'v3': '/api/v3'}
+    monkeypatch.setattr(collection, 'get_available_api_versions', mock_avail_ver)
+
     artifact_path, mock_open = collection_artifact
 
     error_response = {

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1004,7 +1004,7 @@ def test_get_available_api_versions_v3_auth_required_without_auth(galaxy_server,
     error_response = {'code': 'unauthorized', 'detail': 'The request was not authorized'}
     artifact_path, mock_open = collection_artifact
 
-    return_content = StringIO(json.dumps(error_response))
+    return_content = StringIO(to_text(json.dumps(error_response)))
     mock_open.side_effect = urllib_error.HTTPError('https://galaxy.server.com', 401, 'msg', {'WWW-Authenticate': 'Bearer'}, return_content)
     with pytest.raises(AnsibleError):
         collection.get_available_api_versions(galaxy_server)


### PR DESCRIPTION
##### SUMMARY

Make ansible-galaxy v3 aware, so that it can publish and download to Automation Hub. Not sure if we'll need to do anything special as far as authentication.

Fixes ansible/galaxy-dev#60


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy












