### PR TITLE
nxos_l3_interfaces: Exclude mgmt0 *Fixes testbed breakage*

### DIFF
--- a/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -17,7 +17,8 @@ __metaclass__ = type
 from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import dict_diff, to_list, remove_empties
 from ansible.module_utils.network.nxos.facts.facts import Facts
-from ansible.module_utils.network.nxos.utils.utils import get_interface_type, normalize_interface, search_obj_in_list, validate_ipv4_addr, validate_ipv6_addr, sanitize_interface_facts
+from ansible.module_utils.network.nxos.utils.utils import get_interface_type, normalize_interface, search_obj_in_list, validate_ipv4_addr, validate_ipv6_addr
+from ansible.module_utils.network.nxos.utils.utils import sanitize_interface_facts
 
 
 class L3_interfaces(ConfigBase):
@@ -48,6 +49,7 @@ class L3_interfaces(ConfigBase):
         """
         facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
         l3_interfaces_facts = facts['ansible_network_resources'].get('l3_interfaces')
+
         if not l3_interfaces_facts:
             return []
         return sanitize_interface_facts(l3_interfaces_facts)

--- a/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -18,7 +18,7 @@ from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import dict_diff, to_list, remove_empties
 from ansible.module_utils.network.nxos.facts.facts import Facts
 from ansible.module_utils.network.nxos.utils.utils import get_interface_type, normalize_interface, search_obj_in_list, validate_ipv4_addr, validate_ipv6_addr
-from ansible.module_utils.network.nxos.utils.utils import sanitize_interface_facts
+from ansible.module_utils.network.nxos.utils.utils import remove_rsvd_interfaces
 
 
 class L3_interfaces(ConfigBase):
@@ -52,7 +52,7 @@ class L3_interfaces(ConfigBase):
 
         if not l3_interfaces_facts:
             return []
-        return sanitize_interface_facts(l3_interfaces_facts)
+        return remove_rsvd_interfaces(l3_interfaces_facts)
 
     def edit_config(self, commands):
         return self._connection.edit_config(commands)

--- a/lib/ansible/module_utils/network/nxos/utils/utils.py
+++ b/lib/ansible/module_utils/network/nxos/utils/utils.py
@@ -103,6 +103,12 @@ def get_interface_type(interface):
         return 'unknown'
 
 
+def sanitize_interface_facts(interfaces):
+    """Exclude reserved interfaces from user management
+    """
+    return [i for i in interfaces if i['name'] != 'mgmt0']
+
+
 def vlan_range_to_list(vlans):
     result = []
     if vlans:

--- a/lib/ansible/module_utils/network/nxos/utils/utils.py
+++ b/lib/ansible/module_utils/network/nxos/utils/utils.py
@@ -103,7 +103,7 @@ def get_interface_type(interface):
         return 'unknown'
 
 
-def sanitize_interface_facts(interfaces):
+def remove_rsvd_interfaces(interfaces):
     """Exclude reserved interfaces from user management
     """
     return [i for i in interfaces if i['name'] != 'mgmt0']

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -136,16 +136,3 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         # self.execute_module(changed=True, commands=replaced)
 
 
-def build_args(data, type, state=None, check_mode=None):
-    if state is None:
-        state = 'merged'
-    if check_mode is None:
-        check_mode = False
-    args = {
-        'state': state,
-        '_ansible_check_mode': check_mode,
-        'config': {
-            type: data
-        }
-    }
-    return args

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -134,5 +134,3 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         # playbook['state'] = 'replaced'
         # set_module_args(playbook, ignore_provider_arg)
         # self.execute_module(changed=True, commands=replaced)
-
-

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -1,0 +1,151 @@
+# (c) 2019 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from textwrap import dedent
+from units.compat.mock import patch
+from units.modules.utils import AnsibleFailJson
+from ansible.modules.network.nxos import nxos_l3_interfaces
+from ansible.module_utils.network.nxos.config.l3_interfaces.l3_interfaces import L3_interfaces
+from .nxos_module import TestNxosModule, load_fixture, set_module_args
+
+ignore_provider_arg = True
+
+
+class TestNxosL3InterfacesModule(TestNxosModule):
+
+    module = nxos_l3_interfaces
+
+    def setUp(self):
+        super(TestNxosL3InterfacesModule, self).setUp()
+
+        self.mock_FACT_LEGACY_SUBSETS = patch('ansible.module_utils.network.nxos.facts.facts.FACT_LEGACY_SUBSETS')
+        self.FACT_LEGACY_SUBSETS = self.mock_FACT_LEGACY_SUBSETS.start()
+
+        self.mock_get_resource_connection_config = patch('ansible.module_utils.network.common.cfg.base.get_resource_connection')
+        self.get_resource_connection_config = self.mock_get_resource_connection_config.start()
+
+        self.mock_get_resource_connection_facts = patch('ansible.module_utils.network.common.facts.facts.get_resource_connection')
+        self.get_resource_connection_facts = self.mock_get_resource_connection_facts.start()
+
+        self.mock_edit_config = patch('ansible.module_utils.network.nxos.config.l3_interfaces.l3_interfaces.L3_interfaces.edit_config')
+        self.edit_config = self.mock_edit_config.start()
+
+    def tearDown(self):
+        super(TestNxosL3InterfacesModule, self).tearDown()
+        self.mock_FACT_LEGACY_SUBSETS.stop()
+        self.mock_get_resource_connection_config.stop()
+        self.mock_get_resource_connection_facts.stop()
+        self.mock_edit_config.stop()
+
+    def load_fixtures(self, commands=None, device=''):
+        self.mock_FACT_LEGACY_SUBSETS.return_value = dict()
+        self.get_resource_connection_config.return_value = None
+        self.edit_config.return_value = None
+
+    # ---------------------------
+    # L3_interfaces Test Cases
+    # ---------------------------
+
+    # 'state' logic behaviors
+    #
+    # - 'merged'    : Update existing device state with any differences in the play.
+    # - 'deleted'   : Reset existing device state to default values. Ignores any
+    #                 play attrs other than 'name'. Scope is limited to interfaces
+    #                 in the play.
+    # - 'overridden': The play is the source of truth. Similar to replaced but the
+    #                 scope includes all interfaces; ie. it will also reset state
+    #                 on interfaces not found in the play.
+    # - 'replaced'  : Scope is limited to the interfaces in the play.
+
+    SHOW_CMD = 'show running-config | section ^interface'
+
+    def test_1(self):
+        # Verify raise when playbook specifies mgmt0
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: ''}
+        playbook = dict(config=[dict(name='mgmt0')])
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module({'failed': True, 'msg': "The 'mgmt0' interface is not allowed to be managed by this module"})
+
+    def test_2(self):
+        # Change existing config states
+        existing = dedent('''\
+          interface mgmt0
+            ip address 10.0.0.254/24
+          interface Ethernet1/1
+            ip address 10.1.1.1/24
+          interface Ethernet1/2
+            ip address 10.1.2.1/24
+          interface Ethernet1/3
+            ip address 10.1.3.1/24
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(
+                name='Ethernet1/1',
+                ipv4=[{'address': '192.168.1.1/24'}]),
+            dict(name='Ethernet1/2'),
+            # Eth1/3 not present! Thus overridden should set Eth1/3 to defaults;
+            # replaced should ignore Eth1/3.
+        ])
+        # Expected result commands for each 'state'
+        merged = ['interface Ethernet1/1', 'ip address 192.168.1.1/24']
+        deleted = ['interface Ethernet1/1', 'no ip address',
+                   'interface Ethernet1/2', 'no ip address']
+        overridden = ['interface Ethernet1/1', 'no ip address',
+                      'interface Ethernet1/2', 'no ip address',
+                      'interface Ethernet1/3', 'no ip address',
+                      'interface Ethernet1/1', 'ip address 192.168.1.1/24']
+        replaced = ['interface Ethernet1/1', 'no ip address', 'ip address 192.168.1.1/24',
+                    'interface Ethernet1/2', 'no ip address']
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=merged)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)
+
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden)
+
+        # TBD: 'REPLACED' BEHAVIOR IS INCORRECT,
+        #      IT IS WRONGLY IGNORING ETHERNET1/2.
+        #      ****************** SKIP TEST FOR NOW *****************
+        # playbook['state'] = 'replaced'
+        # set_module_args(playbook, ignore_provider_arg)
+        # self.execute_module(changed=True, commands=replaced)
+
+
+def build_args(data, type, state=None, check_mode=None):
+    if state is None:
+        state = 'merged'
+    if check_mode is None:
+        check_mode = False
+    args = {
+        'state': state,
+        '_ansible_check_mode': check_mode,
+        'config': {
+            type: data
+        }
+    }
+    return args


### PR DESCRIPTION
##### SUMMARY
- This change is needed for 2.9
- This fix excludes `mgmt0` from the list of manageable interfaces. See new method `remove_rsvd_interfaces`.
  - The current code includes an `overridden` integration test that results in removing the ip address from `mgmt0`, which breaks the test along with subsequent tests.
  - Users should not modify mgmt0 settings with this module; if necessary they can use the nxos_config module.

- I also included a simple unit test that verifies basic functionality and checks for `mgmt0` usage. This test should be expanded upon with more detailed tests at some point.
- Note: I think `mgmt0` should be excluded from all of the interface modules. I'll add my checks to those modules if necessary but I wanted to get this initial fix out now since it's breaking our regression testbeds.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos` `nxos_l3_interfaces`

##### ADDITIONAL INFORMATION
Tested with unit test and `N9K` hardware.

_edit_:
Note that my interface list cleanup occurs in the module instead of the facts method. This seemed to make more sense to me and Mike. But it does cause another side effect when asserting against `ansible_facts.network_resources.l3_interfaces` since `mgmt0` will still appear there. 