### PR TITLE
Azure fix _info/_facts return values for some modules

### DIFF
--- a/changelogs/fragments/azure-fact-fix.yaml
+++ b/changelogs/fragments/azure-fact-fix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- azure_rm_securitygroup_info - Fix up instances when ``ansible_facts`` is returned for the older ``_facts`` alias.
+- azure_rm_networkinterface_info - Fix up instances when ``ansible_facts`` is returned for the older ``_facts`` alias.

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_info.py
@@ -273,7 +273,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_info=dict(azure_networkinterfaces=[])
         )
 
         self.name = None
@@ -308,7 +307,9 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             results = self.list_all()
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_networkinterfaces'] = self.serialize_nics(results)
+            self.results['ansible_facts'] = {
+                'azure_networkinterfaces': self.serialize_nics(results)
+            }
         self.results['networkinterfaces'] = self.to_dict_list(results)
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_info.py
@@ -307,7 +307,8 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
         else:
             results = self.list_all()
 
-        self.results['ansible_info']['azure_networkinterfaces'] = self.serialize_nics(results)
+        if is_old_facts:
+            self.results['ansible_facts']['azure_networkinterfaces'] = self.serialize_nics(results)
         self.results['networkinterfaces'] = self.to_dict_list(results)
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_info.py
@@ -207,7 +207,6 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(azure_publicipaddresses=[])
         )
 
         self.name = None
@@ -240,7 +239,9 @@ class AzureRMPublicIPInfo(AzureRMModuleBase):
         raw = self.filter(result)
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_publicipaddresses'] = self.serialize(raw)
+            self.results['ansible_facts'] = {
+                'azure_publicipaddresses': self.serialize(raw),
+            }
         self.results['publicipaddresses'] = self.format(raw)
 
         return self.results

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_info.py
@@ -59,7 +59,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-azure_securitygroups:
+securitygroups:
     description:
         - List containing security group dicts.
     returned: always
@@ -268,9 +268,13 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
             setattr(self, key, kwargs[key])
 
         if self.name is not None:
-            self.results['ansible_info']['azure_securitygroups'] = self.get_item()
+            info = self.get_item()
         else:
-            self.results['ansible_info']['azure_securitygroups'] = self.list_items()
+            info = self.list_items()
+
+        if is_old_facts:
+            self.results['ansible_facts']['azure_securitygroups'] = info
+        self.results['securitygroups'] = info
 
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_info.py
@@ -247,7 +247,6 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_info=dict(azure_securitygroups=[])
         )
 
         self.name = None
@@ -273,7 +272,9 @@ class AzureRMSecurityGroupInfo(AzureRMModuleBase):
             info = self.list_items()
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_securitygroups'] = info
+            self.results['ansible_facts'] = {
+                'azure_securitygroups': info
+            }
         self.results['securitygroups'] = info
 
         return self.results

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -133,11 +133,11 @@
 - name: Gather facts for all accounts
   azure_rm_securitygroup_info:
       resource_group: "{{ resource_group }}"
-  register: output
+  register: output_groups
 
 - assert:
       that:
-          - output.securitygroups | length > 0
+          - output_groups.securitygroups | length > 0
 
 - name: Create security group with source_address_prefixes
   azure_rm_securitygroup:
@@ -290,7 +290,7 @@
       resource_group: "{{ resource_group }}"
       name: "{{ item.name }}"
       state: absent
-  with_items: "{{ azure_securitygroups }}"
+  with_items: "{{ output_groups.securitygroups }}"
 
 - name: Should have no security groups remaining
   azure_rm_securitygroup_info:

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -35,7 +35,7 @@
 - assert: { that: "{{ output.state.rules | length }} == 2" }
 
 - name: Gather facts by tags
-  azure_rm_securitygroup_facts:
+  azure_rm_securitygroup_info:
       resource_group: "{{ resource_group }}"
       tags:
         - testing
@@ -43,7 +43,7 @@
   register: output
 
 - assert:
-      that: azure_securitygroups | length == 1
+      that: output.securitygroups | length == 1
 
 - name: Add/Update rules on existing security group
   azure_rm_securitygroup:
@@ -121,23 +121,23 @@
           - output.state.tags.delete == 'on-exit'
 
 - name: Gather facts for one accounts
-  azure_rm_securitygroup_facts:
+  azure_rm_securitygroup_info:
       resource_group: "{{ resource_group }}"
       name: "{{ secgroupname }}"
   register: output
 
 - assert:
       that:
-          - azure_securitygroups | length == 1
+          - output.securitygroups | length == 1
 
 - name: Gather facts for all accounts
-  azure_rm_securitygroup_facts:
+  azure_rm_securitygroup_info:
       resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
       that:
-          - azure_securitygroups | length > 0
+          - output.securitygroups | length > 0
 
 - name: Create security group with source_address_prefixes
   azure_rm_securitygroup:
@@ -293,10 +293,10 @@
   with_items: "{{ azure_securitygroups }}"
 
 - name: Should have no security groups remaining
-  azure_rm_securitygroup_facts:
+  azure_rm_securitygroup_info:
       resource_group: "{{ resource_group }}"
   register: output
 
 - assert:
       that:
-          - azure_securitygroups | length == 0
+          - output.securitygroups | length == 0

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/azure_test_minimal.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/azure_test_minimal.yml
@@ -66,19 +66,19 @@
     state: absent
 
 - name: Query auto created NIC
-  azure_rm_networkinterface_facts:
+  azure_rm_networkinterface_info:
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}01"
   register: nic_result
 
 - name: Query auto created security group
-  azure_rm_securitygroup_facts:
+  azure_rm_securitygroup_info:
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}01"
   register: nsg_result
 
 - name: Query auto created public IP
-  azure_rm_publicipaddress_facts:
+  azure_rm_publicipaddress_info:
     resource_group: "{{ resource_group }}"
     name: "{{ vm_name }}01"
   register: pip_result
@@ -87,9 +87,9 @@
   assert:
     that:
       # what about the default storage group?
-      - nic_result.ansible_facts.azure_networkinterfaces | length == 0
-      - nsg_result.ansible_facts.azure_securitygroups | length == 0
-      - pip_result.ansible_facts.azure_publicipaddresses | length == 0
+      - nic_result.networkinterfaces | length == 0
+      - nsg_result.securitygroups | length == 0
+      - pip_result.publicipaddresses | length == 0
 
 - name: Destroy subnet
   azure_rm_subnet:


### PR DESCRIPTION
##### SUMMARY
CI is failing in devel and stable-2.9 after a recent `_facts` to `_info` change in Azure modules https://app.shippable.com/github/ansible/ansible/runs/141099/123/console. This PR is trying to make the `azure_rm_virtualmachine` integration test to start working again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_network_interface_info
azure_rm_securitygroup_info