### PR TITLE
Allow ansible to update configuration options of running Proxmox LXC containers

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -388,6 +388,7 @@ def update_instance(module, proxmox, vmid, node, **kwargs):
             vm.config.put(**updateable_configs)
             module.exit_json(changed=True, msg="VM with vmid = %s was updated" % vmid)
 
+
 def start_instance(module, proxmox, vm, vmid, timeout):
     taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.start.post()
     while timeout:

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -386,7 +386,7 @@ def update_instance(module, proxmox, vmid, node, **kwargs):
 
         if updateable_configs:
             vm.config.put(**updateable_configs)
-
+            module.exit_json(changed=True, msg="VM with vmid = %s was updated" % vmid)
 
 def start_instance(module, proxmox, vm, vmid, timeout):
     taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.start.post()

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -368,6 +368,7 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
         time.sleep(1)
     return False
 
+
 def update_instance(module, proxmox, vmid, node, **kwargs):
     proxmox_node = proxmox.nodes(node)
     kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
@@ -385,6 +386,7 @@ def update_instance(module, proxmox, vmid, node, **kwargs):
 
         if updateable_configs:
             vm.config.put(**updateable_configs)
+
 
 def start_instance(module, proxmox, vm, vmid, timeout):
     taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.start.post()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently Ansible doesn't modify containers using the Proxmox module probably because containers need to get restarted for certain options.
This PR is supposed to introduce the feature of modifying the configuration options of running containers, which are allowed to be changed by proxmox.
All other configuration options are ignored,
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Proxmox module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
