### PR TITLE
Return commands key instead of xml in result for junos rm

### DIFF
--- a/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
@@ -76,7 +76,7 @@ class Interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_interfaces_facts = self.get_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
@@ -77,7 +77,7 @@ class L2_interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_l2_interfaces_facts = self.get_l2_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -81,7 +81,7 @@ class L3_interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_interfaces_facts = self.get_l3_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/junos/config/lacp/lacp.py
@@ -75,7 +75,7 @@ class Lacp(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_lacp_facts = self.get_lacp_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
@@ -73,7 +73,7 @@ class Lacp_interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
@@ -75,7 +75,7 @@ class Lag_interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_lag_interfaces_facts = self.get_lag_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/junos/config/lldp_global/lldp_global.py
@@ -73,7 +73,7 @@ class Lldp_global(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_lldp_global_facts = self.get_lldp_global_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
@@ -74,7 +74,7 @@ class Lldp_interfaces(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_lldp_interfaces_facts = self.get_lldp_interfaces_facts()
 

--- a/lib/ansible/module_utils/network/junos/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/junos/config/vlans/vlans.py
@@ -92,7 +92,7 @@ class Vlans(ConfigBase):
                 if self._module._diff:
                     result['diff'] = {'prepared': diff}
 
-        result['xml'] = config_xmls
+        result['commands'] = config_xmls
 
         changed_vlans_facts = self.get_vlans_facts()
 

--- a/test/integration/targets/junos_l3_interfaces/tests/netconf/junos_l3_interfaces.yml
+++ b/test/integration/targets/junos_l3_interfaces/tests/netconf/junos_l3_interfaces.yml
@@ -20,8 +20,8 @@
 - assert:
     that:
       - result is changed
-      - "'<nc:address><nc:name>192.168.100.1/24</nc:name></nc:address>' in result.xml[0]"
-      - "'<nc:address><nc:name>10.200.16.20/24</nc:name></nc:address>' in result.xml[0]"
+      - "'<nc:address><nc:name>192.168.100.1/24</nc:name></nc:address>' in result.commands[0]"
+      - "'<nc:address><nc:name>10.200.16.20/24</nc:name></nc:address>' in result.commands[0]"
       - "result.after[0].name == 'ge-1/0/0'"
       - "result.after[0].ipv4[0]['address'] == '192.168.100.1/24'"
       - "result.after[0].ipv4[1]['address'] == '10.200.16.20/24'"
@@ -61,8 +61,8 @@
 - assert:
     that:
       - result is changed
-      - "'<nc:address><nc:name>100.64.0.1/10</nc:name></nc:address>' in result.xml[0]"
-      - "'<nc:address><nc:name>100.64.0.2/10</nc:name></nc:address>' in result.xml[0]"
+      - "'<nc:address><nc:name>100.64.0.1/10</nc:name></nc:address>' in result.commands[0]"
+      - "'<nc:address><nc:name>100.64.0.2/10</nc:name></nc:address>' in result.commands[0]"
       - "result.after[0].name == 'ge-1/0/0'"
       - "result.after[0].ipv4[0]['address'] == '192.168.100.1/24'"
       - "result.after[0].ipv4[1]['address'] == '10.200.16.20/24'"
@@ -79,7 +79,7 @@
 - assert:
     that:
       - result is changed
-      - "'<nc:name>ge-2/0/0</nc:name><nc:unit><nc:name>0</nc:name><nc:family><nc:inet><nc:address delete=\"delete\"/>' in result.xml[0]"
+      - "'<nc:name>ge-2/0/0</nc:name><nc:unit><nc:name>0</nc:name><nc:family><nc:inet><nc:address delete=\"delete\"/>' in result.commands[0]"
 
 - name: Override all config
   junos_l3_interfaces:
@@ -96,4 +96,4 @@
 - assert:
     that:
       - result is changed
-      - "'<nc:name>fxp0</nc:name><nc:unit><nc:name>0</nc:name><nc:family><nc:inet><nc:dhcp/></nc:inet>' in result.xml[0]"
+      - "'<nc:name>fxp0</nc:name><nc:unit><nc:name>0</nc:name><nc:family><nc:inet><nc:dhcp/></nc:inet>' in result.commands[0]"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/61773

*  Change `xml` key name to `commands` key to be in sync with
   other platform resource modules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_interfaces
junos_l2_interfaces
junos_l3_interfaces
junos_lldp_global
junos_lldp_interfaces
junos_lag_interfaces
junos_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
