### PR TITLE
[2.7] Mark aws_s3 tests as unstable

### DIFF
--- a/test/integration/targets/aws_s3/aliases
+++ b/test/integration/targets/aws_s3/aliases
@@ -1,2 +1,3 @@
+unstable
 cloud/aws
 shippable/aws/group1


### PR DESCRIPTION
##### SUMMARY
Rather than backport a non-critical fix to 2.7 in #61770 we've decided to mark the tests as unstable.

##### ISSUE TYPE
- Tests Pull Request

##### COMPONENT NAME
aws_s3
