### PR TITLE
Changes references to ansible_facts (FB_S3USER)

### DIFF
--- a/changelogs/fragments/61356-purefb_s3user_change_facts_to_s3user_info.yaml
+++ b/changelogs/fragments/61356-purefb_s3user_change_facts_to_s3user_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - purefb_s3user - change resulting fact dict from I(ansible_facts) to I(s3user_info)  (https://github.com/ansible/ansible/pull/61356)

--- a/lib/ansible/modules/storage/purestorage/purefb_s3user.py
+++ b/lib/ansible/modules/storage/purestorage/purefb_s3user.py
@@ -52,9 +52,10 @@ EXAMPLES = r'''
     account: bar
     fb_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
+  register: result
 
-  debug:
-    var: ansible_facts.fb_s3user
+- debug:
+    msg: "S3 User: {{ result['s3user_info'] }}"
 
 - name: Delete object store user foo in account bar
   purefb_s3user:
@@ -120,7 +121,7 @@ def update_s3user(module, blade):
             delete_s3user(module, blade)
             module.fail_json(msg='Object Store User {0}: Creation failed'.format(user))
     changed = True
-    module.exit_json(changed=changed, ansible_facts=s3user_facts)
+    module.exit_json(changed=changed, s3user_info=s3user_facts)
 
 
 def create_s3user(module, blade):
@@ -143,7 +144,7 @@ def create_s3user(module, blade):
         changed = True
     except Exception:
         module.fail_json(msg='Object Store User {0}: Creation failed'.format(user))
-    module.exit_json(changed=changed, ansible_facts=s3user_facts)
+    module.exit_json(changed=changed, s3user_info=s3user_facts)
 
 
 def delete_s3user(module, blade):


### PR DESCRIPTION
##### SUMMARY
ansible_facts should not be used as in this module based on new core requirements.
Change resulting dict to be `s3user_info` and modify examples

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefb_s3user.py