### PR TITLE
always generate public key, dont look at the id_rsa.pub file

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1055,7 +1055,11 @@ class User(object):
         cmd.append(ssh_key_file)
 
         (rc, out, err) = self.execute_command(cmd, obey_checkmode=False)
-        return out.strip()
+        if rc == 0:
+            ssh_public_key = out.strip()
+        else:
+            ssh_public_key = err.strip()
+        return ssh_public_key
 
     def create_user(self):
         # by default we use the create_user_useradd method

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1046,13 +1046,16 @@ class User(object):
         return self.execute_command(cmd, obey_checkmode=False)
 
     def get_ssh_public_key(self):
-        ssh_public_key_file = '%s.pub' % self.get_ssh_key_path()
-        try:
-            with open(ssh_public_key_file, 'r') as f:
-                ssh_public_key = f.read().strip()
-        except IOError:
+        ssh_key_file = self.get_ssh_key_path()
+        if not os.path.exists(ssh_key_file):
             return None
-        return ssh_public_key
+        cmd = [self.module.get_bin_path('ssh-keygen', True)]
+        cmd.append('-y')
+        cmd.append('-f')
+        cmd.append(ssh_key_file)
+
+        (rc, out, err) = self.execute_command(cmd, obey_checkmode=False)
+        return out.strip()
 
     def create_user(self):
         # by default we use the create_user_useradd method


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change: Don't look at .pub file that may be missing/broken, just generate the public key from pricate, same as the fingerprint is generated.
Rationale: when private key already exist before running the module, public file may be missing\not related to private key.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Not sure if it's a bugfix/Feature request.
Reproduction:
1. Run the module to find public key when id_rsa.pub doesn't exist. Return will be as followed.
<!--- Paste verbatim command output below, e.g. before and after your change -->
tasks:
- name: create ssh key on root user
  user:
    name: root
    generate_ssh_key: yes
    ssh_key_bits: 2048
    ssh_key_file: .ssh/id_rsa
  delegate_facts: True
  become: yes
  run_once: True
  register: ssh_key

- debug:
    msg: "{{ ssh_key }}"
```paste below
 {
    "msg": {
        "append": false, 
        "changed": false, 
        "comment": "root", 
        "failed": false, 
        "group": 0, 
        "home": "/root", 
        "move_home": false, 
        "name": "root", 
        "shell": "/bin/bash", 
        "ssh_fingerprint": "2048 SHA256:BkXokyTeJ/xtOcNry0bpwCaqgMuiDPittt0VBU9ImM8 no comment (RSA)", 
        "ssh_key_file": "/root/.ssh/id_rsa", 
        "ssh_public_key": null, 
        "state": "present", 
        "uid": 0
    }
}


```
