### PR TITLE
postgresql modules: add seealso section

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -88,6 +88,19 @@ options:
       - Set I(version=latest) to update the extension to the latest available version.
     type: str
     version_added: '2.9'
+seealso:
+- name: PostgreSQL extensions
+  description: General information about PostgreSQL extensions.
+  link: https://www.postgresql.org/docs/current/external-extensions.html
+- name: CREATE EXTENSION reference
+  description: Complete reference of the CREATE EXTENSION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-createextension.html
+- name: ALTER EXTENSION reference
+  description: Complete reference of the ALTER EXTENSION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-alterextension.html
+- name: DROP EXTENSION reference
+  description: Complete reference of the DROP EXTENSION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-droppublication.html
 notes:
 - The default authentication assumes that you are either logging in as
   or sudo'ing to the C(postgres) account on the host.

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -19,8 +19,6 @@ module: postgresql_idx
 short_description: Create or drop indexes from a PostgreSQL database
 description:
 - Create or drop indexes from a PostgreSQL database.
-- For more information see U(https://www.postgresql.org/docs/current/sql-createindex.html),
-  U(https://www.postgresql.org/docs/current/sql-dropindex.html).
 version_added: '2.8'
 
 options:
@@ -105,11 +103,27 @@ options:
   cascade:
     description:
     - Automatically drop objects that depend on the index,
-      and in turn all objects that depend on those objects U(https://www.postgresql.org/docs/current/sql-dropindex.html).
+      and in turn all objects that depend on those objects.
     - It used only with I(state=absent).
     - Mutually exclusive with I(concurrent=yes)
     type: bool
     default: no
+
+seealso:
+- module: postgresql_table
+- module: postgresql_tablespace
+- name: PostgreSQL indexes reference
+  description: General information about PostgreSQL indexes.
+  link: https://www.postgresql.org/docs/current/indexes.html
+- name: CREATE INDEX reference
+  description: Complete reference of the CREATE INDEX command documentation.
+  link: https://www.postgresql.org/docs/current/sql-createindex.html
+- name: ALTER INDEX reference
+  description: Complete reference of the ALTER INDEX command documentation.
+  link: https://www.postgresql.org/docs/current/sql-alterindex.html
+- name: DROP INDEX reference
+  description: Complete reference of the DROP INDEX command documentation.
+  link: https://www.postgresql.org/docs/current/sql-dropindex.html
 
 notes:
 - The index building process can affect database performance.

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -46,6 +46,8 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
+seealso:
+- module: postgresql_ping
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment: postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -30,10 +30,6 @@ description:
 - Be carefull when marking a language as trusted since this could be a potential
   security breach. Untrusted languages allow only users with the PostgreSQL superuser
   privilege to use this language to create new functions.
-- For more information about PostgreSQL languages see the official documentation
-  U(https://www.postgresql.org/docs/current/sql-createlanguage.html),
-  U(https://www.postgresql.org/docs/current/sql-alterlanguage.html),
-  U(https://www.postgresql.org/docs/current/sql-droplanguage.html).
 version_added: '1.7'
 options:
   lang:
@@ -107,6 +103,19 @@ options:
     type: str
     aliases: [ ssl_rootcert ]
     version_added: '2.8'
+seealso:
+- name: PostgreSQL languages
+  description: General information about PostgreSQL languages.
+  link: https://www.postgresql.org/docs/current/xplang.html
+- name: CREATE LANGUAGE reference
+  description: Complete reference of the CREATE LANGUAGE command documentation.
+  link: https://www.postgresql.org/docs/current/sql-createlanguage.html
+- name: ALTER LANGUAGE reference
+  description: Complete reference of the ALTER LANGUAGE command documentation.
+  link: https://www.postgresql.org/docs/current/sql-alterlanguage.html
+- name: DROP LANGUAGE reference
+  description: Complete reference of the DROP LANGUAGE command documentation.
+  link: https://www.postgresql.org/docs/current/sql-droplanguage.html
 author:
 - Jens Depuydt (@jensdepuydt)
 - Thomas O'Donnell (@andytom)

--- a/lib/ansible/modules/database/postgresql/postgresql_membership.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_membership.py
@@ -18,15 +18,12 @@ DOCUMENTATION = r'''
 module: postgresql_membership
 short_description: Add or remove PostgreSQL roles from groups
 description:
-- Adds or removes PostgreSQL roles from groups (other roles)
-  U(https://www.postgresql.org/docs/current/role-membership.html).
-- Users are roles with login privilege (see U(https://www.postgresql.org/docs/current/role-attributes.html) for more information).
+- Adds or removes PostgreSQL roles from groups (other roles).
+- Users are roles with login privilege.
 - Groups are PostgreSQL roles usually without LOGIN privelege.
 - "Common use case:"
-- 1) add a new group (groups) by M(postgresql_user) module
-  U(https://docs.ansible.com/ansible/latest/modules/postgresql_user_module.html) with I(role_attr_flags=NOLOGIN)
+- 1) add a new group (groups) by M(postgresql_user) module with I(role_attr_flags=NOLOGIN)
 - 2) grant them desired privileges by M(postgresql_privs) module
-  U(https://docs.ansible.com/ansible/latest/modules/postgresql_privs_module.html)
 - 3) add desired PostgreSQL users to the new group (groups) by this module
 version_added: '2.8'
 options:
@@ -74,6 +71,16 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
+seealso:
+- module: postgresql_user
+- module: postgresql_privs
+- module: postgresql_owner
+- name: PostgreSQL role membership reference
+  description: Complete reference of the PostgreSQL role membership documentation.
+  link: https://www.postgresql.org/docs/current/role-membership.html
+- name: PostgreSQL role attributes reference
+  description: Complete reference of the PostgreSQL role attributes documentation.
+  link: https://www.postgresql.org/docs/current/role-attributes.html
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment: postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_owner.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_owner.py
@@ -20,8 +20,6 @@ short_description: Change an owner of PostgreSQL database object
 description:
 - Change an owner of PostgreSQL database object.
 - Also allows to reassign the ownership of database objects owned by a database role to another role.
-- For more information about REASSIGN OWNED BY command
-  see U(https://www.postgresql.org/docs/current/sql-reassign-owned.html).
 version_added: '2.8'
 
 options:
@@ -51,7 +49,6 @@ options:
     - Pay attention - it reassignes all objects owned by this role(s) in the I(db)!
     - If role(s) exists, always returns changed True.
     - Cannot reassign ownership of objects that are required by the database system.
-    - For more information see U(https://www.postgresql.org/docs/current/sql-reassign-owned.html).
     - Mutually exclusive with C(obj_type).
     type: list
   fail_on_role:
@@ -74,6 +71,13 @@ options:
     - Permissions checking for SQL commands is carried out as though
       the session_role were the one that had logged in originally.
     type: str
+seealso:
+- module: postgresql_user
+- module: postgresql_privs
+- module: postgresql_membership
+- name: PostgreSQL REASSIGN OWNED command reference
+  description: Complete reference of the PostgreSQL REASSIGN OWNED command documentation.
+  link: https://www.postgresql.org/docs/current/sql-reassign-owned.html
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment: postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -112,6 +112,11 @@ notes:
    - With the 'order' parameter you can control which field is used to sort first, next and last.
    - The module supports a check mode and a diff mode.
 
+seealso:
+- name: PostgreSQL pg_hba.conf file reference
+  description: Complete reference of the PostgreSQL pg_hba.conf file documentation.
+  link: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
+
 requirements:
     - ipaddress
 

--- a/lib/ansible/modules/database/postgresql/postgresql_ping.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ping.py
@@ -27,6 +27,8 @@ options:
     type: str
     aliases:
     - login_db
+seealso:
+- module: postgresql_info
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment: postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -172,6 +172,20 @@ notes:
   another user also, R can still access database objects via these privileges.
 - When revoking privileges, C(RESTRICT) is assumed (see PostgreSQL docs).
 
+seealso:
+- module: postgresql_user
+- module: postgresql_owner
+- module: postgresql_membership
+- name: PostgreSQL privileges
+  description: General information about PostgreSQL privileges.
+  link: https://www.postgresql.org/docs/current/ddl-priv.html
+- name: PostgreSQL GRANT command reference
+  description: Complete reference of the PostgreSQL GRANT command documentation.
+  link: https://www.postgresql.org/docs/current/sql-grant.html
+- name: PostgreSQL REVOKE command reference
+  description: Complete reference of the PostgreSQL REVOKE command documentation.
+  link: https://www.postgresql.org/docs/current/sql-revoke.html
+
 extends_documentation_fragment:
 - postgres
 


### PR DESCRIPTION
##### SUMMARY
postgresql modules: add seealso section

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_info.py```
```lib/ansible/modules/database/postgresql/postgresql_lang.py```
```lib/ansible/modules/database/postgresql/postgresql_ext.py```
```lib/ansible/modules/database/postgresql/postgresql_idx.py```
```lib/ansible/modules/database/postgresql/postgresql_membership.py```
```lib/ansible/modules/database/postgresql/postgresql_owner.py```
```lib/ansible/modules/database/postgresql/postgresql_pg_hba.py```
```lib/ansible/modules/database/postgresql/postgresql_pg_ping.py```
```lib/ansible/modules/database/postgresql/postgresql_privs.py```

