### PR TITLE
influxdb_user: Fixed Multiple No Privileges

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -173,7 +173,7 @@ def set_user_grants(module, client, user_name, grants):
                 if v['privilege'] == 'ALL PRIVILEGES':
                     v['privilege'] = 'ALL'
                     current_grants[i] = v
-            parsed_grants.add(current_grants[i])
+                parsed_grants.add(current_grants[i])
 
         # check if the current grants are included in the desired ones
         for current_grant in parsed_grants:

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -166,16 +166,17 @@ def set_user_grants(module, client, user_name, grants):
 
     try:
         current_grants = client.get_list_privileges(user_name)
+        parsed_grants = []
         # Fix privileges wording
         for i, v in enumerate(current_grants):
-            if v['privilege'] == 'ALL PRIVILEGES':
-                v['privilege'] = 'ALL'
-                current_grants[i] = v
-            elif v['privilege'] == 'NO PRIVILEGES':
-                del(current_grants[i])
+            if v['privilege'] != 'NO PRIVILEGES':
+                if v['privilege'] == 'ALL PRIVILEGES':
+                    v['privilege'] = 'ALL'
+                    current_grants[i] = v
+            parsed_grants.add(current_grants[i])
 
         # check if the current grants are included in the desired ones
-        for current_grant in current_grants:
+        for current_grant in parsed_grants:
             if current_grant not in grants:
                 if not module.check_mode:
                     client.revoke_privilege(current_grant['privilege'],
@@ -185,7 +186,7 @@ def set_user_grants(module, client, user_name, grants):
 
         # check if the desired grants are included in the current ones
         for grant in grants:
-            if grant not in current_grants:
+            if grant not in parsed_grants:
                 if not module.check_mode:
                     client.grant_privilege(grant['privilege'],
                                            grant['database'],

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -172,8 +172,7 @@ def set_user_grants(module, client, user_name, grants):
             if v['privilege'] != 'NO PRIVILEGES':
                 if v['privilege'] == 'ALL PRIVILEGES':
                     v['privilege'] = 'ALL'
-                    current_grants[i] = v
-                parsed_grants.add(current_grants[i])
+                parsed_grants.add(v)
 
         # check if the current grants are included in the desired ones
         for current_grant in parsed_grants:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
The current implementation iterates through the grants and removes the NO PRIVILEGE entries in the list. 

However if a user has no privileges to 2 or more influx databases, the list will change size and there will always be 1 remaining NO PRIVILEGE entry in the list. This will result in an exception (error parsing query: found NO, expected READ, WRITE, ALL [PRIVILEGES] at line 1) when trying to revoke this privilege. 

My proposed solution is to create a new list that excludes the NO PRIVILEGES entries in the first place.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
influxdb_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To replicate:
1) Create 2 or more influx databases
2) Add influx User

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
