### PR TITLE
Backport of 61832 Fix mysql.py logic related to 53326 (#61832)

### DIFF
--- a/changelogs/fragments/61989-mysql_fix_mysql_connect_logic.yml
+++ b/changelogs/fragments/61989-mysql_fix_mysql_connect_logic.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql - Fix ``mysql_connect`` function's logic related to the ``cursor_class`` keyword argument (https://github.com/ansible/ansible/pull/61832).

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -84,7 +84,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     except Exception as e:
         module.fail_json(msg="unable to connect to database: %s" % to_native(e))
 
-    if cursor_class is not None:
+    if cursor_class == 'DictCursor':
         return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
     else:
         return db_connection.cursor()

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -257,7 +257,8 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'mysql_driver.cursors.DictCursor',
+        cursor = mysql_connect(module, login_user, login_password, config_file,
+                               ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
                                connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):


### PR DESCRIPTION
(cherry picked from commit e4d4e49388770fcc4c39bbba4fddfb343f41b099)

##### SUMMARY
Backport of #61832 Fix mysql.py logic related to 53326

It doesn't change the module's external behavior, just fix a certain mistake in the mysql_connect() logic to prevent future problems, so a changelog fragment isn't needed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
