### PR TITLE
Fixes IOS L3 intermittent zuul failure

### DIFF
--- a/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -206,19 +206,38 @@ class L3_Interfaces(ConfigBase):
 
     def verify_diff_again(self, want, have):
         """
-        Verify the IPV4 difference again when sometimes due to
-        difference in order, set difference may result into difference,
+        Verify the IPV4 difference again as sometimes due to
+        change in order of set, set difference may result into change,
         when there's actually no difference between want and have
         :param want: want_dict IPV4
         :param have: have_dict IPV4
         :return: diff
         """
-        for each in want[0]:
-            diff = True
-            for every in have[0]:
-                if every == each:
-                    diff = False
+        diff = False
+        for each in want:
+            each_want = dict(each)
+            for every in have:
+                every_have = dict(every)
+                if each_want.get('address') != every_have.get('address') and \
+                        each_want.get('secondary') != every_have.get('secondary') and \
+                        len(each_want.keys()) == len(every_have.keys()):
+                    diff = True
                     break
+                elif each_want.get('dhcp_client') != every_have.get('dhcp_client') and each_want.get(
+                        'dhcp_client') is not None:
+                    diff = True
+                    break
+                elif each_want.get('dhcp_hostname') != every_have.get('dhcp_hostname') and each_want.get(
+                        'dhcp_hostname') is not None:
+                    diff = True
+                    break
+                elif each_want.get('address') != every_have.get('address') and len(each_want.keys()) == len(
+                        every_have.keys()):
+                    diff = True
+                    break
+            if diff:
+                break
+
         return diff
 
     def _set_config(self, want, have, module):

--- a/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -254,7 +254,7 @@ class L3_Interfaces(ConfigBase):
             if have.get('ipv4'):
                 ipv4 = tuple(set(dict(want_dict).get('ipv4')) - set(dict(have_dict).get('ipv4')))
                 if ipv4:
-                    ipv4 = ipv4 if check_diff_again(dict(want_dict).get('ipv4'), dict(have_dict).get('ipv4')) else ()
+                    ipv4 = ipv4 if self.check_diff_again(dict(want_dict).get('ipv4'), dict(have_dict).get('ipv4')) else ()
             else:
                 diff = want_dict - have_dict
                 ipv4 = dict(diff).get('ipv4')

--- a/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -204,33 +204,22 @@ class L3_Interfaces(ConfigBase):
 
         return commands
 
-    def check_diff_again(self, want, have):
+    def verify_diff_again(self, want, have):
         """
-        Check the IPV4 difference again when secondary IP is configured,
-        as sometimes due to difference in order set difference may result
-        into difference, when there's actually no difference between
-        want and have
+        Verify the IPV4 difference again when sometimes due to
+        difference in order, set difference may result into difference,
+        when there's actually no difference between want and have
         :param want: want_dict IPV4
         :param have: have_dict IPV4
         :return: diff
         """
-        ip = True
-        sec_ip = True
-        for each in want:
-            secondary_want = True if dict(each).get('secondary') else False
-            for every in have:
-                secondary_have = True if dict(every).get('secondary') else False
-                if secondary_want and secondary_have is False:
-                    continue
-                elif secondary_want and secondary_have:
-                    sec_ip = False if dict(each).get('address') == dict(every).get('address') else True
-                elif secondary_want is False and secondary_have is False:
-                    ip = False if dict(each).get('address') == dict(every).get('address') else True
-
-        if ip or sec_ip:
-            return True
-        elif ip is False and sec_ip is False:
-            return False
+        for each in want[0]:
+            diff = True
+            for every in have[0]:
+                if every == each:
+                    diff = False
+                    break
+        return diff
 
     def _set_config(self, want, have, module):
         # Set the interface config based on the want and have config
@@ -254,7 +243,7 @@ class L3_Interfaces(ConfigBase):
             if have.get('ipv4'):
                 ipv4 = tuple(set(dict(want_dict).get('ipv4')) - set(dict(have_dict).get('ipv4')))
                 if ipv4:
-                    ipv4 = ipv4 if self.check_diff_again(dict(want_dict).get('ipv4'), dict(have_dict).get('ipv4')) else ()
+                    ipv4 = ipv4 if self.verify_diff_again(dict(want_dict).get('ipv4'), dict(have_dict).get('ipv4')) else ()
             else:
                 diff = want_dict - have_dict
                 ipv4 = dict(diff).get('ipv4')

