### PR TITLE
Support relative imports in AnsiballZ.

### DIFF
--- a/changelogs/fragments/relative-import.yaml
+++ b/changelogs/fragments/relative-import.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Ansible now supports relative imports of module_utils files in modules and module_utils.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -63,6 +63,38 @@ Modules
 * The ``win_get_url`` and ``win_uri`` module now sends requests with a default ``User-Agent`` of ``ansible-httpget``. This can be changed by using the ``http_agent`` key.
 
 
+Writing modules
+---------------
+
+* Module and module_utils files can now use relative imports to include other module_utils files.
+  This is useful for shortening long import lines, especially in collections.
+
+  Example of using a relative import in collections:
+
+  .. code-block:: python
+
+    # File: ansible_collections/my_namespace/my_collection/plugins/modules/my_module.py
+    # Old way to use an absolute import to import module_utils from the collection:
+    from ansible_collections.my_namespace.my_collection.plugins.module_utils import my_util
+    # New way using a relative import:
+    from ..module_utils import my_util
+
+  Modules and module_utils shipped with Ansible can use relative imports as well but the savings
+  are smaller:
+
+  .. code-block:: python
+
+    # File: ansible/modules/system/ping.py
+    # Old way to use an absolute import to import module_utils from core:
+    from ansible.module_utils.basic import AnsibleModule
+    # New way using a relative import:
+    from ...module_utils.basic import AnsibleModule
+
+  Each single dot (``.``) represents one level of the tree (equivalent to ``../`` in filesystem relative links).
+
+  .. seealso:: `The Python Relative Import Docs <https://www.python.org/dev/peps/pep-0328/#guido-s-decision>`_ go into more detail of how to write relative imports.
+
+
 Modules removed
 ---------------
 

--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -28,6 +28,7 @@
 #    ./hacking/test-module.py -m lib/ansible/modules/files/lineinfile.py -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
 #    ./hacking/test-module.py -m lib/ansible/modules/commands/command.py -a "echo hello" -n -o "test_hello"
 
+import glob
 import optparse
 import os
 import subprocess
@@ -193,8 +194,19 @@ def ansiballz_setup(modfile, modname, interpreters):
         sys.exit(err)
     debug_dir = lines[1].strip()
 
+    # All the directories in an AnsiBallZ that modules can live
+    core_dirs = glob.glob(os.path.join(debug_dir, 'ansible/modules'))
+    collection_dirs = glob.glob(os.path.join(debug_dir, 'ansible_collections/*/*/plugins/modules'))
+
+    # There's only one module in an AnsiBallZ payload so look for the first module and then exit
+    for module_dir in core_dirs + collection_dirs:
+        for dirname, directories, filenames in os.walk(module_dir):
+            for filename in filenames:
+                if filename == modname + '.py':
+                    modfile = os.path.join(dirname, filename)
+                    break
+
     argsfile = os.path.join(debug_dir, 'args')
-    modfile = os.path.join(debug_dir, '__main__.py')
 
     print("* ansiballz module detected; extracted module source to: %s" % debug_dir)
     return modfile, argsfile

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1094,11 +1094,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         if shebang is None:
             shebang = u'#!/usr/bin/python'
 
-        # Enclose the parts of the interpreter in quotes because we're
-        # substituting it into the template as a Python string
-        interpreter_parts = interpreter.split(u' ')
-        interpreter = u"'{0}'".format(u"', '".join(interpreter_parts))
-
         # FUTURE: the module cache entry should be invalidated if we got this value from a host-dependent source
         rlimit_nofile = C.config.get_config_value('PYTHON_MODULE_RLIMIT_NOFILE', variables=task_vars)
 
@@ -1137,7 +1132,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             ansible_module=module_name,
             params=python_repred_params,
             shebang=shebang,
-            interpreter=interpreter,
             coding=ENCODING_STRING,
             year=now.year,
             month=now.month,

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -932,8 +932,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                     # Create the module zip data
                     zipoutput = BytesIO()
                     zf = zipfile.ZipFile(zipoutput, mode='w', compression=compression_method)
