### PR TITLE
github_deploy_key: Clarity on mutual exclusion of Username and Token

### DIFF
--- a/lib/ansible/modules/source_control/github_deploy_key.py
+++ b/lib/ansible/modules/source_control/github_deploy_key.py
@@ -57,10 +57,10 @@ options:
     default: 'no'
   username:
     description:
-      - The username to authenticate with.
+      - The username to authenticate with. Should not be set when using personal access token
   password:
     description:
-      - The password to authenticate with. A personal access token can be used here in place of a password.
+      - The password to authenticate with. Alternatively, a personal access token can be used instead of I(username) and I(password) combination.
   token:
     description:
       - The OAuth2 token or personal access token to authenticate with. Mutually exclusive with I(password).


### PR DESCRIPTION
##### SUMMARY
Although there is an example showing that username is not required with personal access token, it will be nice to more clearly state in options description. 
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
