### PR TITLE
Allow password to be null in Scheduled Task for gMSA

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task.ps1
+++ b/lib/ansible/modules/windows/win_scheduled_task.ps1
@@ -686,9 +686,6 @@ if ($null -ne $username -and $null -ne $group) {
     Fail-Json -obj $result -message "username and group can not be set at the same time"
 }
 if ($null -ne $logon_type) {
-    if ($logon_type -eq [TASK_LOGON_TYPE]::TASK_LOGON_PASSWORD -and $null -eq $password) {
-        Fail-Json -obj $result -message "password must be set when logon_type=password"
-    }
     if ($logon_type -eq [TASK_LOGON_TYPE]::TASK_LOGON_S4U -and $null -eq $password) {
         Fail-Json -obj $result -message "password must be set when logon_type=s4u"
     }

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -266,9 +266,9 @@ options:
     description:
     - The password for the user account to run the scheduled task as.
     - This is required when running a task without the user being logged in,
-      excluding the builtin service accounts.
+      excluding the builtin service accounts and Group Managed Service Accounts (gMSA).
     - If set, will always result in a change unless C(update_password) is set
-      to C(no) and no othr changes are required for the service.
+      to C(no) and no other changes are required for the service.
     type: str
     version_added: '2.4'
   update_password:
@@ -376,7 +376,7 @@ options:
   priority:
     description:
     - The priority level (0-10) of the task.
-    - When creating a new task the default if C(7).
+    - When creating a new task the default is C(7).
     - See U(https://msdn.microsoft.com/en-us/library/windows/desktop/aa383512.aspx)
       for details on the priority levels.
     type: int
@@ -430,6 +430,8 @@ notes:
 - The option names and structure for actions and triggers of a service follow
   the C(RegisteredTask) naming standard and requirements, it would be useful to
   read up on this guide if coming across any issues U(https://msdn.microsoft.com/en-us/library/windows/desktop/aa382542.aspx).
+- A Group Managed Service Account (gMSA) can be used by setting C(logon_type) to C(password) 
+  and omitting the password parameter. For more information on gMSAs, see U(https://techcommunity.microsoft.com/t5/Core-Infrastructure-and-Security/Windows-Server-2012-Group-Managed-Service-Accounts/ba-p/255910)
 seealso:
 - module: win_scheduled_task_stat
 author:
@@ -479,6 +481,12 @@ EXAMPLES = r'''
     name: TaskName2
     username: DOMAIN\User
     logon_type: s4u
+
+- name: Change above task to use a gMSA, where the password is managed automatically
+  win_scheduled_task:
+    name: TaskName2
+    username: DOMAIN\gMsaSvcAcct$
+    logon_type: password
 
 - name: Create task with multiple triggers
   win_scheduled_task:

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -430,8 +430,9 @@ notes:
 - The option names and structure for actions and triggers of a service follow
   the C(RegisteredTask) naming standard and requirements, it would be useful to
   read up on this guide if coming across any issues U(https://msdn.microsoft.com/en-us/library/windows/desktop/aa382542.aspx).
-- A Group Managed Service Account (gMSA) can be used by setting C(logon_type) to C(password) 
-  and omitting the password parameter. For more information on gMSAs, see U(https://techcommunity.microsoft.com/t5/Core-Infrastructure-and-Security/Windows-Server-2012-Group-Managed-Service-Accounts/ba-p/255910)
+- A Group Managed Service Account (gMSA) can be used by setting C(logon_type) to C(password)
+  and omitting the password parameter. For more information on gMSAs,
+  see U(https://techcommunity.microsoft.com/t5/Core-Infrastructure-and-Security/Windows-Server-2012-Group-Managed-Service-Accounts/ba-p/255910)
 seealso:
 - module: win_scheduled_task_stat
 author:

--- a/test/integration/targets/win_scheduled_task/tasks/failures.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/failures.yml
@@ -16,14 +16,6 @@
   register: fail_username_and_group
   failed_when: fail_username_and_group.msg != 'username and group can not be set at the same time'
 
-- name: fail logon type password but no password set
-  win_scheduled_task:
-    name: '{{test_scheduled_task_name}}'
-    state: present
-    logon_type: password
-  register: fail_lt_password_not_set
-  failed_when: fail_lt_password_not_set.msg != 'password must be set when logon_type=password'
-
 - name: fail logon type s4u but no password set
   win_scheduled_task:
     name: '{{test_scheduled_task_name}}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #60989

Removes early validation of password parameter so that it can be omitted with `logon_type: password`. This allows for using Group Managed Service Accounts (gMSA) with Scheduled Tasks.

Documentation updated to reflect the new capability with new example (a few unrelated typos fixed too).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_scheduled_task

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I considered a few different approaches to changing the validation and handling of the password parameter. 

1. Add an additional parameter specific to gMSA or named generically that disables the check for password. So something like `allow_no_password` or `use_gmsa`, and when set, the check for missing password on `logon_type: password` would not be done. It would keep the existing validation while allowing for explicit override.
1. Trying to determine if the user name is a gMSA (maybe check for the trailing `$`?)
1. Removing the validation.

Ultimately went with 3 because:
- It's very simple (deleting a few lines)
- In testing, found that it was fine to let the task creation process return logon errors in the case of a password really being required (same as would happen if the password were wrong)
- The error message from further down the chain, "The user name or password is incorrect", is in my opinion sufficient for someone to determine what they've done wrong if they were supposed to give a password but didn't
- An additional parameter being set just to change the validation behavior seemed unintuitive
- Although gMSAs always end in `$` and must be 15 characters or fewer (because they're a subclass of computer objects), trying to guess seemed like the wrong behavior
- This is not a breaking change

I'm open to changing the approach though if consensus is against that.

<!--- Paste verbatim command output below, e.g. before and after your change -->
In the case of calling the module with `logon_type: password` and no `password` supplied:

The error message before:
```
fatal: [computer]: FAILED! => {"changed": false, "msg": "password must be set when logon_type=password"}
```

The error message now:
```
fatal: [computer]: FAILED! => {"changed": false, "msg": "failed to modify scheduled task: The user name or password is incorrect. (Exception from HRESULT: 0x8007052E)"}
```