### PR TITLE
pacman: remove 'recurse' deprecated option

### DIFF
--- a/changelogs/fragments/61961-pacman_remove_recurse_option.yaml
+++ b/changelogs/fragments/61961-pacman_remove_recurse_option.yaml
@@ -1,0 +1,2 @@
+removed_features:
+  - pacman - Removed deprecated ``recurse`` option, use ``extra_args=--recursive`` instead

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -62,7 +62,7 @@ Noteworthy module changes
 * :ref:`vmware_host_ntp <vmware_host_ntp_module>` now returns ``host_ntp_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_service_manager <vmware_host_service_manager_module>` now returns ``host_service_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_tag <vmware_tag_module>` now returns ``tag_status`` instead of Ansible internal key ``results``.
-
+* The deprecated ``recurse`` option in :ref:`pacman <pacman_module>` module has been removed, you should use ``extra_args=--recursive`` instead.
 
 Plugins
 =======

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -64,6 +64,7 @@ Noteworthy module changes
 * :ref:`vmware_tag <vmware_tag_module>` now returns ``tag_status`` instead of Ansible internal key ``results``.
 * The deprecated ``recurse`` option in :ref:`pacman <pacman_module>` module has been removed, you should use ``extra_args=--recursive`` instead.
 
+
 Plugins
 =======
 

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -37,17 +37,6 @@ options:
         default: present
         choices: [ absent, latest, present ]
 
-    recurse:
-        description:
-            - When removing a package, also remove its dependencies, provided
-              that they are not required by other packages and were not
-              explicitly installed by a user.
-              This option is deprecated since 2.8 and will be removed in 2.10,
-              use `extra_args=--recursive`.
-        default: no
-        type: bool
-        version_added: "1.3"
-
     force:
         description:
             - When removing package, force remove package, without any checks.
@@ -429,7 +418,6 @@ def main():
         argument_spec=dict(
             name=dict(type='list', aliases=['pkg', 'package']),
             state=dict(type='str', default='present', choices=['present', 'installed', 'latest', 'absent', 'removed']),
-            recurse=dict(type='bool', default=False),
             force=dict(type='bool', default=False),
             extra_args=dict(type='str', default=''),
             upgrade=dict(type='bool', default=False),
@@ -451,13 +439,6 @@ def main():
         p['state'] = 'present'
     elif p['state'] in ['absent', 'removed']:
         p['state'] = 'absent'
-
-    if p['recurse']:
-        module.deprecate('Option `recurse` is deprecated and will be removed in '
-                         'version 2.10. Please use `extra_args=--recursive` '
-                         'instead', '2.10')
-        if p['state'] == 'absent':
-            p['extra_args'] += " --recursive"
 
     if p["update_cache"] and not module.check_mode:
         update_package_db(module, pacman_path)


### PR DESCRIPTION
##### SUMMARY

`recurse` option is scheduled to be remove in 2.10

fix #61892

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

pacman