### PR TITLE
Specify xml commands in junos_l3_interfaces doc

### DIFF
--- a/lib/ansible/modules/network/junos/junos_l3_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interfaces.py
@@ -374,10 +374,10 @@ after:
      of the parameters above.
   type: list
 commands:
-  description: The set of commands pushed to the remote device.
+  description: The set of commands in xml pushed to the remote device.
   returned: always
   type: list
-  sample: ['command 1', 'command 2', 'command 3']
+  sample: ['xml 1', 'xml 2', 'xml 3']
 """
 
 


### PR DESCRIPTION
##### SUMMARY
Specify xml commands in junos_l3_interfaces doc

As junos_l3_interfaces module is using netconf by default, this PR specifies
that on the documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
junos_l3_interfaces