### PR TITLE
WIP: fix impossible to omit or pass a default value to published_ports

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1232,7 +1232,7 @@ class TaskParameters(DockerBaseClass):
                     self.fail("Failed to convert %s to bytes: %s" % (param_name, exc))
 
         self.publish_all_ports = False
-        self.published_ports = self._parse_publish_ports()
+        self.published_ports = self._parse_publish_ports() if self.published_ports else None
         if self.published_ports in ('all', 'ALL'):
             self.publish_all_ports = True
             self.published_ports = None


### PR DESCRIPTION
##### SUMMARY
Hi,

When you want to pass an empty list or a null/None value to published_ports on docker_container it's actually impossible, so you get this error

```
File \"/tmp/ansible_docker_container_payload_ZOZc5l/__main__.py\", line 1448, in _parse_publish_ports\r\n  File \"/tmp/ansible_docker_container_payload_ZOZc5l/__main__.py\", line 1003, in parse_port_range\r\nValueError: invalid literal for int() with base 10: ''\r\n",
 ```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ADDITIONAL INFORMATION
#61698