### PR TITLE
Update ansible-test network inventory handling.

### DIFF
--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -399,7 +399,13 @@ def command_network_integration(args):
     else:
         inventory_path = os.path.join(data_context().content.root, inventory_relative_path)
 
-    if not args.explain and not args.platform and not os.path.isfile(inventory_path):
+    if args.no_temp_workdir:
+        # temporary solution to keep DCI tests working
+        inventory_exists = os.path.exists(inventory_path)
+    else:
+        inventory_exists = os.path.isfile(inventory_path)
+
+    if not args.explain and not args.platform and not inventory_exists:
         raise ApplicationError(
             'Inventory not found: %s\n'
             'Use --inventory to specify the inventory path.\n'


### PR DESCRIPTION
##### SUMMARY

Update ansible-test network inventory handling.

DCI uses an inventory directory instead of a file, along with --no-temp-workdir.

This changes the inventory check to keep that scenario working until all DCI jobs can be migrated to Zuul.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
