### PR TITLE
[stable-2.9] Fix ansible-test collections requirements installation.

### DIFF
--- a/changelogs/fragments/ansible-test-collections-requirements.yml
+++ b/changelogs/fragments/ansible-test-collections-requirements.yml
@@ -1,0 +1,3 @@
+bugfixes:
+    - ansible-test now correctly installs the requirements specified by the collection's unit and integration tests
+      instead of the requirements specified for Ansible's own unit and integration tests

--- a/test/integration/network-integration.requirements.txt
+++ b/test/integration/network-integration.requirements.txt
@@ -1,0 +1,5 @@
+pexpect # for _user test
+scp # for Cisco ios
+selectors2 # for ncclient
+ncclient # for Junos
+jxmlease # for Junos

--- a/test/lib/ansible_test/_data/requirements/network-integration.txt
+++ b/test/lib/ansible_test/_data/requirements/network-integration.txt
@@ -1,10 +1,6 @@
 cryptography
 jinja2
 junit-xml
+ordereddict ; python_version < '2.7' # ansible-test junit callback plugin requirement
 paramiko
 pyyaml
-pexpect # for _user test
-scp # for Cisco ios
-selectors2 # for ncclient
-ncclient # for Junos
-jxmlease # for Junos

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -1,49 +1,7 @@
-boto3
-placebo
 cryptography
-pycrypto
 jinja2
 mock
-passlib
-pypsrp
 pytest
 pytest-mock
 pytest-xdist
-python-memcached
-pytz
-pyvmomi
 pyyaml
-redis
-requests
-setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools (sanity_ok)
-unittest2 ; python_version < '2.7'
-importlib ; python_version < '2.7'
-netaddr
-ipaddress
-netapp-lib
-solidfire-sdk-python
-
-# requirements for F5 specific modules
-f5-sdk ; python_version >= '2.7'
-f5-icontrol-rest ; python_version >= '2.7'
-deepdiff
-
-# requirement for Fortinet specific modules
-pyFMG
-
-# requirement for aci_rest module
-xmljson
-
-# requirement for winrm connection plugin tests
-pexpect
-
-# requirement for the linode module
-linode-python # APIv3
-linode_api4 ; python_version > '2.6' # APIv4
-
-# requirement for the gitlab module
-python-gitlab
-httmock
-
-# requirment for kubevirt modules
-openshift ; python_version >= '2.7'

--- a/test/lib/ansible_test/_data/requirements/windows-integration.txt
+++ b/test/lib/ansible_test/_data/requirements/windows-integration.txt
@@ -2,6 +2,7 @@ cryptography
 jinja2
 junit-xml
 ntlm-auth
+ordereddict ; python_version < '2.7' # ansible-test junit callback plugin requirement
 requests-ntlm
 requests-credssp
 pypsrp

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -415,6 +415,11 @@ class PathMapper:
                             command: self.integration_all_target,
                         }
 
+                    if name == command + '.requirements' and ext == '.txt':
+                        return {
+                            command: self.integration_all_target,
+                        }
+
             return {
                 'integration': self.integration_all_target,
                 'windows-integration': self.integration_all_target,

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -335,6 +335,23 @@ def generate_pip_install(pip, command, packages=None):
         if command == 'sanity':
             options += ['-r', os.path.join(data_context().content.root, 'test', 'sanity', 'requirements.txt')]
 
+    if command == 'units':
+        requirements = os.path.join(data_context().content.unit_path, 'requirements.txt')
+
+        if os.path.exists(requirements) and os.path.getsize(requirements):
+            options += ['-r', requirements]
+
+    if command in ('integration', 'windows-integration', 'network-integration'):
+        requirements = os.path.join(data_context().content.integration_path, 'requirements.txt')
+
+        if os.path.exists(requirements) and os.path.getsize(requirements):
+            options += ['-r', requirements]
+
+        requirements = os.path.join(data_context().content.integration_path, '%s.requirements.txt' % command)
+
+        if os.path.exists(requirements) and os.path.getsize(requirements):
+            options += ['-r', requirements]
+
     if packages:
         options += packages
 

--- a/test/units/requirements.txt
+++ b/test/units/requirements.txt
@@ -1,0 +1,42 @@
+boto3
+placebo
+pycrypto
+passlib
+pypsrp
+python-memcached
+pytz
+pyvmomi
+redis
+requests
+setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools (sanity_ok)
+unittest2 ; python_version < '2.7'
+importlib ; python_version < '2.7'
+netaddr
+ipaddress
+netapp-lib
+solidfire-sdk-python
+
+# requirements for F5 specific modules
+f5-sdk ; python_version >= '2.7'
+f5-icontrol-rest ; python_version >= '2.7'
+deepdiff
+
+# requirement for Fortinet specific modules
+pyFMG
+
+# requirement for aci_rest module
+xmljson
+
+# requirement for winrm connection plugin tests
+pexpect
+
+# requirement for the linode module
+linode-python # APIv3
+linode_api4 ; python_version > '2.6' # APIv4
+
+# requirement for the gitlab module
+python-gitlab
+httmock
+
+# requirment for kubevirt modules
+openshift ; python_version >= '2.7'


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test collections requirements installation.

* Fix location of unit test requirements.

* Preserve ansible-test unit test requirements.

* Remove redundant unit test requirements.

* Fix location of network test requirements.

* Preserve ansible-test network test requirements.

* Remove redundant network test requirements.

* Add missing ordereddict requirements.

* Load collection requirements correctly.

* Add changelog fragment.

Backport of #62181

(cherry picked from commit cdc4926)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
