### PR TITLE
luks_device.py: Allow manipulate LUKS containers with label or UUID

### DIFF
--- a/changelogs/fragments/58973_luks_device-add-label-and-uuid-support.yml
+++ b/changelogs/fragments/58973_luks_device-add-label-and-uuid-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - luks_device - added support to use UUIDs, and labels with LUKS2 containers

--- a/test/units/modules/crypto/test_luks_device.py
+++ b/test/units/modules/crypto/test_luks_device.py
@@ -3,6 +3,8 @@ __metaclass__ = type
 
 import pytest
 from ansible.modules.crypto import luks_device
+from units.compat.mock import patch
+from ansible.module_utils import basic
 
 
 class DummyModule(object):
@@ -15,6 +17,15 @@ class DummyModule(object):
 
     def get_bin_path(self, command, dummy):
         return command
+
+    def run_command(self, cmd):
+        out = None
+        if len(cmd) > 0:
+            if cmd[0] == 'blkid':
+                out = '/dev/dummy:UUID="25e718ef-89d5-4089-8f1a-33896326b734"'\
+                      ' LABEL="labelName" TYPE="crypto_LUKS"'
+
+        return out
 
 
 # ===== Handler & CryptHandler methods tests =====
@@ -62,15 +73,16 @@ def test_run_luks_remove(monkeypatch):
 
 # ===== ConditionsHandler methods data and tests =====
 
-# device, key, state, is_luks, expected
+# device, key, state, is_luks, label, expected
 LUKS_CREATE_DATA = (
-    ("dummy", "key", "present", False, True),
-    (None, "key", "present", False, False),
-    ("dummy", None, "present", False, False),
-    ("dummy", "key", "absent", False, False),
-    ("dummy", "key", "opened", True, False),
-    ("dummy", "key", "closed", True, False),
-    ("dummy", "key", "present", True, False))
+    ("dummy", "key", "present", False, None, True),
+    (None, "key", "present", False, None, False),
+    (None, "key", "present", False, "labelName", True),
+    ("dummy", None, "present", False, None, False),
+    ("dummy", "key", "absent", False, None, False),
+    ("dummy", "key", "opened", True, None, False),
+    ("dummy", "key", "closed", True, None, False),
+    ("dummy", "key", "present", True, None, False))
 
 # device, state, is_luks, expected
 LUKS_REMOVE_DATA = (
@@ -85,52 +97,62 @@ LUKS_OPEN_DATA = (
     ("dummy", "key", "absent", "name", None, False),
     ("dummy", "key", "closed", "name", None, False),
     ("dummy", "key", "opened", "name", None, True),
-    (None, "key", "opened", "name", None, False),
+    (None, "key", "opened", "name", None, True),
     ("dummy", None, "opened", "name", None, False),
     ("dummy", "key", "opened", "name", "name", False),
     ("dummy", "key", "opened", "beer", "name", "exception"))
 
-# device, dev_by_name, name, name_by_dev, state, expected
+# device, dev_by_name, name, name_by_dev, state, label, expected
 LUKS_CLOSE_DATA = (
-    ("dummy", "dummy", "name", "name", "present", False),
-    ("dummy", "dummy", "name", "name", "absent", False),
-    ("dummy", "dummy", "name", "name", "opened", False),
-    ("dummy", "dummy", "name", "name", "closed", True),
-    (None, "dummy", "name", "name", "closed", True),
-    ("dummy", "dummy", None, "name", "closed", True),
-    (None, "dummy", None, "name", "closed", False))
+    ("dummy", "dummy", "name", "name", "present", None, False),
+    ("dummy", "dummy", "name", "name", "absent", None, False),
+    ("dummy", "dummy", "name", "name", "opened", None, False),
+    ("dummy", "dummy", "name", "name", "closed", None, True),
+    (None, "dummy", "name", "name", "closed", None, True),
+    ("dummy", "dummy", None, "name", "closed", None, True),
+    (None, "dummy", None, "name", "closed", None, False))
 
