### PR TITLE
Fix errors that would cause sanity checks to fail if implemented

### DIFF
--- a/lib/ansible/module_utils/pure.py
+++ b/lib/ansible/module_utils/pure.py
@@ -28,6 +28,9 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 HAS_PURESTORAGE = True
 try:
     from purestorage import purestorage

--- a/lib/ansible/modules/storage/purestorage/purefa_dsrole.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_dsrole.py
@@ -31,6 +31,7 @@ options:
   role:
     description:
     - The directory service role to work on
+    type: str
     choices: [ array_admin, ops_admin, readonly, storage_admin ]
   group_base:
     type: str

--- a/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pgsnap.py
@@ -30,6 +30,7 @@ options:
   suffix:
     description:
     - Suffix of snapshot name.
+    type: str
   state:
     description:
     - Define whether the protection group snapshot should exist or not.

--- a/lib/ansible/modules/storage/purestorage/purefb_fs.py
+++ b/lib/ansible/modules/storage/purestorage/purefb_fs.py
@@ -418,7 +418,7 @@ def main():
             user_quota=dict(type='str'),
             group_quota=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
-            size=dict()
+            size=dict(default='32G')
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
Add fixes to ensure python 3.6 sanity checks pass if they were all enforced

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/pure.py
purefa_dsrole.py
purefa_pgsnap.py
purefb_fs.py