### PR TITLE
aws_codecommit: Fix integration tests and Add support for updating the description

### DIFF
--- a/changelogs/fragments/61263-aws_codecommit-description.yml
+++ b/changelogs/fragments/61263-aws_codecommit-description.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_codecommit - Support updating the description

--- a/hacking/aws_config/testing_policies/devops-policy.json
+++ b/hacking/aws_config/testing_policies/devops-policy.json
@@ -6,11 +6,11 @@
         "Effect": "Allow",
         "Action": [
           "codecommit:ListRepositories",
-          "codecommit:CreateRepositories",
-          "codecommit:DeleteRpositories"
+          "codecommit:*Repository",
+          "codecommit:*RepositoryDescription"
         ],
         "Resource": [
-          "arn:aws:codecommit:*"
+          "*"
         ]
       }
     ]

--- a/test/integration/targets/aws_codecommit/tasks/main.yml
+++ b/test/integration/targets/aws_codecommit/tasks/main.yml
@@ -7,11 +7,21 @@
       region: "{{ aws_region }}"
   block:
   # ============================================================
+  - name: Create a repository (CHECK MODE)
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      description: original comment
+      state: present
+    register: output
+    check_mode: yes
+  - assert:
+      that:
+        - output is changed
 
   - name: Create a repository
     aws_codecommit:
       name: "{{ resource_prefix }}_repo"
-      comment: original comment
+      description: original comment
       state: present
     register: output
   - assert:
@@ -19,17 +29,44 @@
         - output is changed
         - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
         - output.repository_metadata.repository_description == 'original comment'
-  # ============================================================
-  - name: Create a repository (CHECK MODE)
+
+  - name: No-op update to repository
     aws_codecommit:
-      name: "{{ resource_prefix }}_check_repo"
-      comment: original comment
+      name: "{{ resource_prefix }}_repo"
+      description: original comment
+      state: present
+    register: output
+  - assert:
+      that:
+        - output is not changed
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+        - output.repository_metadata.repository_description == 'original comment'
+
+  - name: Update repository description (CHECK MODE)
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      description: new comment
       state: present
     register: output
     check_mode: yes
   - assert:
       that:
         - output is changed
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+        - output.repository_metadata.repository_description == 'original comment'
+
+  - name: Update repository description
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      description: new comment
+      state: present
+    register: output
+  - assert:
+      that:
+        - output is changed
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+        - output.repository_metadata.repository_description == 'new comment'
+
   # ============================================================
   - name: Delete  a repository (CHECK MODE)
     aws_codecommit:
@@ -49,6 +86,15 @@
   - assert:
       that:
         - output is changed
+
+  - name: Delete a non-existent repository
+    aws_codecommit:
+      name: "{{ resource_prefix }}_repo"
+      state: absent
+    register: output
+  - assert:
+      that:
+        - output is not changed
 
   always:
      ###### TEARDOWN STARTS HERE ######

--- a/test/integration/targets/aws_codecommit/tasks/main.yml
+++ b/test/integration/targets/aws_codecommit/tasks/main.yml
@@ -17,8 +17,8 @@
   - assert:
       that:
         - output is changed
-        - output['repository_metadata'].repository_name == '{{ resource_prefix }}_repo'
-        - output['repository_metadata'].repository_description == 'original comment'
+        - output.repository_metadata.repository_name == '{{ resource_prefix }}_repo'
+        - output.repository_metadata.repository_description == 'original comment'
   # ============================================================
   - name: Create a repository (CHECK MODE)
     aws_codecommit:

--- a/test/integration/targets/aws_codecommit/tasks/main.yml
+++ b/test/integration/targets/aws_codecommit/tasks/main.yml
@@ -1,21 +1,18 @@
 ---
-- block:
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
   # ============================================================
-  - name: set connection information for all tasks
-    set_fact:
-      aws_connection_info: &aws_connection_info
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
-    no_log: true
-  # ============================================================
+
   - name: Create a repository
     aws_codecommit:
       name: "{{ resource_prefix }}_repo"
       comment: original comment
       state: present
-      <<: *aws_connection_info
     register: output
   - assert:
       that:
@@ -28,7 +25,6 @@
       name: "{{ resource_prefix }}_check_repo"
       comment: original comment
       state: present
-      <<: *aws_connection_info
     register: output
     check_mode: yes
   - assert:
@@ -39,17 +35,16 @@
     aws_codecommit:
       name: "{{ resource_prefix }}_repo"
       state: absent
-      <<: *aws_connection_info
     register: output
     check_mode: yes
   - assert:
       that:
         - output is changed
+
   - name: Delete  a repository
     aws_codecommit:
       name: "{{ resource_prefix }}_repo"
       state: absent
-      <<: *aws_connection_info
     register: output
   - assert:
       that:
@@ -61,5 +56,4 @@
       aws_codecommit:
         name: "{{ resource_prefix }}_repo"
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

- Fix integration tests
- Rename 'comment' option to 'description', since that's what we're actually modifying
- Add support for updating the description
- Always return repository metadata when the repository exists

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/aws_codecommit.py

##### ADDITIONAL INFORMATION

A part of the cleanup for #55775