### PR TITLE
s3_bucket: Allow empty encryption_key_id with aws:kms

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -133,6 +133,25 @@ EXAMPLES = '''
     name: mydobucket
     s3_url: 'https://nyc3.digitaloceanspaces.com'
 
+# Create a bucket with AES256 encryption
+- s3_bucket:
+    name: mys3bucket
+    state: present
+    encryption: "AES256"
+
+# Create a bucket with aws:kms encryption, KMS key
+- s3_bucket:
+    name: mys3bucket
+    state: present
+    encryption: "aws:kms"
+    encryption_key_id: "arn:aws:kms:us-east-1:1234/5678example"
+
+# Create a bucket with aws:kms encryption, default key
+- s3_bucket:
+    name: mys3bucket
+    state: present
+    encryption: "aws:kms"
+    encryption_key_id:
 '''
 
 import json
@@ -326,7 +345,7 @@ def create_or_update_bucket(s3_client, module, location):
             changed = True
         elif encryption != 'none' and (encryption != current_encryption_algorithm) or (encryption == 'aws:kms' and current_encryption_key != encryption_key_id):
             expected_encryption = {'SSEAlgorithm': encryption}
-            if encryption == 'aws:kms':
+            if encryption == 'aws:kms' and encryption_key_id is not None:
                 expected_encryption.update({'KMSMasterKeyID': encryption_key_id})
             try:
                 put_bucket_encryption(s3_client, name, expected_encryption)

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -151,7 +151,6 @@ EXAMPLES = '''
     name: mys3bucket
     state: present
     encryption: "aws:kms"
-    encryption_key_id:
 '''
 
 import json
@@ -679,7 +678,6 @@ def main():
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
-        required_if=[['encryption', 'aws:kms', ['encryption_key_id']]]
     )
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/test/integration/targets/s3_bucket/tasks/main.yml
+++ b/test/integration/targets/s3_bucket/tasks/main.yml
@@ -394,6 +394,21 @@
           - output.changed
           - not output.encryption
 
+    - name: Enable aws:kms encryption with KMS master key
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-encrypt-ansible"
+        state: present
+        encryption: "aws:kms"
+        encryption_key_id:
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.encryption
+          - output.encryption.SSEAlgorithm == 'aws:kms'
+
     # ============================================================
     - name: Pause to help with s3 bucket eventual consistency
       pause:

--- a/test/integration/targets/s3_bucket/tasks/main.yml
+++ b/test/integration/targets/s3_bucket/tasks/main.yml
@@ -399,13 +399,26 @@
         name: "{{ resource_prefix }}-testbucket-encrypt-ansible"
         state: present
         encryption: "aws:kms"
-        encryption_key_id:
         <<: *aws_connection_info
       register: output
 
     - assert:
         that:
           - output.changed
+          - output.encryption
+          - output.encryption.SSEAlgorithm == 'aws:kms'
+
+    - name: Enable aws:kms encryption with KMS master key (idempotent)
+      s3_bucket:
+        name: "{{ resource_prefix }}-testbucket-encrypt-ansible"
+        state: present
+        encryption: "aws:kms"
+        <<: *aws_connection_info
+      register: output
+
+    - assert:
+        that:
+          - not output.changed
           - output.encryption
           - output.encryption.SSEAlgorithm == 'aws:kms'
 


### PR DESCRIPTION
##### SUMMARY

s3_bucket: Allow empty `encryption_key_id` with `aws:kms` to use KMS master key
Add tests and examples to cover this usage

Fixes: #61687


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3_bucket.py

