### PR TITLE
Fix ansible-connection persist after playbook run complete issue

### DIFF
--- a/changelogs/fragments/ansible-connection_persist_issue.yaml
+++ b/changelogs/fragments/ansible-connection_persist_issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-connection persists even after playbook run is completed (https://github.com/ansible/ansible/pull/61591)

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -120,7 +120,7 @@ class ConnectionProcess(object):
 
     def run(self):
         try:
-            while True:
+            while not self.connection._conn_closed:
                 signal.signal(signal.SIGALRM, self.connect_timeout)
                 signal.signal(signal.SIGTERM, self.handler)
                 signal.alarm(self.connection.get_option('persistent_connect_timeout'))

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -275,6 +275,7 @@ class NetworkConnectionBase(ConnectionBase):
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(NetworkConnectionBase, self).__init__(play_context, new_stdin, *args, **kwargs)
         self._messages = []
+        self._conn_closed = False
 
         self._network_os = self._play_context.network_os
 
@@ -335,6 +336,7 @@ class NetworkConnectionBase(ConnectionBase):
         self.queue_message('vvvv', 'reset call on connection instance')
 
     def close(self):
+        self._conn_closed = True
         if self._connected:
             self._connected = False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  PR https://github.com/ansible/ansible/pull/59153 to add support
   for delaying the connection initialization with remote host introduced an old issue of ansible-connection persisting even after playbook run is finished till either command timeout or connect timeout is triggered.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/cli/scripts/ansible_connection_cli_stub.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/203