### PR TITLE
Updating link for guest_id info

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -170,7 +170,7 @@ options:
     - This field is required when creating a virtual machine, not required when creating from the template.
     - >
          Valid values are referenced here:
-         U(https://code.vmware.com/apis/358/vsphere#/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
+         U(https://code.vmware.com/apis/358/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
     version_added: '2.3'
   disk:
     description:


### PR DESCRIPTION
##### SUMMARY
The link documenting possible values of the `geust_id` option is invalid. This PR is changing the link to point to the latest documentation page.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`vmware_guest`

##### ADDITIONAL INFORMATION
N/A