### PR TITLE
[stable-2.9] Fix ansible-test pytest plugin loading. (#62119)

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-plugin-loading.yml
+++ b/changelogs/fragments/ansible-test-pytest-plugin-loading.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now loads the collection loader plugin early enough for ansible_collections imports to work in unit test conftest.py modules

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -1,4 +1,4 @@
-"""Enable unit testing of Ansible collections."""
+"""Enable unit testing of Ansible collections. PYTEST_DONT_REWRITE"""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -20,6 +20,12 @@ def collection_pypkgpath(self):
 
 def pytest_configure():
     """Configure this pytest plugin."""
+    try:
+        if pytest_configure.executed:
+            return
+    except AttributeError:
+        pytest_configure.executed = True
+
     from ansible.utils.collection_loader import AnsibleCollectionLoader
 
     # allow unit tests to import code from collections
@@ -32,3 +38,6 @@ def pytest_configure():
     # original idea from https://stackoverflow.com/questions/50174130/how-do-i-pytest-a-project-using-pep-420-namespace-packages/50175552#50175552
     # noinspection PyProtectedMember
     py._path.local.LocalPath.pypkgpath = collection_pypkgpath  # pylint: disable=protected-access
+
+
+pytest_configure()

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_coverage.py
@@ -1,10 +1,16 @@
-"""Monkey patch os._exit when running under coverage so we don't lose coverage data in forks, such as with `pytest --boxed`."""
+"""Monkey patch os._exit when running under coverage so we don't lose coverage data in forks, such as with `pytest --boxed`. PYTEST_DONT_REWRITE"""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
 def pytest_configure():
     """Configure this pytest plugin."""
+    try:
+        if pytest_configure.executed:
+            return
+    except AttributeError:
+        pytest_configure.executed = True
+
     try:
         import coverage
     except ImportError:
@@ -57,3 +63,6 @@ def pytest_configure():
 
     if cov:
         cov.start()
+
+
+pytest_configure()

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -122,9 +122,7 @@ def command_units(args):
 
         if plugins:
             env['PYTHONPATH'] += ':%s' % os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest/plugins')
-
-            for plugin in plugins:
-                cmd.extend(['-p', plugin])
+            env['PYTEST_PLUGINS'] = ','.join(plugins)
 
         if args.collect_only:
             cmd.append('--collect-only')


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test pytest plugin loading. (#62119)

* Avoid assertion rewriting in pytest plugins.

Adding PYTEST_DONT_REWRITE to the ansible-test pytest plugin docstrings disables assertion rewriting in pytest for those plugins.

This avoids warnings during test execution if the plugins are loaded multiple times (such as being imported within tests).

* Run ansible-test pytest plugins early.

The ansible-test pytest plugins need to load and run earlier than conftest modules.

To facilitate this, the pytest_configure function is run during loading, which works since they are loaded (but not always run) before conftest modules are loaded.

A check has also been added to the pytest_configure functions to prevent them from running multiple times in the same process.

* Load pytest plugins using an env var.

The -p command line option loads plugins before conftest, but only during collection.
The PYTEST_PLUGINS environment variable loads plugins before confest, both during collection and test execution.

Backport of https://github.com/ansible/ansible/pull/62119

(cherry picked from commit aaa6d2e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
