### PR TITLE
Add support for Kylin linux to hostname module

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -678,11 +678,13 @@ class DebianHostname(Hostname):
     distribution = 'Debian'
     strategy_class = DebianStrategy
 
+    
 class KylinHostname(Hostname):
     platform = 'Linux'
     distribution = 'Kylin'
     strategy_class = DebianStrategy
 
+    
 class CumulusHostname(Hostname):
     platform = 'Linux'
     distribution = 'Cumulus-linux'

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -678,7 +678,7 @@ class DebianHostname(Hostname):
     distribution = 'Debian'
     strategy_class = DebianStrategy
 
-class DebianHostname(Hostname):
+class KylinHostname(Hostname):
     platform = 'Linux'
     distribution = 'Kylin'
     strategy_class = DebianStrategy

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -678,13 +678,13 @@ class DebianHostname(Hostname):
     distribution = 'Debian'
     strategy_class = DebianStrategy
 
-    
+
 class KylinHostname(Hostname):
     platform = 'Linux'
     distribution = 'Kylin'
     strategy_class = DebianStrategy
 
-    
+
 class CumulusHostname(Hostname):
     platform = 'Linux'
     distribution = 'Cumulus-linux'

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -678,6 +678,10 @@ class DebianHostname(Hostname):
     distribution = 'Debian'
     strategy_class = DebianStrategy
 
+class DebianHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Kylin'
+    strategy_class = DebianStrategy
 
 class CumulusHostname(Hostname):
     platform = 'Linux'


### PR DESCRIPTION
Add support for Kylin linux to hostname module


The following error is reported using hostname module on Kylin OS 
![图片](https://user-images.githubusercontent.com/22290449/64606021-e68e9e80-d3f7-11e9-982f-2758281170e2.png)

```
cat  /etc/os-release

NAME="Kylin"
VERSION="4.0.2 (juniper)"
ID=kylin
ID_LIKE=debian
PRETTY_NAME="Kylin 4.0.2"
VERSION_ID="4.0.2"
HOME_URL="http://www.kylinos.cn/"
SUPPORT_URL="http://www.kylinos.cn/content/service/service.html"
BUG_REPORT_URL="http://www.kylinos.cn/"
UBUNTU_CODENAME=juniper

```

