### PR TITLE
[stable-2.9] debian: prepare the ansible-test package

### DIFF
--- a/packaging/debian/ansible-test.install
+++ b/packaging/debian/ansible-test.install
@@ -1,0 +1,2 @@
+debian/tmp/usr/bin/ansible-test usr/bin
+debian/tmp/usr/lib/python2.7/dist-packages/ansible_test usr/lib/python2.7/dist-packages

--- a/packaging/debian/ansible.install
+++ b/packaging/debian/ansible.install
@@ -1,4 +1,15 @@
 examples/hosts etc/ansible
 docs/man/man1/*.1 usr/share/man/man1
-bin/* usr/bin
+debian/tmp/usr/bin/ansible-galaxy usr/bin
+debian/tmp/usr/bin/ansible-vault usr/bin
+debian/tmp/usr/bin/ansible-doc usr/bin
+debian/tmp/usr/bin/ansible-console usr/bin
+debian/tmp/usr/bin/ansible-connection usr/bin
+debian/tmp/usr/bin/ansible-inventory usr/bin
+debian/tmp/usr/bin/ansible-config usr/bin
+debian/tmp/usr/bin/ansible-pull usr/bin
+debian/tmp/usr/bin/ansible-playbook usr/bin
+debian/tmp/usr/bin/ansible usr/bin
 examples/ansible.cfg etc/ansible
+debian/tmp/usr/lib/python2.7/dist-packages/ansible usr/lib/python2.7/dist-packages
+debian/tmp/usr/lib/python2.7/dist-packages/ansible-*.egg-info

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,20 @@ Package: ansible
 Architecture: all
 Depends: python-jinja2, python-yaml, python-paramiko, python-httplib2, python-six, python-crypto (>= 2.6), python-setuptools, sshpass, ${misc:Depends}, ${python:Depends}
 Description: Ansible IT Automation
- A radically simple IT automation platform that makes your applications and
- systems easier to deploy. Avoid writing scripts or custom code to deploy and
- update your applications— automate in a language that approaches plain English,
- using SSH, with no agents to install on remote systems.
+ Ansible is a radically simple model-driven configuration management,
+ multi-node deployment, and remote task execution system. Ansible works
+ over SSH and does not require any software or daemons to be installed
+ on remote nodes. Extension modules can be written in any language and
+ are transferred to managed machines automatically.
+
+Package: ansible-test
+Architecture: all
+Depends: ansible (= ${binary:Version}), python-virtualenv, ${misc:Depends}
+Description: Ansible IT Automation
+ Ansible is a radically simple model-driven configuration management,
+ multi-node deployment, and remote task execution system. Ansible works
+ over SSH and does not require any software or daemons to be installed
+ on remote nodes. Extension modules can be written in any language and
+ are transferred to managed machines automatically.
+ This package installs the ansible-test command for testing modules and
+ plugins developed for ansible.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 # -- makefile --
 
-DEB_PYTHON2_MODULE_PACKAGES=ansible
+DEB_PYTHON2_MODULE_PACKAGES=ansible ansible_test
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk


### PR DESCRIPTION
- Generate an extra package for `ansible-test`.
- Manually install the files because CDBS get confused by our two
  Python packages
- Refresh the package descriptions to match what is done with the RPM
(cherry picked from commit 3f9316b)

Co-authored-by: Gonéri Le Bouder <goneri@lebouder.net>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
