### PR TITLE
[stable-2.8] Fix typo in postgresql_privs.py (#61365)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -45,7 +45,7 @@ options:
   type:
     description:
     - Type of database object to set privileges on.
-    - The `default_prives` choice is available starting at version 2.7.
+    - The `default_privs` choice is available starting at version 2.7.
     - The 'foreign_data_wrapper' and 'foreign_server' object types are available from Ansible version '2.8'.
     type: str
     default: table


### PR DESCRIPTION
##### SUMMARY
Backport of #61365 for Ansible 2.8

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

(cherry picked from commit 0074fa5672cf4d4e5b74e595394988deb9b01350)