### PR TITLE
Fix galaxy server reference in the docs

### DIFF
--- a/docs/docsite/rst/reference_appendices/galaxy.rst
+++ b/docs/docsite/rst/reference_appendices/galaxy.rst
@@ -28,7 +28,7 @@ also use it to create a new role, remove roles, or perform tasks on the Galaxy w
 
 The command line tool by default communicates with the Galaxy website API using the server address *https://galaxy.ansible.com*. Since the `Galaxy project <https://github.com/ansible/galaxy>`_
 is an open source project, you may be running your own internal Galaxy server and wish to override the default server address. You can do this using the *--server* option
-or by setting the Galaxy server value in your *ansible.cfg* file. For information on setting the value in *ansible.cfg* visit `Galaxy Settings <./intro_configuration.html#galaxy-settings>`_.
+or by setting the Galaxy server value in your *ansible.cfg* file. For information on setting the value in *ansible.cfg* see :ref:`galaxy_server`.
 
 
 Installing Roles


### PR DESCRIPTION
##### SUMMARY
There is a dead link at https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool. This just repoints it to the config option to get it working again. There should be a bigger conversation on how this page fits in with the collection tech preview page that is being added with 2.9.

Fixes https://github.com/ansible/ansible/issues/61553

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/reference_appendices/galaxy.rst