### PR TITLE
Docs formatting: recursively preprocess suboptions

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -190,8 +190,6 @@ Parameters
             {% if value.suboptions %}
                 {% if value.suboptions.items %}
                     @{ loop(value.suboptions|dictsort) }@
-                {% elif value.suboptions[0].items %}
-                    @{ loop(value.suboptions[0]|dictsort) }@
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -190,6 +190,8 @@ Parameters
             {% if value.suboptions %}
                 {% if value.suboptions.items %}
                     @{ loop(value.suboptions|dictsort) }@
+                {% elif value.suboptions[0].items %}
+                    @{ loop(value.suboptions[0]|dictsort) }@
                 {% endif %}
             {% endif %}
         {% endfor %}

--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -422,27 +422,27 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
         if 'options' in doc and doc['options']:
             for (k, v) in iteritems(doc['options']):
                 # Error out if there's no description
-                if 'description' not in doc['options'][k]:
+                if 'description' not in v:
                     raise AnsibleError("Missing required description for parameter '%s' in '%s' " % (k, module))
 
                 # Make sure description is a list of lines for later formatting
-                if isinstance(doc['options'][k]['description'], string_types):
-                    doc['options'][k]['description'] = [doc['options'][k]['description']]
-                elif not isinstance(doc['options'][k]['description'], (list, tuple)):
+                if isinstance(v['description'], string_types):
+                    v['description'] = [v['description']]
+                elif not isinstance(v['description'], (list, tuple)):
                     raise AnsibleError("Invalid type for options['%s']['description']."
                                        " Must be string or list of strings.  Got %s" %
-                                       (k, type(doc['options'][k]['description'])))
+                                       (k, type(v['description'])))
 
                 # Error out if required isn't a boolean (people have been putting
                 # information on when something is required in here.  Those need
                 # to go in the description instead).
-                required_value = doc['options'][k].get('required', False)
+                required_value = v.get('required', False)
                 if not isinstance(required_value, bool):
                     raise AnsibleError("Invalid required value '%s' for parameter '%s' in '%s' (must be truthy)" % (required_value, k, module))
 
                 # Strip old version_added information for options
-                if 'version_added' in doc['options'][k] and too_old(doc['options'][k]['version_added']):
-                    del doc['options'][k]['version_added']
+                if 'version_added' in v and too_old(v['version_added']):
+                    del v['version_added']
 
                 option_names.append(k)
 

--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -374,6 +374,12 @@ def process_options(options):
             if 'version_added' in v and too_old(v['version_added']):
                 del v['version_added']
 
+            if 'suboptions' in v and v['suboptions']:
+                if isinstance(v['suboptions'], dict):
+                    v['suboptions'] = process_options(v['suboptions'])
+                elif isinstance(v['suboptions'][0], dict):
+                    v['suboptions'] = process_options(v['suboptions'][0])
+
             option_names.append(k)
 
     option_names.sort()

--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -346,7 +346,7 @@ def too_old(added):
     return added_float < TOO_OLD_TO_BE_NOTABLE
 
 
-def process_options(options):
+def process_options(module, options):
     option_names = []
 
     if options:
@@ -376,9 +376,9 @@ def process_options(options):
 
             if 'suboptions' in v and v['suboptions']:
                 if isinstance(v['suboptions'], dict):
-                    v['suboptions'] = process_options(v['suboptions'])
+                    v['suboptions'] = process_options(module, v['suboptions'])
                 elif isinstance(v['suboptions'][0], dict):
-                    v['suboptions'] = process_options(v['suboptions'][0])
+                    v['suboptions'] = process_options(module, v['suboptions'][0])
 
             option_names.append(k)
 
@@ -458,7 +458,7 @@ def process_plugins(module_map, templates, outputname, output_dir, ansible_versi
         if too_old(added):
             del doc['version_added']
 
-        doc['option_keys'] = process_options(doc.get('options'))
+        doc['option_keys'] = process_options(module, doc.get('options'))
         doc['filename'] = fname
         doc['source'] = module_map[module]['source']
         doc['docuri'] = doc['module'].replace('_', '-')

--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -376,9 +376,9 @@ def process_options(module, options):
 
             if 'suboptions' in v and v['suboptions']:
                 if isinstance(v['suboptions'], dict):
-                    v['suboptions'] = process_options(module, v['suboptions'])
+                    process_options(module, v['suboptions'])
                 elif isinstance(v['suboptions'][0], dict):
-                    v['suboptions'] = process_options(module, v['suboptions'][0])
+                    process_options(module, v['suboptions'][0])
 
             option_names.append(k)
 


### PR DESCRIPTION
##### SUMMARY
Right now, suboptions are not processed (i.e. sorted by keys, description massaged, `version_added` removed if too old). Especially the missing description massage has ugly side-effects, see for example the suboptions of `custom_fields` in https://docs.ansible.com/ansible/devel/modules/ecs_certificate_module.html (the description there is a string, instead of a list - that works fine on a higher level, thanks to the massaging code).

CC @ctrufan

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
docs/templates/plugin.rst.j2
