### PR TITLE
Fix up env config source for Galaxy server list

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -308,7 +308,7 @@ class GalaxyCLI(CLI):
                         'key': key,
                     }
                 ],
-                'environment': [
+                'env': [
                     {'name': 'ANSIBLE_GALAXY_SERVER_%s_%s' % (section.upper(), key.upper())},
                 ],
                 'required': required,


### PR DESCRIPTION
##### SUMMARY
The config environment keyword is `env` not `environment`. This PR fixes that entry for the Galaxy server list definitions.

Fixes https://github.com/ansible/ansible/issues/61247

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy