### PR TITLE
Update mysql_db.py, adding encoding to enforce charset for import

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -179,7 +179,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
     return rc, stdout, stderr
 
 
-def db_import(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None):
+def db_import(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None, encoding=None):
     if not os.path.exists(target):
         return module.fail_json(msg="target %s does not exist on the host" % target)
 
@@ -202,6 +202,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     else:
         cmd.append("--host=%s" % pipes.quote(host))
         cmd.append("--port=%i" % port)
+    if encoding is not None:
+        cmd.append("--default-character-set=%s" % pipes.quote(encoding))
     if not all_databases:
         cmd.append("-D")
         cmd.append(pipes.quote(db_name))
@@ -356,7 +358,7 @@ def main():
                                                login_password, db, target,
                                                all_databases,
                                                login_port, config_file,
-                                               socket, ssl_cert, ssl_key, ssl_ca)
+                                               socket, ssl_cert, ssl_key, ssl_ca, encoding)
                 if rc != 0:
                     module.fail_json(msg="%s" % stderr)
                 else:
@@ -388,7 +390,7 @@ def main():
                     if changed:
                         rc, stdout, stderr = db_import(module, login_host, login_user,
                                                        login_password, db, target, all_databases,
-                                                       login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca)
+                                                       login_port, config_file, socket, ssl_cert, ssl_key, ssl_ca, encoding)
                         if rc != 0:
                             module.fail_json(msg="%s" % stderr)
                         else:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -203,7 +203,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     else:
         cmd.append("--host=%s" % pipes.quote(host))
         cmd.append("--port=%i" % port)
-    if ( encoding is not None) and ( encoding != "" ):
+    if (encoding is not None) and (encoding != ""):
         cmd.append("--default-character-set=%s" % pipes.quote(encoding))
     if not all_databases:
         cmd.append("-D")

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -179,7 +179,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
     return rc, stdout, stderr
 
 
-def db_import(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None, encoding=None):
+def db_import(module, host, user, password, db_name, target, all_databases, port, config_file,
+              socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None, encoding=None):
     if not os.path.exists(target):
         return module.fail_json(msg="target %s does not exist on the host" % target)
 
@@ -202,7 +203,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     else:
         cmd.append("--host=%s" % pipes.quote(host))
         cmd.append("--port=%i" % port)
-    if encoding is not None:
+    if ( encoding is not None) and ( encoding != "" ):
         cmd.append("--default-character-set=%s" % pipes.quote(encoding))
     if not all_databases:
         cmd.append("-D")


### PR DESCRIPTION


##### SUMMARY

`encoding` is used for creation of database, but not for import of sql scripts.
The import fails to import `latin1` encoded sql script, cause it consider it's by default some utf8

This commit add `--default-character-set=encoding` when the import function is called with an encoding argument. 
This way this option is added to the mysql command line, and import is successfull.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
mysql_db

##### ADDITIONAL INFORMATION

