### PR TITLE
Remove unsed / duplicate imports for iosxr module_utils

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/facts/facts.py
+++ b/lib/ansible/module_utils/network/iosxr/facts/facts.py
@@ -22,8 +22,6 @@ from ansible.module_utils.network.iosxr.facts.lldp_interfaces.lldp_interfaces im
 from ansible.module_utils.network.iosxr.facts.interfaces.interfaces import InterfacesFacts
 from ansible.module_utils.network.iosxr.facts.legacy.base import Default, Hardware, Interfaces, Config
 from ansible.module_utils.network.iosxr.facts.l2_interfaces.l2_interfaces import L2_InterfacesFacts
-from ansible.module_utils.network.iosxr.facts.legacy.\
-    base import Default, Hardware, Interfaces, Config
 
 
 FACT_LEGACY_SUBSETS = dict(

--- a/lib/ansible/module_utils/network/iosxr/facts/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/facts/interfaces/interfaces.py
@@ -16,7 +16,7 @@ __metaclass__ = type
 from copy import deepcopy
 import re
 from ansible.module_utils.network.common import utils
-from ansible.module_utils.network.iosxr.utils.utils import get_interface_type, normalize_interface
+from ansible.module_utils.network.iosxr.utils.utils import get_interface_type
 from ansible.module_utils.network.iosxr.argspec.interfaces.interfaces import InterfacesArgs
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove duplicate / unused imports. This was caught during running our collections migration script.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr module_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```