### PR TITLE
WIP: Quote bool esque strings

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -143,9 +143,9 @@ Parameters
                                     {% set choice = 'no' %}
                                 {% endif %}
                                 {% if (value.default is not list and value.default == choice) or (value.default is list and choice in value.default) %}
-                                    <li><div style="color: blue"><b>@{ choice | escape }@</b>&nbsp;&larr;</div></li>
+                                    <li><div style="color: blue"><b>@{ (choice|tojson if value.type == 'str' else choice) | escape }@</b>&nbsp;&larr;</div></li>
                                 {% else %}
-                                    <li>@{ choice | escape }@</li>
+                                    <li>@{ (choice|tojson if value.type == 'str' else choice) | escape }@</li>
                                 {% endif %}
                             {% endfor %}
                         </ul>

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -31,8 +31,9 @@ options:
     description:
       - Indicates the desired package state. C(latest) ensures that the latest version is installed. C(build-dep) ensures the package build dependencies
         are installed. C(fixed) attempt to correct a system with broken dependencies in place.
-    default: present
     choices: [ absent, build-dep, latest, present, fixed ]
+    type: str
+    default: present
   update_cache:
     description:
       - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step.
@@ -93,9 +94,10 @@ options:
       - If dist, performs an apt-get dist-upgrade.
       - 'Note: This does not upgrade a specific package, use state=latest for that.'
       - 'Note: Since 2.4, apt-get is used as a fall-back if aptitude is not present.'
-    version_added: "1.1"
+    type: str
     choices: [ dist, full, 'no', safe, 'yes' ]
     default: 'no'
+    version_added: "1.1"
   dpkg_options:
     description:
       - Add dpkg options to apt command. Defaults to '-o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"'


### PR DESCRIPTION
##### SUMMARY
Partial fix for #56788.

When a parameter is of `type: str`, retain quotation marks in the HTML output.

Currently the docs build strips quotation marks from parameter choice lists - see https://github.com/ansible/ansible/pull/56109/files vs. https://docs.ansible.com/ansible/devel/modules/ovirt_disk_module.html

This is especially confusing when a module accepts parameters that look like boolean values but do not function as boolean values. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
apt module
