### PR TITLE
Handle AIX in the at module as it needs different command line parameters

### DIFF
--- a/changelogs/fragments/62154-at-aix.yml
+++ b/changelogs/fragments/62154-at-aix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - at - make module work for AIX

--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -123,7 +123,6 @@ def get_matching_jobs(module, at_cmd, script_file):
     #   If the script text is contained in a job add job number to list.
     for current_job in current_jobs:
         split_current_job = current_job.split()
-
         if get_platform() != 'AIX':
             at_command = "%s -c %s" % (at_cmd, split_current_job[0])
         else:

--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -92,10 +92,10 @@ def add_job(module, result, at_cmd, count, units, command, script_file):
 
 def delete_job(module, result, at_cmd, command, script_file):
     for matching_job in get_matching_jobs(module, at_cmd, script_file):
-        if get_platform() != 'AIX':
-            at_command = "%s -d %s" % (at_cmd, matching_job)
-        else:
+        if get_platform() == 'AIX':
             at_command = "%s -r %s" % (at_cmd, matching_job)
+        else:
+            at_command = "%s -d %s" % (at_cmd, matching_job)
         rc, out, err = module.run_command(at_command, check_rc=True)
         result['changed'] = True
     if command:
@@ -123,10 +123,11 @@ def get_matching_jobs(module, at_cmd, script_file):
     #   If the script text is contained in a job add job number to list.
     for current_job in current_jobs:
         split_current_job = current_job.split()
-        if get_platform() != 'AIX':
-            at_command = "%s -c %s" % (at_cmd, split_current_job[0])
-        else:
+
+        if get_platform() == 'AIX':
             at_command = "%s -lv %s" % (at_cmd, split_current_job[0])
+        else:
+            at_command = "%s -c %s" % (at_cmd, split_current_job[0])
         rc, out, err = module.run_command(at_command, check_rc=True)
         if script_file_string in out:
             matching_jobs.append(split_current_job[0])

--- a/lib/ansible/modules/system/at.py
+++ b/lib/ansible/modules/system/at.py
@@ -123,7 +123,6 @@ def get_matching_jobs(module, at_cmd, script_file):
     #   If the script text is contained in a job add job number to list.
     for current_job in current_jobs:
         split_current_job = current_job.split()
-
         if get_platform() == 'AIX':
             at_command = "%s -lv %s" % (at_cmd, split_current_job[0])
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #62153
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
at

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The AIX at command uses different arguments than other operating systems. Matching and deleting a job doesn't work, as there is no special case code to handle this in the module.

This modification handles the AIX special case without affecting any other operating systems.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
