### PR TITLE
Set get_aws_connection_info to be aws creds compatible

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -278,8 +278,12 @@ def get_aws_connection_info(module, boto3=False):
             security_token = os.environ['AWS_SESSION_TOKEN']
         elif os.environ.get('EC2_SECURITY_TOKEN'):
             security_token = os.environ['EC2_SECURITY_TOKEN']
+        elif HAS_BOTO and boto.config.get('Credentials', 'aws_session_token'):
+            security_token = boto.config.get('Credentials', 'aws_session_token')
         elif HAS_BOTO and boto.config.get('Credentials', 'aws_security_token'):
             security_token = boto.config.get('Credentials', 'aws_security_token')
+        elif HAS_BOTO and boto.config.get('default', 'aws_session_token'):
+            security_token = boto.config.get('default', 'aws_session_token')
         elif HAS_BOTO and boto.config.get('default', 'aws_security_token'):
             security_token = boto.config.get('default', 'aws_security_token')
         else:


### PR DESCRIPTION
##### SUMMARY
ansible was incorrectly ignoring `aws_session_token` from the ~/.aws/credentials file

This patch properly picks up `aws_session_token` before the deprecated
`aws_security_token`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils.ec2.get_aws_connection_info()

##### ADDITIONAL INFORMATION
The session token is used when you are using temporary credentials from AWS. The temporary credentials use three fields instead of the two used by normal aws keys:
* aws_access_key_id
* aws_secret_access_key
* aws_session_token

As some additional background, aws_session_token was originally named aws_security_token. Joy.

Ansible currently correctly supports both aws_session_token, and aws_security_token in environment variables, it also correctly supports aws_security_token (deprecated) in the .aws/credentials file. 
This patch will extend support to also include the new(er) aws_session_token in .aws/credentials file.

In order to reproduce you can request a temporary key from sts, then insert them into your .aws/credentials with the new(er) name of aws_session_token. Then try to create a load balancer with ansible. Ansible will return a 401 from amazon


pre-patch:
```
PLAY [local] *************************************************************************

TASK [create app security group] *****************************************************
 [WARNING]: Platform linux on host localhost is using the discovered Python
interpreter at /usr/bin/python3.5, but future installation of another Python
interpreter could change this. See
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html
for more information.

changed: [localhost]

TASK [launch load balancer] **********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: </ErrorResponse>
fatal: [localhost]: FAILED! => {"changed": false, "msg": "unable to get all load balancers: The security token included in the request is invalid."}

PLAY RECAP ***************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

post-patch:
```
TASK [create app security group] *****************************************************
 [WARNING]: Platform linux on host localhost is using the discovered Python
interpreter at /usr/bin/python3.5, but future installation of another Python
interpreter could change this. See
https://docs.ansible.com/ansible/2.8/reference_appendices/interpreter_discovery.html
for more information.

changed: [localhost]

TASK [launch load balancer] **********************************************************
changed: [localhost]

TASK [create launch config] **********************************************************
[DEPRECATION WARNING]: device_type is deprecated for block devices - use volume_type 
instead. This feature will be removed in version 2.9. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [localhost]

TASK [create autoscale groups] *******************************************************
changed: [localhost]

TASK [create scale down  policy] *****************************************************
changed: [localhost]

TASK [create scale up policy] ********************************************************
changed: [localhost]

TASK [create scale down alarm] *******************************************************
changed: [localhost]

TASK [create scale up alarm] *********************************************************
changed: [localhost]

PLAY RECAP ***************************************************************************
localhost                  : ok=8    changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
