### PR TITLE
fix fact caching plugin name from json to jsonfile

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -127,7 +127,7 @@ Here is an example of setting inventory caching with some fact caching defaults 
 .. code-block:: ini
 
    [defaults]
-   fact_caching = json
+   fact_caching = jsonfile
    fact_caching_connection = /tmp/ansible_facts
    cache_timeout = 3600
 


### PR DESCRIPTION
##### SUMMARY
The fact caching plugin is called "jsonfile" and not just "json". It has probably been renamed in the past.

##### ISSUE TYPE
When running with "fact_caching = json" you will get the warning:

```
 [WARNING]: Unable to load the facts cache plugin (json).
```
