### PR TITLE
AnsibleModule.load_file_common_arguments: allow to override path

### DIFF
--- a/changelogs/fragments/61659-load_file_common_arguments-override-path.yml
+++ b/changelogs/fragments/61659-load_file_common_arguments-override-path.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "``AnsibleModule.load_file_common_arguments`` now allows to simply override ``path``."

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -724,14 +724,17 @@ class AnsibleModule(object):
         deprecate(msg, version)
         self.log('[DEPRECATION WARNING] %s %s' % (msg, version))
 
-    def load_file_common_arguments(self, params):
+    def load_file_common_arguments(self, params, path=None):
         '''
         many modules deal with files, this encapsulates common
         options that the file module accepts such that it is directly
         available to all modules and they can share code.
+
+        Allows to overwrite the path/dest module argument by providing path.
         '''
 
-        path = params.get('path', params.get('dest', None))
+        if path is None:
+            path = params.get('path', params.get('dest', None))
         if path is None:
             return {}
         else:

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -378,12 +378,9 @@ def write_file(module, content, default_mode=None, path=None):
     Uses file arguments from module.
     '''
     # Find out parameters for file
-    file_args = module.load_file_common_arguments(module.params)
+    file_args = module.load_file_common_arguments(module.params, path=path)
     if file_args['mode'] is None:
         file_args['mode'] = default_mode
-    # If the path was set to override module path
-    if path is not None:
-        file_args['path'] = path
     # Create tempfile name
     tmp_fd, tmp_name = tempfile.mkstemp(prefix=b'.ansible_tmp')
     try:

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -558,8 +558,7 @@ def main():
                     msg='Unable to remove source file: %s' % to_native(e), exception=format_exc()
                 )
 
-    params['path'] = b_dest
-    file_args = module.load_file_common_arguments(params)
+    file_args = module.load_file_common_arguments(params, path=b_dest)
 
     if not check_mode:
         changed = module.set_fs_attributes_if_different(file_args, changed)

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -779,9 +779,8 @@ def main():
     if backup_file:
         res_args['backup_file'] = backup_file
 
-    module.params['dest'] = dest
     if not module.check_mode:
-        file_args = module.load_file_common_arguments(module.params)
+        file_args = module.load_file_common_arguments(module.params, path=dest)
         res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
 
     module.exit_json(**res_args)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -536,9 +536,7 @@ def main():
         if not force and checksum and not checksum_mismatch:
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
-            module.params['path'] = dest
-            file_args = module.load_file_common_arguments(module.params)
-            file_args['path'] = dest
+            file_args = module.load_file_common_arguments(module.params, path=dest)
             result['changed'] = module.set_fs_attributes_if_different(file_args, False)
             if result['changed']:
                 module.exit_json(msg="file already exists but file attributes changed", **result)
@@ -633,9 +631,7 @@ def main():
             module.fail_json(msg="The checksum for %s did not match %s; it was %s." % (dest, checksum, destination_checksum), **result)
 
     # allow file attribute changes
-    module.params['path'] = dest
-    file_args = module.load_file_common_arguments(module.params)
-    file_args['path'] = dest
+    file_args = module.load_file_common_arguments(module.params, path=dest)
     result['changed'] = module.set_fs_attributes_if_different(file_args, result['changed'])
 
     # Backwards compat only.  We'll return None on FIPS enabled systems

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -656,8 +656,7 @@ def main():
             # allow file attribute changes
             resp['changed'] = True
             module.params['path'] = dest
-            file_args = module.load_file_common_arguments(module.params)
-            file_args['path'] = dest
+            file_args = module.load_file_common_arguments(module.params, path=dest)
             resp['changed'] = module.set_fs_attributes_if_different(file_args, resp['changed'])
         resp['path'] = dest
 

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -662,8 +662,7 @@ def main():
         except ValueError as e:
             module.fail_json(msg=e.args[0])
 
-    module.params['dest'] = dest
-    file_args = module.load_file_common_arguments(module.params)
+    file_args = module.load_file_common_arguments(module.params, path=dest)
     changed = module.set_fs_attributes_if_different(file_args, changed)
     if changed:
         module.exit_json(state=state, dest=dest, group_id=group_id, artifact_id=artifact_id, version=version, classifier=classifier,

--- a/lib/ansible/modules/system/java_keystore.py
+++ b/lib/ansible/modules/system/java_keystore.py
@@ -234,8 +234,7 @@ def create_jks(module, name, openssl_bin, keytool_bin, keystore_path, password):
 
 
 def update_jks_perm(module, keystore_path):
-    module.params['path'] = keystore_path
-    file_args = module.load_file_common_arguments(module.params)
+    file_args = module.load_file_common_arguments(module.params, path=keystore_path)
     module.set_fs_attributes_if_different(file_args, False)
 
 


### PR DESCRIPTION
##### SUMMARY
There are several modules which want to use `load_file_common_arguments` and `set_fs_attributes_if_different`, but not for the file specified in the module parameters, but for a different one. Most of them either override `module.params['path']`, or modify the result of `load_file_common_arguments`. This is not optimal, since in `load_file_common_arguments`, the path is used to follow links (if `module.params.get('follow') is True`) and to look up the selinux context.

This PR adds an optional argument `path` to `load_file_common_arguments` (default value `None`) which allows to use this path instead of `module.params['path']`/`module.params['dest']`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
