### PR TITLE
Remove leading space in warning messages

### DIFF
--- a/changelogs/fragments/display-warning-remove-erroneous-space.yaml
+++ b/changelogs/fragments/display-warning-remove-erroneous-space.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display - remove leading space when displaying WARNING messages

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -248,7 +248,7 @@ class Display(with_metaclass(Singleton, object)):
     def warning(self, msg, formatted=False):
 
         if not formatted:
-            new_msg = "\n[WARNING]: %s" % msg
+            new_msg = "[WARNING]: %s" % msg
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = "\n".join(wrapped) + "\n"
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When `WARNING` messages are displayed, they are preceded by a leading space. This makes warning messages not line up with other displayed messages, such as deprecations and `vvv` output.

This is due to the preceding newline being converted to a space my `textwrap.wrap()`.

Current behavior:
```
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in
group names by default, this will change, but still be user configurable on deprecation. This
feature will be removed in version 2.10. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
 [WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details


PLAY [Local testing playbook] ***********************************************************************

TASK [Gathering Facts] ******************************************************************************
ok: [localhost]

TASK [testmodule] ***********************************************************************************
 [WARNING]: The value 999 (type int) in a string field was converted to '999' (type string). If this
does not look like what you expect, quote the entire value to ensure it does not change.

 [WARNING]: Some warning

[DEPRECATION WARNING]: Deprecating this. This feature will be removed in version 2.22. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```



With this fix:
```
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in
group names by default, this will change, but still be user configurable on deprecation. This feature
will be removed in version 2.10. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details


PLAY [Local testing playbook] *************************************************************************

TASK [Gathering Facts] ********************************************************************************
ok: [localhost]

TASK [testmodule] *************************************************************************************
[WARNING]: The value 999 (type int) in a string field was converted to '999' (type string). If this
does not look like what you expect, quote the entire value to ensure it does not change.

[WARNING]: Some warning

[DEPRECATION WARNING]: Deprecating this. This feature will be removed in version 2.22. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/utils/display.py`