### PR TITLE
Control exception when import tasks no have arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ changelogs/.plugin-cache.yaml
 .ansible-test-timeout.json
 # ansible-test temporary metadata file for use with delgation
 /metadata-*.json
+# mypy linter
+.mypy_cache

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -72,8 +72,8 @@ class TaskInclude(Task):
             task.args['_raw_params'] = task.args.pop('file', None)
 
         apply_attrs = task.args.get('apply', {})
-
-        if task.action in ('include_tasks', 'import_tasks') and not task.args:
+        
+        if task.action in ('include_tasks', 'import_tasks') and not task.args["_raw_params"]:
             raise AnsibleParserError('Invalid arguments for TASK: %s' % task.action, obj=data)
 
         if apply_attrs and task.action != 'include_tasks':

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -72,6 +72,10 @@ class TaskInclude(Task):
             task.args['_raw_params'] = task.args.pop('file', None)
 
         apply_attrs = task.args.get('apply', {})
+
+        if task.action in ('include_tasks', 'import_tasks') and not task.args:
+            raise AnsibleParserError('Invalid arguments for TASK: %s' % task.action, obj=data)
+
         if apply_attrs and task.action != 'include_tasks':
             raise AnsibleParserError('Invalid options for %s: apply' % task.action, obj=data)
         elif not isinstance(apply_attrs, dict):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If you put an "import_tasks" without args, ansible throw an uncontrolled exception. The trace makes very hard to debug the playbook, specially if you have a big set of playbooks/tasks. This situation should be controlled. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core engine

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
You can reproduce the issue easily with a simple playbook like this:
```
- hosts: localhost
  connection: local
  tasks:
  - name: import_tasks empty 
    import_tasks:
```
ansible returns an error like:
```the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-playbook", line 110, in <module>
    exit_code = cli.run()
  File "/usr/local/lib/python3.7/site-packages/ansible/cli/playbook.py", line 123, in run
    results = pbex.run()
  File "/usr/local/lib/python3.7/site-packages/ansible/executor/playbook_executor.py", line 91, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/__init__.py", line 51, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/__init__.py", line 103, in _load_playbook_data
    entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader, vars=vars)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/play.py", line 115, in load
    return p.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/base.py", line 240, in load_data
    self._attributes[target_name] = method(name, ds[name])
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/play.py", line 146, in _load_tasks
    return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/helpers.py", line 77, in load_list_of_blocks
    loader=loader,
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/block.py", line 95, in load
    return b.load_data(data, variable_manager=variable_manager, loader=loader)
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/base.py", line 240, in load_data
    self._attributes[target_name] = method(name, ds[name])
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/block.py", line 131, in _load_block
    use_handlers=self._use_handlers,
  File "/usr/local/lib/python3.7/site-packages/ansible/playbook/helpers.py", line 237, in load_list_of_tasks
    include_file = loader.path_dwim(include_target)
  File "/usr/local/lib/python3.7/site-packages/ansible/parsing/dataloader.py", line 178, in path_dwim
    given = unquote(given)
  File "/usr/local/lib/python3.7/site-packages/ansible/parsing/quoting.py", line 29, in unquote
    if is_quoted(data):
  File "/usr/local/lib/python3.7/site-packages/ansible/parsing/quoting.py", line 24, in is_quoted
    return len(data) > 1 and data[0] == data[-1] and data[0] in ('"', "'") and data[-2] != '\\'
TypeError: object of type 'NoneType' has no len()
```
Maybe my PR don't control the case in the best place, but I no find another better. 
