### PR TITLE
Fix CSRF handling in jenkins modules #61712

### DIFF
--- a/changelogs/fragments/61713-jenkins_modules_address_improved_csrf_protection.yaml
+++ b/changelogs/fragments/61713-jenkins_modules_address_improved_csrf_protection.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - jenkins_script - Address Improved CSRF protection (https://github.com/ansible/ansible/issues/61712)
+  - jenkins_plugin - Address Improved CSRF protection (https://github.com/ansible/ansible/issues/61712)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #61712.

In the context of [SECURITY-626](https://jenkins.io/doc/upgrade-guide/2.176/#SECURITY-626), the official upgrade guide suggests either using an API token instead of CSRF token (crumb) or retaining a session ID. Since the former potentially requires much more changes, the latter approach looks better. Please read individual commit *full* comments for more details.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
web_infrastructure

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
