### PR TITLE
ansible-test add resource_shortprefix for the cases where we need predictable length resource names

### DIFF
--- a/test/integration/targets/aws_codebuild/defaults/main.yml
+++ b/test/integration/targets/aws_codebuild/defaults/main.yml
@@ -1,10 +1,3 @@
 ---
 # defaults file for aws_codebuild
-
-# IAM role names have to be less than 64 characters
-# The 8 digit identifier at the end of resource_prefix helps determine during
-# which test something was created and allows tests to be run in parallel
-# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
-# we need both sets of digits to keep the resource name unique
-unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
-iam_role_name: "ansible-test-sts-{{ unique_id }}-codebuild-service-role"
+iam_role_name: "{{ resource_shortprefix }}-codebuild"

--- a/test/integration/targets/aws_codepipeline/defaults/main.yml
+++ b/test/integration/targets/aws_codepipeline/defaults/main.yml
@@ -2,11 +2,4 @@
 # defaults file for aws_codepipeline
 
 codepipeline_name: "{{ resource_prefix }}-test-codepipeline"
-
-# IAM role names have to be less than 64 characters
-# The 8 digit identifier at the end of resource_prefix helps determine during
-# which test something was created and allows tests to be run in parallel
-# Shippable resource_prefixes are in the format shippable-123456-123, so in those cases
-# we need both sets of digits to keep the resource name unique
-unique_id: "{{ resource_prefix | regex_search('(\\d+-?)(\\d+)$') }}"
-codepipeline_service_role_name: "ansible-test-sts-{{ unique_id }}-codepipeline-role"
+codepipeline_service_role_name: "{{ resource_shortprefix }}-codepipeline-role"

--- a/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
+++ b/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
@@ -1,3 +1,3 @@
 # the random_num is generated in a set_fact task at the start of the testsuite
-state_machine_name: "{{ resource_prefix }}_step_functions_state_machine_ansible_test_{{ random_num }}"
+state_machine_name: "{{ resource_shortprefix }}_step_functions_state_machine_{{ random_num }}"
 step_functions_role_name: "{{ resource_shortprefix }}-step_functions"

--- a/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
+++ b/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
@@ -1,3 +1,3 @@
 # the random_num is generated in a set_fact task at the start of the testsuite
 state_machine_name: "{{ resource_prefix }}_step_functions_state_machine_ansible_test_{{ random_num }}"
-step_functions_role_name: "ansible-test-sts-{{ resource_prefix }}-step_functions-role"
+step_functions_role_name: "{{ resource_shortprefix }}-step_functions"

--- a/test/integration/targets/ec2_elb_lb/defaults/main.yml
+++ b/test/integration/targets/ec2_elb_lb/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for test_ec2_eip
-tag_prefix: '{{resource_prefix}}'
+elb_name: '{{ resource_shortprefix }}'

--- a/test/integration/targets/ec2_elb_lb/tasks/main.yml
+++ b/test/integration/targets/ec2_elb_lb/tasks/main.yml
@@ -24,7 +24,13 @@
 # test credentials from environment
 # test credential parameters
 
-- block:
+- module_defaults:
+    group/aws:
+      region: "{{ ec2_region }}"
+      ec2_access_key: "{{ ec2_access_key }}"
+      ec2_secret_key: "{{ ec2_secret_key }}"
+      security_token: "{{ security_token | default }}"
+  block:
 
     # ============================================================
     # create test elb with listeners, certificate, and health check
@@ -32,10 +38,6 @@
     - name: Create ELB
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -97,10 +99,6 @@
     - name: Change AZ's
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}c"
@@ -134,10 +132,6 @@
     - name: Update AZ's
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -166,10 +160,6 @@
     - name: Purge Listeners
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -198,10 +188,6 @@
     - name: Add Listeners
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -226,6 +212,7 @@
     # ============================================================
 
     - name: test with no parameters
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
       register: result
       ignore_errors: true
@@ -240,6 +227,7 @@
 
     # ============================================================
     - name: test with only name
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
       register: result
