### PR TITLE
lxd_container: enables to set keys not present in existing config

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -502,6 +502,8 @@ class LXDContainerManagement(object):
         if key == 'config':
             old_configs = dict((k, v) for k, v in self.old_container_json['metadata'][key].items() if not k.startswith('volatile.'))
             for k, v in self.config['config'].items():
+                if k not in old_configs:
+                    return True
                 if old_configs[k] != v:
                     return True
             return False


### PR DESCRIPTION
##### SUMMARY
Changes enable to set new keys which don't exist in a current container's configuration. Currently explicit setting previously unset keys are leads to fail with `KeyError`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lxd_container`