### PR TITLE
Backport 2.8: Set no_log to True for junos_user encrypted_password (#62184)

### DIFF
--- a/changelogs/fragments/62184-junos_user_encrypted_password_fix.yaml
+++ b/changelogs/fragments/62184-junos_user_encrypted_password_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - junos_user - Add no_log=True to junos_user `encrypted_password` (https://github.com/ansible/ansible/pull/62184)

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -314,7 +314,7 @@ def main():
         name=dict(),
         full_name=dict(),
         role=dict(choices=ROLES),
-        encrypted_password=dict(),
+        encrypted_password=dict(no_log=True),
         sshkey=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
         active=dict(type='bool', default=True)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 4e6270750a748ae854481e157821f51eda36ded0)

Add changelog for junos_user fix

##### SUMMARY
- Backport #62184

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
junos_user.py