### PR TITLE
Fix check mode support in win_group

### DIFF
--- a/lib/ansible/modules/windows/win_group.ps1
+++ b/lib/ansible/modules/windows/win_group.ps1
@@ -5,7 +5,7 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy
 
-$params = Parse-Args -supports_check_mode $true
+$params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true

--- a/lib/ansible/modules/windows/win_group.ps1
+++ b/lib/ansible/modules/windows/win_group.ps1
@@ -5,7 +5,7 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy
 
-$params = Parse-Args $args;
+$params = Parse-Args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #61976 

`win_group` never had its check mode flag enabled when the code changes were put in to support it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
skipping: [host] => {
    "changed": false,
    "msg": "remote module does not support check mode"
}
```

After: it checks for changes, returns accurate output, does not make actual changes.