### PR TITLE
aws_asg: Fix idempotency when using tags and metrics

### DIFF
--- a/changelogs/fragments/61284-ec2_asg-idempotency.yml
+++ b/changelogs/fragments/61284-ec2_asg-idempotency.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- aws_ec2 - fix idempotency when managing tags
+- aws_ec2 - fix idempotency when metrics are enable

--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -18,10 +18,12 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:*LaunchConfiguration",
+                "autoscaling:*LoadBalancers",
                 "autoscaling:*AutoScalingGroup",
                 "autoscaling:*MetricsCollection",
                 "autoscaling:PutScalingPolicy",
-                "autoscaling:DeletePolicy"
+                "autoscaling:DeletePolicy",
+                "autoscaling:*Tags"
             ],
             "Resource": [
                 "arn:aws:autoscaling:{{aws_region}}:{{aws_account}}:*"
@@ -125,28 +127,22 @@
             "Sid": "AllowLoadBalancerOperations",
             "Effect": "Allow",
             "Action": [
+                "elasticloadbalancing:*LoadBalancer",
+                "elasticloadbalancing:*LoadBalancers",
+                "elasticloadbalancing:*LoadBalancerListeners",
+                "elasticloadbalancing:*TargetGroup",
                 "elasticloadbalancing:AddTags",
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
                 "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:CreateTargetGroup",
                 "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteLoadBalancerListeners",
                 "elasticloadbalancing:DeleteRule",
-                "elasticloadbalancing:DeleteTargetGroup",
-                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
                 "elasticloadbalancing:DescribeInstanceHealth",
                 "elasticloadbalancing:DescribeLoadBalancer*",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DisableAvailabilityZonesForLoadBalancer",
-                "elasticloadbalancing:EnableAvailabilityZonesForLoadBalancer",
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
                 "elasticloadbalancing:ModifyRule",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
                 "elasticloadbalancing:RemoveTags"
             ],
             "Resource": "*"

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1032,6 +1032,10 @@ def create_autoscaling_group(connection):
         if len(set_tags) > 0:
             have_tags = as_group.get('Tags')
             want_tags = asg_tags
+            if have_tags:
+                have_tags.sort(key=lambda x: x["Key"])
+            if want_tags:
+                want_tags.sort(key=lambda x: x["Key"])
             dead_tags = []
             have_tag_keyvals = [x['Key'] for x in have_tags]
             want_tag_keyvals = [x['Key'] for x in want_tags]

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -672,7 +672,10 @@ def get_properties(autoscaling_group):
     properties['termination_policies'] = autoscaling_group.get('TerminationPolicies')
     properties['target_group_arns'] = autoscaling_group.get('TargetGroupARNs')
     properties['vpc_zone_identifier'] = autoscaling_group.get('VPCZoneIdentifier')
-    properties['metrics_collection'] = autoscaling_group.get('EnabledMetrics')
+    metrics = autoscaling_group.get('EnabledMetrics')
+    if metrics:
+        metrics.sort(key=lambda x: x["Metric"])
+    properties['metrics_collection'] = metrics
 
     if properties['target_group_arns']:
         region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)

--- a/test/integration/targets/ec2_asg/tasks/main.yml
+++ b/test/integration/targets/ec2_asg/tasks/main.yml
@@ -186,6 +186,62 @@
         that:
           - "output.viable_instances == 1"
 
+    - name: Tag asg
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        tags:
+        - tag_a: 'value 1'
+          propagate_at_launch: no
+        - tag_b: 'value 2'
+          propagate_at_launch: yes
+      register: output
+
+    - assert:
+        that:
+          - "output.tags | length == 2"
+          - output is changed
+
+    - name: Re-Tag asg (different order)
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        tags:
+        - tag_b: 'value 2'
+          propagate_at_launch: yes
+        - tag_a: 'value 1'
+          propagate_at_launch: no
+      register: output
+
+    - assert:
+        that:
+          - "output.tags | length == 2"
+          - output is not changed
+
+    - name: Re-Tag asg new tags
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        tags:
+        - tag_c: 'value 3'
+          propagate_at_launch: no
+      register: output
+
+    - assert:
+        that:
+          - "output.tags | length == 1"
+          - output is changed
+
+    - name: Re-Tag asg update propagate_at_launch
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        tags:
+        - tag_c: 'value 3'
+          propagate_at_launch: yes
+      register: output
+
+    - assert:
+        that:
+          - "output.tags | length == 1"
+          - output is changed
+
     # - name: pause for a bit to make sure that the group can't be trivially deleted
     #   pause: seconds=30
     - name: kill asg

--- a/test/integration/targets/ec2_asg/tasks/main.yml
+++ b/test/integration/targets/ec2_asg/tasks/main.yml
@@ -242,6 +242,46 @@
           - "output.tags | length == 1"
           - output is changed
 
+    - name: Enable metrics collection
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: yes
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: Enable metrics collection (check idempotency)
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: yes
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
+    - name: Disable metrics collection
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: no
+      register: output
+
+    - assert:
+        that:
+          - output is changed
+
+    - name: Disable metrics collection (check idempotency)
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: no
+      register: output
+
+    - assert:
+        that:
+          - output is not changed
+
     # - name: pause for a bit to make sure that the group can't be trivially deleted
     #   pause: seconds=30
     - name: kill asg


### PR DESCRIPTION
##### SUMMARY

- Add integration tests for idempotency when managing tags
- Add integration tests for idempotency when metrics are enabled
- Fix idempotency when using tags and metrics
- Update AWS hacking policies to allow management of Tags on ASGs

Fixes: #61195
Fixes: #61085

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/ec2_asg.py

##### ADDITIONAL INFORMATION