@@ -254,6 +242,7 @@
 
     # ============================================================
     - name: test invalid region parameter
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: 'asdf querty 1234'
@@ -278,6 +267,7 @@
 
     # ============================================================
     - name: test valid region parameter
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -304,6 +294,7 @@
     # ============================================================
 
     - name: test invalid ec2_url parameter
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -330,6 +321,7 @@
 
     # ============================================================
     - name: test valid ec2_url parameter
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -356,6 +348,7 @@
 
     # ============================================================
     - name: test credentials from environment
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -383,6 +376,7 @@
 
     # ============================================================
     - name: test credential parameters
+      module_defaults: { group/aws: {} }
       ec2_elb_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -410,11 +404,7 @@
     - name: remove the test load balancer completely
       ec2_elb_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
         state: absent
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
       register: result
 
     - name: assert the load balancer was removed

--- a/test/integration/targets/ec2_elb_lb/tasks/main.yml
+++ b/test/integration/targets/ec2_elb_lb/tasks/main.yml
@@ -31,7 +31,7 @@
 
     - name: Create ELB
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -96,7 +96,7 @@
 
     - name: Change AZ's
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -133,7 +133,7 @@
 
     - name: Update AZ's
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -165,7 +165,7 @@
 
     - name: Purge Listeners
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -197,7 +197,7 @@
 
     - name: Add Listeners
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -241,7 +241,7 @@
     # ============================================================
     - name: test with only name
       ec2_elb_lb:
-        name="{{ tag_prefix }}"
+        name: "{{ elb_name }}"
       register: result
       ignore_errors: true
 
@@ -255,7 +255,7 @@
     # ============================================================
     - name: test invalid region parameter
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: 'asdf querty 1234'
         state: present
         listeners:
@@ -279,7 +279,7 @@
     # ============================================================
     - name: test valid region parameter
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -305,7 +305,7 @@
 
     - name: test invalid ec2_url parameter
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -331,7 +331,7 @@
     # ============================================================
     - name: test valid ec2_url parameter
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -357,7 +357,7 @@
     # ============================================================
     - name: test credentials from environment
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -384,7 +384,7 @@
     # ============================================================
     - name: test credential parameters
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -409,7 +409,7 @@
     # ============================================================
     - name: remove the test load balancer completely
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: absent
         ec2_access_key: "{{ ec2_access_key }}"
@@ -421,5 +421,5 @@
       assert:
         that:
            - 'result.changed'
-           - 'result.elb.name == "{{tag_prefix}}"'
+           - 'result.elb.name == "{{ elb_name }}"'
            - 'result.elb.status == "deleted"'

--- a/test/integration/targets/ec2_instance/defaults/main.yml
+++ b/test/integration/targets/ec2_instance/defaults/main.yml
@@ -12,3 +12,6 @@ subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
 subnet_a_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.32.'
 subnet_b_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.33.0/24'
 subnet_b_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.33.'
+
+role_1_name: '{{ resource_shortprefix }}-ec2-instance-1'
+role_2_name: '{{ resource_shortprefix }}-ec2-instance-2'

--- a/test/integration/targets/ec2_instance/tasks/iam_instance_role.yml
+++ b/test/integration/targets/ec2_instance/tasks/iam_instance_role.yml
@@ -1,7 +1,7 @@
 - block:
     - name: Create IAM role for test
       iam_role:
-        name: "ansible-test-sts-{{ resource_prefix }}-test-policy"
+        name: "{{ role_1_name }}"
         assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
         state: present
         create_instance_profile: yes
@@ -11,7 +11,7 @@
 
     - name: Create second IAM role for test
       iam_role:
-        name: "ansible-test-sts-{{ resource_prefix }}-test-policy-2"
+        name: "{{ role_2_name }}"
         assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
         state: present
         create_instance_profile: yes
@@ -29,7 +29,7 @@
         image_id: "{{ ec2_ami_image }}"
         security_groups: "{{ sg.group_id }}"
         instance_type: "{{ ec2_instance_type }}"
-        instance_role: "ansible-test-sts-{{ resource_prefix }}-test-policy"
+        instance_role: "{{ role_1_name }}"
       register: instance_with_role
 
     - assert:
@@ -108,8 +108,8 @@
         managed_policy:
         - AmazonEC2ContainerServiceRole
       loop:
