### PR TITLE
rabbitmq_publish SSL certificate implementation

### DIFF
--- a/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
+++ b/changelogs/fragments/rabbitmq_publish-certificate-checks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rabbitmq_publish - Support for connecting with SSL certificates.

--- a/lib/ansible/modules/notification/rabbitmq_publish.py
+++ b/lib/ansible/modules/notification/rabbitmq_publish.py
@@ -91,14 +91,17 @@ options:
   cafile:
     description:
       - CA file used during connection to the RabbitMQ server over SSL.
+      - If this option is specified, also I(certfile) and I(keyfile) must be specified.
     version_added: '2.10'
   certfile:
     description:
       - Client certificate to establish SSL connection.
+      - If this option is specified, also I(cafile) and I(keyfile) must be specified.
     version_added: '2.10'
   keyfile:
     description:
       - Client key to establish SSL connection.
+      - If this option is specified, also I(cafile) and I(certfile) must be specified.
     version_added: '2.10'
 
 
@@ -109,7 +112,7 @@ notes:
   - Pika is a pure-Python implementation of the AMQP 0-9-1 protocol that tries to stay fairly independent of the underlying network support library.
   - This module is tested against RabbitMQ. Other AMQP 0.9.1 protocol based servers may work but not tested/guaranteed.
   - The certificate authentication was tested with certificates created
-    from U(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ
+    viaU(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ
     configuration variables C(ssl_options.verify = verify_peer) & C(ssl_options.fail_if_no_peer_cert = true).
 author: "John Imison (@Im0)"
 '''
@@ -185,7 +188,7 @@ def main():
         headers=dict(default={}, type='dict'),
         cafile=dict(type='str', required=False),
         certfile=dict(type='str', required=False),
-        keyfile=dict(type='str', required=False)
+        keyfile=dict(type='str', required=False),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/notification/rabbitmq_publish.py
+++ b/lib/ansible/modules/notification/rabbitmq_publish.py
@@ -91,15 +91,15 @@ options:
   cafile:
     description:
       - CA file used during connection to the RabbitMQ server over SSL.
-    version_added: 2.10
+    version_added: '2.10'
   certfile:
     description:
       - Client certificate to establish SSL connection.
-    version_added: 2.10
+    version_added: '2.10'
   keyfile:
     description:
       - Client key to establish SSL connection.
-    version_added: 2.10
+    version_added: '2.10'
 
 
 

--- a/lib/ansible/modules/notification/rabbitmq_publish.py
+++ b/lib/ansible/modules/notification/rabbitmq_publish.py
@@ -108,7 +108,9 @@ notes:
   - This module requires the pika python library U(https://pika.readthedocs.io/).
   - Pika is a pure-Python implementation of the AMQP 0-9-1 protocol that tries to stay fairly independent of the underlying network support library.
   - This module is tested against RabbitMQ. Other AMQP 0.9.1 protocol based servers may work but not tested/guaranteed.
-  - The certificate authentication was tested with certificates created from U(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ configuration variables C(ssl_options.verify = verify_peer) & C(ssl_options.fail_if_no_peer_cert = true).
+  - The certificate authentication was tested with certificates created
+    from U(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ
+    configuration variables C(ssl_options.verify = verify_peer) & C(ssl_options.fail_if_no_peer_cert = true).
 author: "John Imison (@Im0)"
 '''
 

--- a/lib/ansible/modules/notification/rabbitmq_publish.py
+++ b/lib/ansible/modules/notification/rabbitmq_publish.py
@@ -88,13 +88,27 @@ options:
       - A dictionary of headers to post with the message.
     default: {}
     type: dict
+  cafile:
+    description:
+      - CA file used during connection to the RabbitMQ server over SSL.
+    version_added: 2.10
+  certfile:
+    description:
+      - Client certificate to establish SSL connection.
+    version_added: 2.10
+  keyfile:
+    description:
+      - Client key to establish SSL connection.
+    version_added: 2.10
+
 
 
 requirements: [ pika ]
 notes:
   - This module requires the pika python library U(https://pika.readthedocs.io/).
   - Pika is a pure-Python implementation of the AMQP 0-9-1 protocol that tries to stay fairly independent of the underlying network support library.
-  - This plugin is tested against RabbitMQ. Other AMQP 0.9.1 protocol based servers may work but not tested/guaranteed.
+  - This module is tested against RabbitMQ. Other AMQP 0.9.1 protocol based servers may work but not tested/guaranteed.
+  - The certificate authentication was tested with certificates created from U(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ configuration variables C(ssl_options.verify = verify_peer) & C(ssl_options.fail_if_no_peer_cert = true).
 author: "John Imison (@Im0)"
 '''
 
@@ -120,6 +134,17 @@ EXAMPLES = '''
     url: "amqp://guest:guest@192.168.0.32:5672/%2F"
     body: "Hello world random queue from ansible module rabbitmq_publish"
     content_type: "text/plain"
+
+- name: Publish with certs
+  rabbitmq_publish:
+    url: "amqps://guest:guest@192.168.0.32:5671/%2F"
+    body: "Hello test queue from ansible module rabbitmq_publish via SSL certs"
+    queue: 'test'
+    content_type: "text/plain"
+    cafile: 'ca_certificate.pem'
+    certfile: 'client_certificate.pem'
+    keyfile: 'client_key.pem'
+
 '''
 
 RETURN = '''
@@ -155,11 +180,15 @@ def main():
         durable=dict(default=False, type='bool'),
         exclusive=dict(default=False, type='bool'),
         auto_delete=dict(default=False, type='bool'),
-        headers=dict(default={}, type='dict')
+        headers=dict(default={}, type='dict'),
+        cafile=dict(type='str', required=False),
+        certfile=dict(type='str', required=False),
+        keyfile=dict(type='str', required=False)
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         mutually_exclusive=[['body', 'src']],
+        required_together=[['cafile', 'certfile', 'keyfile']],
         supports_check_mode=False
     )
 

--- a/lib/ansible/modules/notification/rabbitmq_publish.py
+++ b/lib/ansible/modules/notification/rabbitmq_publish.py
@@ -112,7 +112,7 @@ notes:
   - Pika is a pure-Python implementation of the AMQP 0-9-1 protocol that tries to stay fairly independent of the underlying network support library.
   - This module is tested against RabbitMQ. Other AMQP 0.9.1 protocol based servers may work but not tested/guaranteed.
   - The certificate authentication was tested with certificates created
-    viaU(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ
+    via U(https://www.rabbitmq.com/ssl.html#automated-certificate-generation) and RabbitMQ
     configuration variables C(ssl_options.verify = verify_peer) & C(ssl_options.fail_if_no_peer_cert = true).
 author: "John Imison (@Im0)"
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Allowing certificates to be used on connection to the RabbitMQ server.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_publish.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Enabling certificate checks on connection to the RabbitMQ server.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Publish with certs
  rabbitmq_publish:
    url: "amqps://guest:guest@192.168.0.32:5671/%2F"
    body: "Hello test queue from ansible module rabbitmq_publish via SSL certs"
    queue: 'test'
    content_type: "text/plain"
    cafile: 'ca_certificate.pem'
    certfile: 'client_certificate.pem'
    keyfile: 'client_key.pem'

```
