### PR TITLE
cloudwatchevent_rule: Add Support for Input Transformer Feature

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -288,11 +288,11 @@ class CloudWatchEventRule(object):
             if 'role_arn' in target:
                 target_request[''] = target['role_arn']
             if 'input_transformer' in target:
-              if 'input_paths_map' in target['input_transformer'] and 'input_template' in target['input_transformer']:
-                  target_request['InputTransformer'] = {
-                    'InputPathsMap': target['input_transformer']['input_paths_map'],
-                    'InputTemplate': target['input_transformer']['input_template']
-                  }
+                if 'input_paths_map' in target['input_transformer'] and 'input_template' in target['input_transformer']:
+                    target_request['InputTransformer'] = {
+                        'InputPathsMap': target['input_transformer']['input_paths_map'],
+                        'InputTemplate': target['input_transformer']['input_template']
+                    }
             if 'ecs_parameters' in target:
                 target_request['EcsParameters'] = {}
                 ecs_parameters = target['ecs_parameters']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Input Transformer feature of CloudWatch Event rules can be used to customize the text that is taken from an event before it is input to the target of a rule. Details and examples can be found [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatch-Events-Input-Transformer-Tutorial.html).

This commit adds logic to `cloudwatchevent_rule` module to define input transformer.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudwatchevent_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example use case: [AWS Config compliance change notifications](https://docs.aws.amazon.com/config/latest/developerguide/monitor-config-with-cloudwatchevents.html). These can be made human-readable by something like this:

```
cloudwatchevent_rule:
  name: MyConfigComplianceRule
  event_pattern: '{"source":["aws.config"],"detail-type":["Config Rules Compliance Change"]}'
  description: Send notification when Config compliance changes
  targets:
    - id: notifications
      arn: arn:aws:sns:us-east-1:123456789012:notifications
      input_transformer:
        input_paths_map:
          region: $.region
          account: $.account
          title: $.detail-type
          rule-name: $.detail.configRuleName
          resource: $.detail.resourceId
          result: $.detail.newEvaluationResult.complianceType
        input_template: '"<title>. Account: <account>. Region: <region>. Config rule: <rule-name>. Resource <resource> changed to <result>"'
```

which produces a notification similar to this:

```
Config Rules Compliance Change. Account: 123456789012. Region: us-east-1. Config rule vpc-default-security-group-closed. Resource sg-1234abcd changed to COMPLIANT.
```