### PR TITLE
Clarifying pip module requirements in reference to #47361

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,7 +101,9 @@ options:
         in the system and you want to run pip for the Python 3.3 installation.
         It cannot be specified together with the 'virtualenv' parameter (added in 2.1).
         By default, it will take the appropriate version for the python interpreter
-        use by ansible, e.g. pip3 on python 3, and pip2 or pip on python 2.
+        use by ansible, e.g. pip3 on python 3, and pip2 or pip on python 2. Note that
+        the setuptools requirement is for the Python interpreter used by ansible, not
+        by the version of Python used by the specified executable.
     type: path
     version_added: "1.3"
   umask:
@@ -119,6 +121,8 @@ notes:
      the virtualenv needs to be created.
    - By default, this module will use the appropriate version of pip for the
      interpreter used by ansible (e.g. pip3 when using python 3, pip2 otherwise)
+   - The interpreter used by ansible requires the setuptools package, regardless
+     of the version of pip set with the executable option.
 requirements:
 - pip
 - virtualenv

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -121,8 +121,10 @@ notes:
      the virtualenv needs to be created.
    - By default, this module will use the appropriate version of pip for the
      interpreter used by ansible (e.g. pip3 when using python 3, pip2 otherwise)
-   - The interpreter used by ansible requires the setuptools package, regardless
-     of the version of pip set with the executable option.
+   - The interpreter used by ansible
+     (see :ref:`ansible_python_interpreter<ansible_python_interpreter>`)
+     requires the setuptools package, regardless of the version of pip set with
+     the executable option.
 requirements:
 - pip
 - virtualenv


### PR DESCRIPTION
##### SUMMARY
The docs for the pip module had no information on which python needed `setuptools` when using a different version of pip with the `executable` parameter

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pip

##### ADDITIONAL INFORMATION
See https://github.com/ansible/ansible/issues/47361#issuecomment-433892723 