### PR TITLE
Remove unnecessary information about amount of actions in the meta module

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -17,8 +17,6 @@ short_description: Execute Ansible 'actions'
 version_added: '1.2'
 description:
     - Meta tasks are a special kind of task which can influence Ansible internal execution or state.
-    - Prior to Ansible 2.0, the only meta option available was C(flush_handlers).
-    - As of Ansible 2.2, there are five meta tasks which can be used.
     - Meta tasks can be used anywhere within your playbook.
     - This module is also supported for Windows targets.
 options:


### PR DESCRIPTION
##### SUMMARY
Information about the available amount of actions doesn't add real value because is outdated and can be figured out from another part of documentation easily.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meta
