### PR TITLE
RFR: Add a download_only option to the apt module

### DIFF
--- a/changelogs/fragments/61500-apt-download_only.yml
+++ b/changelogs/fragments/61500-apt-download_only.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - Add ``download_only`` parameter to allow for downloading installers without installing  (https://github.com/ansible/ansible/pull/61500)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -265,6 +265,12 @@ EXAMPLES = '''
   apt:
     autoremove: yes
 
+- name: Download package to local cache without installing
+  apt:
+    pkg: foo
+    state: present
+    download_only: yes
+
 '''
 
 RETURN = '''
@@ -697,7 +703,6 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
 
         if download_only:
             download_only = '--download-only'
-            # TODO: Test what happens if you auto-remove while also downloading, they may not be compatible
             autoremove = ''
         else:
             download_only = ''

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -603,10 +603,10 @@ def parse_diff(output):
         diff_end = diff.index('Download complete and in download only mode')
     except ValueError:
         try:
-        # check for end marker line from both apt-get and aptitude
-        diff_end = next(i for i, item in enumerate(diff) if re.match('[0-9]+ (packages )?upgraded', item))
-    except StopIteration:
-        diff_end = len(diff)
+            # check for end marker line from both apt-get and aptitude
+            diff_end = next(i for i, item in enumerate(diff) if re.match('[0-9]+ (packages )?upgraded', item))
+        except StopIteration:
+            diff_end = len(diff)
     diff_start += 1
     diff_end += 1
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -154,7 +154,7 @@ options:
       - Only download packages. Do not install them now.
     type: bool
     default: no
-    version_added: "2.10"
+    version_added: "2.11"
 requirements:
    - python-apt (python 2)
    - python3-apt (python 3)
@@ -708,11 +708,11 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             download_only = ''
 
         if build_dep:
-            cmd = "%s -y %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade,
-                                                            fixed, force_yes, fail_on_autoremove, check_arg, download_only, packages)
+            cmd = "%s -y %s %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed,
+                                                               force_yes, fail_on_autoremove, check_arg, download_only, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade,
-                                                             fixed, force_yes, autoremove, fail_on_autoremove, check_arg, download_only, packages)
+            cmd = "%s -y %s %s %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed,
+                                                                force_yes, autoremove, fail_on_autoremove, check_arg, download_only, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -996,8 +996,8 @@ def upgrade(m, mode="yes", force=False, default_release=None,
                             "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    cmd = '%s -y %s %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, fail_on_autoremove,
-                                       allow_unauthenticated, check_arg, upgrade_command, download_only)
+    cmd = '%s -y %s %s %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, fail_on_autoremove,
+                                          allow_unauthenticated, check_arg, upgrade_command, download_only)
 
     if default_release:
         cmd += " -t '%s'" % (default_release,)
@@ -1203,7 +1203,8 @@ def main():
         force_yes = p['force']
 
         if p['upgrade']:
-            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated, download_only)
+            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove,
+                    fail_on_autoremove, allow_unauthenticated, download_only)
 
         if p['deb']:
             if p['state'] != 'present':

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -153,7 +153,7 @@ options:
     description:
       - Only download packages. Do not install them now.
     type: bool
-    default: 'no'
+    default: no
     version_added: "2.10"
 requirements:
    - python-apt (python 2)

--- a/test/integration/targets/apt/tasks/apt-builddep.yml
+++ b/test/integration/targets/apt/tasks/apt-builddep.yml
@@ -1,55 +1,108 @@
-# test installing build-deps using netcat and quilt as test victims.
+# test installing build-deps using netcat and dpkg-dev as test victims.
 #
-# Deps can be discovered like so (taken from ubuntu 12.04)
+# Deps can be discovered like so (taken from ubuntu 16.04)
 # ====
-# root@localhost:~ # apt-rdepends --build-depends --follow=DEPENDS netcat
+# root@localhost:~  apt-rdepends --build-depends --follow=DEPENDS netcat
 # Reading package lists... Done
 # Building dependency tree
 # Reading state information... Done
 # netcat
-#   Build-Depends: debhelper (>= 8.0.0)
-#   Build-Depends: quilt
+#   Build-Depends: debhelper (>= 9)
+#   Build-Depends: dpkg-dev (>= 1.16.1~)
 # root@localhost:~ #
 # ====
-# Since many things depend on debhelper, let's just uninstall quilt, then
+# Since many things depend on debhelper, and netcat changed it's dependencies to drop quilt in 1.10-41, let's uninstall dpkg-dev, then
 # install build-dep for netcat to get it back.  build-dep doesn't have an
 # uninstall, so we don't need to test for reverse actions (eg, uninstall
 # build-dep and ensure things are clean)
 
-# uninstall quilt
-- name: check quilt with dpkg
-  shell: dpkg -s quilt
-  register: dpkg_result
-  ignore_errors: true
-  tags: ['test_apt_builddep']
+# uninstall dpkg-dev
+- name: uninstall dpkg-dev with apt
+  apt: 
+    pkg: dpkg-dev
+    state: absent
+    purge: yes
+  tags: 
+    - test_apt_builddep
 
