### PR TITLE
[stable-2.9] Fix ansible-test coverage path handling. (#61528)

### DIFF
--- a/changelogs/fragments/ansible-test-powershell-coverage-fix.yml
+++ b/changelogs/fragments/ansible-test-powershell-coverage-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test now creates output directories as needed for powershell coverage output before generating reports

--- a/shippable.yml
+++ b/shippable.yml
@@ -14,12 +14,19 @@ matrix:
     - env: T=sanity/4
     - env: T=sanity/5
 
-    - env: T=units/2.6
-    - env: T=units/2.7
-    - env: T=units/3.5
-    - env: T=units/3.6
-    - env: T=units/3.7
-    - env: T=units/3.8
+    - env: T=units/2.6/1
+    - env: T=units/2.7/1
+    - env: T=units/3.5/1
+    - env: T=units/3.6/1
+    - env: T=units/3.7/1
+    - env: T=units/3.8/1
+
+    - env: T=units/2.6/2
+    - env: T=units/2.7/2
+    - env: T=units/3.5/2
+    - env: T=units/3.6/2
+    - env: T=units/3.7/2
+    - env: T=units/3.8/2
 
     - env: T=windows/2008/1
     - env: T=windows/2008-R2/1

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -6,14 +6,55 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
+group="${args[2]}"
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
-    timeout=99
+    timeout=60
 else
-    timeout=11
+    timeout=6
 fi
+
+group1=()
+group2=()
+
+# create two groups by putting long running network tests into one group
+# add or remove more network platforms as needed to balance the two groups
+
+networks=(
+    f5
+    fortimanager
+    fortios
+    ios
+    junos
+    netact
+    netscaler
+    netvisor
+    nos
+    nso
+    nuage
+    nxos
+    onyx
+    opx
+    ovs
+    radware
+    routeros
+    slxos
+    voss
+    vyos
+)
+
+for network in "${networks[@]}"; do
+    group1+=(--exclude "test/units/modules/network/${network}/")
+    group2+=("test/units/modules/network/${network}/")
+done
+
+case "${group}" in
+    1) options=("${group1[@]}") ;;
+    2) options=("${group2[@]}") ;;
+esac
 
 ansible-test env --timeout "${timeout}" --color -v
 
 # shellcheck disable=SC2086
 ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    "${options[@]}" \


### PR DESCRIPTION
##### SUMMARY

* Fix ansible-test coverage path handling.
* Split CI unit tests into two groups.

Backport of #61528

(cherry picked from commit e4e5005)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

The splitting of unit tests groups was done at the same time since that was the only way to get the tests passing with coverage enabled. Otherwise they would time out due to significant recent additions to the unit tests.