### PR TITLE
Add tests for new alias deprecation functionality

### DIFF
--- a/test/integration/targets/module_utils/library/test_alias_deprecation.py
+++ b/test/integration/targets/module_utils/library/test_alias_deprecation.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts import data
+
+results = {"data": data}
+
+arg_spec = dict(
+    foo=dict(type='str', aliases=['baz'], deprecated_aliases=[dict(name='baz', version='9.99')])
+)
+
+AnsibleModule(argument_spec=arg_spec).exit_json(**results)

--- a/test/integration/targets/module_utils/library/test_alias_deprecation.py
+++ b/test/integration/targets/module_utils/library/test_alias_deprecation.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.facts import data
 

--- a/test/integration/targets/module_utils/module_utils_test.yml
+++ b/test/integration/targets/module_utils/module_utils_test.yml
@@ -49,3 +49,14 @@
       that:
         - result is failed
         - result['msg'] == "Could not find imported module support code for test_failure.  Looked for either foo.py or zebra.py"
+
+  - name: Test that alias deprecation works
+    test_alias_deprecation:
+      baz: 'bar'
+    register: result
+
+  - name: Assert that the deprecation message is given correctly
+    assert:
+      that:
+        - result.deprecations[0].msg == "Alias 'baz' is deprecated. See the module docs for more information"
+        - result.deprecations[0].version == '9.99'

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -102,6 +102,7 @@ def complex_argspec():
         bar3=dict(type='list', elements='path'),
         zardoz=dict(choices=['one', 'two']),
         zardoz2=dict(type='list', choices=['one', 'two', 'three']),
+        zardoz3=dict(type='str', aliases=['zodraz'], deprecated_aliases=[dict(name='zodraz', version='9.99')]),
     )
     mut_ex = (('bar', 'bam'), ('bing', 'bang', 'bong'))
     req_to = (('bam', 'baz'),)
@@ -331,6 +332,14 @@ class TestComplexArgSpecs:
         assert isinstance(am.params['bar3'], list)
         assert am.params['bar3'][0].startswith('/')
         assert am.params['bar3'][1] == 'test/'
+
+    @pytest.mark.parametrize('stdin', [{'foo': 'hello', 'zodraz': 'one'}], indirect=['stdin'])
+    def test_deprecated_alias(self, capfd, mocker, stdin, complex_argspec):
+        """Test a deprecated alias"""
+        am = basic.AnsibleModule(**complex_argspec)
+
+        assert "Alias 'zodraz' is deprecated." in am._deprecations[0]['msg']
+        assert am._deprecations[0]['version'] == '9.99'
 
 
 class TestComplexOptions:


### PR DESCRIPTION
##### SUMMARY
Add unit and integration tests for alias deprecation handler added in #61245

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/integration/targets/module_utils/library/test_alias_deprecation.py
test/integration/targets/module_utils/module_utils_test.yml
test/units/module_utils/basic/test_argument_spec.py
