### PR TITLE
Elaborate on note that docker-priv only works with integration

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -127,7 +127,7 @@ the Ansible continuous integration (CI) system is recommended.
 
    Using Docker Engine to run Docker on a non-Linux host (such as macOS) is not recommended.
    Some tests may fail, depending on the image used for testing.
-   Using the ``--docker-privileged`` option may resolve the issue.
+   Using the ``--docker-privileged`` option when running ``integration`` (not ``network-integration`` or ``windows-integration``) may resolve the issue.
 
 Running Integration Tests
 -------------------------


### PR DESCRIPTION
##### SUMMARY
This PR expands a note so it says an option is only available on integration tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#tests-in-docker-containers
