### PR TITLE
[WIP] cloudscale: fail on invalid tags

### DIFF
--- a/test/integration/targets/cloudscale_server_group/tasks/failures.yml
+++ b/test/integration/targets/cloudscale_server_group/tasks/failures.yml
@@ -1,4 +1,20 @@
 ---
+- name: Fail invalid tags
+  cloudscale_server_group:
+    name: '{{ cloudscale_resource_prefix }}-grp'
+    tags:
+      bool: true
+      number : 1
+      not_bool: "false"
+      not_number: "1"
+  register: grp
+  ignore_errors: True
+- name: 'VERIFY: Fail invalid tags'
+  assert:
+    that:
+      - grp is failed
+      - '"Tags must be text values. Add quotes for the following tags: bool=True, number=1" in grp.msg'
+
 - name: Fail missing params
   cloudscale_server_group:
   register: grp

--- a/test/integration/targets/cloudscale_server_group/tasks/failures.yml
+++ b/test/integration/targets/cloudscale_server_group/tasks/failures.yml
@@ -4,7 +4,7 @@
     name: '{{ cloudscale_resource_prefix }}-grp'
     tags:
       bool: true
-      number : 1
+      number: 1
       not_bool: "false"
       not_number: "1"
   register: grp


### PR DESCRIPTION
##### SUMMARY
tags values are stored as strings by the api. if we have non-string tags and compare them, we get an "always changed" and tags are updated.

I decided to fail early instead of casting the values to strings.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudscale

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
