### PR TITLE
zypper: add additional flag force_resolution

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -91,6 +91,13 @@ options:
         required: false
         default: "no"
         type: bool
+    force_resolution:
+        version_added: "2.10"
+        description:
+          - Adds C(--force-resolution) option to I(zypper). Allows to (un)install packages with conflicting requirements (resolver will choose a solution).
+        required: false
+        default: "no"
+        type: bool
     update_cache:
         version_added: "2.2"
         description:
@@ -338,6 +345,8 @@ def get_cmd(m, subcommand):
             cmd.append('--no-recommends')
         if m.params['force']:
             cmd.append('--force')
+        if m.params['force_resolution']:
+            cmd.append('--force-resolution')
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
     if m.params['extra_args']:
@@ -479,6 +488,7 @@ def main():
             disable_gpg_check=dict(required=False, default='no', type='bool'),
             disable_recommends=dict(required=False, default='yes', type='bool'),
             force=dict(required=False, default='no', type='bool'),
+            force_resolution=dict(required=False, default='no', type='bool'),
             update_cache=dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage=dict(required=False, default='no', type='bool'),
             extra_args=dict(required=False, default=None),

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -413,3 +413,27 @@
       - zypper_result_update_cache is successful
       - zypper_result_update_cache_check is successful
       - zypper_result_update_cache_check is not changed
+
+
+- name: install netcat-openbsd which conflicts with gnu-netcat
+  zypper:
+    name: netcat-openbsd
+    state: present
+
+- name: try installation of gnu-netcat which should fail due to the conflict
+  zypper:
+    name: gnu-netcat
+    state: present
+  ignore_errors: yes
+  register: zypper_pkg_conflict
+
+- assert:
+    that:
+      - zypper_pkg_conflict is failed
+      - "'conflicts with netcat-openbsd provided' in zypper_pkg_conflict.stdout"
+
+- name: retry installation of gnu-netcat with force_resolution set to choose a resolution
+  zypper:
+    name: gnu-netcat
+    state: present
+    force_resolution: True


### PR DESCRIPTION
##### SUMMARY

When trying to install a package which is blocked by an already installed package (like the `x11-video-nvidiaG05` when `x11-video-nvidiaG04` is already installed) the installation of packages currently fail since `zypper` needs a decision.

With the `--force-resolution` option for the `install` subcommand one can allow `zypper` to remove packages to be able find a resolution.

The `extra_args` is also passed to the `search` subcommand which does not know the `--force-resolution` option, which is why a separate flag like `force` or `disable_recommends` is needed.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`force_resolution` option for `zypper` module