### PR TITLE
[stable-2.9] Update Fedora 29 test container and increase Azure test timeout

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,7 @@
 default name=quay.io/ansible/default-test-container:1.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
-fedora29 name=quay.io/ansible/fedora29-test-container:1.8.0 python=3.7
+fedora29 name=quay.io/ansible/fedora29-test-container:1.9.4 python=3.7
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.8.0 python=2.7
 opensuse15 name=quay.io/ansible/opensuse15-test-container:1.8.0 python=3.6

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -137,6 +137,8 @@ trap cleanup EXIT
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=60
+elif [[ "${script}" == "azure" ]]; then
+    timeout=70
 else
     timeout=45
 fi


### PR DESCRIPTION
##### SUMMARY

Backport of two CI fixes:

- temporary bump to 70m the timeout of the Azure job
- rebase the Fedora 29 image to avoid a segfault of librepo

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

test
<!--- Write the short name of the module, plugin, task or feature below -->