### PR TITLE
ansible-test - Continue if the git command returns an error

### DIFF
--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -8,6 +8,7 @@ from . import types as t
 
 from .util import (
     SubprocessError,
+    display,
     raw_command,
 )
 
@@ -124,4 +125,9 @@ class Git:
         :type str_errors: str
         :rtype: str
         """
-        return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
+        try:
+            return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
+        except SubprocessError as spe:
+            display.warning(spe)
+            stdout = spe.stdout
+            return stdout

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -129,5 +129,4 @@ class Git:
             return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
         except SubprocessError as spe:
             display.warning(spe)
-            stdout = spe.stdout
-            return stdout
+            return spe.stdout

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -129,5 +129,5 @@ class Git:
         try:
             return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
         except SubprocessError as spe:
-            display.warning(to_text(spe))
+            display.warning(to_text(spe.message))
             return spe.stdout

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -10,6 +10,7 @@ from .util import (
     SubprocessError,
     display,
     raw_command,
+    to_text,
 )
 
 
@@ -128,5 +129,5 @@ class Git:
         try:
             return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
         except SubprocessError as spe:
-            display.warning(spe)
+            display.warning(to_text(spe))
             return spe.stdout

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -754,6 +754,7 @@ class SubprocessError(ApplicationError):
         super(SubprocessError, self).__init__(message)
 
         self.cmd = cmd
+        self.message = message
         self.status = status
         self.stdout = stdout
         self.stderr = stderr


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On Ubuntu 1604, running `git submodule status --recursive .` results in an error. Catch the error and issue a warning, but continue.

See [these logs](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_47/60947/e404e5210034fd5c504f5ecca8987f2b19b50bf9/third-party-check/ansible-test-network-integration-eos-python35/955983e/job-output.html#l912) for details.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/git.py`