### PR TITLE
Move validate-modules to its own test group

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -12,6 +12,7 @@ matrix:
     - env: T=sanity/2
     - env: T=sanity/3
     - env: T=sanity/4
+    - env: T=sanity/5
 
     - env: T=units/2.6
     - env: T=units/2.7

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -14,10 +14,11 @@ else
 fi
 
 case "${group}" in
-    1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build --skip-test package-data) ;;
+    1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build --skip-test package-data --skip-test validate-modules) ;;
     2) options=(                   --test      ansible-doc --test      docs-build --test      package-data) ;;
     3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/ --exclude lib/ansible/modules/network/) ;;
     4) options=(--test pylint           test/units/           lib/ansible/module_utils/           lib/ansible/modules/network/) ;;
+    5) options=(                                                                                                --test validate-modules) ;;
 esac
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This takes about 20 minutes to run. Moving to its own group to parallelize the execution and reduce overall test time.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`shippable.yml`
`test/utils/shippable/sanity.sh`