### PR TITLE
[stable-2.9] Fix ansible-test to ignore `tests/output/`. (#62084)

### DIFF
--- a/changelogs/fragments/ansible-test-ignore-tests-output.yml
+++ b/changelogs/fragments/ansible-test-ignore-tests-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly ignores the ``tests/output//`` directory when not using git

--- a/test/lib/ansible_test/_internal/provider/source/unversioned.py
+++ b/test/lib/ansible_test/_internal/provider/source/unversioned.py
@@ -48,6 +48,9 @@ class UnversionedSource(SourceProvider):
                 'cache',
                 'output',
             ),
+            'tests': (
+                'output',
+            ),
             'docs/docsite': (
                 '_build',
             ),


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test to ignore `tests/output/`. (#62084)

The `test/results/` directory for Ansible test output was already ignored when not using git.

When Ansible Collections were switched to `tests/output/` the ignore entry was previously overlooked.

Backport of https://github.com/ansible/ansible/pull/62084

(cherry picked from commit f110abb)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
