### PR TITLE
win_robocopy add md5 checksum check for copy

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_system_management_tunnel.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_management_tunnel.py
@@ -1,0 +1,350 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_management_tunnel
+short_description: Management tunnel configuration in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and management_tunnel category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_management_tunnel:
+        description:
+            - Management tunnel configuration.
+        default: null
+        type: dict
+        suboptions:
+            allow_collect_statistics:
+                description:
+                    - Enable/disable collection of run time statistics.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            allow_config_restore:
+                description:
+                    - Enable/disable allow config restore.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            allow_push_configuration:
+                description:
+                    - Enable/disable push configuration.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            allow_push_firmware:
+                description:
+                    - Enable/disable push firmware.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            authorized_manager_only:
+                description:
+                    - Enable/disable restriction of authorized manager only.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            serial_number:
+                description:
+                    - Serial number.
+                type: str
+            status:
+                description:
+                    - Enable/disable FGFM tunnel.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Management tunnel configuration.
+    fortios_system_management_tunnel:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_management_tunnel:
+        allow_collect_statistics: "enable"
+        allow_config_restore: "enable"
+        allow_push_configuration: "enable"
+        allow_push_firmware: "enable"
+        authorized_manager_only: "enable"
+        serial_number: "<your_own_value>"
+        status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_management_tunnel_data(json):
+    option_list = ['allow_collect_statistics', 'allow_config_restore', 'allow_push_configuration',
+                   'allow_push_firmware', 'authorized_manager_only', 'serial_number',
+                   'status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_management_tunnel(data, fos):
+    vdom = data['vdom']
+    system_management_tunnel_data = data['system_management_tunnel']
+    filtered_data = underscore_to_hyphen(filter_system_management_tunnel_data(system_management_tunnel_data))
+
+    return fos.set('system',
+                   'management-tunnel',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_management_tunnel']:
+        resp = system_management_tunnel(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_management_tunnel": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "allow_collect_statistics": {"required": False, "type": "str",
+                                             "choices": ["enable", "disable"]},
+                "allow_config_restore": {"required": False, "type": "str",
+                                         "choices": ["enable", "disable"]},
+                "allow_push_configuration": {"required": False, "type": "str",
+                                             "choices": ["enable", "disable"]},
+                "allow_push_firmware": {"required": False, "type": "str",
+                                        "choices": ["enable", "disable"]},
+                "authorized_manager_only": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                "serial_number": {"required": False, "type": "str"},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_mobile_tunnel.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_mobile_tunnel.py
@@ -1,0 +1,433 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_mobile_tunnel
+short_description: Configure Mobile tunnels, an implementation of Network Mobility (NEMO) extensions for Mobile IPv4 RFC5177 in Fortinet's FortiOS and
+   FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and mobile_tunnel category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_mobile_tunnel:
+        description:
+            - Configure Mobile tunnels, an implementation of Network Mobility (NEMO) extensions for Mobile IPv4 RFC5177.
+        default: null
+        type: dict
+        suboptions:
+            hash_algorithm:
+                description:
+                    - Hash Algorithm (Keyed MD5).
+                type: str
+                choices:
+                    - hmac-md5
+            home_address:
+                description:
+                    - "Home IP address (Format: xxx.xxx.xxx.xxx)."
+                type: str
+            home_agent:
+                description:
+                    - "IPv4 address of the NEMO HA (Format: xxx.xxx.xxx.xxx)."
+                type: str
+            lifetime:
+                description:
+                    - NMMO HA registration request lifetime (180 - 65535 sec, default = 65535).
+                type: int
+            n_mhae_key:
+                description:
+                    - NEMO authentication key.
+                type: str
+            n_mhae_key_type:
+                description:
+                    - NEMO authentication key type (ascii or base64).
+                type: str
+                choices:
+                    - ascii
+                    - base64
+            n_mhae_spi:
+                description:
+                    - "NEMO authentication SPI (default: 256)."
+                type: int
+            name:
+                description:
+                    - Tunnel name.
+                required: true
+                type: str
+            network:
+                description:
+                    - NEMO network configuration.
+                type: list
+                suboptions:
+                    id:
+                        description:
+                            - Network entry ID.
+                        required: true
+                        type: int
+                    interface:
+                        description:
+                            - Select the associated interface name from available options. Source system.interface.name.
+                        type: str
+                    prefix:
+                        description:
+                            - "Class IP and Netmask with correction (Format:xxx.xxx.xxx.xxx xxx.xxx.xxx.xxx or xxx.xxx.xxx.xxx/x)."
+                        type: str
+            reg_interval:
+                description:
+                    - NMMO HA registration interval (5 - 300, default = 5).
+                type: int
+            reg_retry:
+                description:
+                    - Maximum number of NMMO HA registration retries (1 to 30, default = 3).
+                type: int
+            renew_interval:
+                description:
+                    - Time before lifetime expiraton to send NMMO HA re-registration (5 - 60, default = 60).
+                type: int
+            roaming_interface:
+                description:
+                    - Select the associated interface name from available options. Source system.interface.name.
+                type: str
+            status:
+                description:
+                    - Enable/disable this mobile tunnel.
+                type: str
+                choices:
+                    - disable
+                    - enable
+            tunnel_mode:
+                description:
+                    - NEMO tunnnel mode (GRE tunnel).
+                type: str
+                choices:
+                    - gre
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure Mobile tunnels, an implementation of Network Mobility (NEMO) extensions for Mobile IPv4 RFC5177.
+    fortios_system_mobile_tunnel:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_mobile_tunnel:
+        hash_algorithm: "hmac-md5"
+        home_address: "<your_own_value>"
+        home_agent: "<your_own_value>"
+        lifetime: "6"
+        n_mhae_key: "<your_own_value>"
+        n_mhae_key_type: "ascii"
+        n_mhae_spi: "9"
+        name: "default_name_10"
+        network:
+         -
+            id:  "12"
+            interface: "<your_own_value> (source system.interface.name)"
+            prefix: "<your_own_value>"
+        reg_interval: "15"
+        reg_retry: "16"
+        renew_interval: "17"
+        roaming_interface: "<your_own_value> (source system.interface.name)"
+        status: "disable"
+        tunnel_mode: "gre"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_mobile_tunnel_data(json):
+    option_list = ['hash_algorithm', 'home_address', 'home_agent',
+                   'lifetime', 'n_mhae_key', 'n_mhae_key_type',
+                   'n_mhae_spi', 'name', 'network',
+                   'reg_interval', 'reg_retry', 'renew_interval',
+                   'roaming_interface', 'status', 'tunnel_mode']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_mobile_tunnel(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_mobile_tunnel_data = data['system_mobile_tunnel']
+    filtered_data = underscore_to_hyphen(filter_system_mobile_tunnel_data(system_mobile_tunnel_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'mobile-tunnel',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'mobile-tunnel',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_mobile_tunnel']:
+        resp = system_mobile_tunnel(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_mobile_tunnel": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "hash_algorithm": {"required": False, "type": "str",
+                                   "choices": ["hmac-md5"]},
+                "home_address": {"required": False, "type": "str"},
+                "home_agent": {"required": False, "type": "str"},
+                "lifetime": {"required": False, "type": "int"},
+                "n_mhae_key": {"required": False, "type": "str"},
+                "n_mhae_key_type": {"required": False, "type": "str",
+                                    "choices": ["ascii", "base64"]},
+                "n_mhae_spi": {"required": False, "type": "int"},
+                "name": {"required": True, "type": "str"},
+                "network": {"required": False, "type": "list",
+                            "options": {
+                                "id": {"required": True, "type": "int"},
+                                "interface": {"required": False, "type": "str"},
+                                "prefix": {"required": False, "type": "str"}
+                            }},
+                "reg_interval": {"required": False, "type": "int"},
+                "reg_retry": {"required": False, "type": "int"},
+                "renew_interval": {"required": False, "type": "int"},
+                "roaming_interface": {"required": False, "type": "str"},
+                "status": {"required": False, "type": "str",
+                           "choices": ["disable", "enable"]},
+                "tunnel_mode": {"required": False, "type": "str",
+                                "choices": ["gre"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_nat64.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_nat64.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_nat64
+short_description: Configure NAT64 in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and nat64 category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_nat64:
+        description:
+            - Configure NAT64.
+        default: null
+        type: dict
+        suboptions:
+            always_synthesize_aaaa_record:
+                description:
+                    - Enable/disable AAAA record synthesis (default = enable).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            generate_ipv6_fragment_header:
+                description:
+                    - Enable/disable IPv6 fragment header generation.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            nat46_force_ipv4_packet_forwarding:
+                description:
+                    - Enable/disable mandatory IPv4 packet forwarding in nat46.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            nat64_prefix:
+                description:
+                    - "NAT64 prefix must be ::/96 (default = 64:ff9b::/96)."
+                type: str
+            secondary_prefix:
+                description:
+                    - Secondary NAT64 prefix.
+                type: list
+                suboptions:
+                    name:
+                        description:
+                            - NAT64 prefix name.
+                        required: true
+                        type: str
+                    nat64_prefix:
+                        description:
+                            - NAT64 prefix.
+                        type: str
+            secondary_prefix_status:
+                description:
+                    - Enable/disable secondary NAT64 prefix.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            status:
+                description:
+                    - Enable/disable NAT64 (default = disable).
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure NAT64.
+    fortios_system_nat64:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_nat64:
+        always_synthesize_aaaa_record: "enable"
+        generate_ipv6_fragment_header: "enable"
+        nat46_force_ipv4_packet_forwarding: "enable"
+        nat64_prefix: "<your_own_value>"
+        secondary_prefix:
+         -
+            name: "default_name_8"
+            nat64_prefix: "<your_own_value>"
+        secondary_prefix_status: "enable"
+        status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_nat64_data(json):
+    option_list = ['always_synthesize_aaaa_record', 'generate_ipv6_fragment_header', 'nat46_force_ipv4_packet_forwarding',
+                   'nat64_prefix', 'secondary_prefix', 'secondary_prefix_status',
+                   'status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_nat64(data, fos):
+    vdom = data['vdom']
+    system_nat64_data = data['system_nat64']
+    filtered_data = underscore_to_hyphen(filter_system_nat64_data(system_nat64_data))
+
+    return fos.set('system',
+                   'nat64',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_nat64']:
+        resp = system_nat64(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_nat64": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "always_synthesize_aaaa_record": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                "generate_ipv6_fragment_header": {"required": False, "type": "str",
+                                                  "choices": ["enable", "disable"]},
+                "nat46_force_ipv4_packet_forwarding": {"required": False, "type": "str",
+                                                       "choices": ["enable", "disable"]},
+                "nat64_prefix": {"required": False, "type": "str"},
+                "secondary_prefix": {"required": False, "type": "list",
+                                     "options": {
+                                         "name": {"required": True, "type": "str"},
+                                         "nat64_prefix": {"required": False, "type": "str"}
+                                     }},
+                "secondary_prefix_status": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_nd_proxy.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_nd_proxy.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_nd_proxy
+short_description: Configure IPv6 neighbor discovery proxy (RFC4389) in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and nd_proxy category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_nd_proxy:
+        description:
+            - Configure IPv6 neighbor discovery proxy (RFC4389).
+        default: null
+        type: dict
+        suboptions:
+            member:
+                description:
+                    - Interfaces using the neighbor discovery proxy.
+                type: list
+                suboptions:
+                    interface_name:
+                        description:
+                            - Interface name. Source system.interface.name.
+                        type: str
+            status:
+                description:
+                    - Enable/disable neighbor discovery proxy.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure IPv6 neighbor discovery proxy (RFC4389).
+    fortios_system_nd_proxy:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_nd_proxy:
+        member:
+         -
+            interface_name: "<your_own_value> (source system.interface.name)"
+        status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_nd_proxy_data(json):
+    option_list = ['member', 'status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_nd_proxy(data, fos):
+    vdom = data['vdom']
+    system_nd_proxy_data = data['system_nd_proxy']
+    filtered_data = underscore_to_hyphen(filter_system_nd_proxy_data(system_nd_proxy_data))
+
+    return fos.set('system',
+                   'nd-proxy',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_nd_proxy']:
+        resp = system_nd_proxy(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_nd_proxy": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "member": {"required": False, "type": "list",
+                           "options": {
+                               "interface_name": {"required": False, "type": "str"}
+                           }},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_netflow.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_netflow.py
@@ -1,0 +1,326 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_netflow
+short_description: Configure NetFlow in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and netflow category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_netflow:
+        description:
+            - Configure NetFlow.
+        default: null
+        type: dict
+        suboptions:
+            active_flow_timeout:
+                description:
+                    - Timeout to report active flows (1 - 60 min, default = 30).
+                type: int
+            collector_ip:
+                description:
+                    - Collector IP.
+                type: str
+            collector_port:
+                description:
+                    - NetFlow collector port number.
+                type: int
+            inactive_flow_timeout:
+                description:
+                    - Timeout for periodic report of finished flows (10 - 600 sec, default = 15).
+                type: int
+            source_ip:
+                description:
+                    - Source IP address for communication with the NetFlow agent.
+                type: str
+            template_tx_counter:
+                description:
+                    - Counter of flowset records before resending a template flowset record.
+                type: int
+            template_tx_timeout:
+                description:
+                    - Timeout for periodic template flowset transmission (1 - 1440 min, default = 30).
+                type: int
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure NetFlow.
+    fortios_system_netflow:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_netflow:
+        active_flow_timeout: "3"
+        collector_ip: "<your_own_value>"
+        collector_port: "5"
+        inactive_flow_timeout: "6"
+        source_ip: "84.230.14.43"
+        template_tx_counter: "8"
+        template_tx_timeout: "9"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_netflow_data(json):
+    option_list = ['active_flow_timeout', 'collector_ip', 'collector_port',
+                   'inactive_flow_timeout', 'source_ip', 'template_tx_counter',
+                   'template_tx_timeout']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_netflow(data, fos):
+    vdom = data['vdom']
+    system_netflow_data = data['system_netflow']
+    filtered_data = underscore_to_hyphen(filter_system_netflow_data(system_netflow_data))
+
+    return fos.set('system',
+                   'netflow',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_netflow']:
+        resp = system_netflow(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_netflow": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "active_flow_timeout": {"required": False, "type": "int"},
+                "collector_ip": {"required": False, "type": "str"},
+                "collector_port": {"required": False, "type": "int"},
+                "inactive_flow_timeout": {"required": False, "type": "int"},
+                "source_ip": {"required": False, "type": "str"},
+                "template_tx_counter": {"required": False, "type": "int"},
+                "template_tx_timeout": {"required": False, "type": "int"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_network_visibility.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_network_visibility.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_network_visibility
+short_description: Configure network visibility settings in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and network_visibility category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_network_visibility:
+        description:
+            - Configure network visibility settings.
+        default: null
+        type: dict
+        suboptions:
+            destination_hostname_visibility:
+                description:
+                    - Enable/disable logging of destination hostname visibility.
+                type: str
+                choices:
+                    - disable
+                    - enable
+            destination_location:
+                description:
+                    - Enable/disable logging of destination geographical location visibility.
+                type: str
+                choices:
+                    - disable
+                    - enable
+            destination_visibility:
+                description:
+                    - Enable/disable logging of destination visibility.
+                type: str
+                choices:
+                    - disable
+                    - enable
+            hostname_limit:
+                description:
+                    - Limit of the number of hostname table entries (0 - 50000).
+                type: int
+            hostname_ttl:
+                description:
+                    - TTL of hostname table entries (60 - 86400).
+                type: int
+            source_location:
+                description:
+                    - Enable/disable logging of source geographical location visibility.
+                type: str
+                choices:
+                    - disable
+                    - enable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure network visibility settings.
+    fortios_system_network_visibility:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_network_visibility:
+        destination_hostname_visibility: "disable"
+        destination_location: "disable"
+        destination_visibility: "disable"
+        hostname_limit: "6"
+        hostname_ttl: "7"
+        source_location: "disable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_network_visibility_data(json):
+    option_list = ['destination_hostname_visibility', 'destination_location', 'destination_visibility',
+                   'hostname_limit', 'hostname_ttl', 'source_location']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_network_visibility(data, fos):
+    vdom = data['vdom']
+    system_network_visibility_data = data['system_network_visibility']
+    filtered_data = underscore_to_hyphen(filter_system_network_visibility_data(system_network_visibility_data))
+
+    return fos.set('system',
+                   'network-visibility',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_network_visibility']:
+        resp = system_network_visibility(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_network_visibility": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "destination_hostname_visibility": {"required": False, "type": "str",
+                                                    "choices": ["disable", "enable"]},
+                "destination_location": {"required": False, "type": "str",
+                                         "choices": ["disable", "enable"]},
+                "destination_visibility": {"required": False, "type": "str",
+                                           "choices": ["disable", "enable"]},
+                "hostname_limit": {"required": False, "type": "int"},
+                "hostname_ttl": {"required": False, "type": "int"},
+                "source_location": {"required": False, "type": "str",
+                                    "choices": ["disable", "enable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_ntp.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_ntp.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_ntp
+short_description: Configure system NTP information in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and ntp category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_ntp:
+        description:
+            - Configure system NTP information.
+        default: null
+        type: dict
+        suboptions:
+            interface:
+                description:
+                    - FortiGate interface(s) with NTP server mode enabled. Devices on your network can contact these interfaces for NTP services.
+                type: list
+                suboptions:
+                    interface_name:
+                        description:
+                            - Interface name. Source system.interface.name.
+                        type: str
+            ntpserver:
+                description:
+                    - Configure the FortiGate to connect to any available third-party NTP server.
+                type: list
+                suboptions:
+                    authentication:
+                        description:
+                            - Enable/disable MD5 authentication.
+                        type: str
+                        choices:
+                            - enable
+                            - disable
+                    id:
+                        description:
+                            - NTP server ID.
+                        required: true
+                        type: int
+                    key:
+                        description:
+                            - Key for MD5 authentication.
+                        type: str
+                    key_id:
+                        description:
+                            - Key ID for authentication.
+                        type: int
+                    ntpv3:
+                        description:
+                            - Enable to use NTPv3 instead of NTPv4.
+                        type: str
+                        choices:
+                            - enable
+                            - disable
+                    server:
+                        description:
+                            - IP address or hostname of the NTP Server.
+                        type: str
+            ntpsync:
+                description:
+                    - Enable/disable setting the FortiGate system time by synchronizing with an NTP Server.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            server_mode:
+                description:
+                    - Enable/disable FortiGate NTP Server Mode. Your FortiGate becomes an NTP server for other devices on your network. The FortiGate relays
+                       NTP requests to its configured NTP server.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            source_ip:
+                description:
+                    - Source IP address for communication to the NTP server.
+                type: str
+            source_ip6:
+                description:
+                    - Source IPv6 address for communication to the NTP server.
+                type: str
+            syncinterval:
+                description:
+                    - NTP synchronization interval (1 - 1440 min).
+                type: int
+            type:
+                description:
+                    - Use the FortiGuard NTP server or any other available NTP Server.
+                type: str
+                choices:
+                    - fortiguard
+                    - custom
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure system NTP information.
+    fortios_system_ntp:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_ntp:
+        interface:
+         -
+            interface_name: "<your_own_value> (source system.interface.name)"
+        ntpserver:
+         -
+            authentication: "enable"
+            id:  "7"
+            key: "<your_own_value>"
+            key_id: "9"
+            ntpv3: "enable"
+            server: "192.168.100.40"
+        ntpsync: "enable"
+        server_mode: "enable"
+        source_ip: "84.230.14.43"
+        source_ip6: "<your_own_value>"
+        syncinterval: "16"
+        type: "fortiguard"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_ntp_data(json):
+    option_list = ['interface', 'ntpserver', 'ntpsync',
+                   'server_mode', 'source_ip', 'source_ip6',
+                   'syncinterval', 'type']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_ntp(data, fos):
+    vdom = data['vdom']
+    system_ntp_data = data['system_ntp']
+    filtered_data = underscore_to_hyphen(filter_system_ntp_data(system_ntp_data))
+
+    return fos.set('system',
+                   'ntp',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_ntp']:
+        resp = system_ntp(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_ntp": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "interface": {"required": False, "type": "list",
+                              "options": {
+                                  "interface_name": {"required": False, "type": "str"}
+                              }},
+                "ntpserver": {"required": False, "type": "list",
+                              "options": {
+                                  "authentication": {"required": False, "type": "str",
+                                                     "choices": ["enable", "disable"]},
+                                  "id": {"required": True, "type": "int"},
+                                  "key": {"required": False, "type": "str"},
+                                  "key_id": {"required": False, "type": "int"},
+                                  "ntpv3": {"required": False, "type": "str",
+                                            "choices": ["enable", "disable"]},
+                                  "server": {"required": False, "type": "str"}
+                              }},
+                "ntpsync": {"required": False, "type": "str",
+                            "choices": ["enable", "disable"]},
+                "server_mode": {"required": False, "type": "str",
+                                "choices": ["enable", "disable"]},
+                "source_ip": {"required": False, "type": "str"},
+                "source_ip6": {"required": False, "type": "str"},
+                "syncinterval": {"required": False, "type": "int"},
+                "type": {"required": False, "type": "str",
+                         "choices": ["fortiguard", "custom"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_object_tagging.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_object_tagging.py
@@ -1,0 +1,375 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_object_tagging
+short_description: Configure object tagging in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and object_tagging category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_object_tagging:
+        description:
+            - Configure object tagging.
+        default: null
+        type: dict
+        suboptions:
+            address:
+                description:
+                    - Address.
+                type: str
+                choices:
+                    - disable
+                    - mandatory
+                    - optional
+            category:
+                description:
+                    - Tag Category.
+                required: true
+                type: str
+            color:
+                description:
+                    - Color of icon on the GUI.
+                type: int
+            device:
+                description:
+                    - Device.
+                type: str
+                choices:
+                    - disable
+                    - mandatory
+                    - optional
+            interface:
+                description:
+                    - Interface.
+                type: str
+                choices:
+                    - disable
+                    - mandatory
+                    - optional
+            multiple:
+                description:
+                    - Allow multiple tag selection.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            tags:
+                description:
+                    - Tags.
+                type: list
+                suboptions:
+                    name:
+                        description:
+                            - Tag name.
+                        required: true
+                        type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure object tagging.
+    fortios_system_object_tagging:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_object_tagging:
+        address: "disable"
+        category: "<your_own_value>"
+        color: "5"
+        device: "disable"
+        interface: "disable"
+        multiple: "enable"
+        tags:
+         -
+            name: "default_name_10"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_object_tagging_data(json):
+    option_list = ['address', 'category', 'color',
+                   'device', 'interface', 'multiple',
+                   'tags']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_object_tagging(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_object_tagging_data = data['system_object_tagging']
+    filtered_data = underscore_to_hyphen(filter_system_object_tagging_data(system_object_tagging_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'object-tagging',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'object-tagging',
+                          mkey=filtered_data['category'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_object_tagging']:
+        resp = system_object_tagging(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_object_tagging": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "address": {"required": False, "type": "str",
+                            "choices": ["disable", "mandatory", "optional"]},
+                "category": {"required": True, "type": "str"},
+                "color": {"required": False, "type": "int"},
+                "device": {"required": False, "type": "str",
+                           "choices": ["disable", "mandatory", "optional"]},
+                "interface": {"required": False, "type": "str",
+                              "choices": ["disable", "mandatory", "optional"]},
+                "multiple": {"required": False, "type": "str",
+                             "choices": ["enable", "disable"]},
+                "tags": {"required": False, "type": "list",
+                         "options": {
+                             "name": {"required": True, "type": "str"}
+                         }}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_password_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_password_policy.py
@@ -1,0 +1,371 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_password_policy
+short_description: Configure password policy for locally defined administrator passwords and IPsec VPN pre-shared keys in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and password_policy category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_password_policy:
+        description:
+            - Configure password policy for locally defined administrator passwords and IPsec VPN pre-shared keys.
+        default: null
+        type: dict
+        suboptions:
+            apply_to:
+                description:
+                    - Apply password policy to administrator passwords or IPsec pre-shared keys or both. Separate entries with a space.
+                type: str
+                choices:
+                    - admin-password
+                    - ipsec-preshared-key
+            change_4_characters:
+                description:
+                    - Enable/disable changing at least 4 characters for a new password (This attribute overrides reuse-password if both are enabled).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            expire_day:
+                description:
+                    - Number of days after which passwords expire (1 - 999 days, default = 90).
+                type: int
+            expire_status:
+                description:
+                    - Enable/disable password expiration.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            min_lower_case_letter:
+                description:
+                    - Minimum number of lowercase characters in password (0 - 128, default = 0).
+                type: int
+            min_non_alphanumeric:
+                description:
+                    - Minimum number of non-alphanumeric characters in password (0 - 128, default = 0).
+                type: int
+            min_number:
+                description:
+                    - Minimum number of numeric characters in password (0 - 128, default = 0).
+                type: int
+            min_upper_case_letter:
+                description:
+                    - Minimum number of uppercase characters in password (0 - 128, default = 0).
+                type: int
+            minimum_length:
+                description:
+                    - Minimum password length (8 - 128, default = 8).
+                type: int
+            reuse_password:
+                description:
+                    - Enable/disable reusing of password (if both reuse-password and change-4-characters are enabled, change-4-characters overrides).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            status:
+                description:
+                    - Enable/disable setting a password policy for locally defined administrator passwords and IPsec VPN pre-shared keys.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure password policy for locally defined administrator passwords and IPsec VPN pre-shared keys.
+    fortios_system_password_policy:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_password_policy:
+        apply_to: "admin-password"
+        change_4_characters: "enable"
+        expire_day: "5"
+        expire_status: "enable"
+        min_lower_case_letter: "7"
+        min_non_alphanumeric: "8"
+        min_number: "9"
+        min_upper_case_letter: "10"
+        minimum_length: "11"
+        reuse_password: "enable"
+        status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_password_policy_data(json):
+    option_list = ['apply_to', 'change_4_characters', 'expire_day',
+                   'expire_status', 'min_lower_case_letter', 'min_non_alphanumeric',
+                   'min_number', 'min_upper_case_letter', 'minimum_length',
+                   'reuse_password', 'status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_password_policy(data, fos):
+    vdom = data['vdom']
+    system_password_policy_data = data['system_password_policy']
+    filtered_data = underscore_to_hyphen(filter_system_password_policy_data(system_password_policy_data))
+
+    return fos.set('system',
+                   'password-policy',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_password_policy']:
+        resp = system_password_policy(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_password_policy": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "apply_to": {"required": False, "type": "str",
+                             "choices": ["admin-password", "ipsec-preshared-key"]},
+                "change_4_characters": {"required": False, "type": "str",
+                                        "choices": ["enable", "disable"]},
+                "expire_day": {"required": False, "type": "int"},
+                "expire_status": {"required": False, "type": "str",
+                                  "choices": ["enable", "disable"]},
+                "min_lower_case_letter": {"required": False, "type": "int"},
+                "min_non_alphanumeric": {"required": False, "type": "int"},
+                "min_number": {"required": False, "type": "int"},
+                "min_upper_case_letter": {"required": False, "type": "int"},
+                "minimum_length": {"required": False, "type": "int"},
+                "reuse_password": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_password_policy_guest_admin.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_password_policy_guest_admin.py
@@ -1,0 +1,370 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_password_policy_guest_admin
+short_description: Configure the password policy for guest administrators in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and password_policy_guest_admin category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_password_policy_guest_admin:
+        description:
+            - Configure the password policy for guest administrators.
+        default: null
+        type: dict
+        suboptions:
+            apply_to:
+                description:
+                    - Guest administrator to which this password policy applies.
+                type: str
+                choices:
+                    - guest-admin-password
+            change_4_characters:
+                description:
+                    - Enable/disable changing at least 4 characters for a new password (This attribute overrides reuse-password if both are enabled).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            expire_day:
+                description:
+                    - Number of days after which passwords expire (1 - 999 days, default = 90).
+                type: int
+            expire_status:
+                description:
+                    - Enable/disable password expiration.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            min_lower_case_letter:
+                description:
+                    - Minimum number of lowercase characters in password (0 - 128, default = 0).
+                type: int
+            min_non_alphanumeric:
+                description:
+                    - Minimum number of non-alphanumeric characters in password (0 - 128, default = 0).
+                type: int
+            min_number:
+                description:
+                    - Minimum number of numeric characters in password (0 - 128, default = 0).
+                type: int
+            min_upper_case_letter:
+                description:
+                    - Minimum number of uppercase characters in password (0 - 128, default = 0).
+                type: int
+            minimum_length:
+                description:
+                    - Minimum password length (8 - 128, default = 8).
+                type: int
+            reuse_password:
+                description:
+                    - Enable/disable reusing of password (if both reuse-password and change-4-characters are enabled, change-4-characters overrides).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            status:
+                description:
+                    - Enable/disable setting a password policy for locally defined administrator passwords and IPsec VPN pre-shared keys.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure the password policy for guest administrators.
+    fortios_system_password_policy_guest_admin:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_password_policy_guest_admin:
+        apply_to: "guest-admin-password"
+        change_4_characters: "enable"
+        expire_day: "5"
+        expire_status: "enable"
+        min_lower_case_letter: "7"
+        min_non_alphanumeric: "8"
+        min_number: "9"
+        min_upper_case_letter: "10"
+        minimum_length: "11"
+        reuse_password: "enable"
+        status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_password_policy_guest_admin_data(json):
+    option_list = ['apply_to', 'change_4_characters', 'expire_day',
+                   'expire_status', 'min_lower_case_letter', 'min_non_alphanumeric',
+                   'min_number', 'min_upper_case_letter', 'minimum_length',
+                   'reuse_password', 'status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_password_policy_guest_admin(data, fos):
+    vdom = data['vdom']
+    system_password_policy_guest_admin_data = data['system_password_policy_guest_admin']
+    filtered_data = underscore_to_hyphen(filter_system_password_policy_guest_admin_data(system_password_policy_guest_admin_data))
+
+    return fos.set('system',
+                   'password-policy-guest-admin',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_password_policy_guest_admin']:
+        resp = system_password_policy_guest_admin(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_password_policy_guest_admin": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "apply_to": {"required": False, "type": "str",
+                             "choices": ["guest-admin-password"]},
+                "change_4_characters": {"required": False, "type": "str",
+                                        "choices": ["enable", "disable"]},
+                "expire_day": {"required": False, "type": "int"},
+                "expire_status": {"required": False, "type": "str",
+                                  "choices": ["enable", "disable"]},
+                "min_lower_case_letter": {"required": False, "type": "int"},
+                "min_non_alphanumeric": {"required": False, "type": "int"},
+                "min_number": {"required": False, "type": "int"},
+                "min_upper_case_letter": {"required": False, "type": "int"},
+                "minimum_length": {"required": False, "type": "int"},
+                "reuse_password": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_pppoe_interface.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_pppoe_interface.py
@@ -1,0 +1,422 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_pppoe_interface
+short_description: Configure the PPPoE interfaces in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and pppoe_interface category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_pppoe_interface:
+        description:
+            - Configure the PPPoE interfaces.
+        default: null
+        type: dict
+        suboptions:
+            ac_name:
+                description:
+                    - PPPoE AC name.
+                type: str
+            auth_type:
+                description:
+                    - PPP authentication type to use.
+                type: str
+                choices:
+                    - auto
+                    - pap
+                    - chap
+                    - mschapv1
+                    - mschapv2
+            device:
+                description:
+                    - Name for the physical interface. Source system.interface.name.
+                type: str
+            dial_on_demand:
+                description:
+                    - Enable/disable dial on demand to dial the PPPoE interface when packets are routed to the PPPoE interface.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            disc_retry_timeout:
+                description:
+                    - PPPoE discovery init timeout value in (0-4294967295 sec).
+                type: int
+            idle_timeout:
+                description:
+                    - PPPoE auto disconnect after idle timeout (0-4294967295 sec).
+                type: int
+            ipunnumbered:
+                description:
+                    - PPPoE unnumbered IP.
+                type: str
+            ipv6:
+                description:
+                    - Enable/disable IPv6 Control Protocol (IPv6CP).
+                type: str
+                choices:
+                    - enable
+                    - disable
+            lcp_echo_interval:
+                description:
+                    - PPPoE LCP echo interval in (0-4294967295 sec, default = 5).
+                type: int
+            lcp_max_echo_fails:
+                description:
+                    - Maximum missed LCP echo messages before disconnect (0-4294967295, default = 3).
+                type: int
+            name:
+                description:
+                    - Name of the PPPoE interface.
+                required: true
+                type: str
+            padt_retry_timeout:
+                description:
+                    - PPPoE terminate timeout value in (0-4294967295 sec).
+                type: int
+            password:
+                description:
+                    - Enter the password.
+                type: str
+            pppoe_unnumbered_negotiate:
+                description:
+                    - Enable/disable PPPoE unnumbered negotiation.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            service_name:
+                description:
+                    - PPPoE service name.
+                type: str
+            username:
+                description:
+                    - User name.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure the PPPoE interfaces.
+    fortios_system_pppoe_interface:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_pppoe_interface:
+        ac_name: "<your_own_value>"
+        auth_type: "auto"
+        device: "<your_own_value> (source system.interface.name)"
+        dial_on_demand: "enable"
+        disc_retry_timeout: "7"
+        idle_timeout: "8"
+        ipunnumbered: "<your_own_value>"
+        ipv6: "enable"
+        lcp_echo_interval: "11"
+        lcp_max_echo_fails: "12"
+        name: "default_name_13"
+        padt_retry_timeout: "14"
+        password: "<your_own_value>"
+        pppoe_unnumbered_negotiate: "enable"
+        service_name: "<your_own_value>"
+        username: "<your_own_value>"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_pppoe_interface_data(json):
+    option_list = ['ac_name', 'auth_type', 'device',
+                   'dial_on_demand', 'disc_retry_timeout', 'idle_timeout',
+                   'ipunnumbered', 'ipv6', 'lcp_echo_interval',
+                   'lcp_max_echo_fails', 'name', 'padt_retry_timeout',
+                   'password', 'pppoe_unnumbered_negotiate', 'service_name',
+                   'username']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_pppoe_interface(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_pppoe_interface_data = data['system_pppoe_interface']
+    filtered_data = underscore_to_hyphen(filter_system_pppoe_interface_data(system_pppoe_interface_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'pppoe-interface',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'pppoe-interface',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_pppoe_interface']:
+        resp = system_pppoe_interface(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_pppoe_interface": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "ac_name": {"required": False, "type": "str"},
+                "auth_type": {"required": False, "type": "str",
+                              "choices": ["auto", "pap", "chap",
+                                          "mschapv1", "mschapv2"]},
+                "device": {"required": False, "type": "str"},
+                "dial_on_demand": {"required": False, "type": "str",
+                                   "choices": ["enable", "disable"]},
+                "disc_retry_timeout": {"required": False, "type": "int"},
+                "idle_timeout": {"required": False, "type": "int"},
+                "ipunnumbered": {"required": False, "type": "str"},
+                "ipv6": {"required": False, "type": "str",
+                         "choices": ["enable", "disable"]},
+                "lcp_echo_interval": {"required": False, "type": "int"},
+                "lcp_max_echo_fails": {"required": False, "type": "int"},
+                "name": {"required": True, "type": "str"},
+                "padt_retry_timeout": {"required": False, "type": "int"},
+                "password": {"required": False, "type": "str"},
+                "pppoe_unnumbered_negotiate": {"required": False, "type": "str",
+                                               "choices": ["enable", "disable"]},
+                "service_name": {"required": False, "type": "str"},
+                "username": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_probe_response.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_probe_response.py
@@ -1,0 +1,340 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_probe_response
+short_description: Configure system probe response in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and probe_response category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_probe_response:
+        description:
+            - Configure system probe response.
+        default: null
+        type: dict
+        suboptions:
+            http_probe_value:
+                description:
+                    - Value to respond to the monitoring server.
+                type: str
+            mode:
+                description:
+                    - SLA response mode.
+                type: str
+                choices:
+                    - none
+                    - http-probe
+                    - twamp
+            password:
+                description:
+                    - Twamp respondor password in authentication mode
+                type: str
+            port:
+                description:
+                    - Port number to response.
+                type: int
+            security_mode:
+                description:
+                    - Twamp respondor security mode.
+                type: str
+                choices:
+                    - none
+                    - authentication
+            timeout:
+                description:
+                    - An inactivity timer for a twamp test session.
+                type: int
+            ttl_mode:
+                description:
+                    - Mode for TWAMP packet TTL modification.
+                type: str
+                choices:
+                    - reinit
+                    - decrease
+                    - retain
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure system probe response.
+    fortios_system_probe_response:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_probe_response:
+        http_probe_value: "<your_own_value>"
+        mode: "none"
+        password: "<your_own_value>"
+        port: "6"
+        security_mode: "none"
+        timeout: "8"
+        ttl_mode: "reinit"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_probe_response_data(json):
+    option_list = ['http_probe_value', 'mode', 'password',
+                   'port', 'security_mode', 'timeout',
+                   'ttl_mode']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_probe_response(data, fos):
+    vdom = data['vdom']
+    system_probe_response_data = data['system_probe_response']
+    filtered_data = underscore_to_hyphen(filter_system_probe_response_data(system_probe_response_data))
+
+    return fos.set('system',
+                   'probe-response',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_probe_response']:
+        resp = system_probe_response(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_probe_response": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "http_probe_value": {"required": False, "type": "str"},
+                "mode": {"required": False, "type": "str",
+                         "choices": ["none", "http-probe", "twamp"]},
+                "password": {"required": False, "type": "str"},
+                "port": {"required": False, "type": "int"},
+                "security_mode": {"required": False, "type": "str",
+                                  "choices": ["none", "authentication"]},
+                "timeout": {"required": False, "type": "int"},
+                "ttl_mode": {"required": False, "type": "str",
+                             "choices": ["reinit", "decrease", "retain"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_proxy_arp.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_proxy_arp.py
@@ -1,0 +1,326 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_proxy_arp
+short_description: Configure proxy-ARP in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system feature and proxy_arp category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_proxy_arp:
+        description:
+            - Configure proxy-ARP.
+        default: null
+        type: dict
+        suboptions:
+            end_ip:
+                description:
+                    - End IP of IP range to be proxied.
+                type: str
+            id:
+                description:
+                    - Unique integer ID of the entry.
+                required: true
+                type: int
+            interface:
+                description:
+                    - Interface acting proxy-ARP. Source system.interface.name.
+                type: str
+            ip:
+                description:
+                    - IP address or start IP to be proxied.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure proxy-ARP.
+    fortios_system_proxy_arp:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_proxy_arp:
+        end_ip: "<your_own_value>"
+        id:  "4"
+        interface: "<your_own_value> (source system.interface.name)"
+        ip: "<your_own_value>"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_proxy_arp_data(json):
+    option_list = ['end_ip', 'id', 'interface',
+                   'ip']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_proxy_arp(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_proxy_arp_data = data['system_proxy_arp']
+    filtered_data = underscore_to_hyphen(filter_system_proxy_arp_data(system_proxy_arp_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'proxy-arp',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'proxy-arp',
+                          mkey=filtered_data['id'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_proxy_arp']:
+        resp = system_proxy_arp(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_proxy_arp": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "end_ip": {"required": False, "type": "str"},
+                "id": {"required": True, "type": "int"},
+                "interface": {"required": False, "type": "str"},
+                "ip": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_replacemsg_admin.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_replacemsg_admin.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_replacemsg_admin
+short_description: Replacement messages in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system_replacemsg feature and admin category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_replacemsg_admin:
+        description:
+            - Replacement messages.
+        default: null
+        type: dict
+        suboptions:
+            buffer:
+                description:
+                    - Message string.
+                type: str
+            format:
+                description:
+                    - Format flag.
+                type: str
+                choices:
+                    - none
+                    - text
+                    - html
+                    - wml
+            header:
+                description:
+                    - Header flag.
+                type: str
+                choices:
+                    - none
+                    - http
+                    - 8bit
+            msg_type:
+                description:
+                    - Message type.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Replacement messages.
+    fortios_system_replacemsg_admin:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_replacemsg_admin:
+        buffer: "<your_own_value>"
+        format: "none"
+        header: "none"
+        msg_type: "<your_own_value>"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_replacemsg_admin_data(json):
+    option_list = ['buffer', 'format', 'header',
+                   'msg_type']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_replacemsg_admin(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_replacemsg_admin_data = data['system_replacemsg_admin']
+    filtered_data = underscore_to_hyphen(filter_system_replacemsg_admin_data(system_replacemsg_admin_data))
+
+    if state == "present":
+        return fos.set('system.replacemsg',
+                       'admin',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system.replacemsg',
+                          'admin',
+                          mkey=filtered_data['msg-type'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system_replacemsg(data, fos):
+
+    if data['system_replacemsg_admin']:
+        resp = system_replacemsg_admin(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_replacemsg_admin": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "buffer": {"required": False, "type": "str"},
+                "format": {"required": False, "type": "str",
+                           "choices": ["none", "text", "html",
+                                       "wml"]},
+                "header": {"required": False, "type": "str",
+                           "choices": ["none", "http", "8bit"]},
+                "msg_type": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_replacemsg_alertmail.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_replacemsg_alertmail.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_replacemsg_alertmail
+short_description: Replacement messages in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system_replacemsg feature and alertmail category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_replacemsg_alertmail:
+        description:
+            - Replacement messages.
+        default: null
+        type: dict
+        suboptions:
+            buffer:
+                description:
+                    - Message string.
+                type: str
+            format:
+                description:
+                    - Format flag.
+                type: str
+                choices:
+                    - none
+                    - text
+                    - html
+                    - wml
+            header:
+                description:
+                    - Header flag.
+                type: str
+                choices:
+                    - none
+                    - http
+                    - 8bit
+            msg_type:
+                description:
+                    - Message type.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Replacement messages.
+    fortios_system_replacemsg_alertmail:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_replacemsg_alertmail:
+        buffer: "<your_own_value>"
+        format: "none"
+        header: "none"
+        msg_type: "<your_own_value>"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_replacemsg_alertmail_data(json):
+    option_list = ['buffer', 'format', 'header',
+                   'msg_type']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_replacemsg_alertmail(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_replacemsg_alertmail_data = data['system_replacemsg_alertmail']
+    filtered_data = underscore_to_hyphen(filter_system_replacemsg_alertmail_data(system_replacemsg_alertmail_data))
+
+    if state == "present":
+        return fos.set('system.replacemsg',
+                       'alertmail',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system.replacemsg',
+                          'alertmail',
+                          mkey=filtered_data['msg-type'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system_replacemsg(data, fos):
+
+    if data['system_replacemsg_alertmail']:
+        resp = system_replacemsg_alertmail(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_replacemsg_alertmail": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "buffer": {"required": False, "type": "str"},
+                "format": {"required": False, "type": "str",
+                           "choices": ["none", "text", "html",
+                                       "wml"]},
+                "header": {"required": False, "type": "str",
+                           "choices": ["none", "http", "8bit"]},
+                "msg_type": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_replacemsg_auth.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_replacemsg_auth.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_replacemsg_auth
+short_description: Replacement messages in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS device by allowing the
+      user to set and modify system_replacemsg feature and auth category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        choices:
+            - present
+            - absent
+    system_replacemsg_auth:
+        description:
+            - Replacement messages.
+        default: null
+        type: dict
+        suboptions:
+            buffer:
+                description:
+                    - Message string.
+                type: str
+            format:
+                description:
+                    - Format flag.
+                type: str
+                choices:
+                    - none
+                    - text
+                    - html
+                    - wml
+            header:
+                description:
+                    - Header flag.
+                type: str
+                choices:
+                    - none
+                    - http
+                    - 8bit
+            msg_type:
+                description:
+                    - Message type.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Replacement messages.
+    fortios_system_replacemsg_auth:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_replacemsg_auth:
+        buffer: "<your_own_value>"
+        format: "none"
+        header: "none"
+        msg_type: "<your_own_value>"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_replacemsg_auth_data(json):
+    option_list = ['buffer', 'format', 'header',
+                   'msg_type']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_replacemsg_auth(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_replacemsg_auth_data = data['system_replacemsg_auth']
+    filtered_data = underscore_to_hyphen(filter_system_replacemsg_auth_data(system_replacemsg_auth_data))
+
+    if state == "present":
+        return fos.set('system.replacemsg',
+                       'auth',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system.replacemsg',
+                          'auth',
+                          mkey=filtered_data['msg-type'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system_replacemsg(data, fos):
+
+    if data['system_replacemsg_auth']:
+        resp = system_replacemsg_auth(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_replacemsg_auth": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "buffer": {"required": False, "type": "str"},
+                "format": {"required": False, "type": "str",
+                           "choices": ["none", "text", "html",
+                                       "wml"]},
+                "header": {"required": False, "type": "str",
+                           "choices": ["none", "http", "8bit"]},
+                "msg_type": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system_replacemsg(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_snmp_sysinfo.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_snmp_sysinfo.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_snmp_sysinfo
+short_description: SNMP system info configuration in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system_snmp feature and sysinfo category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_snmp_sysinfo:
+        description:
+            - SNMP system info configuration.
+        default: null
+        type: dict
+        suboptions:
+            contact_info:
+                description:
+                    - Contact information.
+                type: str
+            description:
+                description:
+                    - System description.
+                type: str
+            engine_id:
+                description:
+                    - Local SNMP engineID string (maximum 24 characters).
+                type: str
+            location:
+                description:
+                    - System location.
+                type: str
+            status:
+                description:
+                    - Enable/disable SNMP.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            trap_high_cpu_threshold:
+                description:
+                    - CPU usage when trap is sent.
+                type: int
+            trap_log_full_threshold:
+                description:
+                    - Log disk usage when trap is sent.
+                type: int
+            trap_low_memory_threshold:
+                description:
+                    - Memory usage when trap is sent.
+                type: int
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: SNMP system info configuration.
+    fortios_system_snmp_sysinfo:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_snmp_sysinfo:
+        contact_info: "<your_own_value>"
+        description: "<your_own_value>"
+        engine_id: "<your_own_value>"
+        location: "<your_own_value>"
+        status: "enable"
+        trap_high_cpu_threshold: "8"
+        trap_log_full_threshold: "9"
+        trap_low_memory_threshold: "10"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_snmp_sysinfo_data(json):
+    option_list = ['contact_info', 'description', 'engine_id',
+                   'location', 'status', 'trap_high_cpu_threshold',
+                   'trap_log_full_threshold', 'trap_low_memory_threshold']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_snmp_sysinfo(data, fos):
+    vdom = data['vdom']
+    system_snmp_sysinfo_data = data['system_snmp_sysinfo']
+    filtered_data = underscore_to_hyphen(filter_system_snmp_sysinfo_data(system_snmp_sysinfo_data))
+
+    return fos.set('system.snmp',
+                   'sysinfo',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system_snmp(data, fos):
+
+    if data['system_snmp_sysinfo']:
+        resp = system_snmp_sysinfo(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_snmp_sysinfo": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "contact_info": {"required": False, "type": "str"},
+                "description": {"required": False, "type": "str"},
+                "engine_id": {"required": False, "type": "str"},
+                "location": {"required": False, "type": "str"},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]},
+                "trap_high_cpu_threshold": {"required": False, "type": "int"},
+                "trap_log_full_threshold": {"required": False, "type": "int"},
+                "trap_low_memory_threshold": {"required": False, "type": "int"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system_snmp(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system_snmp(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_snmp_user.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_snmp_user.py
@@ -1,0 +1,512 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_snmp_user
+short_description: SNMP user configuration in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system_snmp feature and user category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_snmp_user:
+        description:
+            - SNMP user configuration.
+        default: null
+        type: dict
+        suboptions:
+            auth_proto:
+                description:
+                    - Authentication protocol.
+                type: str
+                choices:
+                    - md5
+                    - sha
+            auth_pwd:
+                description:
+                    - Password for authentication protocol.
+                type: str
+            events:
+                description:
+                    - SNMP notifications (traps) to send.
+                type: list
+                choices:
+                    - cpu-high
+                    - mem-low
+                    - log-full
+                    - intf-ip
+                    - vpn-tun-up
+                    - vpn-tun-down
+                    - ha-switch
+                    - ha-hb-failure
+                    - ips-signature
+                    - ips-anomaly
+                    - av-virus
+                    - av-oversize
+                    - av-pattern
+                    - av-fragmented
+                    - fm-if-change
+                    - fm-conf-change
+                    - bgp-established
+                    - bgp-backward-transition
+                    - ha-member-up
+                    - ha-member-down
+                    - ent-conf-change
+                    - av-conserve
+                    - av-bypass
+                    - av-oversize-passed
+                    - av-oversize-blocked
+                    - ips-pkg-update
+                    - ips-fail-open
+                    - faz-disconnect
+                    - wc-ap-up
+                    - wc-ap-down
+                    - fswctl-session-up
+                    - fswctl-session-down
+                    - load-balance-real-server-down
+                    - device-new
+                    - per-cpu-high
+            ha_direct:
+                description:
+                    - Enable/disable direct management of HA cluster members.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            name:
+                description:
+                    - SNMP user name.
+                required: true
+                type: str
+            notify_hosts:
+                description:
+                    - SNMP managers to send notifications (traps) to.
+                type: list
+            notify_hosts6:
+                description:
+                    - IPv6 SNMP managers to send notifications (traps) to.
+                type: list
+            priv_proto:
+                description:
+                    - Privacy (encryption) protocol.
+                type: str
+                choices:
+                    - aes
+                    - des
+                    - aes256
+                    - aes256cisco
+            priv_pwd:
+                description:
+                    - Password for privacy (encryption) protocol.
+                type: str
+            queries:
+                description:
+                    - Enable/disable SNMP queries for this user.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            query_port:
+                description:
+                    - SNMPv3 query port (default = 161).
+                type: int
+            security_level:
+                description:
+                    - Security level for message authentication and encryption.
+                type: str
+                choices:
+                    - no-auth-no-priv
+                    - auth-no-priv
+                    - auth-priv
+            source_ip:
+                description:
+                    - Source IP for SNMP trap.
+                type: str
+            source_ipv6:
+                description:
+                    - Source IPv6 for SNMP trap.
+                type: str
+            status:
+                description:
+                    - Enable/disable this SNMP user.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            trap_lport:
+                description:
+                    - SNMPv3 local trap port (default = 162).
+                type: int
+            trap_rport:
+                description:
+                    - SNMPv3 trap remote port (default = 162).
+                type: int
+            trap_status:
+                description:
+                    - Enable/disable traps for this SNMP user.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: SNMP user configuration.
+    fortios_system_snmp_user:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_snmp_user:
+        auth_proto: "md5"
+        auth_pwd: "<your_own_value>"
+        events: "cpu-high"
+        ha_direct: "enable"
+        name: "default_name_7"
+        notify_hosts: "<your_own_value>"
+        notify_hosts6: "<your_own_value>"
+        priv_proto: "aes"
+        priv_pwd: "<your_own_value>"
+        queries: "enable"
+        query_port: "13"
+        security_level: "no-auth-no-priv"
+        source_ip: "84.230.14.43"
+        source_ipv6: "<your_own_value>"
+        status: "enable"
+        trap_lport: "18"
+        trap_rport: "19"
+        trap_status: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_snmp_user_data(json):
+    option_list = ['auth_proto', 'auth_pwd', 'events',
+                   'ha_direct', 'name', 'notify_hosts',
+                   'notify_hosts6', 'priv_proto', 'priv_pwd',
+                   'queries', 'query_port', 'security_level',
+                   'source_ip', 'source_ipv6', 'status',
+                   'trap_lport', 'trap_rport', 'trap_status']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def flatten_multilists_attributes(data):
+    multilist_attrs = [[u'events'], [u'notify_hosts'], [u'notify_hosts6']]
+
+    for attr in multilist_attrs:
+        try:
+            path = "data['" + "']['".join(elem for elem in attr) + "']"
+            current_val = eval(path)
+            flattened_val = ' '.join(elem for elem in current_val)
+            exec(path + '= flattened_val')
+        except BaseException:
+            pass
+
+    return data
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_snmp_user(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_snmp_user_data = data['system_snmp_user']
+    system_snmp_user_data = flatten_multilists_attributes(system_snmp_user_data)
+    filtered_data = underscore_to_hyphen(filter_system_snmp_user_data(system_snmp_user_data))
+
+    if state == "present":
+        return fos.set('system.snmp',
+                       'user',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system.snmp',
+                          'user',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system_snmp(data, fos):
+
+    if data['system_snmp_user']:
+        resp = system_snmp_user(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_snmp_user": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "auth_proto": {"required": False, "type": "str",
+                               "choices": ["md5", "sha"]},
+                "auth_pwd": {"required": False, "type": "str"},
+                "events": {"required": False, "type": "list",
+                           "choices": ["cpu-high", "mem-low", "log-full",
+                                       "intf-ip", "vpn-tun-up", "vpn-tun-down",
+                                       "ha-switch", "ha-hb-failure", "ips-signature",
+                                       "ips-anomaly", "av-virus", "av-oversize",
+                                       "av-pattern", "av-fragmented", "fm-if-change",
+                                       "fm-conf-change", "bgp-established", "bgp-backward-transition",
+                                       "ha-member-up", "ha-member-down", "ent-conf-change",
+                                       "av-conserve", "av-bypass", "av-oversize-passed",
+                                       "av-oversize-blocked", "ips-pkg-update", "ips-fail-open",
+                                       "faz-disconnect", "wc-ap-up", "wc-ap-down",
+                                       "fswctl-session-up", "fswctl-session-down", "load-balance-real-server-down",
+                                       "device-new", "per-cpu-high"]},
+                "ha_direct": {"required": False, "type": "str",
+                              "choices": ["enable", "disable"]},
+                "name": {"required": True, "type": "str"},
+                "notify_hosts": {"required": False, "type": "list"},
+                "notify_hosts6": {"required": False, "type": "list"},
+                "priv_proto": {"required": False, "type": "str",
+                               "choices": ["aes", "des", "aes256",
+                                           "aes256cisco"]},
+                "priv_pwd": {"required": False, "type": "str"},
+                "queries": {"required": False, "type": "str",
+                            "choices": ["enable", "disable"]},
+                "query_port": {"required": False, "type": "int"},
+                "security_level": {"required": False, "type": "str",
+                                   "choices": ["no-auth-no-priv", "auth-no-priv", "auth-priv"]},
+                "source_ip": {"required": False, "type": "str"},
+                "source_ipv6": {"required": False, "type": "str"},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]},
+                "trap_lport": {"required": False, "type": "int"},
+                "trap_rport": {"required": False, "type": "int"},
+                "trap_status": {"required": False, "type": "str",
+                                "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system_snmp(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system_snmp(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_storage.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_storage.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_storage
+short_description: Configure logical storage in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and storage category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_storage:
+        description:
+            - Configure logical storage.
+        default: null
+        type: dict
+        suboptions:
+            device:
+                description:
+                    - Partition device.
+                type: str
+            media_status:
+                description:
+                    - The physical status of current media.
+                type: str
+                choices:
+                    - enable
+                    - disable
+                    - fail
+            name:
+                description:
+                    - Storage name.
+                required: true
+                type: str
+            order:
+                description:
+                    - Set storage order.
+                type: int
+            partition:
+                description:
+                    - Label of underlying partition.
+                type: str
+            size:
+                description:
+                    - Partition size.
+                type: int
+            status:
+                description:
+                    - Enable/disable storage.
+                type: str
+                choices:
+                    - enable
+                    - disable
+            usage:
+                description:
+                    - Use hard disk for logging or WAN Optimization (default = log).
+                type: str
+                choices:
+                    - log
+                    - wanopt
+            wanopt_mode:
+                description:
+                    - WAN Optimization mode (default = mix).
+                type: str
+                choices:
+                    - mix
+                    - wanopt
+                    - webcache
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure logical storage.
+    fortios_system_storage:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_storage:
+        device: "<your_own_value>"
+        media_status: "enable"
+        name: "default_name_5"
+        order: "6"
+        partition: "<your_own_value>"
+        size: "8"
+        status: "enable"
+        usage: "log"
+        wanopt_mode: "mix"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_storage_data(json):
+    option_list = ['device', 'media_status', 'name',
+                   'order', 'partition', 'size',
+                   'status', 'usage', 'wanopt_mode']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_storage(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_storage_data = data['system_storage']
+    filtered_data = underscore_to_hyphen(filter_system_storage_data(system_storage_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'storage',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'storage',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_storage']:
+        resp = system_storage(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_storage": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "device": {"required": False, "type": "str"},
+                "media_status": {"required": False, "type": "str",
+                                 "choices": ["enable", "disable", "fail"]},
+                "name": {"required": True, "type": "str"},
+                "order": {"required": False, "type": "int"},
+                "partition": {"required": False, "type": "str"},
+                "size": {"required": False, "type": "int"},
+                "status": {"required": False, "type": "str",
+                           "choices": ["enable", "disable"]},
+                "usage": {"required": False, "type": "str",
+                          "choices": ["log", "wanopt"]},
+                "wanopt_mode": {"required": False, "type": "str",
+                                "choices": ["mix", "wanopt", "webcache"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_switch_interface.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_switch_interface.py
@@ -1,0 +1,396 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_switch_interface
+short_description: Configure software switch interfaces by grouping physical and WiFi interfaces in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and switch_interface category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_switch_interface:
+        description:
+            - Configure software switch interfaces by grouping physical and WiFi interfaces.
+        default: null
+        type: dict
+        suboptions:
+            intra_switch_policy:
+                description:
+                    - Allow any traffic between switch interfaces or require firewall policies to allow traffic between switch interfaces.
+                type: str
+                choices:
+                    - implicit
+                    - explicit
+            member:
+                description:
+                    - Names of the interfaces that belong to the virtual switch.
+                type: list
+                suboptions:
+                    interface_name:
+                        description:
+                            - Physical interface name. Source system.interface.name.
+                        type: str
+            name:
+                description:
+                    - Interface name (name cannot be in use by any other interfaces, VLANs, or inter-VDOM links).
+                required: true
+                type: str
+            span:
+                description:
+                    - Enable/disable port spanning. Port spanning echoes traffic received by the software switch to the span destination port.
+                type: str
+                choices:
+                    - disable
+                    - enable
+            span_dest_port:
+                description:
+                    - SPAN destination port name. All traffic on the SPAN source ports is echoed to the SPAN destination port. Source system.interface.name.
+                type: str
+            span_direction:
+                description:
+                    - "The direction in which the SPAN port operates, either: rx, tx, or both."
+                type: str
+                choices:
+                    - rx
+                    - tx
+                    - both
+            span_source_port:
+                description:
+                    - Physical interface name. Port spanning echoes all traffic on the SPAN source ports to the SPAN destination port.
+                type: list
+                suboptions:
+                    interface_name:
+                        description:
+                            - Physical interface name. Source system.interface.name.
+                        type: str
+            type:
+                description:
+                    - "Type of switch based on functionality: switch for normal functionality, or hub to duplicate packets to all port members."
+                type: str
+                choices:
+                    - switch
+                    - hub
+            vdom:
+                description:
+                    - VDOM that the software switch belongs to. Source system.vdom.name.
+                type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure software switch interfaces by grouping physical and WiFi interfaces.
+    fortios_system_switch_interface:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_switch_interface:
+        intra_switch_policy: "implicit"
+        member:
+         -
+            interface_name: "<your_own_value> (source system.interface.name)"
+        name: "default_name_6"
+        span: "disable"
+        span_dest_port: "<your_own_value> (source system.interface.name)"
+        span_direction: "rx"
+        span_source_port:
+         -
+            interface_name: "<your_own_value> (source system.interface.name)"
+        type: "switch"
+        vdom: "<your_own_value> (source system.vdom.name)"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_switch_interface_data(json):
+    option_list = ['intra_switch_policy', 'member', 'name',
+                   'span', 'span_dest_port', 'span_direction',
+                   'span_source_port', 'type', 'vdom']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_switch_interface(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_switch_interface_data = data['system_switch_interface']
+    filtered_data = underscore_to_hyphen(filter_system_switch_interface_data(system_switch_interface_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'switch-interface',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'switch-interface',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_switch_interface']:
+        resp = system_switch_interface(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_switch_interface": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "intra_switch_policy": {"required": False, "type": "str",
+                                        "choices": ["implicit", "explicit"]},
+                "member": {"required": False, "type": "list",
+                           "options": {
+                               "interface_name": {"required": False, "type": "str"}
+                           }},
+                "name": {"required": True, "type": "str"},
+                "span": {"required": False, "type": "str",
+                         "choices": ["disable", "enable"]},
+                "span_dest_port": {"required": False, "type": "str"},
+                "span_direction": {"required": False, "type": "str",
+                                   "choices": ["rx", "tx", "both"]},
+                "span_source_port": {"required": False, "type": "list",
+                                     "options": {
+                                         "interface_name": {"required": False, "type": "str"}
+                                     }},
+                "type": {"required": False, "type": "str",
+                         "choices": ["switch", "hub"]},
+                "vdom": {"required": False, "type": "str"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_tos_based_priority.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_tos_based_priority.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_tos_based_priority
+short_description: Configure Type of Service (ToS) based priority table to set network traffic priorities in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and tos_based_priority category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_tos_based_priority:
+        description:
+            - Configure Type of Service (ToS) based priority table to set network traffic priorities.
+        default: null
+        type: dict
+        suboptions:
+            id:
+                description:
+                    - Item ID.
+                required: true
+                type: int
+            priority:
+                description:
+                    - ToS based priority level to low, medium or high (these priorities match firewall traffic shaping priorities) (default = medium).
+                type: str
+                choices:
+                    - low
+                    - medium
+                    - high
+            tos:
+                description:
+                    - "Value of the ToS byte in the IP datagram header (0-15, 8: minimize delay, 4: maximize throughput, 2: maximize reliability, 1: minimize
+                       monetary cost, and 0: default service)."
+                type: int
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure Type of Service (ToS) based priority table to set network traffic priorities.
+    fortios_system_tos_based_priority:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_tos_based_priority:
+        id:  "3"
+        priority: "low"
+        tos: "5"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_tos_based_priority_data(json):
+    option_list = ['id', 'priority', 'tos']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_tos_based_priority(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_tos_based_priority_data = data['system_tos_based_priority']
+    filtered_data = underscore_to_hyphen(filter_system_tos_based_priority_data(system_tos_based_priority_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'tos-based-priority',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'tos-based-priority',
+                          mkey=filtered_data['id'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_tos_based_priority']:
+        resp = system_tos_based_priority(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_tos_based_priority": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "id": {"required": True, "type": "int"},
+                "priority": {"required": False, "type": "str",
+                             "choices": ["low", "medium", "high"]},
+                "tos": {"required": False, "type": "int"}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_vdom_exception.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_vdom_exception.py
@@ -1,0 +1,355 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_vdom_exception
+short_description: Global configuration objects that can be configured independently for all VDOMs or for the defined VDOM scope in Fortinet's FortiOS and
+   FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and vdom_exception category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_vdom_exception:
+        description:
+            - Global configuration objects that can be configured independently for all VDOMs or for the defined VDOM scope.
+        default: null
+        type: dict
+        suboptions:
+            id:
+                description:
+                    - Index <1-4096>.
+                required: true
+                type: int
+            object:
+                description:
+                    - Name of the configuration object that can be configured independently for all VDOMs.
+                type: str
+                choices:
+                    - log.fortianalyzer.setting
+                    - log.fortianalyzer.override-setting
+            oid:
+                description:
+                    - Object ID.
+                type: int
+            scope:
+                description:
+                    - Determine whether the configuration object can be configured separately for all VDOMs or if some VDOMs share the same configuration.
+                type: str
+                choices:
+                    - all
+                    - inclusive
+                    - exclusive
+            vdom:
+                description:
+                    - Names of the VDOMs.
+                type: list
+                suboptions:
+                    name:
+                        description:
+                            - VDOM name. Source system.vdom.name.
+                        required: true
+                        type: str
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Global configuration objects that can be configured independently for all VDOMs or for the defined VDOM scope.
+    fortios_system_vdom_exception:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_vdom_exception:
+        id:  "3"
+        object: "log.fortianalyzer.setting"
+        oid: "5"
+        scope: "all"
+        vdom:
+         -
+            name: "default_name_8 (source system.vdom.name)"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_vdom_exception_data(json):
+    option_list = ['id', 'object', 'oid',
+                   'scope', 'vdom']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_vdom_exception(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_vdom_exception_data = data['system_vdom_exception']
+    filtered_data = underscore_to_hyphen(filter_system_vdom_exception_data(system_vdom_exception_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'vdom-exception',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'vdom-exception',
+                          mkey=filtered_data['id'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_vdom_exception']:
+        resp = system_vdom_exception(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_vdom_exception": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "id": {"required": True, "type": "int"},
+                "object": {"required": False, "type": "str",
+                           "choices": ["log.fortianalyzer.setting", "log.fortianalyzer.override-setting"]},
+                "oid": {"required": False, "type": "int"},
+                "scope": {"required": False, "type": "str",
+                          "choices": ["all", "inclusive", "exclusive"]},
+                "vdom": {"required": False, "type": "list",
+                         "options": {
+                             "name": {"required": True, "type": "str"}
+                         }}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_vdom_link.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_vdom_link.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_vdom_link
+short_description: Configure VDOM links in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and vdom_link category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    state:
+        description:
+            - Indicates whether to create or remove the object.
+        type: str
+        required: true
+        choices:
+            - present
+            - absent
+    system_vdom_link:
+        description:
+            - Configure VDOM links.
+        default: null
+        type: dict
+        suboptions:
+            name:
+                description:
+                    - VDOM link name (maximum = 8 characters).
+                required: true
+                type: str
+            type:
+                description:
+                    - "VDOM link type: PPP or Ethernet."
+                type: str
+                choices:
+                    - ppp
+                    - ethernet
+            vcluster:
+                description:
+                    - Virtual cluster.
+                type: str
+                choices:
+                    - vcluster1
+                    - vcluster2
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure VDOM links.
+    fortios_system_vdom_link:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      state: "present"
+      system_vdom_link:
+        name: "default_name_3"
+        type: "ppp"
+        vcluster: "vcluster1"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_vdom_link_data(json):
+    option_list = ['name', 'type', 'vcluster']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_vdom_link(data, fos):
+    vdom = data['vdom']
+    state = data['state']
+    system_vdom_link_data = data['system_vdom_link']
+    filtered_data = underscore_to_hyphen(filter_system_vdom_link_data(system_vdom_link_data))
+
+    if state == "present":
+        return fos.set('system',
+                       'vdom-link',
+                       data=filtered_data,
+                       vdom=vdom)
+
+    elif state == "absent":
+        return fos.delete('system',
+                          'vdom-link',
+                          mkey=filtered_data['name'],
+                          vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_vdom_link']:
+        resp = system_vdom_link(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "state": {"required": True, "type": "str",
+                  "choices": ["present", "absent"]},
+        "system_vdom_link": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "name": {"required": True, "type": "str"},
+                "type": {"required": False, "type": "str",
+                         "choices": ["ppp", "ethernet"]},
+                "vcluster": {"required": False, "type": "str",
+                             "choices": ["vcluster1", "vcluster2"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_system_vdom_netflow.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_vdom_netflow.py
@@ -1,0 +1,312 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fortios_system_vdom_netflow
+short_description: Configure NetFlow per VDOM in Fortinet's FortiOS and FortiGate.
+description:
+    - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
+      user to set and modify system feature and vdom_netflow category.
+      Examples include all parameters and values need to be adjusted to datasources before usage.
+      Tested with FOS v6.0.5
+version_added: "2.9"
+author:
+    - Miguel Angel Munoz (@mamunozgonzalez)
+    - Nicolas Thomas (@thomnico)
+notes:
+    - Requires fortiosapi library developed by Fortinet
+    - Run as a local_action in your playbook
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or FortiGate IP address.
+        type: str
+        required: false
+    username:
+        description:
+            - FortiOS or FortiGate username.
+        type: str
+        required: false
+    password:
+        description:
+            - FortiOS or FortiGate password.
+        type: str
+        default: ""
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a
+              virtual instance of the FortiGate that can be configured and
+              used as a different unit.
+        type: str
+        default: root
+    https:
+        description:
+            - Indicates if the requests towards FortiGate must use HTTPS protocol.
+        type: bool
+        default: true
+    ssl_verify:
+        description:
+            - Ensures FortiGate certificate must be verified by a proper CA.
+        type: bool
+        default: true
+    system_vdom_netflow:
+        description:
+            - Configure NetFlow per VDOM.
+        default: null
+        type: dict
+        suboptions:
+            collector_ip:
+                description:
+                    - NetFlow collector IP address.
+                type: str
+            collector_port:
+                description:
+                    - NetFlow collector port number.
+                type: int
+            source_ip:
+                description:
+                    - Source IP address for communication with the NetFlow agent.
+                type: str
+            vdom_netflow:
+                description:
+                    - Enable/disable NetFlow per VDOM.
+                type: str
+                choices:
+                    - enable
+                    - disable
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.122.40"
+   username: "admin"
+   password: ""
+   vdom: "root"
+   ssl_verify: "False"
+  tasks:
+  - name: Configure NetFlow per VDOM.
+    fortios_system_vdom_netflow:
+      host:  "{{ host }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      vdom:  "{{ vdom }}"
+      https: "False"
+      system_vdom_netflow:
+        collector_ip: "<your_own_value>"
+        collector_port: "4"
+        source_ip: "84.230.14.43"
+        vdom_netflow: "enable"
+'''
+
+RETURN = '''
+build:
+  description: Build number of the fortigate image
+  returned: always
+  type: str
+  sample: '1547'
+http_method:
+  description: Last method used to provision the content into FortiGate
+  returned: always
+  type: str
+  sample: 'PUT'
+http_status:
+  description: Last result given by FortiGate on last operation applied
+  returned: always
+  type: str
+  sample: "200"
+mkey:
+  description: Master key (id) used in the last call to FortiGate
+  returned: success
+  type: str
+  sample: "id"
+name:
+  description: Name of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "urlfilter"
+path:
+  description: Path of the table used to fulfill the request
+  returned: always
+  type: str
+  sample: "webfilter"
+revision:
+  description: Internal revision number
+  returned: always
+  type: str
+  sample: "17.0.2.10658"
+serial:
+  description: Serial number of the unit
+  returned: always
+  type: str
+  sample: "FGVMEVYYQT3AB5352"
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: str
+  sample: "success"
+vdom:
+  description: Virtual domain used
+  returned: always
+  type: str
+  sample: "root"
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: str
+  sample: "v5.6.3"
+
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+from ansible.module_utils.network.fortimanager.common import FAIL_SOCKET_MSG
+
+
+def login(data, fos):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    ssl_verify = data['ssl_verify']
+
+    fos.debug('on')
+    if 'https' in data and not data['https']:
+        fos.https('off')
+    else:
+        fos.https('on')
+
+    fos.login(host, username, password, verify=ssl_verify)
+
+
+def filter_system_vdom_netflow_data(json):
+    option_list = ['collector_ip', 'collector_port', 'source_ip',
+                   'vdom_netflow']
+    dictionary = {}
+
+    for attribute in option_list:
+        if attribute in json and json[attribute] is not None:
+            dictionary[attribute] = json[attribute]
+
+    return dictionary
+
+
+def underscore_to_hyphen(data):
+    if isinstance(data, list):
+        for elem in data:
+            elem = underscore_to_hyphen(elem)
+    elif isinstance(data, dict):
+        new_data = {}
+        for k, v in data.items():
+            new_data[k.replace('_', '-')] = underscore_to_hyphen(v)
+        data = new_data
+
+    return data
+
+
+def system_vdom_netflow(data, fos):
+    vdom = data['vdom']
+    system_vdom_netflow_data = data['system_vdom_netflow']
+    filtered_data = underscore_to_hyphen(filter_system_vdom_netflow_data(system_vdom_netflow_data))
+
+    return fos.set('system',
+                   'vdom-netflow',
+                   data=filtered_data,
+                   vdom=vdom)
+
+
+def is_successful_status(status):
+    return status['status'] == "success" or \
+        status['http_method'] == "DELETE" and status['http_status'] == 404
+
+
+def fortios_system(data, fos):
+
+    if data['system_vdom_netflow']:
+        resp = system_vdom_netflow(data, fos)
+
+    return not is_successful_status(resp), \
+        resp['status'] == "success", \
+        resp
+
+
+def main():
+    fields = {
+        "host": {"required": False, "type": "str"},
+        "username": {"required": False, "type": "str"},
+        "password": {"required": False, "type": "str", "default": "", "no_log": True},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "https": {"required": False, "type": "bool", "default": True},
+        "ssl_verify": {"required": False, "type": "bool", "default": True},
+        "system_vdom_netflow": {
+            "required": False, "type": "dict", "default": None,
+            "options": {
+                "collector_ip": {"required": False, "type": "str"},
+                "collector_port": {"required": False, "type": "int"},
+                "source_ip": {"required": False, "type": "str"},
+                "vdom_netflow": {"required": False, "type": "str",
+                                 "choices": ["enable", "disable"]}
+
+            }
+        }
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+
+    # legacy_mode refers to using fortiosapi instead of HTTPAPI
+    legacy_mode = 'host' in module.params and module.params['host'] is not None and \
+                  'username' in module.params and module.params['username'] is not None and \
+                  'password' in module.params and module.params['password'] is not None
+
+    if not legacy_mode:
+        if module._socket_path:
+            connection = Connection(module._socket_path)
+            fos = FortiOSHandler(connection)
+
+            is_error, has_changed, result = fortios_system(module.params, fos)
+        else:
+            module.fail_json(**FAIL_SOCKET_MSG)
+    else:
+        try:
+            from fortiosapi import FortiOSAPI
+        except ImportError:
+            module.fail_json(msg="fortiosapi module is required")
+
+        fos = FortiOSAPI()
+
+        login(module.params, fos)
+        is_error, has_changed, result = fortios_system(module.params, fos)
+        fos.logout()
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -45,6 +45,7 @@ options:
     type: bool
     default: no
   checksum:
+    version_added: '2.9'
     description:
     - Use md5 checksum hash on existing dest files to compare with the src files.
     type: bool

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -44,6 +44,11 @@ options:
     - If C(flags) is set, this will be ignored.
     type: bool
     default: no
+  checksum:
+    description:
+    - Use md5 checksum hash on existing dest files to compare with the src files.
+    type: bool
+    default: no
   flags:
     description:
       - Directly supply Robocopy flags.
@@ -68,6 +73,13 @@ EXAMPLES = r'''
 
 - name: Sync the contents of one directory to another, including subdirectories
   win_robocopy:
+    src: C:\DirectoryOne
+    dest: C:\DirectoryTwo
+    recurse: yes
+
+- name: Sync the contents of one directory to another, including subdirectories, using md5 checksum hash on destination files
+  win_robocopy:
+    checksum: true
     src: C:\DirectoryOne
     dest: C:\DirectoryTwo
     recurse: yes

--- a/test/units/modules/network/fortios/test_fortios_system_management_tunnel.py
+++ b/test/units/modules/network/fortios/test_fortios_system_management_tunnel.py
@@ -1,0 +1,199 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_management_tunnel
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_management_tunnel.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_management_tunnel_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_management_tunnel': {
+            'allow_collect_statistics': 'enable',
+            'allow_config_restore': 'enable',
+            'allow_push_configuration': 'enable',
+            'allow_push_firmware': 'enable',
+            'authorized_manager_only': 'enable',
+            'serial_number': 'test_value_8',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_management_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'allow-collect-statistics': 'enable',
+        'allow-config-restore': 'enable',
+        'allow-push-configuration': 'enable',
+        'allow-push-firmware': 'enable',
+        'authorized-manager-only': 'enable',
+        'serial-number': 'test_value_8',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'management-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_management_tunnel_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_management_tunnel': {
+            'allow_collect_statistics': 'enable',
+            'allow_config_restore': 'enable',
+            'allow_push_configuration': 'enable',
+            'allow_push_firmware': 'enable',
+            'authorized_manager_only': 'enable',
+            'serial_number': 'test_value_8',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_management_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'allow-collect-statistics': 'enable',
+        'allow-config-restore': 'enable',
+        'allow-push-configuration': 'enable',
+        'allow-push-firmware': 'enable',
+        'authorized-manager-only': 'enable',
+        'serial-number': 'test_value_8',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'management-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_management_tunnel_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_management_tunnel': {
+            'allow_collect_statistics': 'enable',
+            'allow_config_restore': 'enable',
+            'allow_push_configuration': 'enable',
+            'allow_push_firmware': 'enable',
+            'authorized_manager_only': 'enable',
+            'serial_number': 'test_value_8',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_management_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'allow-collect-statistics': 'enable',
+        'allow-config-restore': 'enable',
+        'allow-push-configuration': 'enable',
+        'allow-push-firmware': 'enable',
+        'authorized-manager-only': 'enable',
+        'serial-number': 'test_value_8',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'management-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_management_tunnel_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_management_tunnel': {
+            'random_attribute_not_valid': 'tag',
+            'allow_collect_statistics': 'enable',
+            'allow_config_restore': 'enable',
+            'allow_push_configuration': 'enable',
+            'allow_push_firmware': 'enable',
+            'authorized_manager_only': 'enable',
+            'serial_number': 'test_value_8',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_management_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'allow-collect-statistics': 'enable',
+        'allow-config-restore': 'enable',
+        'allow-push-configuration': 'enable',
+        'allow-push-firmware': 'enable',
+        'authorized-manager-only': 'enable',
+        'serial-number': 'test_value_8',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'management-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_mobile_tunnel.py
+++ b/test/units/modules/network/fortios/test_fortios_system_mobile_tunnel.py
@@ -1,0 +1,329 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_mobile_tunnel
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_mobile_tunnel.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_mobile_tunnel_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_mobile_tunnel': {
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'hash-algorithm': 'hmac-md5',
+        'home-address': 'test_value_4',
+        'home-agent': 'test_value_5',
+        'lifetime': '6',
+        'n-mhae-key': 'test_value_7',
+        'n-mhae-key-type': 'ascii',
+        'n-mhae-spi': '9',
+        'name': 'default_name_10',
+                'reg-interval': '11',
+                'reg-retry': '12',
+                'renew-interval': '13',
+                'roaming-interface': 'test_value_14',
+                'status': 'disable',
+                'tunnel-mode': 'gre'
+    }
+
+    set_method_mock.assert_called_with('system', 'mobile-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_mobile_tunnel_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_mobile_tunnel': {
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'hash-algorithm': 'hmac-md5',
+        'home-address': 'test_value_4',
+        'home-agent': 'test_value_5',
+        'lifetime': '6',
+        'n-mhae-key': 'test_value_7',
+        'n-mhae-key-type': 'ascii',
+        'n-mhae-spi': '9',
+        'name': 'default_name_10',
+                'reg-interval': '11',
+                'reg-retry': '12',
+                'renew-interval': '13',
+                'roaming-interface': 'test_value_14',
+                'status': 'disable',
+                'tunnel-mode': 'gre'
+    }
+
+    set_method_mock.assert_called_with('system', 'mobile-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_mobile_tunnel_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_mobile_tunnel': {
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'mobile-tunnel', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_mobile_tunnel_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_mobile_tunnel': {
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'mobile-tunnel', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_mobile_tunnel_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_mobile_tunnel': {
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'hash-algorithm': 'hmac-md5',
+        'home-address': 'test_value_4',
+        'home-agent': 'test_value_5',
+        'lifetime': '6',
+        'n-mhae-key': 'test_value_7',
+        'n-mhae-key-type': 'ascii',
+        'n-mhae-spi': '9',
+        'name': 'default_name_10',
+                'reg-interval': '11',
+                'reg-retry': '12',
+                'renew-interval': '13',
+                'roaming-interface': 'test_value_14',
+                'status': 'disable',
+                'tunnel-mode': 'gre'
+    }
+
+    set_method_mock.assert_called_with('system', 'mobile-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_mobile_tunnel_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_mobile_tunnel': {
+            'random_attribute_not_valid': 'tag',
+            'hash_algorithm': 'hmac-md5',
+            'home_address': 'test_value_4',
+            'home_agent': 'test_value_5',
+            'lifetime': '6',
+            'n_mhae_key': 'test_value_7',
+            'n_mhae_key_type': 'ascii',
+            'n_mhae_spi': '9',
+            'name': 'default_name_10',
+            'reg_interval': '11',
+            'reg_retry': '12',
+            'renew_interval': '13',
+            'roaming_interface': 'test_value_14',
+            'status': 'disable',
+            'tunnel_mode': 'gre'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_mobile_tunnel.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'hash-algorithm': 'hmac-md5',
+        'home-address': 'test_value_4',
+        'home-agent': 'test_value_5',
+        'lifetime': '6',
+        'n-mhae-key': 'test_value_7',
+        'n-mhae-key-type': 'ascii',
+        'n-mhae-spi': '9',
+        'name': 'default_name_10',
+                'reg-interval': '11',
+                'reg-retry': '12',
+                'renew-interval': '13',
+                'roaming-interface': 'test_value_14',
+                'status': 'disable',
+                'tunnel-mode': 'gre'
+    }
+
+    set_method_mock.assert_called_with('system', 'mobile-tunnel', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_nat64.py
+++ b/test/units/modules/network/fortios/test_fortios_system_nat64.py
@@ -1,0 +1,191 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_nat64
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_nat64.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_nat64_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nat64': {
+            'always_synthesize_aaaa_record': 'enable',
+            'generate_ipv6_fragment_header': 'enable',
+            'nat46_force_ipv4_packet_forwarding': 'enable',
+            'nat64_prefix': 'test_value_6',
+            'secondary_prefix_status': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nat64.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'always-synthesize-aaaa-record': 'enable',
+        'generate-ipv6-fragment-header': 'enable',
+        'nat46-force-ipv4-packet-forwarding': 'enable',
+        'nat64-prefix': 'test_value_6',
+        'secondary-prefix-status': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'nat64', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_nat64_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nat64': {
+            'always_synthesize_aaaa_record': 'enable',
+            'generate_ipv6_fragment_header': 'enable',
+            'nat46_force_ipv4_packet_forwarding': 'enable',
+            'nat64_prefix': 'test_value_6',
+            'secondary_prefix_status': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nat64.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'always-synthesize-aaaa-record': 'enable',
+        'generate-ipv6-fragment-header': 'enable',
+        'nat46-force-ipv4-packet-forwarding': 'enable',
+        'nat64-prefix': 'test_value_6',
+        'secondary-prefix-status': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'nat64', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_nat64_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nat64': {
+            'always_synthesize_aaaa_record': 'enable',
+            'generate_ipv6_fragment_header': 'enable',
+            'nat46_force_ipv4_packet_forwarding': 'enable',
+            'nat64_prefix': 'test_value_6',
+            'secondary_prefix_status': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nat64.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'always-synthesize-aaaa-record': 'enable',
+        'generate-ipv6-fragment-header': 'enable',
+        'nat46-force-ipv4-packet-forwarding': 'enable',
+        'nat64-prefix': 'test_value_6',
+        'secondary-prefix-status': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'nat64', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_nat64_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nat64': {
+            'random_attribute_not_valid': 'tag',
+            'always_synthesize_aaaa_record': 'enable',
+            'generate_ipv6_fragment_header': 'enable',
+            'nat46_force_ipv4_packet_forwarding': 'enable',
+            'nat64_prefix': 'test_value_6',
+            'secondary_prefix_status': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nat64.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'always-synthesize-aaaa-record': 'enable',
+        'generate-ipv6-fragment-header': 'enable',
+        'nat46-force-ipv4-packet-forwarding': 'enable',
+        'nat64-prefix': 'test_value_6',
+        'secondary-prefix-status': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'nat64', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_nd_proxy.py
+++ b/test/units/modules/network/fortios/test_fortios_system_nd_proxy.py
@@ -1,0 +1,143 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_nd_proxy
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_nd_proxy.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_nd_proxy_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nd_proxy': {'status': 'enable'
+                            },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nd_proxy.fortios_system(input_data, fos_instance)
+
+    expected_data = {'status': 'enable'
+                     }
+
+    set_method_mock.assert_called_with('system', 'nd-proxy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_nd_proxy_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nd_proxy': {'status': 'enable'
+                            },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nd_proxy.fortios_system(input_data, fos_instance)
+
+    expected_data = {'status': 'enable'
+                     }
+
+    set_method_mock.assert_called_with('system', 'nd-proxy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_nd_proxy_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nd_proxy': {'status': 'enable'
+                            },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nd_proxy.fortios_system(input_data, fos_instance)
+
+    expected_data = {'status': 'enable'
+                     }
+
+    set_method_mock.assert_called_with('system', 'nd-proxy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_nd_proxy_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_nd_proxy': {
+            'random_attribute_not_valid': 'tag', 'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_nd_proxy.fortios_system(input_data, fos_instance)
+
+    expected_data = {'status': 'enable'
+                     }
+
+    set_method_mock.assert_called_with('system', 'nd-proxy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_netflow.py
+++ b/test/units/modules/network/fortios/test_fortios_system_netflow.py
@@ -1,0 +1,199 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_netflow
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_netflow.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_netflow_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_netflow': {
+            'active_flow_timeout': '3',
+            'collector_ip': 'test_value_4',
+            'collector_port': '5',
+            'inactive_flow_timeout': '6',
+            'source_ip': '84.230.14.7',
+            'template_tx_counter': '8',
+            'template_tx_timeout': '9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'active-flow-timeout': '3',
+        'collector-ip': 'test_value_4',
+        'collector-port': '5',
+        'inactive-flow-timeout': '6',
+        'source-ip': '84.230.14.7',
+        'template-tx-counter': '8',
+        'template-tx-timeout': '9'
+    }
+
+    set_method_mock.assert_called_with('system', 'netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_netflow_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_netflow': {
+            'active_flow_timeout': '3',
+            'collector_ip': 'test_value_4',
+            'collector_port': '5',
+            'inactive_flow_timeout': '6',
+            'source_ip': '84.230.14.7',
+            'template_tx_counter': '8',
+            'template_tx_timeout': '9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'active-flow-timeout': '3',
+        'collector-ip': 'test_value_4',
+        'collector-port': '5',
+        'inactive-flow-timeout': '6',
+        'source-ip': '84.230.14.7',
+        'template-tx-counter': '8',
+        'template-tx-timeout': '9'
+    }
+
+    set_method_mock.assert_called_with('system', 'netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_netflow_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_netflow': {
+            'active_flow_timeout': '3',
+            'collector_ip': 'test_value_4',
+            'collector_port': '5',
+            'inactive_flow_timeout': '6',
+            'source_ip': '84.230.14.7',
+            'template_tx_counter': '8',
+            'template_tx_timeout': '9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'active-flow-timeout': '3',
+        'collector-ip': 'test_value_4',
+        'collector-port': '5',
+        'inactive-flow-timeout': '6',
+        'source-ip': '84.230.14.7',
+        'template-tx-counter': '8',
+        'template-tx-timeout': '9'
+    }
+
+    set_method_mock.assert_called_with('system', 'netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_netflow_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_netflow': {
+            'random_attribute_not_valid': 'tag',
+            'active_flow_timeout': '3',
+            'collector_ip': 'test_value_4',
+            'collector_port': '5',
+            'inactive_flow_timeout': '6',
+            'source_ip': '84.230.14.7',
+            'template_tx_counter': '8',
+            'template_tx_timeout': '9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'active-flow-timeout': '3',
+        'collector-ip': 'test_value_4',
+        'collector-port': '5',
+        'inactive-flow-timeout': '6',
+        'source-ip': '84.230.14.7',
+        'template-tx-counter': '8',
+        'template-tx-timeout': '9'
+    }
+
+    set_method_mock.assert_called_with('system', 'netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_network_visibility.py
+++ b/test/units/modules/network/fortios/test_fortios_system_network_visibility.py
@@ -1,0 +1,191 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_network_visibility
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_network_visibility.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_network_visibility_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_network_visibility': {
+            'destination_hostname_visibility': 'disable',
+            'destination_location': 'disable',
+            'destination_visibility': 'disable',
+            'hostname_limit': '6',
+            'hostname_ttl': '7',
+            'source_location': 'disable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_network_visibility.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'destination-hostname-visibility': 'disable',
+        'destination-location': 'disable',
+        'destination-visibility': 'disable',
+        'hostname-limit': '6',
+        'hostname-ttl': '7',
+        'source-location': 'disable'
+    }
+
+    set_method_mock.assert_called_with('system', 'network-visibility', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_network_visibility_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_network_visibility': {
+            'destination_hostname_visibility': 'disable',
+            'destination_location': 'disable',
+            'destination_visibility': 'disable',
+            'hostname_limit': '6',
+            'hostname_ttl': '7',
+            'source_location': 'disable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_network_visibility.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'destination-hostname-visibility': 'disable',
+        'destination-location': 'disable',
+        'destination-visibility': 'disable',
+        'hostname-limit': '6',
+        'hostname-ttl': '7',
+        'source-location': 'disable'
+    }
+
+    set_method_mock.assert_called_with('system', 'network-visibility', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_network_visibility_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_network_visibility': {
+            'destination_hostname_visibility': 'disable',
+            'destination_location': 'disable',
+            'destination_visibility': 'disable',
+            'hostname_limit': '6',
+            'hostname_ttl': '7',
+            'source_location': 'disable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_network_visibility.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'destination-hostname-visibility': 'disable',
+        'destination-location': 'disable',
+        'destination-visibility': 'disable',
+        'hostname-limit': '6',
+        'hostname-ttl': '7',
+        'source-location': 'disable'
+    }
+
+    set_method_mock.assert_called_with('system', 'network-visibility', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_network_visibility_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_network_visibility': {
+            'random_attribute_not_valid': 'tag',
+            'destination_hostname_visibility': 'disable',
+            'destination_location': 'disable',
+            'destination_visibility': 'disable',
+            'hostname_limit': '6',
+            'hostname_ttl': '7',
+            'source_location': 'disable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_network_visibility.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'destination-hostname-visibility': 'disable',
+        'destination-location': 'disable',
+        'destination-visibility': 'disable',
+        'hostname-limit': '6',
+        'hostname-ttl': '7',
+        'source-location': 'disable'
+    }
+
+    set_method_mock.assert_called_with('system', 'network-visibility', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_ntp.py
+++ b/test/units/modules/network/fortios/test_fortios_system_ntp.py
@@ -1,0 +1,183 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_ntp
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_ntp.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_ntp_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_ntp': {'ntpsync': 'enable',
+                       'server_mode': 'enable',
+                       'source_ip': '84.230.14.5',
+                       'source_ip6': 'test_value_6',
+                       'syncinterval': '7',
+                       'type': 'fortiguard'
+                       },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_ntp.fortios_system(input_data, fos_instance)
+
+    expected_data = {'ntpsync': 'enable',
+                     'server-mode': 'enable',
+                     'source-ip': '84.230.14.5',
+                     'source-ip6': 'test_value_6',
+                     'syncinterval': '7',
+                     'type': 'fortiguard'
+                     }
+
+    set_method_mock.assert_called_with('system', 'ntp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_ntp_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_ntp': {'ntpsync': 'enable',
+                       'server_mode': 'enable',
+                       'source_ip': '84.230.14.5',
+                       'source_ip6': 'test_value_6',
+                       'syncinterval': '7',
+                       'type': 'fortiguard'
+                       },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_ntp.fortios_system(input_data, fos_instance)
+
+    expected_data = {'ntpsync': 'enable',
+                     'server-mode': 'enable',
+                     'source-ip': '84.230.14.5',
+                     'source-ip6': 'test_value_6',
+                     'syncinterval': '7',
+                     'type': 'fortiguard'
+                     }
+
+    set_method_mock.assert_called_with('system', 'ntp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_ntp_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_ntp': {'ntpsync': 'enable',
+                       'server_mode': 'enable',
+                       'source_ip': '84.230.14.5',
+                       'source_ip6': 'test_value_6',
+                       'syncinterval': '7',
+                       'type': 'fortiguard'
+                       },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_ntp.fortios_system(input_data, fos_instance)
+
+    expected_data = {'ntpsync': 'enable',
+                     'server-mode': 'enable',
+                     'source-ip': '84.230.14.5',
+                     'source-ip6': 'test_value_6',
+                     'syncinterval': '7',
+                     'type': 'fortiguard'
+                     }
+
+    set_method_mock.assert_called_with('system', 'ntp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_ntp_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_ntp': {
+            'random_attribute_not_valid': 'tag', 'ntpsync': 'enable',
+            'server_mode': 'enable',
+            'source_ip': '84.230.14.5',
+            'source_ip6': 'test_value_6',
+            'syncinterval': '7',
+            'type': 'fortiguard'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_ntp.fortios_system(input_data, fos_instance)
+
+    expected_data = {'ntpsync': 'enable',
+                     'server-mode': 'enable',
+                     'source-ip': '84.230.14.5',
+                     'source-ip6': 'test_value_6',
+                     'syncinterval': '7',
+                     'type': 'fortiguard'
+                     }
+
+    set_method_mock.assert_called_with('system', 'ntp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_object_tagging.py
+++ b/test/units/modules/network/fortios/test_fortios_system_object_tagging.py
@@ -1,0 +1,259 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_object_tagging
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_object_tagging.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_object_tagging_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_object_tagging': {
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'address': 'disable',
+        'category': 'test_value_4',
+        'color': '5',
+        'device': 'disable',
+        'interface': 'disable',
+        'multiple': 'enable',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'object-tagging', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_object_tagging_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_object_tagging': {
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'address': 'disable',
+        'category': 'test_value_4',
+        'color': '5',
+        'device': 'disable',
+        'interface': 'disable',
+        'multiple': 'enable',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'object-tagging', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_object_tagging_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_object_tagging': {
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'object-tagging', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_object_tagging_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_object_tagging': {
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'object-tagging', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_object_tagging_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_object_tagging': {
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'address': 'disable',
+        'category': 'test_value_4',
+        'color': '5',
+        'device': 'disable',
+        'interface': 'disable',
+        'multiple': 'enable',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'object-tagging', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_object_tagging_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_object_tagging': {
+            'random_attribute_not_valid': 'tag',
+            'address': 'disable',
+            'category': 'test_value_4',
+            'color': '5',
+            'device': 'disable',
+            'interface': 'disable',
+            'multiple': 'enable',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_object_tagging.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'address': 'disable',
+        'category': 'test_value_4',
+        'color': '5',
+        'device': 'disable',
+        'interface': 'disable',
+        'multiple': 'enable',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'object-tagging', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_password_policy.py
+++ b/test/units/modules/network/fortios/test_fortios_system_password_policy.py
@@ -1,0 +1,231 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_password_policy
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_password_policy.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_password_policy_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy': {
+            'apply_to': 'admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_password_policy_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy': {
+            'apply_to': 'admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_password_policy_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy': {
+            'apply_to': 'admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_password_policy_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy': {
+            'random_attribute_not_valid': 'tag',
+            'apply_to': 'admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_password_policy_guest_admin.py
+++ b/test/units/modules/network/fortios/test_fortios_system_password_policy_guest_admin.py
@@ -1,0 +1,231 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_password_policy_guest_admin
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_password_policy_guest_admin.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_password_policy_guest_admin_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy_guest_admin': {
+            'apply_to': 'guest-admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy_guest_admin.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'guest-admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy-guest-admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_password_policy_guest_admin_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy_guest_admin': {
+            'apply_to': 'guest-admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy_guest_admin.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'guest-admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy-guest-admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_password_policy_guest_admin_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy_guest_admin': {
+            'apply_to': 'guest-admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy_guest_admin.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'guest-admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy-guest-admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_password_policy_guest_admin_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_password_policy_guest_admin': {
+            'random_attribute_not_valid': 'tag',
+            'apply_to': 'guest-admin-password',
+            'change_4_characters': 'enable',
+            'expire_day': '5',
+            'expire_status': 'enable',
+            'min_lower_case_letter': '7',
+            'min_non_alphanumeric': '8',
+            'min_number': '9',
+            'min_upper_case_letter': '10',
+            'minimum_length': '11',
+            'reuse_password': 'enable',
+            'status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_password_policy_guest_admin.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'apply-to': 'guest-admin-password',
+        'change-4-characters': 'enable',
+        'expire-day': '5',
+        'expire-status': 'enable',
+        'min-lower-case-letter': '7',
+        'min-non-alphanumeric': '8',
+        'min-number': '9',
+        'min-upper-case-letter': '10',
+        'minimum-length': '11',
+        'reuse-password': 'enable',
+        'status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'password-policy-guest-admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_pppoe_interface.py
+++ b/test/units/modules/network/fortios/test_fortios_system_pppoe_interface.py
@@ -1,0 +1,349 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_pppoe_interface
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_pppoe_interface.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_pppoe_interface_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_pppoe_interface': {
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'ac-name': 'test_value_3',
+        'auth-type': 'auto',
+        'device': 'test_value_5',
+        'dial-on-demand': 'enable',
+        'disc-retry-timeout': '7',
+        'idle-timeout': '8',
+        'ipunnumbered': 'test_value_9',
+        'ipv6': 'enable',
+                'lcp-echo-interval': '11',
+                'lcp-max-echo-fails': '12',
+                'name': 'default_name_13',
+                'padt-retry-timeout': '14',
+                'password': 'test_value_15',
+                'pppoe-unnumbered-negotiate': 'enable',
+                'service-name': 'test_value_17',
+                'username': 'test_value_18'
+    }
+
+    set_method_mock.assert_called_with('system', 'pppoe-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_pppoe_interface_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_pppoe_interface': {
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'ac-name': 'test_value_3',
+        'auth-type': 'auto',
+        'device': 'test_value_5',
+        'dial-on-demand': 'enable',
+        'disc-retry-timeout': '7',
+        'idle-timeout': '8',
+        'ipunnumbered': 'test_value_9',
+        'ipv6': 'enable',
+                'lcp-echo-interval': '11',
+                'lcp-max-echo-fails': '12',
+                'name': 'default_name_13',
+                'padt-retry-timeout': '14',
+                'password': 'test_value_15',
+                'pppoe-unnumbered-negotiate': 'enable',
+                'service-name': 'test_value_17',
+                'username': 'test_value_18'
+    }
+
+    set_method_mock.assert_called_with('system', 'pppoe-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_pppoe_interface_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_pppoe_interface': {
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'pppoe-interface', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_pppoe_interface_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_pppoe_interface': {
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'pppoe-interface', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_pppoe_interface_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_pppoe_interface': {
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'ac-name': 'test_value_3',
+        'auth-type': 'auto',
+        'device': 'test_value_5',
+        'dial-on-demand': 'enable',
+        'disc-retry-timeout': '7',
+        'idle-timeout': '8',
+        'ipunnumbered': 'test_value_9',
+        'ipv6': 'enable',
+                'lcp-echo-interval': '11',
+                'lcp-max-echo-fails': '12',
+                'name': 'default_name_13',
+                'padt-retry-timeout': '14',
+                'password': 'test_value_15',
+                'pppoe-unnumbered-negotiate': 'enable',
+                'service-name': 'test_value_17',
+                'username': 'test_value_18'
+    }
+
+    set_method_mock.assert_called_with('system', 'pppoe-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_pppoe_interface_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_pppoe_interface': {
+            'random_attribute_not_valid': 'tag',
+            'ac_name': 'test_value_3',
+            'auth_type': 'auto',
+            'device': 'test_value_5',
+            'dial_on_demand': 'enable',
+            'disc_retry_timeout': '7',
+            'idle_timeout': '8',
+            'ipunnumbered': 'test_value_9',
+            'ipv6': 'enable',
+            'lcp_echo_interval': '11',
+            'lcp_max_echo_fails': '12',
+            'name': 'default_name_13',
+            'padt_retry_timeout': '14',
+            'password': 'test_value_15',
+            'pppoe_unnumbered_negotiate': 'enable',
+            'service_name': 'test_value_17',
+            'username': 'test_value_18'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_pppoe_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'ac-name': 'test_value_3',
+        'auth-type': 'auto',
+        'device': 'test_value_5',
+        'dial-on-demand': 'enable',
+        'disc-retry-timeout': '7',
+        'idle-timeout': '8',
+        'ipunnumbered': 'test_value_9',
+        'ipv6': 'enable',
+                'lcp-echo-interval': '11',
+                'lcp-max-echo-fails': '12',
+                'name': 'default_name_13',
+                'padt-retry-timeout': '14',
+                'password': 'test_value_15',
+                'pppoe-unnumbered-negotiate': 'enable',
+                'service-name': 'test_value_17',
+                'username': 'test_value_18'
+    }
+
+    set_method_mock.assert_called_with('system', 'pppoe-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_probe_response.py
+++ b/test/units/modules/network/fortios/test_fortios_system_probe_response.py
@@ -1,0 +1,199 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_probe_response
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_probe_response.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_probe_response_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_probe_response': {
+            'http_probe_value': 'test_value_3',
+            'mode': 'none',
+            'password': 'test_value_5',
+            'port': '6',
+            'security_mode': 'none',
+            'timeout': '8',
+            'ttl_mode': 'reinit'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_probe_response.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'http-probe-value': 'test_value_3',
+        'mode': 'none',
+                'password': 'test_value_5',
+                'port': '6',
+                'security-mode': 'none',
+                'timeout': '8',
+                'ttl-mode': 'reinit'
+    }
+
+    set_method_mock.assert_called_with('system', 'probe-response', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_probe_response_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_probe_response': {
+            'http_probe_value': 'test_value_3',
+            'mode': 'none',
+            'password': 'test_value_5',
+            'port': '6',
+            'security_mode': 'none',
+            'timeout': '8',
+            'ttl_mode': 'reinit'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_probe_response.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'http-probe-value': 'test_value_3',
+        'mode': 'none',
+                'password': 'test_value_5',
+                'port': '6',
+                'security-mode': 'none',
+                'timeout': '8',
+                'ttl-mode': 'reinit'
+    }
+
+    set_method_mock.assert_called_with('system', 'probe-response', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_probe_response_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_probe_response': {
+            'http_probe_value': 'test_value_3',
+            'mode': 'none',
+            'password': 'test_value_5',
+            'port': '6',
+            'security_mode': 'none',
+            'timeout': '8',
+            'ttl_mode': 'reinit'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_probe_response.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'http-probe-value': 'test_value_3',
+        'mode': 'none',
+                'password': 'test_value_5',
+                'port': '6',
+                'security-mode': 'none',
+                'timeout': '8',
+                'ttl-mode': 'reinit'
+    }
+
+    set_method_mock.assert_called_with('system', 'probe-response', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_probe_response_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_probe_response': {
+            'random_attribute_not_valid': 'tag',
+            'http_probe_value': 'test_value_3',
+            'mode': 'none',
+            'password': 'test_value_5',
+            'port': '6',
+            'security_mode': 'none',
+            'timeout': '8',
+            'ttl_mode': 'reinit'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_probe_response.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'http-probe-value': 'test_value_3',
+        'mode': 'none',
+                'password': 'test_value_5',
+                'port': '6',
+                'security-mode': 'none',
+                'timeout': '8',
+                'ttl-mode': 'reinit'
+    }
+
+    set_method_mock.assert_called_with('system', 'probe-response', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_proxy_arp.py
+++ b/test/units/modules/network/fortios/test_fortios_system_proxy_arp.py
@@ -1,0 +1,229 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_proxy_arp
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_proxy_arp.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_proxy_arp_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_proxy_arp': {
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'end-ip': 'test_value_3',
+        'id': '4',
+        'interface': 'test_value_5',
+        'ip': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system', 'proxy-arp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_proxy_arp_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_proxy_arp': {
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'end-ip': 'test_value_3',
+        'id': '4',
+        'interface': 'test_value_5',
+        'ip': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system', 'proxy-arp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_proxy_arp_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_proxy_arp': {
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'proxy-arp', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_proxy_arp_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_proxy_arp': {
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'proxy-arp', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_proxy_arp_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_proxy_arp': {
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'end-ip': 'test_value_3',
+        'id': '4',
+        'interface': 'test_value_5',
+        'ip': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system', 'proxy-arp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_proxy_arp_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_proxy_arp': {
+            'random_attribute_not_valid': 'tag',
+            'end_ip': 'test_value_3',
+            'id': '4',
+            'interface': 'test_value_5',
+            'ip': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_proxy_arp.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'end-ip': 'test_value_3',
+        'id': '4',
+        'interface': 'test_value_5',
+        'ip': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system', 'proxy-arp', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_replacemsg_admin.py
+++ b/test/units/modules/network/fortios/test_fortios_system_replacemsg_admin.py
@@ -1,0 +1,229 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_replacemsg_admin
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_replacemsg_admin.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_replacemsg_admin_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_admin': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_admin_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_admin': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_admin_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_admin': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'admin', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_admin_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_admin': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'admin', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_admin_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_admin': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_replacemsg_admin_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_admin': {
+            'random_attribute_not_valid': 'tag',
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_admin.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'admin', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_replacemsg_alertmail.py
+++ b/test/units/modules/network/fortios/test_fortios_system_replacemsg_alertmail.py
@@ -1,0 +1,229 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_replacemsg_alertmail
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_replacemsg_alertmail.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_replacemsg_alertmail_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_alertmail': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'alertmail', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_alertmail_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_alertmail': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'alertmail', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_alertmail_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_alertmail': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'alertmail', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_alertmail_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_alertmail': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'alertmail', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_alertmail_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_alertmail': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'alertmail', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_replacemsg_alertmail_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_alertmail': {
+            'random_attribute_not_valid': 'tag',
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_alertmail.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'alertmail', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_replacemsg_auth.py
+++ b/test/units/modules/network/fortios/test_fortios_system_replacemsg_auth.py
@@ -1,0 +1,229 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_replacemsg_auth
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_replacemsg_auth.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_replacemsg_auth_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_auth': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'auth', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_auth_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_auth': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'auth', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_auth_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_auth': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'auth', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_replacemsg_auth_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_replacemsg_auth': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.replacemsg', 'auth', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_replacemsg_auth_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_auth': {
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'auth', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_replacemsg_auth_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_replacemsg_auth': {
+            'random_attribute_not_valid': 'tag',
+            'buffer': 'test_value_3',
+            'format': 'none',
+            'header': 'none',
+            'msg_type': 'test_value_6'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_replacemsg_auth.fortios_system_replacemsg(input_data, fos_instance)
+
+    expected_data = {
+        'buffer': 'test_value_3',
+        'format': 'none',
+        'header': 'none',
+        'msg-type': 'test_value_6'
+    }
+
+    set_method_mock.assert_called_with('system.replacemsg', 'auth', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_snmp_sysinfo.py
+++ b/test/units/modules/network/fortios/test_fortios_system_snmp_sysinfo.py
@@ -1,0 +1,207 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_snmp_sysinfo
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_snmp_sysinfo.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_snmp_sysinfo_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_sysinfo': {
+            'contact_info': 'test_value_3',
+            'description': 'test_value_4',
+            'engine_id': 'test_value_5',
+            'location': 'test_value_6',
+            'status': 'enable',
+            'trap_high_cpu_threshold': '8',
+            'trap_log_full_threshold': '9',
+            'trap_low_memory_threshold': '10'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_sysinfo.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'contact-info': 'test_value_3',
+        'description': 'test_value_4',
+        'engine-id': 'test_value_5',
+        'location': 'test_value_6',
+        'status': 'enable',
+        'trap-high-cpu-threshold': '8',
+        'trap-log-full-threshold': '9',
+        'trap-low-memory-threshold': '10'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'sysinfo', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_snmp_sysinfo_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_sysinfo': {
+            'contact_info': 'test_value_3',
+            'description': 'test_value_4',
+            'engine_id': 'test_value_5',
+            'location': 'test_value_6',
+            'status': 'enable',
+            'trap_high_cpu_threshold': '8',
+            'trap_log_full_threshold': '9',
+            'trap_low_memory_threshold': '10'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_sysinfo.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'contact-info': 'test_value_3',
+        'description': 'test_value_4',
+        'engine-id': 'test_value_5',
+        'location': 'test_value_6',
+        'status': 'enable',
+        'trap-high-cpu-threshold': '8',
+        'trap-log-full-threshold': '9',
+        'trap-low-memory-threshold': '10'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'sysinfo', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_snmp_sysinfo_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_sysinfo': {
+            'contact_info': 'test_value_3',
+            'description': 'test_value_4',
+            'engine_id': 'test_value_5',
+            'location': 'test_value_6',
+            'status': 'enable',
+            'trap_high_cpu_threshold': '8',
+            'trap_log_full_threshold': '9',
+            'trap_low_memory_threshold': '10'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_sysinfo.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'contact-info': 'test_value_3',
+        'description': 'test_value_4',
+        'engine-id': 'test_value_5',
+        'location': 'test_value_6',
+        'status': 'enable',
+        'trap-high-cpu-threshold': '8',
+        'trap-log-full-threshold': '9',
+        'trap-low-memory-threshold': '10'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'sysinfo', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_snmp_sysinfo_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_sysinfo': {
+            'random_attribute_not_valid': 'tag',
+            'contact_info': 'test_value_3',
+            'description': 'test_value_4',
+            'engine_id': 'test_value_5',
+            'location': 'test_value_6',
+            'status': 'enable',
+            'trap_high_cpu_threshold': '8',
+            'trap_log_full_threshold': '9',
+            'trap_low_memory_threshold': '10'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_sysinfo.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'contact-info': 'test_value_3',
+        'description': 'test_value_4',
+        'engine-id': 'test_value_5',
+        'location': 'test_value_6',
+        'status': 'enable',
+        'trap-high-cpu-threshold': '8',
+        'trap-log-full-threshold': '9',
+        'trap-low-memory-threshold': '10'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'sysinfo', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_snmp_user.py
+++ b/test/units/modules/network/fortios/test_fortios_system_snmp_user.py
@@ -1,0 +1,339 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_snmp_user
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_snmp_user.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_snmp_user_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_user': {
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'auth-proto': 'md5',
+        'auth-pwd': 'test_value_4',
+        'ha-direct': 'enable',
+        'name': 'default_name_6',
+                'priv-proto': 'aes',
+                'priv-pwd': 'test_value_8',
+                'queries': 'enable',
+                'query-port': '10',
+                'security-level': 'no-auth-no-priv',
+                'source-ip': '84.230.14.12',
+                'source-ipv6': 'test_value_13',
+                'status': 'enable',
+                'trap-lport': '15',
+                'trap-rport': '16',
+                'trap-status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'user', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_snmp_user_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_user': {
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'auth-proto': 'md5',
+        'auth-pwd': 'test_value_4',
+        'ha-direct': 'enable',
+        'name': 'default_name_6',
+                'priv-proto': 'aes',
+                'priv-pwd': 'test_value_8',
+                'queries': 'enable',
+                'query-port': '10',
+                'security-level': 'no-auth-no-priv',
+                'source-ip': '84.230.14.12',
+                'source-ipv6': 'test_value_13',
+                'status': 'enable',
+                'trap-lport': '15',
+                'trap-rport': '16',
+                'trap-status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'user', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_snmp_user_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_snmp_user': {
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.snmp', 'user', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_snmp_user_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_snmp_user': {
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system.snmp', 'user', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_snmp_user_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_user': {
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'auth-proto': 'md5',
+        'auth-pwd': 'test_value_4',
+        'ha-direct': 'enable',
+        'name': 'default_name_6',
+                'priv-proto': 'aes',
+                'priv-pwd': 'test_value_8',
+                'queries': 'enable',
+                'query-port': '10',
+                'security-level': 'no-auth-no-priv',
+                'source-ip': '84.230.14.12',
+                'source-ipv6': 'test_value_13',
+                'status': 'enable',
+                'trap-lport': '15',
+                'trap-rport': '16',
+                'trap-status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'user', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_snmp_user_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_user': {
+            'random_attribute_not_valid': 'tag',
+            'auth_proto': 'md5',
+            'auth_pwd': 'test_value_4',
+            'ha_direct': 'enable',
+            'name': 'default_name_6',
+            'priv_proto': 'aes',
+            'priv_pwd': 'test_value_8',
+            'queries': 'enable',
+            'query_port': '10',
+            'security_level': 'no-auth-no-priv',
+            'source_ip': '84.230.14.12',
+            'source_ipv6': 'test_value_13',
+            'status': 'enable',
+            'trap_lport': '15',
+            'trap_rport': '16',
+            'trap_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_user.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'auth-proto': 'md5',
+        'auth-pwd': 'test_value_4',
+        'ha-direct': 'enable',
+        'name': 'default_name_6',
+                'priv-proto': 'aes',
+                'priv-pwd': 'test_value_8',
+                'queries': 'enable',
+                'query-port': '10',
+                'security-level': 'no-auth-no-priv',
+                'source-ip': '84.230.14.12',
+                'source-ipv6': 'test_value_13',
+                'status': 'enable',
+                'trap-lport': '15',
+                'trap-rport': '16',
+                'trap-status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'user', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_storage.py
+++ b/test/units/modules/network/fortios/test_fortios_system_storage.py
@@ -1,0 +1,279 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_storage
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_storage.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_storage_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_storage': {
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'device': 'test_value_3',
+        'media-status': 'enable',
+        'name': 'default_name_5',
+                'order': '6',
+                'partition': 'test_value_7',
+                'size': '8',
+                'status': 'enable',
+                'usage': 'log',
+                'wanopt-mode': 'mix'
+    }
+
+    set_method_mock.assert_called_with('system', 'storage', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_storage_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_storage': {
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'device': 'test_value_3',
+        'media-status': 'enable',
+        'name': 'default_name_5',
+                'order': '6',
+                'partition': 'test_value_7',
+                'size': '8',
+                'status': 'enable',
+                'usage': 'log',
+                'wanopt-mode': 'mix'
+    }
+
+    set_method_mock.assert_called_with('system', 'storage', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_storage_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_storage': {
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'storage', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_storage_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_storage': {
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'storage', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_storage_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_storage': {
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'device': 'test_value_3',
+        'media-status': 'enable',
+        'name': 'default_name_5',
+                'order': '6',
+                'partition': 'test_value_7',
+                'size': '8',
+                'status': 'enable',
+                'usage': 'log',
+                'wanopt-mode': 'mix'
+    }
+
+    set_method_mock.assert_called_with('system', 'storage', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_storage_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_storage': {
+            'random_attribute_not_valid': 'tag',
+            'device': 'test_value_3',
+            'media_status': 'enable',
+            'name': 'default_name_5',
+            'order': '6',
+            'partition': 'test_value_7',
+            'size': '8',
+            'status': 'enable',
+            'usage': 'log',
+            'wanopt_mode': 'mix'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_storage.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'device': 'test_value_3',
+        'media-status': 'enable',
+        'name': 'default_name_5',
+                'order': '6',
+                'partition': 'test_value_7',
+                'size': '8',
+                'status': 'enable',
+                'usage': 'log',
+                'wanopt-mode': 'mix'
+    }
+
+    set_method_mock.assert_called_with('system', 'storage', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_switch_interface.py
+++ b/test/units/modules/network/fortios/test_fortios_system_switch_interface.py
@@ -1,0 +1,259 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_switch_interface
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_switch_interface.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_switch_interface_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_switch_interface': {
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'intra-switch-policy': 'implicit',
+        'name': 'default_name_4',
+                'span': 'disable',
+                'span-dest-port': 'test_value_6',
+                'span-direction': 'rx',
+                'type': 'switch',
+                'vdom': 'test_value_9'
+    }
+
+    set_method_mock.assert_called_with('system', 'switch-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_switch_interface_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_switch_interface': {
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'intra-switch-policy': 'implicit',
+        'name': 'default_name_4',
+                'span': 'disable',
+                'span-dest-port': 'test_value_6',
+                'span-direction': 'rx',
+                'type': 'switch',
+                'vdom': 'test_value_9'
+    }
+
+    set_method_mock.assert_called_with('system', 'switch-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_switch_interface_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_switch_interface': {
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'switch-interface', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_switch_interface_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_switch_interface': {
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'switch-interface', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_switch_interface_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_switch_interface': {
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'intra-switch-policy': 'implicit',
+        'name': 'default_name_4',
+                'span': 'disable',
+                'span-dest-port': 'test_value_6',
+                'span-direction': 'rx',
+                'type': 'switch',
+                'vdom': 'test_value_9'
+    }
+
+    set_method_mock.assert_called_with('system', 'switch-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_switch_interface_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_switch_interface': {
+            'random_attribute_not_valid': 'tag',
+            'intra_switch_policy': 'implicit',
+            'name': 'default_name_4',
+            'span': 'disable',
+            'span_dest_port': 'test_value_6',
+            'span_direction': 'rx',
+            'type': 'switch',
+            'vdom': 'test_value_9'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_switch_interface.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'intra-switch-policy': 'implicit',
+        'name': 'default_name_4',
+                'span': 'disable',
+                'span-dest-port': 'test_value_6',
+                'span-direction': 'rx',
+                'type': 'switch',
+                'vdom': 'test_value_9'
+    }
+
+    set_method_mock.assert_called_with('system', 'switch-interface', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_tos_based_priority.py
+++ b/test/units/modules/network/fortios/test_fortios_system_tos_based_priority.py
@@ -1,0 +1,219 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_tos_based_priority
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_tos_based_priority.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_tos_based_priority_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_tos_based_priority': {
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'priority': 'low',
+        'tos': '5'
+    }
+
+    set_method_mock.assert_called_with('system', 'tos-based-priority', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_tos_based_priority_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_tos_based_priority': {
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'priority': 'low',
+        'tos': '5'
+    }
+
+    set_method_mock.assert_called_with('system', 'tos-based-priority', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_tos_based_priority_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_tos_based_priority': {
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'tos-based-priority', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_tos_based_priority_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_tos_based_priority': {
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'tos-based-priority', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_tos_based_priority_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_tos_based_priority': {
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'priority': 'low',
+        'tos': '5'
+    }
+
+    set_method_mock.assert_called_with('system', 'tos-based-priority', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_tos_based_priority_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_tos_based_priority': {
+            'random_attribute_not_valid': 'tag',
+            'id': '3',
+            'priority': 'low',
+            'tos': '5'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_tos_based_priority.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'priority': 'low',
+        'tos': '5'
+    }
+
+    set_method_mock.assert_called_with('system', 'tos-based-priority', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_vdom_exception.py
+++ b/test/units/modules/network/fortios/test_fortios_system_vdom_exception.py
@@ -1,0 +1,239 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_vdom_exception
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_vdom_exception.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_vdom_exception_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_exception': {
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'object': 'log.fortianalyzer.setting',
+        'oid': '5',
+        'scope': 'all',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-exception', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_vdom_exception_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_exception': {
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'object': 'log.fortianalyzer.setting',
+        'oid': '5',
+        'scope': 'all',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-exception', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_vdom_exception_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_vdom_exception': {
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'vdom-exception', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_vdom_exception_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_vdom_exception': {
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'vdom-exception', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_vdom_exception_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_exception': {
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'object': 'log.fortianalyzer.setting',
+        'oid': '5',
+        'scope': 'all',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-exception', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_vdom_exception_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_exception': {
+            'random_attribute_not_valid': 'tag',
+            'id': '3',
+            'object': 'log.fortianalyzer.setting',
+            'oid': '5',
+            'scope': 'all',
+
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_exception.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'id': '3',
+        'object': 'log.fortianalyzer.setting',
+        'oid': '5',
+        'scope': 'all',
+
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-exception', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_vdom_link.py
+++ b/test/units/modules/network/fortios/test_fortios_system_vdom_link.py
@@ -1,0 +1,219 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_vdom_link
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_vdom_link.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_vdom_link_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_link': {
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'type': 'ppp',
+                'vcluster': 'vcluster1'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-link', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_vdom_link_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_link': {
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'type': 'ppp',
+                'vcluster': 'vcluster1'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-link', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_vdom_link_removal(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_vdom_link': {
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'vdom-link', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_vdom_link_deletion_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    delete_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    delete_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.delete', return_value=delete_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'absent',
+        'system_vdom_link': {
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    delete_method_mock.assert_called_with('system', 'vdom-link', mkey=ANY, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_vdom_link_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_link': {
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'type': 'ppp',
+                'vcluster': 'vcluster1'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-link', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_vdom_link_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_link': {
+            'random_attribute_not_valid': 'tag',
+            'name': 'default_name_3',
+            'type': 'ppp',
+            'vcluster': 'vcluster1'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_link.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'name': 'default_name_3',
+                'type': 'ppp',
+                'vcluster': 'vcluster1'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-link', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200

--- a/test/units/modules/network/fortios/test_fortios_system_vdom_netflow.py
+++ b/test/units/modules/network/fortios/test_fortios_system_vdom_netflow.py
@@ -1,0 +1,175 @@
+# Copyright 2019 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <https://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+import pytest
+from mock import ANY
+from ansible.module_utils.network.fortios.fortios import FortiOSHandler
+
+try:
+    from ansible.modules.network.fortios import fortios_system_vdom_netflow
+except ImportError:
+    pytest.skip("Could not load required modules for testing", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def connection_mock(mocker):
+    connection_class_mock = mocker.patch('ansible.modules.network.fortios.fortios_system_vdom_netflow.Connection')
+    return connection_class_mock
+
+
+fos_instance = FortiOSHandler(connection_mock)
+
+
+def test_system_vdom_netflow_creation(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_netflow': {
+            'collector_ip': 'test_value_3',
+            'collector_port': '4',
+            'source_ip': '84.230.14.5',
+            'vdom_netflow': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'collector-ip': 'test_value_3',
+        'collector-port': '4',
+        'source-ip': '84.230.14.5',
+        'vdom-netflow': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
+def test_system_vdom_netflow_creation_fails(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'POST', 'http_status': 500}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_netflow': {
+            'collector_ip': 'test_value_3',
+            'collector_port': '4',
+            'source_ip': '84.230.14.5',
+            'vdom_netflow': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'collector-ip': 'test_value_3',
+        'collector-port': '4',
+        'source-ip': '84.230.14.5',
+        'vdom-netflow': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 500
+
+
+def test_system_vdom_netflow_idempotent(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'error', 'http_method': 'DELETE', 'http_status': 404}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_netflow': {
+            'collector_ip': 'test_value_3',
+            'collector_port': '4',
+            'source_ip': '84.230.14.5',
+            'vdom_netflow': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'collector-ip': 'test_value_3',
+        'collector-port': '4',
+        'source-ip': '84.230.14.5',
+        'vdom-netflow': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert not changed
+    assert response['status'] == 'error'
+    assert response['http_status'] == 404
+
+
+def test_system_vdom_netflow_filter_foreign_attributes(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_vdom_netflow': {
+            'random_attribute_not_valid': 'tag',
+            'collector_ip': 'test_value_3',
+            'collector_port': '4',
+            'source_ip': '84.230.14.5',
+            'vdom_netflow': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_vdom_netflow.fortios_system(input_data, fos_instance)
+
+    expected_data = {
+        'collector-ip': 'test_value_3',
+        'collector-port': '4',
+        'source-ip': '84.230.14.5',
+        'vdom-netflow': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system', 'vdom-netflow', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200


### PR DESCRIPTION
##### SUMMARY
Adds the option to enable checksum comparison between source and destination files to make sure the destination file is updated in case the metadata didn't changed. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_robocopy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sometime it happens that a sourcefile has different data than the destination file, but metadata like last change time etc haven't been changed. This kind of metadata is used by robocopy to know if a file needs to be copied or not. Since robocopy doesn't have checksum checking between source and destination file, this addition when enabled on the module, will do the following before running the robocopy command:
* gets all files from src
* if dest file exists: checksum of both files are compared & if checksum is not equal: file is copied
* continues to execute robocopy

When files are excluded with /xf argument, they will also be excluded for the checksum comparison.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
