### PR TITLE
Update azure_rm_aks.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_aks.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_aks.py
@@ -215,6 +215,7 @@ EXAMPLES = '''
         location: eastus
         resource_group: myResourceGroup
         dns_prefix: akstest
+        kubernetes_version: 1.14.6
         linux_profile:
           admin_username: azureuser
           ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAA...
@@ -254,7 +255,7 @@ state:
         dns_prefix: aks9860bdcd89
         id: "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourcegroups/myResourceGroup/providers/Microsoft.ContainerService/managedClusters/aks9860bdc"
         kube_config: "......"
-        kubernetes_version: 1.13.5
+        kubernetes_version: 1.14.6
         linux_profile:
            admin_username: azureuser
            ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADA.....


### PR DESCRIPTION
##### SUMMARY
Update Examples with 'kubernetes_version' as the module throws an error, 'Unsupported kubernetes version', if none is specified.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Running a playbook with just the example text generates an error, "Unsupported kubernetes version," as no 'kubernetes_version' property is in the example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
azure_rm_aks

##### ADDITIONAL INFORMATION
Version information:

```
# pip show ansible
Name: ansible
Version: 2.8.4
Summary: Radically simple IT automation
Home-page: https://ansible.com/
Author: Ansible, Inc.
Author-email: info@ansible.com
License: GPLv3+
Location: /usr/lib/python2.7/dist-packages
Requires:

# ansible --version
ansible 2.8.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/x/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
```

Output prior to change:
```error
ansible-playbook 2.8.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/x/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.15+ (default, Nov 27 2018, 23:36:35) [GCC 7.3.0]
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAYBOOK: aks-3-node-b1s.yml ***********************************************************************************************************************************************
1 plays in aks-3-node-b1s.yml

PLAY [localhost] ***********************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************
task path: /home/x/aks-3-node-b1s.yml:1
ok: [localhost]
META: ran handlers

TASK [Resource Group] ******************************************************************************************************************************************************
task path: /home/x/aks-3-node-b1s.yml:8
ok: [localhost] => {"changed": false, "contains_resources": false, "state": {"id": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/test-lab", "location": "eastus", "name": "test-lab", "provisioning_state": "Succeeded", "tags": {"environment": "test", "owner": "sysops"}}}

TASK [Azure Container Services (AKS) Instance] *****************************************************************************************************************************
task path: /x/aks-3-node-b1s.yml:16
 [WARNING]: Azure API profile latest does not define an entry for ContainerServiceClient
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported kubernetes version. Expected one of [u'1.12.7', u'1.14.6', u'1.14.5', u'1.11.9', u'1.10.12', u'1.10.13', u'1.12.8', u'1.13.10', u'1.13.9', u'1.11.10'] but got None"}

PLAY RECAP *****************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

Output after change is successful.