### PR TITLE
tower_credential: Missing 'kind' attribute (#61324)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -221,7 +221,7 @@ KIND_CHOICES = {
 
 def credential_type_for_v1_kind(params, module):
     credential_type_res = tower_cli.get_resource('credential_type')
-    kind = params.pop('kind')
+    kind = params.get('kind')
     arguments = {'managed_by_tower': True}
     if kind == 'ssh':
         if params.get('vault_password'):


### PR DESCRIPTION
In the 'tower_credential' module, when the credential 'kind' is set to
'vault', the code expects the other parameter 'vault_id' to be set.
Unfortunately, in the module 'credential_type_for_v1_kind' method, the
'kind' parameter is popped, i.e. remove from the module dict of
parameters leading to the following error:

> Parameter 'vault_id' is only valid if parameter 'kind' is specified as
'vault'

Fixes: #45644, #61324

Testing Done: Manually create a playbook with a task as follow
  - name: Create vault with ID 'bar' exists
    tower_credential:
      name: Foobar vault
      organization: Foobar
      kind: vault
      vault_id: bar
      vault_password: foobar

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
