### PR TITLE
Changes references to ansible_facts (FA_RA)

### DIFF
--- a/changelogs/fragments/61355-purefa_ra_change_facts_to_ra_info.yaml
+++ b/changelogs/fragments/61355-purefa_ra_change_facts_to_ra_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefa_ra - change resulting fact dict from I(ansible_facts) to I(ra_info)  (https://github.com/ansible/ansible/pull/61355)

--- a/lib/ansible/modules/storage/purestorage/purefa_ra.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_ra.py
@@ -38,9 +38,10 @@ EXAMPLES = r'''
   purefa_ra:
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
+  register: result
 
-  debug:
-    var: ansible_facts.fa_ra
+- debug:
+    msg: "Remote Assist: {{ result['ra_info'] }}"
 
 - name: Disable Remote Assist port
   purefa_ra:
@@ -75,7 +76,7 @@ def enable_ra(module, array):
                                  'port': ra_data['port']}
         except Exception:
             module.fail_json(msg='Getting Remote Assist failed')
-    module.exit_json(changed=changed, ansible_facts=ra_facts)
+    module.exit_json(changed=changed, ra_info=ra_facts)
 
 
 def disable_ra(module, array):


### PR DESCRIPTION
##### SUMMARY
ansible_facts should not be used as in this module based on new core requirements.
Change resulting dict to be `ra_info` and modify examples

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_ra.py