### PR TITLE
Bugfix of issue 60707: add python-apt package to requirements of package_facts module

### DIFF
--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -37,6 +37,7 @@ options:
 version_added: "2.5"
 requirements:
     - For 'portage' support it requires the `qlist` utility, which is part of 'app-portage/portage-utils'.
+    - For Debian-based systems `python-apt` package must be installed on targeted hosts.
 author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -339,7 +339,9 @@ def main():
                 module.warn('Failed to retrieve packages with %s: %s' % (pkgmgr, to_text(e)))
 
     if found == 0:
-        module.fail_json(msg='Could not detect a supported package manager from the following list: %s' % managers)
+        msg = ('Could not detect a supported package manager from the following list: %s, '
+               'or the required Python library is not installed. Check warnings for details.' % managers)
+        module.fail_json(msg=msg)
 
     # Set the facts, this will override the facts in ansible_facts that might exist from previous runs
     # when using operating system level or distribution package managers

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -36,8 +36,8 @@ options:
     version_added: "2.8"
 version_added: "2.5"
 requirements:
-    - For 'portage' support it requires the `qlist` utility, which is part of 'app-portage/portage-utils'.
-    - For Debian-based systems `python-apt` package must be installed on targeted hosts.
+    - For 'portage' support it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'.
+    - For Debian-based systems C(python-apt) package must be installed on targeted hosts.
 author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)


### PR DESCRIPTION
##### SUMMARY
Issue #60707 : add python-apt package to requirements of package_facts module

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
package_facts
```lib/ansible/modules/packaging/os/package_facts.py```

##### ADDITIONAL INFORMATION
package_facts uses ```apt``` library if OS is Debian-based

lib/ansible/modules/packaging/os/package_facts.py
```
186 class APT(LibMgr):
187 
188     LIB = 'apt'
```
lib/ansible/module_utils/facts/packages.py
```
 55 class LibMgr(PkgMgr):
 56 
 57     LIB = None
 58 
 59     def __init__(self):
 60 
 61         self._lib = None
 62         super(LibMgr, self).__init__()
 63 
 64     def is_available(self):
 65         found = False
 66         try:
 67             self._lib = __import__(self.LIB)
 68             found = True
 69         except ImportError:
 70             pass
 71         return found
```

fixes #60707
closes #60707