### PR TITLE
mysql_variable: Add a flag 'persist' to MySQL query

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -37,6 +37,7 @@ options:
             - If true, sets variable persistently (will survive mysql restarts)
         type: bool
         default: False
+        version_added: "2.10"
 extends_documentation_fragment:
 - mysql
 '''

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -99,7 +99,7 @@ def setvariable(cursor, mysqlvar, value, persist):
     should be passed as numeric literals.
 
     """
-    persist_keyword = persist ? "PERSIST" : "GLOBAL"
+    persist_keyword = "PERSIST" if persist else "GLOBAL"
     query = "SET %s %s = " % (persist_keyword, mysql_quote_identifier(mysqlvar, 'vars'))
     try:
         cursor.execute(query + "%s", (value,))

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -32,6 +32,11 @@ options:
         description:
             - If set, then sets variable value to this
         type: str
+    persist:
+        description:
+            - If true, sets variable persistently (will survive mysql restarts)
+        type: bool
+        default: False
 extends_documentation_fragment:
 - mysql
 '''
@@ -44,6 +49,12 @@ EXAMPLES = r'''
 - mysql_variables:
     variable: read_only
     value: 1
+
+- name: Set read_only variable persistently
+- mysql_variables:
+    variable: read_only
+    value: 1
+    persist: yes
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY
Fixes #60119 by adding a `persist` flag (False by default) and using it to choose between GLOBAL or PERSIST keywords in the MySQL query.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_variables

##### ADDITIONAL INFORMATION

