### PR TITLE
Properly hide limit and list-hosts args from ansible-inventory

### DIFF
--- a/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
+++ b/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
@@ -1,3 +1,4 @@
 bugfixes:
 - ansible-inventory - Properly hide arguments that should not be shown
   (https://github.com/ansible/ansible/issues/61604)
+- ansible-inventory - Restore functionality to allow ``--graph`` to be limited by a host pattern

--- a/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
+++ b/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-inventory - Properly hide arguments that should not be shown
+  (https://github.com/ansible/ansible/issues/61604)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -36,6 +36,14 @@ class AnsibleVersion(argparse.Action):
         parser.exit()
 
 
+class UnrecognizedArgument(argparse.Action):
+    def __init__(self, option_strings, dest, const=True, default=None, required=False, help=None, metavar=None, nargs=0):
+        super(UnrecognizedArgument, self).__init__(option_strings=option_strings, dest=dest, nargs=nargs, const=const,
+                                                   default=default, required=required, help=help)
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error('unrecognized arguments: %s' % option_string)
+
+
 class PrependListAction(argparse.Action):
     """A near clone of ``argparse._AppendAction``, but designed to prepend list values
     instead of appending.

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -40,6 +40,7 @@ class UnrecognizedArgument(argparse.Action):
     def __init__(self, option_strings, dest, const=True, default=None, required=False, help=None, metavar=None, nargs=0):
         super(UnrecognizedArgument, self).__init__(option_strings=option_strings, dest=dest, nargs=nargs, const=const,
                                                    default=default, required=required, help=help)
+
     def __call__(self, parser, namespace, values, option_string=None):
         parser.error('unrecognized arguments: %s' % option_string)
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -64,8 +64,9 @@ class InventoryCLI(CLI):
         opt_help.add_basedir_options(self.parser)
 
         # remove unused default options
-        self.parser.add_argument('--limit', default=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
-        self.parser.add_argument('--list-hosts', default=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --list-hosts'))
+        self.parser.add_argument('--limit', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
+        self.parser.add_argument('-l', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
+        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --list-hosts'))
 
         self.parser.add_argument('args', metavar='host|group', nargs='?')
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -112,7 +112,7 @@ class InventoryCLI(CLI):
 
         # set host pattern to default if not supplied
         if options.args:
-            options.pattern = options.args[0]
+            options.pattern = options.args
         else:
             options.pattern = 'all'
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -64,8 +64,8 @@ class InventoryCLI(CLI):
         opt_help.add_basedir_options(self.parser)
 
         # remove unused default options
-        self.parser.add_argument('-l', '--limit', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
-        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --list-hosts'))
+        self.parser.add_argument('-l', '--limit', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument, nargs='?')
+        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument)
 
         self.parser.add_argument('args', metavar='host|group', nargs='?')
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -64,8 +64,7 @@ class InventoryCLI(CLI):
         opt_help.add_basedir_options(self.parser)
 
         # remove unused default options
-        self.parser.add_argument('--limit', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
-        self.parser.add_argument('-l', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
+        self.parser.add_argument('-l', '--limit', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
         self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --list-hosts'))
 
         self.parser.add_argument('args', metavar='host|group', nargs='?')


### PR DESCRIPTION
##### SUMMARY

Properly hide limit and list-hosts args from ansible-inventory. Fixes #61604

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/inventory.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```