### PR TITLE
Fixes to ecs_certificate cert chain for #61738

### DIFF
--- a/changelogs/fragments/61738-ecs-certificate-invalid-chain.yaml
+++ b/changelogs/fragments/61738-ecs-certificate-invalid-chain.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ecs_certificate - Fix formatting of contents of full_chain_path.

--- a/changelogs/fragments/61738-ecs-certificate-invalid-chain.yaml
+++ b/changelogs/fragments/61738-ecs-certificate-invalid-chain.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ecs_certificate - Fix formatting of contents of full_chain_path.
+  - ecs_certificate - Fix formatting of contents of ``full_chain_path``.

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -768,17 +768,23 @@ class EcsCertificate(object):
                     if self.backup:
                         self.backup_file = module.backup_local(self.path)
                     crypto_utils.write_file(module, to_bytes(self.cert_details.get('endEntityCert')))
-                    if self.full_chain_path:
+                    if self.full_chain_path and self.cert_details.get('chainCerts'):
                         if self.backup:
                             self.backup_full_chain_file = module.backup_local(self.full_chain_path)
-                        crypto_utils.write_file(module, to_bytes(self.cert_details.get('chainCerts')), path=self.full_chain_path)
+                        chain_string = ''
+                        for chain_cert in self.cert_details.get('chainCerts'):
+                            chain_string = chain_string + chain_cert + '\n'
+                        crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
                     self.changed = True
         # If there is no certificate present in path but a tracking ID was specified, save it to disk
         elif not os.path.exists(self.path) and self.tracking_id:
             if not module.check_mode:
                 crypto_utils.write_file(module, to_bytes(self.cert_details.get('endEntityCert')))
-                if self.full_chain_path:
-                    crypto_utils.write_file(module, to_bytes(self.cert_details.get('chainCerts')), path=self.full_chain_path)
+                if self.full_chain_path and self.cert_details.get('chainCerts'):
+                    chain_string = ''
+                    for chain_cert in self.cert_details.get('chainCerts'):
+                        chain_string = chain_string + chain_cert + '\n'
+                    crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
             self.changed = True
 
     def dump(self):

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -771,9 +771,7 @@ class EcsCertificate(object):
                     if self.full_chain_path and self.cert_details.get('chainCerts'):
                         if self.backup:
                             self.backup_full_chain_file = module.backup_local(self.full_chain_path)
-                        chain_string = ''
-                        for chain_cert in self.cert_details.get('chainCerts'):
-                            chain_string = chain_string + chain_cert + '\n'
+                        chain_string = '\n'.join(self.cert_details.get('chainCerts'))
                         crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
                     self.changed = True
         # If there is no certificate present in path but a tracking ID was specified, save it to disk
@@ -781,9 +779,7 @@ class EcsCertificate(object):
             if not module.check_mode:
                 crypto_utils.write_file(module, to_bytes(self.cert_details.get('endEntityCert')))
                 if self.full_chain_path and self.cert_details.get('chainCerts'):
-                    chain_string = ''
-                    for chain_cert in self.cert_details.get('chainCerts'):
-                        chain_string = chain_string + chain_cert + '\n'
+                    chain_string = '\n'.join(self.cert_details.get('chainCerts'))
                     crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
             self.changed = True
 

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -771,7 +771,7 @@ class EcsCertificate(object):
                     if self.full_chain_path and self.cert_details.get('chainCerts'):
                         if self.backup:
                             self.backup_full_chain_file = module.backup_local(self.full_chain_path)
-                        chain_string = '\n'.join(self.cert_details.get('chainCerts'))
+                        chain_string = '\n'.join(self.cert_details.get('chainCerts')) + '\n'
                         crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
                     self.changed = True
         # If there is no certificate present in path but a tracking ID was specified, save it to disk
@@ -779,7 +779,7 @@ class EcsCertificate(object):
             if not module.check_mode:
                 crypto_utils.write_file(module, to_bytes(self.cert_details.get('endEntityCert')))
                 if self.full_chain_path and self.cert_details.get('chainCerts'):
