### PR TITLE
[stable-2.9] Connect before reading the prompt? (#61797)

### DIFF
--- a/changelogs/fragments/61797-netcli-get_prompt.yaml
+++ b/changelogs/fragments/61797-netcli-get_prompt.yaml
@@ -1,0 +1,2 @@
+- bugfixes:
+  - "network_cli - ensure connection is established before returning the current prompt"

--- a/changelogs/fragments/61797-netcli-get_prompt.yaml
+++ b/changelogs/fragments/61797-netcli-get_prompt.yaml
@@ -1,2 +1,2 @@
-- bugfixes:
+bugfixes:
   - "network_cli - ensure connection is established before returning the current prompt"

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -346,6 +346,7 @@ class Connection(NetworkConnectionBase):
         name += "paramiko [%s]" % self._play_context.remote_addr
         return name
 
+    @ensure_connect
     def get_prompt(self):
         """Returns the current prompt from the device"""
         return self._matched_prompt


### PR DESCRIPTION
(cherry picked from commit a365e77)

Co-authored-by: Nathaniel Case <ncase@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli

Depends-On: https://github.com/ansible/ansible/pull/61899