### PR TITLE
aws_codebuild tests - add retries and delay instead of a pause task

### DIFF
--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 # defaults file for aws_codebuild
+
+# IAM role names have to be less than 64 characters
+# The 8 digit identifier at the end of resource_prefix helps determine during
+# which test something was created and allows tests to be run in parallel
+iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"

--- a/test/integration/targets/aws_codebuild/tasks/main.yml
+++ b/test/integration/targets/aws_codebuild/tasks/main.yml
@@ -16,13 +16,6 @@
           region: "{{ aws_region }}"
       no_log: yes
 
-    # IAM role names have to be less than 64 characters
-    # The 8 digit identifier at the end of resource_prefix helps determine during
-    # which test something was created and allows tests to be run in parallel
-    - name: set the role name
-      set_fact:
-        iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
-
     - name: create IAM role needed for CodeBuild
       iam_role:
         name: "{{ iam_role_name }}"

--- a/test/integration/targets/aws_codebuild/tasks/main.yml
+++ b/test/integration/targets/aws_codebuild/tasks/main.yml
@@ -16,18 +16,21 @@
           region: "{{ aws_region }}"
       no_log: yes
 
+    # IAM role names have to be less than 64 characters
+    # The 8 digit identifier at the end of resource_prefix helps determine during
+    # which test something was created and allows tests to be run in parallel
+    - name: set the role name
+      set_fact:
+        iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
+
     - name: create IAM role needed for CodeBuild
       iam_role:
-        name: "ansible-test-sts-{{ resource_prefix }}-codebuild-service-role"
+        name: "{{ iam_role_name }}"
         description: Role with permissions for CodeBuild actions.
         assume_role_policy_document: "{{ lookup('file', 'codebuild_iam_trust_policy.json') }}"
         state: present
         <<: *aws_connection_info
       register: codebuild_iam_role
-
-    - name: Wait until IAM role is available
-      pause:
-        seconds: 10
 
     - name: Set variable with aws account id
       set_fact:
@@ -61,6 +64,9 @@
         state: present
         <<: *aws_connection_info
       register: output
+      retries: 10
+      delay: 5
+      until: output is success
 
     - assert:
         that:
@@ -115,6 +121,6 @@
 
     - name: cleanup IAM role created for CodeBuild test
       iam_role:
-        name: "{{ resource_prefix }}-codebuild-service-role"
+        name: "{{ iam_role_name }}"
         state: absent
         <<: *aws_connection_info

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -2,4 +2,8 @@
 # defaults file for aws_codepipeline
 
 codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
-codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix }}-codepipeline-role"
+
+# IAM role names have to be less than 64 characters
+# The 8 digit identifier at the end of resource_prefix helps determine during
+# which test something was created and allows tests to be run in parallel
+codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"

--- a/test/integration/targets/aws_codepipeline/tasks/main.yml
+++ b/test/integration/targets/aws_codepipeline/tasks/main.yml
@@ -25,10 +25,6 @@
         <<: *aws_connection_info
       register: codepipeline_iam_role
 
-    - name: Pause a few seconds to ensure IAM role is available to next task
-      pause:
-        seconds: 10
-
     # ================== integration test ==========================================
 
     - name: create CodePipeline
@@ -69,6 +65,9 @@
         state: present
         <<: *aws_connection_info
       register: output
+      retries: 10
+      delay: 5
+      until: output is success
 
     - assert:
         that:


### PR DESCRIPTION
##### SUMMARY
Fixes https://app.shippable.com/github/ansible/ansible/runs/141595/113/tests by adding a longer amount of time for the IAM role to become viable for codebuild

Also shorten the IAM role name length to make running locally easier

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
aws_codebuild tests

