### PR TITLE
routeros_facts: fix for error when there's more than 10 interfaces

### DIFF
--- a/lib/ansible/modules/network/routeros/routeros_facts.py
+++ b/lib/ansible/modules/network/routeros/routeros_facts.py
@@ -246,6 +246,7 @@ class Interfaces(FactsBase):
     ]
 
     DETAIL_RE = re.compile(r'([\w\d\-]+)=\"?(\w{3}/\d{2}/\d{4}\s\d{2}:\d{2}:\d{2}|[\w\d\-\.:/]+)')
+    WRAPPED_LINE_RE = re.compile(r'^\s+(?!\d)')
 
     def populate(self):
         super(Interfaces, self).populate()
@@ -307,8 +308,8 @@ class Interfaces(FactsBase):
         for line in data.split('\n'):
             if len(line) == 0 or line[:5] == 'Flags':
                 continue
-            elif re.match(r'\s\d', line[:2]):
-                preprocessed.append(line[2:])
+            elif not re.match(self.WRAPPED_LINE_RE, line):
+                preprocessed.append(line)
             else:
                 preprocessed[-1] += line
         return preprocessed

--- a/test/units/modules/network/routeros/fixtures/routeros_facts/interface_print_detail_without-paging
+++ b/test/units/modules/network/routeros/fixtures/routeros_facts/interface_print_detail_without-paging
@@ -3,5 +3,32 @@ Flags: D - dynamic, X - disabled, R - running, S - slave
        mac-address=00:1C:42:36:52:90 last-link-up-time=sep/25/2018 06:30:04
        link-downs=0
  1  R  name="ether2" default-name="ether2" type="ether" mtu=1500 actual-mtu=1500
-       mac-address=00:1C:42:36:52:90 last-link-up-time=sep/25/2018 06:30:04
+       mac-address=00:1C:42:36:52:91 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 2  R  name="ether3" default-name="ether3" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:92 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 3  R  name="ether4" default-name="ether4" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:93 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 4  R  name="ether5" default-name="ether5" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:94 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 5  R  name="ether6" default-name="ether6" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:95 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 6  R  name="ether7" default-name="ether7" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:96 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 7  R  name="ether8" default-name="ether8" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:97 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 8  R  name="ether9" default-name="ether9" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:98 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+ 9  R  name="ether10" default-name="ether10" type="ether" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:99 last-link-up-time=sep/25/2018 06:30:04
+       link-downs=0
+10  R  name="pppoe" default-name="pppoe" type="ppp" mtu=1500 actual-mtu=1500
+       mac-address=00:1C:42:36:52:00 last-link-up-time=sep/25/2018 06:30:04
        link-downs=0

--- a/test/units/modules/network/routeros/fixtures/routeros_facts/ip_address_print_detail_without-paging
+++ b/test/units/modules/network/routeros/fixtures/routeros_facts/ip_address_print_detail_without-paging
@@ -5,3 +5,6 @@ Flags: X - disabled, I - invalid, D - dynamic
 
  1 D address=10.37.129.3/24 network=10.37.129.0 interface=ether1
      actual-interface=ether1
+
+ 2 D address=10.37.0.0/24 network=10.37.0.1 interface=pppoe
+     actual-interface=pppoe

--- a/test/units/modules/network/routeros/test_routeros_facts.py
+++ b/test/units/modules/network/routeros/test_routeros_facts.py
@@ -91,12 +91,8 @@ class TestRouterosFactsModule(TestRouterosModule):
     def test_routeros_facts_interfaces(self):
         set_module_args(dict(gather_subset='interfaces'))
         result = self.execute_module()
-        self.assertEqual(
-            result['ansible_facts']['ansible_net_all_ipv4_addresses'][0], '10.37.129.3'
-        )
-        self.assertEqual(
-            result['ansible_facts']['ansible_net_all_ipv4_addresses'][0],
-            result['ansible_facts']['ansible_net_interfaces']['ether1']['ipv4'][0]['address']
+        self.assertIn(
+            result['ansible_facts']['ansible_net_all_ipv4_addresses'][0], ['10.37.129.3', '10.37.0.0']
         )
         self.assertEqual(
             result['ansible_facts']['ansible_net_all_ipv6_addresses'], ['fe80::21c:42ff:fe36:5290']

--- a/test/units/modules/network/routeros/test_routeros_facts.py
+++ b/test/units/modules/network/routeros/test_routeros_facts.py
@@ -106,7 +106,7 @@ class TestRouterosFactsModule(TestRouterosModule):
             result['ansible_facts']['ansible_net_interfaces']['ether1']['ipv6'][0]['address']
         )
         self.assertEqual(
-            len(result['ansible_facts']['ansible_net_interfaces'].keys()), 2
+            len(result['ansible_facts']['ansible_net_interfaces'].keys()), 11
         )
         self.assertEqual(
             len(result['ansible_facts']['ansible_net_neighbors'].keys()), 4


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's a KeyError when number of interfaces gathered from the device is more than 10. I tweaked the regular expression that is used to preprocess RouterOS output and added a regression test so that this bug does not crawl back in.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #61374.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`routeros_facts`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
