### PR TITLE
fix inaccurate task headers for host_pinned strategy

### DIFF
--- a/changelogs/fragments/61845-default-callback-host_pinned_jumbled_task_headers.yml
+++ b/changelogs/fragments/61845-default-callback-host_pinned_jumbled_task_headers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - default callback - fixed issue causing inaccurate task headers while using host_pinned strategy

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -202,9 +202,9 @@ class CallbackModule(CallbackBase):
 
         # Preserve task name, as all vars may not be available for templating
         # when we need it later
-        if self._play.strategy == 'free':
-            # Explicitly set to None for strategy 'free' to account for any cached
-            # task title from a previous non-free play
+        if self._play.strategy in ['free', 'host_pinned']:
+            # Explicitly set to None for strategy 'free' or 'host_pinned' to 
+            # ensure accurate task headers
             self._last_task_name = None
         else:
             self._last_task_name = task.get_name().strip()

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -203,7 +203,7 @@ class CallbackModule(CallbackBase):
         # Preserve task name, as all vars may not be available for templating
         # when we need it later
         if self._play.strategy in ['free', 'host_pinned']:
-            # Explicitly set to None for strategy 'free' or 'host_pinned' to 
+            # Explicitly set to None for strategy 'free' or 'host_pinned' to
             # ensure accurate task headers
             self._last_task_name = None
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using the host_pinned strategy the task header will be inaccurate.  This is due to caching the task name.  This is not an issue with the free strategy because task name caching is essentially disabled by setting the last task name to None every time a task starts.

I felt the simplest change was to add the host_pinned string to the conditional that already prevents this issue for the free strategy.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
default callback plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Using the host_pinned strategy task results do not always match the task header under which they are printed.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
**Jumbled, wrong task name headers: (note that CREATE SNAPSHOT DIRECTORY shows 
both skipped and ok on r2)**

TASK [fisv_network_snapshot : CREATE SNAPSHOT DIRECTORY] ***********************
skipping: [r2]

TASK [fisv_network_snapshot : CREATE SNAPSHOT DIRECTORY] ***********************
ok: [r2]

TASK [fisv_network_snapshot : VALIDATION SNAPSHOT] *****************************

TASK [fisv_network_snapshot : VALIDATION SNAPSHOT] *****************************
ok: [r1]

TASK [fisv_network_snapshot : VALIDATION SNAPSHOT] *****************************
ok: [r1] => (item=show version)
ok: [r2] => (item=show version)
ok: [r1] => (item=show cdp neighbors)
ok: [r2] => (item=show cdp neighbors)
ok: [r1] => (item=show ip route)
ok: [r2] => (item=show ip route)
ok: [r1] => (item=show interfaces)
ok: [r2] => (item=show interfaces)
ok: [r1] => (item=show standby brief)
ok: [r2] => (item=show standby brief)
ok: [r1] => (item=show ip eigrp neighbors)
ok: [r2] => (item=show ip eigrp neighbors)
ok: [r1] => (item=show running-config)

TASK [fisv_network_snapshot : MAKE SNAPSHOT DICTIONARY] ************************

TASK [fisv_network_snapshot : MAKE SNAPSHOT DICTIONARY] ************************
ok: [r2] => (item=show running-config)```


**After the change results belong to the appropriate task header**

TASK [fisv_network_snapshot : CREATE SNAPSHOT DIRECTORY] ***********************
ok: [r2]
ok: [r1]

TASK [fisv_network_snapshot : VALIDATION SNAPSHOT] *****************************
ok: [r1] => (item=show version)
ok: [r2] => (item=show version)
ok: [r2] => (item=show cdp neighbors)
ok: [r1] => (item=show cdp neighbors)
ok: [r2] => (item=show ip route)
ok: [r1] => (item=show ip route)
ok: [r2] => (item=show interfaces)
ok: [r1] => (item=show interfaces)
ok: [r1] => (item=show standby brief)
ok: [r2] => (item=show standby brief)
ok: [r1] => (item=show ip eigrp neighbors)
ok: [r2] => (item=show ip eigrp neighbors)
ok: [r1] => (item=show running-config)
ok: [r2] => (item=show running-config)

TASK [fisv_network_snapshot : MAKE SNAPSHOT DICTIONARY] ************************
ok: [r1] => (item=show version)
ok: [r1] => (item=show cdp neighbors)
ok: [r1] => (item=show ip route)
ok: [r1] => (item=show interfaces)
ok: [r1] => (item=show standby brief)
ok: [r1] => (item=show ip eigrp neighbors)
ok: [r1] => (item=show running-config)
ok: [r2] => (item=show version)
ok: [r2] => (item=show cdp neighbors)
ok: [r2] => (item=show ip route)
ok: [r2] => (item=show interfaces)
ok: [r2] => (item=show standby brief)
ok: [r2] => (item=show ip eigrp neighbors)
ok: [r2] => (item=show running-config)