### PR TITLE
Azure private tag prefix support (fixes azure_vm_virtualmachine idempotency and stranded resources)

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1094,7 +1094,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     changed = True
                     vm_dict['properties']['hardwareProfile']['vmSize'] = self.vm_size
 
-                update_tags, vm_dict['tags'] = self.update_tags(vm_dict.get('tags', dict()))
+                update_tags, vm_dict['tags'] = self.update_tags(vm_dict.get('tags', dict()), private_prefix='_own_')
                 if update_tags:
                     differences.append('Tags')
                     changed = True
@@ -1999,10 +1999,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         valid_name = False
         if self.tags is None:
             self.tags = {}
-
-        if self.tags.get('_own_sa_', None):
-            # We previously created one in the same invocation
-            return self.get_storage_account(self.tags['_own_sa_'])
 
         if vm_dict and vm_dict.get('tags', {}).get('_own_sa_', None):
             # We previously created one in a previous invocation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It was possible for tags used internally to track resources that a module manages (like azure_vm_virtualmachine manages the Storage Account and saves it with _own_sa_ as a tag) to be corrupted by an external update in module params.  If the user modified _own_sa_ then the original storage account would be orphaned, and a new one would be created.

Generally, internal tags SHOULD have a better prefix than "_own_" however that's what is there now.
The azure common update_tags mechanism was updated so that an optional private tag prefix could be specified.  Any incoming tag creations or updates on those tags will be ignored and a debug message generated.  Any tag deletions that would normally occur on those tags will not occur through the update_tags mechanism (which is used to apply the user's tags in params to the object in question).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #61767

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Without this change if one creates a VM with azure_vm_virtualmachine using a playbook that contains a tag, then runs the playbook again, the old storage account would be orphaned and a new storage account would be created.  This issue likely appeared with support for boot diagnostics.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
