### PR TITLE
Revert "svc module: fix a typo"

### DIFF
--- a/lib/ansible/modules/system/svc.py
+++ b/lib/ansible/modules/system/svc.py
@@ -196,7 +196,7 @@ class Svc(object):
             if re.search(' up ', out):
                 self.state = 'start'
             elif re.search(' down ', out):
-                self.state = 'stop'
+                self.state = 'stopp'
             else:
                 self.state = 'unknown'
                 return


### PR DESCRIPTION
Reverts ansible/ansible#62174

it was not a typo, its part of 'star(ed)' 'stopp(ed)' state detection