### PR TITLE
Add 'min' to gather_subset ios_facts documentation

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -43,7 +43,7 @@ options:
       - When supplied, this argument restricts the facts collected
          to a given subset.
       - Possible values for this argument include
-         C(all), C(hardware), C(config), and C(interfaces).
+         C(all), C(min), C(hardware), C(config), and C(interfaces).
       - Specify a list of values to include a larger subset.
       - Use a value with an initial C(!) to collect all facts except that subset.
     required: false


### PR DESCRIPTION
##### SUMMARY
Add 'min' to gather_subset options documentation - ios_facts
Resolves #61535

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_facts documentation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
