### PR TITLE
Adding 3 new methods, get/monitor/execute, to support other FortiOS modules

### DIFF
--- a/lib/ansible/module_utils/network/fortios/fortios.py
+++ b/lib/ansible/module_utils/network/fortios/fortios.py
@@ -96,6 +96,17 @@ class FortiOSHandler(object):
                 url += '?vdom=' + vdom
         return url
 
+    def mon_url(self, path, name, vdom=None, mkey=None):
+        url = '/api/v2/monitor/' + path + '/' + name
+        if mkey:
+            url = url + '/' + str(mkey)
+        if vdom:
+            if vdom == "global":
+                url += '?global=1'
+            else:
+                url += '?vdom=' + vdom
+        return url
+
     def schema(self, path, name, vdom=None):
         if vdom is None:
             url = self.cmdb_url(path, name) + "?action=schema"
@@ -132,6 +143,20 @@ class FortiOSHandler(object):
                 return None
         return mkey
 
+    def get(self, path, name, vdom=None, mkey=None, parameters=None):
+        url = self.cmdb_url(path, name, vdom, mkey=mkey)
+
+        status, result_data = self._conn.send_request(url=url, params=parameters, method='GET')
+
+        return self.formatresponse(result_data, vdom=vdom)
+
+    def monitor(self, path, name, vdom=None, mkey=None, parameters=None):
+        url = self.mon_url(path, name, vdom, mkey)
+
+        status, result_data = self._conn.send_request(url=url, params=parameters, method='GET')
+
+        return self.formatresponse(result_data, vdom=vdom)
+
     def set(self, path, name, data, mkey=None, vdom=None, parameters=None):
 
         if not mkey:
@@ -155,6 +180,14 @@ class FortiOSHandler(object):
         url = self.cmdb_url(path, name, vdom, mkey=None)
 
         status, result_data = self._conn.send_request(url=url, params=parameters, data=json.dumps(data), method='POST')
+
+        return self.formatresponse(result_data, vdom=vdom)
+
+    def execute(self, path, name, data, vdom=None,
+                mkey=None, parameters=None, timeout=300):
+        url = self.mon_url(path, name, vdom, mkey=mkey)
+
+        status, result_data = self._conn.send_request(url=url, params=parameters, data=json.dumps(data), method='POST', timeout=timeout)
 
         return self.formatresponse(result_data, vdom=vdom)
 


### PR DESCRIPTION

##### SUMMARY
This PR is to enhance the existing fortios module_utils module
I added 3 new methods (features) in fortios module_utils module
get method to retrieve configurational data (GET)
monitor method to retrieve operational data (GET)
execute method to perform action (POST)
(mon_url method supports the monitor and execute methods to get monitor API URL)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
fortios module_utils module

##### ADDITIONAL INFORMATION
These 3 methods (features) will be helpful in these areas,
1) For future FortiOS modules development or enhancement
2) Help FortiOS modules use httpapi connection, and remove the dependency on the fortiosapi python library (fortiosapi python libray is required in legacy mode with local connection)
