### PR TITLE
lookup_rabbitmq pika > 1.0.0 is_closing bug fix

### DIFF
--- a/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
+++ b/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - lookup_rabbitmq - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.
+  - rabbitmq lookup plugin - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.

--- a/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
+++ b/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lookup_rabbitmq - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.

--- a/lib/ansible/plugins/lookup/rabbitmq.py
+++ b/lib/ansible/plugins/lookup/rabbitmq.py
@@ -180,7 +180,7 @@ class LookupModule(LookupBase):
             else:
                 break
 
-        if connection.is_closing or connection.is_closed:
+        if connection.is_closed:
             return [ret]
         else:
             try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

In pika v1.0.0 BlockingChannel.is_closing was removed.  Updating plugin accordingly.

Ref: https://github.com/pika/pika/pull/1034

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/lookup/rabbitmq.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
* Install pika 1.0.0 or later
* Do a basic lookup: `{{ lookup('rabbitmq', url='amqp://guest:guest@192.168.0.32:5672/%2F', queue='hello') }}`
* Receive error below
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'rabbitmq'. Error was a <type 'exceptions.AttributeError'>, original message: 'BlockingConnection' object has no attribute 'is_closing'"
}

```
Work around was to stay on pika version 0.13.1.  This bug fix allows pika 1.0.0 and above to be used.
