### PR TITLE
Use relative submodule status in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-submodules.yml
+++ b/changelogs/fragments/ansible-test-submodules.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now correctly enumerates submodules when a collection resides below the repository root

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -39,7 +39,7 @@ class Git:
 
     def get_submodule_paths(self):  # type: () -> t.List[str]
         """Return a list of submodule paths recursively."""
-        cmd = ['submodule', 'status', '--recursive']
+        cmd = ['submodule', 'status', '--recursive', '.']
         output = self.run_git_split(cmd, '\n')
         submodule_paths = [re.search(r'^.[0-9a-f]+ (?P<path>[^ ]+)', line).group('path') for line in output]
         return submodule_paths


### PR DESCRIPTION
##### SUMMARY

The `git submodule status` command is relative to the current git repository by default.
When running from a repository subdirectory paths can be returned above the current directory.
Specifying the current directory with `git submodule status` avoids listing submodules above that directory.

This will fix issues when testing a collection that is rooted below the repository root when that repository uses submodules.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
