### PR TITLE
loop_control with pause, loop should not pause when a task is skipped

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -348,7 +348,7 @@ class TaskExecutor:
             templar.available_variables = task_vars
 
             # pause between loop iterations
-            if loop_pause and ran_once:
+            if loop_pause and ran_once and 'skipped' not in res:
                 try:
                     time.sleep(float(loop_pause))
                 except ValueError as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The general use case for pausing between tasks is to wait for something to finish as a result of a task execution before running the next task. When a task is skipped, there is no point to pause for the next task, pausing will result only in slowing down the loop without any benefit.

I think this should be the default behavior, if the actual behavior is still wanted we can add a new directive like "pause_between_skipped_tasks" (shoud default to "false")

see #62057
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
executor
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
