### PR TITLE
Fix k8s module showing diff for generated nodePorts

### DIFF
--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -118,7 +118,9 @@ def dict_merge(a, b):
         if isinstance(result.get(k), dict):
             result[k] = dict_merge(result[k], v)
         elif isinstance(result.get(k), list):
-            result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(len(result[k]))]
+            result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(min(len(result[k]), len(v)))]
+            if len(v) > len(result[k]):
+                result[k] += [deepcopy(v[len(result[k]) + i]) for i in range(len(v) - len(result[k]))]
         else:
             result[k] = deepcopy(v)
     return result

--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -115,13 +115,12 @@ def dict_merge(a, b):
         return b
     result = deepcopy(a)
     for k, v in b.items():
-        if k in result and isinstance(result[k], dict):
+        if isinstance(result.get(k), dict):
             result[k] = dict_merge(result[k], v)
+        elif isinstance(result.get(k), list):
+            result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(len(result[k]))]
         else:
-            if isinstance(result[k], list):
-                result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(len(result[k]))]
-            else:
-                result[k] = deepcopy(v)
+            result[k] = deepcopy(v)
     return result
 
 

--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -118,7 +118,10 @@ def dict_merge(a, b):
         if k in result and isinstance(result[k], dict):
             result[k] = dict_merge(result[k], v)
         else:
-            result[k] = deepcopy(v)
+            if isinstance(result[k], list):
+                result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(len(result[k]))]
+            else:
+                result[k] = deepcopy(v)
     return result
 
 


### PR DESCRIPTION
In scope of ansible#60510

##### SUMMARY
k8s module shows diff for generated nodePorts:
```
    TASK [Create service] ************************************
    --- before
    +++ after
    @@ -2,10 +2,9 @@
         "spec": {
             "ports": [
                 {
    -                "nodePort": 31495,
                     "port": 80,
                     "protocol": "TCP",
                     "targetPort": 8080
                 }
             ]
         }
```
The definition for this service ports is:
```
        ports:
          - port: 80
            protocol: TCP
            targetPort: 8080
```
The issue is in common/dict_transformations.py dict_merge function:
```
diff --git a/lib/ansible/module_utils/common/dict_transformations.py b/lib/ansible/module_utils/common/dict_transformations.py
index 831fbc5385..ab27b53887 100644
--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -118,7 +118,10 @@ def dict_merge(a, b):
         if k in result and isinstance(result[k], dict):
             result[k] = dict_merge(result[k], v)
         else:
-            result[k] = deepcopy(v)
+            if isinstance(result[k], list):
+                result[k] = [dict_merge(result[k][i], v[i]) if isinstance(result[k][i], dict) else deepcopy(v[i]) for i in range(len(result[k]))]
+            else:
+                result[k] = deepcopy(v)
     return result
```
I haven't properly tested the patch, not sure it works in all cases. @willthames asked me to create a PR for this. Any help in testing and getting this merged in is highly appreciated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s module

##### ADDITIONAL INFORMATION