### PR TITLE
test: disable the docker swarm tests

### DIFF
--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group2
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_info/aliases
+++ b/test/integration/targets/docker_swarm_info/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group1
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group4
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service_info/aliases
+++ b/test/integration/targets/docker_swarm_service_info/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group3
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/inventory_docker_swarm/aliases
+++ b/test/integration/targets/inventory_docker_swarm/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group2
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive


### PR DESCRIPTION
##### SUMMARY

`docker_swarm` tests tend to hang during the creation of the Swarn
cluster.

See: https://github.com/ansible/ansible/issues/61815

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

docker_swarm