### PR TITLE
[2.8] fix erroneous failures in docker_compose due to deprecation warnings …

### DIFF
--- a/changelogs/fragments/60961-docker_compose-fix-deprecation-warning.yml
+++ b/changelogs/fragments/60961-docker_compose-fix-deprecation-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_compose - fix issue where docker deprecation warning results in ansible erroneously reporting a failure"


### PR DESCRIPTION
…… (#61650)

* fix erroneous failures in docker_compose due to deprecation warnings from docker (#60961)

* Update error handling to work with new method of capturing output

Co-Authored-By: Felix Fontein <felix@fontein.de>

* update error handling

* fix syntax error

* fix indentation

* fix indentation (again)

* remove erroneous line

(cherry picked from commit 0c73e47a42f69901ea892f9d0e58acb554f4e668)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Consistently capture stdout and stderr to prevent any output from causing erroneous failures

fixes #60961
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_compose
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
