### PR TITLE
[stable-2.9] Fix rpm dependencies for ansible-test

### DIFF
--- a/changelogs/fragments/fix-rpm-spec.yaml
+++ b/changelogs/fragments/fix-rpm-spec.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix the upstream rpm spec file.  The ansible-test package requirement on
+    the main ansible package was formatted incorrectly.

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -160,7 +160,7 @@ are transferred to managed machines automatically.
 
 %package -n ansible-test
 Summary: Tool for testing ansible plugin and module code
-Requires: %{name}-%{version}-%{release}
+Requires: %{name} = %{version}-%{release}
 %if 0%{?rhel} >= 8
 # Will use the python3 stdlib venv
 #Requires: python3-virtualenv


### PR DESCRIPTION
Needs to require ansible = version rather than ansible-version
(cherry picked from commit 59afffa)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
