### PR TITLE
[stable-2.9] Fix issues with ansible-test --venv option. (#62033)

### DIFF
--- a/changelogs/fragments/ansible-test-execv-wrapper-shebang.yml
+++ b/changelogs/fragments/ansible-test-execv-wrapper-shebang.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly handles creation of Python execv wrappers when the selected interpreter is a script

--- a/changelogs/fragments/ansible-test-sanity-requirements.yml
+++ b/changelogs/fragments/ansible-test-sanity-requirements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly installs requirements for multiple Python versions when running sanity tests

--- a/changelogs/fragments/ansible-test-venv-activation.yml
+++ b/changelogs/fragments/ansible-test-venv-activation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly activates virtual environments created using the --venv option

--- a/changelogs/fragments/ansible-test-venv-pythonpath.yml
+++ b/changelogs/fragments/ansible-test-venv-pythonpath.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly registers its own code in a virtual environment when running from an install

--- a/test/lib/ansible_test/_internal/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/sanity/__init__.py
@@ -89,8 +89,6 @@ def command_sanity(args):
     if args.delegate:
         raise Delegate(require=changes, exclude=args.exclude)
 
-    install_command_requirements(args)
-
     tests = sanity_get_tests()
 
     if args.test:
@@ -107,6 +105,8 @@ def command_sanity(args):
 
     total = 0
     failed = []
+
+    requirements_installed = set()  # type: t.Set[str]
 
     for test in tests:
         if args.list_tests:
@@ -180,6 +180,10 @@ def command_sanity(args):
                 sanity_targets = SanityTargets(tuple(all_targets), tuple(usable_targets))
 
                 if usable_targets or test.no_targets:
+                    if version not in requirements_installed:
+                        requirements_installed.add(version)
+                        install_command_requirements(args, version)
+
                     if isinstance(test, SanityCodeSmellTest):
                         result = test.test(args, sanity_targets, version)
                     elif isinstance(test, SanityMultipleVersion):

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import os
 import shutil
+import sys
 import tempfile
 import textwrap
 
@@ -204,22 +205,7 @@ def get_python_path(args, interpreter):
     else:
         display.info('Injecting "%s" as a execv wrapper for the "%s" interpreter.' % (injected_interpreter, interpreter), verbosity=1)
 
-        code = textwrap.dedent('''
-        #!%s
-
-        from __future__ import absolute_import
-
-        from os import execv
-        from sys import argv
-
-        python = '%s'
-
-        execv(python, [python] + argv[1:])
-        ''' % (interpreter, interpreter)).lstrip()
-
-        write_text_file(injected_interpreter, code)
-
-        os.chmod(injected_interpreter, MODE_FILE_EXECUTE)
+        create_interpreter_wrapper(interpreter, injected_interpreter)
 
     os.chmod(python_path, MODE_DIRECTORY)
 
@@ -229,6 +215,30 @@ def get_python_path(args, interpreter):
     PYTHON_PATHS[interpreter] = python_path
 
     return python_path
+
+
+def create_interpreter_wrapper(interpreter, injected_interpreter):  # type: (str, str) -> None
+    """Create a wrapper for the given Python interpreter at the specified path."""
+    # sys.executable is used for the shebang to guarantee it is a binary instead of a script
+    # injected_interpreter could be a script from the system or our own wrapper created for the --venv option
+    shebang_interpreter = sys.executable
+
+    code = textwrap.dedent('''
+    #!%s
+
+    from __future__ import absolute_import
+
+    from os import execv
+    from sys import argv
+
+    python = '%s'
+
+    execv(python, [python] + argv[1:])
+    ''' % (shebang_interpreter, interpreter)).lstrip()
+
+    write_text_file(injected_interpreter, code)
+
+    os.chmod(injected_interpreter, MODE_FILE_EXECUTE)
 
 
 def cleanup_python_paths():


### PR DESCRIPTION
##### SUMMARY

* Fix ansible-test venv activation.

When using the ansible-test --venv option, an execv wrapper for each python interpreter is now used instead of a symbolic link.

* Fix ansible-test execv wrapper generation.

Use the currently running Python interpreter for the shebang in the execv wrapper instead of the selected interpreter.

This allows the wrapper to work when the selected interpreter is a script instead of a binary.

* Fix ansible-test sanity requirements install.

When running sanity tests on multiple Python versions, install requirements for all versions used instead of only the default version.

* Fix ansible-test --venv when installed.

When running ansible-test from an install, the --venv delegation option needs to make sure the ansible-test code is available in the created virtual environment.

Exposing system site packages does not work because the virtual environment may be for a different Python version than the one on which ansible-test is installed.

Backport of https://github.com/ansible/ansible/pull/62033

(cherry picked from commit c77ab110514900ee439c7281a1d1dd14504cf44a)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test