-        - "ansible-test-sts-{{ resource_prefix }}-test-policy"
-        - "ansible-test-sts-{{ resource_prefix }}-test-policy-2"
+        - "{{ role_1_name }}"
+        - "{{ role_2_name }}"
       register: removed
       until: removed is not failed
       ignore_errors: yes

--- a/test/integration/targets/elb_classic_lb/defaults/main.yml
+++ b/test/integration/targets/elb_classic_lb/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for test_ec2_eip
-tag_prefix: '{{resource_prefix}}'
+elb_name: '{{ resource_shortprefix }}'

--- a/test/integration/targets/elb_classic_lb/tasks/main.yml
+++ b/test/integration/targets/elb_classic_lb/tasks/main.yml
@@ -24,7 +24,13 @@
 # test credentials from environment
 # test credential parameters
 
-- block:
+- module_defaults:
+    group/aws:
+      region: "{{ ec2_region }}"
+      ec2_access_key: "{{ ec2_access_key }}"
+      ec2_secret_key: "{{ ec2_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+  block:
 
     # ============================================================
     # create test elb with listeners, certificate, and health check
@@ -32,10 +38,6 @@
     - name: Create ELB
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -97,10 +99,6 @@
     - name: Change AZ's
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}c"
@@ -134,10 +132,6 @@
     - name: Update AZ's
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -166,10 +160,6 @@
     - name: Purge Listeners
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -198,10 +188,6 @@
     - name: Add Listeners
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
         state: present
         zones:
           - "{{ ec2_region }}a"
@@ -226,6 +212,7 @@
     # ============================================================
 
     - name: test with no parameters
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
       register: result
       ignore_errors: true
@@ -240,6 +227,7 @@
 
     # ============================================================
     - name: test with only name
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
       register: result
@@ -254,6 +242,7 @@
 
     # ============================================================
     - name: test invalid region parameter
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: 'asdf querty 1234'
@@ -278,6 +267,7 @@
 
     # ============================================================
     - name: test valid region parameter
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -304,6 +294,7 @@
     # ============================================================
 
     - name: test invalid ec2_url parameter
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -330,6 +321,7 @@
 
     # ============================================================
     - name: test valid ec2_url parameter
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -356,6 +348,7 @@
 
     # ============================================================
     - name: test credentials from environment
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -383,6 +376,7 @@
 
     # ============================================================
     - name: test credential parameters
+      module_defaults: { group/aws: {} }
       elb_classic_lb:
         name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
@@ -410,11 +404,7 @@
     - name: remove the test load balancer completely
       elb_classic_lb:
         name: "{{ elb_name }}"
-        region: "{{ ec2_region }}"
         state: absent
-        ec2_access_key: "{{ ec2_access_key }}"
-        ec2_secret_key: "{{ ec2_secret_key }}"
-        security_token: "{{ security_token }}"
       register: result
 
     - name: assert the load balancer was removed

--- a/test/integration/targets/elb_classic_lb/tasks/main.yml
+++ b/test/integration/targets/elb_classic_lb/tasks/main.yml
@@ -31,7 +31,7 @@
 
     - name: Create ELB
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -96,7 +96,7 @@
 
     - name: Change AZ's
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -133,7 +133,7 @@
 
     - name: Update AZ's
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -165,7 +165,7 @@
 
     - name: Purge Listeners
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -197,7 +197,7 @@
 
     - name: Add Listeners
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         ec2_access_key: "{{ ec2_access_key }}"
         ec2_secret_key: "{{ ec2_secret_key }}"
@@ -241,7 +241,7 @@
     # ============================================================
     - name: test with only name
       elb_classic_lb:
-        name="{{ tag_prefix }}"
+        name: "{{ elb_name }}"
       register: result
       ignore_errors: true
 
@@ -255,7 +255,7 @@
     # ============================================================
     - name: test invalid region parameter
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: 'asdf querty 1234'
         state: present
         listeners:
@@ -279,7 +279,7 @@
     # ============================================================
     - name: test valid region parameter
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -305,7 +305,7 @@
 
     - name: test invalid ec2_url parameter
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -331,7 +331,7 @@
     # ============================================================
     - name: test valid ec2_url parameter
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -357,7 +357,7 @@
     # ============================================================
     - name: test credentials from environment
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -384,7 +384,7 @@
     # ============================================================
     - name: test credential parameters
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: present
         zones:
