### PR TITLE
azure: fixed conflict caused by outdated azure-cli-core

### DIFF
--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -1,7 +1,7 @@
 packaging
 requests[security]
 xmltodict
-azure-cli-core==2.0.35
+azure-cli-core==2.0.71
 azure-cli-nspkg==3.0.2
 azure-common==1.1.11
 azure-mgmt-authorization==0.51.1

--- a/test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt
+++ b/test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt
@@ -1,7 +1,7 @@
 packaging
 requests[security]
 xmltodict
-azure-cli-core==2.0.35
+azure-cli-core==2.0.71
 azure-cli-nspkg==3.0.2
 azure-common==1.1.11
 azure-mgmt-authorization==0.51.1


### PR DESCRIPTION
##### SUMMARY
The pinned version of azure-cli-core caused installation conflicts due
to requesting wrong versions of tabulate, creating conflicts with
ansible molecule.

The newer version of azure-cli-core fixed this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
azure

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Collecting tabulate<=0.8.2,>=0.7.7 (from azure-cli-core==2.0.35->ansible[azure])
...
ERROR: molecule 2.23.dev8+gabf4956c has requirement tabulate>=0.8.3, but you'll have tabulate 0.8.2 which is incompatible.
```

