### PR TITLE
Recursively remove empty values

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -388,10 +388,22 @@ def params_to_launch_data(module, template_params):
     if module.params.get('iam_instance_profile'):
         template_params['iam_instance_profile'] = determine_iam_role(module, module.params['iam_instance_profile'])
     params = snake_dict_to_camel_dict(
-        dict((k, v) for k, v in template_params.items() if v is not None),
+        remove_none(template_params),
         capitalize_first=True,
     )
     return params
+
+
+def remove_none(obj):
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(remove_none(x) for x in obj if x is not None)
+    elif isinstance(obj, dict):
+        return type(obj)(
+            (remove_none(k), remove_none(v))
+            for k, v in obj.items() if k is not None and v is not None
+        )
+    else:
+        return obj
 
 
 def delete_template(module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current implementation of removing null template params doesn't support nested lists which causes problems.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #61394

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloud/amazon/ec2_launch_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For example if one of the `spot_options` is set it till keep the other null options as well. It should remove them leaving only the one that was set.
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
    "invocation": {
        "module_args": {
           ...
            "instance_market_options": {
                "market_type": "spot", 
                "spot_options": {
                    "block_duration_minutes": null, 
                    "instance_interruption_behavior": null, 
                    "max_price": null, 
                    "spot_instance_type": "one-time"
                }
            },
            ...
    }
```
After:
```
        "launch_template_data": {
            ...
            "instance_market_options": {
                "market_type": "spot", 
                "spot_options": {
                    "spot_instance_type": "one-time"
                }
            },
            ...
         }
```
