### PR TITLE
add max_allocated_storage parameter to rds_instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -241,6 +241,10 @@ options:
         aliases:
           - username
         type: str
+    max_allocated_storage:
+        description:
+          - The upper limit to which Amazon RDS can automatically scale the storage of the DB instance.
+        type: int
     monitoring_interval:
         description:
           - The interval, in seconds, when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting
@@ -904,6 +908,9 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
     changing_params = {}
     current_options = get_current_attributes_with_inconsistent_keys(instance)
 
+    if current_options.get("MaxAllocatedStorage") is None:
+        current_options["MaxAllocatedStorage"] = None
+
     for option in current_options:
         current_option = current_options[option]
         desired_option = modify_params.pop(option, None)
@@ -1094,6 +1101,7 @@ def main():
         license_model=dict(),
         master_user_password=dict(aliases=['password'], no_log=True),
         master_username=dict(aliases=['username']),
+        max_allocated_storage=dict(type='int'),
         monitoring_interval=dict(type='int'),
         monitoring_role_arn=dict(),
         multi_az=dict(type='bool'),

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -245,6 +245,7 @@ options:
         description:
           - The upper limit to which Amazon RDS can automatically scale the storage of the DB instance.
         type: int
+        version_added: "2.9"
     monitoring_interval:
         description:
           - The interval, in seconds, when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting
@@ -647,6 +648,11 @@ master_username:
   returned: always
   type: str
   sample: test
+max_allocated_storage:
+  description: The upper limit to which Amazon RDS can automatically scale the storage of the DB instance.
+  returned: When max allocated storage is present.
+  type: int
+  sample: 100
 monitoring_interval:
   description:
     - The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance.

--- a/test/integration/targets/rds_instance/tasks/test_modification.yml
+++ b/test/integration/targets/rds_instance/tasks/test_modification.yml
@@ -136,6 +136,7 @@
           that:
             - result.changed
             - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == 30'
+            - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage == 100'
             - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
             - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
             - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'
@@ -164,6 +165,7 @@
           that:
             - not result.changed
             - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == 30'
+            - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage == 100'
             - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
             - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == "db.t2.medium"'
             - '"engine_version" in result.pending_modified_values or result.engine_version == "10.2.21"'

--- a/test/integration/targets/rds_instance/tasks/test_modification.yml
+++ b/test/integration/targets/rds_instance/tasks/test_modification.yml
@@ -127,6 +127,7 @@
           allow_major_version_upgrade: true
           auto_minor_version_upgrade: false
           port: 1150
+          max_allocated_storage: 100
           apply_immediately: True
           <<: *aws_connection_info
         register: result
@@ -152,6 +153,7 @@
           allow_major_version_upgrade: true
           auto_minor_version_upgrade: false
           port: 1150
+          max_allocated_storage: 100
           <<: *aws_connection_info
         register: result
         retries: 30


### PR DESCRIPTION
##### SUMMARY

Fixes: #60921

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

rds_instance

##### ADDITIONAL INFORMATION

This parameter is also an `inconsistent_keys` . It must exists in the current_position, even if aws does not return it. otherwise `get_changing_options_with_consistent_keys` throws an `KeyError: 'MaxAllocatedStorage`
