### PR TITLE
backport of 62065: postgresql: fix typos in modules

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_copy.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_copy.py
@@ -80,7 +80,7 @@ notes:
 - Supports PostgreSQL version 9.4+.
 - COPY command is only allowed to database superusers.
 - if I(check_mode=yes), we just check the src/dst table availability
-  and return the COPY query that aclually has not been executed.
+  and return the COPY query that actually has not been executed.
 - If i(check_mode=yes) and the source has been passed as SQL, the module
   will execute it and rolled the transaction back but pay attention
   it can affect database performance (e.g., if SQL collects a lot of data).

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -22,12 +22,12 @@ description:
   relationship with a PostgreSQL database.
 - The module can be used on the machine where executed or on a remote host.
 - When removing a language from a database, it is possible that dependencies prevent
-  the database from being removed. In that case, you can specify casade to
+  the database from being removed. In that case, you can specify I(cascade=yes) to
   automatically drop objects that depend on the language (such as functions in the
   language).
 - In case the language can't be deleted because it is required by the
-  database system, you can specify fail_on_drop=no to ignore the error.
-- Be carefull when marking a language as trusted since this could be a potential
+  database system, you can specify I(fail_on_drop=no) to ignore the error.
+- Be careful when marking a language as trusted since this could be a potential
   security breach. Untrusted languages allow only users with the PostgreSQL superuser
   privilege to use this language to create new functions.
 version_added: '1.7'
@@ -60,21 +60,21 @@ options:
     description:
     - If C(yes), fail when removing a language. Otherwise just log and continue.
     - In some cases, it is not possible to remove a language (used by the db-system).
-    - When dependencies block the removal, consider using C(cascade).
+    - When dependencies block the removal, consider using I(cascade).
     type: bool
     default: 'yes'
   cascade:
     description:
     - When dropping a language, also delete object that depend on this language.
-    - Only used when C(state=absent).
+    - Only used when I(state=absent).
     type: bool
     default: 'no'
   session_role:
     version_added: '2.8'
     description:
     - Switch to session_role after connecting.
-    - The specified session_role must be a role that the current login_user is a member of.
-    - Permissions checking for SQL commands is carried out as though the session_role were the one that had logged in originally.
+    - The specified I(session_role) must be a role that the current I(login_user) is a member of.
+    - Permissions checking for SQL commands is carried out as though the I(session_role) were the one that had logged in originally.
     type: str
   state:
     description:
@@ -90,7 +90,7 @@ options:
   ssl_mode:
     description:
       - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - See U(https://www.postgresql.org/docs/current/static/libpq-ssl.html) for more information on the modes.
       - Default of C(prefer) matches libpq default.
     type: str
     default: prefer

--- a/lib/ansible/modules/database/postgresql/postgresql_membership.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_membership.py
@@ -20,7 +20,7 @@ short_description: Add or remove PostgreSQL roles from groups
 description:
 - Adds or removes PostgreSQL roles from groups (other roles).
 - Users are roles with login privilege.
-- Groups are PostgreSQL roles usually without LOGIN privelege.
+- Groups are PostgreSQL roles usually without LOGIN privilege.
 - "Common use case:"
 - 1) add a new group (groups) by M(postgresql_user) module with I(role_attr_flags=NOLOGIN)
 - 2) grant them desired privileges by M(postgresql_privs) module

--- a/lib/ansible/modules/database/postgresql/postgresql_owner.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_owner.py
@@ -46,7 +46,7 @@ options:
     description:
     - The list of role names. The ownership of all the objects within the current database,
       and of all shared objects (databases, tablespaces), owned by this role(s) will be reassigned to I(owner).
-    - Pay attention - it reassignes all objects owned by this role(s) in the I(db)!
+    - Pay attention - it reassigns all objects owned by this role(s) in the I(db)!
     - If role(s) exists, always returns changed True.
     - Cannot reassign ownership of objects that are required by the database system.
     - Mutually exclusive with C(obj_type).
@@ -161,7 +161,7 @@ class PgOwnership(object):
 
     Arguments:
         module (AnsibleModule): Object of Ansible module class.
-        cursor (psycopg2.connect.cursor): Cursor object for interraction with the database.
+        cursor (psycopg2.connect.cursor): Cursor object for interaction with the database.
         role (str): Role name to set as a new owner of objects.
 
     Important:
@@ -367,7 +367,7 @@ class PgOwnership(object):
         self.changed = exec_sql(self, query, ddl=True)
 
     def __role_exists(self, role):
