### PR TITLE
Fix failure due to missing API version check

### DIFF
--- a/changelogs/fragments/61925-fix_purefa_fact_info_api_check.yml
+++ b/changelogs/fragments/61925-fix_purefa_fact_info_api_check.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- purefa_info - Fix missing API version check when calling I(admins) or I(all) as the subset
+- _purefa_facts - Fix missing API version check when calling I(admins) or I(all) as the subset

--- a/lib/ansible/modules/storage/purestorage/_purefa_facts.py
+++ b/lib/ansible/modules/storage/purestorage/_purefa_facts.py
@@ -340,6 +340,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pure import get_system, purefa_argument_spec
 
 
+ADMIN_API_VERSION = '1.14'
 S3_REQUIRED_API_VERSION = '1.16'
 LATENCY_REQUIRED_API_VERSION = '1.16'
 AC_REQUIRED_API_VERSION = '1.14'
@@ -461,14 +462,16 @@ def generate_config_dict(array):
 
 
 def generate_admin_dict(array):
+    api_version = array._list_available_rest_versions()
     admin_facts = {}
-    admins = array.list_admins()
-    for admin in range(0, len(admins)):
-        admin_name = admins[admin]['name']
-        admin_facts[admin_name] = {
-            'type': admins[admin]['type'],
-            'role': admins[admin]['role'],
-        }
+    if ADMIN_API_VERSION in api_version:
+        admins = array.list_admins()
+        for admin in range(0, len(admins)):
+            admin_name = admins[admin]['name']
+            admin_facts[admin_name] = {
+                'type': admins[admin]['type'],
+                'role': admins[admin]['role'],
+            }
     return admin_facts
 
 

--- a/lib/ansible/modules/storage/purestorage/purefa_info.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_info.py
@@ -408,6 +408,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pure import get_system, purefa_argument_spec
 import time
 
+ADMIN_API_VERSION = '1.14'
 S3_REQUIRED_API_VERSION = '1.16'
 LATENCY_REQUIRED_API_VERSION = '1.16'
 AC_REQUIRED_API_VERSION = '1.14'
@@ -530,13 +531,15 @@ def generate_config_dict(array):
 
 def generate_admin_dict(array):
     admin_info = {}
-    admins = array.list_admins()
-    for admin in range(0, len(admins)):
-        admin_name = admins[admin]['name']
-        admin_info[admin_name] = {
-            'type': admins[admin]['type'],
-            'role': admins[admin]['role'],
-        }
+    api_version = array._list_available_rest_versions()
+    if ADMIN_API_VERSION in api_version:
+        admins = array.list_admins()
+        for admin in range(0, len(admins)):
+            admin_name = admins[admin]['name']
+            admin_info[admin_name] = {
+                'type': admins[admin]['type'],
+                'role': admins[admin]['role'],
+            }
     return admin_info
 
 


### PR DESCRIPTION
##### SUMMARY
Add check for correct API version before calling endpoint when the selected subset is either `admins` or `all`
Fix for bug #61924

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_purefa_facts.py
purefa_info.py

##### ADDITIONAL INFORMATION
Fixing both to modules ensure the deprecated module and the new module get the same fix 