### PR TITLE
[stable-2.9] Properly hide limit and list-hosts args from ansible-inv…

### DIFF
--- a/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
+++ b/changelogs/fragments/61604-ansible-inventory-hide-args.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-inventory - Properly hide arguments that should not be shown
+  (https://github.com/ansible/ansible/issues/61604)
+- ansible-inventory - Restore functionality to allow ``--graph`` to be limited by a host pattern

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -36,6 +36,15 @@ class AnsibleVersion(argparse.Action):
         parser.exit()
 
 
+class UnrecognizedArgument(argparse.Action):
+    def __init__(self, option_strings, dest, const=True, default=None, required=False, help=None, metavar=None, nargs=0):
+        super(UnrecognizedArgument, self).__init__(option_strings=option_strings, dest=dest, nargs=nargs, const=const,
+                                                   default=default, required=required, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error('unrecognized arguments: %s' % option_string)
+
+
 class PrependListAction(argparse.Action):
     """A near clone of ``argparse._AppendAction``, but designed to prepend list values
     instead of appending.

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -64,8 +64,8 @@ class InventoryCLI(CLI):
         opt_help.add_basedir_options(self.parser)
 
         # remove unused default options
-        self.parser.add_argument('--limit', default=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --limit'))
-        self.parser.add_argument('--list-hosts', default=argparse.SUPPRESS, type=lambda v: self.parser.error('unrecognized arguments: --list-hosts'))
+        self.parser.add_argument('-l', '--limit', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument, nargs='?')
+        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument)
 
         self.parser.add_argument('args', metavar='host|group', nargs='?')
 
@@ -112,7 +112,7 @@ class InventoryCLI(CLI):
 
         # set host pattern to default if not supplied
         if options.args:
-            options.pattern = options.args[0]
+            options.pattern = options.args
         else:
             options.pattern = 'all'
 


### PR DESCRIPTION
…entory (#61618)

* Properly hide limit and list-hosts args from ansible-inventory. Fixes #61604

* Add changelog fragment

* Consolidate limit

* Fix positional argument with --graph

* Properly error for hidden arguments

* linting issue

* host pattern changelog
(cherry picked from commit 8331c8f)

Co-authored-by: Matt Martz <matt@sivel.net>
