### PR TITLE
Added hostname option in gcp_compute inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -233,7 +233,7 @@ class GcpInstance(object):
             elif order == "name":
                 name = self.json[u"name"]
             elif order == "hostname":
-                name = self.json[u"name"] if u"hostname" in self.json else self.json[u"name"]
+                name = self.json[u"hostname"] if u"hostname" in self.json else self.json[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -41,8 +41,8 @@ DOCUMENTATION = """
         hostnames:
           description: A list of options that describe the ordering for which
               hostnames should be assigned. Currently supported hostnames are
-              'public_ip', 'private_ip', or 'name'.
-          default: ['public_ip', 'private_ip', 'name']
+              'public_ip', 'private_ip', 'name', or 'hostname'.
+          default: ['public_ip', 'private_ip', 'name', 'hostname']
           type: list
         auth_kind:
             description:
@@ -232,6 +232,8 @@ class GcpInstance(object):
                 name = self._get_privateip()
             elif order == "name":
                 name = self.json[u"name"]
+            elif order == "hostname":
+                name = item[u"hostname"] if u"hostname" in item else item[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 
@@ -411,7 +413,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not items:
             return
 
-        hostname_ordering = ["public_ip", "private_ip", "name"]
+        hostname_ordering = ["public_ip", "private_ip", "name", "hostname"]
         if self.get_option("hostnames"):
             hostname_ordering = self.get_option("hostnames")
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -233,7 +233,7 @@ class GcpInstance(object):
             elif order == "name":
                 name = self.json[u"name"]
             elif order == "hostname":
-                name = item[u"hostname"] if u"hostname" in item else item[u"name"]
+                name = self.json[u"name"] if u"hostname" in self.json else self.json[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -226,16 +226,25 @@ class GcpInstance(object):
         """
         for order in self.hostname_ordering:
             name = None
-            if order == "public_ip":
-                name = self._get_publicip()
-            elif order == "private_ip":
-                name = self._get_privateip()
-            elif order == "name":
-                name = self.json[u"name"]
-            elif order == "hostname":
-                name = self.json[u"hostname"] if u"hostname" in self.json else self.json[u"name"]
-            else:
-                raise AnsibleParserError("%s is not a valid hostname precedent" % order)
+            switch (order) {
+                case "public_ip":
+                    name = self._get_publicip()
+                    break
+                case "private_ip":
+                    name = self._get_privateip()
+                    break
+                case "name":
+                    name = self.json[u"name"]
+                    break
+                case "hostname":
+                    if u"hostname" in self.json
+                        name = self.json[u"hostname"]
+                     else
+                        self.json[u"name"]
+                    break
+                default:
+                    raise AnsibleParserError("%s is not a valid hostname precedent" % order)
+            }
 
             if name:
                 return name

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -234,9 +234,9 @@ class GcpInstance(object):
                 name = self.json[u"name"]
             elif order == "hostname":
                 if u"hostname" in self.json:
-                  name = self.json[u"hostname"]
+                    name = self.json[u"hostname"]
                 else:
-                  self.json[u"name"]
+                    self.json[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -226,25 +226,19 @@ class GcpInstance(object):
         """
         for order in self.hostname_ordering:
             name = None
-            switch (order) {
-                case "public_ip":
-                    name = self._get_publicip()
-                    break
-                case "private_ip":
-                    name = self._get_privateip()
-                    break
-                case "name":
-                    name = self.json[u"name"]
-                    break
-                case "hostname":
-                    if u"hostname" in self.json
-                        name = self.json[u"hostname"]
-                     else
-                        self.json[u"name"]
-                    break
-                default:
-                    raise AnsibleParserError("%s is not a valid hostname precedent" % order)
-            }
+            if order == "public_ip":
+                name = self._get_publicip()
+            elif order == "private_ip":
+                name = self._get_privateip()
+            elif order == "name":
+                name = self.json[u"name"]
+            elif order == "hostname":
+                if u"hostname" in self.json
+                    name = self.json[u"hostname"]
+                 else
+                    self.json[u"name"]
+            else:
+                raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 
             if name:
                 return name

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -233,10 +233,10 @@ class GcpInstance(object):
             elif order == "name":
                 name = self.json[u"name"]
             elif order == "hostname":
-                if u"hostname" in self.json
-                    name = self.json[u"hostname"]
-                 else
-                    self.json[u"name"]
+                if u"hostname" in self.json:
+                  name = self.json[u"hostname"]
+                else:
+                  self.json[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/lib/ansible/plugins/inventory/gcp_compute.py
+++ b/lib/ansible/plugins/inventory/gcp_compute.py
@@ -236,7 +236,7 @@ class GcpInstance(object):
                 if u"hostname" in self.json:
                     name = self.json[u"hostname"]
                 else:
-                    self.json[u"name"]
+                    name = self.json[u"name"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 


### PR DESCRIPTION
##### SUMMARY
In our environment we sometimes have the same server name in multiple projects. In order to connect internally to servers we must use either the hostname or private ip of the machine. The hostname is much more visually identifiable.

Currently the GCP inventory plugin only supports using public_ip, private_ip or name (servername) as the hostname for inventory. This PR adds the option to use the server hostname so Ansible will display and connect to machines using their hostname.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gcp_compute

##### ADDITIONAL INFORMATION
Although the private_ip option for hostname would work in our scenario, it's hard to identify which machine each ip refers to. By using the hostname, our internal DNS can route ansible to the appropriate internal ip address while still displaying an easily identifiable name.
