### PR TITLE
[stable-2.8] Disable Hetzner Cloud integration tests due to authentication issues (#61375).

### DIFF
--- a/test/integration/targets/hcloud_datacenter_facts/aliases
+++ b/test/integration/targets/hcloud_datacenter_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_floating_ip_facts/aliases
+++ b/test/integration/targets/hcloud_floating_ip_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_image_facts/aliases
+++ b/test/integration/targets/hcloud_image_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_location_facts/aliases
+++ b/test/integration/targets/hcloud_location_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server_facts/aliases
+++ b/test/integration/targets/hcloud_server_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_server_type_facts/aliases
+++ b/test/integration/targets/hcloud_server_type_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_ssh_key/aliases
+++ b/test/integration/targets/hcloud_ssh_key/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_ssh_key_facts/aliases
+++ b/test/integration/targets/hcloud_ssh_key_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_volume/aliases
+++ b/test/integration/targets/hcloud_volume/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled

--- a/test/integration/targets/hcloud_volume_facts/aliases
+++ b/test/integration/targets/hcloud_volume_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61375 for Ansible 2.8

(cherry picked from commit 31b49334b99fbce799d5ba537bd29f69dc42c849)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/hcloud_datacenter_info/aliases`
`test/integration/targets/hcloud_floating_ip_info/aliases`
`test/integration/targets/hcloud_image_info/aliases`
`test/integration/targets/hcloud_location_info/aliases`
`test/integration/targets/hcloud_network/aliases`
`test/integration/targets/hcloud_network_info/aliases`
`test/integration/targets/hcloud_rdns/aliases`
`test/integration/targets/hcloud_route/aliases`
`test/integration/targets/hcloud_server/aliases`
`test/integration/targets/hcloud_server_info/aliases`
`test/integration/targets/hcloud_server_network/aliases`
`test/integration/targets/hcloud_server_type_info/aliases`
`test/integration/targets/hcloud_ssh_key/aliases`
`test/integration/targets/hcloud_ssh_key_info/aliases`
`test/integration/targets/hcloud_subnetwork/aliases`
`test/integration/targets/hcloud_volume/aliases`
`test/integration/targets/hcloud_volume_info/aliases`