### PR TITLE
Working credential helper based login/logout.

### DIFF
--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -62,11 +62,16 @@ except ImportError as exc:
     HAS_DOCKER_PY = False
 
 try:
-    from docker.credentials.errors import CredentialsNotFound
+    from docker.credentials.errors import InitializationError, CredentialsNotFound
     from docker.credentials import Store
 except ImportError:
-    from dockerpycreds.errors import CredentialsNotFound
+    from dockerpycreds.errors import StoreError, CredentialsNotFound
     from dockerpycreds.store import Store
+
+    # This isn't used in earlier versions of the Store API,
+    # but we need it for more modern tests.
+    class InitializationError(StoreError):
+        pass
 
 
 

--- a/lib/ansible/module_utils/docker/common.py
+++ b/lib/ansible/module_utils/docker/common.py
@@ -62,10 +62,10 @@ except ImportError as exc:
     HAS_DOCKER_PY = False
 
 try:
-    from docker.credentials.errors import InitializationError, CredentialsNotFound
+    from docker.credentials.errors import StoreError, CredentialsNotFound
     from docker.credentials import Store
 except ImportError:
-    from dockerpycreds.errors import InitializationError, CredentialsNotFound
+    from dockerpycreds.errors import StoreError, CredentialsNotFound
     from dockerpycreds.store import Store
 
 try:

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -76,7 +76,7 @@ extends_documentation_fragment:
   - docker.docker_py_1_documentation
 requirements:
   - "L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) >= 1.8.0 (use L(docker-py,https://pypi.org/project/docker-py/) for Python 2.6)"
-  - "L(Python bindings for docker credentials store API) >= 0.2.1 (use L(docker-pycreds,https://pypi.org/project/docker-pycreds/) when using Docker SDK for Python < 4.0.0)
+  - "L(Python bindings for docker credentials store API) >= 0.2.1 (use L(docker-pycreds,https://pypi.org/project/docker-pycreds/) when using Docker SDK for Python < 4.0.0)"
   - "Docker API >= 1.20"
   - "Only to be able to logout, that is for I(state) = C(absent): the C(docker) command line utility"
 author:

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -46,6 +46,11 @@ options:
       - The plaintext password for the registry account
     type: str
     required: yes
+  email:
+    required: False
+    description:
+      - Does nothing, do not use.
+    type: str
   reauthorize:
     description:
       - Refresh existing authentication found in the configuration file.

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -76,7 +76,8 @@ extends_documentation_fragment:
   - docker.docker_py_1_documentation
 requirements:
   - "L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) >= 1.8.0 (use L(docker-py,https://pypi.org/project/docker-py/) for Python 2.6)"