-                    # Note: If we need to import from release.py first,
-                    # remember to catch all exceptions: https://github.com/ansible/ansible/issues/16523
                     zf.writestr('ansible/__init__.py',
                                 b'from pkgutil import extend_path\n__path__=extend_path(__path__,__name__)\n__version__="' +
                                 to_bytes(__version__) + b'"\n__author__="' +

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -927,12 +927,17 @@ def _add_module_to_zip(zf, remote_module_fqn, b_module_data):
     if module_path_parts[0] == 'ansible':
         # The ansible namespace is setup as part of the module_utils setup...
         start = 2
+        existing_paths = frozenset()
     else:
         # ... but ansible_collections and other toplevels are not
         start = 1
+        existing_paths = frozenset(zf.namelist())
 
     for idx in range(start, len(module_path_parts)):
         package_path = '/'.join(module_path_parts[:idx]) + '/__init__.py'
+        # If a collections module uses module_utils from a collection then most packages will have already been added by recursive_finder.
+        if package_path in existing_paths:
+            continue
         # Note: We don't want to include more than one ansible module in a payload at this time
         # so no need to fill the __init__.py with namespace code
         zf.writestr(package_path, b'')

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -79,7 +79,7 @@ except ImportError:
 # Python2 & 3 way to get NoneType
 NoneType = type(None)
 
-from ansible.module_utils._text import to_native, to_bytes, to_text
+from ._text import to_native, to_bytes, to_text
 from ansible.module_utils.common.text.converters import (
     jsonify,
     container_to_bytes as json_dict_unicode_to_bytes,

--- a/lib/ansible/modules/cloud/amazon/lambda_event.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_event.py
@@ -393,7 +393,6 @@ def lambda_event_stream(module, aws):
 
 def main():
     """Produce a list of function suffixes which handle lambda events."""
-    this_module = sys.modules[__name__]
     source_choices = ["stream", "sqs"]
 
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -131,7 +131,7 @@ EXAMPLES = """
 """
 
 # import module snippets
-from ansible.module_utils.basic import AnsibleModule
+from ...module_utils.basic import AnsibleModule
 
 from ansible.module_utils.facts.namespace import PrefixFactNamespace
 from ansible.module_utils.facts import ansible_collector

--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -199,8 +199,7 @@ def _run_module(wrapped_cmd, jid, job_path):
     os.rename(tmp_job_path, job_path)
 
 
-if __name__ == '__main__':
-
+def main():
     if len(sys.argv) < 5:
         print(json.dumps({
             "failed": True,
@@ -334,3 +333,7 @@ if __name__ == '__main__':
             "msg": "FATAL ERROR: %s" % e
         }))
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansiballz_python/library/custom_module.py
+++ b/test/integration/targets/ansiballz_python/library/custom_module.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ..module_utils.basic import AnsibleModule
+from ..module_utils.custom_util import forty_two
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict()
+    )
+
+    module.exit_json(answer=forty_two())
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansiballz_python/library/custom_module.py
+++ b/test/integration/targets/ansiballz_python/library/custom_module.py
@@ -3,8 +3,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ..module_utils.basic import AnsibleModule
-from ..module_utils.custom_util import forty_two
+from ..module_utils.basic import AnsibleModule  # pylint: disable=relative-beyond-top-level
+from ..module_utils.custom_util import forty_two  # pylint: disable=relative-beyond-top-level
 
 
 def main():

--- a/test/integration/targets/ansiballz_python/module_utils/custom_util.py
+++ b/test/integration/targets/ansiballz_python/module_utils/custom_util.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+def forty_two():
+    return 42

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -32,6 +32,10 @@
     ansible_python_module_rlimit_nofile: '{{ rlimit_original_return.rlimit_nofile[1] + 1 }}'
   register: rlimit_above_hard_return
 
+- name: run a role module which uses a role module_util using relative imports
+  custom_module:
+  register: custom_module_return
+
 - assert:
     that:
       # make sure ansible-test was able to set the limit unless it exceeds the hard limit or the value is lower on macOS
@@ -54,3 +58,6 @@
 
       # setting the limit higher than the existing hard limit should use the hard limit (except on macOS)
       - rlimit_above_hard_return.rlimit_nofile[0] == rlimit_original_return.rlimit_nofile[1] or ansible_distribution == 'MacOSX'
+
+      # custom module returned the correct answer
+      - custom_module_return.answer == 42

--- a/test/integration/targets/collections_relative_imports/aliases
+++ b/test/integration/targets/collections_relative_imports/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+skip/python2.6

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util1.py
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util1.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+def one():
+    return 1

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util2.py
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util2.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from .my_util1 import one
+
+
+def two():
+    return one() * 2

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util3.py
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util3.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from . import my_util2
+
+
+def three():
+    return my_util2.two() + 1

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/my_module.py
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/my_module.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.my_util2 import two
+from ..module_utils import my_util3
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(),
+        supports_check_mode=True
+    )
+
+    result = dict(
+        two=two(),
+        three=my_util3.three(),
+    )
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: fully qualified module usage with relative imports
+  my_ns.my_col.my_module:
+- name: collection relative module usage with relative imports
+  my_module:

