### PR TITLE
vmware: add the vmware_guest_instantclone module

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -322,6 +322,14 @@ def gather_vm_facts(content, vm):
             pass
     if vm.summary.runtime.dasVmProtection:
         facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
+    try:
+        facts['instant_clone_frozen'] = vm.summary.runtime.instantCloneFrozen
+    except:
+        # This property is only available to vSphere 6.7 and later
+        # This value will only affect instant clone operations
+        # which are not available to all ESXi and vSphere installations.
+        pass
+
 
     datastores = vm.datastore
     for ds in datastores:

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -322,13 +322,11 @@ def gather_vm_facts(content, vm):
             pass
     if vm.summary.runtime.dasVmProtection:
         facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
-    try:
-        facts['instant_clone_frozen'] = vm.summary.runtime.instantCloneFrozen
-    except:
+    if vm.summary.runtime.instantCloneFrozen is not None:
         # This property is only available to vSphere 6.7 and later
         # This value will only affect instant clone operations
         # which are not available to all ESXi and vSphere installations.
-        pass
+        facts['instant_clone_frozen'] = vm.summary.runtime.instantCloneFrozen
 
 
     datastores = vm.datastore

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -242,14 +242,6 @@ options:
     default: 'no'
     type: bool
     version_added: '2.4'
-  instant_clone:
-    description:
-    - Whether to create an instant linked clone from the running VM specified by name in the C(template) parameter.
-    - The template VM must be a VM and not a template and must be running.
-    - Requires vSphere 6.7 to function.
-    - For best results place the VM into a frozen state.
-    default: 'no'
-    type: bool
   force:
     description:
     - Ignore warnings and complete the actions.
@@ -376,15 +368,6 @@ options:
     - Specify convert disk type while cloning template or virtual machine.
     choices: [ thin, thick, eagerzeroedthick ]
     version_added: '2.8'
-  instant_clone:
-    description:
-    - Used to perform an instant clone of a running VM specified in the C(template) parameter. Requires a vSphere instance and cannot be used with a standalone ESXi installation.
-    - When this parameter is used only the C(hostname), C(username), C(password), C(validate_certs), C(datacenter), C(name), C(template), and C(customvalues) parameters are honored.
-    - A VM name or UUID can be used to specify the source VM to clone from in the C(template) parameter.
-    - For best results it's recommeneded to place the VM into a frozen state. U(https://vdc-repo.vmware.com/vmwb-repository/dcr-public/cdbbd51c-4824-4a1b-ad43-45df55a76a76/8cb3ed93-cac2-46aa-b329-db5a096af5bc/doc/GUID-73AA07B6-BD83-4BB6-ACD0-F56ECB800607.html)
-    default: 'no'
-    type: bool
-    version_added: '2.9'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -582,21 +565,6 @@ EXAMPLES = r'''
       memory_mb: 512
       num_cpus: 2
       scsi: paravirtual
-  delegate_to: localhost
-
-- name: Create an instant clone from a running or frozen source VM
-  vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcetner_password }}"
-    validate_certs: no
-    datacenter: "{{ vm_datacenter }}"
-    name: "{{ new_clone_vm_name }}"
-    template: "{{ instantclone_source_vm_uuid_or_name }}"
-    instant_clone: yes
-    customvalues:
-      - key: foo.bar.test
-        value: "Can anyone hear me?"
   delegate_to: localhost
 '''
 
@@ -2134,103 +2102,11 @@ class PyVmomiHelper(PyVmomi):
                 self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
         return resource_pool
 
