### PR TITLE
[stable-2.9] aws_s3 - wait for the bucket before setting ACLs (#61735)

### DIFF
--- a/changelogs/fragments/61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
+++ b/changelogs/fragments/61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_s3 - Try to wait for the bucket to exist before setting the access control list.

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -389,6 +389,9 @@ def create_bucket(module, s3, bucket, location=None):
             s3.create_bucket(Bucket=bucket, CreateBucketConfiguration=configuration)
         else:
             s3.create_bucket(Bucket=bucket)
+        if module.params.get('permission') and not module.params.get('ignore_nonexistent_bucket'):
+            # Wait for the bucket to exist before setting ACLs
+            s3.get_waiter('bucket_exists').wait(Bucket=bucket)
         for acl in module.params.get('permission'):
             s3.put_bucket_acl(ACL=acl, Bucket=bucket)
     except botocore.exceptions.ClientError as e:

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -389,7 +389,7 @@ def create_bucket(module, s3, bucket, location=None):
             s3.create_bucket(Bucket=bucket, CreateBucketConfiguration=configuration)
         else:
             s3.create_bucket(Bucket=bucket)
-        if module.params.get('permission') and not module.params.get('ignore_nonexistent_bucket'):
+        if module.params.get('permission'):
             # Wait for the bucket to exist before setting ACLs
             s3.get_waiter('bucket_exists').wait(Bucket=bucket)
         for acl in module.params.get('permission'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61735 for Ansible 2.9
This is to address test failures like [this one]().
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/amazon/aws_s3.py`