### PR TITLE
Fetch group facts from junos

### DIFF
--- a/lib/ansible/module_utils/network/junos/facts/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/facts/interfaces/interfaces.py
@@ -60,12 +60,25 @@ class InterfacesFacts(object):
                 <interfaces/>
             </configuration>
             """
+            group_config_filter = """
+            <configuration>
+                <groups>
+                    <interfaces/>
+                </groups>
+            </configuration>
+            """
             data = connection.get_configuration(filter=config_filter)
+            group_data = connection.get_configuration(
+                filter=group_config_filter)
 
         if isinstance(data, string_types):
             data = etree.fromstring(to_bytes(data, errors='surrogate_then_replace'))
 
+        if isinstance(group_data, string_types):
+            group_data = etree.fromstring(to_bytes(group_data, errors='surrogate_then_replace'))
+
         resources = data.xpath('configuration/interfaces/interface')
+        resources += group_data.xpath('configuration/groups/interfaces/interface')
 
         objs = []
         for resource in resources:


### PR DESCRIPTION
##### SUMMARY
Add support for fetching groups facts in JunOS

This PR adds support for fetching interfaces data from configuration groups in
JunOS, which was previously omitted.

Fixes #61183
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_facts