### PR TITLE
[stable-2.9] Properly exclude tests/output/ from code coverage.

### DIFF
--- a/changelogs/fragments/ansible-test-collections-coverage-noise.yml
+++ b/changelogs/fragments/ansible-test-collections-coverage-noise.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly excludes the ``tests/output/`` directory from code coverage

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -111,11 +111,11 @@ include =
         # temporary work-around for import sanity test
         coverage_config += '''
 include =
-     %s/*
+    %s/*
 
 omit =
-    */test/results/*
-''' % data_context().content.root
+    %s/*
+''' % (data_context().content.root, os.path.join(data_context().content.root, data_context().content.results_path))
     else:
         coverage_config += '''
 include =


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Properly exclude tests/output/ from code coverage.

Backport of https://github.com/ansible/ansible/pull/62098

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
