### PR TITLE
allow external collections under the ansible NS (#61908)

### DIFF
--- a/changelogs/fragments/allow_ansible_ns.yml
+++ b/changelogs/fragments/allow_ansible_ns.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- allow external collections to be created in the 'ansible' collection namespace (https://github.com/ansible/ansible/issues/59988)

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/ansible/builtin/plugins/modules/ping.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/ansible/builtin/plugins/modules/ping.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, source='overridden ansible.builtin (should not be possible)')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/ansible/bullcoll/plugins/modules/bullmodule.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/ansible/bullcoll/plugins/modules/bullmodule.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, source='user_ansible_bullcoll')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -22,6 +22,16 @@
       name: testns.testcoll.maskedmodule
     register: maskedmodule_out
 
+  # ensure the ansible ns can have real collections added to it
+  - name: call an external module in the ansible namespace
+    ansible.bullcoll.bullmodule:
+    register: bullmodule_out
+
+  # ensure the ansible ns cannot override ansible.builtin externally
+  - name: call an external module in the ansible.builtin collection (should use the built in module)
+    ansible.builtin.ping:
+    register: builtin_ping_out
+
   # action in a collection subdir
   - name: test subdir action FQ
     testns.testcoll.action_subdir.subdir_ping_action:
@@ -59,6 +69,9 @@
       - systestmodule_out.source == 'sys'
       - contentadjmodule_out.source == 'content_adj'
       - not maskedmodule_out.plugin_path
+      - bullmodule_out.source == 'user_ansible_bullcoll'
+      - builtin_ping_out.source is not defined
+      - builtin_ping_out.ping == 'pong'
       - subdir_ping_action_out is not changed
       - subdir_ping_module_out is not changed
       - granular_out.mu_result == 'thingtocall in leaf'


### PR DESCRIPTION
##### SUMMARY
backport fix to allow external collections in the `ansible` collections namespace

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection_loader

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
