### PR TITLE
luks_device.py: allows user explicity define luks format version

### DIFF
--- a/changelogs/fragments/58973-luks_device_add-type-option.yml
+++ b/changelogs/fragments/58973-luks_device_add-type-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- luks_device - added the `type` option that allows user explicit define the LUKS container format version (can be `luks1` or `luks2`)

--- a/changelogs/fragments/58973-luks_device_add-type-option.yml
+++ b/changelogs/fragments/58973-luks_device_add-type-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- luks_device - added the `type` option that allows user explicit define the LUKS container format version (can be `luks1` or `luks2`)
+- luks_device - added the ``type`` option that allows user explicit define the LUKS container format version


### PR DESCRIPTION
##### SUMMARY
 Allow user pass an option 'type' that explicits define the version of LUKS container.

- if type is defined and label too, label takes the preference (LUKS2 will be used)
- if type is defined and label not, luks format will use the preference of user.
- if type and label is not defined it will be used the default option of cryptsetup binary.

Fixes #58973

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/crypto/luks_device.py

##### ADDITIONAL INFORMATION
Reproduce with the playbook bellow, change the commentary of label and type as you wish.

```
---
- name: test issue 58973
  gather_facts: no
  hosts: localhost
  remote_user: root
  tasks:
    - name: create LUKS container
      luks_device:
        device: "/dev/loop0"
        state: "present"
        keyfile: "/root/password"
        #label: personalLabelName
        type: luks1
```