### PR TITLE
Typo in example for ios_l2_interface - allow_vlans

### DIFF
--- a/lib/ansible/modules/network/ios/_ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/_ios_l2_interface.py
@@ -82,7 +82,7 @@ EXAMPLES = """
     name: GigabitEthernet0/5
     mode: trunk
     native_vlan: 10
-    trunk_vlans: 5-10
+    trunk_allowed_vlans: 5-10
 - name: Ensure GigabitEthernet0/5 is a trunk port and ensure 2-50 are being tagged (doesn't mean others aren't also being tagged)
   ios_l2_interface:
     name: GigabitEthernet0/5


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
trunk_vlans -> trunk_allowed_vlans
The description says 'only has vlans' but the example doesn't use the right parameter
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interface documentation, examples

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```before
- name: Ensure GigabitEthernet0/5 only has vlans 5-10 as trunk vlans
  ios_l2_interface:
    name: GigabitEthernet0/5
    mode: trunk
    native_vlan: 10
    trunk_vlans: 5-10

after
- name: Ensure GigabitEthernet0/5 only has vlans 5-10 as trunk vlans
  ios_l2_interface:
    name: GigabitEthernet0/5
    mode: trunk
    native_vlan: 10
    trunk_allowed_vlans: 5-10
```
