### PR TITLE
JUNOS: Set no_log to True for junos_user encrypted_password

### DIFF
--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -314,7 +314,7 @@ def main():
         name=dict(),
         full_name=dict(),
         role=dict(choices=ROLES),
-        encrypted_password=dict(),
+        encrypted_password=dict(no_log=True),
         sshkey=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
         active=dict(type='bool', default=True)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes #60627

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
junos_user.py
