### PR TITLE
Revert "shippable: temporary bump the timeout for Azure jobs"

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -137,8 +137,6 @@ trap cleanup EXIT
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=60
-elif [[ "${script}" == "azure" ]]; then
-    timeout=70
 else
     timeout=45
 fi


### PR DESCRIPTION
##### SUMMARY

The Azure timeout should not accure anymore since
173d47d1f429847ca351da92b69a0e05d25bb313.

This reverts commit aaa8835311f39db42843efe19bd07c4691009eef.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

test/utils/shippable/shippable.sh

<!--- Write the short name of the module, plugin, task or feature below -->