### PR TITLE
Fix creation of DigitalOcean droplets using digital_ocean_droplet module

### DIFF
--- a/changelogs/fragments/61655-fix-digital-ocean-droplet-create.yaml
+++ b/changelogs/fragments/61655-fix-digital-ocean-droplet-create.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - digital_ocean_droplet - Fix creation of DigitalOcean droplets using digital_ocean_droplet module (https://github.com/ansible/ansible/pull/61655)

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_droplet.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_droplet.py
@@ -252,7 +252,9 @@ class DODroplet(object):
             self.module.exit_json(changed=False, data=droplet_data)
         if self.module.check_mode:
             self.module.exit_json(changed=True)
-        response = self.rest.post('droplets', data=self.module.params)
+        request_params = dict(self.module.params)
+        del request_params['id']
+        response = self.rest.post('droplets', data=request_params)
         json_data = response.json
         if response.status_code >= 400:
             self.module.fail_json(changed=False, msg=json_data['message'])


### PR DESCRIPTION
##### SUMMARY
The DigitalOcean API to [create a new droplet](https://developers.digitalocean.com/documentation/v2/#create-a-new-droplet) started rejecting requests with an `id` attribute. Ansible includes the module parameter `id`, even if it's the default `null`. That makes it impossible to create a new droplet with the `digital_ocean_droplet` module in Ansible 2.8 and later.

Fixes #61664

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_droplet

##### ADDITIONAL INFORMATION
```
$ ansible -m digital_ocean_droplet -a 'image=ubuntu-18-04-x64 region=nyc1 size=s-1vcpu-1gb name=ansible-repro' localhost
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "msg": "found unpermitted parameters: id"
}
```
