### PR TITLE
Fix race condition in test_sunos_get_uptime_facts

### DIFF
--- a/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
+++ b/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
@@ -11,6 +11,7 @@ def test_sunos_get_uptime_facts(mocker):
 
     inst = sunos.SunOSHardware(module)
 
-    expected = int(time.time()) - 1548249689
-    result = inst.get_uptime_facts()
-    assert expected == result['uptime_seconds']
+    with mocker.patch('time.time', return_value=1567052602.5089788):
+        expected = int(time.time()) - 1548249689
+        result = inst.get_uptime_facts()
+        assert expected == result['uptime_seconds']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Mock `time.time()` to return consistent time value.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py`

##### ADDITIONAL INFORMATION

[Example test failure](https://app.shippable.com/github/ansible/ansible/runs/140731/10/tests) due to hitting the race condition:
```
mocker = <pytest_mock.MockFixture object at 0x7f15b3c35cd0>

    def test_sunos_get_uptime_facts(mocker):
        kstat_output = '\nunix:0:system_misc:boot_time\t1548249689\n'
    
        module_mock = mocker.patch('ansible.module_utils.basic.AnsibleModule')
        module = module_mock()
        module.run_command.return_value = (0, kstat_output, '')
    
        inst = sunos.SunOSHardware(module)
    
        expected = int(time.time()) - 1548249689
        result = inst.get_uptime_facts()
>       assert expected == result['uptime_seconds']
E       assert 18783181 == 18783182
E         -18783181
E         +18783182
```