### PR TITLE
[WIP] Look for galaxy API info from galaxy_server.url

### DIFF
--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -446,11 +446,11 @@ following entries like so:
     password=my_pass
 
     [galaxy_server.release_galaxy]
-    url=https://galaxy.ansible.com/
+    url=https://galaxy.ansible.com/api/
     token=my_token
 
     [galaxy_server.test_galaxy]
-    url=https://galaxy-dev.ansible.com/
+    url=https://galaxy-dev.ansible.com/api/
     token=my_token
 
 .. note::

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -39,7 +39,7 @@ def g_connect(versions):
 
                 # Determine the type of Galaxy server we are talking to. First try it unauthenticated then with Bearer
                 # auth for Automation Hub.
-                n_url = _urljoin(self.api_server, 'api')
+                n_url = _urljoin(self.api_server, "/")
                 error_context_msg = 'Error when finding available api versions from %s (%s)' % (self.name, n_url)
 
                 try:


### PR DESCRIPTION
For galaxy.ansible.com, the url configured in ansible.conf
should point to the base path of the galaxy api now.
For galaxy.ansible.com, that means:

[galaxy_server.release_galaxy]
url=https://galaxy.ansible.com/api/
token=my_token

So when looking for api 'available_versions', get
https://galaxy.ansible.com/api/ and it's contents
will have 'available_versions'

For other endpoint that may start the api in a different
deeper path, the url config will be

[galaxy_server.example]
url=https://galaxystuff.example.com/api/ansible/blip/

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
