### PR TITLE
Add mount_point option to approle login

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -249,7 +249,11 @@ class HashiVault:
         if secret_id is None:
             raise AnsibleError("Authentication method app role requires a secret_id")
 
-        self.client.auth_approle(role_id, secret_id)
+        mount_point = kwargs.get('mount_point')
+        if mount_point is None:
+            mount_point = 'approle'
+
+        self.client.auth_approle(role_id, secret_id, mount_point)
 
 
 class LookupModule(LookupBase):


### PR DESCRIPTION
##### SUMMARY
**hashi_vault** allows to set a `mount_point` for LDAP login (auth_ldap), but not for Approle login (auth_approle). Some custom setups have their approles also mounted on a different path in Vault and [HVAC](https://github.com/hvac/hvac/blob/develop/hvac/v1/__init__.py#L1470) already allows this, so I see no point in **hashi_vault** not providing this option for approle login.

Fixes #57970

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
**hashi_vault** Lookup Plugin

##### ADDITIONAL INFORMATION
Tried to make this as trivial as possible by copying the parameter from auth_ldap.