### PR TITLE
ec2_launch_template: Add default_version and latest_version to output

### DIFF
--- a/changelogs/fragments/61279-ec2_launch_template-output.yml
+++ b/changelogs/fragments/61279-ec2_launch_template-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_launch_template - Update output to include latest_version and default_version, matching the documentation

--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -507,6 +507,10 @@ def format_module_output(module):
             int(v['version_number']) == int(template['latest_version_number'])
         )
     ][0]
+    if "version_number" in output['default_template']:
+        output['default_version'] = output['default_template']['version_number']
+    if "version_number" in output['latest_template']:
+        output['latest_version'] = output['latest_template']['version_number']
     return output
 
 

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml
@@ -17,6 +17,7 @@
   block:
     - include_tasks: cpu_options.yml
     - include_tasks: iam_instance_role.yml
+    - include_tasks: versions.yml
 
   always:
   - debug:

--- a/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/versions.yml
+++ b/test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/versions.yml
@@ -1,0 +1,62 @@
+- block:
+  - name: create simple instance template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+      instance_type: c4.large
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - lt.default_version == 1
+        - lt.latest_version == 1
+
+  - name: update simple instance template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      default_version: 1
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+      instance_type: m5.large
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - lt.default_version == 1
+        - lt.latest_version == 2
+
+  - name: update simple instance template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      image_id: "{{ ec2_ami_image[aws_region] }}"
+      tags:
+        TestId: "{{ resource_prefix }}"
+      instance_type: t3.medium
+    register: lt
+
+  - name: instance with cpu_options created with the right options
+    assert:
+      that:
+        - lt is success
+        - lt is changed
+        - lt.default_version == 3
+        - lt.latest_version == 3
+
+  always:
+  - name: delete the template
+    ec2_launch_template:
+      name: "{{ resource_prefix }}-simple"
+      state: absent
+    register: del_lt
+    retries: 10
+    until: del_lt is not failed
+    ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
ec2_launch_template: Add default_version and latest_version to output matching the documentation
- Add tests for default/latest version manipulation

Fixes: #61084

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/ec2_launch_template.py

##### ADDITIONAL INFORMATION

Note: Tests don't run under docker without changes from #61260