### PR TITLE
[stable-2.9] ansible-test - Continue if the git command returns an error (#61605)

### DIFF
--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -8,7 +8,9 @@ from . import types as t
 
 from .util import (
     SubprocessError,
+    display,
     raw_command,
+    to_text,
 )
 
 
@@ -124,4 +126,8 @@ class Git:
         :type str_errors: str
         :rtype: str
         """
-        return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
+        try:
+            return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
+        except SubprocessError as spe:
+            display.warning(to_text(spe.message))
+            return spe.stdout

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -754,6 +754,7 @@ class SubprocessError(ApplicationError):
         super(SubprocessError, self).__init__(message)
 
         self.cmd = cmd
+        self.message = message
         self.status = status
         self.stdout = stdout
         self.stderr = stderr


### PR DESCRIPTION

* ansible-test - Contiune if the git command returns an error

* Just return stdout

* Use to_text() when displaying exception

* Add a message property to SubprocessError
(cherry picked from commit e218c98)

Co-authored-by: Sam Doran <sdoran@redhat.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
