### PR TITLE
managed_zone documentation update

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -79,7 +79,7 @@ options:
     - Identifies the managed zone addressed by this request.
     - 'This field represents a link to a ManagedZone resource in GCP. It can be specified
       in two ways. First, you can place a dictionary with 2 keys: ''name'' and value of
-      your resource''s name, ''dnsName'' and the value of the DNS name manged by this zone
+      your resource's name, ''dnsName'' and the value of the DNS name managed by this zone
       Alternatively, you can add `register: name-of-resource`
       to a gcp_dns_managed_zone task and then set this managed_zone field to "{{ name-of-resource
       }}"'

--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -78,8 +78,9 @@ options:
     description:
     - Identifies the managed zone addressed by this request.
     - 'This field represents a link to a ManagedZone resource in GCP. It can be specified
-      in two ways. First, you can place a dictionary with key ''name'' and value of
-      your resource''s name Alternatively, you can add `register: name-of-resource`
+      in two ways. First, you can place a dictionary with 2 keys: ''name'' and value of
+      your resource''s name, ''dnsName'' and the value of the DNS name manged by this zone
+      Alternatively, you can add `register: name-of-resource`
       to a gcp_dns_managed_zone task and then set this managed_zone field to "{{ name-of-resource
       }}"'
     required: true

--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set.py
@@ -79,7 +79,7 @@ options:
     - Identifies the managed zone addressed by this request.
     - 'This field represents a link to a ManagedZone resource in GCP. It can be specified
       in two ways. First, you can place a dictionary with 2 keys: ''name'' and value of
-      your resource's name, ''dnsName'' and the value of the DNS name managed by this zone
+      your resource''s name, ''dnsName'' and the value of the DNS name managed by this zone
       Alternatively, you can add `register: name-of-resource`
       to a gcp_dns_managed_zone task and then set this managed_zone field to "{{ name-of-resource
       }}"'


### PR DESCRIPTION
##### SUMMARY
Add verbiage indicating the need for a `dnsName` key in the `managed_zone` dictionary if one doesn't register a resource from a gcp_dns_manged_zone task.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
