### PR TITLE
[stable-2.9] Call get_capabilities to initiate device connection for nxos_file_copy action plugin

### DIFF
--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -452,6 +452,10 @@ class ActionModule(ActionBase):
         if socket_path is None:
             socket_path = self._connection.socket_path
         self.conn = Connection(socket_path)
+
+        # Call get_capabilities() to start the connection to the device.
+        self.conn.get_capabilities()
+
         self.socket_timeout = self.conn.get_option('persistent_command_timeout')
 
         # This action plugin support two modes of operation.


### PR DESCRIPTION
Fix needed in 2.9

##### SUMMARY
Now that https://github.com/ansible/ansible/pull/61570 is fixed and merged to devel, the `nxos_file_copy` action plugin needs to start the connection to the device.

This PR adds a call to self.conn.get_capabilities() to make sure the connection gets established.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_file_copy

##### ADDITIONAL INFORMATION
This PR fixes the issue described in https://github.com/ansible/ansible/issues/61568 for the nxos_file_copy action plugin.