### PR TITLE
win_domain_user: Make Identification of the user to work with more robust

### DIFF
--- a/changelogs/fragments/win_domain_user-identity.yaml
+++ b/changelogs/fragments/win_domain_user-identity.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_user - Added the ``identity`` module option to explicitly set the identity of the user when searching for it - https://github.com/ansible/ansible/issues/45298

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -78,7 +78,7 @@ $domain_password = Get-AnsibleParam -obj $params -name "domain_password" -type "
 $domain_server = Get-AnsibleParam -obj $params -name "domain_server" -type "str"
 
 # User account parameters
-$username = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $description = Get-AnsibleParam -obj $params -name "description" -type "str"
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $password_expired = Get-AnsibleParam -obj $params -name "password_expired" -type "bool"
@@ -125,7 +125,7 @@ if ($null -ne $domain_server) {
 }
 
 try {
-    $user_obj = Get-ADUser -Identity $username -Properties * @extra_args
+    $user_obj = Get-ADUser -Identity $name -Properties * @extra_args
     $user_guid = $user_obj.ObjectGUID
 }
 catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {
@@ -140,7 +140,7 @@ If ($state -eq 'present') {
     # If the account does not exist, create it
     If (-not $user_obj) {
         $create_args = @{}
-        $create_args.Name = $username
+        $create_args.Name = $name
         If ($null -ne $path){
           $create_args.Path = $path
         }
@@ -268,7 +268,7 @@ If ($state -eq 'present') {
         try {
             $user_obj = $user_obj | Set-ADUser -WhatIf:$check_mode -PassThru @set_args
         } catch {
-            Fail-Json $result "failed to change user $($username): $($_.Exception.Message)"
+            Fail-Json $result "failed to change user $($name): $($_.Exception.Message)"
         }
         $result.changed = $true
     }
@@ -363,12 +363,12 @@ If ($user_obj) {
         $user_groups += $group.name
     }
     $result.groups = $user_groups
-    $result.msg = "User '$username' is present"
+    $result.msg = "User '$name' is present"
     $result.state = "present"
 }
 Else {
-    $result.name = $username
-    $result.msg = "User '$username' is absent"
+    $result.name = $name
+    $result.msg = "User '$name' is absent"
     $result.state = "absent"
 }
 

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -139,14 +139,13 @@ If ($state -eq 'present') {
 
     # If the account does not exist, create it
     If (-not $user_obj) {
+        $create_args = @{}
+        $create_args.Name = $username
         If ($null -ne $path){
-            $user_obj = New-ADUser -Name $username -Path $path -WhatIf:$check_mode -PassThru @extra_args
-            $user_guid = $user_obj.ObjectGUID
+          $create_args.Path = $path
         }
-        Else {
-            $user_obj = New-ADUser -Name $username -WhatIf:$check_mode -PassThru @extra_args
-            $user_guid = $user_obj.ObjectGUID
-        }
+        $user_obj = New-ADUser @create_args -WhatIf:$check_mode -PassThru @extra_args
+        $user_guid = $user_obj.ObjectGUID
         $new_user = $true
         $result.created = $true
         $result.changed = $true

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -79,6 +79,7 @@ $domain_server = Get-AnsibleParam -obj $params -name "domain_server" -type "str"
 
 # User account parameters
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$identity = Get-AnsibleParam -obj $params -name "identity" -type "str" -default $name
 $description = Get-AnsibleParam -obj $params -name "description" -type "str"
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $password_expired = Get-AnsibleParam -obj $params -name "password_expired" -type "bool"
@@ -125,7 +126,7 @@ if ($null -ne $domain_server) {
 }
 
 try {
-    $user_obj = Get-ADUser -Identity $name -Properties * @extra_args
+    $user_obj = Get-ADUser -Identity $identity -Properties * @extra_args
     $user_guid = $user_obj.ObjectGUID
 }
 catch [Microsoft.ActiveDirectory.Management.ADIdentityNotFoundException] {

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -144,6 +144,10 @@ If ($state -eq 'present') {
         If ($null -ne $path){
           $create_args.Path = $path
         }
+        If ($null -ne $upn){
+          $create_args.UserPrincipalName  = $upn
+          $create_args.SamAccountName  = $upn.Split('@')[0]
+        }
         $user_obj = New-ADUser @create_args -WhatIf:$check_mode -PassThru @extra_args
         $user_guid = $user_obj.ObjectGUID
         $new_user = $true

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -23,6 +23,15 @@ options:
       - Name of the user to create, remove or modify.
     type: str
     required: true
+  identity:
+    description:
+      - Identity parameter used to find the User in the Active Directory.
+      - This value can be in the forms C(Distinguished Name), C(objectGUID),
+        C(objectSid) or C(sAMAccountName).
+      - Default to C(name) if not set.
+    type: str
+    required: false
+    default $name
   state:
     description:
       - When C(present), creates or updates the user account.

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -31,7 +31,8 @@ options:
       - Default to C(name) if not set.
     type: str
     required: false
-    default $name
+    default: $name
+    version_added: '2.9'
   state:
     description:
       - When C(present), creates or updates the user account.

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -30,9 +30,7 @@ options:
         C(objectSid) or C(sAMAccountName).
       - Default to C(name) if not set.
     type: str
-    required: false
-    default: $name
-    version_added: '2.9'
+    version_added: '2.10'
   state:
     description:
       - When C(present), creates or updates the user account.


### PR DESCRIPTION
##### SUMMARY

######  Add a `identity` parameter to give the full control over how the User if found in the Active Directory.

`name` in AD is the LDAP `CN` and the `-Identify` parameter of the *-ADUser does not consider the `CN`. Therefor win_domain_user only worked if `Name` and `sAmAccountName` where the same. With this Parameter the user can precisely control which user is updated.

######  Ensure we keep working with the same user

By setting `$user_guid` to the users ObjectGUID after we found him for the first time or after creation. we ensure that all subsequent operations work with the same user. If the module has started woring on a user but can not find him for later operations the outcome was not very deterministic. This allows us to update even the property of the user over which we identified him in the first place.

This Fixes #45298 

######  Set the UserPrincipalName and SamAccountName on create

`SamAccountName` is used by *-AdUser to identify the user and its therefor important to set it at the beginning. If a user is created but the module fails after the creation before setting it later the user will not be found and updated if we retry the same action again leading to orphaned user objects.
Further more the `SamAccountName` can only be 20 characters. If not provided upon create the Name will be used and the action fail if the limit is exceeded. This limits the Name to 20 characters too for creating users.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_domain_user


##### ADDITIONAL INFORMATION
This would replace #60360 and #60359 from @ShachafGoldstein which both helped me to get to this solutions which would allow us to create our users completely with ansible.