### PR TITLE
Fix ansible-test coverage --all

### DIFF
--- a/changelogs/fragments/62096-test-coverage-all.yml
+++ b/changelogs/fragments/62096-test-coverage-all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test coverage - Fix the ``--all`` argument when generating coverage reports - https://github.com/ansible/ansible/issues/62096

--- a/test/lib/ansible_test/_internal/cover.py
+++ b/test/lib/ansible_test/_internal/cover.py
@@ -175,7 +175,7 @@ def _command_coverage_combine_python(args):
             updated.add_arcs({filename: list(arc_data[filename])})
 
         if args.all:
-            updated.add_arcs(dict((source, []) for source in sources))
+            updated.add_arcs(dict((source[0], []) for source in sources))
 
         if not args.explain:
             output_file = coverage_file + group


### PR DESCRIPTION
##### SUMMARY
Using `--all` in `ansible-test coverage` causes a stack trace due to dict key being a tuple. This has been fixed to ensure we only pass in the key and not the (key, line_numbers) tuple.

Fixes https://github.com/ansible/ansible/issues/62096

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test