### PR TITLE
Remove willthames from AWS and Openshift notifications

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -46,52 +46,28 @@ files:
     ignored: ryansb
   $modules/cloud/amazon/:
     ignored: erydo seiffert simplesteph nadirollo tedder
-  $modules/cloud/amazon/aws_api_gateway.py: willthames
   $modules/cloud/amazon/aws_kms.py:
-    maintainers: willthames
     ignored: tedder
   $modules/cloud/amazon/cloudformation.py:
     maintainers: ryansb
     ignored: tedder
-  $modules/cloud/amazon/cloudfront_info.py: willthames
   $modules/cloud/amazon/cloudtrail.py: $team_ansible
   $modules/cloud/amazon/ec2.py:
     maintainers: $team_ansible
     ignored: skvidal
-  $modules/cloud/amazon/ec2_ami.py: willthames
   $modules/cloud/amazon/ec2_asg.py: $team_ansible s-hertel ryansb
   $modules/cloud/amazon/ec2_group.py: $team_ansible
-  $modules/cloud/amazon/ec2_group_info.py: willthames
   $modules/cloud/amazon/ec2_instance.py: Shaps
-  $modules/cloud/amazon/ec2_instance_info.py: willthames
   $modules/cloud/amazon/ec2_key.py: $team_ansible
   $modules/cloud/amazon/ec2_lc.py: $team_ansible
-  $modules/cloud/amazon/ec2_lc_info.py: willthames
   $modules/cloud/amazon/ec2_metric_alarm.py: $team_ansible
   $modules/cloud/amazon/ec2_tag.py: $team_ansible
   $modules/cloud/amazon/ec2_vol.py: $team_ansible
-  $modules/cloud/amazon/ec2_vpc_endpoint.py: willthames
-  $modules/cloud/amazon/ec2_vpc_endpoint_info.py: willthames
-  $modules/cloud/amazon/ec2_vpc_igw.py: willthames
-  $modules/cloud/amazon/ec2_vpc_igw_info.py: willthames
-  $modules/cloud/amazon/ec2_vpc_nat_gateway_info.py: willthames
   $modules/cloud/amazon/ec2_vpc_net.py: $team_ansible
   $modules/cloud/amazon/ec2_vpc_net_info.py: whiter
-  $modules/cloud/amazon/ec2_vpc_peering_info.py: willthames
-  $modules/cloud/amazon/ec2_vpc_subnet.py: willthames
-  $modules/cloud/amazon/ecs_cluster.py: willthames
-  $modules/cloud/amazon/ecs_ecr.py: willthames
-  $modules/cloud/amazon/ecs_service.py: willthames
-  $modules/cloud/amazon/ecs_service_info.py: willthames
-  $modules/cloud/amazon/ecs_task.py: willthames
-  $modules/cloud/amazon/ecs_taskdefinition.py: willthames
-  $modules/cloud/amazon/ecs_taskdefinition_info.py: willthames
   $modules/cloud/amazon/elasticache.py: alachaum
-  $modules/cloud/amazon/elb_target_group_info.py: willthames
   $modules/cloud/amazon/iam.py: $team_ansible
   $modules/cloud/amazon/iam_cert.py: $team_ansible
-  $modules/cloud/amazon/iam_group.py: willthames
-  $modules/cloud/amazon/iam_managed_policy.py: willthames
   $modules/cloud/amazon/iam_policy.py: $team_ansible
   $modules/cloud/amazon/rds.py:
     ignored: bpennypacker
@@ -99,9 +75,6 @@ files:
   $modules/cloud/amazon/rds_subnet_group.py: scottanderson42
   $modules/cloud/amazon/route53.py:
     ignored: bpennypacker
-  $modules/cloud/amazon/route53_health_check.py: willthames
-  $modules/cloud/amazon/sns.py: willthames
-  $modules/cloud/amazon/sns_topic.py: willthames
   $modules/cloud/atomic/: krsacme
   $modules/cloud/azure/:
     ignored: chouseknecht jwhitbeck
@@ -592,7 +565,7 @@ files:
     labels:
       - cloud
       - aws
-    notified: ryansb s-hertel willthames
+    notified: s-hertel
   contrib/inventory/vmware.py:
     keywords:
       - vmware inventory
@@ -1114,7 +1087,7 @@ files:
     labels: networking
   $plugins/connection/kubectl.py:
     support: community
-    maintainers: chouseknecht maxamillion fabianvf flaper87 willthames
+    maintainers: chouseknecht maxamillion fabianvf flaper87
     labels: k8s
   $plugins/connection/lxd.py:
     maintainers: mattclay
@@ -1124,7 +1097,7 @@ files:
     labels: networking
   $plugins/connection/oc.py:
     support: community
-    maintainers: chouseknecht maxamillion fabianvf flaper87 willthames
+    maintainers: chouseknecht maxamillion fabianvf flaper87
   $plugins/connection/network_cli.py:
     support: network
     maintainers: $team_networking
@@ -1235,7 +1208,7 @@ files:
     maintainers: $team_netbox
   $plugins/inventory/openshift.py:
     support: community
-    maintainers: chouseknecht maxamillion fabianvf flaper87 willthames
+    maintainers: chouseknecht maxamillion fabianvf flaper87
   $plugins/inventory/openstack.py:
     maintainers: $team_openstack
     keywords:


### PR DESCRIPTION
##### SUMMARY
I no longer desire to be mentioned on most AWS changes.
If there are modules I'm on the authors list then I'll remain
notified.

Also remove me from openshift and kubectl plugins, I don't use
those.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
botmeta

##### ADDITIONAL INFORMATION
Restore some work-life balance