### PR TITLE
loop_control: add option to configure pausing after skipped tasks

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -327,7 +327,7 @@ To control the time (in seconds) between the execution of each item in a task lo
 
     # main.yml
     - name: create servers, pause 3s before creating next
-      digital_ocean:
+      digital_ocean_droplet:
         name: "{{ item }}"
         state: present
       loop:
@@ -335,6 +335,25 @@ To control the time (in seconds) between the execution of each item in a task lo
         - server2
       loop_control:
         pause: 3
+
+To avoid pausing after skipped tasks add ``pause_after_skipped_tasks: no`` to ``loop_control``::
+
+    # main.yml
+    - name: create servers for students only, don't pause when iterating through teachers
+      digital_ocean_droplet:
+        name: "{{ item }}-server"
+        state: present
+      when: item is match("student")
+      loop:
+        - teacher1
+        - teacher2
+        - teacher3
+        - student1
+        - student2
+        - student3
+      loop_control:
+        pause: 3
+        pause_after_skipped_tasks: no
 
 Tracking progress through a loop with ``index_var``
 ---------------------------------------------------

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -323,7 +323,9 @@ Pausing within a loop
 ---------------------
 .. versionadded:: 2.2
 
-To control the time (in seconds) between the execution of each item in a task loop, use the ``pause`` directive with ``loop_control``::
+To control the time (in seconds) between the execution of each item in a task loop, use the ``pause`` directive with ``loop_control``
+
+.. code-block:: yaml
 
     # main.yml
     - name: create servers, pause 3s before creating next
@@ -336,7 +338,9 @@ To control the time (in seconds) between the execution of each item in a task lo
       loop_control:
         pause: 3
 
-To avoid pausing after skipped tasks add ``pause_after_skipped_tasks: no`` to ``loop_control``::
+To avoid pausing after skipped tasks add ``pause_after_skipped_tasks: no`` to ``loop_control``
+
+.. code-block:: yaml
 
     # main.yml
     - name: create servers for students only, don't pause when iterating through teachers

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -284,6 +284,7 @@ class TaskExecutor:
         index_var = None
         label = None
         loop_pause = 0
+        loop_pause_after_skipped_tasks = True
         extended = False
         templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
 
@@ -292,6 +293,7 @@ class TaskExecutor:
             loop_var = templar.template(self._task.loop_control.loop_var)
             index_var = templar.template(self._task.loop_control.index_var)
             loop_pause = templar.template(self._task.loop_control.pause)
+            loop_pause_after_skipped_tasks = templar.template(self._task.loop_control.pause_after_skipped_tasks)
             extended = templar.template(self._task.loop_control.extended)
 
             # This may be 'None',so it is templated below after we ensure a value and an item is assigned
@@ -343,7 +345,7 @@ class TaskExecutor:
             templar.available_variables = task_vars
 
             # pause between loop iterations
-            if loop_pause and ran_once:
+            if ran_once and loop_pause and (loop_pause_after_skipped_tasks or 'skipped' not in res or not res['skipped']):
                 try:
                     time.sleep(float(loop_pause))
                 except ValueError as e:

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -29,6 +29,7 @@ class LoopControl(FieldAttributeBase):
     _index_var = FieldAttribute(isa='str')
     _label = FieldAttribute(isa='str')
     _pause = FieldAttribute(isa='float', default=0)
+    _pause_after_skipped_tasks = FieldAttribute(isa='bool', default=True)
     _extended = FieldAttribute(isa='bool')
 
     def __init__(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The general use case for pausing between tasks is to wait for something to finish as a result of a task execution before running the next task. When a task is skipped, there is no point to pause for the next task, pausing will result only in slowing down the loop without any benefit.

This PR adds an option `pause_after_skipped_tasks` that allows configuring pausing behavior after a skipped task, if `True`(default) the loop will pause regardless of the task execution (skipped or not), if `False` the loop will pause only after the task is executed.

Fixes #62057
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
loop_control
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