@@ -409,7 +409,7 @@
     # ============================================================
     - name: remove the test load balancer completely
       elb_classic_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         region: "{{ ec2_region }}"
         state: absent
         ec2_access_key: "{{ ec2_access_key }}"
@@ -421,5 +421,5 @@
       assert:
         that:
            - 'result.changed'
-           - 'result.elb.name == "{{tag_prefix}}"'
+           - 'result.elb.name == "{{elb_name}}"'
            - 'result.elb.status == "deleted"'

--- a/test/integration/targets/sts_assume_role/defaults/main.yml
+++ b/test/integration/targets/sts_assume_role/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for sts_assume_role
+
+# IAM role names have to be less than 64 characters
+iam_role_name: "{{ resource_shortprefix }}-sts-assume-role"

--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -1,39 +1,25 @@
 ---
 # tasks file for sts_assume_role
 
-- block:
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: get ARN of calling user
+      aws_caller_info:
+      register: aws_caller_info
 
-    # ============================================================
-    # TODO create simple ansible sts_get_caller_identity module
-    - blockinfile:
-        path: "{{ output_dir }}/sts.py"
-        create: yes
-        block: |
-          #!/usr/bin/env python
-          import boto3
-          sts = boto3.client('sts')
-          response = sts.get_caller_identity()
-          print(response['Account'])
-
-    - name: get the aws account id
-      command: "{{ ansible_python.executable }} '{{ output_dir }}/sts.py'"
-      environment:
-        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
-        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
-        AWS_SESSION_TOKEN: "{{ security_token }}"
-      register: result
-
-    - name: register account id
+    - name: extract account id
       set_fact:
-        aws_account: "{{ result.stdout | replace('\n', '') }}"
+        aws_account: "{{ aws_caller_info.account }}"
 
     # ============================================================
     - name: create test iam role
       iam_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        name: "ansible-test-sts-{{ resource_prefix }}"
+        name: "{{ iam_role_name }}"
         assume_role_policy_document:  "{{ lookup('template','policy.json.j2') }}"
         create_instance_profile: False
         managed_policy:
@@ -48,6 +34,7 @@
 
     # ============================================================
     - name: test with no parameters
+      module_defaults: { group/aws: {} }
       sts_assume_role:
       register: result
       ignore_errors: true
@@ -61,10 +48,6 @@
     # ============================================================
     - name: test with empty parameters
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn:
         role_session_name:
         policy:
@@ -78,8 +61,8 @@
     - name: assert with empty parameters
       assert:
         that:
-           - 'result.failed'
-           - "'Missing required parameter in input:' in result.msg"
+          - 'result.failed'
+          - "'Missing required parameter in input:' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert with empty parameters
@@ -92,9 +75,6 @@
     # ============================================================
     - name: test with only 'role_arn' parameter
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
         role_arn: "{{ test_role.iam_role.arn }}"
       register: result
       ignore_errors: true
@@ -108,9 +88,6 @@
     # ============================================================
     - name: test with only 'role_session_name' parameter
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
         role_session_name: "AnsibleTest"
       register: result
       ignore_errors: true
@@ -124,10 +101,6 @@
     # ============================================================
     - name: test assume role with invalid policy
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: "AnsibleTest"
         policy: "invalid policy"
@@ -151,10 +124,6 @@
     # ============================================================
     - name: test assume role with invalid duration seconds
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         duration_seconds: invalid duration
@@ -170,10 +139,6 @@
     # ============================================================
     - name: test assume role with invalid external id
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         external_id: invalid external id
@@ -197,10 +162,6 @@
     # ============================================================
     - name: test assume role with invalid mfa serial number
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         mfa_serial_number: invalid serial number
@@ -224,10 +185,6 @@
     # ============================================================
     - name: test assume role with invalid mfa token code
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         mfa_token: invalid token code
@@ -251,10 +208,6 @@
     # ============================================================
     - name: test assume role with invalid role_arn
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: invalid role arn
         role_session_name: AnsibleTest
       register: result
@@ -277,10 +230,6 @@
     # ============================================================
     - name: test assume not existing sts role
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region}}"
         role_arn: "arn:aws:iam::123456789:role/non-existing-role"
         role_session_name: "AnsibleTest"
       register: result
