### PR TITLE
FreeIPA: Add option to add new host to hostgroup, while keeping current record

### DIFF
--- a/changelogs/fragments/62189-dont_delete_host_from_hostgroup.yml
+++ b/changelogs/fragments/62189-dont_delete_host_from_hostgroup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add clear option to module Identity/ipa to choose to keep or not all host/hostgroup from hostgroup

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -191,16 +191,17 @@ class IPAClient(object):
                 result.append(key)
         return result
 
-    def modify_if_diff(self, name, ipa_list, module_list, add_method, remove_method, item=None):
+    def modify_if_diff(self, name, ipa_list, module_list, add_method, remove_method, item=None, clear=True):
         changed = False
-        diff = list(set(ipa_list) - set(module_list))
-        if len(diff) > 0:
-            changed = True
-            if not self.module.check_mode:
-                if item:
-                    remove_method(name=name, item={item: diff})
-                else:
-                    remove_method(name=name, item=diff)
+        if clear :
+            diff = list(set(ipa_list) - set(module_list))
+            if len(diff) > 0:
+                changed = True
+                if not self.module.check_mode:
+                    if item:
+                        remove_method(name=name, item={item: diff})
+                    else:
+                        remove_method(name=name, item=diff)
 
         diff = list(set(module_list) - set(ipa_list))
         if len(diff) > 0:

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -193,7 +193,7 @@ class IPAClient(object):
 
     def modify_if_diff(self, name, ipa_list, module_list, add_method, remove_method, item=None, clear=True):
         changed = False
-        if clear :
+        if clear:
             diff = list(set(ipa_list) - set(module_list))
             if len(diff) > 0:
                 changed = True

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -44,6 +44,7 @@ options:
     description:
     - assign only hosts and hostgroup to that host-group, others are removed
     default: true
+    version_added: "2.10"
   state:
     description:
     - State to ensure.


### PR DESCRIPTION

##### SUMMARY
When we add new host or hosgroup to IP hostgroup,  old host or hostgroup are deleted. This PR add capability to add NEW host to hostgroup and keep current record

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module Identity/ipa
module_utils ipa
##### ADDITIONAL INFORMATION
We can this feature to others modules like pa_role, ipa_group,...
