### PR TITLE
Work around virtualenv/venv issue in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-virtualenv-venv.yml
+++ b/changelogs/fragments/ansible-test-virtualenv-venv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly creates a virtual environment using ``venv`` when running in a ``virtualenv`` created virtual environment

--- a/test/lib/ansible_test/_data/virtualenvcheck.py
+++ b/test/lib/ansible_test/_data/virtualenvcheck.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Detect the real python interpreter when running in a virtual environment created by the 'virtualenv' module."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+
+try:
+    from sys import real_prefix
+except ImportError:
+    real_prefix = None
+
+print(json.dumps(dict(
+    real_prefix=real_prefix,
+)))

--- a/test/lib/ansible_test/_internal/venv.py
+++ b/test/lib/ansible_test/_internal/venv.py
@@ -25,10 +25,6 @@ from .util_common import (
     run_command,
 )
 
-from .data import (
-    data_context,
-)
-
 
 def create_virtual_environment(args,  # type: EnvironmentConfig
                                version,  # type: str

--- a/test/lib/ansible_test/_internal/venv.py
+++ b/test/lib/ansible_test/_internal/venv.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import json
 import os
 
 from . import types as t
@@ -15,12 +16,17 @@ from .util import (
     SubprocessError,
     get_available_python_versions,
     SUPPORTED_PYTHON_VERSIONS,
+    ANSIBLE_TEST_DATA_ROOT,
     display,
     remove_tree,
 )
 
 from .util_common import (
     run_command,
+)
+
+from .data import (
+    data_context,
 )
 
 
@@ -85,6 +91,15 @@ def run_venv(args,  # type: EnvironmentConfig
              path,  # type: str
              ):  # type: (...) -> bool
     """Create a virtual environment using the 'venv' module. Not available on Python 2.x."""
+    cmd = [run_python, os.path.join(os.path.join(ANSIBLE_TEST_DATA_ROOT, 'virtualenvcheck.py'))]
+    check_result = json.loads(run_command(args, cmd, capture=True, always=True)[0])
+    real_prefix = check_result['real_prefix']
+
+    if real_prefix:
+        # we must use the real python to create a virtual environment with venv
+        # attempting to use python from a virtualenv created virtual environment results in a copy of that environment instead
+        run_python = os.path.join(real_prefix, 'bin', 'python')
+
     cmd = [run_python, '-m', 'venv']
 
     if system_site_packages:


### PR DESCRIPTION
##### SUMMARY

Work around virtualenv/venv issue in ansible-test.

Creating a virtual environment using `venv` when running in a virtual environment created by `virtualenv` results in a copy of the original virtual environment instead of creation of a new one.

To work around this, `ansible-test` now identifies when it is running in a `virtualenv` created virtual environment and uses the real Python interpreter to create the `venv` virtual environment.

Resolves https://github.com/ansible/ansible/issues/62105

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
