### PR TITLE
Backport of 62067: mysql_info: fix typo

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -183,7 +183,7 @@ class MySQL_Info(object):
 
     Arguments:
         module (AnsibleModule): Object of AnsibleModule class.
-        cursor (pymysql/mysql-python): Cursor class for interraction with
+        cursor (pymysql/mysql-python): Cursor class for interaction with
             the database.
 
     Note:


### PR DESCRIPTION
(cherry picked from commit e589e22b7e4028c88796d39f7e5d6aee9143f67e)

##### SUMMARY
Backport of #62067: mysql_info: fix typo

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request