### PR TITLE
ansible-galaxy fix --server option for roles

### DIFF
--- a/changelogs/fragments/ansible-galaxy-role-server.yaml
+++ b/changelogs/fragments/ansible-galaxy-role-server.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy role - Fix issue where ``--server`` was not being used for certain ``ansible-galaxy role`` actions - https://github.com/ansible/ansible/issues/61609

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -405,7 +405,7 @@ class GalaxyCLI(CLI):
                 display.vvv("found role %s in yaml file" % to_text(role))
                 if "name" not in role and "src" not in role:
                     raise AnsibleError("Must specify name or src for role")
-                return [GalaxyRole(self.galaxy, **role)]
+                return [GalaxyRole(self.galaxy, self.api, **role)]
             else:
                 b_include_path = to_bytes(requirement["include"], errors="surrogate_or_strict")
                 if not os.path.isfile(b_include_path):
@@ -414,7 +414,7 @@ class GalaxyCLI(CLI):
 
                 with open(b_include_path, 'rb') as f_include:
                     try:
-                        return [GalaxyRole(self.galaxy, **r) for r in
+                        return [GalaxyRole(self.galaxy, self.api, **r) for r in
                                 (RoleRequirement.role_yaml_parse(i) for i in yaml.safe_load(f_include))]
                     except Exception as e:
                         raise AnsibleError("Unable to load data from include requirements file: %s %s"
@@ -722,7 +722,7 @@ class GalaxyCLI(CLI):
         for role in context.CLIARGS['args']:
 
             role_info = {'path': roles_path}
-            gr = GalaxyRole(self.galaxy, role)
+            gr = GalaxyRole(self.galaxy, self.api, role)
 
             install_info = gr.install_info
             if install_info:
@@ -827,7 +827,7 @@ class GalaxyCLI(CLI):
             # (and their dependencies, unless the user doesn't want us to).
             for rname in context.CLIARGS['args']:
                 role = RoleRequirement.role_yaml_parse(rname.strip())
-                roles_left.append(GalaxyRole(self.galaxy, **role))
+                roles_left.append(GalaxyRole(self.galaxy, self.api, **role))
 
         for role in roles_left:
             # only process roles in roles files when names matches if given
@@ -871,7 +871,7 @@ class GalaxyCLI(CLI):
                         display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()
                         dep_info = dep_req.role_yaml_parse(dep)
-                        dep_role = GalaxyRole(self.galaxy, **dep_info)
+                        dep_role = GalaxyRole(self.galaxy, self.api, **dep_info)
                         if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
                             # we know we can skip this, as it's not going to
                             # be found on galaxy.ansible.com
@@ -913,7 +913,7 @@ class GalaxyCLI(CLI):
             raise AnsibleOptionsError('- you must specify at least one role to remove.')
 
         for role_name in context.CLIARGS['args']:
-            role = GalaxyRole(self.galaxy, role_name)
+            role = GalaxyRole(self.galaxy, self.api, role_name)
             try:
                 if role.remove():
                     display.display('- successfully removed %s' % role_name)
@@ -941,7 +941,7 @@ class GalaxyCLI(CLI):
         if context.CLIARGS['role']:
             # show the requested role, if it exists
             name = context.CLIARGS['role']
-            gr = GalaxyRole(self.galaxy, name)
+            gr = GalaxyRole(self.galaxy, self.api, name)
             if gr.metadata:
                 display.display('# %s' % os.path.dirname(gr.path))
                 _display_role(gr)
@@ -964,7 +964,7 @@ class GalaxyCLI(CLI):
                 path_files = os.listdir(role_path)
                 path_found = True
                 for path_file in path_files:
-                    gr = GalaxyRole(self.galaxy, path_file, path=path)
+                    gr = GalaxyRole(self.galaxy, self.api, path_file, path=path)
                     if gr.metadata:
                         _display_role(gr)
             for w in warnings:

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -44,6 +44,7 @@ class Galaxy(object):
     ''' Keeps global galaxy info '''
 
     def __init__(self):
+        # TODO: eventually remove this as it contains a mismash of properties that aren't really global
 
         # roles_path needs to be a list and will be by default
         roles_path = context.CLIARGS.get('roles_path', C.DEFAULT_ROLES_PATH)

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -31,13 +31,11 @@ import yaml
 from distutils.version import LooseVersion
 from shutil import rmtree
 
-import ansible.constants as C
 from ansible import context
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import open_url
 from ansible.playbook.role.requirement import RoleRequirement
-from ansible.galaxy.api import GalaxyAPI
 from ansible.utils.display import Display
 
 display = Display()
@@ -50,7 +48,7 @@ class GalaxyRole(object):
     META_INSTALL = os.path.join('meta', '.galaxy_install_info')
     ROLE_DIRS = ('defaults', 'files', 'handlers', 'meta', 'tasks', 'templates', 'vars', 'tests')
 
-    def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None):
+    def __init__(self, galaxy, api, name, src=None, version=None, scm=None, path=None):
 
         self._metadata = None
         self._install_info = None
@@ -59,6 +57,7 @@ class GalaxyRole(object):
         display.debug('Validate TLS certificates: %s' % self._validate_certs)
 
         self.galaxy = galaxy
+        self.api = api
 
         self.name = name
         self.version = version
@@ -205,17 +204,16 @@ class GalaxyRole(object):
                 role_data = self.src
                 tmp_file = self.fetch(role_data)
             else:
-                api = GalaxyAPI(self.galaxy, 'role_default', C.GALAXY_SERVER)
-                role_data = api.lookup_role_by_name(self.src)
+                role_data = self.api.lookup_role_by_name(self.src)
                 if not role_data:
-                    raise AnsibleError("- sorry, %s was not found on %s." % (self.src, api.api_server))
+                    raise AnsibleError("- sorry, %s was not found on %s." % (self.src, self.api.api_server))
 
                 if role_data.get('role_type') == 'APP':
                     # Container Role
                     display.warning("%s is a Container App role, and should only be installed using Ansible "
                                     "Container" % self.name)
 
-                role_versions = api.fetch_role_related('versions', role_data['id'])
+                role_versions = self.api.fetch_role_related('versions', role_data['id'])
                 if not self.version:
                     # convert the version names to LooseVersion objects
                     # and sort them to get the latest version. If there


### PR DESCRIPTION
##### SUMMARY
The `--server` option for `ansible-galaxy role ...` was not being used for certain commands. This PR makes sure we use the Galaxy server option just like we do for collections.

Fixes https://github.com/ansible/ansible/issues/61609

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy