### PR TITLE
files: fix docs about type of the mode parameter

### DIFF
--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -96,20 +96,6 @@ def get_flags_from_attributes(attributes):
     return ''.join(flags)
 
 
-def get_file_arg_spec():
-    arg_spec = dict(
-        mode=dict(type='raw'),
-        owner=dict(),
-        group=dict(),
-        seuser=dict(),
-        serole=dict(),
-        selevel=dict(),
-        setype=dict(),
-        attributes=dict(aliases=['attr']),
-    )
-    return arg_spec
-
-
 class LockTimeout(Exception):
     pass
 

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -75,7 +75,7 @@ options:
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.
-    type: path
+    type: raw
   directory_mode:
     description:
     - When doing a recursive copy set the mode for the directories.

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -25,7 +25,7 @@ options:
       C(u=rw,g=r,o=r)).
     - As of Ansible 2.6, the mode may also be the special string C(preserve).
     - When set to C(preserve) the file will be given the same permissions as the source file.
-    type: str
+    type: raw
   owner:
     description:
     - Name of the user that should own the file/directory, as would be fed to I(chown).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

`mode` is an octal or symbolic mode, for the unix file permission.  It is
not a path, as the docs for the copy module suggest.

Document the various mode parameters as being of type as "raw".

The `directory_mode` parameter of the copy module was already of type
"raw".  Perhaps this looks a bit weird, but the documentation text for
`mode` is very explicit about how it allows both integer and string values.

`ansible-test sanity --test validate-modules` missed some inconcistencies
between the docs and the code due to how the common file arguments work.
(I noticed it yelled at me if I introduce a discrepancy elsewhere).
I think this change removes inconsistencies.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
copy

##### ADDITIONAL INFORMATION
n/a