### PR TITLE
aws_s3 - wait for the bucket before setting ACLs

### DIFF
--- a/changelogs/fragments/61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
+++ b/changelogs/fragments/61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_s3 - Try to wait for the bucket to exist before setting the access control list.

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -389,6 +389,9 @@ def create_bucket(module, s3, bucket, location=None):
             s3.create_bucket(Bucket=bucket, CreateBucketConfiguration=configuration)
         else:
             s3.create_bucket(Bucket=bucket)
+        if module.params.get('permission') and not module.params.get('ignore_nonexistent_bucket'):
+            # Wait for the bucket to exist before setting ACLs
+            s3.get_waiter('bucket_exists').wait(Bucket=bucket)
         for acl in module.params.get('permission'):
             s3.put_bucket_acl(ACL=acl, Bucket=bucket)
     except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
##### SUMMARY
Fixes https://app.shippable.com/github/ansible/ansible/runs/141512/114/tests

Wait for the bucket to become available if possible before setting ACLs

I waited conditionally on whether there were permissions and ignore_nonexistent_bucket is not True since 
1) drop-ins often don't support ACLs and they get around the issue by setting permissions to null
2) some people use the module without read permissions and can't query if the bucket exists (skirting around the issue via ignore_nonexistent_bucket).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_s3 tests
