### PR TITLE
explicited RouterOS does not support connection: local

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -33,6 +33,8 @@ Connections Available
 .. |enable_mode| replace:: Enable Mode |br| (Privilege Escalation)
 
 
+RouterOS does not support ``ansible_connection: local``. You must use ``ansible_connection: network_cli``.
+
 Using CLI in Ansible
 ====================
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

[Settings by Platform](https://docs.ansible.com/ansible/devel/network/user_guide/platform_index.html#settings-by-platform) matrix says that RouterOS does not support local connection plugin.

So I specified that like VOSS/NOS etc Platform Options Page.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