-    def deploy_instantclone(self):
-        # Ensure required param is given
-        if self.params['template'] == 'FOOBAR':
-            self.module.fail_json(msg='In order to create an instant clone the base VM name or UUID must be specified in the template parameter.')
-        # Gather needed facts from the base VM for the instant clone
-        vm = self.cache.find_obj(self.content, [vim.VirtualMachine], self.params['template'])
-        if vm is None:
-            self.module.fail_json(msg="Failed to find the vm %s" % self.params['template'])
-        vm_state = self.gather_facts(vm)
-        # An instant clone requires the base VM to be running, fail if it is not
-        if vm_state['hw_power_status'] != 'poweredOn':
-            self.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
-        if vm_state['instant_clone_frozen'] is None:
-            self.module.fail_json(msg='Unable to determine if VM is frozen. Is vSphere running 6.7 or later?')
-
-        config = []
-        if len(self.params['customvalues']) != 0:
-            for kv in self.params['customvalues']:
-                if 'key' not in kv or 'value' not in kv:
-                    self.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
-                ov = vim.OptionValue()
-                ov.key = kv['key']
-                ov.value = kv['value']
-                config.append(ov)
-
-        instantclone_spec = vim.VirtualMachineInstantCloneSpec()
-        location_spec = vim.VirtualMachineRelocateSpec()
-        if vm_state['instant_clone_frozen'] is False:
-            # VM is not frozen, need to do prep work for instant clone
-            vm_network_adapters = []
-            devices = vm.config.hardware.device
-            for device in devices:
-                if isinstance(device, vim.VirtualEthernetCard):
-                    vm_network_adapters.append(device)
-
-            for vm_network_adapter in vm_network_adapters:
-                # Standard network
-                if isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardNetworkBackingInfo):
-                    network_id = vm_network_adapter.backing.network
-                    device_spec = vim.VirtualDeviceConfigSpec()
-                    device_spec.operation = 'edit'
-                    device_spec.device = vm_network_adapter
-                    device_spec.device.backing = vim.VirtualEthernetCardNetworkBackingInfo()
-                    device_spec.device.backing.deviceName = network_id
-                    connectable = vim.VirtualDeviceConnectInfo()
-                    connectable.migrateConnect = 'disconnect'
-                    device_spec.device.connectable = connectable
-                    location_spec.deviceChange.append(device_spec)
-                # Distributed network switch
-                elif isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardDistributedVirtualPortBackingInfo):
-                    network_id = vm_network_adapter.backing.port
-                    # If the port key isn't cleared the VM clone will fail as the port is in use by the running source VM.
-                    network_id.portKey = None
-                    device_spec = vim.VirtualDeviceConfigSpec()
-                    device_spec.operation = 'edit'
-                    device_spec.device = vm_network_adapter
-                    device_spec.device.backing = vim.VirtualEthernetCardDistributedVirtualPortBackingInfo()
-                    device_spec.device.backing.port = network_id
-                    connectable = vim.VirtualDeviceConnectInfo()
-                    connectable.migrateConnect = 'disconnect'
-                    device_spec.device.connectable = connectable
-                    location_spec.deviceChange.append(device_spec)
-                else:
-                    self.module.exit_json(msg='Unknown network backing type of "%s" only Virtual Distributed switches and Standard swtiches are supported.'
-                                          % vm_network_adapter.__class__.__name__.split('.')[-1])
-
-            instantclone_spec.config = config
-            instantclone_spec.location = location_spec
-            instantclone_spec.name = self.params['name']
-
-        else:
-            # VM is frozen, can clone without prep work
-            instantclone_spec.config = config
-            instantclone_spec.location = location_spec
-            instantclone_spec.name = self.params['name']
-
-        task = vm.InstantClone_Task(instantclone_spec)
-        wait_for_task(task)
-        if task.info.state == 'error':
-            kwargs = {
-                'changed': self.change_applied,
-                'failed': True,
-                'msg': task.info.error.msg,
-                'clone_method': 'InstantClone_Task'
-            }
-            return kwargs
-
-        vm = task.info.result
-        vm_facts = self.gather_facts(vm)
-        return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
-
     def deploy_vm(self):
         # https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/clone_vm.py
         # https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.CloneSpec.html
         # https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.vm.ConfigSpec.html
         # https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.RelocateSpec.html
-        # https://vdc-download.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.vm.InstantCloneSpec.html
 
         # FIXME:
         #   - static IPs
@@ -2276,7 +2152,8 @@ class PyVmomiHelper(PyVmomi):
                 'folder': self.folder,
                 'full_search_path': fullpath,
             }
-            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.folder, fullpath), details=details)
+            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.folder, fullpath),
+                                  details=details)
 
         destfolder = f_obj
 
@@ -2365,7 +2242,8 @@ class PyVmomiHelper(PyVmomi):
                     if snapshot_src is not None:
                         self.relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking
                     else:
-                        self.module.fail_json(msg="Parameter 'linked_src' and 'snapshot_src' are required together for linked clone operation.")
+                        self.module.fail_json(msg="Parameter 'linked_src' and 'snapshot_src' are"
+                                                  " required together for linked clone operation.")
 
                 clonespec = vim.vm.CloneSpec(template=self.params['is_template'], location=self.relospec)
                 if self.customspec:
@@ -2374,9 +2252,11 @@ class PyVmomiHelper(PyVmomi):
                 if snapshot_src is not None:
                     if vm_obj.snapshot is None:
                         self.module.fail_json(msg="No snapshots present for virtual machine or template [%(template)s]" % self.params)
-                    snapshot = self.get_snapshots_by_name_recursively(snapshots=vm_obj.snapshot.rootSnapshotList, snapname=snapshot_src)
+                    snapshot = self.get_snapshots_by_name_recursively(snapshots=vm_obj.snapshot.rootSnapshotList,
+                                                                      snapname=snapshot_src)
                     if len(snapshot) != 1:
-                        self.module.fail_json(msg='virtual machine "%(template)s" does not contain snapshot named "%(snapshot_src)s"' % self.params)
+                        self.module.fail_json(msg='virtual machine "%(template)s" does not contain'
+                                                  ' snapshot named "%(snapshot_src)s"' % self.params)
 
                     clonespec.snapshot = snapshot[0].snapshot
 
@@ -2385,9 +2265,10 @@ class PyVmomiHelper(PyVmomi):
                 try:
                     task = vm_obj.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
                 except vim.fault.NoPermission as e:
-                    self.module.fail_json(
-                        msg="Failed to clone virtual machine %s to folder %s due to permission issue: %s" %
-                            (self.params['name'], destfolder, to_native(e.msg)))
+                    self.module.fail_json(msg="Failed to clone virtual machine %s to folder %s "
+                                              "due to permission issue: %s" % (self.params['name'],
+                                                                               destfolder,
+                                                                               to_native(e.msg)))
                 self.change_detected = True
             else:
                 # ConfigSpec require name for VM creation
