### PR TITLE
[2.8] acme_certificate: make compatible to Buypass' ACME v2 testing endpoint

### DIFF
--- a/changelogs/fragments/60727-acme_certificate-acme-compatibility.yml
+++ b/changelogs/fragments/60727-acme_certificate-acme-compatibility.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - improve compatibility when finalizing ACME v2 orders. Fixes problem with Buypass' ACME v2 testing endpoint."

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -637,12 +637,10 @@ class ACMEClient(object):
         if info['status'] not in [200]:
             raise ModuleFailException("Error new cert: CODE: {0} RESULT: {1}".format(info['status'], result))
 
-        order = info['location']
-
         status = result['status']
         while status not in ['valid', 'invalid']:
             time.sleep(2)
-            result, dummy = self.account.get_request(order)
+            result, dummy = self.account.get_request(self.order_uri)
             status = result['status']
 
         if status != 'valid':


### PR DESCRIPTION
##### SUMMARY
Backport of #60727 to stable-2.8. Improves compatibility so that other CA should work as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
