### PR TITLE
[stable-2.9] bump hcloud version to 1.4.1 (#62097)

### DIFF
--- a/test/lib/ansible_test/_data/requirements/integration.cloud.hcloud.txt
+++ b/test/lib/ansible_test/_data/requirements/integration.cloud.hcloud.txt
@@ -1,1 +1,1 @@
-hcloud>=1.3.0 ; python_version >= '2.7' # Python 2.6 is not supported (sanity_ok); Only hcloud >= 1.3.0 supports Networks.
+hcloud>=1.4.1 ; python_version >= '2.7' # Python 2.6 is not supported (sanity_ok); Only hcloud >= 1.3.0 supports Networks; hcloud >= 1.4.1 is needed to allow a wider range of requests versions to be used


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] bump hcloud version to 1.4.1 (#62097)

* bump hcloud version to 1.4.1

`hcloud`<=1.4.0 has requirement `requests==2.20.0`. This prevents the
installation of the Vcenter Automation SDK which depends on `requests>=2.22.0`.

`hcloud` 1.4.1 does not have the problem: https://github.com/hetznercloud/hcloud-python/commit/8bff356efb17f45458519f73beab5d8b41a79b8e
Bumping the dependency will resolve the issue.

Backport of https://github.com/ansible/ansible/pull/62097

(cherry picked from commit 0f52b18)

Co-authored-by: Gonéri Le Bouder <goneri@lebouder.net>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
