### PR TITLE
Allow junos_config changes the candidate configuration only

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -448,7 +448,8 @@ def main():
                 if diff:
                     if commit:
                         kwargs = {
-                            'comment': module.params['comment']
+                            'comment': module.params['comment'],
+                            'check': module.params['check_commit']
                         }
 
                         confirm = module.params['confirm']


### PR DESCRIPTION
This allows junos_config to changes the candidate configuration only and
does not commit it as the active configuration at once w/ the
'check_commit' option.

##### SUMMARY
Current code of junos_config does not allow users to change the candidate
configuration only, check it, and it will commit at once always if any changes
were given w/ the 'line' or 'src' option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_config

##### ADDITIONAL INFORMATION
I heard that most network admins prefer not to commit configuration changes
at once and do like this:

1. Create/update the candidate configuration: set ... for example
2. Check it: commit check
3. Commit it: commit

But it does not look possible w/ junos_config because it tries to commit
changes w/o check always regardless of the value of the 'check_commit' option
if my understanding of its code is correct.