### PR TITLE
[stable-2.8] fixes assert statements in tests (#59998)

### DIFF
--- a/test/units/modules/network/f5/test_bigip_monitor_tcp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp.py
@@ -307,7 +307,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -337,7 +337,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_send(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py
@@ -246,7 +246,7 @@ class TestManagerEcho(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -275,7 +275,7 @@ class TestManagerEcho(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_timeout(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py
@@ -253,7 +253,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -282,7 +282,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_timeout(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_monitor_udp.py
+++ b/test/units/modules/network/f5/test_bigip_monitor_udp.py
@@ -305,7 +305,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_interval_larger_than_new_timeout(self, *args):
         set_module_args(dict(
@@ -335,7 +335,7 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "must be less than" in str(ex)
+        assert "must be less than" in str(ex.value)
 
     def test_update_send(self, *args):
         set_module_args(dict(

--- a/test/units/modules/network/f5/test_bigip_remote_syslog.py
+++ b/test/units/modules/network/f5/test_bigip_remote_syslog.py
@@ -231,4 +231,4 @@ class TestManager(unittest.TestCase):
         with pytest.raises(F5ModuleError) as ex:
             mm.exec_module()
 
-        assert "Multiple occurrences of hostname" in str(ex)
+        assert "Multiple occurrences of hostname" in str(ex.value)

--- a/test/units/modules/network/f5/test_bigip_selfip.py
+++ b/test/units/modules/network/f5/test_bigip_selfip.py
@@ -105,7 +105,7 @@ class TestParameters(unittest.TestCase):
         p = ModuleParameters(params=args)
         with pytest.raises(F5ModuleError) as ex:
             assert p.allow_service == ['grp', 'tcp:80', 'udp:53']
-        assert 'The provided protocol' in str(ex)
+        assert 'The provided protocol' in str(ex.value)
 
     def test_api_parameters(self):
         args = dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #59998 for Ansible 2.8
(cherry picked from commit d00aaf66d7f224d24bc66b1de751de086a3771b0)
Needed by #60500
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/units/modules/network/f5/test_bigip_monitor_tcp.py`
`test/units/modules/network/f5/test_bigip_monitor_tcp_echo.py`
`test/units/modules/network/f5/test_bigip_monitor_tcp_half_open.py`
`test/units/modules/network/f5/test_bigip_monitor_udp.py`
`test/units/modules/network/f5/test_bigip_remote_syslog.py`
`test/units/modules/network/f5/test_bigip_selfip.py`