### PR TITLE
[WIP] Pre-fetch default test image for unit, sanity, network, and windows tests

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -9,6 +9,28 @@ script="${args[0]}"
 
 test="$1"
 
+function get_default_image_version {
+    # Find the completion file and parse it to get the default test image version
+    # Returns 'latest' if unable to parse the completion file
+
+    version='latest'
+    completion_file="$(find test -type f -name 'docker.txt' | tail -n 1)"
+    if [[ -f "$completion_file" ]]; then
+        found_version=$(grep 'default' "$completion_file" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+
+        if [[ -n "$found_version" ]]; then
+            version="$found_version"
+        fi
+    fi
+
+    echo "$version"
+}
+
+# Pull correct version of default test image only for certain tests
+if [[ "${script}" =~ (units|sanity|windows|network) ]]; then
+    docker pull "quay.io/ansible/default-test-container:$(get_default_image_version)"
+fi
+
 docker images ansible/ansible
 docker images quay.io/ansible/*
 docker ps


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- add function to get the correct default test image version
- fetch the image prior to running `ansible-test`

The idea behind this is that `ansible-test` fetches the image, which can take minutes. We would like to keep the unit test timeout low. Fetching the image before `ansible-test` runs means the fetching time does not count against the test execution time.

We recently split the unit tests and reduced the timeout to six minutes. That was causing failures in nightly builds when they run on fresh instances and we had to raise the timeout back up to 11 minutes. (I think we don't see consistent failures of unit tests during the day because instances are getting reused. At least that's my guess based on seeing a non-zero `uptime` in the console). We would like to keep the timeouts low and have it not be affected by the time it takes to pull the default test image.

Replaces #61728
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/utils/shippable/shippable.sh`