### PR TITLE
Provide verbose details about which galaxy server was used

### DIFF
--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -320,6 +320,7 @@ class CollectionRequirement:
                 resp = json.load(open_url(n_collection_url, validate_certs=api.validate_certs, headers=headers))
             except urllib_error.HTTPError as err:
                 if err.code == 404:
+                    display.vvv("Collection '%s' is not available from server %s %s" % (collection, api.name, api.api_server))
                     continue
                 raise
 
@@ -338,6 +339,7 @@ class CollectionRequirement:
                     resp = json.load(open_url(to_native(resp['next'], errors='surrogate_or_strict'),
                                               validate_certs=api.validate_certs, headers=headers))
 
+            display.vvv("Collection '%s' obtained from server %s %s" % (collection, api.name, api.api_server))
             break
         else:
             raise AnsibleError("Failed to find collection %s:%s" % (collection, requirement))


### PR DESCRIPTION
##### SUMMARY
This adds debug messages so that people can ascertain the source for the requirements they are using. As far as I can tell, there's no other output telling the user what the correspondence is.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/collection.py

##### ADDITIONAL INFORMATION
I'm building examples for such cases:

https://github.com/AlanCoding/collection-requirements-cases

Here is the output for a case that makes use of @chrismeyersfsu https://galaxy.ansible.com/chrismeyersfsu/test_things, which is not available on https://galaxy-dev.ansible.com. It first tries galaxy-dev, and gets a 404. It then installs from the release galaxy. These debugging statements make that traceable.

```
ANSIBLE_CONFIG=fallback_not_found/ansible.cfg ansible-galaxy collection install -r fallback_not_found/collections/requirements.yml -p dest -vvvv
ansible-galaxy 2.9.0.dev0
  config file = /Users/alancoding/Documents/repos/collection-requirements-cases/fallback_not_found/ansible.cfg
  configured module search path = ['/Users/alancoding/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/Documents/repos/ansible/lib/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible3/bin/ansible-galaxy
  python version = 3.6.5 (default, Apr 25 2018, 14:23:58) [GCC 4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.1)]
Using /Users/alancoding/Documents/repos/collection-requirements-cases/fallback_not_found/ansible.cfg as config file
Reading requirement file at '/Users/alancoding/Documents/repos/collection-requirements-cases/fallback_not_found/collections/requirements.yml'
 [WARNING]: The specified collections path '/Users/alancoding/Documents/repos/collection-requirements-cases/dest' is not part of the configured Ansible collections paths
'/Users/alancoding/.ansible/collections:/usr/share/ansible/collections'. The installed collection won't be picked up in an Ansible run.

Processing requirement collection 'chrismeyersfsu.test_things'
Collection requirement 'chrismeyersfsu.test_things' is the name of a collection
Opened /Users/alancoding/.ansible/galaxy_token
Collection 'chrismeyersfsu.test_things' is not available from server 'dev_galaxy'
Opened /Users/alancoding/.ansible/galaxy_token
Collection 'chrismeyersfsu.test_things' obtained from server 'release_galaxy'
Processing requirement collection 'chrismeyersfsu.tower_modules'
Collection requirement 'chrismeyersfsu.tower_modules' is the name of a collection
Collection 'chrismeyersfsu.tower_modules' is not available from server 'dev_galaxy'
Collection 'chrismeyersfsu.tower_modules' obtained from server 'release_galaxy'
Installing 'chrismeyersfsu.test_things:2.0.0' to '/Users/alancoding/Documents/repos/collection-requirements-cases/dest/ansible_collections/chrismeyersfsu/test_things'
Downloading https://galaxy.ansible.com/download/chrismeyersfsu-test_things-2.0.0.tar.gz to /Users/alancoding/.ansible/tmp/ansible-local-71101wiwp7slp/tmpufq4ureq
Validating downloaded file hash 77eaccad30c4177c265d023b2f6f042718d24519c7ed1b5ac79772259919d035 with expected hash 77eaccad30c4177c265d023b2f6f042718d24519c7ed1b5ac79772259919d035
Installing 'chrismeyersfsu.tower_modules:0.0.1' to '/Users/alancoding/Documents/repos/collection-requirements-cases/dest/ansible_collections/chrismeyersfsu/tower_modules'
Downloading https://galaxy.ansible.com/download/chrismeyersfsu-tower_modules-0.0.1.tar.gz to /Users/alancoding/.ansible/tmp/ansible-local-71101wiwp7slp/tmpufq4ureq
Validating downloaded file hash 28ee9154a29daa3346ab079b399ffccdce689d0de2598c206deb7b54de32f8fe with expected hash 28ee9154a29daa3346ab079b399ffccdce689d0de2598c206deb7b54de32f8fe
```
