### PR TITLE
Fix network resource module wording and typographical errors

### DIFF
--- a/lib/ansible/modules/network/eos/eos_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_interfaces.py
@@ -85,7 +85,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in.
+    - The state of the configuration after module completion.
     type: str
 
 """
@@ -254,12 +254,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: The configuration returned will always be in the same format of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: The configuration returned will always be in the same format of the parameters above.

--- a/lib/ansible/modules/network/eos/eos_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_interfaces.py
@@ -85,7 +85,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion.
+    - The state the configuration should be left in.
     type: str
 
 """
@@ -254,12 +254,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: The configuration returned will always be in the same format of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: The configuration returned will always be in the same format of the parameters above.

--- a/lib/ansible/modules/network/eos/eos_l2_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interfaces.py
@@ -87,7 +87,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -264,12 +264,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will always be in the same format of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will always be in the same format of the parameters above.

--- a/lib/ansible/modules/network/eos/eos_l2_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_l2_interfaces.py
@@ -87,7 +87,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -264,12 +264,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: The configuration returned will always be in the same format of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: The configuration returned will always be in the same format of the parameters above.

--- a/lib/ansible/modules/network/eos/eos_l3_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_l3_interfaces.py
@@ -86,7 +86,7 @@ options:
             type: str
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -262,14 +262,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_l3_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_l3_interfaces.py
@@ -86,7 +86,7 @@ options:
             type: str
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -262,14 +262,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lacp.py
+++ b/lib/ansible/modules/network/eos/eos_lacp.py
@@ -64,7 +64,7 @@ options:
             type: int
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -135,14 +135,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lacp.py
+++ b/lib/ansible/modules/network/eos/eos_lacp.py
@@ -64,7 +64,7 @@ options:
             type: int
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -135,14 +135,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lacp_interfaces.py
@@ -66,7 +66,7 @@ options:
         choices: ['fast', 'normal']
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -207,14 +207,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lacp_interfaces.py
@@ -66,7 +66,7 @@ options:
         choices: ['fast', 'normal']
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -207,14 +207,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lag_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lag_interfaces.py
@@ -78,7 +78,7 @@ options:
               - passive
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -208,14 +208,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lag_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lag_interfaces.py
@@ -78,7 +78,7 @@ options:
               - passive
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -208,14 +208,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lldp_global.py
+++ b/lib/ansible/modules/network/eos/eos_lldp_global.py
@@ -95,7 +95,7 @@ options:
             type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -199,14 +199,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lldp_global.py
+++ b/lib/ansible/modules/network/eos/eos_lldp_global.py
@@ -95,7 +95,7 @@ options:
             type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -199,14 +199,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lldp_interfaces.py
@@ -63,7 +63,7 @@ options:
         type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -205,14 +205,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_lldp_interfaces.py
@@ -63,7 +63,7 @@ options:
         type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -205,14 +205,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_vlans.py
+++ b/lib/ansible/modules/network/eos/eos_vlans.py
@@ -70,7 +70,7 @@ options:
         - suspend
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -197,14 +197,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/eos/eos_vlans.py
+++ b/lib/ansible/modules/network/eos/eos_vlans.py
@@ -70,7 +70,7 @@ options:
         - suspend
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -197,14 +197,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/exos/exos_lldp_global.py
+++ b/lib/ansible/modules/network/exos/exos_lldp_global.py
@@ -86,7 +86,7 @@ options:
 
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -385,14 +385,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/exos/exos_lldp_global.py
+++ b/lib/ansible/modules/network/exos/exos_lldp_global.py
@@ -86,7 +86,7 @@ options:
 
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -385,14 +385,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/ios/ios_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_interfaces.py
@@ -88,7 +88,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -362,12 +362,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_interfaces.py
@@ -88,7 +88,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -362,12 +362,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_l2_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interfaces.py
@@ -98,7 +98,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -320,12 +320,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will always be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will always be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_l2_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interfaces.py
@@ -98,7 +98,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -320,12 +320,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will always be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will always be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -107,7 +107,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -400,12 +400,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -107,7 +107,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -400,12 +400,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_lacp.py
+++ b/lib/ansible/modules/network/ios/ios_lacp.py
@@ -63,7 +63,7 @@ options:
             required: True
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -138,14 +138,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_lacp.py
+++ b/lib/ansible/modules/network/ios/ios_lacp.py
@@ -63,7 +63,7 @@ options:
             required: True
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -138,14 +138,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
@@ -74,7 +74,7 @@ options:
           type: int
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -315,14 +315,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
@@ -74,7 +74,7 @@ options:
           type: int
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -315,14 +315,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_lag_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lag_interfaces.py
@@ -85,7 +85,7 @@ options:
             type: int
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -348,12 +348,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_lag_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lag_interfaces.py
@@ -85,7 +85,7 @@ options:
             type: int
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -348,12 +348,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_lldp_global.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_global.py
@@ -126,7 +126,7 @@ options:
             type: bool
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -214,12 +214,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_lldp_global.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_global.py
@@ -126,7 +126,7 @@ options:
             type: bool
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -214,12 +214,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: dict
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: dict
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
@@ -97,7 +97,7 @@ options:
             type: bool
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -453,14 +453,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
@@ -97,7 +97,7 @@ options:
             type: bool
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -453,14 +453,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_vlans.py
+++ b/lib/ansible/modules/network/ios/ios_vlans.py
@@ -87,7 +87,7 @@ options:
         - disabled
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -416,14 +416,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/ios/ios_vlans.py
+++ b/lib/ansible/modules/network/ios/ios_vlans.py
@@ -87,7 +87,7 @@ options:
         - disabled
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -416,14 +416,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
@@ -85,7 +85,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -323,12 +323,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
@@ -85,7 +85,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -323,12 +323,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
@@ -111,7 +111,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -387,12 +387,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
@@ -111,7 +111,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -387,12 +387,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
@@ -91,7 +91,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 """
 
@@ -381,12 +381,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
@@ -91,7 +91,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 """
 
