### PR TITLE
correct behaviour of win_iis_webapplication when no applicationpool is specified

### DIFF
--- a/changelogs/fragments/61227-win_iis_webapplication-apppool-change.yml
+++ b/changelogs/fragments/61227-win_iis_webapplication-apppool-change.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_iis_webapplication - now uses the current application pool of the website instead of the DefaultAppPool if none was specified.

--- a/lib/ansible/modules/windows/win_iis_webapplication.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapplication.ps1
@@ -27,6 +27,12 @@ if ($null -eq (Get-Module "WebAdministration" -ErrorAction SilentlyContinue)) {
 
 # Application info
 $application = Get-WebApplication -Site $site -Name $name
+$website = Get-Website -Name $site
+
+# Set ApplicationPool to current if not specified
+if (!$application_pool) {
+  $application_pool = $website.applicationPool
+}
 
 try {
   # Add application

--- a/lib/ansible/modules/windows/win_iis_webapplication.py
+++ b/lib/ansible/modules/windows/win_iis_webapplication.py
@@ -40,6 +40,7 @@ options:
   application_pool:
     description:
     - The application pool in which the new site executes.
+    - If not specified, the application pool of the current website will be used.
     type: str
 seealso:
 - module: win_iis_virtualdirectory


### PR DESCRIPTION
##### SUMMARY
Correct behaviour of win_iis_webapplication when no applicationpool is specified.  
Actual behaviour: If you don't speficy an application_pool, the module will assign the DefaultAppPool. In some situations this leads to errors (403.18), and it's also not a recommended configuration.  
New behaviour: the application pool of the actual website will be used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_iis_webapplication

##### ADDITIONAL INFORMATION


If the website had an applicationpool "MyTestAppPool", and you speficy:
```
    - name: test win_iis_webapplication default applicationpool
      win_iis_webapplication:
        name: test
        site: TestWebsite
        physical_path: 'C:\Temp\Test'
```
Then the DefaultAppPool was used:
```
changed: [192.168.1.10] => {"application_pool": "DefaultAppPool", "changed": true, "physical_path": "C:\Temp\Test"}
```
After the change, the application pool of the current website is used:
```
changed: [192.168.1.10] => {"application_pool": "MyTestAppPool", "changed": true, "physical_path": "C:\Temp\Test"}
```
