### PR TITLE
json-ify environment values

### DIFF
--- a/changelogs/fragments/environment-dict.yaml
+++ b/changelogs/fragments/environment-dict.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Setting an environment value on a task that is a dict or list will be converted to JSON - https://github.com/ansible/ansible/issues/60956

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -238,6 +238,13 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             for environment in environments:
                 if environment is None or len(environment) == 0:
                     continue
+
+                # Ensure any env values that are dicts are converted to JSON
+                # https://github.com/ansible/ansible/issues/60956
+                for env_key, env_val in environment.items():
+                    if isinstance(env_val, dict) or isinstance(env_val, list):
+                        environment[env_key] = json.dumps(env_val)
+
                 temp_environment = self._templar.template(environment)
                 if not isinstance(temp_environment, dict):
                     raise AnsibleError("environment must be a dictionary, received %s (%s)" % (temp_environment, type(temp_environment)))

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -239,15 +239,16 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 if environment is None or len(environment) == 0:
                     continue
 
-                # Ensure any env values that are dicts are converted to JSON
-                # https://github.com/ansible/ansible/issues/60956
-                for env_key, env_val in environment.items():
-                    if isinstance(env_val, dict) or isinstance(env_val, list):
-                        environment[env_key] = json.dumps(env_val)
-
                 temp_environment = self._templar.template(environment)
                 if not isinstance(temp_environment, dict):
                     raise AnsibleError("environment must be a dictionary, received %s (%s)" % (temp_environment, type(temp_environment)))
+
+                # Ensure any env values that are dicts are converted to JSON
+                # https://github.com/ansible/ansible/issues/60956
+                for env_key, env_val in temp_environment.items():
+                    if isinstance(env_val, dict) or isinstance(env_val, list):
+                        temp_environment[env_key] = json.dumps(env_val)
+
                 # very deliberately using update here instead of combine_vars, as
                 # these environment settings should not need to merge sub-dicts
                 final_environment.update(temp_environment)

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -444,3 +444,27 @@
   file:
     path: "{{ output_dir_test }}/afile.txt"
     state: absent
+
+# https://github.com/ansible/ansible/issues/60956
+- set_fact:
+    some_var: some_value
+
+- set_fact:
+    bla:
+      foo: bar
+      aaa: '{{ some_var }}'
+
+- name: test out dict/list as json var
+  shell: env | grep testvar
+  register: shell_dict_env
+  environment:
+    testvar: '{{ item }}'
+  loop:
+  - '{{ bla }}'
+  - [ '{{ bla }}' ]
+
+- name: assert test var was passed through correctly
+  assert:
+    that:
+    - 'shell_dict_env.results[0].stdout_lines == [''testvar={"foo": "bar", "aaa": "some_value"}'']'
+    - 'shell_dict_env.results[1].stdout_lines == [''testvar=[{"foo": "bar", "aaa": "some_value"}]'']'

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -314,3 +314,27 @@
     win_file:
       path: C:\ansible test link
       state: absent
+
+# https://github.com/ansible/ansible/issues/60956
+- set_fact:
+    some_var: some_value
+
+- set_fact:
+    bla:
+      foo: bar
+      aaa: '{{ some_var }}'
+
+- name: test out dict/list as json var
+  win_shell: $env:testvar
+  register: shell_dict_env
+  environment:
+    testvar: '{{ item }}'
+  loop:
+  - '{{ bla }}'
+  - [ '{{ bla }}' ]
+
+- name: assert test var was passed through correctly
+  assert:
+    that:
+    - 'shell_dict_env.results[0].stdout_lines == [''{"foo": "bar", "aaa": "some_value"}'']'
+    - 'shell_dict_env.results[1].stdout_lines == [''[{"foo": "bar", "aaa": "some_value"}]'']'


### PR DESCRIPTION
##### SUMMARY
If an environment value (of an env key) set on a task is a dict or a list then the actual env value may not be what's expected. This PR converts these values to a json to ensure consistency across shell plugins.

Fixes https://github.com/ansible/ansible/issues/60956

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
environment

##### OTHER
Using the following playbook as an example