--- a/lib/ansible/module_utils/network/ios/utils/utils.py
+++ b/lib/ansible/module_utils/network/ios/utils/utils.py
@@ -9,7 +9,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import collections
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.network.common.utils import is_masklen, to_netmask
 
@@ -31,7 +30,7 @@ def add_command_to_config_list(interface, cmd, commands):
 
 def dict_to_set(sample_dict):
     # Generate a set with passed dictionary for comparison
-    test_dict = collections.OrderedDict()
+    test_dict = dict()
     if isinstance(sample_dict, dict):
         for k, v in iteritems(sample_dict):
             if v is not None:

--- a/lib/ansible/module_utils/network/ios/utils/utils.py
+++ b/lib/ansible/module_utils/network/ios/utils/utils.py
@@ -9,6 +9,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import collections
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.network.common.utils import is_masklen, to_netmask
 
@@ -30,7 +31,7 @@ def add_command_to_config_list(interface, cmd, commands):
 
 def dict_to_set(sample_dict):
     # Generate a set with passed dictionary for comparison
-    test_dict = {}
+    test_dict = collections.OrderedDict()
     if isinstance(sample_dict, dict):
         for k, v in iteritems(sample_dict):
             if v is not None:

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/_populate_config.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/_populate_config.yaml
@@ -5,8 +5,8 @@
   vars:
     lines: |
       interface GigabitEthernet 0/1
-      ip address dhcp client-id GigabitEthernet 0/0 hostname test.com
+      ip address 203.0.113.27 255.255.255.0
       interface GigabitEthernet 0/2
-      ip address 192.168.2.1 255.255.255.0 secondary
-      ip address 192.168.2.2 255.255.255.0
-      ipv6 address fd5d:12c9:2201:1::1/64
+      ip address 192.0.2.1 255.255.255.0 secondary
+      ip address 192.0.2.2 255.255.255.0
+      ipv6 address 2001:db8:0:3::/64

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -15,11 +15,11 @@
               dhcp_hostname: test.com
           - name: GigabitEthernet0/2
             ipv4:
-            - address: 192.168.3.1/24
+            - address: 198.51.100.1/24
               secondary: True
-            - address: 192.168.3.2/24
+            - address: 198.51.100.2/24
             ipv6:
-            - address: fd5d:12c9:2201:1::1/64
+            - address: 2001:db8:0:3::/64
         state: merged
       register: result
 

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/overridden.yaml
@@ -15,8 +15,8 @@
             - address: dhcp
           - name: GigabitEthernet0/2
             ipv4:
-            - address: 192.168.4.1/24
-            - address: 192.168.4.2/24
+            - address: 198.51.100.1/24
+            - address: 198.51.100.2/24
               secondary: True
         state: overridden
       register: result

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
@@ -12,12 +12,12 @@
         config:
           - name: GigabitEthernet0/1
             ipv4:
-            - address: 192.168.3.1/24
+            - address: 203.0.114.1/24
           - name: GigabitEthernet0/2
             ipv4:
-            - address: 192.168.4.1/24
+            - address: 198.51.100.1/24
               secondary: True
-            - address: 192.168.4.2/24
+            - address: 198.51.100.2/24
         state: replaced
       register: result
 

--- a/test/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/test/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -13,9 +13,9 @@ merged:
     - "interface GigabitEthernet0/1"
     - "ip address dhcp client-id GigabitEthernet 0/0 hostname test.com"
     - "interface GigabitEthernet0/2"
-    - "ip address 192.168.3.1 255.255.255.0 secondary"
-    - "ip address 192.168.3.2 255.255.255.0"
-    - "ipv6 address fd5d:12c9:2201:1::1/64"
+    - "ip address 198.51.100.1 255.255.255.0 secondary"
+    - "ip address 198.51.100.2 255.255.255.0"
+    - "ipv6 address 2001:db8:0:3::/64"
 
   after:
     - name: loopback888
@@ -29,11 +29,11 @@ merged:
         dhcp_hostname: test.com
       name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.3.1 255.255.255.0
+      - address: 198.51.100.1 255.255.255.0
         secondary: true
