### PR TITLE
Show doc URL for sanity test failures

### DIFF
--- a/test/lib/ansible_test/_internal/test.py
+++ b/test/lib/ansible_test/_internal/test.py
@@ -4,11 +4,13 @@ __metaclass__ = type
 
 import datetime
 import os
+import re
 
 from . import types as t
 
 from .util import (
     display,
+    get_ansible_version,
 )
 
 from .util_common import (
@@ -276,6 +278,10 @@ class TestFailure(TestResult):
             for message in self.messages:
                 display.error(message.format(show_confidence=True))
 
+            doc_url = self.find_docs()
+            if doc_url:
+                display.info('See documentation for help: %s' % doc_url)
+
     def write_lint(self):
         """Write lint results to stdout."""
         if self.summary:
@@ -358,7 +364,15 @@ class TestFailure(TestResult):
         """
         :rtype: str
         """
-        testing_docs_url = 'https://docs.ansible.com/ansible/devel/dev_guide/testing'
+
+        # Use the major.minor version for the URL only if this a release that
+        # matches the pattern 2.4.0, otherwise, use 'devel'
+        ansible_version = get_ansible_version()
+        url_version = 'devel'
+        if re.search(r'^[0-9.]+$', ansible_version):
+            url_version = '.'.join(ansible_version.split('.')[:2])
+
+        testing_docs_url = 'https://docs.ansible.com/ansible/%s/dev_guide/testing' % url_version
         testing_docs_dir = 'docs/docsite/rst/dev_guide/testing'
 
         url = '%s/%s/' % (testing_docs_url, self.command)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add an info message containing the link to documentation for failed sanity tests. It will link to `devel` docs when running against a pre-release version, otherwise link to the appropriate version of the docs.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Example output:
```
ERROR: Found 3 validate-modules issue(s) which need to be resolved:
ERROR: lib/ansible/modules/files/file.py:0:0: E401 Python SyntaxError while parsing module
ERROR: test/sanity/ignore.txt:2272:1: A100 Ignoring 'E322' on 'lib/ansible/modules/files/file.py' is unnecessary
ERROR: test/sanity/ignore.txt:2273:1: A100 Ignoring 'E324' on 'lib/ansible/modules/files/file.py' is unnecessary
See documentation for help: https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/validate-modules.html
Running sanity test 'yamllint' with Python 3.7
ERROR: Found 1 yamllint issue(s) which need to be resolved:
ERROR: lib/ansible/modules/files/file.py:330:26: python-syntax-error invalid syntax (<unknown>, line 330)
See documentation for help: https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/yamllint.html
ERROR: The 6 sanity test(s) listed below (out of 42) failed. See error output above for details.
ansible-doc
compile --python 3.7
import --python 3.7
pylint
validate-modules
yamllint
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/test.py`