### PR TITLE
[stable-2.9] Fix ansible-test vcenter test filtering.

### DIFF
--- a/changelogs/fragments/ansible-test-vcenter-plugin.yml
+++ b/changelogs/fragments/ansible-test-vcenter-plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly activates the vcenter plugin for vcenter tests when docker is available

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -61,7 +61,7 @@ class VcenterProvider(CloudProvider):
         :type targets: tuple[TestTarget]
         :type exclude: list[str]
         """
-        if self.vmware_test_platform == 'govcsim':
+        if self.vmware_test_platform == 'govcsim' or (self.vmware_test_platform == '' and not os.path.isfile(self.config_static_path)):
             docker = find_executable('docker', required=False)
 
             if docker:
@@ -72,8 +72,8 @@ class VcenterProvider(CloudProvider):
 
             if skipped:
                 exclude.append(skip)
-                display.warning('Excluding tests marked "%s" which require the "docker" command: %s'
-                                % (skip.rstrip('/'), ', '.join(skipped)))
+                display.warning('Excluding tests marked "%s" which require the "docker" command or config (see "%s"): %s'
+                                % (skip.rstrip('/'), self.config_template_path, ', '.join(skipped)))
         else:
             if os.path.isfile(self.config_static_path):
                 return


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test vcenter test filtering.

The default behavior of the ansible-test vcenter plugin is to use the govcsim container to run tests.

However, unless the govcsim mode was specified using the VMWARE_TEST_PLATFORM environment variable, the filter code would skip the tests unless the tests ran on Shippable or the user had an ansible-core-ci key.

Now the filter correctly recognizes that govcsim is the default.

Backport of https://github.com/ansible/ansible/pull/62185

(cherry picked from commit cd4882e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
