### PR TITLE
Increase unit test timeout to account for long image download times

### DIFF
--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -11,7 +11,7 @@ group="${args[2]}"
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=60
 else
-    timeout=6
+    timeout=11
 fi
 
 group1=()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The unit tests were split into two groups and the timeout reduced. Unfortunately, a lot of the test time is being eaten up downloading the test image which is causing the test to be terminated before it can complete successfully.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/utils/shippable/units.sh`
