### PR TITLE
[stable-2.9] Add proper hostname cleanup for nxos tests

### DIFF
--- a/test/integration/targets/nxos_config/tasks/main.yaml
+++ b/test/integration/targets/nxos_config/tasks/main.yaml
@@ -1,4 +1,15 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: nxapi.yaml, tags: ['nxapi'] }
-- { include: cli_config.yaml, tags: ['cli_config'] }
+# Some of the tests in this suite change the hostname to switch.
+# This block/always ensures the hostname gets changed back to
+# the correct name.
+- block:
+  - { include: cli.yaml, tags: ['cli'] }
+  - { include: nxapi.yaml, tags: ['nxapi'] }
+  - { include: cli_config.yaml, tags: ['cli_config'] }
+
+  always:
+  - name: "Change hostname back to {{ inventory_hostname_short }}"
+    nxos_config:
+      lines:
+        - "hostname {{ inventory_hostname_short }}"
+      match: none

--- a/test/integration/targets/nxos_smoke/tasks/main.yaml
+++ b/test/integration/targets/nxos_smoke/tasks/main.yaml
@@ -1,3 +1,14 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: nxapi.yaml, tags: ['nxapi'] }
+# Some of the tests in this suite change the hostname to switch.
+# This block/always ensures the hostname gets changed back to
+# the correct name.
+- block:
+  - { include: cli.yaml, tags: ['cli'] }
+  - { include: nxapi.yaml, tags: ['nxapi'] }
+
+  always:
+  - name: "Change hostname back to {{ inventory_hostname_short }}"
+    nxos_config:
+      lines:
+        - "hostname {{ inventory_hostname_short }}"
+      match: none


### PR DESCRIPTION
Fix needed in 2.9

##### SUMMARY
Several tests in the `nxos_config` and `nxos_smoke` integration test suites configure the nxos hostname to be `switch`.  This breaks nightly runs for tests that run after the test if the name does not get set back properly.

This fix adds a task inside a block/always to make sure the proper hostname gets reconfigured when the tests are complete.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_config
nxos_smoke