### PR TITLE
docs: Update apt_key.py add requirements of gpg

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -29,6 +29,8 @@ notes:
       To generate a full-fingerprint imported key: C(apt-key adv --list-public-keys --with-fingerprint --with-colons)."
     - If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
     - Adding a new key requires an apt cache update (e.g. using the apt module's update_cache option)
+requirements:
+    - gpg (in bin paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
 options:
     id:
         description:

--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -30,7 +30,7 @@ notes:
     - If you specify both the key id and the URL with C(state=present), the task can verify or add the key as needed.
     - Adding a new key requires an apt cache update (e.g. using the apt module's update_cache option)
 requirements:
-    - gpg (in bin paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
+    - gpg
 options:
     id:
         description:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The module needs to have gpg installed, otherwise it will end up with error {"changed": false, "msg": "Failed to find required executable gpg in paths: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
apt_key
