### PR TITLE
Validate file copy, align with documentation.

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -101,7 +101,7 @@ Function Copy-File($source, $dest) {
         $new_dest_checksum = Get-FileChecksum $dest
         if ( $new_dest_checksum -eq $source_checksum ) {
             # Properly validated that the move was successful.
-            return ,@( diff = $diff; checksum = $new_dest_checksum )
+            return ,@{ diff = $diff; checksum = $new_dest_checksum }
         }
         # Return an error if the file in it's new desitantion turns out to be
         # the previous version and the checksum of the source file isn't the


### PR DESCRIPTION
##### SUMMARY
Validate file copy with a post-copy checksum, align with documentation. Adds another check that the file copy actually occurred as expected ($result.changed=$true, but no change actually occurred). Updates returned values to exclude checksums if $result.changed isn't $true.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
win_copy

##### ADDITIONAL INFORMATION
Changed:
1. Added checksum of file, post-copy. (to bring in line with docs)
2. Removed value for checksum if $result.changed is $false.

Added:
1. Validation that the post-copy checksum equals the source file's checksum.
2. Validation that the post-copy checksum does not equal the original destination file's checksum and that the original source file's checksum doesn't either ( Acopy == Bdest but Aoriginal != Bdest and $result.changed == $true ) - indicates a failure when one wasn't expected or recorded.

