### PR TITLE
ansible_tower: Add custom_virtualenv attribute when applicable (#60200)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -171,6 +171,13 @@ options:
       version_added: 2.7
       type: bool
       default: 'no'
+    custom_virtualenv:
+      version_added: "2.9"
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+      type: str
+      required: False
+      default: ''
     state:
       description:
         - Desired state of the resource.
@@ -197,6 +204,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
     survey_enabled: yes
     survey_spec: "{{ lookup('file', 'my_survey.json') }}"
+    custom_virtualenv: "/var/lib/awx/venv/custom-venv/"
 '''
 
 from ansible.module_utils.ansible_tower import TowerModule, tower_auth_config, tower_check_mode
@@ -277,6 +285,7 @@ def main():
         playbook=dict(required=True),
         credential=dict(default=''),
         vault_credential=dict(default=''),
+        custom_virtualenv=dict(type='str', required=False, default=''),
         forks=dict(type='int'),
         limit=dict(default=''),
         verbosity=dict(type='int', choices=[0, 1, 2, 3, 4], default=0),

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
@@ -30,6 +30,13 @@ options:
     description:
       description:
         - The description to use for the organization.
+    custom_virtualenv:
+      version_added: "2.9"
+      description:
+        - Local absolute file path containing a custom Python virtualenv to use.
+      type: str
+      required: False
+      default: ''
     state:
       description:
         - Desired state of the resource.
@@ -44,6 +51,14 @@ EXAMPLES = '''
   tower_organization:
     name: "Foo"
     description: "Foo bar organization"
+    state: present
+    tower_config_file: "~/tower_cli.cfg"
+
+- name: Create tower organization using 'foo-venv' as default Python virtualenv
+  tower_organization:
+    name: "Foo"
+    description: "Foo bar organization using foo-venv"
+    custom_virtualenv: "/var/lib/awx/venv/foo-venv/"
     state: present
     tower_config_file: "~/tower_cli.cfg"
 '''
@@ -63,6 +78,7 @@ def main():
     argument_spec = dict(
         name=dict(required=True),
         description=dict(),
+        custom_virtualenv=dict(type='str', required=False, default=''),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 
@@ -70,6 +86,7 @@ def main():
 
     name = module.params.get('name')
     description = module.params.get('description')
+    custom_virtualenv = module.params.get('custom_virtualenv')
     state = module.params.get('state')
 
     json_output = {'organization': name, 'state': state}
@@ -80,7 +97,7 @@ def main():
         organization = tower_cli.get_resource('organization')
         try:
             if state == 'present':
-                result = organization.modify(name=name, description=description, create_on_missing=True)
+                result = organization.modify(name=name, description=description, custom_virtualenv=custom_virtualenv, create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = organization.delete(name=name)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -77,6 +77,9 @@ options:
       version_added: "2.8"
       description:
         - Local absolute file path containing a custom Python virtualenv to use
+      type: str
+      required: False
+      default: ''
     organization:
       description:
         - Primary key of organization for project.
@@ -135,7 +138,7 @@ def main():
         scm_update_on_launch=dict(type='bool', default=False),
         scm_update_cache_timeout=dict(type='int', default=0),
         job_timeout=dict(type='int', default=0),
-        custom_virtualenv=dict(),
+        custom_virtualenv=dict(type='str', required=False, default=''),
         local_path=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
     )


### PR DESCRIPTION
##### SUMMARY
In Ansible Tower/AWX, there are three kinds of objects that can be tied
to custom python virtual environment:
  - job template
  - project
  - organization

This patch updates the three ansible modules that creates those objects
so that the 'custom_virtualenv' attribute can be set if specified.

Fixes #60200

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_tower

##### ADDITIONAL INFORMATION
Testing Done: via a playbook, test organization, projet then template creation
without any 'custom_virtualenv' attribute specified. Check that the
resources get created and that their python env is set to default. Then
re-do the same test but this time with the 'custom_virtualenv' attribute
specified. Ensure in AWX UI that those resources have the right
'custom_virtualenv' set.