### PR TITLE
win_become - don't dispose logon token until end

### DIFF
--- a/changelogs/fragments/win_become-shared-token.yaml
+++ b/changelogs/fragments/win_become-shared-token.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_become - Do not dispose of one of the logon tokens until after the process has run


### PR DESCRIPTION
##### SUMMARY
A change made in 2.9 for Ansible.Become disposed of a user token if it was not usable or the elevated token was retrieved. This had the side effect of any downstream processes no longer being able to get the linked token during their execution because the only handle was disposed. This change makes sure we keep the handle open until the process has finished. This seems to be an issue when running the `win_mapped_drive` module which gets the linked token if running as an admin. It does not occur all the time but enough to make sure we guarantee at least 1 handle stays open until the process is finished.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Become.cs