### PR TITLE
Fix exos_facts httpapi

### DIFF
--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -212,7 +212,7 @@ def get_resource_connection(module):
 
     capabilities = get_capabilities(module)
     network_api = capabilities.get('network_api')
-    if network_api in ('cliconf', 'nxapi', 'eapi'):
+    if network_api in ('cliconf', 'nxapi', 'eapi', 'exosapi'):
         module._connection = Connection(module._socket_path)
     elif network_api == 'netconf':
         module._connection = NetconfConnection(module._socket_path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hit the issue when I was rewriting exos_facts as part of [exos_lldp_global](https://github.com/ansible/ansible/pull/60988) using RMB.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/common/network.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
# cat ansible_hosts
R_SW1 ansible_host=10.68.5.64 ansible_network_os=exos ansible_connection=httpapi ansible_user=admin ansible_ssh_pass=
```

```
# cat exos.yaml
---
- name: Basic Configuration 
  hosts: R_SW1
  gather_facts: false
  tasks:
    - name: Get facts
      exos_facts:
        gather_subset: 'default'
        gather_network_resources: '!all'
```
```
ansible-playbook -i ansible_hosts exos.yaml -v
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before**:
```
< TASK [Get facts] >
fatal: [R_SW1]: FAILED! => {"changed": false, "msg": "Invalid connection type exosapi"}
R_SW1                      : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

**After**:
```
< TASK [Get facts] >
ok: [R_SW1] => {"ansible_facts": {"ansible_net_gather_network_resources": [], "ansible_net_gather_subset": ["default"], "ansible_net_hostname": "X460G2-24t-10G4", "ansible_net_model": "X460G2-24t-10G4", "ansible_net_serialnum": "1538N-42127", "ansible_net_version": "30.3.1.2", "ansible_network_resources": {}}, "changed": false}
R_SW1                      : ok=1   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```