### PR TITLE
added option 'cert_update' to update certificates

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -337,20 +337,20 @@ def get_x509_sha256_cert(module, path):
 
 def get_x509_sha256_url(module, url):
     ''' Get SHA256 fingerprint from certificate via url '''
-    x509_cert_url = (url,443)
+    x509_cert_url = (url, 443)
     conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     conn.connect(x509_cert_url)
 
     # Create SSL socket without validating remote
     # certificate. Do not transfer data over
-    # this socket. 
+    # this socket.
     ssl_upgrade = ssl.create_default_context()
     ssl_upgrade.check_hostname = False
     ssl_upgrade.verify_mode = ssl.CERT_NONE
     conn = ssl_upgrade.wrap_socket(conn, server_hostname=x509_cert_url[0])
 
     sha256_fingerprint = conn.getpeercert(True)
-    sha256_fingerprint = load_certificate(FILETYPE_ASN1,sha256_fingerprint)
+    sha256_fingerprint = load_certificate(FILETYPE_ASN1, sha256_fingerprint)
     sha256_fingerprint = sha256_fingerprint.digest("sha256")
 
     return sha256_fingerprint
@@ -359,7 +359,7 @@ def get_x509_sha256_url(module, url):
 def get_keystore_sha256(module, executable, keystore_path, keystore_pass, path, cert_alias):
     ''' Get SHA256 fingerprint from JAVA keystore '''
     list_cmd = ("%s -v -list -keystore '%s' -storepass '%s' "
-               "-alias '%s'") % (executable, keystore_path, keystore_pass, cert_alias)
+                "-alias '%s'") % (executable, keystore_path, keystore_pass, cert_alias)
 
     # List SHA256 fingerprint von alias certificate from keystore
     (list_rc, list_out, list_err) = module.run_command(list_cmd, check_rc=True)
@@ -507,7 +507,6 @@ def main():
         else:
             if module.check_mode:
                 module.exit_json(changed=False)
-
 
     module.exit_json(changed=False)
 

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -5,9 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from OpenSSL.crypto import load_certificate, FILETYPE_PEM, FILETYPE_ASN1
-import socket
-import ssl
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -192,8 +189,16 @@ cmd:
   sample: "keytool -importcert -noprompt -keystore"
 '''
 
+try:
+    from OpenSSL.crypto import load_certificate, FILETYPE_PEM, FILETYPE_ASN1
+except ImportError:
+    PYOPENSSL_FOUND = False
+else:
+    PYOPENSSL_FOUND = True
 import os
 import re
+import socket
+import ssl
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
@@ -441,6 +446,9 @@ def main():
     executable = module.params.get('executable')
     state = module.params.get('state')
     delete_skip_exit = False
+
+    if not PYOPENSSL_FOUND:
+        module.fail_json(msg="PYOPENSSL is missing. Please install PYOPENSSL.")
 
     if path and not cert_alias:
         module.fail_json(changed=False,


### PR DESCRIPTION
Update certificates for given alias name in JKS if SHA256 fingerprint of certificates doesn't match


##### SUMMARY
This is a new feature to give the optional (default: False) possibility to update certificates for a given alias name. This may be interesting when using LetsEncrypt certificates and the certificate needs to be replaced within the JKS. If enabled it will check [local|remote] certificate for import and the already present one in JKS and validate their SHA256 fingerprints. If it won't match the certificate will be replaced (by deleting and readding the certificate) in the JKS. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
New option: cert_update (bool)

##### ADDITIONAL INFORMATION
```
changed: [localhost] => {
    "changed": true, 
    "cmd": "keytool -importcert -noprompt -keystore '/data/ssl/tomcat_keystore.jks' -storepass '********' -alias 'Webserver'", 
    "diff": {
        "after": "Webserver\n", 
        "before": "\n"
    }, 
    "invocation": {
        "module_args": {
            "cert_alias": "Webserver", 
            "cert_path": null, 
            "cert_port": 443, 
            "cert_update": true, 
            "cert_url": "example.org", 
            "executable": "keytool", 
            "keystore_create": true, 
            "keystore_pass": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "keystore_path": "/data/ssl/tomcat_keystore.jks", 
            "keystore_type": null, 
            "pkcs12_alias": null, 
            "pkcs12_password": null, 
            "pkcs12_path": null, 
            "state": "present"
        }
    }, 
    "msg": "", 
    "rc": 0, 
    "stdout": "", 
    "stdout_lines": []
}
```