### PR TITLE
Aws ssm version support

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -221,7 +221,7 @@ class LookupModule(LookupBase):
             params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
                                                     tag_value_key_name="Value")
             for i in terms:
-                if i in params:
+                if i.split(':',1)[0] in params:
                     ret.append(params[i])
                 elif i in response['InvalidParameters']:
                     ret.append(None)

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -221,7 +221,7 @@ class LookupModule(LookupBase):
             params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
                                                     tag_value_key_name="Value")
             for i in terms:
-                if i.split(':',1)[0] in params:
+                if i.split(':', 1)[0] in params:
                     ret.append(params[i])
                 elif i in response['InvalidParameters']:
                     ret.append(None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS parameter store supports parameter versioning. The api allows for this with the syntax 'parameterName:versionNumber'. Currently, the aws_ssm module performs a string comparison on input parameters vs returned parameter names. When a version number is included, said string comparison fails as the name of the parameter returned by the api does not include the ':versionNumber'.

This is a simple change to remove the ':versionNumber' from the parameterName before the string comparison is performed. 

I chose not to include version as an additional parameter both to capitalize on boto3's native functionality and to avoid weird collisions when using the bypath option of the module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
{{ lookup('aws_ssm', '/os/test/uw-deploy/orgDataDir.db.pass:10', region='us-east-1') }}
```
Given this example, looking for version 10 of a parameter the boto3 response body looks like this
```
{
  "InvalidParameters": [],
  "Parameters": [
    {
      "Name": "/os/test/uw-deploy/orgDataDir.db.pass",
      "LastModifiedDate": "datetime.datetime(2019, 8, 20, 20, 20, 5, 666000, tzinfo=tzlocal())",
      "Value": "****",
      "Selector": ":1",
      "Version": 10,
      "Type": "SecureString",
      "ARN": "arn:aws:ssm:us-east-1:591355805062:parameter/os/test/uw-deploy/orgDataDir.db.pass"
    }
  ]
}
```
since `"/os/test/uw-deploy/orgDataDir.db.pass" != '/os/test/uw-deploy/orgDataDir.db.pass:10'` this falls into the else block and throws the AnsibleError on line 229.

When given a version number that doesnt exist, the behavior is as such:
```
{{ lookup('aws_ssm', '/os/test/uw-deploy/orgDataDir.db.pass:11', region='us-east-1') }}

{
  "InvalidParameters": ["/os/test/uw-deploy/orgDataDir.db.pass:11"],
  "Parameters": []
}
```
Because in this case the version number is included in the response, we do not want to remove it when performing the string comparison. If something that is not a number is passed after the colon, the behavior is the same.

Since aws does not allow colons in parameter names this should not cause any issues.