### PR TITLE
Added an argument to provide a different DNS server for querying records

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -43,7 +43,7 @@ options:
         description:
             - Query for existing DNS on this server.
             - When omitted value of C(server) will be used.
-        version_added: 2.10
+        version_added: "2.10"
     port:
         description:
             - Use this TCP port when connecting to C(server).

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -43,7 +43,7 @@ options:
         description:
             - Query for existing DNS on this server.
             - When omitted value of C(server) will be used.
-        version_added: 2.9
+        version_added: 2.10
     port:
         description:
             - Use this TCP port when connecting to C(server).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `query_server` argument to allow providing a different DNS server for situations where master DNS server refuses queries.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nsupdate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
