### PR TITLE
core: Handle empty extra vars in cli

### DIFF
--- a/changelogs/fragments/extra-vars.yml
+++ b/changelogs/fragments/extra-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Handle empty extra vars in ansible cli (https://github.com/ansible/ansible/issues/61497).

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -60,6 +60,8 @@ def parse_kv(args, check_raw=False):
     if args is not None:
         try:
             vargs = split_args(args)
+        except IndexError as e:
+            raise AnsibleParserError("Unable to parse argument string", orig_exc=e)
         except ValueError as ve:
             if 'no closing quotation' in str(ve).lower():
                 raise AnsibleParserError("error parsing argument string, try quoting the entire line.", orig_exc=ve)


### PR DESCRIPTION
##### SUMMARY

Intended to deal with #61497, but did not.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/extra-vars.yml
lib/ansible/parsing/splitter.py
test/integration/targets/ansible/runme.sh