@@ -2401,9 +2282,11 @@ class PyVmomiHelper(PyVmomi):
                 try:
                     task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
                 except vmodl.fault.InvalidRequest as e:
-                    self.module.fail_json(msg="Failed to create virtual machine due to invalid configuration parameter %s" % to_native(e.msg))
+                    self.module.fail_json(msg="Failed to create virtual machine due to invalid configuration "
+                                              "parameter %s" % to_native(e.msg))
                 except vim.fault.RestrictedVersion as e:
-                    self.module.fail_json(msg="Failed to create virtual machine due to product versioning restrictions: %s" % to_native(e.msg))
+                    self.module.fail_json(msg="Failed to create virtual machine due to "
+                                              "product versioning restrictions: %s" % to_native(e.msg))
                 self.change_detected = True
             self.wait_for_task(task)
         except TypeError as e:
@@ -2705,7 +2588,6 @@ def main():
         vapp_properties=dict(type='list', default=[]),
         datastore=dict(type='str'),
         convert=dict(type='str', choices=['thin', 'thick', 'eagerzeroedthick']),
-        instant_clone=dict(type='bool', default=False),
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
@@ -2779,18 +2661,7 @@ def main():
             raise AssertionError()
     # VM doesn't exist
     else:
-        if module.params['instant_clone']:
-            if module.check_mode:
-                result.update(
-                    change=True,
-                    desired_operation='deploy_instantclone',
-                )
-                module.exit_json(**result)
-            result = pyv.deploy_instantclone()
-            if result['failed']:
-                module.fail_json(msg='Failed to create an instant clone machine: "%s"' % result['msg'])
-
-        elif module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
+        if module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
             if module.check_mode:
                 result.update(
                     changed=True,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: vmware_guest_snapshot
+module: vmware_guest_instantclone
 short_description: Manages virtual machines instant clones in vCenter
 description:
     - This module can be used to create instant clones of a given virtual machine.
@@ -29,9 +29,19 @@ requirements:
 options:
    name:
     description:
-    - Name of the new instant clone VM
+    - Name of the new instant clone VM.
     required: True
     type: str
+   source_vm:
+    description:
+    - Name of the source VM to clone from, for best results ensure it is in a frozen state.
+    required: True
+    type: str
+   customvalues:
+    description:
+    - A Key / Value list of custom configuration parameters.
+    required: False
+    type: list
 extends_documentation_fragment: vmware.documentation
 '''
 EXAMPLES = r'''
@@ -53,6 +63,7 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.vmware import (find_obj, gather_vm_facts, vmware_argument_spec,
                                          set_vm_power_state, PyVmomi, wait_for_task, TaskError)
 
+
 def deploy_instantclone(module):
     # Ensure required params are given
     if module.params['source_vm'] is None:
@@ -70,7 +81,7 @@ def deploy_instantclone(module):
     if vm_state['instant_clone_frozen'] is None:
         module.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
 
-    # Build VM config object
+    # Build VM config dict
     config = []
     # If customvalues is not empty, fill config
     if len(module.params['customvalues']) != 0:
@@ -153,6 +164,7 @@ def deploy_instantclone(module):
         'instance': vm_facts,
         'clone_method': 'InstantClone_Task'
     }