--- a/test/integration/targets/collections_relative_imports/runme.sh
+++ b/test/integration/targets/collections_relative_imports/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_COLLECTIONS_PATHS="${PWD}/collection_root" ansible-playbook test.yml -i ../../inventory "$@"

--- a/test/integration/targets/collections_relative_imports/test.yml
+++ b/test/integration/targets/collections_relative_imports/test.yml
@@ -1,0 +1,3 @@
+- hosts: testhost
+  roles:
+    - my_ns.my_col.test

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -38,6 +38,15 @@ def main():
         # noinspection PyPep8Naming
         AnsibleCollectionLoader = None
 
+    # These are the public attribute sof a doc-only module
+    doc_keys = ('ANSIBLE_METADATA',
+                'DOCUMENTATION',
+                'EXAMPLES',
+                'RETURN',
+                'absolute_import',
+                'division',
+                'print_function')
+
     class ImporterAnsibleModuleException(Exception):
         """Exception thrown during initialization of ImporterAnsibleModule."""
 
@@ -80,17 +89,21 @@ def main():
             if not path.startswith('lib/ansible/modules/'):
                 return
 
+            # __init__ in module directories is empty (enforced by a different test)
+            if path.endswith('__init__.py'):
+                return
+
             # async_wrapper is not an Ansible module
             if path == 'lib/ansible/modules/utilities/logic/async_wrapper.py':
                 return
 
-            # run code protected by __name__ conditional
-            name = '__main__'
+            name = calculate_python_module_name(path)
             # show the Ansible module responsible for the exception, even if it was thrown in module_utils
             filter_dir = os.path.join(base_dir, 'lib/ansible/modules')
         else:
-            # do not run code protected by __name__ conditional
-            name = 'module_import_test'
+            # Calculate module name
+            name = calculate_python_module_name(path)
+
             # show the Ansible file responsible for the exception, even if it was thrown in 3rd party code
             filter_dir = base_dir
 
@@ -98,15 +111,58 @@ def main():
 
         try:
             if imp:
