### PR TITLE
Add HMAC lookup

### DIFF
--- a/lib/ansible/plugins/lookup/hmac.py
+++ b/lib/ansible/plugins/lookup/hmac.py
@@ -38,7 +38,7 @@ DOCUMENTATION = """
             description: List of strings to calculate HMAC signatures
             required: True
         secret:
-            description: Secret to use to create the signature`
+            description: Secret to use to create the signature
             required: True
         encoding:
             description: Encoding of the secret.  Can be any Python-valid string encoding or "base64"
@@ -55,7 +55,7 @@ DOCUMENTATION = """
 EXAMPLE = """
 - name: Calculate HMAC using password
   debug:
-    msg: "{{ lookup('hmac', 'string_to_be_signed', secret=hmac_secret }}"
+    msg: "{{ lookup('hmac', 'string_to_be_signed', secret=hmac_secret) }}"
 
 - name: Calculate HMAC using base64-encoded password
   debug:
@@ -70,6 +70,8 @@ RETURN = """
   _raw:
     description: base64-encoded hmac signature
 """
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -78,7 +80,9 @@ import hmac
 import hashlib
 from inspect import getmembers
 
+
 class LookupModule(LookupBase):
+
 
     def run(self, terms, inject=None, variables=None, **kwargs):
         try:
@@ -108,7 +112,7 @@ class LookupModule(LookupBase):
             elif algorithm == 'sha512':
                 hasher = hashlib.sha512
             else:
-                raise Exception("Unknown hash method: {}".format(algorithm))
+                raise Exception("Unknown hash method: {0}".format(algorithm))
             ret = []
             for term in terms:
                 mac = hmac.new(secret_bytes, term.encode(), hasher).digest()
@@ -116,4 +120,4 @@ class LookupModule(LookupBase):
                 ret.append(mac_b64)
             return ret
         except Exception as e:
-            raise AnsibleError('HMAC Failed: {}'.format(str(e)))
+            raise AnsibleError('HMAC Failed: {0}'.format(str(e)))

--- a/lib/ansible/plugins/lookup/hmac.py
+++ b/lib/ansible/plugins/lookup/hmac.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# (c) 2019, Daryl Banttari <dbanttari@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: hmac
+    author:
+        - Daryl Banttari <dbanttari@gmail.com>
+    version_added: 2.9
+    requirements:
+        - base64
+        - hmac
+        - hashlib
+    short_description: Calculates an HMAC authorization token
+    description:
+        - This lookup calculates an HMAC authorization token
+        - Result is a base64-encoded string
+    options:
+        _terms:
+            description: List of strings to calculate HMAC signatures
+            required: True
+        secret:
+            description: Secret to use to create the signature`
+            required: True
+        encoding:
+            description: Encoding of the secret.  Can be any Python-valid string encoding or "base64"
+            required: false
+            default: utf-8
+        algorithm:
+            description: Hash algorithm to use (see https://docs.python.org/3/library/hashlib.html)
+            required: false
+            default: sha256
+    notes:
+        - If HMACs from different secrets are needed, you'll need to make multiple calls to this lookup
+"""
+
+EXAMPLE = """
+- name: Calculate HMAC using password
+  debug:
+    msg: "{{ lookup('hmac', 'string_to_be_signed', secret=hmac_secret }}"
+
+- name: Calculate HMAC using base64-encoded password
+  debug:
+    msg: "{{ lookup('hmac', 'string_to_be_signed', secret=hmac_secret, encoding='base64') }}"
+
+- name: Calculate SHA512 HMAC using base64-encoded password
+  debug:
+    msg: "{{ lookup('hmac', 'string_to_be_signed', secret=hmac_secret, encoding='base64', algorithm='sha512') }}"
+"""
+
+RETURN = """
+  _raw:
+    description: base64-encoded hmac signature
+"""
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from base64 import b64encode, b64decode
+import hmac
+import hashlib
+from inspect import getmembers
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, inject=None, variables=None, **kwargs):
+        try:
+            if isinstance(terms, str):
+                terms = [terms]
+            secret = kwargs.get('secret')
+            encoding = kwargs.get('encoding', 'utf-8')
+            if encoding == 'base64':
+                secret_bytes = b64decode(secret)
+            else:
+                secret_bytes = secret.encode(encoding)
+            algorithm = kwargs.get('algorithm', 'sha256').lower()
+            # was looking at using `inspect` to get a reference without this mess
+            # (python2's hmac method doesn't accept a string argument for hasher)
+            # but that was leading to some non-trivial code complication, so with
+            # deference to the KISS principle:
+            if algorithm == 'md5':
+                hasher = hashlib.md5
+            elif algorithm == 'sha1':
+                hasher = hashlib.sha1
+            elif algorithm == 'sha224':
+                hasher = hashlib.sha224
+            elif algorithm == 'sha256':
+                hasher = hashlib.sha256
+            elif algorithm == 'sha384':
+                hasher = hashlib.sha384
+            elif algorithm == 'sha512':
+                hasher = hashlib.sha512
+            else:
+                raise Exception("Unknown hash method: {}".format(algorithm))
+            ret = []
+            for term in terms:
+                mac = hmac.new(secret_bytes, term.encode(), hasher).digest()
+                mac_b64 = b64encode(mac).decode('utf-8')
+                ret.append(mac_b64)
+            return ret
+        except Exception as e:
+            raise AnsibleError('HMAC Failed: {}'.format(str(e)))