-                    chain_string = '\n'.join(self.cert_details.get('chainCerts'))
+                    chain_string = '\n'.join(self.cert_details.get('chainCerts')) + '\n'
                     crypto_utils.write_file(module, to_bytes(chain_string), path=self.full_chain_path)
             self.changed = True
 

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -206,7 +206,7 @@
 
   - assert:
       that:
-        - openssl_result.stdout_lines[0].endswith(': OK')
+         - "' OK' in openssl_result.stdout_lines[0]"
 
   always:
     - name: clean-up temporary folder

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -201,14 +201,12 @@
 
   # For bug 61738, verify that the full chain is valid
   - name: Verify that the full chain path can be successfully imported
-    openssl_pkcs12:
-      action: export
-      certificate_path: '{{ example4_cert_path }}'
-      other_certificates: '{{ example4_full_chain_path }}'
-      friendly_name: pkcs12alias
-      path: '{{ example4_p12_path }}'
-      passphrase: pkcs12passphrase
+    command: openssl verify "{{ example4_full_chain_path }}"
+    register: openssl_result
 
+  - assert:
+      that:
+        - openssl_result.stdout_lines[0].endswith(': OK')
 
   always:
     - name: clean-up temporary folder

--- a/test/integration/targets/ecs_certificate/tasks/main.yml
+++ b/test/integration/targets/ecs_certificate/tasks/main.yml
@@ -169,6 +169,7 @@
   - name: Test a request with all of the various optional possible fields populated
     ecs_certificate:
       path: '{{ example4_cert_path }}'
+      full_chain_path: '{{ example4_full_chain_path }}'
       csr: '{{ csr_path }}'
       subject_alt_name: '{{ example4_subject_alt_name }}'
       eku: '{{ example4_eku }}'
@@ -197,6 +198,17 @@
         - example4_result.backup_full_chain_file is undefined
         - example4_result.tracking_id > 0
         - example4_result.serial_number is string
+
+  # For bug 61738, verify that the full chain is valid
+  - name: Verify that the full chain path can be successfully imported
+    openssl_pkcs12:
+      action: export
+      certificate_path: '{{ example4_cert_path }}'
+      other_certificates: '{{ example4_full_chain_path }}'
+      friendly_name: pkcs12alias
+      path: '{{ example4_p12_path }}'
+      passphrase: pkcs12passphrase
+
 
   always:
     - name: clean-up temporary folder

--- a/test/integration/targets/ecs_certificate/vars/main.yml
+++ b/test/integration/targets/ecs_certificate/vars/main.yml
@@ -49,5 +49,5 @@ example4_custom_fields:
   email2: sales@ansible.testcertificates.com
   dropdown2: Dropdown 2 Value 1
 example4_cert_expiry: 2020-08-15
-exampel4_full_chain_path: '{{ tmpdir_path }}/issuedcert_2_chain.pem'
+example4_full_chain_path: '{{ tmpdir_path }}/issuedcert_2_chain.pem'
 example4_p12_path: '{{ tmpdir_path }}/issuedcert_2.p12'

--- a/test/integration/targets/ecs_certificate/vars/main.yml
+++ b/test/integration/targets/ecs_certificate/vars/main.yml
@@ -49,3 +49,5 @@ example4_custom_fields:
   email2: sales@ansible.testcertificates.com
   dropdown2: Dropdown 2 Value 1
 example4_cert_expiry: 2020-08-15
+exampel4_full_chain_path: '{{ tmpdir_path }}/issuedcert_2_chain.pem'
+example4_p12_path: '{{ tmpdir_path }}/issuedcert_2.p12'

--- a/test/integration/targets/ecs_certificate/vars/main.yml
+++ b/test/integration/targets/ecs_certificate/vars/main.yml
@@ -50,4 +50,3 @@ example4_custom_fields:
   dropdown2: Dropdown 2 Value 1
 example4_cert_expiry: 2020-08-15
 example4_full_chain_path: '{{ tmpdir_path }}/issuedcert_2_chain.pem'
-example4_p12_path: '{{ tmpdir_path }}/issuedcert_2.p12'


### PR DESCRIPTION
##### SUMMARY
Fixes for bug ticket #61738 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ecs_certificate

##### ADDITIONAL INFORMATION
The cert chain is returned from ECS API as an array, so we can't write it directly to disk - proper PEM formatting says to append the elements in order.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
