### PR TITLE
VMware: fix to create vm using a customization spec with an ip address

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1696,6 +1696,23 @@ class PyVmomiHelper(PyVmomi):
             cc_mgr = self.content.customizationSpecManager
             if cc_mgr.DoesCustomizationSpecExist(name=custom_spec_name):
                 temp_spec = cc_mgr.GetCustomizationSpec(name=custom_spec_name)
+                spec_adapter_counter = 0
+                if len(temp_spec.spec.nicSettingMap) != len(self.params['networks']):
+                    self.module.fail_json(msg="Number of custom spec network adapter mappings does not equal the num. of defined network adapter mappings")
+                for guest_map in temp_spec.spec.nicSettingMap:
+                    if 'ip' in self.params['networks'][spec_adapter_counter] and 'netmask' in self.params['networks'][spec_adapter_counter]:
+                        guest_map.adapter.ip = vim.vm.customization.FixedIp()
+                        guest_map.adapter.ip.ipAddress = str(self.params['networks'][spec_adapter_counter]['ip'])
+                        guest_map.adapter.subnetMask = str(self.params['networks'][spec_adapter_counter]['netmask'])
+                    spec_adapter_counter += 1
+                if len(temp_spec.spec.nicSettingMap) != len(self.params['networks']):
+                    self.module.fail_json(msg="Number of custom spec network adapter mappings does not equal the num. of defined network adapter mappings")
+                for guest_map in temp_spec.spec.nicSettingMap:
+                    if 'ip' in self.params['networks'][spec_adapter_counter] and 'netmask' in self.params['networks'][spec_adapter_counter]:
+                        guest_map.adapter.ip = vim.vm.customization.FixedIp()
+                        guest_map.adapter.ip.ipAddress = str(self.params['networks'][spec_adapter_counter]['ip'])
+                        guest_map.adapter.subnetMask = str(self.params['networks'][spec_adapter_counter]['netmask'])
+                    spec_adapter_counter += 1
                 self.customspec = temp_spec.spec
                 return
             else:


### PR DESCRIPTION
##### SUMMARY

In vSphere you can configure a customization spec to accept user input upon VM creation. One of the most common configuration is to allow a user to specify an IP address upon VM creation using a customization spec. The orignal vmware_guest module did not account for this functionality. My fix allows for one NIC to be used as an input with a customization spec. 

Fixes issue number #55560

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
vmware_guest
vmware_guest_customization_facts

##### ADDITIONAL INFORMATION

```paste below

```
