### PR TITLE
Renaming `onepassword_facts` to `onepassword_info`.

### DIFF
--- a/changelogs/fragments/61237_rename-onepassword_facts-to-onepassword_info.yaml
+++ b/changelogs/fragments/61237_rename-onepassword_facts-to-onepassword_info.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - The ``onepassword_facts`` module has been renamed to ``onepassword_info``.
+    When called with the new name, the module no longer returns ``ansible_facts``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -287,7 +287,7 @@ be removed in Ansible 2.13. Please update update your playbooks accordingly.
 * The ``memset_memstore_facts`` module was renamed to :ref:`memset_memstore_info <memset_memstore_info_module>`.
 * The ``memset_server_facts`` module was renamed to :ref:`memset_server_info <memset_server_info_module>`.
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
-* The ``onepassword_facts`` module was renamed to :red:`onepassword_info <onepassword_info_module>`.
+* The ``onepassword_facts`` module was renamed to :ref:`onepassword_info <onepassword_info_module>`.
   When called with the new name, the module no longer returns ``ansible_facts``.
 * The ``python_requirements_facts`` module was renamed to :ref:`python_requirements_info <python_requirements_info_module>`.
 * The ``rds_instance_facts`` module was renamed to :ref:`rds_instance_info <rds_instance_info_module>`.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -95,7 +95,7 @@ The following modules will be removed in Ansible 2.13. Please update update your
 * purefb_facts use :ref:`purefb_info <purefb_info_module>` instead.
 
 * vyos_interface use :ref:`vyos_interfaces <vyos_interfaces_module>` instead.
- 
+
 * vyos_l3_interface use :ref:`vyos_l3_interfaces <vyos_l3_interfaces_module>` instead.
 
 * vyos_linkagg use :ref:`vyos_lag_interfaces <vyos_lag_interfaces_module>` instead.
@@ -287,6 +287,8 @@ be removed in Ansible 2.13. Please update update your playbooks accordingly.
 * The ``memset_memstore_facts`` module was renamed to :ref:`memset_memstore_info <memset_memstore_info_module>`.
 * The ``memset_server_facts`` module was renamed to :ref:`memset_server_info <memset_server_info_module>`.
 * The ``one_image_facts`` module was renamed to :ref:`one_image_info <one_image_info_module>`.
+* The ``onepassword_facts`` module was renamed to :red:`onepassword_info <onepassword_info_module>`.
+  When called with the new name, the module no longer returns ``ansible_facts``.
 * The ``python_requirements_facts`` module was renamed to :ref:`python_requirements_info <python_requirements_info_module>`.
 * The ``rds_instance_facts`` module was renamed to :ref:`rds_instance_info <rds_instance_info_module>`.
 * The ``rds_snapshot_facts`` module was renamed to :ref:`rds_snapshot_info <rds_snapshot_info_module>`.

--- a/lib/ansible/modules/identity/_onepassword_facts.py
+++ b/lib/ansible/modules/identity/_onepassword_facts.py
@@ -1,0 +1,1 @@
+onepassword_info.py

--- a/lib/ansible/modules/identity/onepassword_info.py
+++ b/lib/ansible/modules/identity/onepassword_info.py
@@ -96,6 +96,7 @@ EXAMPLES = '''
   onepassword_info:
     search_terms: My 1Password item
   delegate_to: localhost
+  register_to: my_1password_item
   no_log: true         # Don't want to log the secrets to the console!
 
 # Gather secrets from 1Password, with more advanced search terms:
@@ -107,6 +108,7 @@ EXAMPLES = '''
         section: Custom section name     # optional, defaults to 'None'
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
   delegate_to: localhost
+  register_to: my_1password_item
   no_log: True                           # Don't want to log the secrets to the console!
 
 # Gather secrets combining simple and advanced search terms to retrieve two items, one of which we fetch two
