### PR TITLE
Update os_security_group_rule.py to support adding 132 SCTP rule

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -29,8 +29,8 @@ options:
      required: true
    protocol:
       description:
-        - IP protocols TCP UDP ICMP 112 (VRRP)
-      choices: ['tcp', 'udp', 'icmp', '112', None]
+        - IP protocols TCP UDP ICMP 112 (VRRP) 132 (SCTP)
+      choices: ['tcp', 'udp', 'icmp', '112', '132', None]
    port_range_min:
       description:
         - Starting port
@@ -273,7 +273,7 @@ def main():
         # NOTE(Shrews): None is an acceptable protocol value for
         # Neutron, but Nova will balk at this.
         protocol=dict(default=None,
-                      choices=[None, 'tcp', 'udp', 'icmp', '112']),
+                      choices=[None, 'tcp', 'udp', 'icmp', '112', '132']),
         port_range_min=dict(required=False, type='int'),
         port_range_max=dict(required=False, type='int'),
         remote_ip_prefix=dict(required=False, default=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, this module does not support to add 132 SCTP rule in security group rule of openstack. Could we add this support in this module? Thanks~

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_security_group_rule.py

##### ADDITIONAL INFORMATION
Normally, we could use below openstack command to add 132 SCTP as below (e.g.):
openstack security group rule create --protocol 132 --ingress --ethertype IPv4 --remote-ip 0.0.0.0/0 default

However, now, os_security_group_rule.py only support the choices of protocol: None, tcp, udp, icmp, 112)
With this code change, it could extend to support one more protocol 132 SCTP.