### PR TITLE
Reenable docker_swarm_info, docker_swarm_service, docker_swarm_service_info, inventory_docker_swarm tests

### DIFF
--- a/test/integration/targets/docker_swarm_info/aliases
+++ b/test/integration/targets/docker_swarm_info/aliases
@@ -1,5 +1,4 @@
 shippable/posix/group1
-disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service/aliases
+++ b/test/integration/targets/docker_swarm_service/aliases
@@ -1,5 +1,4 @@
 shippable/posix/group4
-disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/docker_swarm_service_info/aliases
+++ b/test/integration/targets/docker_swarm_service_info/aliases
@@ -1,5 +1,4 @@
 shippable/posix/group3
-disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive

--- a/test/integration/targets/inventory_docker_swarm/aliases
+++ b/test/integration/targets/inventory_docker_swarm/aliases
@@ -1,5 +1,4 @@
 shippable/posix/group2
-disabled  # See: https://github.com/ansible/ansible/issues/61815
 skip/osx
 skip/freebsd
 destructive


### PR DESCRIPTION
##### SUMMARY
I don't think these tests should be disabled. The problem seem to be the `docker_swarm` tests, not the others.

Let's run the tests a few times and see whether these also have problems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_info
docker_swarm_service
docker_swarm_service_info
lib/ansible/plugins/inventory/docker_swarm.py
