### PR TITLE
Allow junos_config changes the candidate configuration only (#61969)

### DIFF
--- a/changelogs/fragments/junos_config_check_commit.yaml
+++ b/changelogs/fragments/junos_config_check_commit.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- junos_config - allow validate config before committing to running configuration (https://github.com/ansible/ansible/pull/61969)

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -448,7 +448,8 @@ def main():
                 if diff:
                     if commit:
                         kwargs = {
-                            'comment': module.params['comment']
+                            'comment': module.params['comment'],
+                            'check': module.params['check_commit']
                         }
 
                         confirm = module.params['confirm']


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows junos_config to changes the candidate configuration only and
does not commit it as the active configuration at once w/ the
'check_commit' option.

(cherry picked from commit 483e76ee58f8bfb50fb51005684cc9e9c4c1a41f)
Merged to devel https://github.com/ansible/ansible/pull/61969
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
