### PR TITLE
[2.9] openssh_keypair: make sure public key has same permissions as private key

### DIFF
--- a/changelogs/fragments/61658-openssh_keypair-public-key-permissions.yml
+++ b/changelogs/fragments/61658-openssh_keypair-public-key-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssh_keypair - public key's file attributes (permissions, owner, group, etc.) are now set to the same values as the private key."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -673,6 +673,7 @@ Noteworthy module changes
 * The deprecated ``force`` option in ``win_firewall_rule`` has been removed.
 * :ref:`openssl_certificate <openssl_certificate_module>`'s ``ownca`` provider creates authority key identifiers if not explicitly disabled with ``ownca_create_authority_key_identifier: no``. This is only the case for the ``cryptography`` backend, which is selected by default if the ``cryptography`` library is available.
 * :ref:`openssl_certificate <openssl_certificate_module>`'s ``ownca`` and ``selfsigned`` providers create subject key identifiers if not explicitly disabled with ``ownca_create_subject_key_identifier: never_create`` resp. ``selfsigned_create_subject_key_identifier: never_create``. If a subject key identifier is provided by the CSR, it is taken; if not, it is created from the public key. This is only the case for the ``cryptography`` backend, which is selected by default if the ``cryptography`` library is available.
+* :ref:`openssh_keypair <openssh_keypair_module>` now applies the same file permissions and ownership to both public and private keys (both get the same ``mode``, ``owner``, ``group``, etc.). If you need to change permissions / ownership on one key, use the :ref:`file <file_module>` to modify it after it is created.
 
 
 Plugins


### PR DESCRIPTION
##### SUMMARY
Backport of #61658 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssh_keypair
