### PR TITLE
win_robocopy add md5 checksum check for copy

### DIFF
--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -44,6 +44,12 @@ options:
     - If C(flags) is set, this will be ignored.
     type: bool
     default: no
+  checksum:
+    version_added: '2.9'
+    description:
+    - Use md5 checksum hash on existing dest files to compare with the src files.
+    type: bool
+    default: no
   flags:
     description:
       - Directly supply Robocopy flags.
@@ -68,6 +74,13 @@ EXAMPLES = r'''
 
 - name: Sync the contents of one directory to another, including subdirectories
   win_robocopy:
+    src: C:\DirectoryOne
+    dest: C:\DirectoryTwo
+    recurse: yes
+
+- name: Sync the contents of one directory to another, including subdirectories, using md5 checksum hash on destination files
+  win_robocopy:
+    checksum: true
     src: C:\DirectoryOne
     dest: C:\DirectoryTwo
     recurse: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the option to enable checksum comparison between source and destination files to make sure the destination file is updated in case the metadata didn't changed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_robocopy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sometime it happens that a sourcefile has different data than the destination file, but metadata like last change time etc haven't been changed. This kind of metadata is used by robocopy to know if a file needs to be copied or not. Since robocopy doesn't have checksum checking between source and destination file, this addition when enabled on the module, will do the following before running the robocopy command:
* gets all files from src
* if dest file exists: checksum of both files are compared & if checksum is not equal: file is copied
* continues to execute robocopy

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
