### PR TITLE
Bug fix for #53271 (return commands for cli_config)

### DIFF
--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -18,7 +18,7 @@ DOCUMENTATION = """
 module: cli_config
 version_added: "2.7"
 author: "Trishna Guha (@trishnaguha)"
-notes: 
+notes:
   - The commands will be returned only for platforms that do not support onbox diff.
     The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
 short_description: Push text based configuration to network devices over network_cli

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -185,7 +185,7 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The set of commands that will be pushed to the remote device
-  note: The commands will be returned only for platforms that does not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
+  notes: The commands will be returned only for platforms that do not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
   returned: always
   type: list
   sample: ['interface Loopback999', 'no shutdown']
@@ -286,12 +286,16 @@ def run(module, device_operations, connection, candidate, running, rollback_id):
             else:
                 candidate = config_diff.splitlines()
 
-            kwargs = {'candidate': candidate, 'commit': commit, 'replace': replace,
-                      'comment': commit_comment}
+            kwargs = {
+                'candidate': candidate,
+                'commit': commit,
+                'replace': replace,
+                'comment': commit_comment
+            }
             if commit:
                 connection.edit_config(**kwargs)
             result['changed'] = True
-            result['commands'] = config_diff.split('\n')            
+            result['commands'] = config_diff.split('\n')
 
         if banner_diff:
             candidate = json.dumps(banner_diff)

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -18,8 +18,9 @@ DOCUMENTATION = """
 module: cli_config
 version_added: "2.7"
 author: "Trishna Guha (@trishnaguha)"
-notes: The commands will be returned only for platforms that do not support onbox diff.
-      The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
+notes: 
+  - The commands will be returned only for platforms that do not support onbox diff.
+    The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
 short_description: Push text based configuration to network devices over network_cli
 description:
   - This module provides platform agnostic way of pushing text based

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -18,7 +18,8 @@ DOCUMENTATION = """
 module: cli_config
 version_added: "2.7"
 author: "Trishna Guha (@trishnaguha)"
-notes: The commands will be returned only for platforms that do not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
+notes: The commands will be returned only for platforms that do not support onbox diff. 
+        The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
 short_description: Push text based configuration to network devices over network_cli
 description:
   - This module provides platform agnostic way of pushing text based

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -18,8 +18,8 @@ DOCUMENTATION = """
 module: cli_config
 version_added: "2.7"
 author: "Trishna Guha (@trishnaguha)"
-notes: The commands will be returned only for platforms that do not support onbox diff. 
-        The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
+notes: The commands will be returned only for platforms that do not support onbox diff.
+      The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff
 short_description: Push text based configuration to network devices over network_cli
 description:
   - This module provides platform agnostic way of pushing text based

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -185,6 +185,7 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The set of commands that will be pushed to the remote device
+  note: The commands will be returned only for platforms that does not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
   returned: always
   type: list
   sample: ['interface Loopback999', 'no shutdown']
@@ -290,6 +291,7 @@ def run(module, device_operations, connection, candidate, running, rollback_id):
             if commit:
                 connection.edit_config(**kwargs)
             result['changed'] = True
+            result['commands'] = config_diff.split('\n')            
 
         if banner_diff:
             candidate = json.dumps(banner_diff)

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -18,6 +18,7 @@ DOCUMENTATION = """
 module: cli_config
 version_added: "2.7"
 author: "Trishna Guha (@trishnaguha)"
+notes: The commands will be returned only for platforms that do not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
 short_description: Push text based configuration to network devices over network_cli
 description:
   - This module provides platform agnostic way of pushing text based
@@ -185,7 +186,6 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The set of commands that will be pushed to the remote device
-  notes: The commands will be returned only for platforms that do not support onbox diff. The C(--diff) option with the playbook will return the difference in configuration for devices that has support for onbox diff.
   returned: always
   type: list
   sample: ['interface Loopback999', 'no shutdown']


### PR DESCRIPTION
##### SUMMARY
Added fix to include the pushed commands in the results dictionary for the cli_config module.

Fixes #53271

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/cli/cli_config.py