### PR TITLE
[stable-2.8] Fix pipelining in buildah connection plugin

### DIFF
--- a/changelogs/fragments/59745-fix-pipelining-in-buildah-connection-plugin.yml
+++ b/changelogs/fragments/59745-fix-pipelining-in-buildah-connection-plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Pipelining now works with the buildah plugin.

--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -120,7 +120,7 @@ class Connection(ConnectionBase):
         # shlex.split has a bug with text strings on Python-2.6 and can only handle text strings on Python-3
         cmd_args_list = shlex.split(to_native(cmd, errors='surrogate_or_strict'))
 
-        rc, stdout, stderr = self._buildah("run", cmd_args_list)
+        rc, stdout, stderr = self._buildah("run", cmd_args_list, in_data)
 
         display.vvvvv("STDOUT %r STDERR %r" % (stderr, stderr))
         return rc, stdout, stderr


### PR DESCRIPTION
##### SUMMARY

This backports https://github.com/ansible/ansible/pull/59745 to stable-2.8. The buildah connection plugin advertises pipelining support, but did not actually pass the contents of `in_data` to buildah. With this fix, pipelining works correctly with the buildah connection plugin.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

```plugins/connection/buildah.py```
