### PR TITLE
Add flake8 config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+show-source = true
+max-line-length = 160
+ignore = E402,W503,W504,E741

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -61,6 +61,7 @@ def assemble_files_to_ship(complete_file_list):
         'hacking/test-module',
         'hacking/test-module.py',
         '.cherry_picker.toml',
+        '.flake8',
         '.mailmap',
         # Possibly should be included
         'examples/scripts/uptime.py',


### PR DESCRIPTION
##### SUMMARY
Add flake8 config file

Even if ansible-test is handling pep8 testing, this commit brings back
and updates the missing flake8 config that went away when removing
legaxy tox.ini.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
flake8