### PR TITLE
ec2_launch_template: Fix integration tests

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -33,6 +33,9 @@
             "Sid": "AllowUnspecifiedEC2Resource",
             "Effect": "Allow",
             "Action": [
+                "ec2:*LaunchTemplate",
+                "ec2:*LaunchTemplateVersion",
+                "ec2:*LaunchTemplateVersions",
                 "ec2:AllocateAddress",
                 "ec2:AssociateAddress",
                 "ec2:AssociateDhcpOptions",

--- a/test/integration/targets/ec2_launch_template/meta/main.yml
+++ b/test/integration/targets/ec2_launch_template/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
@@ -12,7 +12,7 @@
     group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - include_tasks: cpu_options.yml

--- a/test/integration/targets/ec2_launch_template/playbooks/version_fail.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/version_fail.yml
@@ -7,7 +7,7 @@
     group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   tasks:
     - block:
@@ -23,7 +23,7 @@
           register: ec2_lt
           ignore_errors: yes
 
-        - name: check that graceful error message is returned when creation with cpu_options and old botocore 
+        - name: check that graceful error message is returned when creation with cpu_options and old botocore
           assert:
             that:
               - ec2_lt is failed


### PR DESCRIPTION
##### SUMMARY
Fix integration tests for ec2_launch_template
- Update AWS Policy to allow tests to run
- Update metadata so that prep modules are pulled into the test container
- Ignore security_token if it's not defined.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/ec2_launch_template.py

##### ADDITIONAL INFORMATION

See also #55775