### PR TITLE
Add ecs_domain module

### DIFF
--- a/changelogs/fragments/62007-add-domain-module.yml
+++ b/changelogs/fragments/62007-add-domain-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ecs_domain - Addition of ``ecs_domain `` module (https://github.com/ansible/ansible/pull/60883).
+  - ecs_domain - Addition of ``ecs_domain`` module (https://github.com/ansible/ansible/pull/60883).

--- a/changelogs/fragments/62007-add-domain-module.yml
+++ b/changelogs/fragments/62007-add-domain-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ecs_domain - Addition of ``ecs_domain `` module (https://github.com/ansible/ansible/pull/60883).

--- a/changelogs/fragments/62007-add-domain-module.yml
+++ b/changelogs/fragments/62007-add-domain-module.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ecs_domain - Addition of ``ecs_domain`` module (https://github.com/ansible/ansible/pull/60883).

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -67,11 +67,11 @@ options:
     verification_email:
         description:
             - Email address to be used to verify domain ownership.
-            - Email address must be either an email address present in the WHOIS data for I(domain_name), or one of the following constructed emails:
-              admin@I(domain_name)), administrator@I(domain_name), webmaster@I(domain_name), hostmaster@I(domain_name), postmaster@I(domain_name)'
-            - Note that if I(domain_name) includes subdomains, the top level domain should be used. For example, if requesting validation of
+            - 'Email address must be either an email address present in the WHOIS data for I(domain_name), or one of the following constructed emails:
+              admin@I(domain_name), administrator@I(domain_name), webmaster@I(domain_name), hostmaster@I(domain_name), postmaster@I(domain_name)'
+            - 'Note that if I(domain_name) includes subdomains, the top level domain should be used. For example, if requesting validation of
               example1.ansible.com, or test.example2.ansible.com, and you want to use the "admin" preconstructed name, the email address should be
-              admin@ansible.com.
+              admin@ansible.com.'
             - If using the email values from the WHOIS data for the domain or it's top level namespace, they must be exact matches.
             - If C(verification_method=EMAIL) but I(verification_email) is not provided, the first email address found in WHOIS data for the domain will be
               used.
@@ -212,6 +212,7 @@ from ansible.module_utils.ecs.api import (
 import datetime
 import time
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 def calculate_days_remaining(expiry_date):

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -24,7 +24,7 @@ description:
     - Request validation or re-validation of a domain with the Entrust Certificate Services (ECS) API.
     - Requires credentials for the L(Entrust Certificate Services,https://www.entrustdatacard.com/products/categories/ssl-certificates) (ECS) API.
     - If the domain is already in the validation process, no new validation will be requested, but the validation data (if applicable) will be returned.
-    - If the domain is already in the validation process but the verification_method specified is different than the current verification_method,
+    - If the domain is already in the validation process but the I(verification_method) specified is different than the current I(verification_method),
       the verification_method will be updated and validation data (if applicable) will be returned.
     - If the domain is an active, validated domain, the return value of I(changed) will be false, unless C(domain_status=EXPIRED), in which case a re-validation
       will be performed.

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -35,7 +35,7 @@ description:
     - If C(verification_method=EMAIL), the email address(es) that the validation email(s) were sent to will be in the return parameter I(emails). This is
       purely informational. For domains requested using this module, this will always be a list of size 1.
 notes:
-    - There is a small delay (typically about 5 seconds, but as long as 60) before obtaining the random values when requesting a validation
+    - There is a small delay (typically about 5 seconds, but can be as long as 60 seconds) before obtaining the random values when requesting a validation
       while C(verification_method=DNS) or C(verification_method=WEB_SERVER). Be aware of that if doing many domain validation requests.
 options:
     client_id:

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -80,7 +80,7 @@ options:
         type: str
 seealso:
     - module: openssl_certificate
-      description: Can be used to request certificates from ECS, with C(provider=ECS).
+      description: Can be used to request certificates from ECS, with C(provider=entrust).
     - module: ecs_certificate
       description: Can be used to request a Certificate from ECS using a verified domain.
 extends_documentation_fragment:
@@ -179,24 +179,24 @@ client_id:
     type: int
     sample: 1
 ov_eligible:
-    description: Whether the domain is eligible for submission of "OV" certificates. Will never be C(False) if I(ov_eligible) is C(True)
+    description: Whether the domain is eligible for submission of "OV" certificates. Will never be C(false) if I(ov_eligible) is C(true)
     returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
     type: bool
-    sample: True
+    sample: true
 ov_days_remaining:
     description: The number of days the domain remains eligible for submission of "OV" certificates. Will never be less than the value of I(ev_days_remaining)
-    returned: success and I(ov_eligible) is C(True) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    returned: success and I(ov_eligible) is C(true) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
     type: int
     sample: 129
 ev_eligible:
-    description: Whether the domain is eligible for submission of "EV" certificates. Will never be C(True) if I(ov_eligible) is C(False)
+    description: Whether the domain is eligible for submission of "EV" certificates. Will never be C(true) if I(ov_eligible) is C(false)
     returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
     type: bool
-    sample: True
+    sample: true
 ev_days_remaining:
     description: The number of days the domain remains eligible for submission of "EV" certificates. Will never be greater than the value of
                  I(ov_days_remaining)
-    returned: success and I(ev_eligible) is C(True) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    returned: success and I(ev_eligible) is C(true) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
     type: int
     sample: 94
 

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -28,15 +28,15 @@ description:
       the I(verification_method) will be updated and validation data (if applicable) will be returned.
     - If the domain is an active, validated domain, the return value of I(changed) will be false, unless C(domain_status=EXPIRED), in which case a re-validation
       will be performed.
-    - If C(verification_method=DNS), details about the required DNS entry will be specified in the return parameters I(dns_contents), I(dns_location), and
+    - If C(verification_method=dns), details about the required DNS entry will be specified in the return parameters I(dns_contents), I(dns_location), and
       I(dns_resource_type).
-    - If C(verification_method=WEB_SERVER), details about the required file details will be specified in the return parameters I(file_contents) and
+    - If C(verification_method=web_server), details about the required file details will be specified in the return parameters I(file_contents) and
       I(file_location).
-    - If C(verification_method=EMAIL), the email address(es) that the validation email(s) were sent to will be in the return parameter I(emails). This is
+    - If C(verification_method=email), the email address(es) that the validation email(s) were sent to will be in the return parameter I(emails). This is
       purely informational. For domains requested using this module, this will always be a list of size 1.
 notes:
     - There is a small delay (typically about 5 seconds, but can be as long as 60 seconds) before obtaining the random values when requesting a validation
-      while C(verification_method=DNS) or C(verification_method=WEB_SERVER). Be aware of that if doing many domain validation requests.
+      while C(verification_method=dns) or C(verification_method=web_server). Be aware of that if doing many domain validation requests.
 options:
     client_id:
         description:
@@ -52,17 +52,17 @@ options:
     verification_method:
         description:
             - The verification method to be used to prove control of the domain.
-            - If C(verification_method=EMAIL) and the value I(verification_email) is specified, that value is used for the email validation. If
+            - If C(verification_method=email) and the value I(verification_email) is specified, that value is used for the email validation. If
               I(verification_email) is not provided, the first value present in WHOIS data will be used. An email will be sent to the address in
               I(verification_email) with instructions on how to verify control of the domain.
-            - If C(verification_method=DNS), the value I(dns_contents) must be stored in location I(dns_location), with a DNS record type of
-              I(verification_DNS_record_type). To prove domain ownership, update your DNS records so the text string returned by I(dns_contents) is available at
-              I(DNS_location).
-            - If C(verification_method=WEB_SERVER), the contents of return value I(file_contents) must be made available on a web server accessible at location
+            - If C(verification_method=dns), the value I(dns_contents) must be stored in location I(dns_location), with a DNS record type of
+              I(verification_dns_record_type). To prove domain ownership, update your DNS records so the text string returned by I(dns_contents) is available at
+              I(dns_location).
+            - If C(verification_method=web_server), the contents of return value I(file_contents) must be made available on a web server accessible at location
               I(file_location).
-            - If C(verification_method=MANUAL), the domain will be validated with a manual process. This is not recommended.
+            - If C(verification_method=manual), the domain will be validated with a manual process. This is not recommended.
         type: str
-        choices: [ 'DNS', 'EMAIL', 'MANUAL', 'WEB_SERVER']
+        choices: [ 'dns', 'email', 'manual', 'web_server']
         required: true
     verification_email:
         description:
@@ -73,10 +73,10 @@ options:
               example1.ansible.com, or test.example2.ansible.com, and you want to use the "admin" preconstructed name, the email address should be
               admin@ansible.com.'
             - If using the email values from the WHOIS data for the domain or it's top level namespace, they must be exact matches.
-            - If C(verification_method=EMAIL) but I(verification_email) is not provided, the first email address found in WHOIS data for the domain will be
+            - If C(verification_method=email) but I(verification_email) is not provided, the first email address found in WHOIS data for the domain will be
               used.
             - To verify domain ownership, domain owner must follow the instructions in the email they receive.
-            - Only allowed if C(verification_method=EMAIL)
+            - Only allowed if C(verification_method=email)
         type: str
 seealso:
     - module: openssl_certificate
@@ -92,7 +92,7 @@ EXAMPLES = r'''
   ecs_domain:
     domain_name: ansible.com
     client_id: 2
-    verification_method: EMAIL
+    verification_method: email
     verification_email: admin@ansible.com
     entrust_api_user: apiusername
     entrust_api_key: a^lv*32!cd9LnT
@@ -103,7 +103,7 @@ EXAMPLES = r'''
         request revalidation if expires within 90 days
   ecs_domain:
     domain_name: ansible.com
-    verification_method: DNS
+    verification_method: dns
     entrust_api_user: apiusername
     entrust_api_key: a^lv*32!cd9LnT
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
@@ -113,7 +113,7 @@ EXAMPLES = r'''
         if fewer than 60 days remaining of EV eligibility.
   ecs_domain:
     domain_name: ansible.com
-    verification_method: WEB_SERVER
+    verification_method: web_server
     entrust_api_user: apiusername
     entrust_api_key: a^lv*32!cd9LnT
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
@@ -122,7 +122,7 @@ EXAMPLES = r'''
 - name: Request domain validation using manual validation.
   ecs_domain:
     domain_name: ansible.com
-    verification_method: MANUAL
+    verification_method: manual
     entrust_api_user: apiusername
     entrust_api_key: a^lv*32!cd9LnT
     entrust_api_client_cert_path: /etc/ssl/entrust/ecs-client.crt
@@ -140,37 +140,37 @@ verification_method:
     description: Verification method used to request the domain validation. If C(changed) will be the same as I(verification_method) input parameter.
     returned: changed or success
     type: str
-    sample: DNS
+    sample: dns
 file_location:
     description: The location that ECS will be expecting to be able to find the file for domain verification, containing the contents of I(file_contents).
-    returned: I(verification_method) is C(WEB_SERVER)
+    returned: I(verification_method) is C(web_server)
     type: str
     sample: http://ansible.com/.well-known/pki-validation/abcd.txt
 file_contents:
     description: The contents of the file that ECS will be expecting to find at C(file_location).
-    returned: I(verification_method) is C(WEB_SERVER)
+    returned: I(verification_method) is C(web_server)
     type: str
     sample: AB23CD41432522FF2526920393982FAB
 emails:
     description:
         - The list of emails used to request validation of this domain.
         - Domains requested using this module will only have a list of size 1.
-    returned: I(verification_method) is C(EMAIL)
+    returned: I(verification_method) is C(email)
     type: list
     sample: [ admin@ansible.com, administrator@ansible.com ]
 dns_location:
-    description: The location that ECS will be expecting to be able to find the DNS entry for domain verification, containing the contents of I(DNS_contents).
-    returned: changed and if I(verification_method) is C(DNS)
+    description: The location that ECS will be expecting to be able to find the DNS entry for domain verification, containing the contents of I(dns_contents).
+    returned: changed and if I(verification_method) is C(dns)
     type: str
     sample: _pki-validation.ansible.com
 dns_contents:
-    description: The value that ECS will be expecting to find in the DNS record located at I(DNS_location).
-    returned: changed and if I(verification_method) is C(DNS)
+    description: The value that ECS will be expecting to find in the DNS record located at I(dns_location).
+    returned: changed and if I(verification_method) is C(dns)
     type: str
     sample: AB23CD41432522FF2526920393982FAB
 dns_resource_type:
-    description: The type of resource record that ECS will be expecting for the DNS record located at I(DNS_location).
-    returned: changed and if I(verification_method) is C(DNS)
+    description: The type of resource record that ECS will be expecting for the DNS record located at I(dns_location).
+    returned: changed and if I(verification_method) is C(dns)
     type: str
     sample: TXT
 client_id:
@@ -266,7 +266,7 @@ class EcsDomain(object):
 
     def set_domain_details(self, domain_details):
         if domain_details.get('verificationMethod'):
-            self.verification_method = domain_details['verificationMethod']
+            self.verification_method = domain_details['verificationMethod'].lower()
         self.domain_status = domain_details['verificationStatus']
         self.ov_eligible = domain_details.get('ovEligible')
         self.ov_days_remaining = calculate_days_remaining(domain_details.get('ovExpiry'))
@@ -274,14 +274,14 @@ class EcsDomain(object):
         self.ev_days_remaining = calculate_days_remaining(domain_details.get('evExpiry'))
         self.client_id = domain_details['clientId']
 
-        if self.verification_method == 'DNS' and domain_details.get('dnsMethod'):
+        if self.verification_method == 'dns' and domain_details.get('dnsMethod'):
             self.dns_location = domain_details['dnsMethod']['recordDomain']
             self.dns_resource_type = domain_details['dnsMethod']['recordType']
             self.dns_contents = domain_details['dnsMethod']['recordValue']
-        elif self.verification_method == 'WEB_SERVER' and domain_details.get('webServerMethod'):
+        elif self.verification_method == 'web_server' and domain_details.get('webServerMethod'):
             self.file_location = domain_details['webServerMethod']['fileLocation']
             self.file_contents = domain_details['webServerMethod']['fileContents']
-        elif self.verification_method == 'EMAIL' and domain_details.get('emailMethod'):
+        elif self.verification_method == 'email' and domain_details.get('emailMethod'):
             self.emails = domain_details['emailMethod']
 
     def check(self, module):
@@ -308,8 +308,8 @@ class EcsDomain(object):
         if not self.check(module):
             body = {}
 
-            body['verificationMethod'] = module.params['verification_method']
-            if module.params['verification_method'] == 'EMAIL':
+            body['verificationMethod'] = module.params['verification_method'].upper()
+            if module.params['verification_method'] == 'email':
                 emailMethod = {}
                 if module.params['verification_email']:
                     emailMethod['emailSource'] = 'SPECIFIED'
@@ -330,13 +330,13 @@ class EcsDomain(object):
                 result = self.ecs_client.GetDomain(clientId=module.params['client_id'], domain=module.params['domain_name'])
 
                 # It takes a bit of time before the random values are available
-                if module.params['verification_method'] == 'DNS' or module.params['verification_method'] == 'WEB_SERVER':
+                if module.params['verification_method'] == 'dns' or module.params['verification_method'] == 'web_server':
                     for i in range(4):
                         # Check both that random values are now available, and that they're different than were populated by previous 'check'
-                        if module.params['verification_method'] == 'DNS':
+                        if module.params['verification_method'] == 'dns':
                             if result.get('dnsMethod') and result['dnsMethod']['recordValue'] != self.dns_contents:
                                 break
-                        elif module.params['verification_method'] == 'WEB_SERVER':
+                        elif module.params['verification_method'] == 'web_server':
                             if result.get('webServerMethod') and result['webServerMethod']['fileContents'] != self.file_contents:
                                 break
                     time.sleep(10)
@@ -366,14 +366,14 @@ class EcsDomain(object):
         if self.emails:
             result['emails'] = self.emails
 
-        if self.verification_method == 'DNS':
+        if self.verification_method == 'dns':
             result['dns_location'] = self.dns_location
             result['dns_contents'] = self.dns_contents
             result['dns_resource_type'] = self.dns_resource_type
-        elif self.verification_method == 'WEB_SERVER':
+        elif self.verification_method == 'web_server':
             result['file_location'] = self.file_location
             result['file_contents'] = self.file_contents
-        elif self.verification_method == 'EMAIL':
+        elif self.verification_method == 'email':
             result['emails'] = self.emails
 
         return result
@@ -383,7 +383,7 @@ def ecs_domain_argument_spec():
     return dict(
         client_id=dict(type='int', default=1),
         domain_name=dict(type='str', required=True),
-        verification_method=dict(type='str', choices=['DNS', 'EMAIL', 'MANUAL', 'WEB_SERVER']),
+        verification_method=dict(type='str', choices=['dns', 'email', 'manual', 'web_server']),
         verification_email=dict(type='str'),
     )
 
@@ -396,7 +396,7 @@ def main():
         supports_check_mode=False,
     )
 
-    if module.params['verification_email'] and module.params['verification_method'] != 'EMAIL':
+    if module.params['verification_email'] and module.params['verification_method'] != 'email':
         module.fail_json(msg='The verification_email field is invalid when verification_method="{0}".'.format(module.params['verification_method']))
 
     domain = EcsDomain(module)

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -1,0 +1,379 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Entrust Datacard Corporation.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ecs_domain
+author:
+    - Chris Trufan (@ctrufan)
+version_added: '2.10'
+short_description: Request validation of a domain with the Entrust Certificate Services (ECS) API.
+description:
+    - Request validation or re-validation of a domain with the Entrust Certificate Services (ECS) API.
+    - Requires credentials for the L(Entrust Certificate Services,https://www.entrustdatacard.com/products/categories/ssl-certificates) (ECS) API.
+    - In the case of validation modes that require action on returned data (C(FILE) and C(DNS)) module will return the data needed to validate.
+    - For C(validation_method=DNS), the returned DNS value must be present at the location specified by return parameter I(location).
+notes:
+    - There is a small delay (typically about 5 seconds, but as long as 30) before obtaining the random values when requesting a validation.
+      Be aware of that if doing bulk domain requests.
+options:
+    client_id:
+        description:
+            - The client ID to request the domain be associated with.
+            - If no client ID is specified, the domain will be added under the primary client with ID of 1.
+        type: int
+        default: 1
+    force:
+        description:
+            - Force a reverification regardless of state of current domain.
+            - This can be used to change the state of an in process verification.
+        type: bool
+        default: false
+    domain_name:
+        description:
+            - The domain name to be verified or reverified.
+        type: str
+        required: true
+    verification_method:
+        description:
+            - The verification method to be used to prove control of the domain.
+            - If C(verification_method=EMAIL), the value I(verification_email) is required, and no values are returned for I(verification_content) and
+              I(verification_location). An email will be sent to the address in I(verification_email) with instructions on how to verify control of the domain.
+            - If C(verification_method=DNS), the value I(DNS_contents) must be stored in location I(DNS_location), with a DNS record type of
+              I(verification_DNS_record_type). To prove domain ownership, update your DNS records so the text string returned by I(DNS_contents) is available at
+              I(DNS_location).
+            - If C(verification_method=WEB_SERVER), the contents of return value I(file_contents) must be made available on a web server accessible at location
+              I(file_location).
+            - If C(verification_method=MANUAL), the domain will be validated with a manual process. This is not recommended.
+        type: str
+        choices: [ 'DNS', 'EMAIL', 'MANUAL', 'WEB_SERVER']
+        required: true
+    verification_email:
+        description:
+            - email address to be used to verify domain ownership.
+            - 'email address must be either an email address present in the WHOIS data for I(domain_name), or one of the following constructed emails:
+              admin@I(domain_name)), administrator@I(domain_name), webmaster@I(domain_name), hostmaster@I(domain_name), postmaster@I(domain_name)'
+            - To verify domain ownership, domain owner must follow the instructions in the email they receive.
+            - Required if C(verification_method=EMAIL)
+            - Only allowed if C(verification_method=EMAIL)
+        type: str
+    ov_remaining_days:
+        description:
+            - The number of days the domain must have left being valid for OV eligibility, if it is already a validated domain. I(ov_days_remaining) is
+              less than I(ov_remaining_days), a new validation will be requested using I(validation_method).
+        type: int
+        default: 60
+    ev_remaining_days:
+        description:
+            - The number of days the domain must have left being valid for EV eligibility, if it is already a validated domain. I(ev_days_remaining) is
+              less than I(ev_remaining_days), a new validation will be requested using I(validation_method).
+        type: int
+seealso:
+    - module: openssl_certificate
+      description: Can be used to request certificates from ECS, with C(provider=ECS).
+    - module: ecs_certificate
+      description: Can be used to request a Certificate from ECS using a verified domain.
+extends_documentation_fragment:
+    - ecs_credential
+'''
+
+EXAMPLES = r'''
+- name: Request domain validation using email validation for client ID of 2.
+  ecs_domain:
+    domain_name: ansible.com
+    client_id: 2
+    verification_method: EMAIL
+    verification_email: admin@ansible.com
+
+- name: Request domain validation using DNS. If domain is already valid,
+        request revalidation if expires within 90 days
+  ecs_domain:
+    domain_name: ansible.com
+    verification_method: DNS
+    ov_remaining_days: 90
+
+- name: Request domain validation using web server validation, and revalidate
+        if fewer than 60 days remaining of EV eligibility.
+  ecs_domain:
+    domain_name: ansible.com
+    verification_method: WEB_SERVER
+    ev_remaining_days: 60
+
+- name: Request domain validation using manual validation.
+  ecs_domain:
+    domain_name: ansible.com
+    verification_method: MANUAL
+'''
+
+RETURN = '''
+domain_status:
+    description: Status of the current domain. Will be one of C(APPROVED), C(DECLINED), C(CANCELLED), C(INITIAL_VERIFICATION), C(DECLINED), C(CANCELLED),
+                 C(RE_VERIFICATION), C(EXPIRED), C(EXPIRING)
+    returned: changed or success
+    type: str
+    sample: APPROVED
+verification_method:
+    description: Verification method used to request the domain validation. If C(changed) will be the same as I(verification_method) input parameter.
+    returned: changed or success
+    type: str
+    sample: DNS
+file_location:
+    description: The location that ECS will be expecting to be able to find the file for domain verification, containing the contents of I(file_contents).
+    returned: I(verification_method) is C(WEB_SERVER)
+    type: str
+    sample: http://ansible.com/.well-known/pki-validation/abcd.txt
+file_contents:
+    description: The contents of the file that ECS will be expecting to find at C(file_location).
+    returned: I(verification_method) is C(WEB_SERVER)
+    type: str
+    sample: AB23CD41432522FF2526920393982FAB
+emails:
+    description:
+        - The list of emails used to request validation of this domain.
+        - Domains requested using this module will only have a list of size 1.
+    returned: I(verification_method) is C(EMAIL)
+    type: list
+    sample: [ admin@ansible.com, administrator@ansible.com ]
+dns_location:
+    description: The location that ECS will be expecting to be able to find the DNS entry for domain verification, containing the contents of I(DNS_contents).
+    returned: changed and if I(verification_method) is C(DNS)
+    type: str
+    sample: _pki-validation.ansible.com
+dns_contents:
+    description: The value that ECS will be expecting to find in the DNS record located at I(DNS_location).
+    returned: changed and if I(verification_method) is C(DNS)
+    type: str
+    sample: AB23CD41432522FF2526920393982FAB
+dns_resource_type:
+    description: The type of resource record that ECS will be expecting for the DNS record located at I(DNS_location).
+    returned: changed and if I(verification_method) is C(DNS)
+    type: str
+    sample: TXT
+client_id:
+    description: Client ID that the domain belongs to. If the input value I(client_id) is specified, this will always be the same as I(client_id)
+    returned: changed or success
+    type: int
+    sample: 1
+ov_eligible:
+    description: Whether the domain is eligible for submission of "OV" certificates. Will never be C(False) if I(ov_eligible) is C(True)
+    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    type: bool
+    sample: True
+ov_days_remaining:
+    description: The number of days the domain remains eligible for submission of "OV" certificates. Will never be less than the value of I(ev_days_remaining)
+    returned: success and I(ov_eligible) is C(True) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    type: int
+    sample: 129
+ev_eligible:
+    description: Whether the domain is eligible for submission of "EV" certificates. Will never be C(True) if I(ov_eligible) is C(False)
+    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    type: bool
+    sample: True
+ev_days_remaining:
+    description: The number of days the domain remains eligible for submission of "EV" certificates. Will never be greater than the value of
+                 I(ov_days_remaining)
+    returned: success and I(ev_eligible) is C(True) and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    type: int
+    sample: 94
+
+'''
+
+from ansible.module_utils.ecs.api import (
+    ecs_client_argument_spec,
+    ECSClient,
+    RestOperationException,
+    SessionConfigurationException,
+)
+
+import datetime
+import time
+from ansible.module_utils.basic import AnsibleModule
+
+
+def calculate_days_remaining(expiry_date):
+    days_remaining = None
+    if expiry_date:
+        expiry_datetime = datetime.datetime.strptime(expiry_date, '%Y-%m-%dT%H:%M:%SZ')
+        days_remaining = (expiry_datetime - datetime.datetime.now()).days
+    return days_remaining
+
+
+class EcsDomain(object):
+    '''
+    Entrust Certificate Services domain class.
+    '''
+
+    def __init__(self, module):
+        self.changed = False
+        self.domain_status = None
+        self.verification_method = None
+        self.file_location = None
+        self.file_contents = None
+        self.dns_location = None
+        self.dns_contents = None
+        self.dns_resource_type = None
+        self.emails = None
+        self.ov_eligible = None
+        self.ov_days_remaining = None
+        self.ev_eligble = None
+        self.ev_days_remaining = None
+        # Note that verification_method is the 'current' verification
+        # method of the domain, we'll use module.params when requesting a new
+        # one, in case the verification method has changed.
+        self.verification_method = None
+
+        self.force = module.params['force']
+
+    def set_domain_details(self, domain_details):
+        self.verification_method = domain_details['verificationMethod']
+        self.domain_status = domain_details['status']
+        self.ov_eligible = domain_details.get('ovEligible')
+        self.ov_days_remaining = convert_days_remaining(domain_details.get('ovExpiry'))
+        self.ev_eligible = domain_details.get('evEligible')
+        self.ev_days_remaining = convert_days_remaining(domain_details.get('evExpiry'))
+        self.client_id = domain_details['clientId']
+
+        if self.verification_method == 'DNS' and domain_details.get('dnsMethod'):
+            self.dns_location = domain_details['dnsMethod']['recordDomain']
+            self.dns_resource_type = domain_details['dnsMethod']['recordType']
+            self.dns_contents = domain_details['dnsMethod']['recordValue']
+        elif self.verification_method == 'WEB_SERVER' and domain_details.get('webServerMethod'):
+            self.file_location = domain_details['webServerMethod']['fileLocation']
+            self.file_contents = domain_details['webServerMethod']['fileContents']
+        elif self.verification_method == 'EMAIL' and domain_details.get('emailMethod'):
+            self.emails = domain_details['emailMethod']
+
+    def check(self, module):
+        try:
+            domain_details = self.ecs_client.GetDomain(clientId=module.params['client_id'], domain=self.domain_name)
+            set_domain_details(domain_details)
+            if self.domain_status != 'APPROVED' and self.domain_status != 'INITIAL_VERIFICATION' and
+            self.domain_status != 'RE_VERIFICATION' and self.domain_status != 'EXPIRING':
+                return False
+
+            # If domain verification is in process, we want to return the random values and treat it as a valid.
+            if self.domain_status == 'INITIAL_VERIFICATION' or self.domain_status == 'RE_VERIFICATION':
+                # Unless the verification method has changed, in which case we need to do a reverify request.
+                if self.verification_method != module.params['verification_method']:
+                    return False
+
+            # Need to check if value is not none, because 0 is a valid input
+            if module.params['ev_remaining_days'] is not None and self.ev_days_remaining < module.params['ev_remaining_days']:
+                return False
+            if self.ov_days_remaining < module.params['ov_remaining_days']:
+                return False
+
+            return True
+        except RestOperationException as e:
+            module.fail_json('Failed to get domain details for domain. Likely does not exist.')
+
+    def request_domain(self, module):
+        if not self.check(module) or self.force:
+            body = {}
+
+            body['verificationMethod'] = module.params['verification_method']
+            if module.params['verification_method'] == 'EMAIL':
+                emailMethod = {}
+                emailMethod['emailSource'] = 'SPECIFIED'
+                emailMethod['email'] = module.params['verification_email']
+            # Only populate domain name in body if it is not an existing domain
+            if not self.domain_status:
+                body['domainName'] = module.params['domain_name']
+            try:
+                if not self.domain_status:
+                    self.ecs_client.AddDomainRequest(clientId=module.params['client_id'], Body=body)
+                else:
+                    self.ecs_client.ReverifyDomainRequest(clientId=module.params['client_id'], domain=module.params['domain_name'], Body=body)
+
+                time.sleep(5)
+                result = self.ecs_client.GetDomain(clientId=module.params['client_id'], domain=module.params['domain_name'])
+
+                # It takes a bit of time before the random values are available
+                if module.params['verification_method'] == 'DNS' or module.params['verification_method'] == 'FILE'
+                for i in range(2):
+                    # Check both that random values are now available, and that they're different than were populated by previous 'check'
+                    if module.params['verification_method'] == 'DNS':
+                        if result.get('dnsMethod') and result.get['dnsMethod']['recordValue'] != self.dns_contents:
+                            break
+                    elif module.params['verification_method'] == 'WEB_SERVER':
+                        if result.get('webServerMethod') and result.get['webServerMethod']['fileContents'] != self.file_contents:
+                            break
+                    time.sleep(10)
+                    result = self.ecs_client.GetDomain(clientId=module.params['client_id'], domain=module.params['domain_name'])
+                self.changed = True
+                set_domain_details(result)
+            except RestOperationException as e:
+                module.fail_json(msg='Failed to request domain validation from Entrust (ECS) {0}'.format(e.message))
+
+    def dump(self):
+        result = {
+            'changed': self.changed,
+            'client_id': self.client_id,
+            'domain_status': self.domain_status,
+            'verification_method': self.verification_method,
+            'ov_eligible': self.ov_eligible,
+            'ov_days_remaining': self.ov_days_remaining,
+            'ev_eligible': self.ev_eligible,
+            'ev_days_remaining': self.ev_days_remaining,
+            'emails': self.emails,
+        }
+
+        if self.verification_method == 'DNS':
+            result['dns_location'] = self.dns_location
+            result['dns_contents'] = self.dns_contents
+            result['dns_resource_type'] = self.dns_resource_type
+        elif self.verification_method == 'FILE':
+            result['file_location'] = self.file_location
+            result['file_contents'] = self.file_contents
+        elif self.verification_method == 'EMAIL':
+            result['emails'] = self.emails
+
+        return result
+
+
+def ecs_domain_argument_spec():
+    return dict(
+        client_id=dict(type='int', default=1),
+        domain_name=dict(type='str', required=True),
+        verification_method=dict(type='str', choices=['DNS', 'EMAIL', 'MANUAL', 'WEB_SERVER']),
+        verification_email=dict(type='str'),
+        ov_remaining_days=dict(type='int', default=60),
+        ev_remaining_days=dict(type='int'),
+        force=dict(type='bool', default=False),
+    )
+
+
+def main():
+    ecs_argument_spec = ecs_client_argument_spec()
+    ecs_argument_spec.update(ecs_domain_argument_spec())
+    module = AnsibleModule(
+        argument_spec=ecs_argument_spec,
+        required_if=(
+            ['verification_method', 'EMAIL', ['verification_email']]
+        ),
+        supports_check_mode=False,
+    )
+
+    if module.params['verification_email'] and module.params['verification_method'] != 'EMAIL':
+        module.fail_json(msg='The verification_email field is invalid when verification_method="{0}".'.format(module.params['verification_method']))
+
+    domain = EcsDomain(module)
+    domain.request_validation(module)
+    result = domain.dump()
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -25,7 +25,7 @@ description:
     - Requires credentials for the L(Entrust Certificate Services,https://www.entrustdatacard.com/products/categories/ssl-certificates) (ECS) API.
     - If the domain is already in the validation process, no new validation will be requested, but the validation data (if applicable) will be returned.
     - If the domain is already in the validation process but the I(verification_method) specified is different than the current I(verification_method),
-      the verification_method will be updated and validation data (if applicable) will be returned.
+      the I(verification_method) will be updated and validation data (if applicable) will be returned.
     - If the domain is an active, validated domain, the return value of I(changed) will be false, unless C(domain_status=EXPIRED), in which case a re-validation
       will be performed.
     - If C(verification_method=DNS), details about the required DNS entry will be specified in the return parameters I(dns_contents), I(dns_location), and

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -35,8 +35,8 @@ description:
     - If C(verification_method=EMAIL), the email address(es) that the validation email(s) were sent to will be in the return parameter I(emails). This is
       purely informational. For domains requested using this module, this will always be a list of size 1.
 notes:
-    - There is a small delay (typically about 5 seconds, but as long as 30) before obtaining the random values when requesting a validation.
-      Be aware of that if doing bulk domain requests.
+    - There is a small delay (typically about 5 seconds, but as long as 60) before obtaining the random values when requesting a validation
+      while C(verification_method=DNS) or C(verification_method=WEB_SERVER). Be aware of that if doing many domain validation requests.
 options:
     client_id:
         description:
@@ -330,8 +330,8 @@ class EcsDomain(object):
                 result = self.ecs_client.GetDomain(clientId=module.params['client_id'], domain=module.params['domain_name'])
 
                 # It takes a bit of time before the random values are available
-                if module.params['verification_method'] == 'DNS' or module.params['verification_method'] == 'FILE':
-                    for i in range(2):
+                if module.params['verification_method'] == 'DNS' or module.params['verification_method'] == 'WEB_SERVER':
+                    for i in range(4):
                         # Check both that random values are now available, and that they're different than were populated by previous 'check'
                         if module.params['verification_method'] == 'DNS':
                             if result.get('dnsMethod') and result['dnsMethod']['recordValue'] != self.dns_contents:
@@ -362,7 +362,7 @@ class EcsDomain(object):
         if self.ev_eligible:
             result['ev_eligible'] = self.ev_eligible
         if self.ev_days_remaining:
-            result['ov_days_remaining'] = self.ev_days_remaining
+            result['ev_days_remaining'] = self.ev_days_remaining
         if self.emails:
             result['emails'] = self.emails
 

--- a/lib/ansible/modules/crypto/entrust/ecs_domain.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_domain.py
@@ -180,7 +180,7 @@ client_id:
     sample: 1
 ov_eligible:
     description: Whether the domain is eligible for submission of "OV" certificates. Will never be C(false) if I(ov_eligible) is C(true)
-    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION), C(EXPIRING), or C(EXPIRED).
     type: bool
     sample: true
 ov_days_remaining:
@@ -190,7 +190,7 @@ ov_days_remaining:
     sample: 129
 ev_eligible:
     description: Whether the domain is eligible for submission of "EV" certificates. Will never be C(true) if I(ov_eligible) is C(false)
-    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING).
+    returned: success and I(domain_status) is C(APPROVED), C(RE_VERIFICATION) or C(EXPIRING), or C(EXPIRED).
     type: bool
     sample: true
 ev_days_remaining:
@@ -355,11 +355,11 @@ class EcsDomain(object):
 
         if self.verification_method:
             result['verification_method'] = self.verification_method
-        if self.ov_eligible:
+        if self.ov_eligible is not None:
             result['ov_eligible'] = self.ov_eligible
         if self.ov_days_remaining:
             result['ov_days_remaining'] = self.ov_days_remaining
-        if self.ev_eligible:
+        if self.ev_eligible is not None:
             result['ev_eligible'] = self.ev_eligible
         if self.ev_days_remaining:
             result['ev_days_remaining'] = self.ev_days_remaining

--- a/test/integration/targets/ecs_domain/aliases
+++ b/test/integration/targets/ecs_domain/aliases
@@ -1,0 +1,15 @@
+# Not enabled due to lack of access to test environments. May be enabled using custom integration_config.yml
+# Example integation_config.yml
+# ---
+# entrust_api_user:
+# entrust_api_key:
+# entrust_api_client_cert_path: /var/integration-testing/publicCert.pem
+# entrust_api_client_cert_key_path: /var/integration-testing/privateKey.pem
+# entrust_api_ip_address: 127.0.0.1
+# entrust_cloud_ip_address: 127.0.0.1
+# # Used for certificate path validation of QA environments - we chose not to support disabling path validation ever.
+# cacerts_bundle_path_local: /var/integration-testing/cacerts
+
+### WARNING: This test will update HOSTS file and CERTIFICATE STORE of target host, in order to be able to validate
+# to a QA environment. ###
+unsupported

--- a/test/integration/targets/ecs_domain/defaults/main.yml
+++ b/test/integration/targets/ecs_domain/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for test_ecs_domain

--- a/test/integration/targets/ecs_domain/meta/main.yml
+++ b/test/integration/targets/ecs_domain/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -234,33 +234,31 @@
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
-      verification_method: WEB_SERVER
+      verification_method: MANUAL
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
-    register: file_existing_domain
+    register: manual_existing_domain
 
   - debug:
-      var: file_existing_domain
+      var: manual_existing_domain
 
   - assert:
       that:
-        - file_existing_domain is not failed
-        - not file_existing_domain.changed
-        - file_existing_domain.verification_method is undefined
-        - file_existing_domain.dns_location is undefined
-        - file_existing_domain.dns_contents is undefined
-        - file_existing_domain.dns_resource_type is undefined
-        - file_existing_domain.file_location is undefined
-        - file_existing_domain.file_contents is undefined
-        - file_existing_domain.emails is undefined
+        - manual_existing_domain is not failed
+        - not manual_existing_domain.changed
+        - manual_existing_domain.dns_location is undefined
+        - manual_existing_domain.dns_contents is undefined
+        - manual_existing_domain.dns_resource_type is undefined
+        - manual_existing_domain.file_location is undefined
+        - manual_existing_domain.file_contents is undefined
+        - manual_existing_domain.emails is undefined
 
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
       verification_method: WEB_SERVER
-      ov_remaining_days: 600
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -274,6 +272,7 @@
       that:
         - file_existing_domain_revalidate is not failed
         - file_existing_domain_revalidate.changed
+        - file_existing_domain_revalidate.verification_method == 'RE_VERIFICATION'
         - file_existing_domain_revalidate.verification_method == 'WEB_SERVER'
         - file_existing_domain_revalidate.dns_location is undefined
         - file_existing_domain_revalidate.dns_contents is undefined

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -109,7 +109,7 @@
     ecs_domain:
       domain_name: EMAIL.{{ common_name }}
       verification_method: EMAIL
-      verification_email: admin@{{ domain_name }}
+      verification_email: admin@testcertificates.com
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -129,7 +129,32 @@
         - email_result.dns_resource_type is undefined
         - email_result.file_location is undefined
         - email_result.file_contents is undefined
-        - email_result.emails is list
+        - email_result.emails[0] == 'admin@testcertificates.com'
+
+  - name: Have ECS request a domain validation via EMAIL with no address provided
+    ecs_domain:
+      domain_name: EMAIL2.{{ common_name }}
+      verification_method: EMAIL
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: email_result2
+
+  - debug:
+      var: email_result2
+
+  - assert:
+      that:
+        - email_result2 is not failed
+        - email_result2.changed
+        - email_result2.verification_method == 'EMAIL'
+        - email_result2.dns_location is undefined
+        - email_result2.dns_contents is undefined
+        - email_result2.dns_resource_type is undefined
+        - email_result2.file_location is undefined
+        - email_result2.file_contents is undefined
+        - email_result2.emails is defined
 
   - name: Have ECS request a domain validation via MANUAL
     ecs_domain:
@@ -184,7 +209,11 @@
   - name: Have ECS request a domain validation via FILE for DNS, to change verification method
     ecs_domain:
       domain_name: DNS.{{ common_name }}
-      verification_method: FILE
+      verification_method: WEB_SERVER
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: dns_result_now_file
 
   - debug:
@@ -194,7 +223,7 @@
       that:
         - dns_result_now_file is not failed
         - dns_result_now_file.changed
-        - dns_result_now_file.verification_method == 'FILE'
+        - dns_result_now_file.verification_method == 'WEB_SERVER'
         - dns_result_now_file.dns_location is undefined
         - dns_result_now_file.dns_contents is undefined
         - dns_result_now_file.dns_resource_type is undefined
@@ -205,7 +234,7 @@
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
-      verification_method: FILE
+      verification_method: WEB_SERVER
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -230,8 +259,8 @@
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
-      verification_method: FILE
-      ov_days_remaining: 600
+      verification_method: WEB_SERVER
+      ov_remaining_days: 600
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -245,7 +274,7 @@
       that:
         - file_existing_domain_revalidate is not failed
         - file_existing_domain_revalidate.changed
-        - file_existing_domain_revalidate.verification_method == 'FILE'
+        - file_existing_domain_revalidate.verification_method == 'WEB_SERVER'
         - file_existing_domain_revalidate.dns_location is undefined
         - file_existing_domain_revalidate.dns_contents is undefined
         - file_existing_domain_revalidate.dns_resource_type is undefined

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -65,9 +65,6 @@
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: dns_result
 
-  - debug:
-      var: dns_result
-
   - assert:
       that:
         - dns_result is not failed
@@ -89,9 +86,6 @@
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: file_result
-
-  - debug:
-      var: file_result
 
   - assert:
       that:
@@ -116,9 +110,6 @@
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: email_result
 
-  - debug:
-      var: email_result
-
   - assert:
       that:
         - email_result is not failed
@@ -140,9 +131,6 @@
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: email_result2
-
-  - debug:
-      var: email_result2
 
   - assert:
       that:
@@ -166,9 +154,6 @@
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: manual_result
 
-  - debug:
-      var: manual_result
-
   - assert:
       that:
         - manual_result is not failed
@@ -190,9 +175,6 @@
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: dns_result2
-
-  - debug:
-      var: dns_result2
 
   - assert:
       that:
@@ -216,9 +198,6 @@
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: dns_result_now_file
 
-  - debug:
-      var: dns_result_now_file
-
   - assert:
       that:
         - dns_result_now_file is not failed
@@ -241,9 +220,6 @@
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: manual_existing_domain
 
-  - debug:
-      var: manual_existing_domain
-
   - assert:
       that:
         - manual_existing_domain is not failed
@@ -264,9 +240,6 @@
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
       entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: file_existing_domain_revalidate
-
-  - debug:
-      var: file_existing_domain_revalidate
 
   - assert:
       that:

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -69,6 +69,7 @@
       that:
         - dns_result is not failed
         - dns_result.changed
+        - dns_result.domain_status == 'INITIAL_VERIFICATION'
         - dns_result.verification_method == 'DNS'
         - dns_result.dns_location is string
         - dns_result.dns_contents is string
@@ -91,6 +92,7 @@
       that:
         - file_result is not failed
         - file_result.changed
+        - file_result.domain_status == 'INITIAL_VERIFICATION'
         - file_result.verification_method == 'WEB_SERVER'
         - file_result.dns_location is undefined
         - file_result.dns_contents is undefined
@@ -114,6 +116,7 @@
       that:
         - email_result is not failed
         - email_result.changed
+        - email_result.domain_status == 'INITIAL_VERIFICATION'
         - email_result.verification_method == 'EMAIL'
         - email_result.dns_location is undefined
         - email_result.dns_contents is undefined
@@ -136,6 +139,7 @@
       that:
         - email_result2 is not failed
         - email_result2.changed
+        - email_result2.domain_status == 'INITIAL_VERIFICATION'
         - email_result2.verification_method == 'EMAIL'
         - email_result2.dns_location is undefined
         - email_result2.dns_contents is undefined
@@ -158,6 +162,7 @@
       that:
         - manual_result is not failed
         - manual_result.changed
+        - manual_result.domain_status == 'INITIAL_VERIFICATION'
         - manual_result.verification_method == 'MANUAL'
         - manual_result.dns_location is undefined
         - manual_result.dns_contents is undefined
@@ -180,6 +185,7 @@
       that:
         - dns_result2 is not failed
         - not dns_result2.changed
+        - dns_result2.domain_status == 'INITIAL_VERIFICATION'
         - dns_result2.verification_method == 'DNS'
         - dns_result2.dns_location is string
         - dns_result2.dns_contents is string
@@ -202,6 +208,7 @@
       that:
         - dns_result_now_file is not failed
         - dns_result_now_file.changed
+        - dns_result_now_file.domain_status == 'INITIAL_VERIFICATION'
         - dns_result_now_file.verification_method == 'WEB_SERVER'
         - dns_result_now_file.dns_location is undefined
         - dns_result_now_file.dns_contents is undefined
@@ -224,6 +231,7 @@
       that:
         - manual_existing_domain is not failed
         - not manual_existing_domain.changed
+        - manual_existing_domain.domain_status == 'RE_VERIFICATION'
         - manual_existing_domain.dns_location is undefined
         - manual_existing_domain.dns_contents is undefined
         - manual_existing_domain.dns_resource_type is undefined
@@ -245,7 +253,7 @@
       that:
         - file_existing_domain_revalidate is not failed
         - file_existing_domain_revalidate.changed
-        - file_existing_domain_revalidate.verification_method == 'RE_VERIFICATION'
+        - file_existing_domain_revalidate.domain_status == 'RE_VERIFICATION'
         - file_existing_domain_revalidate.verification_method == 'WEB_SERVER'
         - file_existing_domain_revalidate.dns_location is undefined
         - file_existing_domain_revalidate.dns_contents is undefined

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -1,0 +1,233 @@
+---
+## Verify that integration_config was specified
+- block:
+  - assert:
+      that:
+        - entrust_api_user is defined
+        - entrust_api_key is defined
+        - entrust_api_ip_address is defined
+        - entrust_cloud_ip_address is defined
+        - entrust_api_client_cert_path is defined or entrust_api_client_cert_contents is defined
+        - entrust_api_client_cert_key_path is defined or entrust_api_client_cert_key_contents
+        - cacerts_bundle_path_local is defined
+
+## SET UP TEST ENVIRONMENT ########################################################################
+- name: copy the files needed for verifying test server certificate to the host
+  copy:
+    src: '{{ cacerts_bundle_path_local }}/'
+    dest: '{{ cacerts_bundle_path }}'
+
+- name: Update the CA certificates for our QA certs (collection may need updating if new QA environments used)
+  command: c_rehash {{ cacerts_bundle_path }}
+
+- name: Update hosts file
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    regexp: 'api.entrust.net$'
+    line: '{{ entrust_api_ip_address }} api.entrust.net'
+
+- name: Update hosts file
+  lineinfile:
+    path: /etc/hosts
+    state: present
+    regexp: 'cloud.entrust.net$'
+    line: '{{ entrust_cloud_ip_address }} cloud.entrust.net'
+
+- name: Clear out the temporary directory for storing the API connection information
+  file:
+    path: '{{ tmpdir_path }}'
+    state: absent
+
+- name: Create a directory for storing the API connection Information
+  file:
+    path: '{{ tmpdir_path }}'
+    state: directory
+
+- name: Copy the files needed for the connection to entrust API to the host
+  copy:
+    src: '{{ entrust_api_client_cert_path }}'
+    dest: '{{ entrust_api_cert }}'
+
+- name: Copy the files needed for the connection to entrust API to the host
+  copy:
+    src: '{{ entrust_api_client_cert_key_path }}'
+    dest: '{{ entrust_api_cert_key }}'
+
+- block:
+  - name: Have ECS request a domain validation via DNS
+    ecs_domain:
+      domain_name: DNS.{{ common_name }}
+      verification_method: DNS
+    register: dns_result
+
+  - debug:
+      var: dns_result
+
+  - assert:
+      that:
+        - dns_result is not failed
+        - dns_result.changed
+        - dns_result.verification_method == 'DNS'
+        - dns_result.dns_location is string
+        - dns_result.dns_contents is string
+        - dns_result.dns_resource_type is string
+        - dns_result.file_location is undefined
+        - dns_result.file_contents is undefined
+        - dns_result.emails is undefined
+
+  - name: Have ECS request a domain validation via WEB_SERVER
+    ecs_domain:
+      domain_name: FILE.{{ common_name }}
+      verification_method: WEB_SERVER
+    register: file_result
+
+  - debug:
+      var: file_result
+
+  - assert:
+      that:
+        - file_result is not failed
+        - file_result.changed
+        - file_result.verification_method == 'WEB_SERVER'
+        - file_result.dns_location is undefined
+        - file_result.dns_contents is undefined
+        - file_result.dns_resource_type is undefined
+        - file_result.file_location is string
+        - file_result.file_contents is string
+        - file_result.emails is undefined
+
+  - name: Have ECS request a domain validation via EMAIL
+    ecs_domain:
+      domain_name: EMAIL.{{ common_name }}
+      verification_method: EMAIL
+      verification_email: admin@{{ domain_name }}
+    register: email_result
+
+  - debug:
+      var: email_result
+
+  - assert:
+      that:
+        - email_result is not failed
+        - email_result.changed
+        - email_result.verification_method == 'EMAIL'
+        - email_result.dns_location is undefined
+        - email_result.dns_contents is undefined
+        - email_result.dns_resource_type is undefined
+        - email_result.file_location is undefined
+        - email_result.file_contents is undefined
+        - email_result.emails is list
+
+  - name: Have ECS request a domain validation via MANUAL
+    ecs_domain:
+      domain_name: MANUAL.{{ common_name }}
+      verification_method: MANUAL
+    register: manual_result
+
+  - debug:
+      var: manual_result
+
+  - assert:
+      that:
+        - manual_result is not failed
+        - manual_result.changed
+        - manual_result.verification_method == 'MANUAL'
+        - manual_result.dns_location is undefined
+        - manual_result.dns_contents is undefined
+        - manual_result.dns_resource_type is undefined
+        - manual_result.file_location is undefined
+        - manual_result.file_contents is undefined
+        - manual_result.emails is undefined
+
+- name: Have ECS request a domain validation via DNS that remains unchanged
+  ecs_domain:
+    domain_name: DNS.{{ common_name }}
+    verification_method: DNS
+  register: dns_result2
+
+- debug:
+    var: dns_result2
+
+- assert:
+    that:
+      - dns_result2 is not failed
+      - not dns_result2.changed
+      - dns_result2.verification_method == 'DNS'
+      - dns_result2.dns_location is string
+      - dns_result2.dns_contents is string
+      - dns_result2.dns_resource_type is string
+      - dns_result2.file_location is undefined
+      - dns_result2.file_contents is undefined
+      - dns_result2.emails is undefined
+
+- name: Have ECS request a domain validation via FILE for DNS, to change verification method
+  ecs_domain:
+    domain_name: DNS.{{ common_name }}
+    verification_method: FILE
+  register: dns_result_now_file
+
+- debug:
+    var: dns_result_now_file
+
+- assert:
+    that:
+      - dns_result_now_file is not failed
+      - dns_result_now_file.changed
+      - dns_result_now_file.verification_method == 'FILE'
+      - dns_result_now_file.dns_location is undefined
+      - dns_result_now_file.dns_contents is undefined
+      - dns_result_now_file.dns_resource_type is undefined
+      - dns_result_now_file.file_location is string
+      - dns_result_now_file.file_contents is string
+      - dns_result_now_file.emails is undefined
+
+  - name: Request revalidation of an approved domain
+    ecs_domain:
+      domain_name: {{ existing_domain_common_name }}
+      verification_method: FILE
+    register: file_existing_domain
+
+- debug:
+    var: file_existing_domain
+
+- assert:
+    that:
+      - file_existing_domain is not failed
+      - not file_existing_domain.changed
+      - file_existing_domain.verification_method is undefined
+      - file_existing_domain.dns_location is undefined
+      - file_existing_domain.dns_contents is undefined
+      - file_existing_domain.dns_resource_type is undefined
+      - file_existing_domain.file_location is undefined
+      - file_existing_domain.file_contents is undefined
+      - file_existing_domain.emails is undefined
+
+- name: Request revalidation of an approved domain
+  ecs_domain:
+    domain_name: {{ existing_domain_common_name }}
+    verification_method: FILE
+    ov_days_remaining: 600
+  register: file_existing_domain_revalidate
+
+- debug:
+    var: file_existing_domain_revalidate
+
+- assert:
+    that:
+      - file_existing_domain_revalidate is not failed
+      - file_existing_domain_revalidate.changed
+      - file_existing_domain_revalidate.verification_method == 'FILE'
+      - file_existing_domain_revalidate.dns_location is undefined
+      - file_existing_domain_revalidate.dns_contents is undefined
+      - file_existing_domain_revalidate.dns_resource_type is undefined
+      - file_existing_domain_revalidate.file_location is string
+      - file_existing_domain_revalidate.file_contents is string
+      - file_existing_domain_revalidate.emails is undefined
+
+
+  always:
+    - name: clean-up temporary folder
+      file:
+        path: '{{ tmpdir_path }}'
+        state: absent

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -55,10 +55,10 @@
     dest: '{{ entrust_api_cert_key }}'
 
 - block:
-  - name: Have ECS request a domain validation via DNS
+  - name: Have ECS request a domain validation via dns
     ecs_domain:
-      domain_name: DNS.{{ common_name }}
-      verification_method: DNS
+      domain_name: dns.{{ common_name }}
+      verification_method: dns
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -70,7 +70,7 @@
         - dns_result is not failed
         - dns_result.changed
         - dns_result.domain_status == 'INITIAL_VERIFICATION'
-        - dns_result.verification_method == 'DNS'
+        - dns_result.verification_method == 'dns'
         - dns_result.dns_location is string
         - dns_result.dns_contents is string
         - dns_result.dns_resource_type is string
@@ -78,10 +78,10 @@
         - dns_result.file_contents is undefined
         - dns_result.emails is undefined
 
-  - name: Have ECS request a domain validation via WEB_SERVER
+  - name: Have ECS request a domain validation via web_server
     ecs_domain:
       domain_name: FILE.{{ common_name }}
-      verification_method: WEB_SERVER
+      verification_method: web_server
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -93,7 +93,7 @@
         - file_result is not failed
         - file_result.changed
         - file_result.domain_status == 'INITIAL_VERIFICATION'
-        - file_result.verification_method == 'WEB_SERVER'
+        - file_result.verification_method == 'web_server'
         - file_result.dns_location is undefined
         - file_result.dns_contents is undefined
         - file_result.dns_resource_type is undefined
@@ -101,10 +101,10 @@
         - file_result.file_contents is string
         - file_result.emails is undefined
 
-  - name: Have ECS request a domain validation via EMAIL
+  - name: Have ECS request a domain validation via email
     ecs_domain:
-      domain_name: EMAIL.{{ common_name }}
-      verification_method: EMAIL
+      domain_name: email.{{ common_name }}
+      verification_method: email
       verification_email: admin@testcertificates.com
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
@@ -117,7 +117,7 @@
         - email_result is not failed
         - email_result.changed
         - email_result.domain_status == 'INITIAL_VERIFICATION'
-        - email_result.verification_method == 'EMAIL'
+        - email_result.verification_method == 'email'
         - email_result.dns_location is undefined
         - email_result.dns_contents is undefined
         - email_result.dns_resource_type is undefined
@@ -125,10 +125,10 @@
         - email_result.file_contents is undefined
         - email_result.emails[0] == 'admin@testcertificates.com'
 
-  - name: Have ECS request a domain validation via EMAIL with no address provided
+  - name: Have ECS request a domain validation via email with no address provided
     ecs_domain:
-      domain_name: EMAIL2.{{ common_name }}
-      verification_method: EMAIL
+      domain_name: email2.{{ common_name }}
+      verification_method: email
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -140,7 +140,7 @@
         - email_result2 is not failed
         - email_result2.changed
         - email_result2.domain_status == 'INITIAL_VERIFICATION'
-        - email_result2.verification_method == 'EMAIL'
+        - email_result2.verification_method == 'email'
         - email_result2.dns_location is undefined
         - email_result2.dns_contents is undefined
         - email_result2.dns_resource_type is undefined
@@ -148,10 +148,10 @@
         - email_result2.file_contents is undefined
         - email_result2.emails is defined
 
-  - name: Have ECS request a domain validation via MANUAL
+  - name: Have ECS request a domain validation via manual
     ecs_domain:
-      domain_name: MANUAL.{{ common_name }}
-      verification_method: MANUAL
+      domain_name: manual.{{ common_name }}
+      verification_method: manual
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -163,7 +163,7 @@
         - manual_result is not failed
         - manual_result.changed
         - manual_result.domain_status == 'INITIAL_VERIFICATION'
-        - manual_result.verification_method == 'MANUAL'
+        - manual_result.verification_method == 'manual'
         - manual_result.dns_location is undefined
         - manual_result.dns_contents is undefined
         - manual_result.dns_resource_type is undefined
@@ -171,10 +171,10 @@
         - manual_result.file_contents is undefined
         - manual_result.emails is undefined
 
-  - name: Have ECS request a domain validation via DNS that remains unchanged
+  - name: Have ECS request a domain validation via dns that remains unchanged
     ecs_domain:
-      domain_name: DNS.{{ common_name }}
-      verification_method: DNS
+      domain_name: dns.{{ common_name }}
+      verification_method: dns
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -186,7 +186,7 @@
         - dns_result2 is not failed
         - not dns_result2.changed
         - dns_result2.domain_status == 'INITIAL_VERIFICATION'
-        - dns_result2.verification_method == 'DNS'
+        - dns_result2.verification_method == 'dns'
         - dns_result2.dns_location is string
         - dns_result2.dns_contents is string
         - dns_result2.dns_resource_type is string
@@ -194,10 +194,10 @@
         - dns_result2.file_contents is undefined
         - dns_result2.emails is undefined
 
-  - name: Have ECS request a domain validation via FILE for DNS, to change verification method
+  - name: Have ECS request a domain validation via FILE for dns, to change verification method
     ecs_domain:
-      domain_name: DNS.{{ common_name }}
-      verification_method: WEB_SERVER
+      domain_name: dns.{{ common_name }}
+      verification_method: web_server
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -209,7 +209,7 @@
         - dns_result_now_file is not failed
         - dns_result_now_file.changed
         - dns_result_now_file.domain_status == 'INITIAL_VERIFICATION'
-        - dns_result_now_file.verification_method == 'WEB_SERVER'
+        - dns_result_now_file.verification_method == 'web_server'
         - dns_result_now_file.dns_location is undefined
         - dns_result_now_file.dns_contents is undefined
         - dns_result_now_file.dns_resource_type is undefined
@@ -220,7 +220,7 @@
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
-      verification_method: MANUAL
+      verification_method: manual
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -242,7 +242,7 @@
   - name: Request revalidation of an approved domain
     ecs_domain:
       domain_name: '{{ existing_domain_common_name }}'
-      verification_method: WEB_SERVER
+      verification_method: web_server
       entrust_api_user: '{{ entrust_api_user }}'
       entrust_api_key: '{{ entrust_api_key }}'
       entrust_api_client_cert_path: '{{ entrust_api_cert }}'
@@ -254,7 +254,7 @@
         - file_existing_domain_revalidate is not failed
         - file_existing_domain_revalidate.changed
         - file_existing_domain_revalidate.domain_status == 'RE_VERIFICATION'
-        - file_existing_domain_revalidate.verification_method == 'WEB_SERVER'
+        - file_existing_domain_revalidate.verification_method == 'web_server'
         - file_existing_domain_revalidate.dns_location is undefined
         - file_existing_domain_revalidate.dns_contents is undefined
         - file_existing_domain_revalidate.dns_resource_type is undefined

--- a/test/integration/targets/ecs_domain/tasks/main.yml
+++ b/test/integration/targets/ecs_domain/tasks/main.yml
@@ -59,6 +59,10 @@
     ecs_domain:
       domain_name: DNS.{{ common_name }}
       verification_method: DNS
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: dns_result
 
   - debug:
@@ -80,6 +84,10 @@
     ecs_domain:
       domain_name: FILE.{{ common_name }}
       verification_method: WEB_SERVER
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: file_result
 
   - debug:
@@ -102,6 +110,10 @@
       domain_name: EMAIL.{{ common_name }}
       verification_method: EMAIL
       verification_email: admin@{{ domain_name }}
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: email_result
 
   - debug:
@@ -123,6 +135,10 @@
     ecs_domain:
       domain_name: MANUAL.{{ common_name }}
       verification_method: MANUAL
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: manual_result
 
   - debug:
@@ -140,90 +156,102 @@
         - manual_result.file_contents is undefined
         - manual_result.emails is undefined
 
-- name: Have ECS request a domain validation via DNS that remains unchanged
-  ecs_domain:
-    domain_name: DNS.{{ common_name }}
-    verification_method: DNS
-  register: dns_result2
+  - name: Have ECS request a domain validation via DNS that remains unchanged
+    ecs_domain:
+      domain_name: DNS.{{ common_name }}
+      verification_method: DNS
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: dns_result2
 
-- debug:
-    var: dns_result2
+  - debug:
+      var: dns_result2
 
-- assert:
-    that:
-      - dns_result2 is not failed
-      - not dns_result2.changed
-      - dns_result2.verification_method == 'DNS'
-      - dns_result2.dns_location is string
-      - dns_result2.dns_contents is string
-      - dns_result2.dns_resource_type is string
-      - dns_result2.file_location is undefined
-      - dns_result2.file_contents is undefined
-      - dns_result2.emails is undefined
+  - assert:
+      that:
+        - dns_result2 is not failed
+        - not dns_result2.changed
+        - dns_result2.verification_method == 'DNS'
+        - dns_result2.dns_location is string
+        - dns_result2.dns_contents is string
+        - dns_result2.dns_resource_type is string
+        - dns_result2.file_location is undefined
+        - dns_result2.file_contents is undefined
+        - dns_result2.emails is undefined
 
-- name: Have ECS request a domain validation via FILE for DNS, to change verification method
-  ecs_domain:
-    domain_name: DNS.{{ common_name }}
-    verification_method: FILE
-  register: dns_result_now_file
+  - name: Have ECS request a domain validation via FILE for DNS, to change verification method
+    ecs_domain:
+      domain_name: DNS.{{ common_name }}
+      verification_method: FILE
+    register: dns_result_now_file
 
-- debug:
-    var: dns_result_now_file
+  - debug:
+      var: dns_result_now_file
 
-- assert:
-    that:
-      - dns_result_now_file is not failed
-      - dns_result_now_file.changed
-      - dns_result_now_file.verification_method == 'FILE'
-      - dns_result_now_file.dns_location is undefined
-      - dns_result_now_file.dns_contents is undefined
-      - dns_result_now_file.dns_resource_type is undefined
-      - dns_result_now_file.file_location is string
-      - dns_result_now_file.file_contents is string
-      - dns_result_now_file.emails is undefined
+  - assert:
+      that:
+        - dns_result_now_file is not failed
+        - dns_result_now_file.changed
+        - dns_result_now_file.verification_method == 'FILE'
+        - dns_result_now_file.dns_location is undefined
+        - dns_result_now_file.dns_contents is undefined
+        - dns_result_now_file.dns_resource_type is undefined
+        - dns_result_now_file.file_location is string
+        - dns_result_now_file.file_contents is string
+        - dns_result_now_file.emails is undefined
 
   - name: Request revalidation of an approved domain
     ecs_domain:
-      domain_name: {{ existing_domain_common_name }}
+      domain_name: '{{ existing_domain_common_name }}'
       verification_method: FILE
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
     register: file_existing_domain
 
-- debug:
-    var: file_existing_domain
+  - debug:
+      var: file_existing_domain
 
-- assert:
-    that:
-      - file_existing_domain is not failed
-      - not file_existing_domain.changed
-      - file_existing_domain.verification_method is undefined
-      - file_existing_domain.dns_location is undefined
-      - file_existing_domain.dns_contents is undefined
-      - file_existing_domain.dns_resource_type is undefined
-      - file_existing_domain.file_location is undefined
-      - file_existing_domain.file_contents is undefined
-      - file_existing_domain.emails is undefined
+  - assert:
+      that:
+        - file_existing_domain is not failed
+        - not file_existing_domain.changed
+        - file_existing_domain.verification_method is undefined
+        - file_existing_domain.dns_location is undefined
+        - file_existing_domain.dns_contents is undefined
+        - file_existing_domain.dns_resource_type is undefined
+        - file_existing_domain.file_location is undefined
+        - file_existing_domain.file_contents is undefined
+        - file_existing_domain.emails is undefined
 
-- name: Request revalidation of an approved domain
-  ecs_domain:
-    domain_name: {{ existing_domain_common_name }}
-    verification_method: FILE
-    ov_days_remaining: 600
-  register: file_existing_domain_revalidate
+  - name: Request revalidation of an approved domain
+    ecs_domain:
+      domain_name: '{{ existing_domain_common_name }}'
+      verification_method: FILE
+      ov_days_remaining: 600
+      entrust_api_user: '{{ entrust_api_user }}'
+      entrust_api_key: '{{ entrust_api_key }}'
+      entrust_api_client_cert_path: '{{ entrust_api_cert }}'
+      entrust_api_client_cert_key_path: '{{ entrust_api_cert_key }}'
+    register: file_existing_domain_revalidate
 
-- debug:
-    var: file_existing_domain_revalidate
+  - debug:
+      var: file_existing_domain_revalidate
 
-- assert:
-    that:
-      - file_existing_domain_revalidate is not failed
-      - file_existing_domain_revalidate.changed
-      - file_existing_domain_revalidate.verification_method == 'FILE'
-      - file_existing_domain_revalidate.dns_location is undefined
-      - file_existing_domain_revalidate.dns_contents is undefined
-      - file_existing_domain_revalidate.dns_resource_type is undefined
-      - file_existing_domain_revalidate.file_location is string
-      - file_existing_domain_revalidate.file_contents is string
-      - file_existing_domain_revalidate.emails is undefined
+  - assert:
+      that:
+        - file_existing_domain_revalidate is not failed
+        - file_existing_domain_revalidate.changed
+        - file_existing_domain_revalidate.verification_method == 'FILE'
+        - file_existing_domain_revalidate.dns_location is undefined
+        - file_existing_domain_revalidate.dns_contents is undefined
+        - file_existing_domain_revalidate.dns_resource_type is undefined
+        - file_existing_domain_revalidate.file_location is string
+        - file_existing_domain_revalidate.file_contents is string
+        - file_existing_domain_revalidate.emails is undefined
 
 
   always:

--- a/test/integration/targets/ecs_domain/vars/main.yml
+++ b/test/integration/targets/ecs_domain/vars/main.yml
@@ -7,7 +7,7 @@
 cacerts_bundle_path: /etc/pki/tls/certs
 
 common_name: '{{ ansible_date_time.epoch }}.testcertificates.com'
-existing_domain_common_name: 'testcertificates275818065839.local'
+existing_domain_common_name: 'testcertificates.com'
 
 tmpdir_path: /tmp/ecs_cert_test/{{ ansible_date_time.epoch }}
 

--- a/test/integration/targets/ecs_domain/vars/main.yml
+++ b/test/integration/targets/ecs_domain/vars/main.yml
@@ -1,0 +1,15 @@
+---
+# vars file for test_ecs_certificate
+
+# Path on various hosts that cacerts need to be put as a prerequisite to API server cert validation.
+# May need to be customized for some environments based on SSL implementations
+# that ansible "urls" module utility is using as a backing.
+cacerts_bundle_path: /etc/pki/tls/certs
+
+common_name: '{{ ansible_date_time.epoch }}.testcertificates.com'
+existing_domain_common_name: 'testcertificates275818065839.local'
+
+tmpdir_path: /tmp/ecs_cert_test/{{ ansible_date_time.epoch }}
+
+entrust_api_cert: '{{ tmpdir_path }}/authcert.cer'
+entrust_api_cert_key: '{{ tmpdir_path }}/authkey.cer'


### PR DESCRIPTION
##### SUMMARY
Addition of ecs_domain module.

I put it in the 'crypto' folder because it's tied to the ecs_certificate functionality.

If a domain is already in the validation process (initial_Verification or re_verification), the verification method can be updated. Otherwise, returns changed of false - but still returns the validation contents should a user want to act on them.

If a domain is in an "EXPIRING" state, requests a re-verification. I initially had a "days_remaining" parameter, but our API doesn't actually support re-verification of a domain that's expiring very far in the future, so I decided it would be redundant/confusing for end users.

I omitted a 'check_mode' because there's nothing that can functionally be done without a call to the ECS API. If preferable, I can add a check mode that basically just results in nothing being done except parameter validation (which is pretty minimal, basically just a check that the enums specified are valid).

I used uppercase for the parameters because they're an exact match to ECS API parameters customers may be used to using elsewhere, but I can make them lowercase if preferable.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ecs_domain

##### ADDITIONAL INFORMATION
Attached are the results of the integration tests.
[ecs_domain_testresults.txt](https://github.com/ansible/ansible/files/3591760/ecs_domain_testresults.txt)

