### PR TITLE
digital_ocean_droplet: fix for "found unpermitted parameters: id"

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_droplet.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_droplet.py
@@ -252,7 +252,12 @@ class DODroplet(object):
             self.module.exit_json(changed=False, data=droplet_data)
         if self.module.check_mode:
             self.module.exit_json(changed=True)
-        response = self.rest.post('droplets', data=self.module.params)
+        data = self.module.params
+        try:
+            del data['id']
+        except KeyError:
+            pass
+        response = self.rest.post('droplets', data=data)
         json_data = response.json
         if response.status_code >= 400:
             self.module.fail_json(changed=False, msg=json_data['message'])


### PR DESCRIPTION
##### SUMMARY
The DigitalOcean API has been changed, and it throws an error on the droplet creation task now: `found unpermitted parameters: id`. We need to remove the key `id` when calling the API.

The fix should be backported to 2.8 after merging


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request (Fixes #61664)

##### COMPONENT NAME
digital_ocean_droplet

##### ADDITIONAL INFORMATION
Task:
```
- digital_ocean_droplet:
    state: present
    name: XXX
    oauth_token: XXX
    size: s-1vcpu-1gb
    region: lon1
    image: ubuntu-19-04-x64
    wait_timeout: 300
    unique_name: true
    ipv6: true
    ssh_keys: XXX
```
Output:
```paste below
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "backups": false,
            "id": null,
            "image": "ubuntu-19-04-x64",
            "ipv6": true,
            "monitoring": false,
            "name": "XXX",
            "private_networking": false,
            "region": "lon1",
            "size": "s-1vcpu-1gb",
            "ssh_keys": [
                "XXX"
            ],
            "user_data": null,
            "volumes": null
        }
    },
    "msg": "found unpermitted parameters: id"
}
```
