### PR TITLE
vmware/test: clean up dvswitch_0001 and dvswitch_0002

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -31,8 +31,12 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter_name: '{{ dc1 }}'
-    switch_name: '{{ dvswitch1 }}'
     state: absent
+    switch_name: '{{ item }}'
+  loop:
+    - '{{ dvswitch1 }}'
+    - dvswitch_0001
+    - dvswitch_0002
   ignore_errors: yes
 
 - name: Remove the vSwitches

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -86,10 +86,15 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       state: absent
-      switch_name: dvswitch_0001
-    register: dvs_result_0003
+      switch_name: '{{ item }}'
+    loop:
+      - dvswitch_0001
+      - dvswitch_0002
+    register: dvswitch_delete
+  - debug: var=dvswitch_delete
 
-  - name: ensure distributed vswitch is present
+  - name: Ensure the state has changed
     assert:
       that:
-        - dvs_result_0003.changed
+        - dvswitch_delete.results[0] is changed
+        - dvswitch_delete.results[1] is changed


### PR DESCRIPTION
##### SUMMARY

Ensure `dvswitch_0001` and `dvswitch_0002` won't remain after
`vmware_dvswitch` test execution.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

vmware_dvswitch