### PR TITLE
Typo 'state:' net_lldp

### DIFF
--- a/lib/ansible/modules/network/protocol/_net_lldp.py
+++ b/lib/ansible/modules/network/protocol/_net_lldp.py
@@ -42,7 +42,7 @@ EXAMPLES = """
 
 - name: Disable LLDP service
   net_lldp:
-    state: lldp
+    state: absent
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Typo 'state:' net_lldp in example

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
net_lldp module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Enable LLDP service
  net_lldp:
    state: lldp

to :
- name: Enable LLDP service
  net_lldp:
    state: absent
```