-                with open(path, 'r') as module_fd:
-                    with capture_output(capture):
-                        imp.load_module(name, module_fd, os.path.abspath(path), ('.py', 'r', imp.PY_SOURCE))
+                with capture_output(capture):
+                    # On Python2 without absolute_import we have to import parent modules all
+                    # the way up the tree
+                    full_path = os.path.abspath(path)
+                    parent_mod = None
+
+                    py_packages = name.split('.')
+                    # BIG HACK: reimporting module_utils breaks the monkeypatching of basic we did
+                    # above and also breaks modules which import names directly from module_utils
+                    # modules (you'll get errors like ERROR:
+                    # lib/ansible/modules/storage/netapp/na_ontap_vserver_cifs_security.py:151:0:
+                    # AttributeError: 'module' object has no attribute 'netapp').
+                    # So when we import a module_util here, use a munged name.
+                    if 'module_utils' in py_packages:
+                        # Avoid accidental double underscores by using _1 as a prefix
+                        py_packages[-1] = '_1%s' % py_packages[-1]
+                        name = '.'.join(py_packages)
+
+                    for idx in range(1, len(py_packages)):
+                        parent_name = '.'.join(py_packages[:idx])
+                        if parent_mod is None:
+                            toplevel_end = full_path.find('ansible/module')
+                            toplevel = full_path[:toplevel_end]
+                            parent_mod_info = imp.find_module(parent_name, [toplevel])
+                        else:
+                            parent_mod_info = imp.find_module(py_packages[idx - 1], parent_mod.__path__)
+
+                        parent_mod = imp.load_module(parent_name, *parent_mod_info)
+                        # skip distro due to an apparent bug or bad interaction in
+                        # imp.load_module() with our distro/__init__.py.
+                        # distro/__init__.py sets sys.modules['ansible.module_utils.distro']
+                        # = _distro.pyc
+                        # but after running imp.load_module(),
+                        # sys.modules['ansible.module_utils.distro._distro'] = __init__.pyc
+                        # (The opposite of what we set)
+                        # This does not affect runtime so regular import seems to work.  It's
+                        # just imp.load_module()
+                        if name == 'ansible.module_utils.distro._1__init__':
+                            return
+
+                    with open(path, 'r') as module_fd:
+                        module = imp.load_module(name, module_fd, full_path, ('.py', 'r', imp.PY_SOURCE))
+                        if ansible_module:
+                            run_if_really_module(module)
             else:
                 spec = importlib.util.spec_from_file_location(name, os.path.abspath(path))
                 module = importlib.util.module_from_spec(spec)
 
                 with capture_output(capture):
                     spec.loader.exec_module(module)
+                    if ansible_module:
+                        run_if_really_module(module)
 
             capture_report(path, capture, messages)
         except ImporterAnsibleModuleException:
@@ -152,6 +208,34 @@ def main():
             error = '%s:%d:%d: %s: %s' % (source, line, offset, exc_type.__name__, message)
 
             report_message(error, messages)
+
+    def run_if_really_module(module):
+        # Module was removed
+        if ('removed' not in module.ANSIBLE_METADATA['status'] and
+                # Documentation only module
+                [attr for attr in
+                 (frozenset(module.__dict__.keys()).difference(doc_keys))
+                 if not (attr.startswith('__') and attr.endswith('__'))]):
+            # Run main() code for ansible_modules
+            module.main()
+
+    def calculate_python_module_name(path):
+        name = None
+        try:
+            idx = path.index('ansible/modules')
+        except ValueError:
+            try:
+                idx = path.index('ansible/module_utils')
+            except ValueError:
+                try:
+                    idx = path.index('ansible_collections')
+                except ValueError:
+                    # Default
+                    name = 'module_import_test'
+        if name is None:
+            name = path[idx:-len('.py')].replace('/', '.')
+
+        return name
 
     class Capture:
         """Captured output and/or exception."""

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6027,7 +6027,6 @@ test/integration/targets/async_fail/library/async_test.py future-import-boilerpl
 test/integration/targets/async_fail/library/async_test.py metaclass-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py future-import-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py metaclass-boilerplate
-test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1 pslint:PSUseApprovedVerbs
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util2.py pylint:relative-beyond-top-level
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util3.py pylint:relative-beyond-top-level
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/my_module.py pylint:relative-beyond-top-level

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6027,6 +6027,10 @@ test/integration/targets/async_fail/library/async_test.py future-import-boilerpl
 test/integration/targets/async_fail/library/async_test.py metaclass-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py future-import-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py metaclass-boilerplate
