### PR TITLE
remove the word "support" from Windows pages, add Windows Server 2019

### DIFF
--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -12,14 +12,14 @@ their answers.
 
 Does Ansible work with Windows XP or Server 2003?
 ``````````````````````````````````````````````````
-Ansible does not support managing Windows XP or Server 2003 hosts. The
-supported operating system versions are:
+Ansible does not work with Windows XP or Server 2003 hosts. Ansible does work with these Windows operating system versions:
 
 * Windows Server 2008
 * Windows Server 2008 R2
 * Windows Server 2012
 * Windows Server 2012 R2
 * Windows Server 2016
+* Windows Server 2019
 * Windows 7
 * Windows 8.1
 * Windows 10
@@ -29,7 +29,7 @@ Ansible also has minimum PowerShell version requirements - please see
 
 Can I manage Windows Nano Server with Ansible?
 ``````````````````````````````````````````````
-Windows Nano Server is not currently supported by Ansible, since it does
+Ansible does not currently work with Windows Nano Server, since it does
 not have access to the full .NET Framework that is used by the majority of the
 modules and internal components.
 
@@ -64,16 +64,16 @@ installed version and then clone the git repo.
 
 Can I use SSH keys to authenticate to Windows hosts?
 ````````````````````````````````````````````````````
-SSH keys are not supported when using the WinRM or PSRP connection plugins.
-These connection plugins support X509 certificates for authentication instead
-of the SSH key pairs that SSH supports.
+You cannot use SSH keys with the WinRM or PSRP connection plugins.
+These connection plugins use X509 certificates for authentication instead
+of the SSH key pairs that SSH uses.
 
 The way X509 certificates are generated and mapped to a user is different
 from the SSH implementation; consult the :ref:`windows_winrm` documentation for
 more information.
 
-Ansible 2.8 has added experimental support for using the SSH connection plugin,
-which supports authentication with SSH keys, to connect to Windows servers. See :ref:`this question <windows_faq_ssh>`
+Ansible 2.8 has added an experimental option to use the SSH connection plugin,
+which uses SSH keys for authentication, for Windows servers. See :ref:`this question <windows_faq_ssh>`
 for more information.
 
 .. _windows_faq_winrm:
@@ -109,9 +109,8 @@ Some ways to bypass these restrictions are to:
 * Use ``win_psexec`` to run a command on the host. PSExec does not use WinRM
   and so will bypass any of the restrictions.
 
-* To access network resources without any of these workarounds, an
-  authentication option that supports credential delegation can be used. Both
-  CredSSP and Kerberos with credential delegation enabled can support this.
+* To access network resources without any of these workarounds, you can use
+  CredSSP or Kerberos with credential delegation enabled.
 
 See :ref:`become` more info on how to use become. The limitations section at
 :ref:`windows_winrm` has more details around WinRM limitations.
@@ -165,7 +164,7 @@ and there is no equivalent Windows module available.
 
 Can I connect to Windows hosts over SSH?
 ````````````````````````````````````````
-Ansible 2.8 has added experimental support for using the SSH connection plugin
+Ansible 2.8 has added an experimental option to use the SSH connection plugin
 to manage Windows hosts. To connect to Windows hosts over SSH, you must install and configure the `Win32-OpenSSH <https://github.com/PowerShell/Win32-OpenSSH>`_
 fork that is in development with Microsoft on
 the Windows host(s). While most of the basics should work with SSH,

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -12,9 +12,9 @@ Host Requirements
 For Ansible to communicate to a Windows host and use Windows modules, the
 Windows host must meet these requirements:
 
-* Ansible's supported Windows versions generally match those under current
-  and extended support from Microsoft. Supported desktop OSs include
-  Windows 7, 8.1, and 10, and supported server OSs are Windows Server 2008,
+* Ansible can generally manage Windows versions under current
+  and extended support from Microsoft. Ansible can manage desktop OSs including
+  Windows 7, 8.1, and 10, and server OSs including Windows Server 2008,
   2008 R2, 2012, 2012 R2, 2016, and 2019.
 
 * Ansible requires PowerShell 3.0 or newer and at least .NET 4.0 to be
@@ -302,7 +302,7 @@ options are:
 
 * ``Service\AllowUnencrypted``: This option defines whether WinRM will allow
   traffic that is run over HTTP without message encryption. Message level
-  encryption is only supported when ``ansible_winrm_transport`` is ``ntlm``,
+  encryption is only possible when ``ansible_winrm_transport`` is ``ntlm``,
   ``kerberos`` or ``credssp``. By default this is ``false`` and should only be
   set to ``true`` when debugging WinRM messages.
 
@@ -313,8 +313,8 @@ options are:
 * ``Service\Auth\CbtHardeningLevel``: Specifies whether channel binding tokens are
   not verified (None), verified but not required (Relaxed), or verified and
   required (Strict). CBT is only used when connecting with NTLM or Kerberos
-  over HTTPS. The downstream libraries that Ansible currently uses only support
-  passing the CBT with NTLM authentication. Using Kerberos with
+  over HTTPS. The downstream libraries that Ansible currently uses can only
+  pass the CBT with NTLM authentication. Using Kerberos with
   ``CbtHardeningLevel = Strict`` will result in a ``404`` error.
 
 * ``Service\CertificateThumbprint``: This is the thumbprint of the certificate
@@ -440,8 +440,7 @@ Windows host.
 
 Windows SSH Setup
 `````````````````
-Ansible 2.8 has added experimental support for using SSH to connect to a
-Windows host.
+Ansible 2.8 has added an experimental SSH connection for Windows managed nodes.
 
 .. warning::
     Use this feature at your own risk!

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -313,9 +313,7 @@ options are:
 * ``Service\Auth\CbtHardeningLevel``: Specifies whether channel binding tokens are
   not verified (None), verified but not required (Relaxed), or verified and
   required (Strict). CBT is only used when connecting with NTLM or Kerberos
-  over HTTPS. The downstream libraries that Ansible currently uses can only
-  pass the CBT with NTLM or Kerberos authentication. Using Kerberos with
-  ``CbtHardeningLevel = Strict`` will result in a ``404`` error.
+  over HTTPS.
 
 * ``Service\CertificateThumbprint``: This is the thumbprint of the certificate
   used to encrypt the TLS channel used with CredSSP authentication. By default

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -314,7 +314,7 @@ options are:
   not verified (None), verified but not required (Relaxed), or verified and
   required (Strict). CBT is only used when connecting with NTLM or Kerberos
   over HTTPS. The downstream libraries that Ansible currently uses can only
-  pass the CBT with NTLM authentication. Using Kerberos with
+  pass the CBT with NTLM or Kerberos authentication. Using Kerberos with
   ``CbtHardeningLevel = Strict`` will result in a ``404`` error.
 
 * ``Service\CertificateThumbprint``: This is the thumbprint of the certificate


### PR DESCRIPTION
##### SUMMARY
The list of Windows OSs you can manage with Ansible was different on the Windows FAQ and Windows Setup pages. Also, we used the word "support" on these pages in a confusing way. This PR updates the list of Windows OSs Ansible can manage and makes it clear that the lists reflect Ansible's technical capability, not support options from Red Hat.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
windows modules
