### PR TITLE
documentation correct broken hyperlink

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -64,7 +64,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within Docker
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/runner/completion/docker.txt>`_ for options.
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options.
 
 .. note:: Avoiding pulling new Docker images
 


### PR DESCRIPTION
##### SUMMARY
In the documentation page about [integration](https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html), the link to the list of available docker images was broken (404). This PR change the link to the correct destination.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION

