### PR TITLE
VMware: Change return key `results` from VMware modules

### DIFF
--- a/changelogs/fragments/62083-vmware-internal_results.yml
+++ b/changelogs/fragments/62083-vmware-internal_results.yml
@@ -1,0 +1,6 @@
+minor_changes:
+    - vmware_datastore_maintenancemode now returns datastore_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_kernel_manager now returns host_kernel_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_ntp now returns host_ntp_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_host_service_manager now returns host_service_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).
+    - vmware_tag now returns tag_status instead of Ansible internal key results (https://github.com/ansible/ansible/issues/62083).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -57,7 +57,11 @@ No notable changes
 Noteworthy module changes
 -------------------------
 
-No notable changes
+* :ref:`vmware_datastore_maintenancemode <vmware_datastore_maintenancemode_module>` now returns ``datastore_status`` instead of Ansible internal key ``results``.
+* :ref:`vmware_host_kernel_manager <vmware_host_kernel_manager_module>` now returns ``host_kernel_status`` instead of Ansible internal key ``results``.
+* :ref:`vmware_host_ntp <vmware_host_ntp_module>` now returns ``host_ntp_status`` instead of Ansible internal key ``results``.
+* :ref:`vmware_host_service_manager <vmware_host_service_manager_module>` now returns ``host_service_status`` instead of Ansible internal key ``results``.
+* :ref:`vmware_tag <vmware_tag_module>` now returns ``tag_status`` instead of Ansible internal key ``results``.
 
 
 Plugins

--- a/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
@@ -98,11 +98,13 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-results:
+datastore_status:
     description: Action taken for datastore
     returned: always
     type: dict
-    sample:
+    sample: {
+        "ds_226_01": "Datastore 'ds_226_01' is already in maintenance mode."
+    }
 '''
 
 try:
@@ -189,7 +191,7 @@ class VmwareDatastoreMaintenanceMgr(PyVmomi):
         changed = False
         if any(change_datastore_list):
             changed = True
-        self.module.exit_json(changed=changed, results=datastore_results)
+        self.module.exit_json(changed=changed, datastore_status=datastore_results)
 
 
 def main():

--- a/lib/ansible/modules/cloud/vmware/vmware_host_kernel_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_kernel_manager.py
@@ -77,7 +77,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-results:
+host_kernel_status:
     description:
     - dict with information on what was changed, by ESXi host in scope.
     returned: success
@@ -183,7 +183,7 @@ class VmwareKernelManager(PyVmomi):
                 self.results[host.name]['changed'] = changed
                 self.results[host.name]['msg'] = msg
 
-        self.module.exit_json(changed=any(change_list), results=self.results)
+        self.module.exit_json(changed=any(change_list), host_kernel_status=self.results)
 
 
 def main():

--- a/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
@@ -115,7 +115,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-results:
+host_ntp_status:
     description: metadata about host system's NTP configuration
     returned: always
     type: dict
@@ -256,7 +256,7 @@ class VmwareNtpConfigManager(PyVmomi):
 
         if any(change_list):
             changed = True
-        self.module.exit_json(changed=changed, results=self.results)
+        self.module.exit_json(changed=changed, host_ntp_status=self.results)
 
     def check_ntp_servers(self, host):
         """Check configured NTP servers"""

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
@@ -182,7 +182,7 @@ class VmwareServiceManager(PyVmomi):
 
         if any(host_service_state):
             changed = True
-        self.module.exit_json(changed=changed, results=self.results)
+        self.module.exit_json(changed=changed, host_service_status=self.results)
 
     def check_service_state(self, host, service_name):
         host_service_system = host.configManager.serviceSystem

--- a/lib/ansible/modules/cloud/vmware/vmware_tag.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag.py
@@ -99,7 +99,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-results:
+tag_status:
   description: dictionary of tag metadata
   returned: on success
   type: dict
@@ -176,10 +176,9 @@ class VmwareTag(VmwareRestClient):
 
         if tag_id:
             self.module.exit_json(changed=True,
-                                  results=dict(msg="Tag '%s' created." % tag_spec.name,
-                                               tag_id=tag_id))
+                                  tag_status=dict(msg="Tag '%s' created." % tag_spec.name, tag_id=tag_id))
         self.module.exit_json(changed=False,
-                              results=dict(msg="No tag created", tag_id=tag_id))
+                              tag_status=dict(msg="No tag created", tag_id=tag_id))
 
     def state_unchanged(self):
         """
@@ -210,7 +209,7 @@ class VmwareTag(VmwareRestClient):
             results['msg'] = 'Tag %s updated.' % self.tag_name
             changed = True
 
-        self.module.exit_json(changed=changed, results=results)
+        self.module.exit_json(changed=changed, tag_status=results)
 
     def state_delete_tag(self):
         """
@@ -223,8 +222,7 @@ class VmwareTag(VmwareRestClient):
         except Error as error:
             self.module.fail_json(msg="%s" % self.get_error_message(error))
         self.module.exit_json(changed=True,
-                              results=dict(msg="Tag '%s' deleted." % self.tag_name,
-                                           tag_id=tag_id))
+                              tag_status=dict(msg="Tag '%s' deleted." % self.tag_name, tag_id=tag_id))
 
     def check_tag_status(self):
         """


### PR DESCRIPTION

##### SUMMARY
Following modules used internal results key as part of return json, this commit
changes this to appropriate values -
* vmware_datastore_maintenancemode.py
* vmware_host_kernel_manager.py
* vmware_host_ntp.py
* vmware_host_service_manager.py
* vmware_tag.py

Fixes: #62083

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/62083-vmware-internal_results.yml
docs/docsite/rst/porting_guides/porting_guide_2.10.rst
lib/ansible/modules/cloud/vmware/vmware_datastore_maintenancemode.py
lib/ansible/modules/cloud/vmware/vmware_host_kernel_manager.py
lib/ansible/modules/cloud/vmware/vmware_host_ntp.py
lib/ansible/modules/cloud/vmware/vmware_host_service_manager.py
lib/ansible/modules/cloud/vmware/vmware_tag.py