### PR TITLE
Fix omit unrecognized due to leading/trailing spaces.

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -44,15 +44,16 @@ def remove_omit(task_args, omit_token):
         return task_args
 
     new_args = {}
-    for i in iteritems(task_args):
-        if i[1] == omit_token:
+    for key, value in iteritems(task_args):
+        stripped_value = value.strip() if isinstance(value, str) else value
+        if stripped_value == omit_token:
             continue
-        elif isinstance(i[1], dict):
-            new_args[i[0]] = remove_omit(i[1], omit_token)
-        elif isinstance(i[1], list):
-            new_args[i[0]] = [remove_omit(v, omit_token) for v in i[1]]
+        elif isinstance(value, dict):
+            new_args[key] = remove_omit(value, omit_token)
+        elif isinstance(value, list):
+            new_args[key] = [remove_omit(v, omit_token) for v in value]
         else:
-            new_args[i[0]] = i[1]
+            new_args[key] = value
 
     return new_args
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -531,3 +531,20 @@ class TestTaskExecutor(unittest.TestCase):
         }
 
         self.assertEqual(remove_omit(data, omit_token), expected)
+
+    def test_recursive_omit_strips_values(self):
+        omit_token = 'WHATEVER'
+        token = ' ' + omit_token + ' '
+        data = {
+            'foo': token,
+            'bar': {'baz': token},
+            'qux': [{'one': token, 'two': 3}],
+            'a_list': [1, token, 3],
+        }
+
+        expected = {
+            'bar': {},
+            'qux': [{'two': 3}],
+            'a_list': [1, token, 3],
+        }
+        self.assertEqual(remove_omit(data, omit_token), expected)


### PR DESCRIPTION
Closes #61001.

##### SUMMARY

This is a fix for #61001.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

Ansible's executor.

##### ADDITIONAL INFORMATION

This commit ensures any string value is stripped before being compared with the omit token.
This is done in a way that preserves the actual value of the variable, in case leading and trailing spaces matter when the value is not the omit token.