### PR TITLE
Add support for network_cli connection retry

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -846,3 +846,20 @@ Modify the error regex for individual task.
 The terminal plugin regex options ``ansible_terminal_stderr_re`` and ``ansible_terminal_stdout_re`` have
 ``pattern`` and ``flags`` as keys. The value of the ``flags`` key should be a value that is accepted by
 the ``re.compile`` python method.
+
+
+Intermittent failure while using ``network_cli`` connection type due to slower network or remote target host
+------------------------------------------------------------------------------------------------------------
+
+In Ansible 2.9 and later, the network_cli connection plugin configuration option is added to control
+the number of attempts to connect to remote host, the default number of attempts is three.
+The delay time between the retires increases after every attempt by power of 2 in seconds till either
+the maximum attempts are exhausted or any of the ``persistent_command_timeout`` or ``persistent_connect_timeout``
+timer is triggered.
+
+To make this a global setting, add the following to your ``ansible.cfg`` file:
+
+.. code-block:: ini
+
+   [persistent_connection]
+   network_cli_retries = 5

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -851,11 +851,11 @@ the ``re.compile`` python method.
 Intermittent failure while using ``network_cli`` connection type due to slower network or remote target host
 ------------------------------------------------------------------------------------------------------------
 
-In Ansible 2.9 and later, the network_cli connection plugin configuration option is added to control
-the number of attempts to connect to remote host, the default number of attempts is three.
-The delay time between the retires increases after every attempt by power of 2 in seconds till either
-the maximum attempts are exhausted or any of the ``persistent_command_timeout`` or ``persistent_connect_timeout``
-timer is triggered.
+In Ansible 2.9 and later, the ``network_cli`` connection plugin configuration option is added to control
+the number of attempts to connect to a remote host. The default number of attempts is three.
+every attempt by power of 2 in seconds until either the maximum attempts are exhausted or either of the
+the maximum attempts are exhausted or either the ``persistent_command_timeout`` or ``persistent_connect_timeout``
+timers are triggered.
 
 To make this a global setting, add the following to your ``ansible.cfg`` file:
 

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -139,6 +139,11 @@ class ConnectionProcess(object):
                         display.display("jsonrpc request: %s" % data, log_only=True)
 
                     signal.alarm(self.connection.get_option('persistent_command_timeout'))
+
+                    # initialization connection to remote host if not already in connected state
+                    if not self.connection._connected:
+                        self.connection._connect()
+
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -140,10 +140,6 @@ class ConnectionProcess(object):
 
                     signal.alarm(self.connection.get_option('persistent_command_timeout'))
 
-                    # initialization connection to remote host if not already in connected state
-                    if not self.connection._connected:
-                        self.connection._connect()
-
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -260,7 +260,7 @@ options:
     description:
       - Number of attempts to connect to remote host. The delay time between the retires increases after
         every attempt by power of 2 in seconds till either the maximum attempts are exhausted or any of the
-        C(persistent_command_timeout) or C(persistent_connect_timeout) timer is triggered.
+        C(persistent_command_timeout) or C(persistent_connect_timeout) timers are triggered.
     default: 3
     version_added: '2.9'
     type: integer

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -194,6 +194,7 @@ options:
   terminal_stdout_re:
     type: list
     elements: dict
+    version_added: '2.9'
     description:
       - A single regex pattern or a sequence of patterns along with optional flags
         to match the command prompt from the received response chunk. This option
@@ -206,6 +207,7 @@ options:
   terminal_stderr_re:
     type: list
     elements: dict
+    version_added: '2.9'
     description:
       - This option provides the regex pattern and optional flags to match the
         error string from the received response chunk. This option
@@ -217,6 +219,7 @@ options:
       - name: ansible_terminal_stderr_re
   terminal_initial_prompt:
     type: list
+    version_added: '2.9'
     description:
       - A single regex pattern or a sequence of patterns to evaluate the expected
         prompt at the time of initial login to the remote host.
@@ -224,6 +227,7 @@ options:
       - name: ansible_terminal_initial_prompt
   terminal_initial_answer:
     type: list
+    version_added: '2.9'
     description:
       - The answer to reply with if the C(terminal_initial_prompt) is matched. The value can be a single answer
         or a list of answers for multiple terminal_initial_prompt. In case the login menu has
@@ -234,6 +238,7 @@ options:
       - name: ansible_terminal_initial_answer
   terminal_initial_prompt_checkall:
     type: boolean
+    version_added: '2.9'
     description:
       - By default the value is set to I(False) and any one of the prompts mentioned in C(terminal_initial_prompt)
         option is matched it won't check for other prompts. When set to I(True) it will check for all the prompts
@@ -244,6 +249,7 @@ options:
       - name: ansible_terminal_initial_prompt_checkall
   terminal_inital_prompt_newline:
     type: boolean
+    version_added: '2.9'
     description:
       - This boolean flag, that when set to I(True) will send newline in the response if any of values
         in I(terminal_initial_prompt) is matched.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Add network_cli connection configuration option
   to allow retrying the connection initialization with the remote host.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/connection/network_cli.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
