### PR TITLE
acme_* modules: deprecate acme_version default, announce that ACME v1 support will be deprecated eventually

### DIFF
--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -953,7 +953,7 @@ def get_default_argspec():
         account_key_content=dict(type='str', no_log=True),
         account_uri=dict(type='str'),
         acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-        acme_version=dict(type='int', default=1, choices=[1, 2]),
+        acme_version=dict(type='int', choices=[1, 2]),
         validate_certs=dict(type='bool', default=True),
         select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
     )
@@ -970,6 +970,10 @@ def handle_standard_module_arguments(module, needs_acme_v2=False):
             'This should only be done for testing against a local ACME server for '
             'development purposes, but *never* for production purposes.'
         )
+
+    if module.params['acme_version'] is None:
+        module.params['acme_version'] = 1
+        module.deprecate("The option 'acme_version' will be required from Ansible 2.14 on", version='2.14')
 
     if needs_acme_v2 and module.params['acme_version'] < 2:
         module.fail_json(msg='The {0} module requires the ACME v2 protocol!'.format(module._name))

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -961,6 +961,7 @@ def get_default_argspec():
 
 def handle_standard_module_arguments(module, needs_acme_v2=False):
     '''
+    Do standard module setup, argument handling and warning emitting.
     '''
     set_crypto_backend(module)
 

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -952,7 +952,7 @@ def get_default_argspec():
         account_key_src=dict(type='path', aliases=['account_key']),
         account_key_content=dict(type='str', no_log=True),
         account_uri=dict(type='str'),
-        acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
+        acme_directory=dict(type='str'),
         acme_version=dict(type='int', choices=[1, 2]),
         validate_certs=dict(type='bool', default=True),
         select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
@@ -975,6 +975,10 @@ def handle_standard_module_arguments(module, needs_acme_v2=False):
     if module.params['acme_version'] is None:
         module.params['acme_version'] = 1
         module.deprecate("The option 'acme_version' will be required from Ansible 2.14 on", version='2.14')
+
+    if module.params['acme_directory'] is None:
+        module.params['acme_directory'] = 'https://acme-staging.api.letsencrypt.org/directory'
+        module.deprecate("The option 'acme_directory' will be required from Ansible 2.14 on", version='2.14')
 
     if needs_acme_v2 and module.params['acme_version'] < 2:
         module.fail_json(msg='The {0} module requires the ACME v2 protocol!'.format(module._name))

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -941,3 +941,18 @@ def process_links(info, callback):
         link = info['link']
         for url, relation in re.findall(r'<([^>]+)>;rel="(\w+)"', link):
             callback(unquote(url), relation)
+
+
+def get_default_argspec():
+    '''
+    Provides default argument spec for the options documented in the acme doc fragment.
+    '''
+    return dict(
+        account_key_src=dict(type='path', aliases=['account_key']),
+        account_key_content=dict(type='str', no_log=True),
+        account_uri=dict(type='str'),
+        acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
+        acme_version=dict(type='int', default=1, choices=[1, 2]),
+        validate_certs=dict(type='bool', default=True),
+        select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
+    )

--- a/lib/ansible/modules/crypto/acme/acme_account.py
+++ b/lib/ansible/modules/crypto/acme/acme_account.py
@@ -132,7 +132,7 @@ account_uri:
 from ansible.module_utils.acme import (
     ModuleFailException,
     ACMEAccount,
-    set_crypto_backend,
+    handle_standard_module_arguments,
     get_default_argspec,
 )
 
@@ -165,14 +165,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    set_crypto_backend(module)
-
-    if not module.params.get('validate_certs'):
-        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
-                            'This should only be done for testing against a local ACME server for ' +
-                            'development purposes, but *never* for production purposes.')
-    if module.params.get('acme_version') < 2:
-        module.fail_json(msg='The acme_account module requires the ACME v2 protocol!')
+    handle_standard_module_arguments(module, needs_acme_v2=True)
 
     try:
         account = ACMEAccount(module)

