### PR TITLE
Move the ansible-test output_dir.

### DIFF
--- a/test/integration/targets/throttle/test_throttle.yml
+++ b/test/integration/targets/throttle/test_throttle.yml
@@ -2,7 +2,7 @@
 - hosts: localhosts
   gather_facts: false
   vars:
-    throttledir: ~/ansible_testing/throttle.dir/
+    throttledir: "{{ lookup('env', 'OUTPUT_DIR') }}/throttle.dir/"
   tasks:
     - name: Clean throttledir '{{ throttledir }}'
       file:

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -921,7 +921,7 @@ def command_integration_filtered(args, targets, all_targets, inventory_path, pre
 
     check_pyyaml(args, args.python_version)
 
-    test_dir = os.path.expanduser('~/ansible_testing')
+    test_dir = os.path.join(ResultType.TMP.path, 'output_dir')
 
     if not args.explain and any('needs/ssh/' in target.aliases for target in targets):
         max_tries = 20


### PR DESCRIPTION
##### SUMMARY

Move the ansible-test output_dir.

This directory is currently a fixed location to make troubleshooting easier.
It is cleared before each test target runs, but is preserved when a test target finishes.
This allows the contents to be inspected when a test fails.

The previous location was `~/ansible_testing/`.
The new location is within the content root:

- `test/results/.tmp/output_dir` for Ansible
- `tests/output/.tmp/output_dir` for Ansible Collections

Moving the directory reduces the number of places on the filesystem where tests create output.
It also enables the results to be returned from delegated systems.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
