### PR TITLE
[stable-2.7] Fix typo in postgresql_privs.py (#61365)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -40,7 +40,7 @@ options:
   type:
     description:
       - Type of database object to set privileges on.
-      - The `default_prives` choice is available starting at version 2.7.
+      - The `default_privs` choice is available starting at version 2.7.
     default: table
     choices: [table, sequence, function, database,
               schema, language, tablespace, group,


### PR DESCRIPTION
##### SUMMARY
Backport of #61365 for Ansible 2.7

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

(cherry picked from commit 0074fa5672cf4d4e5b74e595394988deb9b01350)