### PR TITLE
openvswitch_db: Fix error when = is used in the other_config:dpdk-extra

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -156,7 +156,7 @@ def map_config_to_obj(module):
     col_value_to_dict = {}
     if NON_EMPTY_MAP_RE.match(col_value):
         for kv in col_value[1:-1].split(', '):
-            k, v = kv.split('=')
+            k, v = kv.split('=', 1)
             col_value_to_dict[k.strip()] = v.strip('\"')
 
     obj = {


### PR DESCRIPTION
##### SUMMARY
Value of other_config:dpdk-extra can have multiple values to be
passed to dpdk, like '--iova-mode=va'. Check for existing values
fails when there is an equal sign in the value too. Ensure split
is done based on the first equals.

Fixes: #60993

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openvswitch_db
