### PR TITLE
rabbitmq_publish fix for incorrectly stating message was not published to the queue

### DIFF
--- a/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
+++ b/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_publish - Fix to ensure the module works correctly for pika v1.0.0 and later. (https://github.com/ansible/ansible/pull/61960)

--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -196,6 +196,6 @@ class RabbitClient():
 
         try:
             self.conn_channel.basic_publish(**args)
-            return 1
+            return True
         except pika.exceptions.UnroutableError:
-            return -1
+            return False

--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -18,6 +18,7 @@ import traceback
 PIKA_IMP_ERR = None
 try:
     import pika
+    import pika.exceptions
     from pika import spec
     HAS_PIKA = True
 except ImportError:
@@ -193,4 +194,8 @@ class RabbitClient():
         if args['exchange'] is None:
             args['exchange'] = ''
 
-        return self.conn_channel.basic_publish(**args)
+        try:
+            self.conn_channel.basic_publish(**args)
+            return 1
+        except pika.exceptions.UnroutableError:
+            return -1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Pika v1.0.0 and above were causing issues for publish_message.  Updated to ensure publish_message works with pika 0.13.1 and 1.0.0 and above.

Fixes: #55919 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_publish.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

* Install pika 1.0.0 or above
* Try to publish a message to a queue
* Even though the message is published onto the queue, the rabbitmq_publish module returned: `Unsuccessful publishing to queue x`
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
