### PR TITLE
Add support for reset_connection in persistent connection

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -352,8 +352,8 @@ class NetworkConnectionBase(ConnectionBase):
                 except Exception:
                     pass
                 finally:
-                    if os.path.exists(self._socket_path ):
-                        os.remove(self._socket_path )
+                    if os.path.exists(self._socket_path):
+                        os.remove(self._socket_path)
                         setattr(self.connection, '_socket_path', None)
                         setattr(self.connection, '_connected', False)
 

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -354,8 +354,8 @@ class NetworkConnectionBase(ConnectionBase):
                 finally:
                     if os.path.exists(self._socket_path):
                         os.remove(self._socket_path)
-                        setattr(self.connection, '_socket_path', None)
-                        setattr(self.connection, '_connected', False)
+                        self._socket_path = None
+                        self._connected = False
 
             if os.path.exists(lock_path):
                 os.remove(lock_path)

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -255,8 +255,14 @@ class Connection(NetworkConnectionBase):
         if self._connected:
             self.queue_message('vvvv', "closing http(s) connection to device")
             self.logout()
-
+        self.shutdown()
         super(Connection, self).close()
+
+    def reset(self):
+        if self._socket_path:
+            self.close()
+            self.queue_message('vvvv', 'resetting persistent connection for socket_path %s for host %s'
+                               % (self._socket_path, self._play_context.remote_addr))
 
     @ensure_connect
     def send(self, path, data, **kwargs):

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -342,4 +342,11 @@ class Connection(NetworkConnectionBase):
     def close(self):
         if self._manager:
             self._manager.close_session()
+        self.shutdown()
         super(Connection, self).close()
+
+    def reset(self):
+        if self._socket_path:
+            self.close()
+            self.queue_message('vvvv', 'resetting persistent connection for socket_path %s for host %s'
+                               % (self._socket_path, self._play_context.remote_addr))

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -433,7 +433,16 @@ class Connection(NetworkConnectionBase):
                 self.paramiko_conn.close()
                 self.paramiko_conn = None
                 self.queue_message('debug', "ssh connection has been closed successfully")
+        self.shutdown()
         super(Connection, self).close()
+
+    def reset(self):
+        if self._socket_path:
+            self.close()
+            self.queue_message('vvvv', 'resetting persistent connection for socket_path %s for host %s'
+                               % (self._socket_path, self._play_context.remote_addr))
+
+        self.queue_message('vvvv', 'reset call on connection instance for host %s' % self._play_context.remote_addr)
 
     def receive(self, command=None, prompts=None, answer=None, newline=True, prompt_retry_check=False, check_all=False):
         '''


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Implement `reset()` method for persistent connections
   (network_cli/netconf/httpapi) to support
   meta: reset_connection
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/plugins/connection/__init__.py
ansible/plugins/connection/httpapi.py
ansible/plugins/connection/netconf.py
ansible/plugins/connection/network_cli.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
