### PR TITLE
Distribution: Added BSD OS family

### DIFF
--- a/changelogs/fragments/add-dragonflybsd-family-map.yaml
+++ b/changelogs/fragments/add-dragonflybsd-family-map.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - add distribution family for DragonFly BSD (https://github.com/ansible/ansible/issues/43739)

--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -13,6 +13,7 @@ This assumes a working ansible version in the path.
 import os.path
 import subprocess
 import json
+import platform
 import sys
 
 from ansible.module_utils import distro
@@ -85,5 +86,9 @@ output = {
     'platform.dist': dist,
     'result': ansible_facts,
 }
+
+system = platform.system()
+if system != 'Linux':
+    output['platform.system'] = system
 
 print(json.dumps(output, indent=4))

--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -50,7 +50,6 @@ for f in filelist:
             with open(f) as fh:
                 fcont[f] = fh.read()
 
-dist = distro.linux_distribution(full_distribution_name=False)
 
 facts = ['distribution', 'distribution_version', 'distribution_release', 'distribution_major_version', 'os_family']
 
@@ -72,6 +71,7 @@ for fact in facts:
         ansible_facts[fact] = "N/A"
 
 nicename = ansible_facts['distribution'] + ' ' + ansible_facts['distribution_version']
+dist = distro.linux_distribution(full_distribution_name=False)
 
 output = {
     'name': nicename,
@@ -90,5 +90,9 @@ output = {
 system = platform.system()
 if system != 'Linux':
     output['platform.system'] = system
+
+release = platform.release()
+if release:
+    output['platform.release'] = release
 
 print(json.dumps(output, indent=4))

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -483,7 +483,10 @@ class Distribution(object):
                      'HP-UX': ['HPUX'],
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
-                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix']}
+                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
+                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD'],
+                     'OpenBSD': ['OpenBSD'],
+                     'NetBSD': ['NetBSD']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -484,9 +484,7 @@ class Distribution(object):
                      'Darwin': ['MacOSX'],
                      'FreeBSD': ['FreeBSD', 'TrueOS'],
                      'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
-                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD'],
-                     'OpenBSD': ['OpenBSD'],
-                     'NetBSD': ['NetBSD']}
+                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD']}
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -588,7 +588,6 @@ class Distribution(object):
         if match:
             dragonfly_facts['distribution_major_version'] = match.group(1)
             dragonfly_facts['distribution_version'] = '%s.%s.%s' % match.groups()[:3]
-            dragonfly_facts['distribution_release'] = '%s.%s.%s-%s' % match.groups()[:4]
         return dragonfly_facts
 
     def get_distribution_NetBSD(self):

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -584,10 +584,12 @@ class Distribution(object):
         dragonfly_facts = {}
         dragonfly_facts['distribution_version'] = platform.release()
         rc, out, err = self.module.run_command("/sbin/sysctl -n kern.version")
-        match = re.match(r'(\d+)\.(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT).*', out)
+        match = re.search(r'v(\d+)\.(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT).*', out)
         if match:
-            dragonfly_facts['distribution_release'] = '%s.%s' % (match.group(1), match.group(2))
-        return {}
+            dragonfly_facts['distribution_major_version'] = match.group(1)
+            dragonfly_facts['distribution_version'] = '%s.%s.%s' % match.groups()[:3]
+            dragonfly_facts['distribution_release'] = '%s.%s.%s-%s' % match.groups()[:4]
+        return dragonfly_facts
 
     def get_distribution_NetBSD(self):
         netbsd_facts = {}

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -464,27 +464,26 @@ class Distribution(object):
     }
 
     # keep keys in sync with Conditionals page of docs
-    OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
-                                'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
-                                'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba'],
-                     'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
-                                'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux'],
-                     'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
-                              'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
-                     'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],
-                     'Mandrake': ['Mandrake', 'Mandriva'],
-                     'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],
-                     'Slackware': ['Slackware'],
-                     'Altlinux': ['Altlinux'],
-                     'SGML': ['SGML'],
-                     'Gentoo': ['Gentoo', 'Funtoo'],
-                     'Alpine': ['Alpine'],
-                     'AIX': ['AIX'],
-                     'HP-UX': ['HPUX'],
-                     'Darwin': ['MacOSX'],
-                     'FreeBSD': ['FreeBSD', 'TrueOS'],
-                     'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
-                     'DragonFly': ['DragonflyBSD', 'Gentoo/DragonflyBSD']}
+    OS_FAMILY_MAP = {
+        'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC', 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux',
+                   'OVS', 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba'],
+        'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon', 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux'],
+        'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed', 'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
+        'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],
+        'Mandrake': ['Mandrake', 'Mandriva'],
+        'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],
+        'Slackware': ['Slackware'],
+        'Altlinux': ['Altlinux'],
+        'SGML': ['SGML'],
+        'Gentoo': ['Gentoo', 'Funtoo'],
+        'Alpine': ['Alpine'],
+        'AIX': ['AIX'],
+        'HP-UX': ['HPUX'],
+        'Darwin': ['MacOSX'],
+        'FreeBSD': ['FreeBSD', 'TrueOS'],
+        'ClearLinux': ['Clear Linux OS', 'Clear Linux Mix'],
+        'DragonFly': ['DragonflyBSD', 'DragonFlyBSD', 'Gentoo/DragonflyBSD', 'Gentoo/DragonFlyBSD'],
+    }
 
     OS_FAMILY = {}
     for family, names in OS_FAMILY_MAP.items():
