### PR TITLE
[stable-2.9] fix nxos_config tests for httpapi

### DIFF
--- a/test/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -25,9 +25,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test cases (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -1,10 +1,6 @@
 ---
 - debug: msg="START common/backup.yaml on connection={{ ansible_connection }}"
 
-# Tasks using nxos_config with become: yes are only supported for network_cli
-- set_fact: test_become=yes
-  when: connection is search('network_cli')
-
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -70,7 +66,6 @@
     backup_options:
       filename: backup.cfg
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:
@@ -92,7 +87,6 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:
@@ -114,7 +108,6 @@
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -1,6 +1,10 @@
 ---
 - debug: msg="START common/backup.yaml on connection={{ ansible_connection }}"
 
+# Tasks using nxos_config with become: yes are only supported for network_cli
+- set_fact: test_become=yes
+  when: connection is search('network_cli')
+
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
 
@@ -66,7 +70,7 @@
     backup_options:
       filename: backup.cfg
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
+  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:
@@ -88,7 +92,7 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-  become: yes
+  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:
@@ -110,7 +114,7 @@
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
+  become: "{{ test_become | default(omit) }}"
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
Fixes nxos_config integration tests for `httpapi`

* Removes connection local tests
* Adds a check to only pass become parameter when the connection is `network_cli` since it's not supported for `httpapi`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_config