--- a/lib/ansible/plugins/lookup/hmac.py
+++ b/lib/ansible/plugins/lookup/hmac.py
@@ -70,8 +70,6 @@ RETURN = """
   _raw:
     description: base64-encoded hmac signature
 """
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -82,7 +80,6 @@ from inspect import getmembers
 
 
 class LookupModule(LookupBase):
-
 
     def run(self, terms, inject=None, variables=None, **kwargs):
         try:

--- a/test/units/plugins/lookup/test_hmac.py
+++ b/test/units/plugins/lookup/test_hmac.py
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# Make coding more python3-ish
-from __future__ import (absolute_import, print_function)
+from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest

--- a/test/units/plugins/lookup/test_hmac.py
+++ b/test/units/plugins/lookup/test_hmac.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# (c) 2019, Daryl Banttari <dbanttari@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+from ansible.plugins.lookup.hmac import LookupModule
+
+class TestHMACLookup(unittest.TestCase):
+
+    testcases = (
+        # simple
+        dict(
+            term='string_to_be_signed',
+            secret='asdf',
+            expected=['qoR/uNWjQQa8sS77mRjUDPqV2ZXa44Y1Xnb/3AUvmlg='],
+        ),
+        # multiple terms
+        # (assert that the hasher hasn't been polluted via multiple update()s)
+        dict(
+            term=['string_to_be_signed2', 'string_to_be_signed'],
+            secret='asdf',
+            expected=['fGW4FjaIgVzGlWLQ/SITPzp2cs5q9I9wOOVO7YsZPu4=','qoR/uNWjQQa8sS77mRjUDPqV2ZXa44Y1Xnb/3AUvmlg='],
+        ),
+        # alternative algorithm
+        dict(
+            term='string_to_be_signed',
+            secret='asdf',
+            encoding='utf-8',
+            algorithm='sha512',
+            expected=['vy7cBvrvVxQIQWvJGB6iE7nHmMovpFBWGRwTDr54DLpxRBpDC77+iOu1GskUEj1jhBRofEjtTNZeaBqqqfr+uA=='],
+        ),
+        # base64-encoded secret + alternative algorithm
+        dict(
+            term='string_to_be_signed',
+            secret='YXNkZg==', # 'asdf' | b64encode
+            encoding='base64',
+            algorithm='sha512',
+            expected=['vy7cBvrvVxQIQWvJGB6iE7nHmMovpFBWGRwTDr54DLpxRBpDC77+iOu1GskUEj1jhBRofEjtTNZeaBqqqfr+uA=='],
+        ),
+    )
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_parse_parameters(self):
+        test = LookupModule()
+        for testcase in self.testcases:
+            self.assertEqual(test.run(testcase['term'], **testcase), testcase['expected'])

--- a/test/units/plugins/lookup/test_hmac.py
+++ b/test/units/plugins/lookup/test_hmac.py
@@ -23,6 +23,7 @@ __metaclass__ = type
 from units.compat import unittest
 from ansible.plugins.lookup.hmac import LookupModule
 
+
 class TestHMACLookup(unittest.TestCase):
 
     testcases = (
@@ -37,7 +38,7 @@ class TestHMACLookup(unittest.TestCase):
         dict(
             term=['string_to_be_signed2', 'string_to_be_signed'],
             secret='asdf',
-            expected=['fGW4FjaIgVzGlWLQ/SITPzp2cs5q9I9wOOVO7YsZPu4=','qoR/uNWjQQa8sS77mRjUDPqV2ZXa44Y1Xnb/3AUvmlg='],
+            expected=['fGW4FjaIgVzGlWLQ/SITPzp2cs5q9I9wOOVO7YsZPu4=', 'qoR/uNWjQQa8sS77mRjUDPqV2ZXa44Y1Xnb/3AUvmlg='],
         ),
         # alternative algorithm
         dict(
@@ -50,7 +51,7 @@ class TestHMACLookup(unittest.TestCase):
         # base64-encoded secret + alternative algorithm
         dict(
             term='string_to_be_signed',
-            secret='YXNkZg==', # 'asdf' | b64encode
+            secret='YXNkZg==',  # 'asdf' | b64encode
             encoding='base64',
             algorithm='sha512',
             expected=['vy7cBvrvVxQIQWvJGB6iE7nHmMovpFBWGRwTDr54DLpxRBpDC77+iOu1GskUEj1jhBRofEjtTNZeaBqqqfr+uA=='],


### PR DESCRIPTION
##### SUMMARY
Create HMAC lookup to simplify signing requests for APIs that use it but don't have Ansible modules

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
hmac

##### ADDITIONAL INFORMATION
```
- name: Calculate HMAC using password
  debug:
    msg: "{{ lookup('hmac', 'string_to_be_signed', secret='asdf') }}"
```
```
TASK [test : Calculate HMAC using password] **********************************************************************
task path: ***/roles/test/tasks/main.yml:7
ok: [localhost] => {
    "msg": "qoR/uNWjQQa8sS77mRjUDPqV2ZXa44Y1Xnb/3AUvmlg="
}
```