### PR TITLE
Change collection PS util import pattern

### DIFF
--- a/changelogs/fragments/powershell-collection_util.yaml
+++ b/changelogs/fragments/powershell-collection_util.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Adjusted PowerShell and C# collection util imports to use a Python package name that reflects the location of the util in the collection. This is a breaking change, for more information see :ref:`porting_2.9_guide` for more information.

--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -86,7 +86,7 @@ module_utils
 
 When coding with ``module_utils`` in a collection, the Python ``import`` statement needs to take into account the FQCN along with the ``ansible_collections`` convention. The resulting Python import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
-The following example snippets shows a Python and PowerShell module using both default Ansible ``module_utils`` and
+The following example snippets show a Python and PowerShell module using both default Ansible ``module_utils`` and
 those provided by a collection. In this example the namespace is ``ansible_example``, the collection is ``community``.
 In the Python example the ``module_util`` in question is called ``qradar`` such that the FQCN is
 ``ansible_example.community.plugins.module_utils.qradar``:

--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -86,10 +86,10 @@ module_utils
 
 When coding with ``module_utils`` in a collection, the Python ``import`` statement needs to take into account the FQCN along with the ``ansible_collections`` convention. The resulting Python import will look like ``from ansible_collections.{namespace}.{collection}.plugins.module_utils.{util} import {something}``
 
-The following example snippet shows a module using both default Ansible ``module_utils`` and
-those provided by a collection. In this example the namespace is
-``ansible_example``, the collection is ``community``, and the ``module_util`` in
-question is called ``qradar`` such that the FQCN is ``ansible_example.community.plugins.module_utils.qradar``:
+The following example snippets shows a Python and PowerShell module using both default Ansible ``module_utils`` and
+those provided by a collection. In this example the namespace is ``ansible_example``, the collection is ``community``.
+In the Python example the ``module_util`` in question is called ``qradar`` such that the FQCN is
+``ansible_example.community.plugins.module_utils.qradar``:
 
 .. code-block:: python
 
@@ -115,6 +115,26 @@ question is called ``qradar`` such that the FQCN is ``ansible_example.community.
         headers={"Content-Type": "application/json"},
         not_rest_data_keys=['state']
     )
+
+
+In the PowerShell example the ``module_util`` in question is called ``hyperv`` such that the FCQN is
+``ansible_example.community.plugins.module_utils.hyperv``:
+
+.. code-block:: powershell
+
+    #!powershell
+    #AnsibleRequires -CSharpUtil Ansible.Basic
+    #AnsibleRequires -PowerShell ansible_collections.ansible_example.community.plugins.module_utils.hyperv
+
+    $spec = @{
+        name = @{ required = $true; type = "str" }
+        state = @{ required = $true; choices = @("present", "absent") }
+    }
+    $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+    Invoke-HyperVFunction -Name $module.Params.name
+
+    $module.ExitJson()
 
 
 roles directory

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -34,6 +34,29 @@ Deprecated
 No notable changes
 
 
+Collection loader changes
+=========================
+
+The way to import a PowerShell of C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+2.8 a util was imported with the following syntax:
+
+.. code-block:: powershell
+
+    #AnsibleRequires -CSharpUtil AnsibleCollections.namespace_name.collection_name.util_filename
+    #AnsibleRequires -PowerShell AnsibleCollections.namespace_name.collection_name.util_filename
+
+In Ansible 2.9 this was changed to:
+
+.. code-block:: powershell
+
+    #AnsibleRequires -CSharpUtil ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+    #AnsibleRequires -PowerShell ansible_collections.namespace_name.collection_name.plugins.module_utils.util_filename
+
+The change in the collection import name also requires any C# util namespaces to be updated with the newer name
+format. This is more verbose but is designed to make sure we avoid plugin name conflicts across separate plugin types
+and to standardise how imports work in PowerShell with how Python modules work.
+
+
 Modules
 =======
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -37,7 +37,7 @@ No notable changes
 Collection loader changes
 =========================
 
-The way to import a PowerShell of C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
+The way to import a PowerShell or C# module util from a collection has changed in the Ansible 2.9 release. In Ansible
 2.8 a util was imported with the following syntax:
 
 .. code-block:: powershell

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -13,7 +13,12 @@ import random
 import re
 
 from distutils.version import LooseVersion
