### PR TITLE
Add option to allow creating protected containers in proxmox.

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -141,6 +141,12 @@ options:
       - Indicate if the container should be unprivileged
     type: bool
     default: 'no'
+protection:
+    version_added: "devel"
+    description:
+      - Indicate if the container should be protected
+    type: bool
+    default: 'no'
 
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
@@ -447,7 +453,8 @@ def main():
             force=dict(type='bool', default='no'),
             state=dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
             pubkey=dict(type='str', default=None),
-            unprivileged=dict(type='bool', default='no')
+            unprivileged=dict(type='bool', default='no'),
+            protection=dict(type='bool', default='no')
         )
     )
 
@@ -470,6 +477,7 @@ def main():
     if module.params['ostemplate'] is not None:
         template_store = module.params['ostemplate'].split(":")[0]
     timeout = module.params['timeout']
+    protection = module.params['protection']
 
     # If password not set get it from PROXMOX_PASSWORD env
     if not api_password:
@@ -528,7 +536,8 @@ def main():
                             searchdomain=module.params['searchdomain'],
                             force=int(module.params['force']),
                             pubkey=module.params['pubkey'],
-                            unprivileged=int(module.params['unprivileged']))
+                            unprivileged=int(module.params['unprivileged'],
+                            protection=int(module.params['protection'])))
 
             module.exit_json(changed=True, msg="deployed VM %s from template %s" % (vmid, module.params['ostemplate']))
         except Exception as e:

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -141,7 +141,7 @@ options:
       - Indicate if the container should be unprivileged
     type: bool
     default: 'no'
-protection:
+  protection:
     version_added: "devel"
     description:
       - Indicate if the container should be protected


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add the possibility to create a container in with protection enabled in proxmox.
Default is kept `false` as it is currently.
This PR adds the argument `protection` which is passed to the proxmox api.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
