### PR TITLE
[stable-2.9] azure_rm_iothub: disable the functional test (#61854)

### DIFF
--- a/test/integration/targets/azure_rm_iothub/aliases
+++ b/test/integration/targets/azure_rm_iothub/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group2
+disabled  # See: https://github.com/ansible/ansible/issues/61852
 destructive


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61854 for Ansible 2.9

(cherry picked from commit 08e01380e676a92634eccb00aa3c1d4cfcf4c192)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/azure_rm_iothub/`
