### PR TITLE
[rabbitmq_vhost] Do not use a default value for -n parameter

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
@@ -67,7 +67,9 @@ class RabbitMqVhost(object):
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
+            cmd = [self._rabbitmqctl, '-q']
+            if self.node is not None:
+                cmd.append(['-n', self.node])
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -112,7 +114,7 @@ def main():
         name=dict(required=True, aliases=['vhost']),
         tracing=dict(default='off', aliases=['trace'], type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
+        node=dict(default=None),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
@@ -30,7 +30,6 @@ options:
   node:
     description:
       - erlang node name of the rabbit we wish to configure
-    default: rabbit
     version_added: "1.2"
   tracing:
     description:


### PR DESCRIPTION
##### SUMMARY
Reposted https://github.com/ansible/ansible-modules-extras/pull/1417 as the change didn't make it to this repository.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_vhost
