### PR TITLE
[stable-2.8] test: disable the docker swarm tests (#61816)

### DIFF
--- a/test/integration/targets/docker_swarm/aliases
+++ b/test/integration/targets/docker_swarm/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group2
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_info/aliases
+++ b/test/integration/targets/docker_swarm_info/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group1
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group4
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service_info/aliases
+++ b/test/integration/targets/docker_swarm_service_info/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group3
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/inventory_docker_swarm/aliases
+++ b/test/integration/targets/inventory_docker_swarm/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group2
+disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61816 for Ansible 2.8

(cherry picked from commit 7132466327)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_swarm`
`test/integration/targets/docker_swarm_info`
`test/integration/targets/docker_swarm_service`
`test/integration/targets/docker_swarm_service_info`
`test/integration/targets/inventory_docker_swarm/aliases`