### PR TITLE
docker modules: improve documentation of list options

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -47,6 +47,7 @@ options:
       - List of Compose file names relative to I(project_src). Overrides C(docker-compose.yml) or C(docker-compose.yaml).
       - Files are loaded and merged in the order given.
     type: list
+    elements: path
   state:
     description:
       - Desired state of the project.
@@ -64,6 +65,7 @@ options:
         on a subset of services.
       - If empty, which is the default, the operation will be performed on all services defined in the Compose file (or inline I(definition)).
     type: list
+    elements: str
   scale:
     description:
       - When I(state) is C(present) scale services. Provide a dictionary of key/value pairs where the key

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -39,10 +39,12 @@ options:
     description:
       - List of capabilities to add to the container.
     type: list
+    elements: str
   cap_drop:
     description:
       - List of capabilities to drop from the container.
     type: list
+    elements: str
     version_added: "2.7"
   cleanup:
     description:
@@ -108,10 +110,12 @@ options:
       - "List of host device bindings to add to the container. Each binding is a mapping expressed
         in the format: <path_on_host>:<path_in_container>:<cgroup_permissions>"
     type: list
+    elements: str
   device_read_bps:
     description:
       - "List of device path and read rate (bytes per second) from device."
     type: list
+    elements: dict
     suboptions:
       path:
         description:
@@ -131,6 +135,7 @@ options:
     description:
       - "List of device and write rate (bytes per second) to device."
     type: list
+    elements: dict
     suboptions:
       path:
         description:
@@ -150,6 +155,7 @@ options:
     description:
       - "List of device and read rate (IO per second) from device."
     type: list
+    elements: dict
     suboptions:
       path:
         description:
@@ -167,6 +173,7 @@ options:
     description:
       - "List of device and write rate (IO per second) to device."
     type: list
+    elements: dict
     suboptions:
       path:
         description:
@@ -184,14 +191,17 @@ options:
     description:
       - list of DNS options
     type: list
+    elements: str
   dns_servers:
     description:
       - List of custom DNS servers.
     type: list
+    elements: str
   dns_search_domains:
     description:
       - List of custom DNS search domains.
     type: list
+    elements: str
   domainname:
     description:
       - Container domainname.
@@ -212,6 +222,7 @@ options:
     description:
       - Command that overwrites the default ENTRYPOINT of the image.
     type: list
+    elements: str
   etc_hosts:
     description:
       - Dict of host-to-IP mappings, where each host name is a key in the dictionary.
@@ -224,6 +235,7 @@ options:
         If the port is already exposed using EXPOSE in a Dockerfile, it does not
         need to be exposed again.
     type: list
+    elements: str
     aliases:
       - exposed
       - expose
@@ -238,6 +250,7 @@ options:
     description:
       - List of additional group names and/or IDs that the container process will run as.
     type: list
+    elements: str
   healthcheck:
     description:
       - 'Configure a check that is run to determine whether or not containers for this service are "healthy".
@@ -332,6 +345,7 @@ options:
       - List of name aliases for linked containers in the format C(container_name:alias).
       - Setting this will force container to be restarted.
     type: list
+    elements: str
   log_driver:
     description:
       - Specify the logging driver. Docker uses I(json-file) by default.
@@ -378,6 +392,7 @@ options:
   mounts:
     version_added: "2.9"
     type: list
+    elements: dict
     description:
       - 'Specification for mounts to be added to the container. More powerful alternative to I(volumes).'
     suboptions:
@@ -479,6 +494,7 @@ options:
         network if C(networks) is specified. You need to explicity use C(purge_networks) to enforce
         the removal of the default network (and all other networks not explicitly mentioned in C(networks)).
     type: list
+    elements: dict
     suboptions:
       name:
         description:
@@ -497,11 +513,13 @@ options:
         description:
           - A list of containers to link to.
         type: list
+        elements: str
       aliases:
         description:
           - List of aliases for this container in this network. These names
             can be used in the network to reach this container.
         type: list
+        elements: str
     version_added: "2.2"
   networks_cli_compatible:
     description:
@@ -579,6 +597,7 @@ options:
         Note that the first bridge network with a com.docker.network.bridge.host_binding_ipv4
         value encountered in the list of C(networks) is the one that will be used.
     type: list
+    elements: str
     aliases:
       - ports
   pull:
@@ -640,6 +659,7 @@ options:
     description:
       - List of security options in the form of C("label:user:User")
     type: list
+    elements: str
   state:
     description:
       - 'I(absent) - A container matching the specified name will be stopped and removed. Use force_kill to kill the container
@@ -692,6 +712,7 @@ options:
     description:
       - Mount a tmpfs directory
     type: list
+    elements: str
     version_added: 2.4
   tty:
     description:
@@ -702,6 +723,7 @@ options:
     description:
       - "List of ulimit options. A ulimit is specified as C(nofile:262144:262144)"
     type: list
+    elements: str
   sysctls:
     description:
       - Dictionary of key,value pairs.
@@ -728,6 +750,7 @@ options:
       - "Note that Ansible 2.7 and earlier only supported one mode, which had to be one of C(ro), C(rw),
         C(z), and C(Z)."
     type: list
+    elements: str
   volume_driver:
     description:
       - The container volume driver.
@@ -736,6 +759,7 @@ options:
     description:
       - List of container names or Ids to get volumes from.
     type: list
+    elements: str
   working_dir:
     description:
       - Path to the working directory.

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -57,6 +57,7 @@ options:
         description:
           - List of image names to consider as cache source.
         type: list
+        elements: str
       dockerfile:
         description:
           - Use with state C(present) and source C(build) to provide an alternate name for the Dockerfile to use when building an image.

--- a/lib/ansible/modules/cloud/docker/docker_image_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_info.py
@@ -38,6 +38,7 @@ options:
         where C(tag) is optional. If a tag is not provided, C(latest) will be used. Instead of image names, also
         image IDs can be used.
     type: list
+    elements: str
     required: yes
 
 extends_documentation_fragment:

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -32,6 +32,7 @@ options:
     description:
       - List of container names or container IDs to connect to a network.
     type: list
+    elements: str
     aliases:
       - containers
 
@@ -115,6 +116,7 @@ options:
         L(Docker docs,https://docs.docker.com/compose/compose-file/compose-file-v2/#ipam) for valid options and values.
         Note that I(iprange) is spelled differently here (we use the notation from the Docker SDK for Python).
     type: list
+    elements: dict
     suboptions:
       subnet:
         description:

--- a/lib/ansible/modules/cloud/docker/docker_node.py
+++ b/lib/ansible/modules/cloud/docker/docker_node.py
@@ -59,6 +59,7 @@ options:
             - If I(labels_state) is C(replace) and I(labels) is not provided or empty then all labels assigned to
               node are removed and I(labels_to_remove) is ignored.
         type: list
+        elements: str
     availability:
         description: Node availability to assign. If not provided then node availability remains unchanged.
         choices:

--- a/lib/ansible/modules/cloud/docker/docker_node_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_info.py
@@ -33,6 +33,7 @@ options:
       - When identifying the node use either the hostname of the node (as registered in Swarm) or node ID.
       - If I(self) is C(true) then this parameter is ignored.
     type: list
+    elements: str
   self:
     description:
       - If C(true), queries the node (i.e. the docker daemon) the module communicates with.

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -41,6 +41,7 @@ options:
         referring to the path of the compose file on the target host
         or the YAML contents of a compose file nested as dictionary.
     type: list
+    # elements: raw
     default: []
   prune:
     description:
@@ -210,7 +211,7 @@ def main():
     module = AnsibleModule(
         argument_spec={
             'name': dict(type='str', required=True),
-            'compose': dict(type='list', default=[]),
+            'compose': dict(type='list', elements='raw', default=[]),
             'prune': dict(type='bool', default=False),
             'with_registry_auth': dict(type='bool', default=False),
             'resolve_image': dict(type='str', choices=['always', 'changed', 'never']),

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -39,6 +39,7 @@ options:
         for idempotency checking.
       - Requires API version >= 1.39.
     type: list
+    elements: str
     version_added: "2.8"
   subnet_size:
     description:
@@ -98,6 +99,7 @@ options:
       - Remote address of one or more manager nodes of an existing Swarm to connect to.
       - Used with I(state=join).
     type: list
+    elements: str
   task_history_retention_limit:
     description:
       - Maximum number of tasks history stored.

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -26,6 +26,7 @@ options:
       - List arguments to be passed to the container.
       - Corresponds to the C(ARG) parameter of C(docker service create).
     type: list
+    elements: str
   command:
     description:
       - Command to execute when the container starts.
@@ -39,6 +40,7 @@ options:
       - Corresponds to the C(--config) option of C(docker service create).
       - Requires API version >= 1.30.
     type: list
+    elements: dict
     suboptions:
       config_id:
         description:
@@ -72,6 +74,7 @@ options:
       - Corresponds to the C(--constraint) option of C(docker service create).
       - Deprecated in 2.8, will be removed in 2.12. Use parameter C(placement.constraints) instead.
     type: list
+    elements: str
   container_labels:
     description:
       - Dictionary of key value pairs.
@@ -83,18 +86,21 @@ options:
       - Corresponds to the C(--dns) option of C(docker service create).
       - Requires API version >= 1.25.
     type: list
+    elements: str
   dns_search:
     description:
       - List of custom DNS search domains.
       - Corresponds to the C(--dns-search) option of C(docker service create).
       - Requires API version >= 1.25.
     type: list
+    elements: str
   dns_options:
     description:
       - List of custom DNS options.
       - Corresponds to the C(--dns-option) option of C(docker service create).
       - Requires API version >= 1.25.
     type: list
+    elements: str
   endpoint_mode:
     description:
       - Service endpoint mode.
@@ -120,6 +126,7 @@ options:
         variable that shows up more than once.
       - If variable also present in I(env), then I(env) value will override.
     type: list
+    elements: path
     version_added: "2.8"
   force_update:
     description:
@@ -134,6 +141,7 @@ options:
       - Corresponds to the C(--group) option of C(docker service update).
       - Requires API version >= 1.25.
     type: list
+    elements: str
     version_added: "2.8"
   healthcheck:
     description:
@@ -271,6 +279,7 @@ options:
       - List of dictionaries describing the service mounts.
       - Corresponds to the C(--mount) option of C(docker service create).
     type: list
+    elements: dict
     suboptions:
       source:
         description:
@@ -365,6 +374,7 @@ options:
         If changes are made the service will then be removed and recreated.
       - Corresponds to the C(--network) option of C(docker service create).
     type: list
+    elements: raw
   placement:
     description:
       - Configures service placement preferences and constraints.
@@ -374,12 +384,14 @@ options:
           - List of the service constraints.
           - Corresponds to the C(--constraint) option of C(docker service create).
         type: list
+        elements: str
       preferences:
         description:
           - List of the placement preferences as key value pairs.
           - Corresponds to the C(--placement-pref) option of C(docker service create).
           - Requires API version >= 1.27.
         type: list
+        elements: dict
     type: dict
     version_added: "2.8"
   publish:
@@ -388,6 +400,7 @@ options:
       - Corresponds to the C(--publish) option of C(docker service create).
       - Requires API version >= 1.25.
     type: list
+    elements: dict
     suboptions:
       published_port:
         description:
@@ -593,6 +606,7 @@ options:
       - Corresponds to the C(--secret) option of C(docker service create).
       - Requires API version >= 1.25.
     type: list
+    elements: dict
     suboptions:
       secret_id:
         description:
@@ -2672,14 +2686,14 @@ def main():
             mode=dict(type='str', choices=['ingress', 'host']),
         )),
         placement=dict(type='dict', options=dict(
-            constraints=dict(type='list'),
-            preferences=dict(type='list'),
+            constraints=dict(type='list', elements='str'),
+            preferences=dict(type='list', elements='dict'),
         )),
-        constraints=dict(type='list', removed_in_version='2.12'),
+        constraints=dict(type='list', elements='str', removed_in_version='2.12'),
         tty=dict(type='bool'),
-        dns=dict(type='list'),
-        dns_search=dict(type='list'),
-        dns_options=dict(type='list'),
+        dns=dict(type='list', elements='str'),
+        dns_search=dict(type='list', elements='str'),
+        dns_options=dict(type='list', elements='str'),
         healthcheck=dict(type='dict', options=dict(
             test=dict(type='raw'),
             interval=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Since #59244 was merged, list options can be documented better. This PR adds the new feature to all docker modules.

I've also added this for return data, even though it's not supported yet.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_compose
docker_container
docker_host_info
docker_image
docker_image_info
docker_network
docker_node
docker_node_info
docker_prune
docker_stack
docker_swarm
docker_swarm_info
docker_swarm_service