@@ -381,12 +381,12 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.
 after:
-  description: The resulting configuration model invocation
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: The configuration returned will alwys be in the same format of the paramters above.

--- a/lib/ansible/modules/network/iosxr/iosxr_lacp.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lacp.py
@@ -72,7 +72,7 @@ options:
                 type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -255,14 +255,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lacp.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lacp.py
@@ -72,7 +72,7 @@ options:
                 type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -255,14 +255,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
@@ -103,7 +103,7 @@ options:
             type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -493,14 +493,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
@@ -103,7 +103,7 @@ options:
             type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -493,14 +493,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lag_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lag_interfaces.py
@@ -108,7 +108,7 @@ options:
         choices: ['dst-ip', 'src-ip']
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -593,14 +593,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lag_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lag_interfaces.py
@@ -108,7 +108,7 @@ options:
         choices: ['dst-ip', 'src-ip']
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -593,14 +593,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lldp_global.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lldp_global.py
@@ -94,7 +94,7 @@ options:
             type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -331,14 +331,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lldp_global.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lldp_global.py
@@ -94,7 +94,7 @@ options:
             type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -331,14 +331,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lldp_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lldp_interfaces.py
@@ -76,7 +76,7 @@ options:
         type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -542,14 +542,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/iosxr/iosxr_lldp_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lldp_interfaces.py
@@ -76,7 +76,7 @@ options:
         type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -542,14 +542,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_interfaces.py
@@ -96,7 +96,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 requirements:
   - ncclient (>=v0.6.4)
@@ -285,14 +285,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_interfaces.py
@@ -96,7 +96,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 requirements:
   - ncclient (>=v0.6.4)
@@ -285,14 +285,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_l2_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interfaces.py
@@ -95,7 +95,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
 requirements:
   - ncclient (>=v0.6.4)
@@ -359,14 +359,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_l2_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l2_interfaces.py
@@ -95,7 +95,7 @@ options:
     - deleted
     default: merged
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
 requirements:
   - ncclient (>=v0.6.4)
@@ -359,14 +359,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_l3_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interfaces.py
@@ -90,7 +90,7 @@ options:
             type: str
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -360,14 +360,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/junos/junos_l3_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interfaces.py
@@ -90,7 +90,7 @@ options:
             type: str
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -360,14 +360,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/junos/junos_lacp.py
+++ b/lib/ansible/modules/network/junos/junos_lacp.py
@@ -60,7 +60,7 @@ options:
         choices: ['revertive', 'non-revertive']
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -146,14 +146,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lacp.py
+++ b/lib/ansible/modules/network/junos/junos_lacp.py
@@ -60,7 +60,7 @@ options:
         choices: ['revertive', 'non-revertive']
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -146,14 +146,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lacp_interfaces.py
@@ -105,7 +105,7 @@ options:
                   type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -473,14 +473,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lacp_interfaces.py
@@ -105,7 +105,7 @@ options:
                   type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -473,14 +473,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lag_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lag_interfaces.py
@@ -82,7 +82,7 @@ options:
             choices: ['primary', 'backup']
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -301,14 +301,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lag_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lag_interfaces.py
@@ -82,7 +82,7 @@ options:
             choices: ['primary', 'backup']
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -301,14 +301,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lldp_global.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_global.py
@@ -73,7 +73,7 @@ options:
         type: int
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -154,14 +154,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lldp_global.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_global.py
@@ -73,7 +73,7 @@ options:
         type: int
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -154,14 +154,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
@@ -60,7 +60,7 @@ options:
         type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -182,14 +182,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
@@ -60,7 +60,7 @@ options:
         type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -182,14 +182,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/junos/junos_vlans.py
+++ b/lib/ansible/modules/network/junos/junos_vlans.py
@@ -72,7 +72,7 @@ options:
         type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -235,14 +235,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: str
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: str
   sample: >

