### PR TITLE
nxos_l2_interfaces: fix for integration tests failing to setup layer2

### DIFF
--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
@@ -17,8 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport trunk native vlan 10
         interface {{ test_int2 }}
+          switchport
           switchport trunk allowed vlan 20
 
   - name: Gather l2_interfaces facts

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
@@ -11,6 +11,12 @@
   ignore_errors: yes
 
 - block:
+  - name: setup2
+    cli_config:
+      config: |
+        interface {{ test_int1 }}
+          switchport
+
   - name: Merged
     nxos_l2_interfaces: &merged
       config:

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
@@ -17,7 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport trunk allowed vlan 11
+        interface {{ test_int2 }}
+          switchport
 
   - name: Gather l2_interfaces facts
     nxos_facts: &facts

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
@@ -17,8 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport access vlan 5
         interface {{ test_int2 }}
+          switchport
           switchport trunk native vlan 15
 
   - name: Gather l2_interfaces facts


### PR DESCRIPTION
##### SUMMARY
All of the `nxos_l2_interfaces` integration tests are failing on our regression platforms because the test interfaces are not initially configured as layer2 interfaces. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_l2_interfaces`

##### ADDITIONAL INFORMATION
All four tests are now passing on my N9K hardware.