@@ -123,7 +125,12 @@ EXAMPLES = '''
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
       - name: A 1Password item with document attachment
   delegate_to: localhost
+  register_to: my_1password_item
   no_log: true                           # Don't want to log the secrets to the console!
+
+- name: Debug a password (for example)
+  debug:
+    msg: "{{ my_1password_item['onepassword']['My 1Password item'] }}"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/identity/onepassword_info.py
+++ b/lib/ansible/modules/identity/onepassword_info.py
@@ -107,7 +107,7 @@ EXAMPLES = '''
   onepassword_info:
     search_terms: My 1Password item
   delegate_to: localhost
-  register_to: my_1password_item
+  register: my_1password_item
   no_log: true         # Don't want to log the secrets to the console!
 
 # Gather secrets from 1Password, with more advanced search terms:
@@ -119,7 +119,7 @@ EXAMPLES = '''
         section: Custom section name     # optional, defaults to 'None'
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
   delegate_to: localhost
-  register_to: my_1password_item
+  register: my_1password_item
   no_log: True                           # Don't want to log the secrets to the console!
 
 # Gather secrets combining simple and advanced search terms to retrieve two items, one of which we fetch two
@@ -136,7 +136,7 @@ EXAMPLES = '''
         vault:   Name of the vault       # optional, only necessary if there is more than 1 Vault available
       - name: A 1Password item with document attachment
   delegate_to: localhost
-  register_to: my_1password_item
+  register: my_1password_item
   no_log: true                           # Don't want to log the secrets to the console!
 
 - name: Debug a password (for example)

--- a/lib/ansible/modules/identity/onepassword_info.py
+++ b/lib/ansible/modules/identity/onepassword_info.py
@@ -39,6 +39,7 @@ description:
       You must now use the C(register) option to use the facts in other tasks.
 options:
     search_terms:
+        type: list
         description:
             - A list of one or more search terms.
             - Each search term can either be a simple string or it can be a dictionary for more control.
@@ -46,19 +47,24 @@ options:
             - When passing a dictionary, the following fields are available.
         suboptions:
             name:
+                type: str
                 description:
                     - The name of the 1Password item to search for (required).
             field:
+                type: str
                 description:
                     - The name of the field to search for within this item (optional, defaults to "password" (or "document" if the item has an attachment).
             section:
+                type: str
                 description:
                     - The name of a section within this item containing the specified field (optional, will search all sections if not specified).
             vault:
+                type: str
                 description:
                     - The name of the particular 1Password vault to search, useful if your 1Password user has access to multiple vaults (optional).
         required: True
     auto_login:
+        type: dict
         description:
             - A dictionary containing authentication details. If this is set, M(onepassword_info) will attempt to sign in to 1Password automatically.
             - Without this option, you must have already logged in via the 1Password CLI before running Ansible.
@@ -66,25 +72,30 @@ options:
               the Ansible Vault is equal to or greater in strength than the 1Password master password.
         suboptions:
             subdomain:
+                type: str
                 description:
                     - 1Password subdomain name (<subdomain>.1password.com).
                     - If this is not specified, the most recent subdomain will be used.
             username:
+                type: str
                 description:
                     - 1Password username.
                     - Only required for initial sign in.
             master_password:
+                type: str
                 description:
                     - The master password for your subdomain.
                     - This is always required when specifying C(auto_login).
                 required: True
             secret_key:
+                type: str
                 description:
                     - The secret key for your subdomain.
                     - Only required for initial sign in.
         default: {}
         required: False
     cli_path:
+        type: path
         description: Used to specify the exact path to the C(op) command line interface
         required: False
         default: 'op'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2308,7 +2308,6 @@ lib/ansible/modules/identity/keycloak/keycloak_client.py validate-modules:E338
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:E324
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:E337
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:E338
-lib/ansible/modules/identity/onepassword_facts.py validate-modules:E337
 lib/ansible/modules/identity/opendj/opendj_backendprop.py validate-modules:E337
 lib/ansible/modules/identity/opendj/opendj_backendprop.py validate-modules:E338
 lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py validate-modules:E324


### PR DESCRIPTION
##### SUMMARY

Renaming `onepassword_facts` module to `onepassword_info`, and stop returning `ansible_facts` when the module is called with the new name.

Fixes #60535.

##### ISSUE TYPE

Bugfix Pull Requests

##### COMPONENT NAME

onepassword_facts