### PR TITLE
Remove deprecated letsencrypt alias of acme_certificate

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -45,7 +45,7 @@ Modules removed
 
 The following modules no longer exist:
 
-* No notable changes
+* letsencrypt use :ref:`acme_certificate <acme_certificate_module>` instead.
 
 
 Deprecation notices

--- a/lib/ansible/modules/crypto/acme/_letsencrypt.py
+++ b/lib/ansible/modules/crypto/acme/_letsencrypt.py
@@ -1,1 +1,28 @@
-acme_certificate.py
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['removed'],
+                    'supported_by': 'community'}
+
+
+from ansible.module_utils.common.removed import removed_module
+
+
+if __name__ == '__main__':
+    removed_module(removed_in="2.10")

--- a/lib/ansible/modules/crypto/acme/_letsencrypt.py
+++ b/lib/ansible/modules/crypto/acme/_letsencrypt.py
@@ -16,6 +16,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['removed'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -1020,8 +1020,6 @@ def main():
         ),
         supports_check_mode=True,
     )
-    if module._name == 'letsencrypt':
-        module.deprecate("The 'letsencrypt' module is being renamed 'acme_certificate'", version='2.10')
     set_crypto_backend(module)
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.


### PR DESCRIPTION
##### SUMMARY
`letsencrypt` has been renamed to `acme_certificate` for 2.6 (#39816), i.e. for 2.10 the deprecated old name will be removed.

Fixes #61890.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
letsencrypt
