### PR TITLE
vmware_guest_disk_info/test: ensure the test VM is running

### DIFF
--- a/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_facts/tasks/main.yml
@@ -9,6 +9,15 @@
     setup_datastore: true
     setup_virtualmachines: true
 
+- name: set state to poweron the first VM
+  vmware_guest_powerstate:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ virtual_machines[0].name }}"
+    folder: '{{ f0 }}'
+    state: powered-on
 
 - name: Gather facts about virtual machine disks
   vmware_guest_disk_facts: &get_facts

--- a/test/integration/targets/vmware_guest_disk_info/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk_info/tasks/main.yml
@@ -9,6 +9,15 @@
     setup_datastore: true
     setup_virtualmachines: true
 
+- name: set state to poweron the first VM
+  vmware_guest_powerstate:
+    validate_certs: no
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: "{{ virtual_machines[0].name }}"
+    folder: '{{ f0 }}'
+    state: powered-on
 
 - name: Gather info about virtual machine disks
   vmware_guest_disk_info: &get_info


### PR DESCRIPTION
##### SUMMARY

`vmware_guest_disk_info` expects the VM to be running. Since
964783fbd2f738e938deedf338d8a36c1b54ccd6, `prepare_vmware_tests`
creates the test VM with the `powered-off` state. This to increase
the performance.
This commit ensures the test-suite actually run against a running VM,
as expected.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

vmware_guest_disk_info
vmware_guest_disk_facts
<!--- Write the short name of the module, plugin, task or feature below -->