+test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1 pslint:PSUseApprovedVerbs
+test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util2.py pylint:relative-beyond-top-level
+test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util3.py pylint:relative-beyond-top-level
+test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/my_module.py pylint:relative-beyond-top-level
 test/integration/targets/expect/files/test_command.py future-import-boilerplate
 test/integration/targets/expect/files/test_command.py metaclass-boilerplate
 test/integration/targets/get_url/files/testserver.py future-import-boilerplate

--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -36,27 +36,29 @@ from ansible.module_utils.six import PY2
 # when basic.py gains new imports
 # We will remove these when we modify AnsiBallZ to store its args in a separate file instead of in
 # basic.py
-MODULE_UTILS_BASIC_IMPORTS = frozenset((('_text',),
-                                        ('basic',),
-                                        ('common', '__init__'),
-                                        ('common', '_collections_compat'),
-                                        ('common', '_json_compat'),
-                                        ('common', 'collections'),
-                                        ('common', 'file'),
-                                        ('common', 'parameters'),
-                                        ('common', 'process'),
-                                        ('common', 'sys_info'),
-                                        ('common', 'text', '__init__'),
-                                        ('common', 'text', 'converters'),
-                                        ('common', 'text', 'formatters'),
-                                        ('common', 'validation'),
-                                        ('common', '_utils'),
-                                        ('distro', '__init__'),
-                                        ('distro', '_distro'),
-                                        ('parsing', '__init__'),
-                                        ('parsing', 'convert_bool'),
-                                        ('pycompat24',),
-                                        ('six', '__init__'),
+MODULE_UTILS_BASIC_IMPORTS = frozenset((('ansible', '__init__'),
+                                        ('ansible', 'module_utils', '__init__'),
+                                        ('ansible', 'module_utils', '_text'),
+                                        ('ansible', 'module_utils', 'basic'),
+                                        ('ansible', 'module_utils', 'common', '__init__'),
+                                        ('ansible', 'module_utils', 'common', '_collections_compat'),
+                                        ('ansible', 'module_utils', 'common', '_json_compat'),
+                                        ('ansible', 'module_utils', 'common', 'collections'),
+                                        ('ansible', 'module_utils', 'common', 'file'),
+                                        ('ansible', 'module_utils', 'common', 'parameters'),
+                                        ('ansible', 'module_utils', 'common', 'process'),
+                                        ('ansible', 'module_utils', 'common', 'sys_info'),
+                                        ('ansible', 'module_utils', 'common', 'text', '__init__'),
+                                        ('ansible', 'module_utils', 'common', 'text', 'converters'),
+                                        ('ansible', 'module_utils', 'common', 'text', 'formatters'),
+                                        ('ansible', 'module_utils', 'common', 'validation'),
+                                        ('ansible', 'module_utils', 'common', '_utils'),
+                                        ('ansible', 'module_utils', 'distro', '__init__'),
+                                        ('ansible', 'module_utils', 'distro', '_distro'),
+                                        ('ansible', 'module_utils', 'parsing', '__init__'),
+                                        ('ansible', 'module_utils', 'parsing', 'convert_bool'),
+                                        ('ansible', 'module_utils', 'pycompat24',),
+                                        ('ansible', 'module_utils', 'six', '__init__'),
                                         ))
 
 MODULE_UTILS_BASIC_FILES = frozenset(('ansible/module_utils/_text.py',
@@ -85,7 +87,9 @@ MODULE_UTILS_BASIC_FILES = frozenset(('ansible/module_utils/_text.py',
                                       'ansible/module_utils/six/__init__.py',
                                       ))
 
-ONLY_BASIC_IMPORT = frozenset((('basic',),))
+ONLY_BASIC_IMPORT = frozenset((('ansible', '__init__'),
+                               ('ansible', 'module_utils', '__init__'),
+                               ('ansible', 'module_utils', 'basic',),))
 ONLY_BASIC_FILE = frozenset(('ansible/module_utils/basic.py',))
 
 ANSIBLE_LIB = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), 'lib', 'ansible')
@@ -95,7 +99,7 @@ ANSIBLE_LIB = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.pa
 def finder_containers():
     FinderContainers = namedtuple('FinderContainers', ['py_module_names', 'py_module_cache', 'zf'])
 
-    py_module_names = set()
+    py_module_names = set((('ansible', '__init__'), ('ansible', 'module_utils', '__init__')))
     # py_module_cache = {('__init__',): b''}
     py_module_cache = {}
 
@@ -146,7 +150,7 @@ class TestRecursiveFinder(object):
         recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'ping.py'), data, *finder_containers)
         mocker.stopall()
 
