### PR TITLE
[stable-2.9] Fix nxos_bfd_global cmd ordering issues and test setup

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bfd_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_bfd_global.py
@@ -274,6 +274,23 @@ fabricpath_vlan:
 """
 
 
+def reorder_cmds(cmds):
+    '''
+    There is a bug in some image versions where bfd echo-interface and
+    bfd echo-rx-interval need to be applied last for them to nvgen properly.
+    '''
+    regex1 = re.compile(r'^bfd echo-interface')
+    regex2 = re.compile(r'^bfd echo-rx-interval')
+    filtered_cmds = [i for i in cmds if not regex1.match(i)]
+    filtered_cmds = [i for i in filtered_cmds if not regex2.match(i)]
+    echo_int_cmd = [i for i in cmds if regex1.match(i)]
+    echo_rx_cmd = [i for i in cmds if regex2.match(i)]
+    filtered_cmds.extend(echo_int_cmd)
+    filtered_cmds.extend(echo_rx_cmd)
+
+    return filtered_cmds
+
+
 def main():
     argument_spec = dict(
         echo_interface=dict(required=False, type='str'),
@@ -299,7 +316,7 @@ def main():
     cmd_ref = NxosCmdRef(module, BFD_CMD_REF)
     cmd_ref.get_existing()
     cmd_ref.get_playvals()
-    cmds = cmd_ref.get_proposed()
+    cmds = reorder_cmds(cmd_ref.get_proposed())
 
     result = {'changed': False, 'commands': cmds, 'warnings': warnings,
               'check_mode': module.check_mode}

--- a/test/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bfd_global/tasks/nxapi.yaml
@@ -25,9 +25,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test cases (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bfd_global/tests/common/sanity.yaml
@@ -85,10 +85,15 @@
     state: disabled
   ignore_errors: yes
 
+- name: Setup supporting loopback interface
+  nxos_config:
+    lines: interface loopback1
+    match: none
+
 - name: feature bfd init
   # 'feature bfd' init is slow on some platforms, retry on fail
   nxos_bfd_global:
-    echo_interface:        "{{ nd_echo }}"
+    slow_timer:            "{{ nd_slow }}"
   delay: 3
   retries: 1
   register: result
@@ -157,6 +162,12 @@
   always:
   - name: Teardown
     nxos_feature: *setup_teardown
+    ignore_errors: yes
+
+  - name: Teardown supporting loopback interface
+    nxos_config:
+      lines: no interface loopback1
+      match: none
     ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_bfd_global sanity test"

--- a/test/units/modules/network/nxos/test_nxos_bfd_global.py
+++ b/test/units/modules/network/nxos/test_nxos_bfd_global.py
@@ -74,6 +74,39 @@ class TestNxosBfdGlobalModule(TestNxosModule):
         ))
         self.execute_module(changed=False)
 
+    def test_bfd_non_defaults_n9k(self):
+        # feature bfd is enabled, apply all non-default values.
+        # This testcase also tests reordering of echo_interface to make sure
+        # it gets applied last.
+        self.execute_show_command.return_value = "feature bfd"
+        self.get_platform_shortname.return_value = 'N9K'
+        set_module_args(dict(
+            echo_interface='loopback1',
+            echo_rx_interval=51,
+            interval={'tx': 51, 'min_rx': 51, 'multiplier': 4},
+            slow_timer=2001,
+            startup_timer=6,
+            ipv4_echo_rx_interval=51,
+            ipv4_interval={'tx': 51, 'min_rx': 51, 'multiplier': 4},
+            ipv4_slow_timer=2001,
+            ipv6_echo_rx_interval=51,
+            ipv6_interval={'tx': 51, 'min_rx': 51, 'multiplier': 4},
+            ipv6_slow_timer=2001
+        ))
+        self.execute_module(changed=True, commands=[
+            'bfd interval 51 min_rx 51 multiplier 4',
+            'bfd ipv4 echo-rx-interval 51',
+            'bfd ipv4 interval 51 min_rx 51 multiplier 4',
+            'bfd ipv4 slow-timer 2001',
+            'bfd ipv6 echo-rx-interval 51',
+            'bfd ipv6 interval 51 min_rx 51 multiplier 4',
+            'bfd ipv6 slow-timer 2001',
+            'bfd slow-timer 2001',
+            'bfd startup-timer 6',
+            'bfd echo-interface loopback1',
+            'bfd echo-rx-interval 51'
+        ])
+
     def test_bfd_defaults_n3k(self):
         # feature bfd is enabled, no non-defaults are set.
         self.execute_show_command.return_value = "feature bfd"


### PR DESCRIPTION
##### SUMMARY
This is needed in 2.9

This PR resolves the following issues
  * Some image versions require certain bfd commands to be entered in a specific order so that they will nvgen.
  * Adds a supporting loopback interface for the integration tests.  This is required on certain image versions.
  * Uses `slow_timer` instead of `echo_interface` for feature bfd init check due to the aforementioned ordering issues.
  * Adds a unit test to verify ordering and removes integration tests for connection local.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_bfd_global