### PR TITLE
Backport 2.9: Handle cases where normal commit operation throws a prompt (#62132)

### DIFF
--- a/changelogs/fragments/62131-iosxr_prompt_fix.yaml
+++ b/changelogs/fragments/62131-iosxr_prompt_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iosxr - support cases where a normal commit operation also throws a prompt (https://github.com/ansible/ansible/pull/62132)

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -191,6 +191,11 @@ class Cliconf(CliconfBase):
                 cmd_obj['command'] = 'commit label {0}'.format(label)
             else:
                 cmd_obj['command'] = 'commit show-error'
+            # In some cases even a normal commit, i.e., !replace,
+            # throws a prompt and we need to handle it before
+            # proceeding further
+            cmd_obj['prompt'] = '(C|c)onfirm'
+            cmd_obj['answer'] = 'y'
 
         self.send_command(**cmd_obj)
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit f1766457a2fae6c72fe4d7373829ec19f77eabc4)

Add changelog for iosxr prompt fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Backport #62132

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cliconf/iosxr.py