-  - "L(Python bindings for docker credentials store API) >= 0.2.1 (use L(docker-pycreds,https://pypi.org/project/docker-pycreds/) when using Docker SDK for Python < 4.0.0)"
+  - "L(Python bindings for docker credentials store API) >= 0.2.1
+    (use L(docker-pycreds,https://pypi.org/project/docker-pycreds/) when using Docker SDK for Python < 4.0.0)"
   - "Docker API >= 1.20"
   - "Only to be able to logout, that is for I(state) = C(absent): the C(docker) command line utility"
 author:
@@ -253,6 +254,7 @@ class LoginManager(DockerBaseClass):
             self.results['actions'].append("Wrote credentials to configured helper %s for %s" % (
                 store.program, self.registry_url))
             self.results['changed'] = True
+
 
 def main():
 

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -76,6 +76,7 @@ extends_documentation_fragment:
   - docker.docker_py_1_documentation
 requirements:
   - "L(Docker SDK for Python,https://docker-py.readthedocs.io/en/stable/) >= 1.8.0 (use L(docker-py,https://pypi.org/project/docker-py/) for Python 2.6)"
+  - "L(Python bindings for docker credentials store API) >= 0.2.1 (use L(docker-pycreds,https://pypi.org/project/docker-pycreds/) when using Docker SDK for Python < 4.0.0)
   - "Docker API >= 1.20"
   - "Only to be able to logout, that is for I(state) = C(absent): the C(docker) command line utility"
 author:

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -46,11 +46,6 @@ options:
       - The plaintext password for the registry account
     type: str
     required: yes
-  email:
-    required: False
-    description:
-      - "The email address for the registry account."
-    type: str
   reauthorize:
     description:
       - Refresh existing authentication found in the configuration file.
@@ -119,14 +114,11 @@ login_results:
     returned: when state='present'
     type: dict
     sample: {
-        "email": "testuer@yahoo.com",
         "serveraddress": "localhost:5000",
         "username": "testuser"
     }
 '''
 
-import base64
-import json
 import os
 import re
 import traceback
@@ -137,8 +129,8 @@ except ImportError:
     # missing Docker SDK for Python handled in ansible.module_utils.docker.common
     pass
 
-from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.docker.common import (
+    CredentialsNotFound,
     AnsibleDockerClient,
     DEFAULT_DOCKER_REGISTRY,
     DockerBaseClass,
@@ -164,6 +156,10 @@ class LoginManager(DockerBaseClass):
         self.email = parameters.get('email')
         self.reauthorize = parameters.get('reauthorize')
         self.config_path = parameters.get('config_path')
+
+        # As far as I can tell, email is not supported by credential helpers at all.
+        if self.email:
+            client.module.deprecate("The email parameter is deprecated and presently does nothing", "2.10")
 
         if parameters['state'] == 'present':
             self.login()
@@ -206,109 +202,56 @@ class LoginManager(DockerBaseClass):
         self.results['login_result'] = response
 
         if not self.check_mode:
-            self.update_config_file()
+            self.update_credentials()
 
     def logout(self):
         '''
         Log out of the registry. On success update the config file.
-        TODO: port to API once docker.py supports this.
 
         :return: None
         '''
 
-        cmd = [self.client.module.get_bin_path('docker', True), "logout", self.registry_url]
-        # TODO: docker does not support config file in logout, restore this when they do
-        # if self.config_path and self.config_file_exists(self.config_path):
-        #     cmd.extend(["--config", self.config_path])
+        # Get the configuration store.
+        store = self.client.get_credential_store_instance(self.registry_url, self.config_path)
 
-        (rc, out, err) = self.client.module.run_command(cmd)
-        if rc != 0:
-            self.fail("Could not log out: %s" % err)
-        if b'Not logged in to ' in out:
+        try:
+            current = store.get(self.registry_url)
+        except CredentialsNotFound:
+            # get raises and exception on not found.
+            self.log("Credentials for %s not present, doing nothing." % (self.registry_url))
             self.results['changed'] = False
-        elif b'Removing login credentials for ' in out:
-            self.results['changed'] = True
-        else:
-            self.client.module.warn('Unable to determine whether logout was successful.')
 
-        # Adding output to actions, so that user can inspect what was actually returned
-        self.results['actions'].append(to_text(out))
+            return
 
-    def config_file_exists(self, path):
-        if os.path.exists(path):
-            self.log("Configuration file %s exists" % (path))
-            return True
-        self.log("Configuration file %s not found." % (path))
-        return False
+        store.erase(self.registry_url)
+        self.results['changed'] = True
 
-    def create_config_file(self, path):
+    def update_credentials(self):
         '''
-        Create a config file with a JSON blob containing an auths key.
+        If the authorization is not stored attempt to store authorization values via
+        the appropriate credential helper or to the config file.
 
         :return: None
         '''
 
-        self.log("Creating docker config file %s" % (path))
-        config_path_dir = os.path.dirname(path)
-        if not os.path.exists(config_path_dir):
-            try:
-                os.makedirs(config_path_dir)
-            except Exception as exc:
-                self.fail("Error: failed to create %s - %s" % (config_path_dir, str(exc)))
-        self.write_config(path, dict(auths=dict()))
-
-    def write_config(self, path, config):
-        try:
-            json.dump(config, open(path, "w"), indent=5, sort_keys=True)
-        except Exception as exc:
-            self.fail("Error: failed to write config to %s - %s" % (path, str(exc)))
-
-    def update_config_file(self):
-        '''
-        If the authorization not stored in the config file or reauthorize is True,
-        update the config file with the new authorization.
-
-        :return: None
-        '''
-
-        path = self.config_path
-        if not self.config_file_exists(path):
-            self.create_config_file(path)
+        # Check to see if credentials already exist.
+        store = self.client.get_credential_store_instance(self.registry_url, self.config_path)
 
         try:
-            # read the existing config
-            config = json.load(open(path, "r"))
-        except ValueError:
-            self.log("Error reading config from %s" % (path))
-            config = dict()
+            current = store.get(self.registry_url)
+        except CredentialsNotFound:
+            # get raises and exception on not found.
+            current = dict(
+                Username='',
+                Secret=''
+            )
 
-        if not config.get('auths'):
-            self.log("Adding auths dict to config.")
-            config['auths'] = dict()
-
-        if not config['auths'].get(self.registry_url):
-            self.log("Adding registry_url %s to auths." % (self.registry_url))
-            config['auths'][self.registry_url] = dict()
-
-        b64auth = base64.b64encode(
-            to_bytes(self.username) + b':' + to_bytes(self.password)
-        )
-        auth = to_text(b64auth)
-
-        encoded_credentials = dict(
-            auth=auth,
-            email=self.email
-        )
-
-        if config['auths'][self.registry_url] != encoded_credentials or self.reauthorize:
-            # Update the config file with the new authorization
-            config['auths'][self.registry_url] = encoded_credentials
-            self.log("Updating config file %s with new authorization for %s" % (path, self.registry_url))
-            self.results['actions'].append("Updated config file %s with new authorization for %s" % (
-                path, self.registry_url))
+        if current['Username'] != self.username or current['Secret'] != self.password or self.reauthorize:
+            store.store(self.registry_url, self.username, self.password)
+            self.log("Writing credentials to configured helper %s for %s" % (store.program, self.registry_url))
+            self.results['actions'].append("Wrote credentials to configured helper %s for %s" % (
+                store.program, self.registry_url))
             self.results['changed'] = True
-            self.write_config(path, config)
-
 
 def main():
 

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -50,3 +50,6 @@ openshift ; python_version >= '2.7'
 
 # requirement for maven_artifact
 semantic_version
+
+# requirement for docker_login
+docker

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -52,4 +52,5 @@ openshift ; python_version >= '2.7'
 semantic_version
 
 # requirement for docker_login
-docker
+docker ; python_version >= '2.7'
+docker-py ; python_version < '2.7'

--- a/test/units/module_utils/docker/test_common.py
+++ b/test/units/module_utils/docker/test_common.py
@@ -11,7 +11,7 @@ from ansible.module_utils import basic
 
 from ansible.module_utils.docker.common import (
     Store,
-    InitializationError,
+    StoreError,
     DockerFileStore,
     AnsibleDockerClient,
     compare_dict_allow_more_present,
@@ -565,7 +565,7 @@ def test_docker_credential_helpers(config):
         store = client.get_credential_store_instance(EXAMPLE_REGISTRY, os.path.join(test_data_dir, config))
 
         assert type(store) == Store
-    except InitializationError as e:
+    except StoreError as e:
         pytest.skip("Credential helper not available.")
 
 

--- a/test/units/module_utils/docker/test_common.py
+++ b/test/units/module_utils/docker/test_common.py
@@ -4,15 +4,14 @@ __metaclass__ = type
 import os
 import pytest
 
-from docker.credentials import Store
-from docker.credentials.errors import InitializationError
 from docker.constants import DEFAULT_DOCKER_API_VERSION
 
-from units.compat.mock import patch
-from units.modules.utils import set_module_args
+from units.modules.utils import patch, set_module_args
 from ansible.module_utils import basic
 
 from ansible.module_utils.docker.common import (
+    Store,
+    InitializationError,
     DockerFileStore,
     AnsibleDockerClient,
     compare_dict_allow_more_present,

--- a/test/units/module_utils/docker/test_common.py
+++ b/test/units/module_utils/docker/test_common.py
@@ -537,21 +537,25 @@ def test_parse_healthcheck():
     }
     assert disabled is False
 
+
 def get_docker_client():
     '''
     Avoid crash while instantiating AnsibleDockerClient in a test context.
     '''
 
-    set_module_args(dict())
+    set_module_args(dict(
+        api_version=DEFAULT_DOCKER_API_VERSION
+    ))
 
     with patch.object(AnsibleDockerClient, 'version') as version:
         version.return_value = dict(
             ApiVersion=DEFAULT_DOCKER_API_VERSION
         )
 
-        client = AnsibleDockerClient( )
+        client = AnsibleDockerClient()
 
     return client
+
 
 @pytest.mark.parametrize("config", CREDENTIAL_HELPERS)
 def test_docker_credential_helpers(config):
@@ -564,6 +568,7 @@ def test_docker_credential_helpers(config):
     except InitializationError as e:
         pytest.skip("Credential helper not available.")
 
+
 def test_docker_legacy_crednetials():
     client = get_docker_client()
 
@@ -574,4 +579,3 @@ def test_docker_legacy_crednetials():
         Username="abc",
         Secret="123"
     )
-

--- a/test/units/module_utils/docker/test_data/desktop-config.json
+++ b/test/units/module_utils/docker/test_data/desktop-config.json
@@ -1,0 +1,13 @@
+{
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/19.03.1 (darwin)"
+  },
+  "auths" : {
+    "registry.example.com" : {
+
+    }
+  },
+  "stackOrchestrator" : "swarm",
+  "credsStore" : "desktop"
+}
+

--- a/test/units/module_utils/docker/test_data/none-config.json
+++ b/test/units/module_utils/docker/test_data/none-config.json
@@ -1,0 +1,12 @@
+{
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/19.03.1 (darwin)"
+  },
+  "auths" : {
+    "registry.example.com" : {
+        "auth": "YWJjOjEyMw=="
+    }
+  },
+  "stackOrchestrator" : "swarm"
+}
+

--- a/test/units/module_utils/docker/test_data/osxkeychain-config.json
+++ b/test/units/module_utils/docker/test_data/osxkeychain-config.json
@@ -1,0 +1,13 @@
+{
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/19.03.1 (darwin)"
+  },
+  "auths" : {
+    "registry.example.com" : {
+
+    }
+  },
+  "stackOrchestrator" : "swarm",
+  "credsStore" : "osxkeychain"
+}
+

--- a/test/units/module_utils/docker/test_data/secretservice-config.json
+++ b/test/units/module_utils/docker/test_data/secretservice-config.json
@@ -1,0 +1,13 @@
+{
+  "HttpHeaders" : {
+    "User-Agent" : "Docker-Client/19.03.1 (darwin)"
+  },
+  "auths" : {
+    "registry.example.com" : {
+
+    }
+  },
+  "stackOrchestrator" : "swarm",
+  "credsStore" : "secretservice"
+}
+


### PR DESCRIPTION
Closed in favor of #61207

##### SUMMARY
This is a potential Fix for #55738

I leveraged [Store](https://github.com/docker/docker-py/blob/master/docker/credentials/store.py) from docker-py/docker ( Also available from [docker-pycreds](https://github.com/shin-/dockerpy-creds) when using docker-py before version 4.0.0. It appears to be installed by along with *python-docker* and *python3-docker* on Ubuntu systems at least.) This natively handles interacting with the credential helpers for both login and logout operations.

To reduce the complexity of docker_login itself,  moved the operations for updating config file based credentials into a class that implements the parts of Store's API that are needed. This pushes the complexity of dealing with the config_file further back and makes the changed/not changed logic much simpler.

Additionally, I've added a few very crude tests since there were none I could see for this module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_login

##### ADDITIONAL INFORMATION
