### PR TITLE
Don't treat no checksum as a checksum match

### DIFF
--- a/changelogs/fragments/61978-get-url-no-checksum.yml
+++ b/changelogs/fragments/61978-get-url-no-checksum.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- get_url - Don't treat no checksum as a checksum match
+  (https://github.com/ansible/ansible/issues/61978)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -540,7 +540,7 @@ def main():
                 checksum_mismatch = True
 
         # Not forcing redownload, unless checksum does not match
-        if not force and not checksum_mismatch:
+        if not force and checksum and not checksum_mismatch:
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
             module.params['path'] = dest

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -257,17 +257,6 @@
       - result is changed
       - "stat_result.stat.mode == '0775'"
 
-- name: Get a file that already exists
-  get_url:
-    url: 'https://{{ httpbin_host }}/get'
-    dest: '{{ remote_tmp_dir }}/test'
-  register: result
-
-- name: Assert that we didn't re-download unnecessarily
-  assert:
-    that:
-      - result is not changed
-
 - name: test checksum match in check mode
   get_url:
     url: 'https://{{ httpbin_host }}/get'
@@ -280,6 +269,41 @@
   assert:
     that:
       - result is not changed
+
+- name: Get a file that already exists with a checksum
+  get_url:
+    url: 'https://{{ httpbin_host }}/cache'
+    dest: '{{ remote_tmp_dir }}/test'
+    checksum: 'sha1:{{ stat_result.stat.checksum }}'
+  register: result
+
+- name: Assert that the file was not downloaded
+  assert:
+    that:
+      - result.msg == 'file already exists'
+
+- name: Get a file that already exists
+  get_url:
+    url: 'https://{{ httpbin_host }}/cache'
+    dest: '{{ remote_tmp_dir }}/test'
+  register: result
+
+- name: Assert that we didn't re-download unnecessarily
+  assert:
+    that:
+      - result is not changed
+      - "'304' in result.msg"
+
+- name: get a file that doesn't respond to If-Modified-Since without checksum
+  get_url:
+    url: 'https://{{ httpbin_host }}/get'
+    dest: '{{ remote_tmp_dir }}/test'
+  register: result
+
+- name: Assert that we downloaded the file
+  assert:
+    that:
+      - result is changed
 
 # https://github.com/ansible/ansible/issues/27617
 


### PR DESCRIPTION
##### SUMMARY
Don't treat no checksum as a checksum match. Fixes #61978

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/net_tools/basics/get_url.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```