### PR TITLE
log which task ended the play

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1080,7 +1080,7 @@ class StrategyBase:
                 for host in self._inventory.get_hosts(iterator._play.hosts):
                     if host.name not in self._tqm._unreachable_hosts:
                         iterator._host_states[host.name].run_state = iterator.ITERATING_COMPLETE
-                msg = "ending play"
+                msg = "ending play by [%s]" % task.get_name()
         elif meta_action == 'end_host':
             if _evaluate_conditional(target_host):
                 iterator._host_states[target_host.name].run_state = iterator.ITERATING_COMPLETE


### PR DESCRIPTION
Before the change no information was available why a playbook has ended.
By introducing this change information will be available which tells us which
task invoked meta end_play.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have playbooks structured in a way that if certain conditions are met the play is ended for good reasons. This can happen in multiple places and also there are multiple checks in one of the playbooks. By adding this change ansible will log which task called the meta action to end the play.

PR #20799 is somewhat related.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
core