### PR TITLE
Fix ansible-doc traceback and sanity test.

### DIFF
--- a/changelogs/fragments/ansible-doc-removed-traceback.yml
+++ b/changelogs/fragments/ansible-doc-removed-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-doc now properly handles removed modules/plugins

--- a/changelogs/fragments/ansible-test-ansible-doc.yml
+++ b/changelogs/fragments/ansible-test-ansible-doc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly handles warnings for removed modules/plugins

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -273,7 +273,10 @@ class DocCLI(CLI):
 
             if not any(filename.endswith(x) for x in C.BLACKLIST_EXTS):
                 doc, plainexamples, returndocs, metadata = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0))
-                doc['filename'] = filename
+
+                if doc:
+                    # doc may be None, such as when the module has been removed
+                    doc['filename'] = filename
 
         except Exception as e:
             display.vvv(traceback.format_exc())

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5512,9 +5512,9 @@ lib/ansible/modules/system/user.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/system/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/system/user.py validate-modules:doc-default-incompatible-type
 lib/ansible/modules/system/xfconf.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/utilities/helper/_accelerate.py ansible-doc
 lib/ansible/modules/utilities/logic/async_status.py use-argspec-type-path
 lib/ansible/modules/utilities/logic/async_status.py validate-modules!skip
+lib/ansible/modules/utilities/logic/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/utilities/logic/async_wrapper.py use-argspec-type-path
 lib/ansible/modules/utilities/logic/wait_for.py pylint:blacklisted-name
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py validate-modules:doc-choices-do-not-match-spec
@@ -5710,7 +5710,7 @@ lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin 
 lib/ansible/plugins/action/nxos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
 lib/ansible/plugins/action/sros.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
 lib/ansible/plugins/action/vyos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`
-lib/ansible/plugins/cache/base.py ansible-doc  # not a plugin, but a stub for backwards compatibility
+lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility
 lib/ansible/plugins/callback/hipchat.py pylint:blacklisted-name
 lib/ansible/plugins/connection/lxc.py pylint:blacklisted-name
 lib/ansible/plugins/doc_fragments/a10.py future-import-boilerplate


### PR DESCRIPTION
##### SUMMARY

Fix a traceback in `ansible-doc` when used on removed modules. Also fix error handling in the `ansible-doc` sanity test in `ansible-test` so that errors are not silently ignored.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-doc
ansible-test
