### PR TITLE
Drop redundant EOL escape from win_updates action

### DIFF
--- a/lib/ansible/plugins/action/win_updates.py
+++ b/lib/ansible/plugins/action/win_updates.py
@@ -105,7 +105,7 @@ class ActionModule(ActionBase):
                                     wrap_async, use_task):
         orig_become = self._play_context.become
         orig_become_method = self._play_context.become_method
-        orig_become_user = self._play_context.become_user\
+        orig_become_user = self._play_context.become_user
 
         if not use_task:
             if orig_become is None or orig_become is False:


### PR DESCRIPTION
Ref: https://github.com/PyCQA/redbaron/issues/186
Ref: https://github.com/bcoca/gravity/commit/31de47ece73

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Needed for collections migration experiments

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_updates action plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

N/A