### PR TITLE
ansible-galaxy - add config to control the display wheel

### DIFF
--- a/changelogs/fragments/ansible-galaxy-progress.yaml
+++ b/changelogs/fragments/ansible-galaxy-progress.yaml
@@ -1,0 +1,2 @@
+minor_features:
+- ansible-galaxy - Added the ability to display the progress wheel through the C.GALAXY_DISPLAY_PROGRESS config option. Also this now defaults to displaying the progress wheel if stdout has a tty.

--- a/changelogs/fragments/ansible-galaxy-progress.yaml
+++ b/changelogs/fragments/ansible-galaxy-progress.yaml
@@ -1,2 +1,2 @@
-minor_features:
+minor_changes:
 - ansible-galaxy - Added the ability to display the progress wheel through the C.GALAXY_DISPLAY_PROGRESS config option. Also this now defaults to displaying the progress wheel if stdout has a tty.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1396,6 +1396,18 @@ GALAXY_TOKEN_PATH:
   - {key: token_path, section: galaxy}
   type: path
   version_added: "2.9"
+GALAXY_DISPLAY_PROGRESS:
+  default: ~
+  description:
+  - Some steps in ``ansible-galaxy`` display a progress wheel which can cause issues on certain displays or when
+    outputing the stdout to a file.
+  - This config option controls whether the display wheel is shown or not.
+  - The default is to show the display wheel if stdout has a tty.
+  env: [{name: ANSIBLE_GALAXY_DISPLAY_PROGRESS}]
+  ini:
+  - {key: display_progress, section: galaxy}
+  type: bool
+  version_added: "2.10"
 HOST_KEY_CHECKING:
   name: Check host keys
   default: True

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -9,6 +9,7 @@ import json
 import operator
 import os
 import shutil
+import sys
 import tarfile
 import tempfile
 import threading
@@ -456,14 +457,18 @@ def _tarfile_extract(tar, member):
 
 @contextmanager
 def _display_progress():
+    config_display = C.GALAXY_DISPLAY_PROGRESS
+    display_wheel = sys.stdout.isatty() if config_display is None else config_display
+
     def progress(display_queue, actual_display):
         actual_display.debug("Starting display_progress display thread")
         t = threading.current_thread()
 
         while True:
             for c in "|/-\\":
-                actual_display.display(c + "\b", newline=False)
-                time.sleep(0.1)
+                if display_wheel:
+                    actual_display.display(c + "\b", newline=False)
+                    time.sleep(0.1)
 
                 # Display a message from the main thread
                 while True:

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -460,15 +460,18 @@ def _display_progress():
     config_display = C.GALAXY_DISPLAY_PROGRESS
     display_wheel = sys.stdout.isatty() if config_display is None else config_display
 
+    if not display_wheel:
+        yield
+        return
+
     def progress(display_queue, actual_display):
         actual_display.debug("Starting display_progress display thread")
         t = threading.current_thread()
 
         while True:
             for c in "|/-\\":
-                if display_wheel:
-                    actual_display.display(c + "\b", newline=False)
-                    time.sleep(0.1)
+                actual_display.display(c + "\b", newline=False)
+                time.sleep(0.1)
 
                 # Display a message from the main thread
                 while True:

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -661,7 +661,7 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
     assert actual_manifest['collection_info']['version'] == '0.1.0'
 
     # Filter out the progress cursor display calls.
-    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2]]
+    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
     assert len(display_msgs) == 3
     assert display_msgs[0] == "Process install dependency map"
     assert display_msgs[1] == "Starting collection install process"
@@ -686,7 +686,7 @@ def test_install_collections_existing_without_force(collection_artifact, monkeyp
     assert actual_files == [b'README.md', b'docs', b'galaxy.yml', b'playbooks', b'plugins', b'roles']
 
     # Filter out the progress cursor display calls.
-    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2]]
+    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
     assert len(display_msgs) == 4
     # Msg1 is the warning about not MANIFEST.json, cannot really check message as it has line breaks which varies based
     # on the path size
@@ -724,7 +724,7 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
     assert actual_manifest['collection_info']['version'] == '0.1.0'
 
     # Filter out the progress cursor display calls.
-    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2]]
+    display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
     assert len(display_msgs) == 3
     assert display_msgs[0] == "Process install dependency map"
     assert display_msgs[1] == "Starting collection install process"


### PR DESCRIPTION
##### SUMMARY
Only displays the progress wheel outputted by `ansible-galaxy` if stdout has a tty. Also adds a config option if something really wants to force it on or off regardless of the tty value.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy