### PR TITLE
crypto modules: improve documentation of list options

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_account.py
+++ b/lib/ansible/modules/crypto/acme/acme_account.py
@@ -69,6 +69,7 @@ options:
       - "Must be specified when state is C(present). Will be ignored
          if state is C(absent) or C(changed_key)."
     type: list
+    elements: str
     default: []
   terms_agreed:
     description:

--- a/lib/ansible/modules/crypto/certificate_complete_chain.py
+++ b/lib/ansible/modules/crypto/certificate_complete_chain.py
@@ -49,6 +49,7 @@ options:
                certificates in PEM format."
             - "Symbolic links will be followed."
         type: list
+        elements: path
         required: yes
     intermediate_certificates:
         description:
@@ -61,6 +62,7 @@ options:
                certificates in PEM format."
             - "Symbolic links will be followed."
         type: list
+        elements: path
         default: []
 '''
 

--- a/lib/ansible/modules/crypto/entrust/ecs_certificate.py
+++ b/lib/ansible/modules/crypto/entrust/ecs_certificate.py
@@ -127,6 +127,7 @@ options:
             - In the case of certificates of type C(STANDARD_SSL) certificates, if the CN of the certificate is <domain>.<tld> only the www.<domain>.<tld> value
               is accepted. If the CN of the certificate is www.<domain>.<tld> only the <domain>.<tld> value is accepted.
         type: list
+        elements: str
     eku:
         description:
             - If specified, overrides the key usage in the I(csr).
@@ -166,6 +167,7 @@ options:
               parameter can be used to force failure if an unapproved organizational unit is provided.
             - A maximum of one OU may be specified for current products. Multiple OUs are reserved for future products.
         type: list
+        elements: str
     end_user_key_storage_agreement:
         description:
             - The end user of the Code Signing certificate must generate and store the private key for this request on cryptographically secure
@@ -192,6 +194,7 @@ options:
     additional_emails:
         description: A list of additional email addresses to receive the delivery notice and expiry notification for the certificate.
         type: list
+        elements: str
     custom_fields:
         description:
             - Mapping of custom fields to associate with the certificate request and certificate.

--- a/lib/ansible/modules/crypto/openssh_cert.py
+++ b/lib/ansible/modules/crypto/openssh_cert.py
@@ -84,6 +84,7 @@ options:
             - "Certificates may be limited to be valid for a set of principal (user/host) names.
               By default, generated certificates are valid for all users or hosts."
         type: list
+        elements: str
     options:
         description:
             - "Specify certificate options when signing a key. The option that are valid for user certificates are:"
@@ -104,6 +105,7 @@ options:
                The C(address_list) is a comma-separated list of one or more address/netmask pairs in CIDR format."
             - "At present, no options are valid for host keys."
         type: list
+        elements: str
     identifier:
         description:
             - Specify the key identity when signing a public key. The identifier that is logged by the server when the certificate is used for authentication.
@@ -534,8 +536,8 @@ def main():
             valid_from=dict(type='str'),
             valid_to=dict(type='str'),
             valid_at=dict(type='str'),
-            principals=dict(type='list'),
-            options=dict(type='list'),
+            principals=dict(type='list', elements='str'),
+            options=dict(type='list', elements='str'),
         ),
         supports_check_mode=True,
         add_file_common_args=True,

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -277,6 +277,7 @@ options:
             - This option is deprecated since Ansible 2.9 and will be removed with the C(assertonly) provider in Ansible 2.13.
               For alternatives, see the example on replacing C(assertonly).
         type: list
+        elements: str
 
     issuer:
         description:
@@ -390,6 +391,7 @@ options:
             - This option is deprecated since Ansible 2.9 and will be removed with the C(assertonly) provider in Ansible 2.13.
               For alternatives, see the example on replacing C(assertonly).
         type: list
+        elements: str
         aliases: [ keyUsage ]
 
     key_usage_strict:
@@ -409,6 +411,7 @@ options:
             - This option is deprecated since Ansible 2.9 and will be removed with the C(assertonly) provider in Ansible 2.13.
               For alternatives, see the example on replacing C(assertonly).
         type: list
+        elements: str
         aliases: [ extendedKeyUsage ]
 
     extended_key_usage_strict:
@@ -428,6 +431,7 @@ options:
             - This option is deprecated since Ansible 2.9 and will be removed with the C(assertonly) provider in Ansible 2.13.
               For alternatives, see the example on replacing C(assertonly).
         type: list
+        elements: str
         aliases: [ subjectAltName ]
 
     subject_alt_name_strict:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -122,6 +122,7 @@ options:
               set to I(false).
             - More at U(https://tools.ietf.org/html/rfc5280#section-4.2.1.6).
         type: list
+        elements: str
         aliases: [ subjectAltName ]
     subject_alt_name_critical:
         description:
@@ -141,6 +142,7 @@ options:
             - This defines the purpose (e.g. encipherment, signature, certificate signing)
               of the key contained in the certificate.
         type: list
+        elements: str
         aliases: [ keyUsage ]
     key_usage_critical:
         description:
@@ -152,6 +154,7 @@ options:
             - Additional restrictions (e.g. client authentication, server authentication)
               on the allowed purposes for which the public key may be used.
         type: list
+        elements: str
         aliases: [ extKeyUsage, extendedKeyUsage ]
     extended_key_usage_critical:
         description:
@@ -162,6 +165,7 @@ options:
         description:
             - Indicates basic constraints, such as if the certificate is a CA.
         type: list
+        elements: str
         version_added: '2.5'
         aliases: [ basicConstraints ]
     basic_constraints_critical:
@@ -254,6 +258,7 @@ options:
             - The C(AuthorityKeyIdentifier) will only be added if at least one of I(authority_key_identifier),
               I(authority_cert_issuer) and I(authority_cert_serial_number) is specified.
         type: list
+        elements: str
         version_added: "2.9"
     authority_cert_serial_number:
         description:

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -33,6 +33,7 @@ options:
         description:
             - List of other certificates to include. Pre 2.8 this parameter was called C(ca_certificates)
         type: list
+        elements: path
         aliases: [ ca_certificates ]
     certificate_path:
         description:


### PR DESCRIPTION
##### SUMMARY
Since #59244 was merged, list options can be documented better. This PR adds the new feature to all crypto modules.

I've also added this for return data, even though it's not supported yet.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_account
acme_account_info
acme_certificate
certificate_complete_chain
ecs_certificate
get_certificate
openssh_cert
openssl_certificate
openssl_certificate_info
openssl_csr
openssl_csr_info
openssl_pkcs12