-- name: uninstall quilt with apt
-  apt: pkg=quilt state=absent purge=yes
-  register: apt_result
-  when: dpkg_result is successful
-  tags: ['test_apt_builddep']
+# download installers without installing
+- name: pre-check absence of dpkg-dev deb
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'dpkg-dev_*'
+  register: pre_builddep_download
+  tags: 
+    - test_apt_builddep
+
+- name: Clean up dpkg-dev deb if it exists
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ pre_builddep_download.files }}"
+  when: pre_builddep_download.matched >= 1
+  tags: 
+    - test_apt_builddep
+
+- name: Confirm absence of dpkg-dev deb
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'dpkg-dev_*'
+  register: builddep_download_absence
+  tags: 
+    - test_apt_builddep
+
+- name: netcat build-dep download_only to cache dpkg-dev dependency
+  apt: 
+    pkg: netcat
+    state: build-dep
+    download_only: true
+  register: builddep_download_result
+  tags: 
+    - test_apt_builddep
+
+- name: check for dpkg-dev deb in apt cache
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'dpkg-dev_*'
+  register: builddep_download_result_file
+  tags: 
+    - test_apt_builddep
+
+- name: verify netcat dependencies are downloaded only
+  assert:
+    that:
+      - builddep_download_absence.matched == 0
+      - builddep_download_result_file.matched >= 1
+  tags: 
+    - test_apt_builddep
 
 # install build-dep for netcat
 - name: install netcat build-dep with apt
-  apt: pkg=netcat state=build-dep
+  apt: 
+    pkg: netcat
+    state: build-dep
   register: apt_result
-  tags: ['test_apt_builddep']
+  tags: 
+    - test_apt_builddep
 
 - name: verify build_dep of netcat
   assert:
     that:
         - "'changed' in apt_result"
-  tags: ['test_apt_builddep']
+  tags: 
+    - test_apt_builddep
 
 # ensure debhelper and qilt are installed
 - name: check build_deps with dpkg
-  shell: dpkg --get-selections | egrep '(debhelper|quilt)'
+  shell: dpkg --get-selections | egrep '(debhelper|dpkg-dev)'
   failed_when: False
   register: dpkg_result
-  tags: ['test_apt_builddep']
+  tags: 
+    - test_apt_builddep
 
 - name: verify build_deps are really there
   assert:
     that:
         - "dpkg_result.rc == 0"
-  tags: ['test_apt_builddep']
+  tags: 
+    - test_apt_builddep

--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -2,6 +2,43 @@
 - name: add architecture {{ apt_foreign_arch }}
   command: dpkg --add-architecture {{ apt_foreign_arch }}
 
+# --download-only
+- name: pre-check absence of hello:{{ apt_foreign_arch }} deb
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: pre_multiarch_download
+
+- name: Clean up hello:{{ apt_foreign_arch }} deb if it exists
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ pre_multiarch_download.files }}"
+  when: pre_multiarch_download.matched >= 1
+
+- name: Confirm absence of hello:{{ apt_foreign_arch }} deb
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: multiarch_download_absence
+  tags: 
+    - test_apt_builddep
+
+- name: download-only hello:{{ apt_foreign_arch }}
+  apt:
+    pkg: "hello:{{ apt_foreign_arch }}"
+    state: present
+    update_cache: yes
+    download_only: yes
+  register: multiarch_download_result
+
+- name: check for downloaded file
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: multiarch_download_result_file
+
+# Install
 - name: install hello:{{ apt_foreign_arch }} with apt
   apt: pkg=hello:{{ apt_foreign_arch }} state=present update_cache=yes
   register: apt_result
@@ -18,9 +55,11 @@
   apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ apt_foreign_arch }}.deb"
   register: apt_multi_secondary
 
-- name: verify installation of hello:{{ apt_foreign_arch }}
+- name: verify download and installation of hello:{{ apt_foreign_arch }}
   assert:
     that:
+        - multiarch_download_absence.matched == 0
+        - multiarch_download_result_file.matched >= 1
         - "apt_multi_initial.changed"
         - "not apt_multi_secondary.changed"
 

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -113,6 +113,46 @@
     that:
         - "not apt_result.changed"
 
+# Download only
+- name: pre-check absence of downloaded file
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: pre_apt_download
+
+- name: Clean up hello dpg if it exists
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ pre_apt_download.files }}"
+  when: pre_apt_download.matched >= 1
+
+- name: Confirm absence of downloaded file
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: apt_download_absence
+
+- name: download hello with apt without installing
+  apt: 
+    name: hello
+    state: present
+    download_only: true
+  register: apt_download_result
+
+- name: check for downloaded file
+  find:
+    path: "/var/cache/apt/archives/"
+    patterns: 'hello_*'
+  register: apt_download_file
+
+- name: verify hello is downloaded only
+  assert:
+    that:
+        - apt_download_absence.matched == 0
+        - apt_download_file.matched >= 1
+        - "'Download complete and in download only mode' in apt_download_result.stdout_lines"
+
 # INSTALL
 - name: install hello with apt
   apt: name=hello state=present


### PR DESCRIPTION
##### SUMMARY

Extend apt module to add the apt/aptitude flag `--download-only` to allow for downloading packages without installing

Fixes #23220

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- apt.py

##### ADDITIONAL INFORMATION
#23220 is a long standing feature request for a useful edge case. Adding the `--download-only` flag will allow for users to download packages ahead of time.

###### BEFORE
```ansible
---
- name: Install hello
  apt: 
    name: hello
    state: present
```
```log
TASK [Install hello] ******************************
changed: [testhost] => {"cache_update_time": 1590261291, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  hello
0 upgraded, 1 newly installed, 0 to remove and 76 not upgraded.
```

###### AFTER
```ansible
- name: download hello without installing
  apt: 
    name: hello
    state: present
    download_only: true
```
```log
TASK [download hello without installing] ******************************
changed: [testhost] => {"cache_update_time": 1590261291, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  hello
0 upgraded, 1 newly installed, 0 to remove and 76 not upgraded.
Need to get 27.4 kB of archives.
After this operation, 106 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 hello amd64 2.10-1build3 [27.4 kB]
Fetched 27.4 kB in 0s (108 kB/s)
Download complete and in download only mode
```