### PR TITLE
Fix rpm dependencies for ansible-test

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -160,7 +160,7 @@ are transferred to managed machines automatically.
 
 %package -n ansible-test
 Summary: Tool for testing ansible plugin and module code
-Requires: %{name}-%{version}-%{release}
+Requires: %{name} = %{version}-%{release}
 %if 0%{?rhel} >= 8
 # Will use the python3 stdlib venv
 #Requires: python3-virtualenv


### PR DESCRIPTION
Needs to require ansible = version rather than ansible-version


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This needs to be backported to the stable-2.9 branch