### PR TITLE
Speed up units using time.sleep by mocking or shortening sleep time

### DIFF
--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -99,8 +99,10 @@ def command_units(args):
             '-p', 'no:cacheprovider',
             '-c', os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest.ini'),
             '--junit-xml', os.path.join(data_context().results, 'junit', 'python%s-units.xml' % version),
-            '--durations=25',
         ]
+
+        if not data_context().content.collection:
+            cmd.append('--durations=25')
 
         if version != '2.6':
             # added in pytest 4.5.0, which requires python 2.7+

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -99,6 +99,7 @@ def command_units(args):
             '-p', 'no:cacheprovider',
             '-c', os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest.ini'),
             '--junit-xml', os.path.join(data_context().results, 'junit', 'python%s-units.xml' % version),
+            '--durations=25',
         ]
 
         if version != '2.6':

--- a/test/units/module_utils/facts/test_timeout.py
+++ b/test/units/module_utils/facts/test_timeout.py
@@ -31,7 +31,7 @@ from ansible.module_utils.facts import timeout
 @pytest.fixture
 def set_gather_timeout_higher():
     default_timeout = timeout.GATHER_TIMEOUT
-    timeout.GATHER_TIMEOUT = timeout.DEFAULT_GATHER_TIMEOUT + 5
+    timeout.GATHER_TIMEOUT = 5
     yield
     timeout.GATHER_TIMEOUT = default_timeout
 
@@ -81,7 +81,8 @@ def test_implicit_file_default_succeeds():
     assert sleep_amount_implicit(1) == 'Succeeded after 1 sec'
 
 
-def test_implicit_file_default_timesout():
+def test_implicit_file_default_timesout(monkeypatch):
+    monkeypatch.setattr(timeout, 'DEFAULT_GATHER_TIMEOUT', 1)
     # sleep_time is greater than the default
     sleep_time = timeout.DEFAULT_GATHER_TIMEOUT + 1
     with pytest.raises(timeout.TimeoutError):
@@ -90,7 +91,7 @@ def test_implicit_file_default_timesout():
 
 def test_implicit_file_overridden_succeeds(set_gather_timeout_higher):
     # Set sleep_time greater than the default timeout and less than our new timeout
-    sleep_time = timeout.DEFAULT_GATHER_TIMEOUT + 1
+    sleep_time = 3
     assert sleep_amount_implicit(sleep_time) == 'Succeeded after {0} sec'.format(sleep_time)
 
 
@@ -101,9 +102,10 @@ def test_implicit_file_overridden_timesout(set_gather_timeout_lower):
         assert sleep_amount_implicit(sleep_time) == '(Not expected to Succeed)'
 
 
-def test_explicit_succeeds():
+def test_explicit_succeeds(monkeypatch):
+    monkeypatch.setattr(timeout, 'DEFAULT_GATHER_TIMEOUT', 1)
     # Set sleep_time greater than the default timeout and less than our new timeout
-    sleep_time = timeout.DEFAULT_GATHER_TIMEOUT + 1
+    sleep_time = 2
     assert sleep_amount_explicit_higher(sleep_time) == 'Succeeded after {0} sec'.format(sleep_time)
 
 

--- a/test/units/modules/network/cnos/cnos_module.py
+++ b/test/units/modules/network/cnos/cnos_module.py
@@ -64,9 +64,13 @@ class TestCnosModule(unittest.TestCase):
 
         self.test_log = tempfile.mkstemp(prefix='ansible-test-cnos-module-', suffix='.log')[1]
 
+        self.mock_sleep = patch('time.sleep')
+        self.mock_sleep.start()
+
     def tearDown(self):
         super(TestCnosModule, self).tearDown()
 
+        self.mock_sleep.stop()
         os.remove(self.test_log)
 
     def execute_module(self, failed=False, changed=False, commands=None,

--- a/test/units/modules/network/enos/enos_module.py
+++ b/test/units/modules/network/enos/enos_module.py
@@ -59,6 +59,13 @@ class AnsibleFailJson(Exception):
 
 class TestEnosModule(unittest.TestCase):
 
+    def setUp(self):
+        self.mock_sleep = patch('time.sleep')
+        self.mock_sleep.start()
+
+    def tearDown(self):
+        self.mock_sleep.stop()
+
     def execute_module(self, failed=False, changed=False, commands=None,
                        sort=True, defaults=False):
 

--- a/test/units/modules/utils.py
+++ b/test/units/modules/utils.py
@@ -40,5 +40,8 @@ class ModuleTestCase(unittest.TestCase):
     def setUp(self):
         self.mock_module = patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
         self.mock_module.start()
+        self.mock_sleep = patch('time.sleep')
+        self.mock_sleep.start()
         set_module_args({})
         self.addCleanup(self.mock_module.stop)
+        self.addCleanup(self.mock_sleep.stop)


### PR DESCRIPTION
##### SUMMARY
Speed up units using time.sleep by mocking or shortening sleep time

This specifically targets tests with a duration longer than 10s.

I've left in `--durations` with a value of 25 to show the top 25 slowest tests. I think this could be helpful to see in context without having to add it later to find problematic tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
many

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```