### PR TITLE
Move instantiation of terminal plugin earlier

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -302,6 +302,9 @@ class Connection(NetworkConnectionBase):
             logging.getLogger('paramiko').setLevel(logging.DEBUG)
 
         if self._network_os:
+            self._terminal = terminal_loader.get(self._network_os, self)
+            if not self._terminal:
+                raise AnsibleConnectionFailure('network os %s is not supported' % self._network_os)
 
             self.cliconf = cliconf_loader.get(self._network_os, self)
             if self.cliconf:
@@ -390,10 +393,6 @@ class Connection(NetworkConnectionBase):
 
             self._ssh_shell = ssh.ssh.invoke_shell()
             self._ssh_shell.settimeout(self.get_option('persistent_command_timeout'))
-
-            self._terminal = terminal_loader.get(self._network_os, self)
-            if not self._terminal:
-                raise AnsibleConnectionFailure('network os %s is not supported' % self._network_os)
 
             self.queue_message('vvvv', 'loaded terminal plugin for network_os %s' % self._network_os)
 

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -34,19 +34,13 @@ from ansible.plugins.loader import connection_loader
 
 class TestConnectionClass(unittest.TestCase):
 
-    @patch("ansible.plugins.connection.paramiko_ssh.Connection._connect")
-    def test_network_cli__connect_error(self, mocked_super):
-        pc = PlayContext()
-        pc.network_os = 'ios'
-        conn = connection_loader.get('network_cli', pc, '/dev/null')
-
-        conn.ssh = MagicMock()
-        conn.receive = MagicMock()
-        conn._network_os = 'does not exist'
-
-        self.assertRaises(AnsibleConnectionFailure, conn._connect)
-
     def test_network_cli__invalid_os(self):
+        pc = PlayContext()
+        pc.network_os = 'does not exist'
+
+        self.assertRaises(AnsibleConnectionFailure, connection_loader.get, 'network_cli', pc, '/dev/null')
+
+    def test_network_cli__no_os(self):
         pc = PlayContext()
         pc.network_os = None
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Should fix `self._terminal == None` errors.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli