### PR TITLE
[2.9] Azure _info modules: fix returned ansible_facts when called as _info

### DIFF
--- a/changelogs/fragments/61805-azure-facts-info.yml
+++ b/changelogs/fragments/61805-azure-facts-info.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- "azure_rm_dnsrecordset_info - no longer returns empty ``azure_dnsrecordset`` facts when called as ``_info`` module."
+- "azure_rm_resourcegroup_info - no longer returns ``azure_resourcegroups`` facts when called as ``_info`` module."
+- "azure_rm_storageaccount_info - no longer returns empty ``azure_storageaccounts`` facts when called as ``_info`` module."
+- "azure_rm_virtualmachineimage_info - no longer returns empty ``azure_vmimages`` facts when called as ``_info`` module."
+- "azure_rm_virtualmachinescaleset_info - fix wrongly empty result, or ``ansible_facts`` result, when called as ``_info`` module."
+- "azure_rm_virtualnetwork_info - no longer returns empty ``azure_virtualnetworks`` facts when called as ``_info`` module."

--- a/lib/ansible/modules/cloud/azure/azure_rm_containerinstance_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_containerinstance_info.py
@@ -202,7 +202,6 @@ class AzureRMContainerInstanceInfo(AzureRMModuleBase):
         # store the results of the module operation
         self.results = dict(
             changed=False,
-            ansible_facts=dict()
         )
         self.resource_group = None
         self.name = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
@@ -179,7 +179,6 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
         # store the results of the module operation
         self.results = dict(
             changed=False,
-            ansible_info=dict(azure_dnsrecordset=[])
         )
 
         self.relative_name = None
@@ -221,7 +220,9 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
             results = self.list_zone()
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_dnsrecordset'] = self.serialize_list(results)
+            self.results['ansible_facts'] = {
+                'azure_dnsrecordset': self.serialize_list(results)
+            }
         self.results['dnsrecordsets'] = self.curated_list(results)
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
@@ -154,7 +154,6 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(azure_resourcegroups=[]),
             resourcegroups=[]
         )
 
@@ -167,20 +166,25 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
                                                        facts_module=True)
 
     def exec_module(self, **kwargs):
+        is_old_facts = self.module._name == 'azure_rm_resourcegroup_facts'
+        if is_old_facts:
+            self.module.deprecate("The 'azure_rm_resourcegroup_facts' module has been renamed to 'azure_rm_resourcegroup_info'", version='2.13')
 
         for key in self.module_arg_spec:
             setattr(self, key, kwargs[key])
 
         if self.name:
-            self.results['ansible_facts']['azure_resourcegroups'] = self.get_item()
+            result = self.get_item()
         else:
-            self.results['ansible_facts']['azure_resourcegroups'] = self.list_items()
+            result = self.list_items()
 
         if self.list_resources:
-            for item in self.results['ansible_facts']['azure_resourcegroups']:
+            for item in result:
                 item['resources'] = self.list_by_rg(item['name'])
 
-        self.results['resourcegroups'] = self.results['ansible_facts']['azure_resourcegroups']
+        if is_old_facts:
+            self.results['ansible_facts']['azure_resourcegroups'] = result
+        self.results['resourcegroups'] = result
 
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_sqlserver_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_sqlserver_info.py
@@ -138,7 +138,6 @@ class AzureRMSqlServerInfo(AzureRMModuleBase):
         # store the results of the module operation
         self.results = dict(
             changed=False,
-            ansible_facts=dict()
         )
         self.resource_group = None
         self.server_name = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_info.py
@@ -371,7 +371,6 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(azure_storageaccounts=[]),
             storageaccounts=[]
         )
 
@@ -407,8 +406,10 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
         filtered = self.filter_tag(results)
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_storageaccounts'] = self.serialize(filtered)
-            self.results['ansible_facts']['storageaccounts'] = self.format_to_dict(filtered)
+            self.results['ansible_facts'] = {
+                'azure_storageaccounts': self.serialize(filtered),
+                'storageaccounts': self.format_to_dict(filtered),
+            }
         self.results['storageaccounts'] = self.format_to_dict(filtered)
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_info.py
@@ -139,7 +139,6 @@ class AzureRMVirtualMachineImageInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(azure_vmimages=[])
         )
 
         self.location = None
@@ -159,6 +158,7 @@ class AzureRMVirtualMachineImageInfo(AzureRMModuleBase):
             setattr(self, key, kwargs[key])
 
         if is_old_facts:
+            self.results['ansible_facts'] = dict()
             if self.location and self.publisher and self.offer and self.sku and self.version:
                 self.results['ansible_facts']['azure_vmimages'] = self.get_item()
             elif self.location and self.publisher and self.offer and self.sku:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset_info.py
@@ -280,9 +280,6 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(
-                azure_vmss=[]
-            )
         )
 
         self.name = None
@@ -308,20 +305,14 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
         if self.name and not self.resource_group:
             self.fail("Parameter error: resource group required when filtering by name.")
 
-        if is_old_facts:
-            if self.name:
-                self.results['ansible_facts']['azure_vmss'] = self.get_item()
-            else:
-                self.results['ansible_facts']['azure_vmss'] = self.list_items()
+        if self.name:
+            result = self.get_item()
         else:
-            if self.name:
-                self.results['vmss'] = self.get_item()
-            else:
-                self.results['vmss'] = self.list_items()
+            result = self.list_items()
 
         if self.format == 'curated':
-            for index in range(len(self.results['ansible_facts']['azure_vmss'])):
-                vmss = self.results['ansible_facts']['azure_vmss'][index]
+            for index in range(len(result)):
+                vmss = result[index]
                 subnet_name = None
                 load_balancer_name = None
                 virtual_network_name = None
@@ -385,13 +376,18 @@ class AzureRMVirtualMachineScaleSetInfo(AzureRMModuleBase):
                     'tags': vmss.get('tags')
                 }
 
-                self.results['ansible_facts']['azure_vmss'][index] = updated
+                result[index] = updated
 
-            # proper result format we want to support in the future
-            # dropping 'ansible_facts' and shorter name 'vmss'
-            self.results['vmss'] = self.results['ansible_facts']['azure_vmss']
-            if not is_old_facts:
-                self.results.pop('ansible_facts', None)
+        if is_old_facts:
+            self.results['ansible_facts'] = {
+                'azure_vmss': result
+            }
+            if self.format == 'curated':
+                # proper result format we want to support in the future
+                # dropping 'ansible_facts' and shorter name 'vmss'
+                self.results['vmss'] = result
+        else:
+            self.results['vmss'] = result
 
         return self.results
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_info.py
@@ -214,7 +214,6 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            ansible_facts=dict(azure_virtualnetworks=[]),
             virtualnetworks=[]
         )
 
@@ -242,7 +241,9 @@ class AzureRMNetworkInterfaceInfo(AzureRMModuleBase):
             results = self.list_items()
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_virtualnetworks'] = self.serialize(results)
+            self.results['ansible_facts'] = {
+                'azure_virtualnetworks': self.serialize(results)
+            }
         self.results['virtualnetworks'] = self.curated(results)
 
         return self.results


### PR DESCRIPTION
##### SUMMARY
Backport of #61805 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_dnsrecordset_info
azure_rm_resourcegroup_info
azure_rm_storageaccount_info
azure_rm_virtualmachineimage_info
azure_rm_virtualmachinescaleset_info
azure_rm_virtualnetwork_info