-from importlib import import_module
+
+# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
+try:
+    from importlib import import_module
+except ImportError:
+    import_module = __import__
 
 from ansible import constants as C
 from ansible.errors import AnsibleError

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -39,8 +39,9 @@ class PSModuleDepFinder(object):
 
         self._re_cs_module = [
             # Reference C# module_util in another C# util
+            # 'using ansible_collections.{namespace}.{collection}.plugins.module_utils.{name}'
             re.compile(to_bytes(r'(?i)^using\s((Ansible\..+)|'
-                                r'(ansible_collections\.[\w.]+\.[\w.]+\.plugins\.module_utils\.[\w.]+));\s*$')),
+                                r'(ansible_collections\.\w+\.\w+\.plugins\.module_utils\.[\w\.]+));\s*$')),
         ]
 
         self._re_cs_in_ps_module = [
@@ -48,7 +49,7 @@ class PSModuleDepFinder(object):
             # '#AnsibleRequires -CSharpUtil Ansible.{name}'
             # '#AnsibleRequires -CSharpUtil ansible_collections.{namespace}.{collection}.plugins.module_utils.{name}'
             re.compile(to_bytes(r'(?i)^#\s*ansiblerequires\s+-csharputil\s+((Ansible\..+)|'
-                                r'(ansible_collections\.[\w.]+\.[\w.]+\.plugins\.module_utils\.[\w.]+))')),
+                                r'(ansible_collections\.\w+\.\w+\.plugins\.module_utils\.[\w\.]+))')),
         ]
 
         self._re_ps_module = [
@@ -59,7 +60,7 @@ class PSModuleDepFinder(object):
             # '#AnsibleRequires -PowerShell ansible_collections.{namespace}.{collection}.plugins.module_utils.{name}'
             # '#AnsibleRequires -PowerShell Ansible.ModuleUtils.{name}'
             re.compile(to_bytes(r'(?i)^#\s*ansiblerequires\s+-powershell\s+(((Ansible\.ModuleUtils\..+))|'
-                                r'(ansible_collections\.[\w.]+\.[\w.]+\.plugins\.module_utils\.[\w.]+))')),
+                                r'(ansible_collections\.\w+\.\w+\.plugins\.module_utils\.[\w\.]+))')),
         ]
 
         self._re_wrapper = re.compile(to_bytes(r'(?i)^#\s*ansiblerequires\s+-wrapper\s+(\w*)'))

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/AnotherCSMU.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/AnotherCSMU.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace AnsibleCollections.testns.testcoll.AnotherCSMU
+namespace ansible_collections.testns.testcoll.plugins.module_utils.AnotherCSMU
 {
     public class AnotherThing
     {

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMU.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMU.cs
@@ -1,15 +1,19 @@
 using System;
 
-using AnsibleCollections.testns.testcoll.AnotherCSMU;
+using ansible_collections.testns.testcoll.plugins.module_utils.AnotherCSMU;
+using ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subcs;
 
-namespace AnsibleCollections.testns.testcoll.MyCSMU
+//TypeAccelerator -Name MyCSMU -TypeName CustomThing
+
+namespace ansible_collections.testns.testcoll.plugins.module_utils.MyCSMU
 {
     public class CustomThing
     {
         public static string HelloWorld()
         {
-            string res = AnotherThing.CallMe();
-            return String.Format("Hello from user_mu collection-hosted MyCSMU, also {0}", res);
+            string res1 = AnotherThing.CallMe();
+            string res2 = NestedUtil.HelloWorld();
+            return String.Format("Hello from user_mu collection-hosted MyCSMU, also {0} and {1}", res1, res2);
         }
     }
 }

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1
@@ -1,4 +1,4 @@
-Function CallMe-FromUserPSMU {
+Function Invoke-FromUserPSMU {
     <#
     .SYNOPSIS
     Test function
@@ -6,4 +6,4 @@ Function CallMe-FromUserPSMU {
     return "from user_mu"
 }
 
-Export-ModuleMember -Function CallMe-FromUserPSMU
+Export-ModuleMember -Function Invoke-FromUserPSMU

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/subcs.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/subcs.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subcs
+{
+    public class NestedUtil
+    {
+        public static string HelloWorld()
+        {
+            string res = "Hello from subpkg.subcs";
+            return res;
+        }
+    }
+}

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/subps.psm1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/subpkg/subps.psm1
@@ -1,0 +1,9 @@
+Function Invoke-SubUserPSMU {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "from subpkg.subps.psm1"
+}
+
+Export-ModuleMember -Function Invoke-SubUserPSMU

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_csmu.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_csmu.ps1
@@ -3,11 +3,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#AnsibleRequires -CSharpUtil AnsibleCollections.testns.testcoll.MyCSMU
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.MyCSMU
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subcs
 
 $spec = @{
     options = @{
-        data = @{ type = "str"; default = "called from $([AnsibleCollections.testns.testcoll.MyCSMU.CustomThing]::HelloWorld())" }
+        data = @{ type = "str"; default = "called from $([ansible_collections.testns.testcoll.plugins.module_utils.MyCSMU.CustomThing]::HelloWorld())" }
     }
     supports_check_mode = $true
 }
@@ -20,4 +21,6 @@ if ($data -eq "crash") {
 
 $module.Result.ping = $data
 $module.Result.source = "user"
+$module.Result.subpkg = [ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subcs.NestedUtil]::HelloWorld()
+$module.Result.type_accelerator = "called from $([MyCSMU]::HelloWorld())"
 $module.ExitJson()

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
@@ -3,11 +3,12 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#AnsibleRequires -Powershell AnsibleCollections.testns.testcoll.MyPSMU
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.MyPSMU
+#AnsibleRequires -PowerShell ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subps
 
 $spec = @{
     options = @{
-        data = @{ type = "str"; default = "called from $(CallMe-FromUserPSMU)" }
+        data = @{ type = "str"; default = "called from $(Invoke-FromUserPSMU)" }
     }
     supports_check_mode = $true
 }
@@ -20,4 +21,5 @@ if ($data -eq "crash") {
 
 $module.Result.ping = $data
 $module.Result.source = "user"
+$module.Result.subpkg = Invoke-SubUserPSMU
 $module.ExitJson()

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # run test playbook
-ansible-playbook -i "${INVENTORY_PATH}"  -i ./a.statichost.yml -v "${TEST_PLAYBOOK}"
+ansible-playbook -i "${INVENTORY_PATH}"  -i ./a.statichost.yml -v "${TEST_PLAYBOOK}" "$@"
 
 # test adjacent with --playbook-dir
 export ANSIBLE_COLLECTIONS_PATHS=''

--- a/test/integration/targets/collections/windows.yml
+++ b/test/integration/targets/collections/windows.yml
@@ -16,5 +16,13 @@
       that:
       - selfcontained_out.source == 'user'
       - csbasic_only_out.source == 'user'
-      - uses_coll_psmu.source == 'user' and 'user_mu' in uses_coll_psmu.ping
-      - uses_coll_csmu.source == 'user' and 'user_mu' in uses_coll_csmu.ping
+      # win_uses_coll_psmu
+      - uses_coll_psmu.source == 'user'
+      - "'user_mu' in uses_coll_psmu.ping"
+      - uses_coll_psmu.subpkg == 'from subpkg.subps.psm1'
+      # win_uses_coll_csmu
+      - uses_coll_csmu.source == 'user'
+      - "'user_mu' in uses_coll_csmu.ping"
+      - "'Hello from subpkg.subcs' in uses_coll_csmu.ping"
+      - uses_coll_csmu.subpkg == 'Hello from subpkg.subcs'
+      - uses_coll_csmu.type_accelerator == uses_coll_csmu.ping

--- a/test/integration/targets/win_module_utils/library/add_type_test.ps1
+++ b/test/integration/targets/win_module_utils/library/add_type_test.ps1
@@ -227,5 +227,50 @@ Add-CSharpType -References $defined_symbol -CompileSymbols "SYMBOL1"
 $actual = [Namespace8.Class8]::GetString()
 Assert-Equals -actual $actual -expected "symbol"
 
+$type_accelerator = @'
+using System;
+
+//TypeAccelerator -Name AnsibleType -TypeName Class9
+
+namespace Namespace9
+{
+    public class Class9
+    {
+        public static string GetString()
+        {
+            return "a";
+        }
+    }
+}
+'@
+Add-CSharpType -Reference $type_accelerator
+$actual = [AnsibleType]::GetString()
+Assert-Equals -actual $actual -expected "a"
+
+$missing_type_class = @'
+using System;
+
+//TypeAccelerator -Name AnsibleTypeMissing -TypeName MissingClass
+
+namespace Namespace10
+{
+    public class Class10
+    {
+        public static string GetString()
+        {
+            return "b";
+        }
+    }
+}
+'@
+$failed = $false
+try {
+    Add-CSharpType -Reference $missing_type_class
+} catch {
+    $failed = $true
+    Assert-Equals -actual $_.Exception.Message -expected "Failed to find compiled class 'MissingClass' for custom TypeAccelerator."
+}
+Assert-Equals -actual $failed -expected $true
+
 $result.res = "success"
 Exit-Json -obj $result

--- a/test/lib/ansible_test/_internal/csharp_import_analysis.py
+++ b/test/lib/ansible_test/_internal/csharp_import_analysis.py
@@ -49,7 +49,7 @@ def get_csharp_module_utils_name(path):  # type: (str) -> str
     base_path = data_context().content.module_utils_csharp_path
 
     if data_context().content.collection:
-        prefix = 'AnsibleCollections.' + data_context().content.collection.prefix
+        prefix = 'ansible_collections.' + data_context().content.collection.prefix + 'plugins.module_utils.'
     else:
         prefix = ''
 
@@ -78,7 +78,7 @@ def extract_csharp_module_utils_imports(path, module_utils, is_pure_csharp):
     if is_pure_csharp:
         pattern = re.compile(r'(?i)^using\s((?:Ansible|AnsibleCollections)\..+);$')
     else:
-        pattern = re.compile(r'(?i)^#\s*ansiblerequires\s+-csharputil\s+((?:Ansible|AnsibleCollections)\..+)')
+        pattern = re.compile(r'(?i)^#\s*ansiblerequires\s+-csharputil\s+((?:Ansible|ansible.collections)\..+)')
 
     with open(path, 'r') as module_file:
         for line_number, line in enumerate(module_file, 1):

--- a/test/lib/ansible_test/_internal/powershell_import_analysis.py
+++ b/test/lib/ansible_test/_internal/powershell_import_analysis.py
@@ -45,7 +45,7 @@ def get_powershell_module_utils_name(path):  # type: (str) -> str
     base_path = data_context().content.module_utils_powershell_path
 
     if data_context().content.collection:
-        prefix = 'AnsibleCollections.' + data_context().content.collection.prefix
+        prefix = 'ansible_collections.' + data_context().content.collection.prefix + '.plugins.module_utils.'
     else:
         prefix = ''
 
@@ -82,7 +82,7 @@ def extract_powershell_module_utils_imports(path, module_utils):
 
         for line in lines:
             line_number += 1
-            match = re.search(r'(?i)^#\s*(?:requires\s+-module(?:s?)|ansiblerequires\s+-powershell)\s*((?:Ansible|AnsibleCollections)\..+)', line)
+            match = re.search(r'(?i)^#\s*(?:requires\s+-module(?:s?)|ansiblerequires\s+-powershell)\s*((?:Ansible|ansible_collections)\..+)', line)
 
             if not match:
                 continue

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6027,7 +6027,6 @@ test/integration/targets/async_fail/library/async_test.py future-import-boilerpl
 test/integration/targets/async_fail/library/async_test.py metaclass-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py future-import-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py metaclass-boilerplate
-test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMU.psm1 pslint:PSUseApprovedVerbs
 test/integration/targets/expect/files/test_command.py future-import-boilerplate
 test/integration/targets/expect/files/test_command.py metaclass-boilerplate
 test/integration/targets/get_url/files/testserver.py future-import-boilerplate


### PR DESCRIPTION
##### SUMMARY
Change the way PowerShell and C# module utils inside a collection are referenced. This is a breaking change but is being done to unify import patterns between the Python, PowerShell, and C#. Collections are a tech preview in 2.8 so this should hopefully be in by 2.9 before the existing pattern is more solidified.

This PR also adds a way to specify a type accelerator inside a C# util to simplify the type name a bit more. This is optional and a suggestion to add to Ansible but can have consequences if 2 utils use the same accelerator.

This also requires some changes in `ansible-test` but waiting to see what @nitzmahone and @mattclay says before delving in there.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
PowerShell
Collections