### PR TITLE
shippable.sh: prefetch the default-test-container

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -17,6 +17,15 @@ for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v '^drydock/'
     docker rm -f "${container}" || true  # ignore errors
 done
 
+for i in network windows sanity; do
+    if [[ "${script}" == "${i}" ]]; then
+        # Prefetch the default test container to avoid any
+        # slow down during the test execution
+        docker pull quay.io/ansible/default-test-container
+        break
+    fi
+done
+
 docker ps
 
 if [ -d /home/shippable/cache/ ]; then


### PR DESCRIPTION
##### SUMMARY

The download of the default-test-container can slow down the
test execution enough to reach a timeout. To avoid this situation,
we predownload the image before we actually start the test.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test/utils/shippable/shippable.sh
<!--- Write the short name of the module, plugin, task or feature below -->