### PR TITLE
Revert "svc: fix a typo (#62174)"

### DIFF
--- a/lib/ansible/modules/system/svc.py
+++ b/lib/ansible/modules/system/svc.py
@@ -196,7 +196,7 @@ class Svc(object):
             if re.search(' up ', out):
                 self.state = 'start'
             elif re.search(' down ', out):
-                self.state = 'stop'
+                self.state = 'stopp'
             else:
                 self.state = 'unknown'
                 return


### PR DESCRIPTION
This reverts commit d838a9021a8f7e951bc5dc5dd40fd5686f58a8c1.

was not a typo, 'ed' is added later on and 'stop' goes to 'stopped'

###### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

svc