### PR TITLE
ansible-test: vcenter+Worldstream: hide password

### DIFF
--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -195,6 +195,9 @@ class VcenterProvider(CloudProvider):
             aci.wait(iterations=160)
 
             data = aci.get().response_json.get('data')
+            for key, value in data.items():
+                if key.endswith('PASSWORD'):
+                    display.sensitive.add(value)
             config = self._populate_config_template(config, data)
             self._write_config(config)
 


### PR DESCRIPTION
##### SUMMARY

Hide the temporary password when `ansible-test` is called with the
`--redact` parameter.

(cherry picked from commit 8e22a60f976d0435a1ed6ccda74fadf53a546b8f)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

test/lib/ansible_test/_internal/cloud/vcenter.py
<!--- Write the short name of the module, plugin, task or feature below -->
