### PR TITLE
Add name_format option to include_vars

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -44,6 +44,22 @@ options:
       - If omitted (null) they will be made top level vars.
     type: str
     version_added: "2.2"
+  name_format:
+    description:
+      - The format to assign into the variable in I(name).
+      - Ignored if I(name) is omitted.
+      - Defaults to C(dict) which preserves the previous behavior of I(name).
+      - With C(dict_by_path), the variable in I(name) is a C(dict) where each key is the full path of the file
+        from which the vars were loaded, and the value is a C(dict) containing those vars.
+      - C(dict_by_file) is the same as above, but only the C(basename) of the file is used as the key. This means
+        that if a file with the same name exists at a different directory level, the last read file will "win"
+        and overwrite that key's values.
+      - C(list_by_path) and C(list_by_file) work the same way as their C(dict_by_*) counterparts, except that they
+        only return the values of the resulting C(dict), so the variable in I(name) will be a list of those values.
+    default: "dict"
+    choices: [ dict, dict_by_path, dict_by_file, list_by_path, list_by_file ]
+    type: str
+    version_added: "2.10"
   depth:
     description:
       - When using C(dir), this module will, by default, recursively go through each sub directory and load up the
@@ -143,6 +159,24 @@ EXAMPLES = r'''
     dir: vars
     ignore_unknown_extensions: True
     extensions: ['', 'yaml', 'yml', 'json']
+
+- name: Include vars files in vars/services in var stuff as a dict per filepath (2.9)
+  include_vars:
+    dir: vars/services
+    name: stuff
+    name_format: dict_by_path
+
+- name: Include vars files in vars/services in var stuff as a dict per filename (2.9)
+  include_vars:
+    dir: vars/services
+    name: stuff
+    name_format: dict_by_file
+
+- name: Include vars files in vars/services in var stuff as a list per filepath (2.9)
+  include_vars:
+    dir: vars/services
+    name: stuff
+    name_format: list_by_path
 '''
 
 RETURN = r'''

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -146,10 +146,13 @@
     name: name_test
     name_format: dict_by_path
 
-- name: Verify that there are 4 base_dir values in dict values
+- name: Verify that there are 6 entries in dict
   assert:
     that:
-      - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 4"
+      - "name_test | length == 6"
+
+      # jinja2 filters not available in some envs
+      # - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 4"
 
 - name: include every directory in vars into var name_test as a dict by file name
   include_vars:
@@ -158,10 +161,13 @@
     name: name_test
     name_format: dict_by_file
 
-- name: Verify that there is 1 base_dir value in dict values
+- name: Verify that there are 4 entries in dict
   assert:
     that:
-      - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 1"
+      - "name_test | length == 4"
+
+      # jinja2 filters not available in some envs
+      # - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 1"
 
 - name: include every directory in vars into var name_test as a list by full file path
   include_vars:
@@ -170,10 +176,13 @@
     name: name_test
     name_format: list_by_path
 
-- name: Verify that there are 4 base_dir values in list
+- name: Verify that there are 6 values in list
   assert:
     that:
-      - "(name_test | selectattr('base_dir','defined') | list | count) == 4"
+      - "name_test | length == 6"
+
+      # jinja2 filters not available in some envs
+      # - "(name_test | selectattr('base_dir','defined') | list | count) == 4"
 
 - name: include every directory in vars into var name_test as a list by file name
   include_vars:
@@ -182,7 +191,10 @@
     name: name_test
     name_format: list_by_file
 
-- name: Verify that there is 1 base_dir value in list
+- name: Verify that there are 4 values in list
   assert:
     that:
-      - "(name_test | selectattr('base_dir','defined') | list | count) == 1"
+      - "name_test | length == 4"
+
+      # jinja2 filters not available in some envs
+      # - "(name_test | selectattr('base_dir','defined') | list | count) == 1"

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -138,3 +138,51 @@
   assert:
     that:
       - "service_name ==  'my_custom_service'"
+
+- name: include every directory in vars into var name_test as a dict by full file path
+  include_vars:
+    dir: vars
+    extensions: ['', 'yaml', 'yml', 'json']
+    name: name_test
+    name_format: dict_by_path
+
+- name: Verify that there are 4 base_dir values in dict values
+  assert:
+    that:
+      - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 4"
+
+- name: include every directory in vars into var name_test as a dict by file name
+  include_vars:
+    dir: vars
+    extensions: ['', 'yaml', 'yml', 'json']
+    name: name_test
+    name_format: dict_by_file
+
+- name: Verify that there is 1 base_dir value in dict values
+  assert:
+    that:
+      - "(name_test.values() | selectattr('base_dir','defined') | list | count) == 1"
+
+- name: include every directory in vars into var name_test as a list by full file path
+  include_vars:
+    dir: vars
+    extensions: ['', 'yaml', 'yml', 'json']
+    name: name_test
+    name_format: list_by_path
+
+- name: Verify that there are 4 base_dir values in list
+  assert:
+    that:
+      - "(name_test | selectattr('base_dir','defined') | list | count) == 4"
+
+- name: include every directory in vars into var name_test as a list by file name
+  include_vars:
+    dir: vars
+    extensions: ['', 'yaml', 'yml', 'json']
+    name: name_test
+    name_format: list_by_file
+
+- name: Verify that there is 1 base_dir value in list
+  assert:
+    that:
+      - "(name_test | selectattr('base_dir','defined') | list | count) == 1"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds supports to `include_vars` to control how the variables are returned in the variable specified by `name`. This allows for retaining values that would have otherwise been overwritten, and using the path or file name of the file they were loaded from.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #61628

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`include_vars`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Consider a directory of files like this:
```
somevars
|__ vars1.yml
|__ vars2.yml
|__ subdir
  |__ vars2.yml
```

`vars1.yml`
```yaml
one: one
two: two
```

`vars2.yml`
```yaml
one: 1
two: 2
```

`subdir/vars2.yml`
```yaml
one: won
two: too
```
In the default case of setting these at the global level, the last applied value wins. That's expected.

Consider this call:
```yaml
- include_vars:
    dir: somevars
    name: my_vars
```

With this PR, you can do this:
```yaml
- include_vars:
    dir: somevars
    name: my_vars
    name_format: dict_by_path
```

And `my_vars` will now be a `dict` with a key per loaded file (full path), and each value is the `dict` containing the values loaded. 

With `name_format: dict_by_file` the result is the same, but using the `basename` of each path, so in the above file structure, there will be 2 entries, not 3 (because `vars2.yml` will have been overwritten when the second file of that name was loaded from the subdirectory).

The `list_by_path` and `list_by_file` formats work the same way as the `dict_by_*` options except that they return a `list` of the resulting `dict`s; useful if you don't care about which files the vars came from, you just want to iterate over each resulting set.

The default value `dict` preserves the existing behavior of the `name:` option, so this change is completely backwards compatible.

`name_format` has no effect is `name:` is not specified.
