### PR TITLE
Add str_strict parameter type instead of warning by default on string conversion

### DIFF
--- a/changelogs/fragments/add-strict-string-parametr-type.yaml
+++ b/changelogs/fragments/add-strict-string-parametr-type.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add new parameter type, ``str_strict``, that will warn or fail when a non-string value is given for a parameter of this type

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -56,13 +56,6 @@ Deprecated
 Modules
 =======
 
-New Module Parameter Type
--------------------------
-
-A new parameter type, ``str_strict``, is now available. This allows module authors to have Ansible take the action specified in ``ANSIBLE_STRING_CONVERSION_ACTION`` (``warn``, ``error``, or ``ignore`` and silently convert to a string) when a value in a ``str_strict`` field is not a string, such as unquoted integer or boolean values.
-
-This is a change from what was introduced in 2.8 where this behavior applied to *all* ``str`` type parameters.
-
 .. warning::
 
 	Links on this page may not point to the most recent versions of modules. We will update them when we can.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -56,6 +56,13 @@ Deprecated
 Modules
 =======
 
+New Module Parameter Type
+-------------------------
+
+A new parameter type, ``str_strict``, is now available. This allows module authors to have Ansible take the action specified in ``ANSIBLE_STRING_CONVERSION_ACTION`` (``warn``, ``error``, or ``ignore`` and silently convert to a string) when a value in a ``str_strict`` field is not a string, such as unquoted integer or boolean values.
+
+This is a change from what was introduced in 2.8 where this behavior applied to *all* ``str`` type parameters.
+
 .. warning::
 
 	Links on this page may not point to the most recent versions of modules. We will update them when we can.

--- a/docs/docsite/rst/porting_guides/porting_guide_base_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_base_2.11.rst
@@ -46,6 +46,15 @@ No notable changes
 Modules
 =======
 
+
+New Module Parameter Type
+-------------------------
+
+A new parameter type, ``str_strict``, is now available. This allows module authors to have Ansible take the action specified in ``ANSIBLE_STRING_CONVERSION_ACTION`` (``warn``, ``error``, or ``ignore`` and silently convert to a string) when a value in a ``str_strict`` field is not a string, such as unquoted integer or boolean values.
+
+This is a change from what was introduced in 2.8 where this behavior applied to *all* ``str`` type parameters.
+
+
 * The ``apt_key`` module has explicitly defined ``file`` as mutually exclusive with ``data``, ``keyserver`` and ``url``. They cannot be used together anymore.
 * The ``meta`` module now supports tags for user-defined tasks. Set the task's tags to 'always' to maintain the previous behavior. Internal ``meta`` tasks continue to always run.
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -968,6 +968,11 @@ class DocCLI(CLI, RoleMixin):
                 if 'default' in opt or not required:
                     default = "[Default: %s" % to_text(opt.pop('default', '(null)')) + "]"
 
+            # Show 'str_strict' as 'str' in the docs
+            if 'type' in opt:
+                if opt['type'] == 'str_strict':
+                    opt['type'] = 'str'
+
             text.append(textwrap.fill(DocCLI.tty_ify(aliases + choices + default), limit,
                                       initial_indent=opt_indent, subsequent_indent=opt_indent))
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2051,8 +2051,8 @@ NETCONF_SSH_CONFIG:
 STRING_CONVERSION_ACTION:
   version_added: '2.8'
   description:
-    - Action to take when a module parameter value is converted to a string (this does not affect variables).
-      For string parameters, values such as '1.00', "['a', 'b',]", and 'yes', 'y', etc.
+    - Action to take when a strict string module parameter value is converted to a string (this does not affect variables).
+      For strict string parameters, values such as '1.00', "['a', 'b',]", and 'yes', 'y', etc.
       will be converted by the YAML parser unless fully quoted.
     - Valid options are 'error', 'warn', and 'ignore'.
     - Since 2.8, this option defaults to 'warn' but will change to 'error' in 2.12.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -742,6 +742,16 @@ class AnsibleModule(object):
         self._set_defaults(pre=True)
 
         # This is for backwards compatibility only.
