### PR TITLE
vmware/test: add vsphere-automation-sdk dep

### DIFF
--- a/test/lib/ansible_test/_data/requirements/integration.cloud.vcenter.txt
+++ b/test/lib/ansible_test/_data/requirements/integration.cloud.vcenter.txt
@@ -1,1 +1,2 @@
 pyvmomi
+git+https://github.com/vmware/vsphere-automation-sdk-python.git


### PR DESCRIPTION
##### SUMMARY

The following modules depend on `vSphere Automation SDK`:

- `vmware_rest_client`
- `vmware_guest_info`
- `vmware_tag_manager`
- `vmware_vm_inventory`

The associated test cannot be run with `govcsim`. But the situation is
changing since we will soon run them on a regular lab, and so, we
need to install the dependency.

Depends-On: https://github.com/ansible/default-test-container/pull/31
Depends-On: https://github.com/ansible/ansible/pull/62285
Depends-On: https://github.com/ansible/ansible/pull/62412

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_rest_client
vmware_guest_info
vmware_tag_manager
vmware_vm_inventory
<!--- Write the short name of the module, plugin, task or feature below -->