### PR TITLE
vcenter provider: Only rely on VMWARE_TEST_PLATFORM

### DIFF
--- a/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/test/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -8,9 +8,9 @@ set -euo pipefail
 PYTHON=${ANSIBLE_TEST_PYTHON_INTERPRETER:-python}
 
 export ANSIBLE_CONFIG=ansible.cfg
-export VMWARE_SERVER="${VCENTER_HOST}"
-export VMWARE_USERNAME="${VMWARE_USERNAME:-user}"
-export VMWARE_PASSWORD="${VMWARE_PASSWORD:-pass}"
+export VMWARE_SERVER="${VCENTER_HOSTNAME}"
+export VMWARE_USERNAME="${VCENTER_USERNAME}"
+export VMWARE_PASSWORD="${VCENTER_PASSWORD}"
 port=5000
 VMWARE_CONFIG=test-config.vmware.yaml
 inventory_cache="$(pwd)/inventory_cache"
@@ -37,16 +37,16 @@ cleanup() {
 
 trap cleanup INT TERM EXIT
 
-echo "DEBUG: Using ${VCENTER_HOST} with username ${VMWARE_USERNAME} and password ${VMWARE_PASSWORD}"
+echo "DEBUG: Using ${VCENTER_HOSTNAME} with username ${VCENTER_USERNAME} and password ${VCENTER_PASSWORD}"
 
 echo "Kill all previous instances"
-curl "http://${VCENTER_HOST}:${port}/killall" > /dev/null 2>&1
+curl "http://${VCENTER_HOSTNAME}:${port}/killall" > /dev/null 2>&1
 
 echo "Start new VCSIM server"
-curl "http://${VCENTER_HOST}:${port}/spawn?datacenter=1&cluster=1&folder=0" > /dev/null 2>&1
+curl "http://${VCENTER_HOSTNAME}:${port}/spawn?datacenter=1&cluster=1&folder=0" > /dev/null 2>&1
 
 echo "Debugging new instances"
-curl "http://${VCENTER_HOST}:${port}/govc_find"
+curl "http://${VCENTER_HOSTNAME}:${port}/govc_find"
 
 # Get inventory
 ansible-inventory -i ${VMWARE_CONFIG} --list

--- a/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
+++ b/test/integration/targets/inventory_vmware_vm_inventory/test_vmware_vm_inventory.yml
@@ -8,7 +8,7 @@
   tasks:
     - name: store the vcenter container ip
       set_fact:
-        vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+        vcsim: "{{ lookup('env', 'VCENTER_HOSTNAME') }}"
 
     - name: Check that there are 'all' and 'otherGuest' groups present in inventory
       assert:

--- a/test/integration/targets/vmware_inventory/runme.sh
+++ b/test/integration/targets/vmware_inventory/runme.sh
@@ -9,9 +9,9 @@ contrib_dir=../../../../contrib/inventory
 echo "DEBUG: using ${contrib_dir}"
 
 export ANSIBLE_CONFIG=ansible.cfg
-export VMWARE_SERVER="${VCENTER_HOST}"
-export VMWARE_USERNAME="${VMWARE_USERNAME:-user}"
-export VMWARE_PASSWORD="${VMWARE_PASSWORD:-pass}"
+export VMWARE_SERVER="${VCENTER_HOSTNAME}"
+export VMWARE_USERNAME="${VCENTER_USERNAME}"
+export VMWARE_PASSWORD="${VCENTER_PASSWORD}"
 
 VMWARE_CONFIG=${contrib_dir}/vmware_inventory.ini
 
@@ -41,16 +41,16 @@ function cleanup {
     fi
 }
 
-echo "DEBUG: Using ${VCENTER_HOST} with username ${VMWARE_USERNAME} and password ${VMWARE_PASSWORD}"
+echo "DEBUG: Using ${VCENTER_HOSTNAME} with username ${VCENTER_USERNAME} and password ${VCENTER_PASSWORD}"
 
 echo "Kill all previous instances"
-curl "http://${VCENTER_HOST}:5000/killall" > /dev/null 2>&1
+curl "http://${VCENTER_HOSTNAME}:5000/killall" > /dev/null 2>&1
 
 echo "Start new VCSIM server"
-curl "http://${VCENTER_HOST}:5000/spawn?datacenter=1&cluster=1&folder=0" > /dev/null 2>&1
+curl "http://${VCENTER_HOSTNAME}:5000/spawn?datacenter=1&cluster=1&folder=0" > /dev/null 2>&1
 
 echo "Debugging new instances"
-curl "http://${VCENTER_HOST}:5000/govc_find"
+curl "http://${VCENTER_HOSTNAME}:5000/govc_find"
 
 # Get inventory
 ansible-playbook -i ./vmware_inventory.sh "./test_vmware_inventory.yml" --connection=local "$@"

--- a/test/integration/targets/vmware_inventory/test_vmware_inventory.yml
+++ b/test/integration/targets/vmware_inventory/test_vmware_inventory.yml
@@ -8,7 +8,7 @@
   tasks:
     - name: store the vcenter container ip
       set_fact:
-        vcsim: "{{ lookup('env', 'VCENTER_HOST') }}"
+        vcsim: "{{ lookup('env', 'VCENTER_HOSTNAME') }}"
 
     - name: Check that groups present in inventory
       assert:

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -51,10 +51,11 @@ class VcenterProvider(CloudProvider):
         # file or hosted in worldstream.  Using an env var value of 'worldstream' with appropriate
         # CI credentials will deploy a dynamic baremetal environment. The simulator is the default
         # if no other config if provided.
-        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', '')
+        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', 'govcsim')
         self.aci = None
         self.insecure = False
         self.proxy = None
+        self.platform = 'vcenter'
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
@@ -74,10 +75,12 @@ class VcenterProvider(CloudProvider):
                 exclude.append(skip)
                 display.warning('Excluding tests marked "%s" which require the "docker" command or config (see "%s"): %s'
                                 % (skip.rstrip('/'), self.config_template_path, ', '.join(skipped)))
-        else:
+        elif self.vmware_test_platform == 'static':
             if os.path.isfile(self.config_static_path):
                 return
 
+            super(VcenterProvider, self).filter(targets, exclude)
+        elif self.vmware_test_platform == 'worldstream':
             aci = self._create_ansible_core_ci()
 
             if os.path.isfile(aci.ci_key):
@@ -95,13 +98,16 @@ class VcenterProvider(CloudProvider):
         self._set_cloud_config('vmware_test_platform', self.vmware_test_platform)
         if self.vmware_test_platform == 'govcsim':
             self._setup_dynamic_simulator()
+            self.managed = True
         elif self.vmware_test_platform == 'worldstream':
             self._setup_dynamic_baremetal()
-        elif self._use_static_config():
-            self._set_cloud_config('vmware_test_platform', 'static')
+            self.managed = True
+        elif self.vmware_test_platform == 'static':
+            self._use_static_config()
             self._setup_static()
         else:
-            self._setup_dynamic_simulator()
+            display.error('Unknown vmware_test_platform: %s' % self.vmware_test_platform)
+            exit(1)
 
     def get_docker_run_options(self):
         """Get any additional options needed when delegating tests to a docker container.
@@ -166,14 +172,14 @@ class VcenterProvider(CloudProvider):
             )
 
         if self.args.docker:
-            vcenter_host = self.DOCKER_SIMULATOR_NAME
+            vcenter_hostname = self.DOCKER_SIMULATOR_NAME
         elif container_id:
-            vcenter_host = self._get_simulator_address()
-            display.info('Found vCenter simulator container address: %s' % vcenter_host, verbosity=1)
+            vcenter_hostname = self._get_simulator_address()
+            display.info('Found vCenter simulator container address: %s' % vcenter_hostname, verbosity=1)
         else:
-            vcenter_host = 'localhost'
+            vcenter_hostname = 'localhost'
 
-        self._set_cloud_config('vcenter_host', vcenter_host)
+        self._set_cloud_config('vcenter_hostname', vcenter_hostname)
 
     def _get_simulator_address(self):
         results = docker_inspect(self.args, self.container_name)
@@ -210,6 +216,9 @@ class VcenterProvider(CloudProvider):
                              provider='vmware')
 
     def _setup_static(self):
+        if not os.path.exists(self.config_static_path):
+            display.error('Configuration file does not exist: %s' % self.config_static_path)
+            exit(1)
         parser = ConfigParser({
             'vcenter_port': '443',
             'vmware_proxy_host': '',
@@ -230,13 +239,11 @@ class VcenterEnvironment(CloudEnvironment):
         """
         :rtype: CloudEnvironmentConfig
         """
-        vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM')
-        if not vmware_test_platform:
-            vmware_test_platform = self._get_cloud_config('vmware_test_platform')
-
-        if vmware_test_platform in ('worldstream', 'static'):
+        try:
+            # We may be in a container, so we cannot just reach VMWARE_TEST_PLATFORM,
+            # We do a try/except instead
             parser = ConfigParser()
-            parser.read(self.config_path)
+            parser.read(self.config_path)  # Worldstream and static
 
             # Most of the test cases use ansible_vars, but we plan to refactor these
             # to use env_vars, output both for now
@@ -247,14 +254,15 @@ class VcenterEnvironment(CloudEnvironment):
                 resource_prefix=self.resource_prefix,
             )
             ansible_vars.update(dict(parser.items('DEFAULT', raw=True)))
-
-        else:
+        except KeyError:  # govcsim
             env_vars = dict(
-                VCENTER_HOST=self._get_cloud_config('vcenter_host'),
+                VCENTER_HOSTNAME=self._get_cloud_config('vcenter_hostname'),
+                VCENTER_USERNAME='user',
+                VCENTER_PASSWORD='pass',
             )
 
             ansible_vars = dict(
-                vcsim=self._get_cloud_config('vcenter_host'),
+                vcsim=self._get_cloud_config('vcenter_hostname'),
             )
 
         return CloudEnvironmentConfig(


### PR DESCRIPTION
##### SUMMARY

Until now, the vcenter provider was switching between `static` and `govcsim` depending on the presence of the following configuration file: `test/integration/cloud-config-vcenter.ini`.
The third potential platform, Worldstream, was enabled using the `VMWARE_TEST_PLATFORM` environment variable.

In order to simplify the logic, we now only rely on `VMWARE_TEST_PLATFORM` for all the cases.
`govcsim` is still the default, this to preserve the original behaviour.

This commit also renames the following variables to be consistent with the rest
of the code base. It also ensures they are alway defined, even with `govcsim`:

- `VCENTER_HOSTNAME`
- `VCENTER_USERNAME`
- `VCENTER_PASSWORD`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware
<!--- Write the short name of the module, plugin, task or feature below -->