### PR TITLE
Fix for junos cli_config replace option

### DIFF
--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -135,7 +135,7 @@ class Cliconf(CliconfBase):
         else:
             self.send_command('top')
             self.discard_changes()
-            self.send_command('exit')
+
         resp['request'] = requests
         resp['response'] = results
         return resp

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -109,7 +109,7 @@ class Cliconf(CliconfBase):
         requests = []
 
         if replace:
-            candidate = 'load replace {0}'.format(replace)
+            candidate = 'load override {0}'.format(replace)
 
         for line in to_list(candidate):
             if not isinstance(line, Mapping):
@@ -133,9 +133,9 @@ class Cliconf(CliconfBase):
                 self.discard_changes()
 
         else:
-            for cmd in ['top', 'exit']:
-                self.send_command(cmd)
-
+            self.send_command('top')
+            self.discard_changes()
+            self.send_command('exit')
         resp['request'] = requests
         resp['response'] = results
         return resp
@@ -193,7 +193,7 @@ class Cliconf(CliconfBase):
         resp = self.send_command(command)
 
         r = resp.splitlines()
-        if len(r) == 1 and '[edit]' in r[0]:
+        if len(r) == 1 and '[edit]' in r[0] or len(r) == 4 and r[1].startswith('- version'):
             resp = ''
 
         return resp

--- a/test/integration/targets/junos_config/tests/cli_config/cli_replace.yaml
+++ b/test/integration/targets/junos_config/tests/cli_config/cli_replace.yaml
@@ -1,0 +1,60 @@
+---
+- debug: msg="START cli_config/cli_replace.yaml on connection={{ ansible_connection }}"
+
+- name: set interface config
+  cli_config:
+    config: "{{ item }}"
+  loop:
+    - "delete interfaces ge-0/0/11"
+    - set interfaces ge-0/0/11 description "test cli_config"
+
+- name: get running configuration
+  cli_command:
+    command: show configuration
+  register: result
+
+- name: copy configuration to file
+  copy:
+    content: "{{ result['stdout'] }}"
+    dest: /tmp/junos01.cfg
+
+- name: "modify interface ge-0/0/11 configuration"
+  replace:
+    path: /tmp/junos01.cfg
+    regexp: 'test cli_config'
+    replace: 'test cli_config replaced'
+
+- name: copy config file to remote host
+  net_put:
+    src: /tmp/junos01.cfg
+    dest: /var/home/{{ ansible_user }}/junos01.cfg
+
+- name: replace syslog test file configuration
+  cli_config:
+    replace: "/var/home/{{ ansible_user }}/junos01.cfg"
+
+- name: get interface configuration
+  cli_command:
+    command: show configuration interfaces ge-0/0/11
+  register: result
+
+- name: assert that interface config change is reflected on device
+  assert:
+    that:
+      - "'test cli_config replaced' in  result.stdout"
+
+- name: replace interface configuration (idempotent)
+  cli_config:
+    replace: "/var/home/{{ ansible_user }}/junos01.cfg"
+  register: result
+
+- name: Assert that the previous task was idempotent
+  assert:
+    that:
+      - "result['changed'] == false"
+
+- name: delete interface config
+  cli_config:
+    config: "delete interfaces ge-0/0/11"
+
+- debug: msg="END cli_config/cli_replace.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  For device that support replace option by loading
   configuration from a file on device `config` option
   is not required and value of `replace` option is the
   path of the configuration file on the device. This fix allows
   invoking run() function in cli_config if `config` option
   is None and `replace` option is not boolean

*  The command to replace running-config on junos device
   is `load override <filename>` and not `load replace <filename>`
   This is fixed in the junos cliconf plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli_config
ansible/plugins/cliconf/junos.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
