### PR TITLE
Skip certain tests on 2016

### DIFF
--- a/test/integration/targets/win_certificate_store/aliases
+++ b/test/integration/targets/win_certificate_store/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group7
+skip/windows/2016  # Host takes a while to run and module isn't OS dependent

--- a/test/integration/targets/win_copy/aliases
+++ b/test/integration/targets/win_copy/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group6
+shippable/windows/group3

--- a/test/integration/targets/win_lineinfile/aliases
+++ b/test/integration/targets/win_lineinfile/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group2
+skip/windows/2016  # Host takes a while to run and module isn't OS dependent

--- a/test/integration/targets/win_nssm/aliases
+++ b/test/integration/targets/win_nssm/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group4
+skip/windows/2016  # Host takes a while to run and module isn't OS dependent

--- a/test/integration/targets/win_rds/aliases
+++ b/test/integration/targets/win_rds/aliases
@@ -1,4 +1,4 @@
-shippable/windows/group3
+shippable/windows/group6
 destructive
 skip/windows/2008  # win_feature is required to install the RDS feature and that doesn't support 2008
 win_rds_cap

--- a/test/integration/targets/win_snmp/aliases
+++ b/test/integration/targets/win_snmp/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group2
+skip/windows/2016  # Host takes a while to run and module isn't OS dependent


### PR DESCRIPTION
##### SUMMARY
With coverage enabled the 2016 hosts are getting close to the group limits and sometimes even exceeds the timeouts. We could create another group, probably will need to in the future, but for now we will just disable some minor tests on that host as they are being tested on other Windows versions. This should tie us over until we sort out a better solution for longer running Windows tests.

I chose modules in the groups that were either;

* Using .NET functions that abstract OS information away from us
* Don't really rely on any OS constructs so us testing on other versions will satisfy our tests, or
* Call a separate binary to manage the resource

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store
win_lineinfile
win_nssm
win_snmp