--- a/lib/ansible/modules/network/junos/junos_vlans.py
+++ b/lib/ansible/modules/network/junos/junos_vlans.py
@@ -72,7 +72,7 @@ options:
         type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -235,14 +235,14 @@ EXAMPLES = """
 
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: str
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: str
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
@@ -68,7 +68,7 @@ options:
         - disable
   state:
     description:
-    - The state the configuration should be left in
+    - The state of the configuration after module completion
     type: str
     choices:
     - merged
@@ -130,14 +130,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
@@ -68,7 +68,7 @@ options:
         - disable
   state:
     description:
-    - The state of the configuration after module completion
+    - The state the configuration should be left in
     type: str
     choices:
     - merged
@@ -130,14 +130,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_interfaces.py
@@ -97,7 +97,7 @@ options:
 
   state:
     description:
-      - The state the configuration should be left in
+      - The state of the configuration after module completion
     type: str
     choices:
       - merged
@@ -238,14 +238,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_interfaces.py
@@ -97,7 +97,7 @@ options:
 
   state:
     description:
-      - The state of the configuration after module completion
+      - The state the configuration should be left in
     type: str
     choices:
       - merged
@@ -238,14 +238,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
@@ -83,7 +83,7 @@ options:
 
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -232,14 +232,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
@@ -83,7 +83,7 @@ options:
 
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -232,14 +232,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
@@ -89,7 +89,7 @@ options:
 
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -206,14 +206,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
@@ -89,7 +89,7 @@ options:
 
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -206,14 +206,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lacp.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp.py
@@ -74,7 +74,7 @@ options:
                 choices: ['primary', 'secondary']
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -145,14 +145,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lacp.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp.py
@@ -74,7 +74,7 @@ options:
                 choices: ['primary', 'secondary']
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -145,14 +145,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
@@ -109,7 +109,7 @@ options:
             type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -215,14 +215,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
@@ -109,7 +109,7 @@ options:
             type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -215,14 +215,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
@@ -75,7 +75,7 @@ options:
             type: bool
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -188,14 +188,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
@@ -75,7 +75,7 @@ options:
             type: bool
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -188,14 +188,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lldp_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_lldp_global.py
@@ -122,7 +122,7 @@ options:
                 type: bool
   state:
     description:
-      - The state the configuration should be left in
+      - The state of the configuration after module completion
     type: str
     choices:
       - merged
@@ -208,14 +208,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_lldp_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_lldp_global.py
@@ -122,7 +122,7 @@ options:
                 type: bool
   state:
     description:
-      - The state of the configuration after module completion
+      - The state the configuration should be left in
     type: str
     choices:
       - merged
@@ -208,14 +208,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_telemetry.py
+++ b/lib/ansible/modules/network/nxos/nxos_telemetry.py
@@ -290,14 +290,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_telemetry.py
+++ b/lib/ansible/modules/network/nxos/nxos_telemetry.py
@@ -290,14 +290,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: dict
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: dict
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_vlans.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlans.py
@@ -79,7 +79,7 @@ options:
         type: int
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
       - merged
@@ -204,14 +204,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/nxos/nxos_vlans.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlans.py
@@ -79,7 +79,7 @@ options:
         type: int
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
       - merged
@@ -204,14 +204,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_interfaces.py
@@ -114,7 +114,7 @@ options:
             type: int
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -834,14 +834,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/vyos/vyos_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_interfaces.py
@@ -114,7 +114,7 @@ options:
             type: int
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -834,14 +834,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
   type: list
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   sample: >
     The configuration returned will always be in the same format

--- a/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
@@ -108,7 +108,7 @@ options:
                 type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -332,14 +332,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
@@ -108,7 +108,7 @@ options:
                 type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -332,14 +332,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lag_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_lag_interfaces.py
@@ -103,7 +103,7 @@ options:
             type: list
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -512,14 +512,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lag_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_lag_interfaces.py
@@ -103,7 +103,7 @@ options:
             type: list
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -512,14 +512,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lldp_global.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp_global.py
@@ -74,7 +74,7 @@ options:
           - sonmp
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -276,14 +276,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lldp_global.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp_global.py
@@ -74,7 +74,7 @@ options:
           - sonmp
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -276,14 +276,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp_interfaces.py
@@ -115,7 +115,7 @@ options:
             type: str
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state the configuration should be left in.
     type: str
     choices:
     - merged
@@ -459,14 +459,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration as structured data prior to module invocation.
+  description: The configuration prior to the model invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The configuration as structured data after module completion.
+  description: The resulting configuration model invocation.
   returned: when changed
   type: list
   sample: >

--- a/lib/ansible/modules/network/vyos/vyos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp_interfaces.py
@@ -115,7 +115,7 @@ options:
             type: str
   state:
     description:
-      - The state the configuration should be left in.
+      - The state of the configuration after module completion.
     type: str
     choices:
     - merged
@@ -459,14 +459,14 @@ EXAMPLES = """
 """
 RETURN = """
 before:
-  description: The configuration prior to the model invocation.
+  description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
   sample: >
     The configuration returned will always be in the same format
      of the parameters above.
 after:
-  description: The resulting configuration model invocation.
+  description: The configuration as structured data after module completion.
   returned: when changed
   type: list
   sample: >


### PR DESCRIPTION
##### SUMMARY
Correct typographical errors in network resource modules added to 2.9 and improve wording of descriptions

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
All network resource modules introduced in v2.9

##### ADDITIONAL INFORMATION

Depends-On: https://github.com/ansible/ansible/pull/61592
