### PR TITLE
influxdb: Add support for 'path' parameter

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -36,6 +36,7 @@ class InfluxDb():
         self.check_lib()
         self.hostname = self.params['hostname']
         self.port = self.params['port']
+        self.path = self.params['path']
         self.username = self.params['username']
         self.password = self.params['password']
         self.database_name = self.params.get('database_name')
@@ -52,6 +53,7 @@ class InfluxDb():
         return dict(
             hostname=dict(type='str', default='localhost'),
             port=dict(type='int', default=8086),
+            path=dict(type='str', default=''),
             username=dict(type='str', default='root', aliases=['login_username']),
             password=dict(type='str', default='root', no_log=True, aliases=['login_password']),
             ssl=dict(type='bool', default=False),
@@ -67,6 +69,7 @@ class InfluxDb():
         args = dict(
             host=self.hostname,
             port=self.port,
+            path=self.path,
             username=self.username,
             password=self.password,
             database=self.database_name,

--- a/lib/ansible/plugins/doc_fragments/influxdb.py
+++ b/lib/ansible/plugins/doc_fragments/influxdb.py
@@ -34,6 +34,11 @@ options:
     - The port on which InfluxDB server is listening
     type: int
     default: 8086
+  path:
+    description:
+    - The path on which InfluxDB server is accessible
+    type: str
+    version_added: "2.10"
   validate_certs:
     description:
     - If set to C(no), the SSL certificates will not be validated.


### PR DESCRIPTION
##### SUMMARY
While it's possible to host InfluxDB on a different path prefix (through a reverse proxy such as nginx or traefik), the Ansible `influxdb_*` modules did't support that use case.

The patch adds a 'path' parameter, which is passed to the influxdb
Python client.

Example for connecting to InfluxDB running on <http://localhost/influxdb>

    - hosts: all
      tasks:
        - influxdb_database:
            database_name: test
            path: influxdb
            port: 80

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
influxdb_user, influxdb_database, influxdb_query, influxdb_write, influxdb_retention_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
