### PR TITLE
Disable Automerge

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -34,7 +34,7 @@
 #           supershipit - supershipiteers can turn a shipit into a supershipit
 #
 
-automerge: True
+automerge: False
 files:
   .github/BOTMETA.yml:
     labels: botmeta


### PR DESCRIPTION
### SUMMARY
A few PRs have been automerged since devel became 2.10 even though they still had `version_added: 2.9`

Let's disable automerge till:
a) We find a proper fix (automerge should so `rebuild_merge`?)
b) We wait 7 days since devel became 1.10 to cause stale_ci


Thanks to resmo for spotting this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