@@ -582,6 +581,12 @@ class Distribution(object):
         return openbsd_facts
 
     def get_distribution_DragonFly(self):
+        dragonfly_facts = {}
+        dragonfly_facts['distribution_version'] = platform.release()
+        rc, out, err = self.module.run_command("/sbin/sysctl -n kern.version")
+        match = re.match(r'(\d+)\.(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT).*', out)
+        if match:
+            dragonfly_facts['distribution_release'] = '%s.%s' % (match.group(1), match.group(2))
         return {}
 
     def get_distribution_NetBSD(self):

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1343,6 +1343,29 @@ TESTSETS = [
             "name": "Linux Mint"
         },
     },
+    {
+        "platform.dist": [
+            "dragonfly",
+            "5.2",
+            ""
+        ],
+        "input": {},
+        "result": {
+            "distribution_release": "5.2-RELEASE",
+            "distribution": "DragonFly",
+            "distribution_major_version": "N/A",
+            "os_family": "DragonFly",
+            "distribution_version": "DragonFly v5.2.0-RELEASE #1: Mo"
+        },
+        "name": "DragonFly DragonFly v5.2.0-RELEASE #1: Mo",
+        "distro": {
+            "codename": "",
+            "version": "5.2",
+            "id": "dragonfly",
+            "version_best": "5.2",
+            "name": "DragonFly"
+        }
+    }
 ]
 
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1373,7 +1373,11 @@ TESTSETS = [
 ]
 
 
-@pytest.mark.parametrize("stdin, testcase", product([{}], TESTSETS), ids=lambda x: x.get('name'), indirect=['stdin'])
+def get_test_name(obj):
+    return obj.get('name')
+
+
+@pytest.mark.parametrize("stdin, testcase", product([{}], TESTSETS), ids=get_test_name, indirect=['stdin'])
 def test_distribution_version(am, mocker, testcase):
     """tests the distribution parsing code of the Facts class
 

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1349,15 +1349,18 @@ TESTSETS = [
             "5.2",
             ""
         ],
+        "platform.system": "DragonFly",
         "input": {},
+        "command_output": "DragonFly v5.6.2-RELEASE #3: Sat Aug 10 10:28:36 EDT 2019\n"
+            "root@www.shiningsilence.com:/usr/obj/home/justin/release/5_6/sys/X86_64_GENERIC",
         "result": {
-            "distribution_release": "5.2-RELEASE",
+            "distribution_release": "5.6.2-RELEASE",
             "distribution": "DragonFly",
-            "distribution_major_version": "N/A",
+            "distribution_major_version": "5",
             "os_family": "DragonFly",
-            "distribution_version": "DragonFly v5.2.0-RELEASE #1: Mo"
+            "distribution_version": "5.6.2"
         },
-        "name": "DragonFly DragonFly v5.2.0-RELEASE #1: Mo",
+        "name": "DragonFly v5.6.2-RELEASE #3",
         "distro": {
             "codename": "",
             "version": "5.2",
@@ -1402,6 +1405,10 @@ def test_distribution_version(am, mocker, testcase):
             return testcase.get('uname_r', None)
         else:
             return None
+
+    def mock_module_run_command(am, command):
+        result = (0, testcase.get('command_output', None), '')
+        return result
 
     def mock_file_exists(fname, allow_empty=False):
         if fname not in testcase['input']:
@@ -1454,6 +1461,7 @@ def test_distribution_version(am, mocker, testcase):
     mocker.patch('ansible.module_utils.distro.id', mock_distro_id)
     mocker.patch('ansible.module_utils.distro.version', mock_distro_version)
     mocker.patch('ansible.module_utils.distro.codename', mock_distro_codename)
+    mocker.patch('ansible.module_utils.basic.AnsibleModule.run_command', mock_module_run_command)
     mocker.patch('os.path.isfile', mock_os_path_is_file)
     mocker.patch('platform.system', mock_platform_system)
     mocker.patch('platform.release', mock_platform_release)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -1350,15 +1350,16 @@ TESTSETS = [
             ""
         ],
         "platform.system": "DragonFly",
+        "platform.release": "5.6-RELEASE",
         "input": {},
         "command_output": "DragonFly v5.6.2-RELEASE #3: Sat Aug 10 10:28:36 EDT 2019\n"
             "root@www.shiningsilence.com:/usr/obj/home/justin/release/5_6/sys/X86_64_GENERIC",
         "result": {
-            "distribution_release": "5.6.2-RELEASE",
+            "distribution_release": "5.6-RELEASE",
             "distribution": "DragonFly",
             "distribution_major_version": "5",
-            "os_family": "DragonFly",
-            "distribution_version": "5.6.2"
+            "distribution_version": "5.6.2",
+            "os_family": "DragonFly"
         },
         "name": "DragonFly v5.6.2-RELEASE #3",
         "distro": {


### PR DESCRIPTION
OS families added for Dragonfly, OpenBSD and NetBSD

SUMMARY
Added OS families Map for Dragonfly, OpenBSD and NetBSD. Fixes #43739

ISSUE TYPE
Bugfix Pull Request