--- a/lib/ansible/modules/crypto/acme/acme_account.py
+++ b/lib/ansible/modules/crypto/acme/acme_account.py
@@ -130,29 +130,27 @@ account_uri:
 '''
 
 from ansible.module_utils.acme import (
-    ModuleFailException, ACMEAccount, set_crypto_backend,
+    ModuleFailException,
+    ACMEAccount,
+    set_crypto_backend,
+    get_default_argspec,
 )
 
 from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
+    argument_spec = get_default_argspec()
+    argument_spec.update(dict(
+        terms_agreed=dict(type='bool', default=False),
+        state=dict(type='str', required=True, choices=['absent', 'present', 'changed_key']),
+        allow_creation=dict(type='bool', default=True),
+        contact=dict(type='list', elements='str', default=[]),
+        new_account_key_src=dict(type='path'),
+        new_account_key_content=dict(type='str', no_log=True),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            account_key_src=dict(type='path', aliases=['account_key']),
-            account_key_content=dict(type='str', no_log=True),
-            account_uri=dict(type='str'),
-            acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-            acme_version=dict(type='int', default=1, choices=[1, 2]),
-            validate_certs=dict(type='bool', default=True),
-            terms_agreed=dict(type='bool', default=False),
-            state=dict(type='str', required=True, choices=['absent', 'present', 'changed_key']),
-            allow_creation=dict(type='bool', default=True),
-            contact=dict(type='list', elements='str', default=[]),
-            new_account_key_src=dict(type='path'),
-            new_account_key_content=dict(type='str', no_log=True),
-            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
-        ),
+        argument_spec=argument_spec,
         required_one_of=(
             ['account_key_src', 'account_key_content'],
         ),

--- a/lib/ansible/modules/crypto/acme/acme_account_info.py
+++ b/lib/ansible/modules/crypto/acme/acme_account_info.py
@@ -194,7 +194,11 @@ orders:
 '''
 
 from ansible.module_utils.acme import (
-    ModuleFailException, ACMEAccount, set_crypto_backend, process_links,
+    ModuleFailException,
+    ACMEAccount,
+    set_crypto_backend,
+    process_links,
+    get_default_argspec,
 )
 
 from ansible.module_utils.basic import AnsibleModule
@@ -238,17 +242,12 @@ def get_order(account, order_url):
 
 
 def main():
+    argument_spec = get_default_argspec()
+    argument_spec.update(dict(
+        retrieve_orders=dict(type='str', default='ignore', choices=['ignore', 'url_list', 'object_list']),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            account_key_src=dict(type='path', aliases=['account_key']),
-            account_key_content=dict(type='str', no_log=True),
-            account_uri=dict(type='str'),
-            acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-            acme_version=dict(type='int', default=1, choices=[1, 2]),
-            validate_certs=dict(type='bool', default=True),
-            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
-            retrieve_orders=dict(type='str', default='ignore', choices=['ignore', 'url_list', 'object_list']),
-        ),
+        argument_spec=argument_spec,
         required_one_of=(
             ['account_key_src', 'account_key_content'],
         ),

--- a/lib/ansible/modules/crypto/acme/acme_account_info.py
+++ b/lib/ansible/modules/crypto/acme/acme_account_info.py
@@ -196,7 +196,7 @@ orders:
 from ansible.module_utils.acme import (
     ModuleFailException,
     ACMEAccount,
-    set_crypto_backend,
+    handle_standard_module_arguments,
     process_links,
     get_default_argspec,
 )
@@ -258,14 +258,7 @@ def main():
     )
     if module._name == 'acme_account_facts':
         module.deprecate("The 'acme_account_facts' module has been renamed to 'acme_account_info'", version='2.12')
