### PR TITLE
pct_to_int - round before int casting

### DIFF
--- a/lib/ansible/utils/helpers.py
+++ b/lib/ansible/utils/helpers.py
@@ -29,7 +29,7 @@ def pct_to_int(value, num_items, min_value=1):
     '''
     if isinstance(value, string_types) and value.endswith('%'):
         value_pct = int(value.replace("%", ""))
-        return int((value_pct / 100.0) * num_items) or min_value
+        return int(round((value_pct / 100.0) * num_items)) or min_value
     else:
         return int(value)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This util function is used to calculate the size of the next batch when using serial with percentages
Currently, the value is directly cast to int which truncates the decimals (~equivalent to round down/floor)
With this change, the size of the batches will be rounded to the nearest integer value (2.6->3; 2.3->2)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

serial percentage
utils helpers

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
