### PR TITLE
ec2_vpc_subnet test cleanup

### DIFF
--- a/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -7,9 +7,13 @@
       region: "{{ aws_region }}"
   block:
 
+    - name: list available AZs
+      aws_az_info:
+      register: region_azs
 
-    - name: set up aws connection info
+    - name: pick an AZ for testing
       set_fact:
+        subnet_az: "{{ region_azs.availability_zones[0].zone_name }}"
 
     # ============================================================
     - name: create a VPC
@@ -26,7 +30,7 @@
     - name: create subnet (expected changed=true) (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -43,7 +47,7 @@
     - name: create subnet (expected changed=true)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -62,7 +66,7 @@
     - name: recreate subnet (expected changed=false) (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -79,7 +83,7 @@
     - name: recreate subnet (expected changed=false)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -97,7 +101,7 @@
     - name: update subnet so instances launched in it are assigned an IP (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -115,7 +119,7 @@
     - name: update subnet so instances launched in it are assigned an IP
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -134,7 +138,7 @@
     - name: add invalid ipv6 block to subnet (expected failed)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: 2001:db8::/64
         tags:
@@ -154,7 +158,7 @@
     - name: add a tag (expected changed=true) (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -172,7 +176,7 @@
     - name: add a tag (expected changed=true)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -193,7 +197,7 @@
     - name: remove tags with default purge_tags=true (expected changed=true) (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           AnotherTag: SomeValue
@@ -209,7 +213,7 @@
     - name: remove tags with default purge_tags=true (expected changed=true)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           AnotherTag: SomeValue
@@ -228,7 +232,7 @@
     - name: change tags with purge_tags=false (expected changed=true) (CHECK MODE)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -246,7 +250,7 @@
     - name: change tags with purge_tags=false (expected changed=true)
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
-        az: "{{ aws_region }}a"
+        az: "{{ subnet_az }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           Name: '{{ec2_vpc_subnet_name}}'

--- a/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -1,23 +1,15 @@
 ---
-# A Note about ec2 environment variable name preference:
-#  - EC2_URL -> AWS_URL
-#  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
-#  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
-#  - EC2_REGION -> AWS_REGION
-#
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
 
-# - include: ../../setup_ec2/tasks/common.yml module_name: ec2_vpc_subnet
-
-- block:
 
     - name: set up aws connection info
       set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
 
     # ============================================================
     - name: create a VPC
@@ -25,7 +17,6 @@
         name: "{{ resource_prefix }}-vpc"
         state: present
         cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info
         tags:
           Name: "{{ resource_prefix }}-vpc"
           Description: "Created by ansible-test"
@@ -40,7 +31,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: vpc_subnet_create
@@ -58,7 +48,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
       register: vpc_subnet_create
 
@@ -78,7 +67,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: vpc_subnet_recreate
@@ -96,7 +84,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
       register: vpc_subnet_recreate
 
@@ -115,7 +102,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
         map_public: true
       check_mode: true
@@ -134,7 +120,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
         map_public: true
       register: vpc_subnet_modify
@@ -155,7 +140,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
       register: vpc_subnet_ipv6_failed
       ignore_errors: yes
@@ -176,7 +160,6 @@
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
           AnotherTag: SomeValue
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: vpc_subnet_add_a_tag
@@ -195,7 +178,6 @@
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
           AnotherTag: SomeValue
-        <<: *aws_connection_info
         state: present
       register: vpc_subnet_add_a_tag
 
@@ -215,7 +197,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           AnotherTag: SomeValue
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: vpc_subnet_remove_tags
@@ -232,7 +213,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
           AnotherTag: SomeValue
-        <<: *aws_connection_info
         state: present
       register: vpc_subnet_remove_tags
 
@@ -253,7 +233,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       check_mode: true
@@ -272,7 +251,6 @@
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       register: vpc_subnet_change_tags
@@ -291,7 +269,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       check_mode: true
       register: result
 
@@ -305,7 +282,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - name: assert state=absent (expected changed=true)
@@ -319,7 +295,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       check_mode: true
       register: result
 
@@ -333,7 +308,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - name: assert state=absent (expected changed=false)
@@ -347,7 +321,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
-        <<: *aws_connection_info
       check_mode: true
       register: subnet_without_az
 
@@ -361,7 +334,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
-        <<: *aws_connection_info
       register: subnet_without_az
 
     - name: check that subnet without AZ works fine
@@ -375,7 +347,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       check_mode: true
       register: result
 
@@ -389,7 +360,6 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - name: assert state=absent (expected changed=true)
@@ -399,27 +369,28 @@
 
     # ============================================================
     # FIXME - Replace by creating IPv6 enabled VPC once ec2_vpc_net module supports it.
+    - name:
+      set_fact:
+        aws_connection_env:
+          AWS_ACCESS_KEY_ID:     "{{ aws_access_key }}"
+          AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+          AWS_SESSION_TOKEN:     "{{ security_token | default(omit) }}"
+          AWS_DEFAULT_REGION:    "{{ aws_region }}"
+      no_log: yes
+
     - name: install aws cli - FIXME temporary this should go for a lighterweight solution
       command: pip install awscli
 
     - name: Assign an Amazon provided IPv6 CIDR block to the VPC
       command: aws ec2 associate-vpc-cidr-block --amazon-provided-ipv6-cidr-block --vpc-id '{{ vpc_result.vpc.id }}'
-      environment:
-          AWS_ACCESS_KEY_ID: '{{aws_access_key}}'
-          AWS_SECRET_ACCESS_KEY: '{{aws_secret_key}}'
-          AWS_SESSION_TOKEN: '{{security_token}}'
-          AWS_DEFAULT_REGION: '{{aws_region}}'
+      environment: '{{ aws_connection_env }}'
 
     - name: wait for the IPv6 CIDR to be assigned
       command: sleep 5
 
     - name: Get the assigned IPv6 CIDR
       command: aws ec2 describe-vpcs --vpc-ids '{{ vpc_result.vpc.id }}'
-      environment:
-          AWS_ACCESS_KEY_ID: '{{aws_access_key}}'
-          AWS_SECRET_ACCESS_KEY: '{{aws_secret_key}}'
-          AWS_SESSION_TOKEN: '{{security_token}}'
-          AWS_DEFAULT_REGION: '{{aws_region}}'
+      environment: '{{ aws_connection_env }}'
       register: vpc_ipv6
 
     - set_fact:
@@ -433,7 +404,6 @@
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: true
         state: present
-        <<: *aws_connection_info
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
@@ -452,7 +422,6 @@
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: true
         state: present
-        <<: *aws_connection_info
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
           Description: '{{ec2_vpc_subnet_description}}'
@@ -475,7 +444,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: true
-        <<: *aws_connection_info
         state: present
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -494,7 +462,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: true
-        <<: *aws_connection_info
         state: present
         tags:
           Name: '{{ec2_vpc_subnet_name}}'
@@ -514,7 +481,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: false
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       check_mode: true
@@ -531,7 +497,6 @@
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
         assign_instances_ipv6: false
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       register: vpc_change_attribute
@@ -548,7 +513,6 @@
         cidr: "10.232.232.144/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}"
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       register: vpc_add_duplicate_ipv6
@@ -565,7 +529,6 @@
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       check_mode: true
@@ -580,7 +543,6 @@
       ec2_vpc_subnet:
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
-        <<: *aws_connection_info
         state: present
         purge_tags: false
       register: vpc_remove_ipv6_cidr
@@ -601,7 +563,6 @@
         purge_tags: false
         tags:
           looks_like_boolean: true
-        <<: *aws_connection_info
       check_mode: true
       register: vpc_subnet_info
 
@@ -618,7 +579,6 @@
         purge_tags: false
         tags:
           looks_like_boolean: true
-        <<: *aws_connection_info
       register: vpc_subnet_info
 
     - name: assert a tag was added
@@ -636,7 +596,6 @@
         purge_tags: false
         tags:
           looks_like_boolean: true
-        <<: *aws_connection_info
       check_mode: true
       register: vpc_subnet_info
 
@@ -653,7 +612,6 @@
         purge_tags: false
         tags:
           looks_like_boolean: true
-        <<: *aws_connection_info
       register: vpc_subnet_info
 
     - name: assert a tag was added
@@ -672,11 +630,9 @@
         cidr: "10.232.232.128/28"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        <<: *aws_connection_info
 
     - name: tidy up VPC
       ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: absent
         cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info

--- a/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -42,7 +42,7 @@
     - name: assert creation would happen
       assert:
         that:
-          - vpc_subnet_create.changed
+          - vpc_subnet_create is changed
 
     - name: create subnet (expected changed=true)
       ec2_vpc_subnet:
@@ -78,7 +78,7 @@
     - name: assert recreation changed nothing (expected changed=false)
       assert:
         that:
-           - 'not vpc_subnet_recreate.changed'
+           - vpc_subnet_recreate is not changed
 
     - name: recreate subnet (expected changed=false)
       ec2_vpc_subnet:
@@ -94,7 +94,7 @@
     - name: assert recreation changed nothing (expected changed=false)
       assert:
         that:
-           - 'not vpc_subnet_recreate.changed'
+           - vpc_subnet_recreate is not changed
            - 'vpc_subnet_recreate.subnet == vpc_subnet_create.subnet'
 
     # ============================================================
@@ -114,7 +114,7 @@
     - name: assert subnet changed
       assert:
         that:
-          - vpc_subnet_modify.changed
+          - vpc_subnet_modify is changed
 
     - name: update subnet so instances launched in it are assigned an IP
       ec2_vpc_subnet:
@@ -131,7 +131,7 @@
     - name: assert subnet changed
       assert:
         that:
-          - vpc_subnet_modify.changed
+          - vpc_subnet_modify is changed
           - vpc_subnet_modify.subnet.map_public_ip_on_launch
 
     # ============================================================
@@ -151,7 +151,7 @@
     - name: assert failure happened (expected failed)
       assert:
         that:
-           - 'vpc_subnet_ipv6_failed.failed'
+           - vpc_subnet_ipv6_failed is failed
            - "'Couldn\\'t associate ipv6 cidr' in vpc_subnet_ipv6_failed.msg"
 
     # ============================================================
@@ -171,7 +171,7 @@
     - name: assert tag addition happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_add_a_tag.changed'
+           - vpc_subnet_add_a_tag is changed
 
     - name: add a tag (expected changed=true)
       ec2_vpc_subnet:
@@ -188,7 +188,7 @@
     - name: assert tag addition happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_add_a_tag.changed'
+           - vpc_subnet_add_a_tag is changed
            - '"Name" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Name"] == ec2_vpc_subnet_name'
            - '"Description" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Description"] == ec2_vpc_subnet_description'
            - '"AnotherTag" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["AnotherTag"] == "SomeValue"'
@@ -208,7 +208,7 @@
     - name: assert tag removal happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_remove_tags.changed'
+           - vpc_subnet_remove_tags is changed
 
     - name: remove tags with default purge_tags=true (expected changed=true)
       ec2_vpc_subnet:
@@ -223,7 +223,7 @@
     - name: assert tag removal happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_remove_tags.changed'
+           - vpc_subnet_remove_tags is changed
            - '"Name" not in vpc_subnet_remove_tags.subnet.tags'
            - '"Description" not in vpc_subnet_remove_tags.subnet.tags'
            - '"AnotherTag" in vpc_subnet_remove_tags.subnet.tags and vpc_subnet_remove_tags.subnet.tags["AnotherTag"] == "SomeValue"'
@@ -245,7 +245,7 @@
     - name: assert tag addition happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_change_tags.changed'
+           - vpc_subnet_change_tags is changed
 
     - name: change tags with purge_tags=false (expected changed=true)
       ec2_vpc_subnet:
@@ -262,7 +262,7 @@
     - name: assert tag addition happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_change_tags.changed'
+           - vpc_subnet_change_tags is changed
            - '"Name" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Name"] == ec2_vpc_subnet_name'
            - '"Description" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Description"] == ec2_vpc_subnet_description'
            - '"AnotherTag" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["AnotherTag"] == "SomeValue"'
@@ -279,7 +279,7 @@
     - name: assert state=absent (expected changed=true)
       assert:
         that:
-           - 'result.changed'
+           - result is changed
 
     - name: test state=absent (expected changed=true)
       ec2_vpc_subnet:
@@ -291,7 +291,7 @@
     - name: assert state=absent (expected changed=true)
       assert:
         that:
-           - 'result.changed'
+           - result is changed
 
     # ============================================================
     - name: test state=absent (expected changed=false) (CHECK MODE)
@@ -305,7 +305,7 @@
     - name: assert state=absent (expected changed=false)
       assert:
         that:
-           - 'not result.changed'
+           - result is not changed
 
     - name: test state=absent (expected changed=false)
       ec2_vpc_subnet:
@@ -317,7 +317,7 @@
     - name: assert state=absent (expected changed=false)
       assert:
         that:
-           - 'not result.changed'
+           - result is not changed
 
     # ============================================================
     - name: create subnet without AZ (CHECK MODE)
@@ -331,7 +331,7 @@
     - name: check that subnet without AZ works fine
       assert:
         that:
-           - 'subnet_without_az.changed'
+           - subnet_without_az is changed
 
     - name: create subnet without AZ
       ec2_vpc_subnet:
@@ -343,7 +343,7 @@
     - name: check that subnet without AZ works fine
       assert:
         that:
-           - 'subnet_without_az.changed'
+           - subnet_without_az is changed
 
     # ============================================================
     - name: remove subnet without AZ (CHECK MODE)
@@ -357,7 +357,7 @@
     - name: assert state=absent (expected changed=true)
       assert:
         that:
-           - 'result.changed'
+           - result is changed
 
     - name: remove subnet without AZ
       ec2_vpc_subnet:
@@ -369,10 +369,11 @@
     - name: assert state=absent (expected changed=true)
       assert:
         that:
-           - 'result.changed'
+           - result is changed
 
     # ============================================================
     # FIXME - Replace by creating IPv6 enabled VPC once ec2_vpc_net module supports it.
+    # See Also https://github.com/ansible/ansible/pull/60983
     - name:
       set_fact:
         aws_connection_env:
@@ -417,7 +418,7 @@
     - name: assert creation with IPv6 happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_ipv6_create.changed'
+           - vpc_subnet_ipv6_create is changed
 
     - name: create subnet with IPv6 (expected changed=true)
       ec2_vpc_subnet:
@@ -434,7 +435,7 @@
     - name: assert creation with IPv6 happened (expected changed=true)
       assert:
         that:
-           - 'vpc_subnet_ipv6_create'
+           - vpc_subnet_ipv6_create is changed
            - 'vpc_subnet_ipv6_create.subnet.id.startswith("subnet-")'
            - "vpc_subnet_ipv6_create.subnet.ipv6_cidr_block == '{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}'"
            - '"Name" in vpc_subnet_ipv6_create.subnet.tags and vpc_subnet_ipv6_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
@@ -458,7 +459,7 @@
     - name: assert recreation changed nothing (expected changed=false)
       assert:
         that:
-           - 'not vpc_subnet_ipv6_recreate.changed'
+           - vpc_subnet_ipv6_recreate is not changed
 
     - name: recreate subnet (expected changed=false)
       ec2_vpc_subnet:
@@ -475,7 +476,7 @@
     - name: assert recreation changed nothing (expected changed=false)
       assert:
         that:
-           - 'not vpc_subnet_ipv6_recreate.changed'
+           - vpc_subnet_ipv6_recreate is not changed
            - 'vpc_subnet_ipv6_recreate.subnet == vpc_subnet_ipv6_create.subnet'
 
     # ============================================================
@@ -493,7 +494,7 @@
     - name: assert assign_instances_ipv6 attribute changed (expected changed=true)
       assert:
         that:
-           - 'vpc_change_attribute.changed'
+           - vpc_change_attribute is changed
 
     - name: change subnet ipv6 attribute (expected changed=true)
       ec2_vpc_subnet:
@@ -508,7 +509,7 @@
     - name: assert assign_instances_ipv6 attribute changed (expected changed=true)
       assert:
         that:
-           - 'vpc_change_attribute.changed'
+           - vpc_change_attribute is changed
            - 'not vpc_change_attribute.subnet.assign_ipv6_address_on_creation'
 
     # ============================================================
@@ -525,7 +526,7 @@
     - name: assert graceful failure (expected failed)
       assert:
         that:
-           - 'vpc_add_duplicate_ipv6.failed'
+           - vpc_add_duplicate_ipv6 is failed
            - "'The IPv6 CIDR \\'{{ vpc_ipv6_cidr | regex_replace('::/56', '::/64') }}\\' conflicts with another subnet' in vpc_add_duplicate_ipv6.msg"
 
     # ============================================================
@@ -541,7 +542,7 @@
     - name: assert subnet ipv6 cidr removed (expected changed=true)
       assert:
         that:
-           - 'vpc_remove_ipv6_cidr.changed'
+           - vpc_remove_ipv6_cidr is changed
 
     - name: remove subnet ipv6 cidr (expected changed=true)
       ec2_vpc_subnet:
@@ -554,7 +555,7 @@
     - name: assert subnet ipv6 cidr removed (expected changed=true)
       assert:
         that:
-           - 'vpc_remove_ipv6_cidr.changed'
+           - vpc_remove_ipv6_cidr is changed
            - "vpc_remove_ipv6_cidr.subnet.ipv6_cidr_block == ''"
            - 'not vpc_remove_ipv6_cidr.subnet.assign_ipv6_address_on_creation'
 
@@ -573,7 +574,7 @@
     - name: assert a tag was added
       assert:
         that:
-          - 'vpc_subnet_info.changed'
+          - vpc_subnet_info is changed
 
     - name: test adding a tag that looks like a boolean to the subnet
       ec2_vpc_subnet:
@@ -588,7 +589,7 @@
     - name: assert a tag was added
       assert:
         that:
-          - 'vpc_subnet_info.changed'
+          - vpc_subnet_info is changed
           - 'vpc_subnet_info.subnet.tags.looks_like_boolean == "True"'
 
     # ============================================================
@@ -603,10 +604,10 @@
       check_mode: true
       register: vpc_subnet_info
 
-    - name: assert a tag was added
+    - name: assert tags haven't changed
       assert:
         that:
-          - 'not vpc_subnet_info.changed'
+          - vpc_subnet_info is not changed
 
     - name: test idempotence adding a tag that looks like a boolean
       ec2_vpc_subnet:
@@ -618,10 +619,10 @@
           looks_like_boolean: true
       register: vpc_subnet_info
 
-    - name: assert a tag was added
+    - name: assert tags haven't changed
       assert:
         that:
-          - 'not vpc_subnet_info.changed'
+          - vpc_subnet_info is not changed
 
   always:
 


### PR DESCRIPTION
##### SUMMARY
Minor fixups for ec2_vpc_subnet integration tests

- use module_defaults
- support not passing session_token
- don't assume AZ a exists
- fix naming of a couple of assertions

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test/integration/targets/ec2_vpc_subnet/tasks/main.yml

##### ADDITIONAL INFORMATION

kinda vaguely linked to #60983 since @jillr's working on the module at the minute