### PR TITLE
Fixes #56832: Remove warning when falling back to apt-get if aptitude unavailable

### DIFF
--- a/changelogs/fragments/56832-remove-aptitude-warning.yml
+++ b/changelogs/fragments/56832-remove-aptitude-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove the unnecessary warning about aptitude not being installed (https://github.com/ansible/ansible/issues/56832).

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1055,7 +1055,6 @@ def main():
     use_apt_get = p['force_apt_get']
 
     if not use_apt_get and not APTITUDE_CMD:
-        module.warn("Could not find aptitude. Using apt-get instead")
         use_apt_get = True
 
     updated_cache = False

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -35,14 +35,6 @@
     when:
       - force_apt_get
 
-  - name: check that warning is given when aptitude not found and force_apt_get not set
-    assert:
-      that:
-        - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings[0]"
-    when:
-      - not aptitude_present
-      - not force_apt_get
-
   - name: check that old version upgraded correctly
     assert:
       that:


### PR DESCRIPTION
##### SUMMARY

Fixes #56832: Remove warning when falling back to apt-get if aptitude unavailable

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

apt

##### ADDITIONAL INFORMATION

For the following task:

```yaml
- name: Update apt cache if needed.
  apt: update_cache=yes cache_valid_time=3600
```

Before (on an ubuntu server):

```
TASK [Update apt cache if needed.] *********************************************
 [WARNING]: Could not find aptitude. Using apt-get instead

changed: [default]
```

After:

```
TASK [Update apt cache if needed.] *********************************************
changed: [default]
```