### PR TITLE
roadmap should reflect upstream release, not downstream

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
@@ -21,7 +21,7 @@ PRs must be raised well in advance of the dates below to have a chance of being 
 - 2019-09-19 Release Candidate 1
 - 2019-09-26 Release Candidate 2 (if needed)
 - 2019-10-03 Release Candidate 3 (if needed)
-- 2019-10-16 Release
+- 2019-10-10 Release
 
 
 


### PR DESCRIPTION
##### SUMMARY
The 2.9 roadmap page showed the downstream release date of October 16. 

Replacing with the upstream release date of October 10.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
roadmap