+
 
 def main():
     argument_spec = vmware_argument_spec()

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vmware_guest_snapshot
+short_description: Manages virtual machines instant clones in vCenter
+description:
+    - This module can be used to create instant clones of a given virtual machine.
+    - All parameters and VMware object names are case sensitive.
+version_added: 2.9
+author:
+    - Dakota Clark (@PDQDakota) <dakota.clark@pdq.com>
+notes:
+    - Tested on vSphere 6.7
+    - For best results, freeze the source VM before use
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+   name:
+    description:
+    - Name of the new instant clone VM
+    required: True
+    type: str
+extends_documentation_fragment: vmware.documentation
+'''
+EXAMPLES = r'''
+'''
+
+RETURN = r'''
+'''
+
+HAS_PYVMOMI = False
+try:
+    from pyVmomi import vim, vmodl, VmomiSupport
+    HAS_PYVMOMI = True
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.network import is_mac
+from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.vmware import (find_obj, gather_vm_facts, vmware_argument_spec,
+                                         set_vm_power_state, PyVmomi, wait_for_task, TaskError)
+
+def deploy_instantclone(module):
+    # Ensure required params are given
+    if module.params['source_vm'] is None:
+        module.fail_json(msg='In order to create an instant clone the source VM name or UUID of a running VM must be specified in the source_vm parameter.')
+    if module.params['name'] is None:
+        module.fail_json(msg='A name for the new VM must be provided in the name parameter.')
+    # Gather needed facts from the base VM for the instant clone
+    vm = find_obj(module.content, [vim.VirtualMachine], module.params['source_vm'])
+    if vm is None:
+        module.fail_json(msg="Failed to find the VM: %s" % module.params['source_vm'])
+    vm_state = gather_vm_facts(module.content, vm)
+    # An instant clone requires the base VM to be running, fail if it is not
+    if vm_state['hw_power_status'] != 'poweredOn':
+        module.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
+    if vm_state['instant_clone_frozen'] is None:
+        module.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
+
+    # Build VM config object
+    config = []
+    # If customvalues is not empty, fill config
+    if len(module.params['customvalues']) != 0:
+        for kv in module.params['customvalues']:
+            if 'key' not in kv or 'value' not in kv:
+                module.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
+            ov = vim.OptionValue()
+            ov.key = kv['key']
+            ov.value = kv['value']
+            config.append(ov)
+
+    instantclone_spec = vim.VirtualMachineInstantCloneSpec()
+    location_spec = vim.VirtualMachineRelocateSpec()
+    if vm_state['instant_clone_frozen'] is False:
+        # VM is not frozen, need to do prep work for instant clone
+        vm_network_adapters = []
+        devices = vm.config.hardware.device
+        for device in devices:
+            if isinstance(device, vim.VirtualEthernetCard):
+                vm_network_adapters.append(device)
+
+        for vm_network_adapter in vm_network_adapters:
+            # Standard network switch
+            if isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardNetworkBackingInfo):
+                network_id = vm_network_adapter.backing.network
+                device_spec = vim.VirtualDeviceConfigSpec()
+                device_spec.operation = 'edit'
+                device_spec.device = vm_network_adapter
+                device_spec.device.backing = vim.VirtualEthernetCardNetworkBackingInfo()
+                device_spec.device.backing.deviceName = network_id
+                connectable = vim.VirtualDeviceConnectInfo()
+                connectable.migrateConnect = 'disconnect'
+                device_spec.device.connectable = connectable
+                location_spec.deviceChange.append(device_spec)
+            # Distributed network switch
+            elif isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardDistributedVirtualPortBackingInfo):
+                network_id = vm_network_adapter.backing.port
+                # If the port key isn't cleared the VM clone will fail as the port is in use by the running source VM.
+                network_id.portKey = None
+                device_spec = vim.VirtualDeviceConfigSpec()
+                device_spec.operation = 'edit'
+                device_spec.device = vm_network_adapter
+                device_spec.device.backing = vim.VirtualEthernetCardDistributedVirtualPortBackingInfo()
+                device_spec.device.backing.port = network_id
+                connectable = vim.VirtualDeviceConnectInfo()
+                connectable.migrateConnect = 'disconnect'
+                device_spec.device.connectable = connectable
+                location_spec.deviceChange.append(device_spec)
+            else:
+                module.module.exit_json(msg='Unknown network backing type of "%s" only Virtual Distributed switches and Standard swtiches are supported.'
+                                        % vm_network_adapter.__class__.__name__.split('.')[-1])
+
+        instantclone_spec.config = config
+        instantclone_spec.location = location_spec
+        instantclone_spec.name = module.params['name']
+
+    else:
+        # VM is frozen, can clone without prep work
+        instantclone_spec.config = config
+        instantclone_spec.location = location_spec
+        instantclone_spec.name = module.params['name']
+
+    task = vm.InstantClone_Task(instantclone_spec)
+    wait_for_task(task)
+
+    if task.info.state == 'error':
+        kwargs = {
+            'changed': module.change_applied,
+            'failed': True,
+            'msg': task.info.error.msg,
+            'clone_method': 'InstantClone_Task'
+        }
+        return kwargs
+
+    clone = task.info.result
+    vm_facts = gather_vm_facts(module.content, clone)
+    return {
+        'changed': module.change_applied,
+        'failed': False,
+        'instance': vm_facts,
+        'clone_method': 'InstantClone_Task'
+    }
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        name=dict(type='str'),
+        source_vm=dict(type='str'),
+        customvalues=dict(type='list', default=[]),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           )
+
+    result = {'failed': False, 'changed': False}
+
+    if module.check_mode:
+        result.update(
+            changed=True,
+            desired_operation='instantclone_vm',
+        )
+        module.exit_json(**result)
+
+    result = deploy_instantclone(module)
+
+    if result['failed']:
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -27,6 +27,13 @@ requirements:
     - "python >= 2.6"
     - PyVmomi
 options:
+   state:
+    description:
+    - Whether a given clone should be present or absent from the vSphere instance.
+    default: present
+    choices: [ present, absent ]
+    required: True
+    type: str
    name:
     description:
     - Name of the new instant clone VM.
@@ -64,111 +71,118 @@ from ansible.module_utils.vmware import (find_obj, gather_vm_facts, vmware_argum
                                          set_vm_power_state, PyVmomi, wait_for_task, TaskError)
 
 
-def deploy_instantclone(module):
-    # Ensure required params are given
-    if module.params['source_vm'] is None:
-        module.fail_json(msg='In order to create an instant clone the source VM name or UUID of a running VM must be specified in the source_vm parameter.')
-    if module.params['name'] is None:
-        module.fail_json(msg='A name for the new VM must be provided in the name parameter.')
-    # Gather needed facts from the base VM for the instant clone
-    vm = find_obj(module.content, [vim.VirtualMachine], module.params['source_vm'])
-    if vm is None:
-        module.fail_json(msg="Failed to find the VM: %s" % module.params['source_vm'])
-    vm_state = gather_vm_facts(module.content, vm)
-    # An instant clone requires the base VM to be running, fail if it is not
-    if vm_state['hw_power_status'] != 'poweredOn':
-        module.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
-    if vm_state['instant_clone_frozen'] is None:
-        module.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
+class PyVmomiHelper(PyVmomi):
+    def __init__(self, module):
+        super(PyVmomiHelper, self).__init__(module)
 
-    # Build VM config dict
-    config = []
-    # If customvalues is not empty, fill config
-    if len(module.params['customvalues']) != 0:
-        for kv in module.params['customvalues']:
-            if 'key' not in kv or 'value' not in kv:
-                module.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
-            ov = vim.OptionValue()
-            ov.key = kv['key']
-            ov.value = kv['value']
-            config.append(ov)
+    def deploy_instantclone(self):
+        # Ensure required params are given
+        if self.module.params['source_vm'] is None:
+            self.module.fail_json(msg='Please specify the source VM name or UUID in the source_vm parameter. The source VM must be running.')
+        if self.module.params['name'] is None:
+            self.module.fail_json(msg='A name for the new VM must be provided in the name parameter.')
+        # Gather needed facts from the base VM for the instant clone
+        vm = find_obj(self.module.content, [vim.VirtualMachine], self.module.params['source_vm'])
+        if vm is None:
+            self.module.fail_json(msg="Failed to find the VM: %s" % self.module.params['source_vm'])
+        vm_state = gather_vm_facts(self.module.content, vm)
+        # An instant clone requires the base VM to be running, fail if it is not
+        if vm_state['hw_power_status'] != 'poweredOn':
+            self.module.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
+        if vm_state['instant_clone_frozen'] is None:
+            self.module.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
 
-    instantclone_spec = vim.VirtualMachineInstantCloneSpec()
-    location_spec = vim.VirtualMachineRelocateSpec()
-    if vm_state['instant_clone_frozen'] is False:
-        # VM is not frozen, need to do prep work for instant clone
-        vm_network_adapters = []
-        devices = vm.config.hardware.device
-        for device in devices:
-            if isinstance(device, vim.VirtualEthernetCard):
-                vm_network_adapters.append(device)
+        # Build VM config dict
+        config = []
+        # If customvalues is not empty, fill config
+        if len(self.module.params['customvalues']) != 0:
+            for kv in self.module.params['customvalues']:
+                if 'key' not in kv or 'value' not in kv:
+                    self.module.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
+                ov = vim.OptionValue()
+                ov.key = kv['key']
+                ov.value = kv['value']
+                config.append(ov)
 
-        for vm_network_adapter in vm_network_adapters:
-            # Standard network switch
-            if isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardNetworkBackingInfo):
-                network_id = vm_network_adapter.backing.network
-                device_spec = vim.VirtualDeviceConfigSpec()
-                device_spec.operation = 'edit'
-                device_spec.device = vm_network_adapter
-                device_spec.device.backing = vim.VirtualEthernetCardNetworkBackingInfo()
-                device_spec.device.backing.deviceName = network_id
-                connectable = vim.VirtualDeviceConnectInfo()
-                connectable.migrateConnect = 'disconnect'
-                device_spec.device.connectable = connectable
-                location_spec.deviceChange.append(device_spec)
-            # Distributed network switch
-            elif isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardDistributedVirtualPortBackingInfo):
-                network_id = vm_network_adapter.backing.port
-                # If the port key isn't cleared the VM clone will fail as the port is in use by the running source VM.
-                network_id.portKey = None
-                device_spec = vim.VirtualDeviceConfigSpec()
-                device_spec.operation = 'edit'
-                device_spec.device = vm_network_adapter
-                device_spec.device.backing = vim.VirtualEthernetCardDistributedVirtualPortBackingInfo()
-                device_spec.device.backing.port = network_id
-                connectable = vim.VirtualDeviceConnectInfo()
-                connectable.migrateConnect = 'disconnect'
-                device_spec.device.connectable = connectable
-                location_spec.deviceChange.append(device_spec)
-            else:
-                module.module.exit_json(msg='Unknown network backing type of "%s" only Virtual Distributed switches and Standard swtiches are supported.'
-                                        % vm_network_adapter.__class__.__name__.split('.')[-1])
-
+        # Begin building the spec
+        instantclone_spec = vim.VirtualMachineInstantCloneSpec()
+        location_spec = vim.VirtualMachineRelocateSpec()
         instantclone_spec.config = config
-        instantclone_spec.location = location_spec
-        instantclone_spec.name = module.params['name']
+        instantclone_spec.name = self.module.params['name']
 
-    else:
-        # VM is frozen, can clone without prep work
-        instantclone_spec.config = config
-        instantclone_spec.location = location_spec
-        instantclone_spec.name = module.params['name']
+        if vm_state['instant_clone_frozen'] is False:
+            # VM is not frozen, need to do prep work for instant clone
+            vm_network_adapters = []
+            devices = vm.config.hardware.device
+            for device in devices:
+                if isinstance(device, vim.VirtualEthernetCard):
+                    vm_network_adapters.append(device)
 
-    task = vm.InstantClone_Task(instantclone_spec)
-    wait_for_task(task)
+            for vm_network_adapter in vm_network_adapters:
+                # Standard network switch
+                if isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardNetworkBackingInfo):
+                    network_id = vm_network_adapter.backing.network
+                    device_spec = vim.VirtualDeviceConfigSpec()
+                    device_spec.operation = 'edit'
+                    device_spec.device = vm_network_adapter
+                    device_spec.device.backing = vim.VirtualEthernetCardNetworkBackingInfo()
+                    device_spec.device.backing.deviceName = network_id
+                    connectable = vim.VirtualDeviceConnectInfo()
+                    connectable.migrateConnect = 'disconnect'
+                    device_spec.device.connectable = connectable
+                    location_spec.deviceChange.append(device_spec)
+                # Distributed network switch
+                elif isinstance(vm_network_adapter.backing, vim.VirtualEthernetCardDistributedVirtualPortBackingInfo):
+                    network_id = vm_network_adapter.backing.port
+                    # If the port key isn't cleared the VM clone will fail as the port is in use by the running source VM.
+                    network_id.portKey = None
+                    device_spec = vim.VirtualDeviceConfigSpec()
+                    device_spec.operation = 'edit'
+                    device_spec.device = vm_network_adapter
+                    device_spec.device.backing = vim.VirtualEthernetCardDistributedVirtualPortBackingInfo()
+                    device_spec.device.backing.port = network_id
+                    connectable = vim.VirtualDeviceConnectInfo()
+                    connectable.migrateConnect = 'disconnect'
+                    device_spec.device.connectable = connectable
+                    location_spec.deviceChange.append(device_spec)
+                else:
+                    self.module.module.exit_json(msg='Unknown network backing type of %s only Virtual Distributed switches and Standard swtiches are supported.'
+                                                 % vm_network_adapter.__class__.__name__.split('.')[-1])
 
-    if task.info.state == 'error':
-        kwargs = {
-            'changed': module.change_applied,
-            'failed': True,
-            'msg': task.info.error.msg,
+            # Finalize the spec for a non-frozen VM
+            instantclone_spec.location = location_spec
+
+        else:
+            # VM is frozen, can clone without prep work
+            # Finalize the spec for a frozen VM
+            instantclone_spec.location = location_spec
+
+        task = vm.InstantClone_Task(instantclone_spec)
+        wait_for_task(task)
+
+        if task.info.state == 'error':
+            kwargs = {
+                'changed': self.module.change_applied,
+                'failed': True,
+                'msg': task.info.error.msg,
+                'clone_method': 'InstantClone_Task'
+            }
+            return kwargs
+
+        clone = task.info.result
+        vm_facts = gather_vm_facts(self.module.content, clone)
+        return {
+            'changed': self.module.change_applied,
+            'failed': False,
+            'instance': vm_facts,
             'clone_method': 'InstantClone_Task'
         }
-        return kwargs
-
-    clone = task.info.result
-    vm_facts = gather_vm_facts(module.content, clone)
-    return {
-        'changed': module.change_applied,
-        'failed': False,
-        'instance': vm_facts,
-        'clone_method': 'InstantClone_Task'
-    }
 
 
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
+        state=dict(default='present', choices=['present', 'absent']),
         name=dict(type='str'),
         source_vm=dict(type='str'),
         customvalues=dict(type='list', default=[]),
@@ -180,14 +194,31 @@ def main():
 
     result = {'failed': False, 'changed': False}
 
-    if module.check_mode:
-        result.update(
-            changed=True,
-            desired_operation='instantclone_vm',
-        )
-        module.exit_json(**result)
+    pyv = PyVmomiHelper(module)
+    vm = pyv.get_vm()
 
-    result = deploy_instantclone(module)
+    # The clone doesn't exist
+    if not vm:
+        if module.params['state'] == 'present':
+            if module.check_mode:
+                result.update(
+                    changed=True,
+                    desired_operation='instantclone_vm',
+                )
+                module.exit_json(**result)
+            # Create and instant clone
+            result = pyv.deploy_instantclone()
+    # The clone is present
+    else:
+        if module.params['state'] == 'absent':
+            if module.check_mode:
+                result.update(
+                    changed=True,
+                    desired_operation='remove_vm',
+                )
+                module.exit_json(**result)
+            # Delete the clone
+            vm.Destory()
 
     if result['failed']:
         module.fail_json(**result)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -76,7 +76,7 @@ class PyVmomiHelper(PyVmomi):
         super(PyVmomiHelper, self).__init__(module)
 
     def deploy_instantclone(self, vm):
-        vm_state = gather_vm_facts(self.module.content, vm)
+        vm_state = gather_vm_facts(self.content, vm)
         # An instant clone requires the base VM to be running, fail if it is not
         if vm_state['hw_power_status'] != 'poweredOn':
             self.module.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
@@ -99,7 +99,7 @@ class PyVmomiHelper(PyVmomi):
         instantclone_spec = vim.VirtualMachineInstantCloneSpec()
         location_spec = vim.VirtualMachineRelocateSpec()
         instantclone_spec.config = config
-        instantclone_spec.name = self.module.params['name']
+        instantclone_spec.name = self.module.params['clone_name']
 
         if vm_state['instant_clone_frozen'] is False:
             # VM is not frozen, need to do prep work for instant clone
@@ -153,7 +153,7 @@ class PyVmomiHelper(PyVmomi):
 
         if task.info.state == 'error':
             kwargs = {
-                'changed': self.module.change_applied,
+                'changed': False,
                 'failed': True,
                 'msg': task.info.error.msg,
                 'clone_method': 'InstantClone_Task'
@@ -161,9 +161,9 @@ class PyVmomiHelper(PyVmomi):
             return kwargs
 
         clone = task.info.result
-        vm_facts = gather_vm_facts(self.module.content, clone)
+        vm_facts = gather_vm_facts(self.content, clone)
         return {
-            'changed': self.module.change_applied,
+            'changed': True,
             'failed': False,
             'instance': vm_facts,
             'clone_method': 'InstantClone_Task'

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -29,7 +29,8 @@ requirements:
 options:
    name:
     description:
-    - Name of the new instant clone VM.
+    - Name of the VM to create an instant clone from.
+    - This is required if C(uuid) or C(moid) is not supplied.
     required: True
     type: str
    name_match:
@@ -53,25 +54,6 @@ options:
     - Whether to use the VMware instance UUID rather than the BIOS UUID.
     default: no
     type: bool
-   folder:
-    description:
-    - Destination folder, absolute path to find an existing guest or create the new guest.
-    - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
-    - This parameter is case sensitive.
-    - This parameter is required, while deploying new virtual machine. version_added 2.5.
-    - 'If multiple machines are found with same name, this parameter is used to identify
-       uniqueness of the virtual machine. version_added 2.5'
-    - 'Examples:'
-    - '   folder: /ha-datacenter/vm'
-    - '   folder: ha-datacenter/vm'
-    - '   folder: /datacenter1/vm'
-    - '   folder: datacenter1/vm'
-    - '   folder: /datacenter1/vm/folder1'
-    - '   folder: datacenter1/vm/folder1'
-    - '   folder: /folder1/datacenter1/vm'
-    - '   folder: folder1/datacenter1/vm'
-    - '   folder: /folder1/datacenter1/vm/folder2'
-    type: str
    datacenter:
     description:
     - Datacenter for the clone operation.
@@ -88,6 +70,7 @@ options:
     type: list
 extends_documentation_fragment: vmware.documentation
 '''