-    set_crypto_backend(module)
-
-    if not module.params.get('validate_certs'):
-        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
-                            'This should only be done for testing against a local ACME server for ' +
-                            'development purposes, but *never* for production purposes.')
-    if module.params.get('acme_version') < 2:
-        module.fail_json(msg='The acme_account module requires the ACME v2 protocol!')
+    handle_standard_module_arguments(module, needs_acme_v2=True)
 
     try:
         account = ACMEAccount(module)

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -414,7 +414,9 @@ all_chains:
 
 from ansible.module_utils.acme import (
     ModuleFailException,
-    write_file, nopad_b64, pem_to_der,
+    write_file,
+    nopad_b64,
+    pem_to_der,
     ACMEAccount,
     HAS_CURRENT_CRYPTOGRAPHY,
     cryptography_get_csr_identifiers,
@@ -422,6 +424,7 @@ from ansible.module_utils.acme import (
     cryptography_get_cert_days,
     set_crypto_backend,
     process_links,
+    get_default_argspec,
 )
 
 import base64
@@ -431,7 +434,6 @@ import os
 import re
 import textwrap
 import time
-import urllib
 from datetime import datetime
 
 from ansible.module_utils.basic import AnsibleModule
@@ -987,30 +989,25 @@ class ACMEClient(object):
 
 
 def main():
+    argument_spec = get_default_argspec()
+    argument_spec.update(dict(
+        modify_account=dict(type='bool', default=True),
+        account_email=dict(type='str'),
+        agreement=dict(type='str'),
+        terms_agreed=dict(type='bool', default=False),
+        challenge=dict(type='str', default='http-01', choices=['http-01', 'dns-01', 'tls-alpn-01']),
+        csr=dict(type='path', required=True, aliases=['src']),
+        data=dict(type='dict'),
+        dest=dict(type='path', aliases=['cert']),
+        fullchain_dest=dict(type='path', aliases=['fullchain']),
+        chain_dest=dict(type='path', aliases=['chain']),
+        remaining_days=dict(type='int', default=10),
+        deactivate_authzs=dict(type='bool', default=False),
+        force=dict(type='bool', default=False),
+        retrieve_all_alternates=dict(type='bool', default=False),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            account_key_src=dict(type='path', aliases=['account_key']),
-            account_key_content=dict(type='str', no_log=True),
-            account_uri=dict(type='str'),
-            modify_account=dict(type='bool', default=True),
-            acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-            acme_version=dict(type='int', default=1, choices=[1, 2]),
-            validate_certs=dict(default=True, type='bool'),
-            account_email=dict(type='str'),
-            agreement=dict(type='str'),
-            terms_agreed=dict(type='bool', default=False),
-            challenge=dict(type='str', default='http-01', choices=['http-01', 'dns-01', 'tls-alpn-01']),
-            csr=dict(type='path', required=True, aliases=['src']),
-            data=dict(type='dict'),
-            dest=dict(type='path', aliases=['cert']),
-            fullchain_dest=dict(type='path', aliases=['fullchain']),
-            chain_dest=dict(type='path', aliases=['chain']),
-            remaining_days=dict(type='int', default=10),
-            deactivate_authzs=dict(type='bool', default=False),
-            force=dict(type='bool', default=False),
-            retrieve_all_alternates=dict(type='bool', default=False),
-            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
-        ),
+        argument_spec=argument_spec,
         required_one_of=(
             ['account_key_src', 'account_key_content'],
             ['dest', 'fullchain_dest'],

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -422,14 +422,13 @@ from ansible.module_utils.acme import (
     cryptography_get_csr_identifiers,
     openssl_get_csr_identifiers,
     cryptography_get_cert_days,
-    set_crypto_backend,
+    handle_standard_module_arguments,
     process_links,
     get_default_argspec,
 )
 
 import base64
 import hashlib
-import locale
 import os
 import re
 import textwrap
@@ -1017,16 +1016,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    set_crypto_backend(module)
-
-    # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
-    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
-    locale.setlocale(locale.LC_ALL, 'C')
-
-    if not module.params.get('validate_certs'):
-        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
-                            'This should only be done for testing against a local ACME server for ' +
-                            'development purposes, but *never* for production purposes.')
+    handle_standard_module_arguments(module)
 
     try:
         if module.params.get('dest'):

--- a/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
@@ -123,27 +123,27 @@ RETURN = '''
 '''
 
 from ansible.module_utils.acme import (
-    ModuleFailException, ACMEAccount, nopad_b64, pem_to_der, set_crypto_backend,
+    ModuleFailException,
+    ACMEAccount,
+    nopad_b64,
+    pem_to_der,
+    set_crypto_backend,
+    get_default_argspec,
 )
 
 from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
+    argument_spec = get_default_argspec()
+    argument_spec.update(dict(
+        private_key_src=dict(type='path'),
+        private_key_content=dict(type='str', no_log=True),
+        certificate=dict(type='path', required=True),
+        revoke_reason=dict(type='int'),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            account_key_src=dict(type='path', aliases=['account_key']),
-            account_key_content=dict(type='str', no_log=True),
-            account_uri=dict(type='str'),
-            acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-            acme_version=dict(type='int', default=1, choices=[1, 2]),
-            validate_certs=dict(type='bool', default=True),
-            private_key_src=dict(type='path'),
-            private_key_content=dict(type='str', no_log=True),
-            certificate=dict(type='path', required=True),
-            revoke_reason=dict(type='int'),
-            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
-        ),
+        argument_spec=argument_spec,
         required_one_of=(
             ['account_key_src', 'account_key_content', 'private_key_src', 'private_key_content'],
         ),

--- a/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
@@ -127,7 +127,7 @@ from ansible.module_utils.acme import (
     ACMEAccount,
     nopad_b64,
     pem_to_der,
-    set_crypto_backend,
+    handle_standard_module_arguments,
     get_default_argspec,
 )
 
@@ -152,12 +152,7 @@ def main():
         ),
         supports_check_mode=False,
     )
-    set_crypto_backend(module)
-
-    if not module.params.get('validate_certs'):
-        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
-                            'This should only be done for testing against a local ACME server for ' +
-                            'development purposes, but *never* for production purposes.')
+    handle_standard_module_arguments(module)
 
     try:
         account = ACMEAccount(module)

