### PR TITLE
Added uptime to default subset - ios_facts

### DIFF
--- a/lib/ansible/module_utils/network/ios/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/ios/facts/legacy/base.py
@@ -51,6 +51,7 @@ class Default(FactsBase):
         if data:
             self.facts['iostype'] = self.parse_iostype(data)
             self.facts['serialnum'] = self.parse_serialnum(data)
+            self.facts['uptime'] = self.parse_uptime(data)
             self.parse_stacks(data)
 
     def parse_iostype(self, data):
@@ -62,6 +63,11 @@ class Default(FactsBase):
 
     def parse_serialnum(self, data):
         match = re.search(r'board ID (\S+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_uptime(self, data):
+        match = re.search(r'uptime is (\S+)', data)
         if match:
             return match.group(1)
 

--- a/lib/ansible/module_utils/network/ios/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/ios/facts/legacy/base.py
@@ -67,7 +67,7 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_uptime(self, data):
-        match = re.search(r'uptime is (\S+)', data)
+        match = re.search(r'uptime is (.+)', data)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -134,6 +134,10 @@ ansible_net_image:
   description: The image file the device is running
   returned: always
   type: str
+ansible_net_uptime:
+  description: The uptime of the device (master)
+  returned: always
+  type: str
 ansible_net_stacked_models:
   description: The model names of each device in the stack
   returned: when multiple devices are configured in a stack


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add uptime for ios_facts
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 ios_facts, ansible_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

It might be interesting to split "interfaces" and "topology" (cdp, lldp) subsets ?
Add restart time, reload reason as in the task 'get_facts' provided in the role 'ansible-network.cisco_ios' ?
Backport changes (cdp neighbors, ios_type, api, python_version) to 2.7 branch ?

Please check before merging, not 100% sure of my code
Feel free to add a unit test for this, otherwise I'll do it when I have time

Copy of #59852 but rebased following the merge of #59716
Referring #57334 #50463

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [10.1.62.10] => {
    "ansible_facts": {
        "ansible_net_filesystems": [
            "flash:"
        ],
        "ansible_net_filesystems_info": {
            "flash:": {
                "spacefree_kb": 942784,
                "spacetotal_kb": 1586040
            }
        },
        "ansible_net_gather_subset": [
            "hardware",
            "default"
        ],
        "ansible_net_hostname": "hostname",
        "ansible_net_image": "flash:packages.conf",
        "ansible_net_memfree_mb": 509320,
        "ansible_net_memtotal_mb": 832828,
        "ansible_net_model": "WS-C3850-48P",
        "ansible_net_serialnum": "FCW0000X0XX",
        "ansible_net_stacked_models": [
            "WS-C3850-48P"
        ],
        "ansible_net_stacked_serialnums": [
            "FCW2030D0KC"
        ],
        **"ansible_net_uptime": "1 week, 5 days, 20 hours, 42 minutes",**
        "ansible_net_version": "16.09.03a"
    }

```
