### PR TITLE
Bug fix for #60224 (nxos_vrf errors with reserved words)

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf.py
@@ -379,10 +379,12 @@ def map_params_to_obj(module):
 
 
 def get_value(arg, config, module):
-    extra_arg_regex = re.compile(r'(?:{0}\s)(?P<value>.*)$'.format(arg), re.M)
     value = ''
     if arg in config:
-        value = extra_arg_regex.search(config).group('value')
+        extra_arg_regex = re.compile(r'(?:{0}\s)(?P<value>.*)'.format(arg), re.M)
+        command = extra_arg_regex.search(config)
+        if command:
+            value = command.group('value')
     return value
 
 


### PR DESCRIPTION
##### SUMMARY
Added fix to handle reserved errors in description in nxos_vrf module.

Fixes #60224

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/nxos/nxos_vrf.py