### PR TITLE
Update _ios_l2_interface.py

### DIFF
--- a/lib/ansible/modules/network/ios/_ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/_ios_l2_interface.py
@@ -118,7 +118,7 @@ from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 def get_interface_type(interface):
     intf_type = 'unknown'
-    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE'):
+    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE', 'TW'):
         intf_type = 'ethernet'
     elif interface.upper().startswith('VL'):
         intf_type = 'svi'


### PR DESCRIPTION
Add support for TwoGigabitEthernet switchports in IOS-XE

##### SUMMARY
Ran into issues using ios_l2_interface against Catalyst 9300 switches when the port type is TwoGigabitEthernet, where this module failed to recognize the port as an L2 port.  Could probably adjust the 'TWE' tag as well, but added 'TW' instead to keep things segregated and easily recognizable. 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interface

##### ADDITIONAL INFORMATION
Error message seen prior to module change:
```
fatal: [hostname]: FAILED! => {"changed": false, "msg": "Ensure interface is configured to be a L2\nport first before using this module. You can use\nthe ios_interface module for this."}
```

Config Before:
```
def get_interface_type(interface):
    intf_type = 'unknown'
    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE'):
```

Config After
```
def get_interface_type(interface):
    intf_type = 'unknown'
    if interface.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE', 'TW'):
```
This is my first public PR so apologies if it's out of sorts!