### PR TITLE
[stable-2.8] Split unit tests into two groups (#61528)

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -13,12 +13,19 @@ matrix:
     - env: T=sanity/3
     - env: T=sanity/4
 
-    - env: T=units/2.6
-    - env: T=units/2.7
-    - env: T=units/3.5
-    - env: T=units/3.6
-    - env: T=units/3.7
-    - env: T=units/3.8
+    - env: T=units/2.6/1
+    - env: T=units/2.7/1
+    - env: T=units/3.5/1
+    - env: T=units/3.6/1
+    - env: T=units/3.7/1
+    - env: T=units/3.8/1
+
+    - env: T=units/2.6/2
+    - env: T=units/2.7/2
+    - env: T=units/3.5/2
+    - env: T=units/3.6/2
+    - env: T=units/3.7/2
+    - env: T=units/3.8/2
 
     - env: T=windows/2008/1
     - env: T=windows/2008-R2/1

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -6,14 +6,55 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
+group="${args[2]}"
 
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
-    timeout=99
+    timeout=60
 else
-    timeout=11
+    timeout=6
 fi
+
+group1=()
+group2=()
+
+# create two groups by putting long running network tests into one group
+# add or remove more network platforms as needed to balance the two groups
+
+networks=(
+    f5
+    fortimanager
+    fortios
+    ios
+    junos
+    netact
+    netscaler
+    netvisor
+    nos
+    nso
+    nuage
+    nxos
+    onyx
+    opx
+    ovs
+    radware
+    routeros
+    slxos
+    voss
+    vyos
+)
+
+for network in "${networks[@]}"; do
+    group1+=(--exclude "test/units/modules/network/${network}/")
+    group2+=("test/units/modules/network/${network}/")
+done
+
+case "${group}" in
+    1) options=("${group1[@]}") ;;
+    2) options=("${group2[@]}") ;;
+esac
 
 ansible-test env --timeout "${timeout}" --color -v
 
 # shellcheck disable=SC2086
 ansible-test units --color -v --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    "${options[@]}" \

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -11,7 +11,7 @@ group="${args[2]}"
 if [[ "${COVERAGE:-}" == "--coverage" ]]; then
     timeout=60
 else
-    timeout=6
+    timeout=11
 fi
 
 group1=()
@@ -23,7 +23,6 @@ group2=()
 networks=(
     f5
     fortimanager
-    fortios
     ios
     junos
     netact


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #61528 for Ansible 2.8. This splits unit tests into two groups and raises the unit test timeout to account for the time needed to download the image. This should help with the unit test timeouts we are seeing in nightly builds. We still need to fix the bigger issue that led us to disable node caching.
(cherry picked from commit e4e5005640bb9fe24e2ffb62b3c3c2607a5964b4)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`shippable.yml`
`test/utils/shippable/units.sh`