### PR TITLE
vmware_guest: don't strip hyphen from default computer name derived from vmware name

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1619,7 +1619,7 @@ class PyVmomiHelper(PyVmomi):
             ident.userData.computerName = vim.vm.customization.FixedName()
             # computer name will be truncated to 15 characters if using VM name
             default_name = self.params['name'].replace(' ', '')
-            default_name = ''.join([c for c in default_name if c not in string.punctuation])
+            default_name = ''.join([c for c in default_name if c not in string.punctuation.replace('-', '')])
             ident.userData.computerName.name = str(self.params['customization'].get('hostname', default_name[0:15]))
             ident.userData.fullName = str(self.params['customization'].get('fullname', 'Administrator'))
             ident.userData.orgName = str(self.params['customization'].get('orgname', 'ACME'))


### PR DESCRIPTION
##### SUMMARY

The docs say hyphen (minus) is allowed:

> Allowed characters are alphanumeric (uppercase and lowercase) and minus, rest of the characters are dropped as per RFC 952.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
#54118
