### PR TITLE
Fix extended loop_control with includes (#61231)

### DIFF
--- a/changelogs/fragments/61231-extended-loop-include.yaml
+++ b/changelogs/fragments/61231-extended-loop-include.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Extended loop variables now work with includes (https://github.com/ansible/ansible/pull/61231)

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -95,6 +95,8 @@ class IncludedFile:
                         task_vars[index_var] = special_vars[index_var] = include_result[index_var]
                     if '_ansible_item_label' in include_result:
                         task_vars['_ansible_item_label'] = special_vars['_ansible_item_label'] = include_result['_ansible_item_label']
+                    if 'ansible_loop' in include_result:
+                        task_vars['ansible_loop'] = special_vars['ansible_loop'] = include_result['ansible_loop']
                     if original_task.no_log and '_ansible_no_log' not in include_args:
                         task_vars['_ansible_no_log'] = special_vars['_ansible_no_log'] = original_task.no_log
 

--- a/test/integration/targets/loop_control/extended.yml
+++ b/test/integration/targets/loop_control/extended.yml
@@ -1,0 +1,12 @@
+- name: loop_control/extended/include https://github.com/ansible/ansible/issues/61218
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: loop on an include
+      include_tasks: inner.yml
+      loop:
+        - first
+        - second
+        - third
+      loop_control:
+        extended: yes

--- a/test/integration/targets/loop_control/inner.yml
+++ b/test/integration/targets/loop_control/inner.yml
@@ -1,0 +1,9 @@
+- name: assert ansible_loop variables in include_tasks
+  assert:
+    that:
+      - ansible_loop.index == ansible_loop.index0 + 1
+      - ansible_loop.revindex == ansible_loop.revindex0 + 1
+      - ansible_loop.first == {{ ansible_loop.index == 1 }}
+      - ansible_loop.last == {{ ansible_loop.index == ansible_loop.length }}
+      - ansible_loop.length == 3
+      - ansible_loop.allitems|join(',') == 'first,second,third'

--- a/test/integration/targets/loop_control/runme.sh
+++ b/test/integration/targets/loop_control/runme.sh
@@ -9,3 +9,4 @@ MATCH='foo_label
 bar_label'
 [ "$(ansible-playbook label.yml "$@" |grep 'item='|sed -e 's/^.*(item=looped_var \(.*\)).*$/\1/')" == "${MATCH}" ]
 
+ansible-playbook extended.yml "$@"


### PR DESCRIPTION
##### SUMMARY
* Fix extended loop_control with includes
* Use assert for testing extended loop_control
* fix typo

(cherry picked from commit a213b9160c7902122d20f05b2fa27a15cd541f4a)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/loop_control.py