-        assert finder_containers.py_module_names == set((('foo', '__init__'),)).union(ONLY_BASIC_IMPORT)
+        assert finder_containers.py_module_names == set((('ansible', 'module_utils', 'foo', '__init__'),)).union(ONLY_BASIC_IMPORT)
         assert finder_containers.py_module_cache == {}
         assert frozenset(finder_containers.zf.namelist()) == frozenset(('ansible/module_utils/foo/__init__.py',)).union(ONLY_BASIC_FILE)
 
@@ -164,7 +168,7 @@ class TestRecursiveFinder(object):
         recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'ping.py'), data, *finder_containers)
         mocker.stopall()
 
-        assert finder_containers.py_module_names == set((('foo',),)).union(ONLY_BASIC_IMPORT)
+        assert finder_containers.py_module_names == set((('ansible', 'module_utils', 'foo',),)).union(ONLY_BASIC_IMPORT)
         assert finder_containers.py_module_cache == {}
         assert frozenset(finder_containers.zf.namelist()) == frozenset(('ansible/module_utils/foo.py',)).union(ONLY_BASIC_FILE)
 
@@ -175,7 +179,7 @@ class TestRecursiveFinder(object):
         name = 'ping'
         data = b'#!/usr/bin/python\nfrom ansible.module_utils import six'
         recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'ping.py'), data, *finder_containers)
-        assert finder_containers.py_module_names == set((('six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
+        assert finder_containers.py_module_names == set((('ansible', 'module_utils', 'six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
         assert finder_containers.py_module_cache == {}
         assert frozenset(finder_containers.zf.namelist()) == frozenset(('ansible/module_utils/six/__init__.py', )).union(MODULE_UTILS_BASIC_FILES)
 
@@ -183,7 +187,7 @@ class TestRecursiveFinder(object):
         name = 'ping'
         data = b'#!/usr/bin/python\nimport ansible.module_utils.six'
         recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'ping.py'), data, *finder_containers)
-        assert finder_containers.py_module_names == set((('six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
+        assert finder_containers.py_module_names == set((('ansible', 'module_utils', 'six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
         assert finder_containers.py_module_cache == {}
         assert frozenset(finder_containers.zf.namelist()) == frozenset(('ansible/module_utils/six/__init__.py', )).union(MODULE_UTILS_BASIC_FILES)
 
@@ -191,6 +195,6 @@ class TestRecursiveFinder(object):
         name = 'ping'
         data = b'#!/usr/bin/python\nfrom ansible.module_utils.six.moves.urllib.parse import urlparse'
         recursive_finder(name, os.path.join(ANSIBLE_LIB, 'modules', 'system', 'ping.py'), data, *finder_containers)
-        assert finder_containers.py_module_names == set((('six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
+        assert finder_containers.py_module_names == set((('ansible', 'module_utils', 'six', '__init__'),)).union(MODULE_UTILS_BASIC_IMPORTS)
         assert finder_containers.py_module_cache == {}
         assert frozenset(finder_containers.zf.namelist()) == frozenset(('ansible/module_utils/six/__init__.py',)).union(MODULE_UTILS_BASIC_FILES)


### PR DESCRIPTION
##### SUMMARY

The module_common changes are a complete hack intended only to get the new integration tests passing.

The tests demonstrate the kinds of relative imports that should be supported.
The final changes to implement this feature should be able to pass the tests.

This is a proof-of-concept implementation for https://github.com/ansible/ansible/issues/59465

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

lib/ansible/executor/module_common.py
