### PR TITLE
K8s kind tests

### DIFF
--- a/test/integration/targets/k8s/aliases
+++ b/test/integration/targets/k8s/aliases
@@ -1,2 +1,2 @@
-cloud/openshift
+cloud/kind
 shippable/cloud/group1

--- a/test/integration/targets/k8s/defaults/main.yml
+++ b/test/integration/targets/k8s/defaults/main.yml
@@ -29,4 +29,4 @@ k8s_pod_template:
   metadata: "{{ k8s_pod_metadata }}"
   spec: "{{ k8s_pod_spec }}"
 
-k8s_openshift: yes
+k8s_openshift: no

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -1,6 +1,7 @@
 - set_fact:
     virtualenv: "{{ remote_tmp_dir }}/virtualenv"
     virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
+    selinux_enabled: '{{ ansible_selinux.status == "enabled" }}'
 
 - set_fact:
     virtualenv_interpreter: "{{ virtualenv }}/bin/python"
@@ -16,7 +17,7 @@
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
-    virtualenv_site_packages: no
+    virtualenv_site_packages: '{{ selinux_enabled | bool }}'
 
 - include_tasks: validate_not_installed.yml
   vars:
@@ -35,7 +36,7 @@
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
-    virtualenv_site_packages: no
+    virtualenv_site_packages: '{{ selinux_enabled | bool }}'
 
 - include_tasks: validate_installed.yml
   vars:
@@ -55,7 +56,7 @@
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
-    virtualenv_site_packages: no
+    virtualenv_site_packages: '{{ selinux_enabled | bool }}'
 
 - include_tasks: older_openshift_fail.yml
   vars:
@@ -75,7 +76,7 @@
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
-    virtualenv_site_packages: no
+    virtualenv_site_packages: '{{ selinux_enabled | bool }}'
 
 - include_tasks: full_test.yml
   vars:

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -39,6 +39,24 @@
         that:
           - wait_pod is successful
 
+    - name: remove Pod with very short timeout
+      k8s:
+        api_version: v1
+        kind: Pod
+        name: wait-pod
+        namespace: "{{ wait_namespace }}"
+        state: absent
+        wait: yes
+        wait_sleep: 2
+        wait_timeout: 5
+      ignore_errors: yes
+      register: short_wait_remove_pod
+
+    - name: check that task failed
+      assert:
+        that:
+          - short_wait_remove_pod is failed
+
     - name: add a daemonset
       k8s:
         definition:
@@ -248,31 +266,6 @@
           - deploy.result.status.availableReplicas == deploy.result.status.replicas
           - updated_deploy_pods.resources[0].spec.containers[0].image.endswith(":2")
 
-    - name: pause a deployment
-      k8s:
-        definition:
-          apiVersion: extensions/v1beta1
-          kind: Deployment
-          metadata:
-            name: wait-deploy
-            namespace: "{{ wait_namespace }}"
-          spec:
-            paused: True
-        apply: no
-        wait: yes
-        wait_condition:
-          type: Progressing
-          status: Unknown
-          reason: DeploymentPaused
-      register: pause_deploy
-
-    - name: check that paused deployment wait worked
-      assert:
-        that:
-          - condition.reason == "DeploymentPaused"
-          - condition.status == "Unknown"
-      vars:
-        condition: '{{ pause_deploy.result.status.conditions | json_query("[?type==`Progressing`]") | first }}'
 
     - name: add a service based on the deployment
       k8s:
@@ -314,6 +307,7 @@
                 app: "{{ k8s_pod_name }}"
             template: "{{ k8s_pod_template }}"
         wait: yes
+        wait_timeout: 10
       vars:
         k8s_pod_name: wait-crash-deploy
         k8s_pod_image: alpine:3.8
@@ -327,23 +321,36 @@
         that:
           - wait_crash_deploy is failed
 
-    - name: remove Pod with very short timeout
+    - name: Create a Job
       k8s:
-        api_version: v1
-        kind: Pod
-        name: wait-pod
-        namespace: "{{ wait_namespace }}"
-        state: absent
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: sleep
+            namespace: '{{ wait_namespace }}'
+          spec:
+            template:
+              spec:
+                containers:
+                - name: sleeper
+                  image: busybox
+                  command: ["sleep", "5"]
+                restartPolicy: Never
+            backoffLimit: 4
         wait: yes
-        wait_sleep: 2
-        wait_timeout: 5
-      ignore_errors: yes
-      register: short_wait_remove_pod
+        wait_condition:
+          type: Complete
+          status: "True"
+      register: wait_condition_job
 
-    - name: check that task failed
+    - name: check that Job succeeded
       assert:
         that:
-          - short_wait_remove_pod is failed
+          - condition.status == "True"
+          - wait_condition_job.result.status.succeeded == 1
+      vars:
+        condition: '{{ wait_condition_job.result.status.conditions | json_query("[?type==`Complete`]") | first }}'
 
   always:
     - name: remove namespace
@@ -353,3 +360,6 @@
         state: absent
 
   when: (nodes.resources | length) > 0
+  module_defaults:
+    k8s:
+      wait_timeout: 300


### PR DESCRIPTION
##### SUMMARY

Updates the `k8s` module tests to use the `bsycorp/kind` container instead of the openshift API server, which should allow full integration tests to run instead of just verifying that we're properly communicating with the API.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
k8s

##### Additional Information
CI won't pass until https://github.com/ansible/ansible/pull/61493 merges