### PR TITLE
ACME modules: bump test container version

### DIFF
--- a/test/integration/targets/acme_inspect/tests/validate.yml
+++ b/test/integration/targets/acme_inspect/tests/validate.yml
@@ -22,7 +22,7 @@
     - account_creation.headers.status == 201
     - "'location' in account_creation.headers"
     - account_creation.output_json.status == 'valid'
-    - not account_creation.output_json.contact
+    - not (account_creation.output_json.contact | default([]))
     - account_creation.output_text | from_json == account_creation.output_json
 
 - name: Check account get output

--- a/test/integration/targets/setup_acme/tasks/obtain-cert.yml
+++ b/test/integration/targets/setup_acme/tasks/obtain-cert.yml
@@ -134,6 +134,6 @@
   when: "challenge_data is changed and challenge == 'tls-alpn-01'"
 - name: ({{ certgen_title }}) Get root certificate
   get_url:
-    url: "http://{{ acme_host }}:5000/root-certificate-for-ca"
+    url: "http://{{ acme_host }}:5000/root-certificate-for-ca/0"
     dest: "{{ output_dir }}/{{ certificate_name }}-root.pem"
 ###############################################################################################

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -45,7 +45,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.6.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.7.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Updates the test container for the ACME modules.

Needs ansible/acme-test-container#15, ~~ansible/ansible#60742~~ and ~~ansible/ansible#61191~~ merged first. Should fail right now.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/cloud/acme.py
test/integration/targets/setup_acme/tasks/obtain-cert.yml
