### PR TITLE
Fix ansible-test to ignore `tests/output/`.

### DIFF
--- a/changelogs/fragments/ansible-test-ignore-tests-output.yml
+++ b/changelogs/fragments/ansible-test-ignore-tests-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly ignores the ``tests/output//`` directory when not using git

--- a/test/lib/ansible_test/_internal/provider/source/unversioned.py
+++ b/test/lib/ansible_test/_internal/provider/source/unversioned.py
@@ -48,6 +48,9 @@ class UnversionedSource(SourceProvider):
                 'cache',
                 'output',
             ),
+            'tests': (
+                'output',
+            ),
             'docs/docsite': (
                 '_build',
             ),


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test to ignore `tests/output/`.

The `test/results/` directory for Ansible test output was already ignored when not using git.

When Ansible Collections were switched to `tests/output/` the ignore entry was previously overlooked.

Resolves https://github.com/ansible/ansible/issues/62075 (when not using git)

When using git, ignore entries should be added to the `.gitignore` file.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
