### PR TITLE
Backport of #61538: postgresql modules: explicit defaults for bool params

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_copy.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_copy.py
@@ -57,6 +57,7 @@ options:
     - Mark I(src)/I(dst) as a program. Data will be copied to/from a program.
     - See block Examples and PROGRAM arg description U(https://www.postgresql.org/docs/current/sql-copy.html).
     type: bool
+    default: no
   options:
     description:
     - Options of COPY command.
@@ -334,7 +335,7 @@ def main():
         dst=dict(type='str', aliases=['destination']),
         columns=dict(type='list', aliases=['column']),
         options=dict(type='dict'),
-        program=dict(type='bool'),
+        program=dict(type='bool', default=False),
         db=dict(type='str', aliases=['login_db']),
         session_role=dict(type='str'),
     )

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -64,6 +64,7 @@ options:
       (e.g., VACUUM).
     - Mutually exclusive with I(check_mode).
     type: bool
+    default: no
     version_added: '2.9'
 author:
 - Felix Archambault (@archf)
@@ -233,7 +234,7 @@ def main():
         named_args=dict(type='dict'),
         session_role=dict(type='str'),
         path_to_script=dict(type='path'),
-        autocommit=dict(type='bool'),
+        autocommit=dict(type='bool', default=False),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/database/postgresql/postgresql_sequence.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_sequence.py
@@ -92,6 +92,7 @@ options:
       has reached its maximum value will return an error. False (NO CYCLE) is
       the default.
     type: bool
+    default: no
   cascade:
     description:
     - Automatically drop objects that depend on the sequence, and in turn all
@@ -99,6 +100,7 @@ options:
     - Ignored if I(state=present).
     - Only used with I(state=absent).
     type: bool
+    default: no
   rename_to:
     description:
     - The new name for the I(sequence).
@@ -471,9 +473,9 @@ def main():
         maxvalue=dict(type='int', aliases=['max']),
         start=dict(type='int'),
         cache=dict(type='int'),
-        cycle=dict(type='bool'),
+        cycle=dict(type='bool', default=False),
         schema=dict(type='str', default='public'),
-        cascade=dict(type='bool'),
+        cascade=dict(type='bool', default=False),
         rename_to=dict(type='str'),
         owner=dict(type='str'),
         newschema=dict(type='str'),

--- a/lib/ansible/modules/database/postgresql/postgresql_table.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_table.py
@@ -464,15 +464,15 @@ def main():
         db=dict(type='str', default='', aliases=['login_db']),
         tablespace=dict(type='str'),
         owner=dict(type='str'),
-        unlogged=dict(type='bool'),
+        unlogged=dict(type='bool', default=False),
         like=dict(type='str'),
         including=dict(type='str'),
         rename=dict(type='str'),
-        truncate=dict(type='bool'),
+        truncate=dict(type='bool', default=False),
         columns=dict(type='list'),
         storage_params=dict(type='list'),
         session_role=dict(type='str'),
-        cascade=dict(type='bool'),
+        cascade=dict(type='bool', default=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
(cherry picked from commit a6d9401c880456958d9a55f341dd82a89f191e8e)

##### SUMMARY
Backport of #61538: postgresql modules: explicit defaults for bool params

##### ISSUE TYPE
- Docs Pull Request