### PR TITLE
fix 61907 - auto_attach yes option not honored in ec2_transit_gateway

### DIFF
--- a/changelogs/fragments/61933-ec2_transit_gateway-honor-auto_attach-setting.yaml
+++ b/changelogs/fragments/61933-ec2_transit_gateway-honor-auto_attach-setting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_transit_gateway - fixed issue where auto_attach set to yes was not being honored (https://github.com/ansible/ansible/issues/61907)

--- a/lib/ansible/modules/cloud/amazon/ec2_transit_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_transit_gateway.py
@@ -367,7 +367,7 @@ class AnsibleEc2Tgw(object):
         if self._module.params.get('asn'):
             options['AmazonSideAsn'] = self._module.params.get('asn')
 
-        options['AutoAcceptSharedAttachments'] = self.enable_option_flag(self._module.params.get('auto_accept'))
+        options['AutoAcceptSharedAttachments'] = self.enable_option_flag(self._module.params.get('auto_attach'))
         options['DefaultRouteTableAssociation'] = self.enable_option_flag(self._module.params.get('auto_associate'))
         options['DefaultRouteTablePropagation'] = self.enable_option_flag(self._module.params.get('auto_propagate'))
         options['VpnEcmpSupport'] = self.enable_option_flag(self._module.params.get('vpn_ecmp_support'))


### PR DESCRIPTION
##### SUMMARY
Update to ec2_transit_gateway module to address auto_attach option not being honored for yes/true.
Fixes 61907

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_transit_gateway

##### ADDITIONAL INFORMATION

```
## Ansible Play - same as bug submission

- name: Create variable for desired region
  set_fact:  
    defined_region: us-east-1

- name: TGW Create in IPA
  ec2_transit_gateway:
    aws_access_key: "{{ sts_aws_access_key }}"
    aws_secret_key: "{{ sts_aws_secret_key }}"
    security_token: "{{ sts_security_token }}"
    description: "My Awesome TGW"
    state: present
    #asn:
    auto_associate: no
    auto_attach: yes
    auto_propagate: no
    dns_support: yes
    vpn_ecmp_support: yes
    region: "{{ defined_region }}"
    tags:
      Name: my-awesome-tgw
      module: ec2_transit_gateway
      my-tag: heck-yeah
  register: tgw_data

- debug: var=tgw_data


## Debug data:  Note auto_accept_shared_attachments is enable as expected now

ok: [localhost] => {
    "tgw_data": {
        "changed": true, 
        "failed": false, 
        "msg": " Transit gateway **REDACTED** created", 
        "transit_gateway": {
            "creation_time": "2019-09-09T12:13:52+00:00", 
            "description": "My Awesome TGW", 
            "options": {
                "amazon_side_asn": 64512, 
                "auto_accept_shared_attachments": "enable", 
                "default_route_table_association": "disable", 
                "default_route_table_propagation": "disable", 
                "dns_support": "enable", 
                "vpn_ecmp_support": "enable"
            }, 
            "owner_id": "REDACTED", 
            "state": "available", 
            "tags": {
                "Name": "my-awesome-tgw", 
                "module": "ec2_transit_gateway", 
                "my-tag": "heck-yeah"
            }, 
            "transit_gateway_arn": "arn:aws:ec2:us-east-1:REDACTED:transit-gateway/REDACTED", 
            "transit_gateway_id": "REDACTED"
        }
    }
}
```