```
---
- hosts: '2019'
  gather_facts: no
  vars:
    some_var: some_value
    bla:
      foo: bar
      aaa: '{{ some_var }}'
      zzz: baz
  tasks:
  - win_shell: $env:testvar
    environment:
      testvar: '{{ item }}'
    loop:
    - '{{ bla }}'
    - [ '{{ bla }}' ]

  - shell: env | grep testvar
    environment:
      testvar: '{{ item }}'
    loop:
    - '{{ bla }}'
    - [ '{{ bla }}' ]
    delegate_to: localhost
```

Here is what happens before the PR

```
TASK [win_shell] ****************************************************************************************
task path: /home/jborean/dev/ansible-tester/adhoc.yml:11
Using module file /home/jborean/dev/ansible/lib/ansible/modules/windows/win_shell.ps1
Pipelining is enabled.
<server2019.domain.local> ESTABLISH WINRM CONNECTION FOR USER: vagrant-domain@DOMAIN.LOCAL on PORT 5985 TO server2019.domain.local
EXEC (via pipeline wrapper)
changed: [2019] => (item={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}) => {
    "ansible_loop_var": "item",                                                                          
    "changed": true,                                                                                                                                                                                                   "cmd": "$env:testvar",                                                                               
    "delta": "0:00:00.344241",                                                                           
    "end": "2019-08-25 09:23:51.109701",                                                                                                                                                                           
    "item": {                                                                                                                                                                                                              "aaa": "some_value",
        "foo": "bar",                                                                                                                                                                                                      "zzz": "baz"                                                                                                                                                                                                   },            
    "rc": 0,                                                                                                                                                                                                       
    "start": "2019-08-25 09:23:50.765459",                                                               
    "stderr": "",              
    "stderr_lines": [],
    "stdout": "System.Collections.Hashtable\r\n",
    "stdout_lines": [         
        "System.Collections.Hashtable"  
    ]              
}                       
Using module file /home/jborean/dev/ansible/lib/ansible/modules/windows/win_shell.ps1
Pipelining is enabled.          
EXEC (via pipeline wrapper)
changed: [2019] => (item=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]) => {
    "ansible_loop_var": "item",
    "changed": true,           
    "cmd": "$env:testvar",  
    "delta": "0:00:00.327646",
    "end": "2019-08-25 09:23:52.640482",
    "item": [                        
        {               
            "aaa": "some_value",
            "foo": "bar",
            "zzz": "baz"
        }
    ],                          
    "rc": 0,             
    "start": "2019-08-25 09:23:52.312835",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "System.Object[]\r\n",
    "stdout_lines": [                     
        "System.Object[]"
    ]                  
}                                                                                                        
                                                    
TASK [shell] ******************************************************************************************** 
task path: /home/jborean/dev/ansible-tester/adhoc.yml:18
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: jborean
<localhost> EXEC /bin/sh -c 'echo ~jborean && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797 `" && echo ansible-tmp-1566768232.8760302-15286391486797="` echo /home/jborean
/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797 `" ) && sleep 0'
Using module file /home/jborean/dev/ansible/lib/ansible/modules/commands/command.py                                                                                                                                
<localhost> PUT /home/jborean/.ansible/tmp/ansible-local-7891ckdydgjc/tmp35yo5qda TO /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797/AnsiballZ_command.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797/ /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797/AnsiballZ_command.py && s
leep 0'                                                                                                  
<localhost> EXEC /bin/sh -c 'testvar='"'"'{'"'"'"'"'"'"'"'"'foo'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'bar'"'"'"'"'"'"'"'"', '"'"'"'"'"'"'"'"'aaa'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'some_value'"'"'"'"'"'"'"'"', '"'"'
"'"'"'"'"'"'zzz'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'baz'"'"'"'"'"'"'"'"'}'"'"' /home/jborean/venvs/ansible-py37/bin/python /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797/AnsiballZ_comman
d.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /home/jborean/.ansible/tmp/ansible-tmp-1566768232.8760302-15286391486797/ > /dev/null 2>&1 && sleep 0'
changed: [2019 -> localhost] => (item={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}) => {
    "ansible_loop_var": "item",
    "changed": true,
    "cmd": "env | grep testvar",
    "delta": "0:00:00.003535",
    "end": "2019-08-26 07:23:53.076507",
    "invocation": {
        "module_args": {
            "_raw_params": "env | grep testvar",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "item": {
        "aaa": "some_value",
        "foo": "bar",
        "zzz": "baz"
    },
    "rc": 0,
    "start": "2019-08-26 07:23:53.072972",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "testvar={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}",
    "stdout_lines": [
        "testvar={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}"
    ]
}
<localhost> EXEC /bin/sh -c 'echo ~jborean && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856 `" && echo ansible-tmp-1566768233.0985906-61227789404856="` echo /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856 `" ) && sleep 0'
Using module file /home/jborean/dev/ansible/lib/ansible/modules/commands/command.py
<localhost> PUT /home/jborean/.ansible/tmp/ansible-local-7891ckdydgjc/tmpp0nn6ko1 TO /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856/AnsiballZ_command.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856/ /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856/AnsiballZ_command.py && sleep 0'
<localhost> EXEC /bin/sh -c 'testvar='"'"'[{'"'"'"'"'"'"'"'"'foo'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'bar'"'"'"'"'"'"'"'"', '"'"'"'"'"'"'"'"'aaa'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'some_value'"'"'"'"'"'"'"'"', '"'"'"'"'"'"'"'"'zzz'"'"'"'"'"'"'"'"': '"'"'"'"'"'"'"'"'baz'"'"'"'"'"'"'"'"'}]'"'"' /home/jborean/venvs/ansible-py37/bin/python /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856/AnsiballZ_command.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /home/jborean/.ansible/tmp/ansible-tmp-1566768233.0985906-61227789404856/ > /dev/null 2>&1 && sleep 0'
changed: [2019 -> localhost] => (item=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]) => {
    "ansible_loop_var": "item",
    "changed": true,
    "cmd": "env | grep testvar",
    "delta": "0:00:00.003162",
    "end": "2019-08-26 07:23:53.233212",
    "invocation": {
        "module_args": {
            "_raw_params": "env | grep testvar",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "item": [
        {
            "aaa": "some_value",
            "foo": "bar",
            "zzz": "baz"
        }
    ],
    "rc": 0,
    "start": "2019-08-26 07:23:53.230050",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "testvar=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]",
    "stdout_lines": [
        "testvar=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]"
    ]
}
```

Here is what happens after the PR

```
TASK [win_shell] ****************************************************************************************
task path: /home/jborean/dev/ansible-tester/adhoc.yml:11                              
Using module file /home/jborean/dev/ansible/lib/ansible/modules/windows/win_shell.ps1
Pipelining is enabled.                                                                                   
<server2019.domain.local> ESTABLISH WINRM CONNECTION FOR USER: vagrant-domain@DOMAIN.LOCAL on PORT 5985 TO server2019.domain.local
EXEC (via pipeline wrapper)                         
changed: [2019] => (item={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}) => {
    "ansible_loop_var": "item",                                                                                                                                                                                    
    "changed": true,                                                                                     
    "cmd": "$env:testvar",                                                                               
    "delta": "0:00:00.329618",                                                                                                                                                                                     
    "end": "2019-08-25 09:23:06.157097",                                                                                                                                                                           
    "item": {                                       
        "aaa": "some_value",                                                                                                                                                                                       
        "foo": "bar",                               
        "zzz": "baz"                                                                                                                                                                                               
    },                                                                                                   
    "rc": 0,                                        
    "start": "2019-08-25 09:23:05.827478",          
    "stderr": "",                                   
    "stderr_lines": [],                             
    "stdout": "{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}\r\n",
    "stdout_lines": [                               
        "{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}"
    ]                                               
}                                                   
Using module file /home/jborean/dev/ansible/lib/ansible/modules/windows/win_shell.ps1
Pipelining is enabled.                              
EXEC (via pipeline wrapper) 
changed: [2019] => (item=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]) => {
    "ansible_loop_var": "item",
    "changed": true,                                
    "cmd": "$env:testvar",            
    "delta": "0:00:00.313245",       
    "end": "2019-08-25 09:23:07.688085",            
    "item": [                                       
        {                                           
            "aaa": "some_value",                    
            "foo": "bar",                           
            "zzz": "baz"                            
        }                                           
    ],                                              
    "rc": 0,                                        
    "start": "2019-08-25 09:23:07.374839",          
    "stderr": "",                                   
    "stderr_lines": [],                             
    "stdout": "[{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}]\r\n",
    "stdout_lines": [                               
        "[{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}]"               
    ]                                               
}                                                                                                        
                                                    
TASK [shell] ********************************************************************************************
task path: /home/jborean/dev/ansible-tester/adhoc.yml:18
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: jborean
<localhost> EXEC /bin/sh -c 'echo ~jborean && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418 `" && echo ansible-tmp-1566768187.9035008-78083565786418="` echo /home/jborean
/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418 `" ) && sleep 0'                                                                                                                                       
Using module file /home/jborean/dev/ansible/lib/ansible/modules/commands/command.py
<localhost> PUT /home/jborean/.ansible/tmp/ansible-local-7389gdide8_w/tmpbbqxe6w7 TO /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418/AnsiballZ_command.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418/ /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418/AnsiballZ_command.py && s
leep 0'                                             
<localhost> EXEC /bin/sh -c 'testvar='"'"'{"foo": "bar", "aaa": "some_value", "zzz": "baz"}'"'"' /home/jborean/venvs/ansible-py37/bin/python /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-780835657864
18/AnsiballZ_command.py && sleep 0'                 
<localhost> EXEC /bin/sh -c 'rm -f -r /home/jborean/.ansible/tmp/ansible-tmp-1566768187.9035008-78083565786418/ > /dev/null 2>&1 && sleep 0'
changed: [2019 -> localhost] => (item={'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}) => {
    "ansible_loop_var": "item",
    "changed": true,
    "cmd": "env | grep testvar",
    "delta": "0:00:00.003325",
    "end": "2019-08-26 07:23:08.105863",
    "invocation": {
        "module_args": {
            "_raw_params": "env | grep testvar",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "item": {
        "aaa": "some_value",
        "foo": "bar",
        "zzz": "baz"
    },
    "rc": 0,
    "start": "2019-08-26 07:23:08.102538",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "testvar={\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}",
    "stdout_lines": [
        "testvar={\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}"
    ]
}
<localhost> EXEC /bin/sh -c 'echo ~jborean && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812 `" && echo ansible-tmp-1566768188.1285756-66597294527812="` echo /home/jborean
/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812 `" ) && sleep 0'
Using module file /home/jborean/dev/ansible/lib/ansible/modules/commands/command.py
<localhost> PUT /home/jborean/.ansible/tmp/ansible-local-7389gdide8_w/tmp6vs7lh90 TO /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812/AnsiballZ_command.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812/ /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812/AnsiballZ_command.py && s
leep 0'
<localhost> EXEC /bin/sh -c 'testvar='"'"'[{"foo": "bar", "aaa": "some_value", "zzz": "baz"}]'"'"' /home/jborean/venvs/ansible-py37/bin/python /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-6659729452
7812/AnsiballZ_command.py && sleep 0'
<localhost> EXEC /bin/sh -c 'rm -f -r /home/jborean/.ansible/tmp/ansible-tmp-1566768188.1285756-66597294527812/ > /dev/null 2>&1 && sleep 0'
changed: [2019 -> localhost] => (item=[{'foo': 'bar', 'aaa': 'some_value', 'zzz': 'baz'}]) => {
    "ansible_loop_var": "item",
    "changed": true,
    "cmd": "env | grep testvar",
    "delta": "0:00:00.003017",
    "end": "2019-08-26 07:23:08.258902",
    "invocation": {
        "module_args": {
            "_raw_params": "env | grep testvar",
            "_uses_shell": true,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": true
        }
    },
    "item": [
        {
            "aaa": "some_value",
            "foo": "bar",
            "zzz": "baz"
        }
    ],
    "rc": 0,
    "start": "2019-08-26 07:23:08.255885",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "testvar=[{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}]",
    "stdout_lines": [
        "testvar=[{\"foo\": \"bar\", \"aaa\": \"some_value\", \"zzz\": \"baz\"}]"
    ]
}
```

We can see that before PowerShell is completely useless as the raw object being sent to the host is an actual dict/list and .NET is not helpful in their ToString implementations. On Python it is slightly more useful but the values aren't fully JSON compliant with their single quotes instead of double quotes. With this PR now both platforms align with each other and the JSON being set as the env var in Python uses double quotes.

An alternative is to set the key inside an actual string like;

```
environment:
  testvar: '"{{ my_dict }}"'`
```

But this causes the env var to be `testvar="{"key": "value"}"` where the value is double quoted potentially causing more issues with parsing it.