+
 EXAMPLES = r'''
 - name: Create an instant clone of a running VM
   vmware_guest_instantclone:
@@ -242,7 +225,6 @@ def main():
         uuid=dict(type='str'),
         moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
-        folder=dict(type='str'),
         datacenter=dict(required=True, type='str'),
         clone_name=dict(required=True, type='str'),
         customvalues=dict(type='list', default=[]),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -239,11 +239,6 @@ def main():
 
     result = {'failed': False, 'changed': False}
 
-    if module.params['folder']:
-        # FindByInventoryPath() does not require an absolute path
-        # so we should leave the input folder path unmodified
-        module.params['folder'] = module.params['folder'].rstrip('/')
-
     pyv = PyVmomiHelper(module)
     vm = pyv.get_vm()
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -143,9 +143,9 @@ class PyVmomiHelper(PyVmomi):
         vm_state = gather_vm_facts(self.content, vm)
         # An instant clone requires the base VM to be running, fail if it is not
         if vm_state['hw_power_status'] != 'poweredOn':
-            self.module.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
+            self.module.fail_json(msg='Unable to instant clone a VM in a "%s" state. It must be powered on.' % vm_state['hw_power_status'])
         if vm_state['instant_clone_frozen'] is None:
-            self.module.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
+            self.module.fail_json(msg='Unable to determine if VM is in a frozen state. Is vSphere running 6.7 or later?')
 
         # Build VM config dict
         config = []
@@ -153,7 +153,7 @@ class PyVmomiHelper(PyVmomi):
         if len(self.module.params['customvalues']) != 0:
             for kv in self.module.params['customvalues']:
                 if 'key' not in kv or 'value' not in kv:
-                    self.module.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
+                    self.module.exit_json(msg="The parameter customvalues items required both 'key' and 'value' fields.")
                 ov = vim.OptionValue()
                 ov.key = kv['key']
                 ov.value = kv['value']
@@ -268,9 +268,6 @@ def main():
     if not vm:
         vm_id = (module.params.get('uuid') or module.params.get('name') or module.params.get('moid'))
         module.fail_json(msg="Unable to find any VM with the identifier: %s" % vm_id)
-
-    if not module.params['clone_name']:
-        module.fail_json(msg='Please specify a name for the new instant clone using the clone_name parameter.')
 
     if module.check_mode:
         result.update(

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_instantclone.py
@@ -17,7 +17,7 @@ short_description: Manages virtual machines instant clones in vCenter
 description:
     - This module can be used to create instant clones of a given virtual machine.
     - All parameters and VMware object names are case sensitive.
-version_added: 2.9
+version_added: 2.10
 author:
     - Dakota Clark (@PDQDakota) <dakota.clark@pdq.com>
 notes:

--- a/test/integration/targets/vmware_guest_instantclone/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_instantclone/tasks/main.yml
@@ -1,0 +1,9 @@
+# Test0001: Create an instant clone
+- name: 0001 - Create an instant clone
+    validate_certs: False
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
+    name: '{{ source_vm }}'
+    clone_name: '{{ name }}'

--- a/test/units/modules/cloud/vmware/test_data/test_vmware_guest_instantclone_with_parameters.json
+++ b/test/units/modules/cloud/vmware/test_data/test_vmware_guest_instantclone_with_parameters.json
@@ -1,0 +1,17 @@
+[
+    [
+        {
+            "name": "sample_vm_001",
+            "hostname": "esxi01.example.com",
+            "username": "administrator@vsphere.local",
+            "password": "Secret@123$%",
+            "validate_certs": "True",
+            "datacenter": "test-datacenter",
+            "clone_name": "clone-test"
+        },
+        {
+            "failed": "True",
+            "msg": "Unknown error while connecting to vCenter or ESXi API at esxi01.example.com:443 : [Errno -2] Name or service not known"
+        }
+    ]
+]

--- a/test/units/modules/cloud/vmware/test_data/test_vmware_guest_instantclone_with_parameters.json
+++ b/test/units/modules/cloud/vmware/test_data/test_vmware_guest_instantclone_with_parameters.json
@@ -11,7 +11,21 @@
         },
         {
             "failed": "True",
-            "msg": "Unknown error while connecting to vCenter or ESXi API at esxi01.example.com:443 : [Errno -2] Name or service not known"
+            "msg": "Unknown error while connecting to vCenter or ESXi API at esxi01.example.com:443 :"
+        }
+    ],
+    [
+        {
+            "hostname": "esxi01.example.com",
+            "username": "administrator@vsphere.local",
+            "password": "Secret@123$%",
+            "validate_certs": "False",
+            "datacenter": "test-datacenter",
+            "clone_name": "clone-test"
+        },
+        {
+            "failed": "True",
+            "msg": "one of the following is required: name, uuid, moid"
         }
     ]
 ]

--- a/test/units/modules/cloud/vmware/test_vmware_guest_instantclone.py
+++ b/test/units/modules/cloud/vmware/test_vmware_guest_instantclone.py
@@ -32,8 +32,7 @@ def test_vmware_guest_instantclone_wo_parameters(capfd):
     out, err = capfd.readouterr()
     results = json.loads(out)
     assert results['failed']
-    # WTF is the order of datacenter and clone_name random in msg??????
-    assert "missing required arguments: datacenter, clone_name" in results['msg']
+    assert "missing required arguments:" in results['msg']
 
 
 @pytest.mark.parametrize('patch_ansible_module, testcase', TEST_CASES, indirect=['patch_ansible_module'])

--- a/test/units/modules/cloud/vmware/test_vmware_guest_instantclone.py
+++ b/test/units/modules/cloud/vmware/test_vmware_guest_instantclone.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+import sys
+import pytest
+import json
+
+pyvmomi = pytest.importorskip('pyVmomi')
+
+if sys.version_info < (2, 7):
+    pytestmark = pytest.mark.skip("vmware_guest_instantclone Ansible modules require Python >= 2.7")
+
+
+from ansible.modules.cloud.vmware import vmware_guest_instantclone
+
+curr_dir = os.path.dirname(__file__)
+test_data_file = open(os.path.join(curr_dir, 'test_data', 'test_vmware_guest_instantclone_with_parameters.json'), 'r')
+TEST_CASES = json.loads(test_data_file.read())
+test_data_file.close()
+
+
+@pytest.mark.parametrize('patch_ansible_module', [{}], indirect=['patch_ansible_module'])
+@pytest.mark.usefixtures('patch_ansible_module')
+def test_vmware_guest_instantclone_wo_parameters(capfd):
+    with pytest.raises(SystemExit):
+        vmware_guest_instantclone.main()
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results['failed']
+    # WTF is the order of datacenter and clone_name random in msg??????
+    assert "missing required arguments: datacenter, clone_name" in results['msg']
+
+
+@pytest.mark.parametrize('patch_ansible_module, testcase', TEST_CASES, indirect=['patch_ansible_module'])
+@pytest.mark.usefixtures('patch_ansible_module')
+def test_vmware_guest_instantclone_with_parameters(mocker, capfd, testcase):
+    if testcase.get('test_ssl_context', None):
+        class mocked_ssl:
+            pass
+        mocker.patch('ansible.module_utils.vmware.ssl', new=mocked_ssl)
+
+    with pytest.raises(SystemExit):
+        vmware_guest_instantclone.main()
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert str(results['failed']) == testcase['failed']
+    assert testcase['msg'] in results['msg']


### PR DESCRIPTION
##### SUMMARY
Adds support for the instant clone API in vSphere to the vmware_guest module.

Instant Cloning is a method of cloning a running or frozen VM that uses Copy on Write for both disk and RAM allocation in order to reduce the amount of resources used by a cloned VM and to reduce the time required for the clone to become available. It requires a vSphere instance for the API to be available, it doesn't work with only an ESXi host.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest module

##### ADDITIONAL INFORMATION
I don't think I have more to add here but please request anything further you'd need of me!
