### PR TITLE
Add checks for Cloud Block Store

### DIFF
--- a/changelogs/fragments/62068-add-pure-cbs-support.yml
+++ b/changelogs/fragments/62068-add-pure-cbs-support.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- purefa_info - Add support for Cloud Block Store (https://github.com/ansible/ansible/pull/62068)
+- purefa_host - Add support for Cloud Block Store (https://github.com/ansible/ansible/pull/62068)

--- a/lib/ansible/modules/storage/purestorage/purefa_info.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_info.py
@@ -965,7 +965,7 @@ def main():
 
     info = {}
 
-    if 'minimum' in subset or 'all' in subset:
+    if 'minimum' in subset or 'all' in subset or 'apps' in subset:
         info['default'] = generate_default_dict(array)
     if 'performance' in subset or 'all' in subset:
         info['performance'] = generate_perf_dict(array)
@@ -1000,7 +1000,10 @@ def main():
         info['nfs_offload'] = generate_nfs_offload_dict(array)
         info['s3_offload'] = generate_s3_offload_dict(array)
     if 'apps' in subset or 'all' in subset:
-        info['apps'] = generate_apps_dict(array)
+        if 'CBS' not in info['default']['array_model']:
+            info['apps'] = generate_apps_dict(array)
+        else:
+            info['apps'] = {}
     if 'arrays' in subset or 'all' in subset:
         info['arrays'] = generate_conn_array_dict(array)
     if 'certs' in subset or 'all' in subset:


### PR DESCRIPTION
##### SUMMARY
Add support for Cloud Block Store virtual array. 
Without this check, info module fails as apps are not supported in CBS
Host module will fail if FC or NVMe data is provided to a CBS based host as only iSCSI is supported

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_info.py
purefa_host.py

##### ADDITIONAL INFORMATION
Cloud Block Store is a virtual version of the FlashArray that resides in the public cloud and only support iSCSI host connectivity.