### PR TITLE
New sysrc module for managing FreeBSD rc files

### DIFF
--- a/lib/ansible/modules/system/sysrc.py
+++ b/lib/ansible/modules/system/sysrc.py
@@ -1,0 +1,263 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2019 David Lundgren <dlundgren@syberisle.net>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = '''
+---
+module: sysrc
+short_description: Manage FreeBSD using sysrc
+requirements: []
+version_added: 2.9
+author: David Lundgren
+description:
+    - Manages /etc/rc.conf for FreeBSD
+options:
+    name:
+        required: true
+        description:
+            - Name of variable in $dest to manage.
+            - NOTE: cannot use . (periods) in the name as sysrc doesn't support OID style names
+    value:
+        required: false
+        description:
+            - The value if "present"
+    state:
+        required: false
+        default: "present"
+        choices: [ present, absent, append, subtract ]
+        description:
+            - Whether the var should be present or absent in $dest.
+            - append/subtract will add or remove the value from a list.
+    dest:
+        required: false
+        default: "/etc/rc.conf"
+        description:
+            - What file should be operated on
+    delim:
+        required: false
+        default: " "
+        description:
+            - Delimiter used in append/subtract mode
+    jail:
+        required: false
+        description:
+            - Name or ID of the jail to operate on
+'''
+
+EXAMPLES = '''
+---
+# enable mysql in the /etc/rc.conf
+- name: Configure mysql pid file
+  sysrc:
+    name: mysql_pidfile
+    value: "/var/run/mysqld/mysqld.pid"
+
+# enable accf_http kld in the boot loader
+- name: enable accf_http kld
+  sysrc:
+    name: accf_http_load
+    state: present
+    value: "YES"
+    dest: /boot/loader.conf
+
+# add gif0 to cloned_interfaces
+- name: add gif0 interface
+  sysrc:
+    name: cloned_interfaces
+    state: append
+    value: "gif0"
+
+# enable nginx on a jail
+- name: add gif0 interface
+  sysrc:
+    name: nginx_enable
+    value: "YES"
+    jail: www
+'''
+
+import re
+from ansible.module_utils.basic import AnsibleModule
+
+class sysrc(object):
+    def __init__(self, module, name, value, dest, delim, jail):
+        self.module  = module
+        self.name    = name
+        self.changed = False
+        self.value   = value
+        self.dest    = dest
+        self.delim   = delim
+        self.jail    = jail
+        self.sysrc   = module.get_bin_path('sysrc', True)
+
+    def has_unknown_variable(self, out, err):
+        # newer versions of sysrc use stderr instead of stdout
+        return err.find("unknown variable") > 0 or out.find("unknown variable") > 0
+
+    def exists(self):
+        # sysrc doesn't really use exit codes
+        (rc, out, err) = self.run_sysrc(self.name)
+        if self.value is None:
+            regex = "%s: " % re.escape(self.name)
+        else:
+            regex = "%s: %s$" % (re.escape(self.name), re.escape(self.value))
+
+        return not self.has_unknown_variable(out, err) and re.match(regex, out) is not None
+
+    def contains(self):
+        (rc, out, err) = self.run_sysrc('-n', self.name)
+        if self.has_unknown_variable(out, err):
+            return False
+
+        return self.value in out.strip().split(self.delim)
+
+    def create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        self.module._verbosity = 5
+        (rc, out, err) = self.run_sysrc("%s=%s" % (self.name, self.value))
+        if out.find("%s:" % (self.name)) == 0 and re.search("\-\> %s$" % re.escape(self.value), out) is not None:
+            self.changed = True
+            return True
+        else:
+            return False
+
+    def destroy(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        (rc, out, err) = self.run_sysrc('-x', self.name)
+        if self.has_unknown_variable(out, err):
+            return False
+
+        self.changed = True
+        return True
+
+    def append(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        setstring = '%s+=%s%s' % (self.name, self.delim, self.value)
+        (rc, out, err) = self.run_sysrc(setstring)
+        if out.find("%s:" % (self.name)) == 0:
+            values = out.split(' -> ')[1].strip().split(self.delim)
+            if self.value in values:
+                self.changed = True
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def subtract(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        setstring = '%s-=%s%s' % (self.name, self.delim, self.value)
+        (rc, out, err) = self.run_sysrc(setstring)
+        if out.find("%s:" % (self.name)) == 0:
+            values = out.split(' -> ')[1].strip().split(self.delim)
+            if self.value in values:
+                return False
+            else:
+                self.changed = True
+                return True
+        else:
+            return False
+
+    def run_sysrc(self, *args):
+        cmd = [self.sysrc, '-f', self.dest]
+        if self.jail:
+            cmd += ['-j', self.jail]
+        cmd.extend(args)
+
+        (rc, out, err) = self.module.run_command(cmd)
+        if self.module._verbosity > 0:
+            self.cmd = cmd
+
+        if self.module._verbosity >= 4:
+            self.cmd_output = out
+
+        return (rc, out, err)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name  = dict(
+                required = True
+            ),
+            value = dict(
+                default = None
+            ),
+            state = dict(
+                default = 'present',
+                choices = [ 'present', 'absent', 'append', 'subtract' ]
+            ),
+            dest  = dict(
+                default = '/etc/rc.conf'
+            ),
+            delim = dict(
+                default = ' '
+            ),
+            jail = dict(
+                default = None
+            ),
+        ),
+        supports_check_mode=True,
+    )
+
+    name   = module.params.pop('name')
+    # OID style names are not supported
+    if not re.match('^[a-zA-Z0-9_]+$', name):
+        module.fail_json(
+            msg="Name may only contain alpha-numeric and underscore characters"
+        )
+
+    value  = module.params.pop('value')
+    state  = module.params.pop('state')
+    dest   = module.params.pop('dest')
+    delim  = module.params.pop('delim')
+    jail   = module.params.pop('jail')
+    result = {
+        'name'  : name,
+        'stated' : state,
+        'state' : state,
+        'value' : value,
+        'dest'  : dest,
+        'delim' : delim,
+        'jail'  : jail,
+    }
+
+    rcValue = sysrc(module, name, value, dest, delim, jail)
+
+    if module._verbosity >= 4:
+        result['existed'] = rcValue.exists()
+
+    if state == 'present':
+        not rcValue.exists() and rcValue.create()
+    elif state == 'absent':
+        rcValue.exists() and rcValue.destroy()
+    elif state == 'append':
+        not rcValue.contains() and rcValue.append()
+    elif state == 'subtract':
+        rcValue.contains() and rcValue.subtract()
+
+    if module._verbosity > 0:
+        result['command'] = ' '.join(rcValue.cmd)
+
+    if module._verbosity >= 4:
+        result['output'] = rcValue.cmd_output
+
+    result['changed'] = rcValue.changed
+
+    module.exit_json(**result)
+
+main()

--- a/test/integration/targets/sysrc/aliases
+++ b/test/integration/targets/sysrc/aliases
@@ -1,3 +1,4 @@
+unsupported
 needs/root
 skip/docker
 skip/osx

--- a/test/integration/targets/sysrc/aliases
+++ b/test/integration/targets/sysrc/aliases
@@ -1,0 +1,4 @@
+needs/root
+skip/docker
+skip/osx
+skip/rhel

--- a/test/integration/targets/sysrc/main/main.yml
+++ b/test/integration/targets/sysrc/main/main.yml
@@ -1,0 +1,201 @@
+---
+- name: Test on FreeBSD VMs
+  when:
+    - ansible_facts.virtualization_type != 'docker'
+    - ansible_facts.distribution == 'FreeBSD'
+  block:
+    ##
+    ## sysrc - /etc/rc.conf manipulation
+    ##
+    - name: add to /etc/rc.conf
+      sysrc:
+        name: sysrc_test
+        value: test
+      register: sysrc_test0
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content0
+
+    - name: add to /etc/rc.conf
+      sysrc:
+        name: sysrc_test
+        value: test
+      register: sysrc_test0_change
+
+    - name: validate results
+      assert:
+        that:
+          - "sysrc_test0 is changed"
+          - "sysrc_test0_change is not changed"
+          - "'sysrc_test=\"test\"' in sysrc_content0.stdout_lines"
+
+    - name: Remove from /etc/rc.conf
+      sysrc:
+        name: sysrc_test
+        state: absent
+      register: sysrc_test1
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content1
+
+    - name: Remove from /etc/rc.conf
+      sysrc:
+        name: sysrc_test
+        state: absent
+      register: sysrc_test1_change
+
+    - name: validate results for key removal
+      assert:
+        that:
+          - sysrc_test1 is changed
+          - sysrc_test1_change is not changed
+          - '"sysrc_test1" not in sysrc_content1.stdout_lines'
+
+    ##
+    ## sysrc - append/subtract
+    ##
+    - name: append value (creates)
+      sysrc:
+        name: sysrc_test_append
+        state: append
+        value: test_a
+      register: sysrc_test2_create
+
+    - name: append value (append)
+      sysrc:
+        name: sysrc_test_append
+        state: append
+        value: test_b
+      register: sysrc_test2
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content2
+
+    - name: append same value
+      sysrc:
+        name: sysrc_test_append
+        state: append
+        value: test_b
+      register: sysrc_test2_change
+
+    - name: validate results for key appending
+      assert:
+        that:
+          - sysrc_test2_create is changed
+          - sysrc_test2 is changed
+          - sysrc_test2_change is not changed
+          - '"sysrc_test_append=\"test_a test_b\"" in sysrc_content2.stdout_lines'
+
+    - name: Subtract value
+      sysrc:
+        name: sysrc_test_append
+        state: subtract
+        value: test_b
+      register: sysrc_test3
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content3
+
+    - name: Subtract value
+      sysrc:
+        name: sysrc_test_append
+        state: subtract
+        value: test_b
+      register: sysrc_test3_change
+
+    - name: validate results for key subtraction
+      assert:
+        that:
+          - sysrc_test3 is changed
+          - sysrc_test3_change is not changed
+          - '"sysrc_test_append=\"test_a\"" in sysrc_content3.stdout_lines'
+
+    ##
+    ## sysrc - append/subtract with delimiter
+    ##
+    - name: append value (delimiter)
+      sysrc:
+        name: sysrc_test_append
+        state: append
+        delim: ','
+        value: test_b
+      register: sysrc_test4
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content4
+
+    - name: append value again (delimiter)
+      sysrc:
+        name: sysrc_test_append
+        state: append
+        delim: ','
+        value: test_b
+      register: sysrc_test4_change
+
+    - name: validate results for key appending
+      assert:
+        that:
+          - sysrc_test4 is changed
+          - sysrc_test4_change is not changed
+          - '"sysrc_test_append=\"test_a,test_b\"" in sysrc_content4.stdout_lines'
+
+    - name: subtract value (delimiter)
+      sysrc:
+        name: sysrc_test_append
+        state: subtract
+        delim: ','
+        value: test_b
+      register: sysrc_test5
+
+    - name: get file content
+      shell: "cat /etc/rc.conf | egrep -v ^\\#"
+      register: sysrc_content5
+
+    - name: subtract value again (delimiter)
+      sysrc:
+        name: sysrc_test_append
+        state: subtract
+        delim: ','
+        value: test_b
+      register: sysrc_test5_change
+
+    - name: validate results for key appending
+      assert:
+        that:
+          - sysrc_test5 is changed
+          - sysrc_test5_change is not changed
+          - '"sysrc_test_append=\"test_a\"" in sysrc_content5.stdout_lines'
+
+    ##
+    ## sysrc - uses alternate file
+    ##
+    - name: use alternate file
+      sysrc:
+        name: sysrc_test
+        value: test
+        dest: /tmp/sysrc_file
+      register: sysrc_test6
+
+    - name: assert file exists
+      stat:
+        path: /tmp/sysrc_file
+      register: sysrc_file
+
+    - name: validate file
+      assert:
+        that:
+          - sysrc_test6 is changed
+          - sysrc_file.stat.exists
+
+    # OID-like variables should fail
+    - name: oid style names should fail
+      register: sysrc_no_oid
+      failed_when: '"Name may only contain alpha-numeric and underscore characters" not in sysrc_no_oid.msg'
+      sysrc:
+        name: a.b
+        value: test

--- a/test/integration/targets/sysrc/main/main.yml
+++ b/test/integration/targets/sysrc/main/main.yml
@@ -52,6 +52,7 @@
           - sysrc_test1 is changed
           - sysrc_test1_change is not changed
           - '"sysrc_test1" not in sysrc_content1.stdout_lines'
+          - '"sysrc_test11" not in sysrc_content1.stdout_lines'
 
     ##
     ## sysrc - append/subtract
@@ -59,14 +60,14 @@
     - name: append value (creates)
       sysrc:
         name: sysrc_test_append
-        state: append
+        state: value_present
         value: test_a
       register: sysrc_test2_create
 
     - name: append value (append)
       sysrc:
         name: sysrc_test_append
-        state: append
+        state: value_present
         value: test_b
       register: sysrc_test2
 
@@ -77,7 +78,7 @@
     - name: append same value
       sysrc:
         name: sysrc_test_append
-        state: append
+        state: value_present
         value: test_b
       register: sysrc_test2_change
 
@@ -92,7 +93,7 @@
     - name: Subtract value
       sysrc:
         name: sysrc_test_append
-        state: subtract
+        state: value_absent
         value: test_b
       register: sysrc_test3
 
@@ -103,7 +104,7 @@
     - name: Subtract value
       sysrc:
         name: sysrc_test_append
-        state: subtract
+        state: value_absent
         value: test_b
       register: sysrc_test3_change
 
@@ -120,7 +121,7 @@
     - name: append value (delimiter)
       sysrc:
         name: sysrc_test_append
-        state: append
+        state: value_present
         delim: ','
         value: test_b
       register: sysrc_test4
@@ -132,7 +133,7 @@
     - name: append value again (delimiter)
       sysrc:
         name: sysrc_test_append
-        state: append
+        state: value_present
         delim: ','
         value: test_b
       register: sysrc_test4_change
@@ -147,7 +148,7 @@
     - name: subtract value (delimiter)
       sysrc:
         name: sysrc_test_append
-        state: subtract
+        state: value_absent
         delim: ','
         value: test_b
       register: sysrc_test5
@@ -159,7 +160,7 @@
     - name: subtract value again (delimiter)
       sysrc:
         name: sysrc_test_append
-        state: subtract
+        state: value_absent
         delim: ','
         value: test_b
       register: sysrc_test5_change
@@ -178,7 +179,7 @@
       sysrc:
         name: sysrc_test
         value: test
-        dest: /tmp/sysrc_file
+        path: /tmp/sysrc_file
       register: sysrc_test6
 
     - name: assert file exists
@@ -199,3 +200,24 @@
       sysrc:
         name: a.b
         value: test
+
+    ##
+    ## sysrc - jail
+    ##
+    - name: creates file in jail
+      register: jail_test0
+      sysrc:
+        name: test_jail
+        value: test
+        jail: testjail
+
+    - name: jail file exists
+      register: jail_file0
+      stat:
+        path: /usr/jails/testjail/etc/rc.conf
+
+    - name: validate jail works
+      assert:
+        that:
+          - jail_test0 is changed
+          - jail_file0.stat.exists


### PR DESCRIPTION
##### SUMMARY
Adds sysrc modules for managing /etc/rc.conf, or specified file, for FreeBSD

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
sysrc

##### ADDITIONAL INFORMATION

Currently you have to use `lineinfile` and this makes using the append/subtract feature of sysrc harder.
