### PR TITLE
os_loadbalancer: Fix the absent function

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_loadbalancer.py
+++ b/lib/ansible/modules/cloud/openstack/os_loadbalancer.py
@@ -293,7 +293,7 @@ def _wait_for_lb(module, cloud, lb, status, failures, interval=5):
         failures = []
 
     while total_sleep < timeout:
-        lb = cloud.load_balancer.get_load_balancer(lb.id)
+        lb = cloud.load_balancer.find_load_balancer(lb.id)
 
         if lb:
             if lb.provisioning_status == status:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use `find_load_balancer` instead of `get_load_balancer` when waiting for resource check to avoid `Not Found` exception.

Fixes #61081
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_loadbalancer

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the PR, when deleting an existing load balancer using the playbook:
```yaml
- name: test delete lb
  connection: local
  hosts: localhost
  tasks:
    - name: delete lb
      os_loadbalancer:
        name: lingxiank8s-lb
        state: absent
        wait: yes
        timeout: 600
```

Previous output:

```paste below
TASK [delete lb] ***************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "changed": false,
    "extra_data": null
}

MSG:

No LoadBalancer found for 730c776d-d6ac-448c-95f8-4727491b297d: Client Error for url: http://192.168.206.8/load-balancer/v2.0/lbaas/loadbalancers/730c776d-d6ac-448c-95f8-4727491b297d, Not Found
```

Current output:
```
TASK [delete lb] ***************************************************************************************************************************************************************************************************************************
changed: [localhost] => {
    "changed": true
}
```
