### PR TITLE
Update Fedora 29 test image

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,7 @@
 default name=quay.io/ansible/default-test-container:1.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
-fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7
+fedora29 name=quay.io/ansible/fedora29-test-container:1.9.4 python=3.7
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.8.0 python=2.7
 opensuse15 name=quay.io/ansible/opensuse15-test-container:1.8.0 python=3.6


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Fedora 29 image we are using has `librepo` 1.9.6 which contains a [bug](https://lists.fedoraproject.org/archives/list/devel-announce@lists.fedoraproject.org/thread/RHZ6V6MFVFAIJ6OEXZ5VL7BPPLHJE4GF/) that causes a segfault. This is causing test failures. The updated image has `librepo` 1.10.5 which fixes the issue.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/completion/docker.txt`