### PR TITLE
Fix documentation and facts_from_proxy value in netapp_e_facts

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_facts.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_facts.py
@@ -16,10 +16,6 @@ module: netapp_e_facts
 short_description: NetApp E-Series retrieve facts about NetApp E-Series storage arrays
 description:
     - The netapp_e_facts module returns a collection of facts regarding NetApp E-Series storage arrays.
-    - When contacting a storage array directly the collection includes details about the array, controllers, management
-      interfaces, hostside interfaces, driveside interfaces, disks, storage pools, volumes, snapshots, and features.
-    - When contacting a web services proxy the collection will include basic information regarding the storage systems
-      that are under its management.
 version_added: '2.2'
 author:
     - Kevin Hulquest (@hulquest)
@@ -32,18 +28,11 @@ EXAMPLES = """
 ---
 - name: Get array facts
   netapp_e_facts:
-      ssid: "{{ netapp_array_id }}"
-      api_url: "https://{{ netapp_e_api_host }}:8443/devmgr/v2"
-      api_username: "{{ netapp_api_username }}"
-      api_password: "{{ netapp_api_password }}"
-      validate_certs: "{{ netapp_api_validate_certs }}"
-- name: Get array facts
-  netapp_e_facts:
-      ssid: 1
-      api_url: https://192.168.1.100:8443/devmgr/v2
-      api_username: myApiUser
-      api_password: myApiPass
-      validate_certs: true
+    ssid: "1"
+    api_url: "https://192.168.1.100:8443/devmgr/v2"
+    api_username: "admin"
+    api_password: "adminpass"
+    validate_certs: true
 """
 
 RETURN = """
@@ -275,7 +264,7 @@ class Facts(NetAppESeriesModule):
 
     def get_array_facts(self):
         """Extract particular facts from the storage array graph"""
-        facts = dict(facts_from_proxy=False, ssid=self.ssid)
+        facts = dict(facts_from_proxy=(not self.is_embedded()), ssid=self.ssid)
         controller_reference_label = self.get_controllers()
         array_facts = None
 
@@ -283,8 +272,7 @@ class Facts(NetAppESeriesModule):
         try:
             rc, array_facts = self.request("storage-systems/%s/graph" % self.ssid)
         except Exception as error:
-            self.module.fail_json(msg="Failed to obtain facts from storage array with id [%s]. Error [%s]"
-                                      % (self.ssid, str(error)))
+            self.module.fail_json(msg="Failed to obtain facts from storage array with id [%s]. Error [%s]" % (self.ssid, str(error)))
 
         facts['netapp_storage_array'] = dict(
             name=array_facts['sa']['saData']['storageArrayLabel'],

--- a/test/units/modules/storage/netapp/test_netapp_e_facts.py
+++ b/test/units/modules/storage/netapp/test_netapp_e_facts.py
@@ -449,6 +449,7 @@ class FactsTest(ModuleTestCase):
         """Verify get_array_facts method returns expected results."""
         self._set_args()
         facts = Facts()
+        facts.is_embedded = lambda: True
         with mock.patch(self.GET_CONTROLLERS_FUNC, return_value={"070000000000000000000001": "A", "070000000000000000000002": "B"}):
             with mock.patch(self.REQUEST_FUNC, side_effect=[(200, self.GRAPH_RESPONSE), (200, self.WORKLOAD_RESPONSE)]):
                 self.assertEquals(facts.get_array_facts(), self.EXPECTED_GET_ARRAY_FACTS)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed facts_from_proxy return value.
Fixed description and example in the module documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netapp_e_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible 2.9.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/swartzn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/swartzn/projects/ansible/ansible/lib/ansible
  executable location = /home/swartzn/projects/ansible/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]

```
