### PR TITLE
Deprecate alias 'thirsty' from all usages

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1427,6 +1427,12 @@ class AnsibleModule(object):
         alias_results, self._legal_inputs = handle_aliases(spec, param, alias_warnings=alias_warnings)
         for option, alias in alias_warnings:
             self._warnings.append('Both option %s and its alias %s are set.' % (option_prefix + option, option_prefix + alias))
+        if 'deprecated_aliases' in spec.keys():
+            if spec['deprecated_aliases']['alias'] in param.keys():
+                self._deprecations.append(
+                    {'msg': "Alias '%s' is deprecated. See the module docs for more information" % spec['deprecated_aliases']['alias'],
+                     'version': spec['deprecated_aliases']['version']})
+
         return alias_results
 
     def _handle_no_log_values(self, spec=None, param=None):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1427,12 +1427,18 @@ class AnsibleModule(object):
         alias_results, self._legal_inputs = handle_aliases(spec, param, alias_warnings=alias_warnings)
         for option, alias in alias_warnings:
             self._warnings.append('Both option %s and its alias %s are set.' % (option_prefix + option, option_prefix + alias))
-        if 'deprecated_aliases' in spec.keys():
-            if spec['deprecated_aliases']['alias'] in param.keys():
-                self._deprecations.append(
-                    {'msg': "Alias '%s' is deprecated. See the module docs for more information" % spec['deprecated_aliases']['alias'],
-                     'version': spec['deprecated_aliases']['version']})
 
+        deprecated_aliases = []
+        for i in spec.keys():
+            if 'deprecated_aliases' in spec[i].keys():
+                for alias in spec[i]['deprecated_aliases']:
+                    deprecated_aliases.append(alias)
+
+        for deprecation in deprecated_aliases:
+            if deprecation['name'] in param.keys():
+                self._deprecations.append(
+                    {'msg': "Alias '%s' is deprecated. See the module docs for more information" % deprecation['name'],
+                     'version': deprecation['version']})
         return alias_results
 
     def _handle_no_log_values(self, spec=None, param=None):

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1409,7 +1409,7 @@ def url_argument_spec():
     '''
     return dict(
         url=dict(type='str'),
-        force=dict(type='bool', default=False, aliases=['thirsty']),
+        force=dict(type='bool', default=False, aliases=['thirsty'], deprecated_aliases=[dict(name='thirsty', version='2.13')]),
         http_agent=dict(type='str', default='ansible-httpget'),
         use_proxy=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),
@@ -1418,7 +1418,6 @@ def url_argument_spec():
         force_basic_auth=dict(type='bool', default=False),
         client_cert=dict(type='path'),
         client_key=dict(type='path'),
-        deprecated_aliases=dict(alias='thirsty', version='2.13'),
     )
 
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1418,6 +1418,7 @@ def url_argument_spec():
         force_basic_auth=dict(type='bool', default=False),
         client_cert=dict(type='path'),
         client_key=dict(type='path'),
+        deprecated_aliases=dict(alias='thirsty', version='2.13'),
     )
 
 

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -512,7 +512,7 @@ def main():
     )
 
     if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version='2.13')
 
     src = module.params['src']
     b_src = to_bytes(src, errors='surrogate_or_strict')

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -60,6 +60,7 @@ options:
     - Influence whether the remote file must always be replaced.
     - If C(yes), the remote file will be replaced when contents are different than the source.
     - If C(no), the file will only be transferred if the destination does not exist.
+    - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: yes
     aliases: [ thirsty ]
@@ -509,6 +510,9 @@ def main():
         add_file_common_args=True,
         supports_check_mode=True,
     )
+
+    if module.params.get('thirsty'):
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
 
     src = module.params['src']
     b_src = to_bytes(src, errors='surrogate_or_strict')

--- a/lib/ansible/modules/files/iso_extract.py
+++ b/lib/ansible/modules/files/iso_extract.py
@@ -56,6 +56,7 @@ options:
     description:
     - If C(yes), which will replace the remote file when contents are different than the source.
     - If C(no), the file will only be extracted and copied if the destination does not already exist.
+    - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: yes
     aliases: [ thirsty ]
@@ -116,6 +117,9 @@ def main():
     files = module.params['files']
     force = module.params['force']
     executable = module.params['executable']
+
+    if module.params.get('thirsty'):
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
 
     result = dict(
         changed=False,

--- a/lib/ansible/modules/files/iso_extract.py
+++ b/lib/ansible/modules/files/iso_extract.py
@@ -119,7 +119,7 @@ def main():
     executable = module.params['executable']
 
     if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version='2.13')
 
     result = dict(
         changed=False,

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -61,6 +61,7 @@ options:
         will only be downloaded if the destination does not exist. Generally
         should be C(yes) only for small local files.
       - Prior to 0.6, this module behaved as if C(yes) was the default.
+      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
     aliases: [ thirsty ]
@@ -445,6 +446,9 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[['checksum', 'sha256sum']],
     )
+
+    if module.params.get('thirsty'):
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
 
     url = module.params['url']
     dest = module.params['dest']

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -448,7 +448,7 @@ def main():
     )
 
     if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version='2.13')
 
     url = module.params['url']
     dest = module.params['dest']

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -154,6 +154,7 @@ options:
   force:
     description:
       - If C(yes) do not get a cached copy.
+      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
     aliases: [ thirsty ]
@@ -573,6 +574,9 @@ def main():
         add_file_common_args=True,
         mutually_exclusive=[['body', 'src']],
     )
+
+    if module.params.get('thirsty'):
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
 
     url = module.params['url']
     body = module.params['body']

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -576,7 +576,7 @@ def main():
     )
 
     if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version=2.13)
+        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version='2.13')
 
     url = module.params['url']
     body = module.params['body']

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -16,6 +16,7 @@ options:
   force:
     description:
       - If C(yes) do not get a cached copy.
+      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
     aliases: [ thirsty ]


### PR DESCRIPTION
Fixes: #61236

##### SUMMARY
Deprecate alias 'thirsty' from all usages
Add handling for a `deprecated_aliases` option in `_handle_aliases` to account for mod_utils arg spec.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/copy.py
lib/ansible/modules/files/iso_extract.py
lib/ansible/modules/net_tools/basics/uri.py
lib/ansible/modules/net_tools/basics/get_url.py
lib/ansible/module_utils/urls.py
lib/ansible/module_utils/basic.py
lib/ansible/plugins/doc_fragments/url.py