### PR TITLE
Add diff and check_mode support to os_server

### DIFF
--- a/changelogs/fragments/62206-add-diff-and-check-support.yml
+++ b/changelogs/fragments/62206-add-diff-and-check-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - os_server now supports diff and check_mode

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -752,9 +752,13 @@ def _present_server(module, cloud):
             msg='The instance is available but not Active state: %s' % server.status)
 
     if server:
-        diff['before'] = server.copy()
+        diff['before'] = cloud.get_openstack_vars(server)
         (changed, server) = _update_server(module, cloud, server)
-        diff['after'] = server
+        if module.check_mode:
+            diff['after'] = server
+        else:
+            diff['after'] = cloud.get_openstack_vars(server)
+
         _exit_hostvars(module, cloud, server, diff, changed)
 
 
@@ -764,8 +768,7 @@ def _absent_server(module, cloud):
     server = cloud.get_server(module.params['name'])
 
     if server:
-        server['adminPass'] = '***'
-        diff['before'] = server
+        diff['before'] = cloud.get_openstack_vars(server)
         changed = _delete_server(module, cloud)
         module.exit_json(changed=changed, result='deleted', diff=diff)
 

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -603,7 +603,7 @@ def _detach_ip_list(cloud, server, extra_ips):
             server_id=server.id, floating_ip_id=ip_id)
 
 
-def _check_ips(module, cloud, server):
+def _update_ips(module, cloud, server):
     changed = False
 
     auto_ip = module.params['auto_ip']
@@ -661,7 +661,7 @@ def _check_ips(module, cloud, server):
     return (changed, server)
 
 
-def _check_security_groups(module, cloud, server):
+def _update_security_groups(module, cloud, server):
     changed = False
 
     # server security groups were added to shade in 1.19. Until then this
@@ -695,8 +695,8 @@ def _get_server_state(module, cloud):
         if server.status not in ('ACTIVE', 'SHUTOFF', 'PAUSED', 'SUSPENDED'):
             module.fail_json(
                 msg="The instance is available but not Active state: " + server.status)
-        (ip_changed, server) = _check_ips(module, cloud, server)
-        (sg_changed, server) = _check_security_groups(module, cloud, server)
+        (ip_changed, server) = _update_ips(module, cloud, server)
+        (sg_changed, server) = _update_security_groups(module, cloud, server)
         (server_changed, server) = _update_server(module, cloud, server)
         _exit_hostvars(module, cloud, server,
                        ip_changed or sg_changed or server_changed)

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -555,16 +555,15 @@ def _create_server(module, cloud):
         if not flavor_dict:
             module.fail_json(msg='Could not find any matching flavor')
 
-    module.params['meta'] = _parse_meta(module.params['meta'])
     if module.check_mode:
         server = dict(
             name=module.params['name'],
-            metadata=module.params['meta'],
             security_groups=module.params['security_groups']
         )
         return server
 
     nics = _network_args(module, cloud)
+    module.params['meta'] = _parse_meta(module.params['meta'])
 
     bootkwargs = dict(
         name=module.params['name'],

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -497,8 +497,8 @@ def _network_args(module, cloud):
 def _parse_meta(meta):
     if isinstance(meta, str):
         metas = {}
-        for kv_str in meta.split(","):
-            k, v = kv_str.split("=")
+        for kv_str in meta.split(','):
+            k, v = kv_str.split('=')
             metas[k] = v
         return metas
     if not meta:
@@ -513,7 +513,7 @@ def _delete_server(module, cloud):
             timeout=module.params['timeout'],
             delete_ips=module.params['delete_fip'])
     except Exception as e:
-        module.fail_json(msg="Error in deleting vm: %s" % e.message)
+        module.fail_json(msg='Error in deleting vm: %s' % e.message)
     module.exit_json(changed=True, result='deleted')
 
 
@@ -527,17 +527,17 @@ def _create_server(module, cloud):
         image_id = cloud.get_image_id(
             module.params['image'], module.params['image_exclude'])
         if not image_id:
-            module.fail_json(msg="Could not find image %s" %
+            module.fail_json(msg='Could not find image %s' %
                              module.params['image'])
 
     if flavor:
         flavor_dict = cloud.get_flavor(flavor)
         if not flavor_dict:
-            module.fail_json(msg="Could not find flavor %s" % flavor)
+            module.fail_json(msg='Could not find flavor %s' % flavor)
     else:
         flavor_dict = cloud.get_flavor_by_ram(flavor_ram, flavor_include)
         if not flavor_dict:
-            module.fail_json(msg="Could not find any matching flavor")
+            module.fail_json(msg='Could not find any matching flavor')
 
     nics = _network_args(module, cloud)
 

--- a/test/units/modules/cloud/openstack/test_os_server.py
+++ b/test/units/modules/cloud/openstack/test_os_server.py
@@ -84,6 +84,9 @@ class FakeCloud(object):
     def get_openstack_vars(self, server):
         return server
 
+    def get_server(self, name):
+        return None
+
     create_server = mock.MagicMock()
 
 
@@ -188,7 +191,7 @@ class TestCreateServer(object):
               - key: value
         '''
         with pytest.raises(AnsibleExit):
-            os_server._create_server(self.module, self.cloud)
+            os_server._present_server(self.module, self.cloud)
 
         assert(self.cloud.create_server.call_count == 1)
         assert(self.cloud.create_server.call_args[1]['image'] == self.cloud.get_image_id('cirros'))
@@ -204,7 +207,7 @@ class TestCreateServer(object):
               - net-name: network1
         '''
         with pytest.raises(AnsibleFail):
-            os_server._create_server(self.module, self.cloud)
+            os_server._present_server(self.module, self.cloud)
 
         assert('missing_flavor' in
                self.module.fail_json.call_args[1]['msg'])
@@ -218,7 +221,7 @@ class TestCreateServer(object):
               - net-name: missing_network
         '''
         with pytest.raises(AnsibleFail):
-            os_server._create_server(self.module, self.cloud)
+            os_server._present_server(self.module, self.cloud)
 
         assert('missing_network' in
                self.module.fail_json.call_args[1]['msg'])

--- a/test/units/modules/cloud/openstack/test_os_server.py
+++ b/test/units/modules/cloud/openstack/test_os_server.py
@@ -173,6 +173,7 @@ class TestCreateServer(object):
         self.module.params = params_from_doc(method)
         self.module.fail_json.side_effect = AnsibleFail()
         self.module.exit_json.side_effect = AnsibleExit()
+        self.module.check_mode = False
 
         self.meta = mock.MagicMock()
         self.meta.gett_hostvars_from_server.return_value = {


### PR DESCRIPTION
##### SUMMARY
This adds diff and check mode feature to the openstack server module along with some minor cleanups.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
os_server.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
playbooks using the os_server module may now run in check mode, the module may also output a diff of changes
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [update instance: os_server] ***************************************************************************************************************************************************
changed: [instance1.fake]
...
TASK [update instance: os_server] ***************************************************************************************************************************************************
--- before
+++ after
@@ -198,6 +198,26 @@
                     "tenant_id": ""
                 }
             ],
+            "tenant_id": "T_ID"
+        },
+        {
+            "description": "PLACEHOLDER",
+            "id": "SG_ID",
+            "location": {
+                "cloud": "envvars",
+                "project": {
+                    "domain_id": null,
+                    "domain_name": null,
+                    "id": "P_ID",
+                    "name": "P_NAME"
+                },
+                "region_name": "",
+                "zone": null
+            },
+            "name": "placeholder",
+            "project_id": "P_ID",
+            "properties": {},
+            "security_group_rules": [],
             "tenant_id": "T_ID"
         }
     ],
changed: [instance1.fake]
```
