### PR TITLE
shippable: temporary bump the timeout for Azure jobs

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -137,6 +137,8 @@ trap cleanup EXIT
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=60
+elif [[ "${script}" == "azure" ]]; then
+    timeout=70
 else
     timeout=45
 fi


### PR DESCRIPTION
##### SUMMARY

Azure tests are slower than usual and reach the 45 minutes timeout. This commit temporary increases the timeout.
See: https://app.shippable.com/github/ansible/ansible/runs/141269/119/console
See: https://github.com/ansible/ansible/pull/61633

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test
<!--- Write the short name of the module, plugin, task or feature below -->