@@ -303,10 +252,6 @@
     # ============================================================
     - name: test assume role
       sts_assume_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
       register: assumed_role
@@ -326,8 +271,7 @@
         aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
         aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
         security_token: "{{ assumed_role.sts_creds.session_token }}"
-        region: "{{ aws_region}}"
-        name: "ansible-test-sts-{{ resource_prefix }}"
+        name: "{{ iam_role_name }}"
         assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
         create_instance_profile: False
         state: present
@@ -346,8 +290,7 @@
         aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
         aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
         security_token: "{{ assumed_role.sts_creds.session_token }}"
-        region: "{{ aws_region}}"
-        name: "ansible-test-sts-{{ resource_prefix }}-new"
+        name: "{{ iam_role_name }}-new"
         assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
         state: present
       register: result
@@ -374,11 +317,10 @@
 
     - name: delete test iam role
       iam_role:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        name: "ansible-test-sts-{{ resource_prefix }}"
-        assume_role_policy_document:  "{{ lookup('template','policy.json.j2') }}"
-        managed_policy:
-          - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        name: "{{ iam_role_name }}"
+        state: absent
+
+    - name: delete test iam role
+      iam_role:
+        name: "{{ iam_role_name }}-new"
         state: absent

--- a/test/lib/ansible_test/_internal/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/cloud/__init__.py
@@ -423,7 +423,11 @@ class CloudProvider(CloudBase):
         :rtype: str
         """
         if is_shippable():
-            prefix = 'shippable-%s-%s' % (
+            prefix = 'ansible-test-shippable-%s-%s' % (
+                os.environ['SHIPPABLE_BUILD_NUMBER'],
+                os.environ['SHIPPABLE_JOB_NUMBER'],
+            )
+            short_prefix = 'ansible-test-%s-%s' % (
                 os.environ['SHIPPABLE_BUILD_NUMBER'],
                 os.environ['SHIPPABLE_JOB_NUMBER'],
             )
@@ -431,15 +435,14 @@ class CloudProvider(CloudBase):
                 os.environ['SHIPPABLE_BUILD_NUMBER'],
                 os.environ['SHIPPABLE_JOB_NUMBER'],
             )
-            return prefix, prefix, unique
+        else:
+            unique = random.randint(10000000, 99999999)
+            node = re.sub(r'[^a-zA-Z0-9]+', '-', platform.node().split('.')[0]).lower()
 
-        resource_random = random.randint(10000000, 99999999)
-        node = re.sub(r'[^a-zA-Z0-9]+', '-', platform.node().split('.')[0]).lower()
+            prefix = 'ansible-test-%s-%d' % (node, unique)
+            short_prefix = 'ansible-test-%d' % (unique)
 
-        prefix = 'ansible-test-%s-%d' % (node, resource_random)
-        short_prefix = 'ansible-test-%d' % (resource_random)
-
-        return prefix, short_prefix, resource_random
+        return prefix, short_prefix, unique
 
 
 class CloudEnvironment(CloudBase):

--- a/test/lib/ansible_test/_internal/cloud/aws.py
+++ b/test/lib/ansible_test/_internal/cloud/aws.py
@@ -99,6 +99,8 @@ class AwsCloudEnvironment(CloudEnvironment):
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
+            resource_shortprefix=self.resource_shortprefix,
+            resource_unique=self.resource_unique,
         )
 
         ansible_vars.update(dict(parser.items('default')))


### PR DESCRIPTION
##### SUMMARY

- ansible-test: add resource_shortprefix to AWS

Then update sts_assume_role integration tests to use this while also...
- migrating to using module_defaults
- using aws_caller_info rather than custom python

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test/lib/ansible_test/_internal/cloud/__init__.py
test/lib/ansible_test/_internal/cloud/aws.py

##### ADDITIONAL INFORMATION
@s-hertel @jillr as discussed in #61731
Once we've got `resource_shortprefix` (or something similar) available I'll line up PRs for each of the remaining places where we're abusing ansible-test-sts-...

I don't want to pull them all into one PR because I've needed to do things like using updating to use module_defaults because I'm not passing a session_token which causes many of the existing tests to fail.