--- a/lib/ansible/modules/crypto/acme/acme_inspect.py
+++ b/lib/ansible/modules/crypto/acme/acme_inspect.py
@@ -248,7 +248,7 @@ output_json:
 from ansible.module_utils.acme import (
     ModuleFailException,
     ACMEAccount,
-    set_crypto_backend,
+    handle_standard_module_arguments,
     get_default_argspec,
 )
 
@@ -278,12 +278,7 @@ def main():
             ['method', 'post', ['account_key_src', 'account_key_content'], True],
         ),
     )
-    set_crypto_backend(module)
-
-    if not module.params.get('validate_certs'):
-        module.warn(warning='Disabling certificate validation for communications with ACME endpoint. ' +
-                            'This should only be done for testing against a local ACME server for ' +
-                            'development purposes, but *never* for production purposes.')
+    handle_standard_module_arguments(module)
 
     result = dict()
     changed = False

--- a/lib/ansible/modules/crypto/acme/acme_inspect.py
+++ b/lib/ansible/modules/crypto/acme/acme_inspect.py
@@ -246,7 +246,10 @@ output_json:
 '''
 
 from ansible.module_utils.acme import (
-    ModuleFailException, ACMEAccount, set_crypto_backend,
+    ModuleFailException,
+    ACMEAccount,
+    set_crypto_backend,
+    get_default_argspec,
 )
 
 from ansible.module_utils.basic import AnsibleModule
@@ -256,20 +259,15 @@ import json
 
 
 def main():
+    argument_spec = get_default_argspec()
+    argument_spec.update(dict(
+        url=dict(type='str'),
+        method=dict(type='str', choices=['get', 'post', 'directory-only'], default='get'),
+        content=dict(type='str'),
+        fail_on_acme_error=dict(type='bool', default=True),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            account_key_src=dict(type='path', aliases=['account_key']),
-            account_key_content=dict(type='str', no_log=True),
-            account_uri=dict(type='str'),
-            acme_directory=dict(type='str', default='https://acme-staging.api.letsencrypt.org/directory'),
-            acme_version=dict(type='int', default=1, choices=[1, 2]),
-            validate_certs=dict(type='bool', default=True),
-            url=dict(type='str'),
-            method=dict(type='str', choices=['get', 'post', 'directory-only'], default='get'),
-            content=dict(type='str'),
-            fail_on_acme_error=dict(type='bool', default=True),
-            select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'openssl', 'cryptography']),
-        ),
+        argument_spec=argument_spec,
         mutually_exclusive=(
             ['account_key_src', 'account_key_content'],
         ),

--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -65,8 +65,8 @@ options:
       - "The ACME version of the endpoint."
       - "Must be 1 for the classic Let's Encrypt ACME endpoint, or 2 for the
          new standardized ACME v2 endpoint."
-      - "The default value is 1. Note that in Ansible 2.14, this option will
-         be required and no longer has a default."
+      - "The default value is 1. Note that in Ansible 2.14, this option I(will
+         be required) and will no longer have a default."
       - "Please also note that we will deprecate ACME v1 support eventually."
     type: int
     choices: [ 1, 2 ]
@@ -78,6 +78,9 @@ options:
       - "For safety reasons the default is set to the Let's Encrypt staging
          server (for the ACME v1 protocol). This will create technically correct,
          but untrusted certificates."
+      - "The default value is U(https://acme-staging.api.letsencrypt.org/directory).
+         Note that in Ansible 2.14, this option I(will be required) and will no longer
+         have a default."
       - "For Let's Encrypt, all staging endpoints can be found here:
          U(https://letsencrypt.org/docs/staging-environment/)"
       - "For Let's Encrypt, the production directory URL for ACME v1 is
@@ -87,7 +90,6 @@ options:
          (staging and production) and against the
          L(Pebble testing server,https://github.com/letsencrypt/Pebble)."
     type: str
-    default: https://acme-staging.api.letsencrypt.org/directory
   validate_certs:
     description:
       - Whether calls to the ACME directory will validate TLS certificates.

--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -65,8 +65,9 @@ options:
       - "The ACME version of the endpoint."
       - "Must be 1 for the classic Let's Encrypt ACME endpoint, or 2 for the
          new standardized ACME v2 endpoint."
+      - "The default value is 1. Note that in Ansible 2.14, this option will
+         be required and no longer has a default."
     type: int
-    default: 1
     choices: [ 1, 2 ]
     version_added: "2.5"
   acme_directory:

--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -42,7 +42,7 @@ options:
       - "Content of the ACME account RSA or Elliptic Curve key."
       - "Mutually exclusive with C(account_key_src)."
       - "Required if C(account_key_src) is not used."
-      - "I(Warning): the content will be written into a temporary file, which will
+      - "*Warning:* the content will be written into a temporary file, which will
          be deleted by Ansible when the module completes. Since this is an
          important private key — it can be used to change the account key,
          or to revoke your certificates without knowing their private keys
@@ -65,8 +65,8 @@ options:
       - "The ACME version of the endpoint."
       - "Must be 1 for the classic Let's Encrypt ACME endpoint, or 2 for the
          new standardized ACME v2 endpoint."
-      - "The default value is 1. Note that in Ansible 2.14, this option I(will
-         be required) and will no longer have a default."
+      - "The default value is 1. Note that in Ansible 2.14, this option *will
+         be required* and will no longer have a default."
       - "Please also note that we will deprecate ACME v1 support eventually."
     type: int
     choices: [ 1, 2 ]
@@ -79,21 +79,21 @@ options:
          server (for the ACME v1 protocol). This will create technically correct,
          but untrusted certificates."
       - "The default value is U(https://acme-staging.api.letsencrypt.org/directory).
-         Note that in Ansible 2.14, this option I(will be required) and will no longer
+         Note that in Ansible 2.14, this option *will be required* and will no longer
          have a default."
       - "For Let's Encrypt, all staging endpoints can be found here:
          U(https://letsencrypt.org/docs/staging-environment/)"
       - "For Let's Encrypt, the production directory URL for ACME v1 is
          U(https://acme-v01.api.letsencrypt.org/directory), and the production
          directory URL for ACME v2 is U(https://acme-v02.api.letsencrypt.org/directory)."
-      - "I(Warning): So far, the module has only been tested against Let's Encrypt
+      - "*Warning:* So far, the module has only been tested against Let's Encrypt
          (staging and production) and against the
          L(Pebble testing server,https://github.com/letsencrypt/Pebble)."
     type: str
   validate_certs:
     description:
       - Whether calls to the ACME directory will validate TLS certificates.
-      - "I(Warning): Should I(only ever) be set to C(no) for testing purposes,
+      - "*Warning:* Should *only ever* be set to C(no) for testing purposes,
          for example when testing against a local Pebble server."
     type: bool
     default: yes

--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -67,6 +67,7 @@ options:
          new standardized ACME v2 endpoint."
       - "The default value is 1. Note that in Ansible 2.14, this option will
          be required and no longer has a default."
+      - "Please also note that we will deprecate ACME v1 support eventually."
     type: int
     choices: [ 1, 2 ]
     version_added: "2.5"


### PR DESCRIPTION
##### SUMMARY
Since everyone should use ACME v2 eventually, having `acme_version` default to 1 is not a good idea anyway.

I also added an announcement in the `acme_version` documentation that ACME v1 support will eventually be deprecated. Right now, people might still use it, but [Let's Encrypt will shut it down eventually (current plan: less than two years from now)](https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430), and also other CAs should migrate to ACME v2 eventually (assuming that our implementation actually works with their ACME v1 implementation at the moment).

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/acme.py
acme_account
acme_account_info
acme_certificate
acme_certificate_revoke
acme_inspect
