### PR TITLE
Fortinet's new module for fortios_user_pop3

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_user_pop3.py
+++ b/lib/ansible/modules/network/fortios/fortios_user_pop3.py
@@ -1,0 +1,347 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_user_pop3
+short_description: POP3 server entry configuration in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify user feature and pop3 category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    user_pop3:
+        description:
+            - POP3 server entry configuration.
+        default: null
+        type: dict
+        suboptions:
+            name:
+                description:
+                    - POP3 server entry name.
+                required: true
+                type: str
+            port:
+                description:
+                    - POP3 service port number.
+                type: int
+            secure:
+                description:
+                    - SSL connection.
+                type: str
+                choices:
+                    - none
+                    - starttls
+                    - pop3s
+            server:
+                description:
+                    - {<name_str|ip_str>} server domain name or IP.
+                type: str
+            ssl_min_proto_version:
+                description:
+                    - Minimum supported protocol version for SSL/TLS connections .
+                type: str
+                choices:
+                    - default
+                    - SSLv3
+                    - TLSv1
+                    - TLSv1-1
+                    - TLSv1-2
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: POP3 server entry configuration.
+    fortios_user_pop3:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      user_pop3:
+        name: "default_name_3"
+        port: "4"
+        secure: "none"
+        server: "192.168.100.40"
+        ssl_min_proto_version: "default"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_user_pop3_data(json):
+    option_list = ['name', 'port', 'secure',
+                   'server', 'ssl_min_proto_version']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def user_pop3(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    user_pop3_data = data['user_pop3']
+    filtered_data = underscore_to_hyphen(filter_user_pop3_data(user_pop3_data))
+
+    if state == "present":
+        return fos.set('user',
+                       'pop3',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('user',
+                          'pop3',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_user(data, fos):
+
+    if data['user_pop3']:
+        resp = user_pop3(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "user_pop3": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "name": {"required": True, "type": "str"},
+                "port": {"required": False, "type": "int"},
+                "secure": {"required": False, "type": "str",
+                           "choices": ["none", "starttls", "pop3s"]},
+                "server": {"required": False, "type": "str"},
+                "ssl_min_proto_version": {"required": False, "type": "str",
+                                          "choices": ["default", "SSLv3", "TLSv1",
+                                                      "TLSv1-1", "TLSv1-2"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_user(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_user(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_user_pop3.py
+++ b/lib/ansible/modules/network/fortios/fortios_user_pop3.py
@@ -105,7 +105,7 @@ options:
                     - pop3s
             server:
                 description:
-                    - {<name_str|ip_str>} server domain name or IP.
+                    - <name_str|ip_str> server domain name or IP.
                 type: str
             ssl_min_proto_version:
                 description:

--- a/lib/ansible/modules/network/fortios/fortios_user_pop3.py
+++ b/lib/ansible/modules/network/fortios/fortios_user_pop3.py
@@ -109,7 +109,7 @@ options:
                 type: str
             ssl_min_proto_version:
                 description:
-                    - Minimum supported protocol version for SSL/TLS connections .
+                    - Minimum supported protocol version for SSL/TLS connections.
                 type: str
                 choices:
                     - default

--- a/test/units/modules/network/fortios/test_fortios_user_pop3.py
+++ b/test/units/modules/network/fortios/test_fortios_user_pop3.py
@@ -1,0 +1,239 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_user_pop3
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_user_pop3.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_user_pop3_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'user_pop3': {
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'port': '4',
+                'secure': 'none',
+                'server': '192.168.100.6',
+                'ssl-min-proto-version': 'default'
+    }
+
+    set_method_mock.assert_called_with('user', 'pop3', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_user_pop3_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'user_pop3': {
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'port': '4',
+                'secure': 'none',
+                'server': '192.168.100.6',
+                'ssl-min-proto-version': 'default'
+    }
+
+    set_method_mock.assert_called_with('user', 'pop3', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_user_pop3_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'user_pop3': {
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('user', 'pop3', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_user_pop3_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'user_pop3': {
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('user', 'pop3', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_user_pop3_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'user_pop3': {
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'port': '4',
+                'secure': 'none',
+                'server': '192.168.100.6',
+                'ssl-min-proto-version': 'default'
+    }
+
+    set_method_mock.assert_called_with('user', 'pop3', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_user_pop3_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'user_pop3': {
+            'random_attribute_not_valid': 'tag',
+            'name': 'default_name_3',
+            'port': '4',
+            'secure': 'none',
+            'server': '192.168.100.6',
+            'ssl_min_proto_version': 'default'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_user_pop3.fortios_user(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'port': '4',
+                'secure': 'none',
+                'server': '192.168.100.6',
+                'ssl-min-proto-version': 'default'
+    }
+
+    set_method_mock.assert_called_with('user', 'pop3', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200


### PR DESCRIPTION
##### SUMMARY
 
Fortinet is adding Ansible support for FortiOS and FortiGate products. This module follows the same structure, guidelines and ideas given in previous approved module for a parallel feature of FortiGate (user device): https://github.com/ansible/ansible/pull/56447
In this case we are providing a different functionality: "Fortios User POP3".
 
Please note that this will be part of other modules to come for FortiGate, including different functionalities: system, wireless-controller, firewall, webfilter, ips, web-proxy, wanopt, application, dlp spamfilter, log, vpn, certificate, user, dnsfilter, antivirus, report, waf, authentication, switch controller, endpoint-control and router. We plan to follow the same style, structure and usage as in the previous module in order to make it easier to comply with Ansible guidelines.
 
This PR has been updated according to suggestions and code reviews given in previous submissions of Fortinet modules.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

fortios_user_pop3

##### ANSIBLE VERSION

```
ansible 2.8.2
python version = 3.7.3 (default, Apr  3 2019, 05:39:12) [GCC 8.3.0]
```