### PR TITLE
Fix ansible-test pytest plugin loading.

### DIFF
--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -20,6 +20,12 @@ def collection_pypkgpath(self):
 
 def pytest_configure():
     """Configure this pytest plugin."""
+    try:
+        if pytest_configure.executed:
+            return
+    except AttributeError:
+        pytest_configure.executed = True
+
     from ansible.utils.collection_loader import AnsibleCollectionLoader
 
     # allow unit tests to import code from collections
@@ -32,3 +38,6 @@ def pytest_configure():
     # original idea from https://stackoverflow.com/questions/50174130/how-do-i-pytest-a-project-using-pep-420-namespace-packages/50175552#50175552
     # noinspection PyProtectedMember
     py._path.local.LocalPath.pypkgpath = collection_pypkgpath  # pylint: disable=protected-access
+
+
+pytest_configure()

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -1,4 +1,4 @@
-"""Enable unit testing of Ansible collections."""
+"""Enable unit testing of Ansible collections. PYTEST_DONT_REWRITE"""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
@@ -6,6 +6,12 @@ __metaclass__ = type
 def pytest_configure():
     """Configure this pytest plugin."""
     try:
+        if pytest_configure.executed:
+            return
+    except AttributeError:
+        pytest_configure.executed = True
+
+    try:
         import coverage
     except ImportError:
         coverage = None
@@ -57,3 +63,6 @@ def pytest_configure():
 
     if cov:
         cov.start()
+
+
+pytest_configure()

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
@@ -1,4 +1,4 @@
-"""Monkey patch os._exit when running under coverage so we don't lose coverage data in forks, such as with `pytest --boxed`."""
+"""Monkey patch os._exit when running under coverage so we don't lose coverage data in forks, such as with `pytest --boxed`. PYTEST_DONT_REWRITE"""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -122,9 +122,7 @@ def command_units(args):
 
         if plugins:
             env['PYTHONPATH'] += ':%s' % os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest/plugins')
-
-            for plugin in plugins:
-                cmd.extend(['-p', plugin])
+            env['PYTEST_PLUGINS'] = ','.join(plugins)
 
         if args.collect_only:
             cmd.append('--collect-only')


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test pytest plugin loading:

- Avoid assertion rewriting in pytest plugins.
- Run ansible-test pytest plugins early.
- Load pytest plugins using an env var.

Resolves https://github.com/ansible/ansible/issues/62113

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
