### PR TITLE
Allow tower inventory plugin to accept integer inventory_id

### DIFF
--- a/changelogs/fragments/61338-tower-inventory-integer-inventory_id.yaml
+++ b/changelogs/fragments/61338-tower-inventory-integer-inventory_id.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- tower inventory plugin - fix TypeError when giving integer_id as integer (https://github.com/ansible/ansible/issues/61333)


### PR DESCRIPTION
##### SUMMARY
Before 2.9, the tower inventory plugin would happily accept `inventory_id` of any type.

It was part of our intention to accept inventory primary key values (which could be integers) or strings (which could be from the Tower feature of named URLs).

It seems that the old config parser would automatically convert the integers to strings (thus the added `to_native` call), and this plugin would rely on that behavior to work.

We never documented this functionality with Named URLs, so that really muddied the waters.

fixes #61333

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/tower.py

##### ADDITIONAL INFORMATION
This will maintain all functionality from Ansible 2.8. We could do additional custom type validation, but it's not high priority for me.
