### PR TITLE
YAML parser - set source file position for vault encrypted strings

### DIFF
--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -109,6 +109,7 @@ class AnsibleConstructor(SafeConstructor):
                                    note=None)
         ret = AnsibleVaultEncryptedUnicode(b_ciphertext_data)
         ret.vault = vault
+        ret.ansible_pos = self._node_position_info(node)
         return ret
 
     def construct_yaml_seq(self, node):


### PR DESCRIPTION
##### SUMMARY
The PR adds the source position to vault encrypted string objects read by the YAML parser, just like it is done for other YAML types (strings, sequences, mappings).

This rather small change will allow third-party script to query the source location of a specific variable by using `VariableManager` and similar techniques.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
YAML Parser hotfix.

##### ADDITIONAL INFORMATION
Third-party scripts can query the source location of variables read by VariableManager by using the ansible_pos attribute of variables. However, this attribute is not set for vault encrypted strings while it is for the other YAML types. This PR will simply add the attribute for this kind of objects as well.
