### PR TITLE
botmeta: unmaintain resmo from cloudstack

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1584,7 +1584,7 @@ macros:
   team_azure: haroldwongms nitzmahone yuwzho yungezz zikalino
   team_bsd: bcoca dagwieers dch jasperla JoergFiedler MacLemon mekanix opoplawski overhacked tuxillo
   team_cloudscale: gaudenz resmo
-  team_cloudstack: resmo dpassante rhtyd
+  team_cloudstack: dpassante rhtyd
   team_crypto: felixfontein MarkusTeufelberger puiterwijk resmo Spredzy Shaps Xyon
   team_cumulus: isharacomix jrrivers
   team_cyberark_conjur: jvanderhoof ryanprior


### PR DESCRIPTION
##### SUMMARY
I no longer run cloudstack and that is why I no longer maintain the modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
botmeta

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
As already announced to the ML /cc @dpassante @rhtyd