-# device, key, new_key, state, expected
+# device, key, new_key, state, label, expected
 LUKS_ADD_KEY_DATA = (
-    ("dummy", "key", "new_key", "present", True),
-    (None, "key", "new_key", "present", False),
-    ("dummy", None, "new_key", "present", False),
-    ("dummy", "key", None, "present", False),
-    ("dummy", "key", "new_key", "absent", "exception"))
+    ("dummy", "key", "new_key", "present", None, True),
+    (None, "key", "new_key", "present", "labelName", True),
+    (None, "key", "new_key", "present", None, False),
+    ("dummy", None, "new_key", "present", None, False),
+    ("dummy", "key", None, "present", None, False),
+    ("dummy", "key", "new_key", "absent", None, "exception"))
 
-# device, remove_key, state, expected
+# device, remove_key, state, label, expected
 LUKS_REMOVE_KEY_DATA = (
-    ("dummy", "key", "present", True),
-    (None, "key", "present", False),
-    ("dummy", None, "present", False),
-    ("dummy", "key", "absent", "exception"))
+    ("dummy", "key", "present", None, True),
+    (None, "key", "present", None, False),
+    (None, "key", "present", "labelName", True),
+    ("dummy", None, "present", None, False),
+    ("dummy", "key", "absent", None, "exception"))
 
 
-@pytest.mark.parametrize("device, keyfile, state, is_luks, expected",
-                         ((d[0], d[1], d[2], d[3], d[4])
+@pytest.mark.parametrize("device, keyfile, state, is_luks, label, expected",
+                         ((d[0], d[1], d[2], d[3], d[4], d[5])
                           for d in LUKS_CREATE_DATA))
-def test_luks_create(device, keyfile, state, is_luks, expected, monkeypatch):
+def test_luks_create(device, keyfile, state, is_luks, label, expected,
+                     monkeypatch):
     module = DummyModule()
 
     module.params["device"] = device
     module.params["keyfile"] = keyfile
     module.params["state"] = state
+    module.params["label"] = label
 
     monkeypatch.setattr(luks_device.CryptHandler, "is_luks",
                         lambda x, y: is_luks)
     crypt = luks_device.CryptHandler(module)
-    conditions = luks_device.ConditionsHandler(module, crypt)
-    assert conditions.luks_create() == expected
+    if device is None:
+        monkeypatch.setattr(luks_device.Handler, "get_device_by_label",
+                            lambda x, y: [0, "/dev/dummy", ""])
+    try:
+        conditions = luks_device.ConditionsHandler(module, crypt)
+        assert conditions.luks_create() == expected
+    except ValueError:
+        assert expected == "exception" or expected is False
 
 
 @pytest.mark.parametrize("device, state, is_luks, expected",
@@ -145,8 +167,11 @@ def test_luks_remove(device, state, is_luks, expected, monkeypatch):
     monkeypatch.setattr(luks_device.CryptHandler, "is_luks",
                         lambda x, y: is_luks)
     crypt = luks_device.CryptHandler(module)
-    conditions = luks_device.ConditionsHandler(module, crypt)
-    assert conditions.luks_remove() == expected
+    try:
+        conditions = luks_device.ConditionsHandler(module, crypt)
+        assert conditions.luks_remove() == expected
+    except ValueError:
+        assert expected == "exception" or expected is False
 
 
 @pytest.mark.parametrize("device, keyfile, state, name, "
@@ -164,6 +189,11 @@ def test_luks_open(device, keyfile, state, name, name_by_dev,
     monkeypatch.setattr(luks_device.CryptHandler,
                         "get_container_name_by_device",
                         lambda x, y: name_by_dev)
+    monkeypatch.setattr(luks_device.CryptHandler,
+                        "get_container_device_by_name",
+                        lambda x, y: "/dev/dummy")
+    monkeypatch.setattr(luks_device.Handler, "_run_command",
+                        lambda x, y: [0, device, ""])
     crypt = luks_device.CryptHandler(module)
     conditions = luks_device.ConditionsHandler(module, crypt)
     try:
@@ -173,15 +203,16 @@ def test_luks_open(device, keyfile, state, name, name_by_dev,
 
 
 @pytest.mark.parametrize("device, dev_by_name, name, name_by_dev, "
-                         "state, expected",
-                         ((d[0], d[1], d[2], d[3], d[4], d[5])
+                         "state, label, expected",
+                         ((d[0], d[1], d[2], d[3], d[4], d[5], d[6])
                           for d in LUKS_CLOSE_DATA))
 def test_luks_close(device, dev_by_name, name, name_by_dev, state,
-                    expected, monkeypatch):
+                    label, expected, monkeypatch):
     module = DummyModule()
     module.params["device"] = device
     module.params["name"] = name
     module.params["state"] = state
+    module.params["label"] = label
 
     monkeypatch.setattr(luks_device.CryptHandler,
                         "get_container_name_by_device",
@@ -190,39 +221,53 @@ def test_luks_close(device, dev_by_name, name, name_by_dev, state,
                         "get_container_device_by_name",
                         lambda x, y: dev_by_name)
     crypt = luks_device.CryptHandler(module)
-    conditions = luks_device.ConditionsHandler(module, crypt)
-    assert conditions.luks_close() == expected
+    try:
+        conditions = luks_device.ConditionsHandler(module, crypt)
+        assert conditions.luks_close() == expected
+    except ValueError:
+        assert expected == "exception" or expected is False
 
 
-@pytest.mark.parametrize("device, keyfile, new_keyfile, state, expected",
-                         ((d[0], d[1], d[2], d[3], d[4])
+@pytest.mark.parametrize("device, keyfile, new_keyfile, state, label, expected",
+                         ((d[0], d[1], d[2], d[3], d[4], d[5])
                           for d in LUKS_ADD_KEY_DATA))
-def test_luks_add_key(device, keyfile, new_keyfile, state, expected, monkeypatch):
+def test_luks_add_key(device, keyfile, new_keyfile, state, label, expected, monkeypatch):
     module = DummyModule()
     module.params["device"] = device
     module.params["keyfile"] = keyfile
     module.params["new_keyfile"] = new_keyfile
     module.params["state"] = state
+    module.params["label"] = label
 
-    conditions = luks_device.ConditionsHandler(module, module)
+    monkeypatch.setattr(luks_device.Handler, "get_device_by_label",
+                        lambda x, y: [0, "/dev/dummy", ""])
+
     try:
+        conditions = luks_device.ConditionsHandler(module, module)
         assert conditions.luks_add_key() == expected
     except ValueError:
-        assert expected == "exception"
+        assert expected == "exception" or expected is False
 
 
-@pytest.mark.parametrize("device, remove_keyfile, state, expected",
-                         ((d[0], d[1], d[2], d[3])
+@pytest.mark.parametrize("device, remove_keyfile, state, label, expected",
+                         ((d[0], d[1], d[2], d[3], d[4])
                           for d in LUKS_REMOVE_KEY_DATA))
-def test_luks_remove_key(device, remove_keyfile, state, expected, monkeypatch):
+def test_luks_remove_key(device, remove_keyfile, state, label, expected, monkeypatch):
 
     module = DummyModule()
     module.params["device"] = device
     module.params["remove_keyfile"] = remove_keyfile
     module.params["state"] = state
+    module.params["label"] = label
 
-    conditions = luks_device.ConditionsHandler(module, module)
+    monkeypatch.setattr(luks_device.Handler, "get_device_by_label",
+                        lambda x, y: [0, "/dev/dummy", ""])
+    monkeypatch.setattr(luks_device.Handler, "_run_command",
+                        lambda x, y: [0, device, ""])
+
+    crypt = luks_device.CryptHandler(module)
     try:
+        conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_remove_key() == expected
     except ValueError:
-        assert expected == "exception"
+        assert expected == "exception" or expected is False

--- a/test/units/modules/crypto/test_luks_device.py
+++ b/test/units/modules/crypto/test_luks_device.py
@@ -18,15 +18,6 @@ class DummyModule(object):
     def get_bin_path(self, command, dummy):
         return command
 
-    def run_command(self, cmd):
-        out = None
-        if len(cmd) > 0:
-            if cmd[0] == 'blkid':
-                out = '/dev/dummy:UUID="25e718ef-89d5-4089-8f1a-33896326b734"'\
-                      ' LABEL="labelName" TYPE="crypto_LUKS"'
-
-        return out
-
 
 # ===== Handler & CryptHandler methods tests =====
 
@@ -97,7 +88,7 @@ LUKS_OPEN_DATA = (
     ("dummy", "key", "absent", "name", None, False),
     ("dummy", "key", "closed", "name", None, False),
     ("dummy", "key", "opened", "name", None, True),
-    (None, "key", "opened", "name", None, True),
+    (None, "key", "opened", "name", None, False),
     ("dummy", None, "opened", "name", None, False),
     ("dummy", "key", "opened", "name", "name", False),
     ("dummy", "key", "opened", "beer", "name", "exception"))
@@ -152,7 +143,7 @@ def test_luks_create(device, keyfile, state, is_luks, label, expected,
         conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_create() == expected
     except ValueError:
-        assert expected == "exception" or expected is False
+        assert expected == "exception"
 
 
 @pytest.mark.parametrize("device, state, is_luks, expected",
@@ -171,7 +162,7 @@ def test_luks_remove(device, state, is_luks, expected, monkeypatch):
         conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_remove() == expected
     except ValueError:
-        assert expected == "exception" or expected is False
+        assert expected == "exception"
 
 
 @pytest.mark.parametrize("device, keyfile, state, name, "
@@ -191,12 +182,12 @@ def test_luks_open(device, keyfile, state, name, name_by_dev,
                         lambda x, y: name_by_dev)
     monkeypatch.setattr(luks_device.CryptHandler,
                         "get_container_device_by_name",
-                        lambda x, y: "/dev/dummy")
+                        lambda x, y: device)
     monkeypatch.setattr(luks_device.Handler, "_run_command",
                         lambda x, y: [0, device, ""])
     crypt = luks_device.CryptHandler(module)
-    conditions = luks_device.ConditionsHandler(module, crypt)
     try:
+        conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_open() == expected
     except ValueError:
         assert expected == "exception"
@@ -225,7 +216,7 @@ def test_luks_close(device, dev_by_name, name, name_by_dev, state,
         conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_close() == expected
     except ValueError:
-        assert expected == "exception" or expected is False
+        assert expected == "exception"
 
 
 @pytest.mark.parametrize("device, keyfile, new_keyfile, state, label, expected",
@@ -246,7 +237,7 @@ def test_luks_add_key(device, keyfile, new_keyfile, state, label, expected, monk
         conditions = luks_device.ConditionsHandler(module, module)
         assert conditions.luks_add_key() == expected
     except ValueError:
-        assert expected == "exception" or expected is False
+        assert expected == "exception"
 
 
 @pytest.mark.parametrize("device, remove_keyfile, state, label, expected",
@@ -270,4 +261,4 @@ def test_luks_remove_key(device, remove_keyfile, state, label, expected, monkeyp
         conditions = luks_device.ConditionsHandler(module, crypt)
         assert conditions.luks_remove_key() == expected
     except ValueError:
-        assert expected == "exception" or expected is False
+        assert expected == "exception"


### PR DESCRIPTION
Per default, on newer versions, cryptsetup creates LUKS containers with VERSION 2 format, but with this change it allow user create containers with `LABEL` identifier as requested on #58973 expliciting `LUKS2` format. It also allow manipulation of LUKS containers with `UUID`

- Allow create a LUKS2 container format with label support
- Allow manipulate (open, close, modify) an LUKS container based on
  both label (LUKS2 format) or UUID (V1 ans V2) instead of using devices only.

This was tested on Fedora Core 30 server and a Slackware 14.2 server.

Fixes: #58973

How to test these new features
```
---
- name: test issue 56872
  gather_facts: no
  hosts: freeipa
  remote_user: root
  tasks:
    - name: create images
      command: dd if=/dev/urandom of=/dev/fedora/test200M bs=100M count=2

    - name: create LUKS container
      luks_device:
        device: "/dev/fedora/test200M"
        state: "present"
        keyfile: "/vault/keyfile"
        label: "personalLabelName"

    - name: open LUKS container
      luks_device:
        state: "opened"
        name: "cryptDiskVol"
        keyfile: "/vault/keyfile"
        label: "personalLabelName"

    - name: close LUKS container
      luks_device:
        state: "closed"
        uuid: ae97ed88-b6eb-40e1-a32e-c2f08d8f0de2
```

Files changed:
- lib/ansible/modules/crypto/luks_device.py