### PR TITLE
Unify ios_logging documentation with accepted options

### DIFF
--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -24,11 +24,11 @@ options:
   dest:
     description:
       - Destination of the logs.
-    choices: ['on', 'host', console', 'monitor', 'buffered']
+    choices: ['on', 'host', 'console', 'monitor', 'buffered']
   name:
     description:
-      - If value of C(dest) is I(host) C(name) should be specified,
-        which indicates hostname or IP address.
+      - The hostname or IP address of the destination.
+      - Required when I(dest=host).
   size:
     description:
       - Size of buffer. The acceptable value is in range from 10 to

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -41,8 +41,8 @@ options:
     choices: ['on', 'host', 'console', 'monitor', 'buffered', 'trap']
   name:
     description:
-      - If value of C(dest) is I(host) C(name) should be specified,
-        which indicates hostname or IP address.
+      - The hostname or IP address of the destination.
+      - Required when I(dest=host).
   size:
     description:
       - Size of buffer. The acceptable value is in range from 4096 to

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -41,9 +41,8 @@ options:
     choices: ['on', 'host', 'console', 'monitor', 'buffered', 'trap']
   name:
     description:
-      - If value of C(dest) is I(file) it indicates file-name,
-        for I(user) it indicates username and for I(host) indicates
-        the host name to be notified.
+      - If value of C(dest) is I(host) C(name) should be specified,
+        which indicates hostname or IP address.
   size:
     description:
       - Size of buffer. The acceptable value is in range from 4096 to


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #61547

The documentation of the `name` parameter mentions options not supported by the module. This PR updates the description to remove them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_logging