### PR TITLE
[stable-2.9] aws_codebuild tests - add retries and delay instead of a pause task (#61731)

### DIFF
--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 # defaults file for aws_codebuild
+
+# IAM role names have to be less than 64 characters
+# The 8 digit identifier at the end of resource_prefix helps determine during
+# which test something was created and allows tests to be run in parallel
+iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"

--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -4,4 +4,7 @@
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel
-iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
+# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
+# we need both sets of digits to keep the resource name unique
+unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+iam_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"

--- a/test/integration/targets/aws_codebuild/tasks/main.yml
+++ b/test/integration/targets/aws_codebuild/tasks/main.yml
@@ -18,16 +18,12 @@
 
     - name: create IAM role needed for CodeBuild
       iam_role:
-        name: "ansible-test-sts-{{ resource_prefix }}-codebuild-service-role"
+        name: "{{ iam_role_name }}"
         description: Role with permissions for CodeBuild actions.
         assume_role_policy_document: "{{ lookup('file', 'codebuild_iam_trust_policy.json') }}"
         state: present
         <<: *aws_connection_info
       register: codebuild_iam_role
-
-    - name: Wait until IAM role is available
-      pause:
-        seconds: 10
 
     - name: Set variable with aws account id
       set_fact:
@@ -61,6 +57,9 @@
         state: present
         <<: *aws_connection_info
       register: output
+      retries: 10
+      delay: 5
+      until: output is success
 
     - assert:
         that:
@@ -115,6 +114,6 @@
 
     - name: cleanup IAM role created for CodeBuild test
       iam_role:
-        name: "{{ resource_prefix }}-codebuild-service-role"
+        name: "{{ iam_role_name }}"
         state: absent
         <<: *aws_connection_info

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -2,4 +2,8 @@
 # defaults file for aws_codepipeline
 
 codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
-codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix }}-codepipeline-role"
+
+# IAM role names have to be less than 64 characters
+# The 8 digit identifier at the end of resource_prefix helps determine during
+# which test something was created and allows tests to be run in parallel
+codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -6,4 +6,7 @@ codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel
-codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
+# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
+# we need both sets of digits to keep the resource name unique
+unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+codepipeline_service_role_name: "ansible-test-sts-{{ unique_id }}-codepipeline-role"

--- a/test/integration/targets/aws_codepipeline/tasks/main.yml
+++ b/test/integration/targets/aws_codepipeline/tasks/main.yml
@@ -25,10 +25,6 @@
         <<: *aws_connection_info
       register: codepipeline_iam_role
 
-    - name: Pause a few seconds to ensure IAM role is available to next task
-      pause:
-        seconds: 10
-
     # ================== integration test ==========================================
 
     - name: create CodePipeline
@@ -69,6 +65,9 @@
         state: present
         <<: *aws_connection_info
       register: output
+      retries: 10
+      delay: 5
+      until: output is success
 
     - assert:
         that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61731 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/aws_codebuild`