-        """Return True if role exists, otherwise return Fasle."""
+        """Return True if role exists, otherwise return False."""
         return exec_sql(self, "SELECT 1 FROM pg_roles WHERE rolname = '%s'" % role, add_to_executed=False)
 
 

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -264,8 +264,8 @@ class PgHba(object):
         self.databases = set(['postgres', 'template0', 'template1'])
 
         # self.databases will be update by add_rule and gives some idea of the number of users
-        # (at least that are handled by this pg_hba) since this migth also be groups with multiple
-        # users, this migth be totally off, but at least it is some info...
+        # (at least that are handled by this pg_hba) since this might also be groups with multiple
+        # users, this might be totally off, but at least it is some info...
         self.users = set(['postgres'])
 
         self.read()
@@ -421,7 +421,7 @@ class PgHbaRule(dict):
         super(PgHbaRule, self).__init__()
 
         if line:
-            # Read valies from line if parsed
+            # Read values from line if parsed
             self.fromline(line)
 
         # read rule cols from parsed items
@@ -525,7 +525,7 @@ class PgHbaRule(dict):
                 raise PgHbaValueError('Mask was specified, but source "{0}" '
                                       'is no valid ip'.format(self['src']))
             # ipaddress module cannot work with ipv6 netmask, so lets convert it to prefixlen
-            # furthermore ipv4 with bad netmask throws 'Rule {} doesnt seem to be an ip, but has a
+            # furthermore ipv4 with bad netmask throws 'Rule {} doesn't seem to be an ip, but has a
             # mask error that doesn't seem to describe what is going on.
             try:
                 mask_as_ip = ipaddress.ip_address(u'{0}'.format(self['mask']))
@@ -614,10 +614,10 @@ class PgHbaRule(dict):
                 # For now, let's assume IPv4/24 or IPv6/96 (both have weight 96).
                 return 96
             if sourceobj[0] == '.':
-                # suffix matching (domain name), let's asume a very large scale
+                # suffix matching (domain name), let's assume a very large scale
                 # and therefore a very low weight IPv4/16 or IPv6/64 (both have weight 64).
                 return 64
-            # hostname, let's asume only one host matches, which is
+            # hostname, let's assume only one host matches, which is
             # IPv4/32 or IPv6/128 (both have weight 128)
             return 128
         raise PgHbaValueError('Cannot deduct the source weight of this source {1}'.format(sourceobj))

--- a/lib/ansible/modules/database/postgresql/postgresql_sequence.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_sequence.py
@@ -41,7 +41,7 @@ options:
     - Specifies the data type of the sequence. Valid types are bigint, integer,
       and smallint. bigint is the default. The data type determines the default
       minimum and maximum values of the sequence. For more info see the
-      documention
+      documentation
       U(https://www.postgresql.org/docs/current/sql-createsequence.html).
     - Supported from PostgreSQL 10.
     choices: [ bigint, integer, smallint ]
@@ -312,11 +312,11 @@ class Sequence(object):
 
     Arguments:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor objec of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg2 library
 
     Attributes:
         module (AnsibleModule) -- object of AnsibleModule class
-        cursor (cursor) -- cursor objec of psycopg2 library
+        cursor (cursor) -- cursor object of psycopg2 library
         changed (bool) --  something was changed after execution or not
         executed_queries (list) -- executed queries
         name (str) -- name of the sequence

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -104,7 +104,7 @@ EXAMPLES = r'''
 - debug:
     msg: "{{ set.name }} {{ set.prev_val_pretty }} >> {{ set.value_pretty }} restart_req: {{ set.restart_required }}"
   when: set.changed
-# Ensure that the restart of PostgreSQL serever must be required for some parameters.
+# Ensure that the restart of PostgreSQL server must be required for some parameters.
 # In this situation you see the same parameter in prev_val and value_prettyue, but 'changed=True'
 # (If you passed the value that was different from the current server setting).
 

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -107,7 +107,7 @@ EXAMPLES = r'''
     db: ansible
     state: absent
 
-- name: Create logical_one logical slot to the database acme if doen't exist
+- name: Create logical_one logical slot to the database acme if doesn't exist
   postgresql_slot:
     name: logical_slot_one
     slot_type: logical


### PR DESCRIPTION
(cherry picked from commit 8b24fe1f0a30a388175c11909cd9021dd580e257)

##### SUMMARY
backport of #62065: postgresql: fix typos in modules

##### ISSUE TYPE
- Docs Pull Request