### PR TITLE
Change mysql.py logic related to #53326

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -84,7 +84,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     except Exception as e:
         module.fail_json(msg="unable to connect to database: %s" % to_native(e))
 
-    if cursor_class is not None:
+    if cursor_class == 'DictCursor':
         return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
     else:
         return db_connection.cursor()

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -257,7 +257,8 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'mysql_driver.cursors.DictCursor',
+        cursor = mysql_connect(module, login_user, login_password, config_file,
+                               ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
                                connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):


### PR DESCRIPTION
##### SUMMARY
Change mysql.py logic related to #53326

I checked it using pymysql and MySQLdb drivers - it works in both cases correctly

if we just remove this keyword_arg as in #53326 it'll break the module, e.g.
it returns (use ```getslave: yes``` option)
```
"Is_Slave": false
```
but actually it must be
```
ok: [mysrv] => {
    "Connect_Retry": 60, 
    "Exec_Master_Log_Pos": 1316, 
    "Is_Slave": true, 
    "Last_Errno": 0, 
    "Last_Error": "", 
    ...
```

So it is not a redundant keyword argument, the cursor must be DictCursor

I checked all modules - the argument is used only by mysql_replication and mysql_info modules (works as expected there).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/module_utils/mysql.py```
```lib/ansible/modules/database/mysql/mysql_replication.py```