-      - address: 192.168.3.2 255.255.255.0
+      - address: 198.51.100.2 255.255.255.0
       ipv6:
-      - address: fd5d:12c9:2201:1::1/64
+      - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 
 
@@ -45,26 +45,24 @@ replaced:
       - address: dhcp
       name: GigabitEthernet0/0
     - ipv4:
-      - address: dhcp
-        dhcp_client: 0
-        dhcp_hostname: test.com
+      - address: 203.0.113.27 255.255.255.0
       name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.2.1 255.255.255.0
+      - address: 192.0.2.1 255.255.255.0
         secondary: true
-      - address: 192.168.2.2 255.255.255.0
+      - address: 192.0.2.2 255.255.255.0
       ipv6:
-      - address: fd5d:12c9:2201:1::1/64
+      - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 
   commands:
     - "interface GigabitEthernet0/1"
-    - "ip address 192.168.3.1 255.255.255.0"
+    - "ip address 203.0.114.1 255.255.255.0"
     - "interface GigabitEthernet0/2"
     - "no ip address"
     - "no ipv6 address"
-    - "ip address 192.168.4.1 255.255.255.0 secondary"
-    - "ip address 192.168.4.2 255.255.255.0"
+    - "ip address 198.51.100.1 255.255.255.0 secondary"
+    - "ip address 198.51.100.2 255.255.255.0"
 
   after:
     - name: loopback888
@@ -73,12 +71,12 @@ replaced:
       - address: dhcp
       name: GigabitEthernet0/0
     - ipv4:
-      - address: 192.168.3.1 255.255.255.0
+      - address: 203.0.114.1 255.255.255.0
       name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.4.1 255.255.255.0
+      - address: 198.51.100.1 255.255.255.0
         secondary: true
-      - address: 192.168.4.2 255.255.255.0
+      - address: 198.51.100.2 255.255.255.0
       name: GigabitEthernet0/2
 
 overridden:
@@ -89,16 +87,14 @@ overridden:
       - address: dhcp
       name: GigabitEthernet0/0
     - ipv4:
-      - address: dhcp
-        dhcp_client: 0
-        dhcp_hostname: test.com
+      - address: 203.0.113.27 255.255.255.0
       name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.2.1 255.255.255.0
+      - address: 192.0.2.1 255.255.255.0
         secondary: true
-      - address: 192.168.2.2 255.255.255.0
+      - address: 192.0.2.2 255.255.255.0
       ipv6:
-      - address: fd5d:12c9:2201:1::1/64
+      - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 
   commands:
@@ -107,8 +103,8 @@ overridden:
     - "interface GigabitEthernet0/2"
     - "no ip address"
     - "no ipv6 address"
-    - "ip address 192.168.4.1 255.255.255.0"
-    - "ip address 192.168.4.2 255.255.255.0 secondary"
+    - "ip address 198.51.100.1 255.255.255.0"
+    - "ip address 198.51.100.2 255.255.255.0 secondary"
 
   after:
     - name: loopback888
@@ -118,9 +114,9 @@ overridden:
       name: GigabitEthernet0/0
     - name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.4.2 255.255.255.0
+      - address: 198.51.100.2 255.255.255.0
         secondary: true
-      - address: 192.168.4.1 255.255.255.0
+      - address: 198.51.100.1 255.255.255.0
       name: GigabitEthernet0/2
 
 deleted:
@@ -131,16 +127,14 @@ deleted:
       - address: dhcp
       name: GigabitEthernet0/0
     - ipv4:
-      - address: dhcp
-        dhcp_client: 0
-        dhcp_hostname: test.com
+      - address: 203.0.113.27 255.255.255.0
       name: GigabitEthernet0/1
     - ipv4:
-      - address: 192.168.2.1 255.255.255.0
+      - address: 192.0.2.1 255.255.255.0
         secondary: true
-      - address: 192.168.2.2 255.255.255.0
+      - address: 192.0.2.2 255.255.255.0
       ipv6:
-      - address: fd5d:12c9:2201:1::1/64
+      - address: 2001:db8:0:3::/64
       name: GigabitEthernet0/2
 
   commands:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes IOS L3 intermittent zuul failure raised in bug #61305. Also, updated the tests IP to use documentation IPs instead of random.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
