### PR TITLE
[Docs] fix theme width on docsite

### DIFF
--- a/docs/docsite/_static/ansible.css
+++ b/docs/docsite/_static/ansible.css
@@ -171,6 +171,10 @@ table.documentation-table .value-required {
     padding: 0.4045em 1.618em;
 }
 
+/* Override sphinx rtd theme max-with of 800px */
+.wy-nav-content {
+    max-width: 100%;
+}
 
 .DocSiteBanner {
     display: flex;
@@ -345,7 +349,6 @@ table {
         background-color: #000;
         text-decoration: none;
         font-family: 'Open Sans', sans-serif;
-        width: 1100px;
     }
 
 
@@ -427,7 +430,6 @@ table {
         background-color: #000;
         text-decoration: none;
         font-family: 'Open Sans', sans-serif;
-        width: 1100px;
     }
 
 
@@ -451,7 +453,6 @@ table {
 
     .ansibleNav{
         height: 45px;
-        width: 1100px;
         font-size: 13px;
         padding: 0px 60px 0px 0px;
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Extend documentation content to full browser screen (override default sphinx rtd theme).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