+            'str': self._check_type_str,
+            'str_strict': self._check_type_str_strict,
+            'list': self._check_type_list,
+            'dict': self._check_type_dict,
+            'bool': self._check_type_bool,
+            'int': self._check_type_int,
+            'float': self._check_type_float,
+            'path': self._check_type_path,
+            'raw': self._check_type_raw,
+            'jsonarg': self._check_type_jsonarg,
         self._CHECK_ARGUMENT_TYPES_DISPATCHER = DEFAULT_TYPE_VALIDATORS
 
         if not bypass_checks:
@@ -1716,6 +1726,9 @@ class AnsibleModule(object):
         return safe_eval(value, locals, include_exceptions)
 
     def _check_type_str(self, value, param=None, prefix=''):
+        return check_type_str(value, allow_conversion=True)
+
+    def _check_type_str_strict(self, value):
         opts = {
             'error': False,
             'warn': False,
@@ -1742,8 +1755,8 @@ class AnsibleModule(object):
                 msg = common_msg.capitalize()
                 raise TypeError(to_native(msg))
             elif self._string_conversion_action == 'warn':
-                msg = ('The value "{0}" (type {1.__class__.__name__}) was converted to "{2}" (type string). '
-                       'If this does not look like what you expect, {3}').format(from_msg, value, to_msg, common_msg)
+                msg = ('The value {0!r} (type {0.__class__.__name__}) in a strict string field was converted to {1!r} (type string). '
+                       'If this does not look like what you expect, {2}').format(value, to_text(value), common_msg)
                 self.warn(to_native(msg))
                 return to_native(value, errors='surrogate_or_strict')
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -742,17 +742,8 @@ class AnsibleModule(object):
         self._set_defaults(pre=True)
 
         # This is for backwards compatibility only.
-            'str': self._check_type_str,
-            'str_strict': self._check_type_str_strict,
-            'list': self._check_type_list,
-            'dict': self._check_type_dict,
-            'bool': self._check_type_bool,
-            'int': self._check_type_int,
-            'float': self._check_type_float,
-            'path': self._check_type_path,
-            'raw': self._check_type_raw,
-            'jsonarg': self._check_type_jsonarg,
         self._CHECK_ARGUMENT_TYPES_DISPATCHER = DEFAULT_TYPE_VALIDATORS
+        self._CHECK_ARGUMENT_TYPES_DISPATCHER['str_strict'] = self._check_type_str_strict
 
         if not bypass_checks:
             self._check_required_arguments()

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1741,23 +1741,20 @@ class AnsibleModule(object):
             return check_type_str(value, allow_conversion)
         except TypeError:
             common_msg = 'quote the entire value to ensure it does not change.'
-            from_msg = '{value!r}'.format(value=value)
             to_msg = '{value!r}'.format(value=to_text(value))
 
             if param is not None:
                 if prefix:
                     param = '{prefix}{param}'.format(prefix=prefix, param=param)
 
-                from_msg = '{param}: {value!r}'.format(param=param, value=value)
                 to_msg = '{param}: {value!r}'.format(param=param, value=to_text(value))
 
             if self._string_conversion_action == 'error':
                 msg = common_msg.capitalize()
                 raise TypeError(to_native(msg))
             elif self._string_conversion_action == 'warn':
-                msg = ('The value {value!r} (type {value.__class__.__name__}) in a strict string field was converted '
-                       'from {from_msg} to {to_msg} (type string). '
-                       'If this does not look like what you expect, {msg}').format(value=value, from_msg=from_msg, to_msg=to_msg, msg=common_msg)
+                msg = ("The value '{value!r}' (type {value.__class__.__name__}) in a strict string field was converted to {to_msg}. "
+                       "If this does not look like what you expect, {msg}").format(value=value, to_msg=to_msg, msg=common_msg)
                 self.warn(to_native(msg))
                 return to_native(value, errors='surrogate_or_strict')
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1728,7 +1728,7 @@ class AnsibleModule(object):
     def _check_type_str(self, value, param=None, prefix=''):
         return check_type_str(value, allow_conversion=True)
 
-    def _check_type_str_strict(self, value):
+    def _check_type_str_strict(self, value, param=None, prefix=''):
         opts = {
             'error': False,
             'warn': False,
@@ -1741,22 +1741,23 @@ class AnsibleModule(object):
             return check_type_str(value, allow_conversion)
         except TypeError:
             common_msg = 'quote the entire value to ensure it does not change.'
-            from_msg = '{0!r}'.format(value)
-            to_msg = '{0!r}'.format(to_text(value))
+            from_msg = '{value!r}'.format(value=value)
+            to_msg = '{value!r}'.format(value=to_text(value))
 
             if param is not None:
                 if prefix:
-                    param = '{0}{1}'.format(prefix, param)
+                    param = '{prefix}{param}'.format(prefix=prefix, param=param)
 
-                from_msg = '{0}: {1!r}'.format(param, value)
-                to_msg = '{0}: {1!r}'.format(param, to_text(value))
+                from_msg = '{param}: {value!r}'.format(param=param, value=value)
+                to_msg = '{param}: {value!r}'.format(param=param, value=to_text(value))
 
             if self._string_conversion_action == 'error':
                 msg = common_msg.capitalize()
                 raise TypeError(to_native(msg))
             elif self._string_conversion_action == 'warn':
-                msg = ('The value {0!r} (type {0.__class__.__name__}) in a strict string field was converted to {1!r} (type string). '
-                       'If this does not look like what you expect, {2}').format(value, to_text(value), common_msg)
+                msg = ('The value {value!r} (type {value.__class__.__name__}) in a strict string field was converted '
+                       'from {from_msg} to {to_msg} (type string). '
+                       'If this does not look like what you expect, {msg}').format(value=value, from_msg=from_msg, to_msg=to_msg, msg=common_msg)
                 self.warn(to_native(msg))
                 return to_native(value, errors='surrogate_or_strict')
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -320,9 +320,9 @@ def list_dict_option_schema(for_collection):
             'version_added_collection': collection_name,
             'default': json_value,
             # Note: Types are strings, not literal bools, such as True or False
-            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str', 'str_strict'),
             # in case of type='list' elements define type of individual item in list
-            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str', 'str_strict'),
             # Recursive suboptions
             'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
         },
@@ -344,9 +344,9 @@ def list_dict_option_schema(for_collection):
             'default': json_value,
             'suboptions': Any(None, *list_dict_suboption_schema),
             # Note: Types are strings, not literal bools, such as True or False
-            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str', 'str_strict'),
             # in case of type='list' elements define type of individual item in list
-            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str', 'str_strict'),
         },
         extra=PREVENT_EXTRA
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To alleviate much of the confusion around the string conversion warning intrudoced in 2.8.0 (f52a088862), change the string type behavior back to the way it behaved prior to 2.8.0 (convert and don't warn).

Give module auhors a new type, `str_strict`, they can use to enforce strict string types.

Related to discussions in #56788 and https://github.com/ansible/ansible/issues/60335#issuecomment-520894152.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/config/base.yml`
`lib/ansible/module_utils/basic.py`
`test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py`
##### ADDITIONAL INFORMATION
The string conversion warning was added in Ansible 2.8.0 (f52a088862). Since then, it has caused more confusion and issues than any benefit it has provided (I should have [listened to Toshio](https://github.com/ansible/ansible/issues/50503#issuecomment-452455543) and many others that considered the automatic conversion a feature not a bug  😄 ).

Further complicating things is the fun number of hoops we go through in the `choices` evaluation. We run `check_argument_types()` before we run `_check_argument_values()`. In `_check_argument_values()` we look at the value of `choices` for a module and convert stringified booleans to `'yes'` or `'no'` strings if those values are in the `choices` list. This is a longstanding feature of Ansible and we should not mess with this behavior since it is helpful.

This PR effectively moves the current behavior of warning, erroring, or ignoring on string conversion to the `str_strict` type and restores the previos behavior for `str` parameters.