### PR TITLE
codebuild/codepipeline - fix regex for shippable resource_prefix

### DIFF
--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -4,4 +4,6 @@
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel
-iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
+# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
+# we need both sets of digits to keep the resource name unique
+iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"

--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -6,4 +6,5 @@
 # which test something was created and allows tests to be run in parallel
 # Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
 # we need both sets of digits to keep the resource name unique
-iam_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+iam_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -9,4 +9,4 @@ codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
 # Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
 # we need both sets of digits to keep the resource name unique
 unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
-codepipeline_service_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"
+codepipeline_service_role_name: "ansible-test-sts-{{ unique_id }}-codepipeline-role"

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -8,4 +8,5 @@ codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
 # which test something was created and allows tests to be run in parallel
 # Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
 # we need both sets of digits to keep the resource name unique
-codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
+codepipeline_service_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -6,4 +6,6 @@ codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
 # IAM role names have to be less than 64 characters
 # The 8 digit identifier at the end of resource_prefix helps determine during
 # which test something was created and allows tests to be run in parallel
-codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('([0-9]+)$') }}-codebuild-service-role"
+# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
+# we need both sets of digits to keep the resource name unique
+codepipeline_service_role_name: "ansible-test-sts-{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"


### PR DESCRIPTION
##### SUMMARY
I assumed shippable resource prefixes were identical to those locally, but they have a different format. This fixes https://app.shippable.com/github/ansible/ansible/runs/141766/113/tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
codebuild, codepipeline