### PR TITLE
Add unit tests for check_point ansible modules

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_global_assignment.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_global_assignment.py
@@ -1,0 +1,117 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_global_assignment
+
+OBJECT = {
+    "global_domain": "Global",
+    "dependent_domain": "domain2",
+    "global_access_policy": "standard",
+    "global_threat_prevention_policy": "standard",
+    "manage_protection_actions": True
+}
+
+CREATE_PAYLOAD = {
+    "global_domain": "Global",
+    "dependent_domain": "domain2",
+    "global_access_policy": "standard",
+    "global_threat_prevention_policy": "standard",
+    "manage_protection_actions": True
+}
+
+UPDATE_PAYLOAD = {
+    "global_domain": "Global2",
+    "dependent_domain": "domain1",
+    "global_threat_prevention_policy": "",
+    "manage_protection_actions": False
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_global_assignment.api_call'
+api_call_object = 'global-assignment'
+
+
+class TestCheckpointGlobalAssignment(object):
+    module = cp_mgmt_global_assignment
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_global_assignment_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_global_assignment_facts.py
@@ -1,0 +1,80 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_global_assignment_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {}
+
+api_call_object = 'global-assignment'
+api_call_object_plural_version = 'global-assignments'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointGlobalAssignmentFacts(object):
+    module = cp_mgmt_global_assignment_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_group.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_group.py
@@ -1,0 +1,117 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_group
+
+OBJECT = {
+    "name": "New Group 5",
+    "members": [
+        "New Host 1",
+        "My Test Host 3"
+    ]
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Group 5",
+    "members": [
+        "New Host 1",
+        "My Test Host 3"
+    ]
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Group 5"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Group 5",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_group.api_call'
+api_call_object = 'group'
+
+
+class TestCheckpointGroup(object):
+    module = cp_mgmt_group
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_group_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_group_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_group_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'group'
+api_call_object_plural_version = 'groups'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointGroupFacts(object):
+    module = cp_mgmt_group_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_group_with_exclusion.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_group_with_exclusion.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_group_with_exclusion
+
+OBJECT = {
+    "name": "Group with exclusion",
+    "include": "New Group 1",
+    "except": "New Group 2"
+}
+
+CREATE_PAYLOAD = {
+    "name": "Group with exclusion",
+    "include": "New Group 1",
+    "except": "New Group 2"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Group with exclusion",
+    "include": "New Group 2",
+    "except": "New Group 1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Group with exclusion",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_group_with_exclusion.api_call'
+api_call_object = 'group-with-exclusion'
+
+
+class TestCheckpointGroupWithExclusion(object):
+    module = cp_mgmt_group_with_exclusion
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_group_with_exclusion_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_group_with_exclusion_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_group_with_exclusion_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'group-with-exclusion'
+api_call_object_plural_version = 'groups-with-exclusion'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointGroupWithExclusionFacts(object):
+    module = cp_mgmt_group_with_exclusion_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_host.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_host.py
@@ -1,0 +1,113 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_host
+
+OBJECT = {
+    "name": "New Host 1",
+    "ip_address": "192.0.2.1"
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Host 1",
+    "ip_address": "192.0.2.1"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Host 1",
+    "color": "blue",
+    "ipv4_address": "192.0.2.2"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Host 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_host.api_call'
+api_call_object = 'host'
+
+
+class TestCheckpointHost(object):
+    module = cp_mgmt_host
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_host_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_host_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_host_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'host'
+api_call_object_plural_version = 'hosts'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointHostFacts(object):
+    module = cp_mgmt_host_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_multicast_address_range.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_multicast_address_range.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_multicast_address_range
+
+OBJECT = {
+    "name": "New Multicast Address Range",
+    "ip_address_first": "224.0.0.1",
+    "ip_address_last": "224.0.0.4"
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Multicast Address Range",
+    "ip_address_first": "224.0.0.1",
+    "ip_address_last": "224.0.0.4"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Multicast Address Range",
+    "ip_address_first": "224.0.0.7",
+    "ip_address_last": "224.0.0.10"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Multicast Address Range",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_multicast_address_range.api_call'
+api_call_object = 'multicast-address-range'
+
+
+class TestCheckpointMulticastAddressRange(object):
+    module = cp_mgmt_multicast_address_range
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_multicast_address_range_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_multicast_address_range_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_multicast_address_range_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'multicast-address-range'
+api_call_object_plural_version = 'multicast-address-ranges'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointMulticastAddressRangeFacts(object):
+    module = cp_mgmt_multicast_address_range_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_network.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_network.py
@@ -46,13 +46,6 @@ DELETE_PAYLOAD = {'name': 'test_new_network', 'state': 'absent'}
 class TestCheckpointNetwork(object):
     module = cp_mgmt_network
 
-    checkpoint_argument_spec_for_objects = dict(
-        auto_publish_session=dict(type='bool'),
-        wait_for_task=dict(type='bool', default=True),
-        state=dict(type='str', required=True, choices=['present', 'absent']),
-        version=dict(type='str')
-    )
-
     @pytest.fixture(autouse=True)
     def module_mock(self, mocker):
         return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
@@ -114,10 +107,3 @@ class TestCheckpointNetwork(object):
         with pytest.raises(AnsibleExitJson) as ex:
             self.module.main()
         return ex.value.args[0]
-
-    def _run_module_with_fail_json(self, module_args):
-        set_module_args(module_args)
-        with pytest.raises(AnsibleFailJson) as exc:
-            self.module.main()
-        result = exc.value.args[0]
-        return result

--- a/test/units/modules/network/check_point/test_cp_mgmt_package.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_package.py
@@ -1,0 +1,133 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_package
+
+OBJECT = {
+    "name": "New_Standard_Package_1",
+    "comments": "My Comments",
+    "color": "orange",
+    "access": True,
+    "threat_prevention": False
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_Standard_Package_1",
+    "comments": "My Comments",
+    "color": "orange",
+    "access": True,
+    "threat_prevention": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_Standard_Package_1",
+    "access_layers": {
+        "add": [
+            {
+                "name": "New Access Layer 1",
+                "position": 1
+            }
+        ]
+    },
+    "threat_layers": {
+        "add": [
+            {
+                "name": "New Layer 1",
+                "position": 2
+            }
+        ]
+    }
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_Standard_Package_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_package.api_call'
+api_call_object = 'package'
+
+
+class TestCheckpointPackage(object):
+    module = cp_mgmt_package
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_package_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_package_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_package_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'package'
+api_call_object_plural_version = 'packages'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointPackageFacts(object):
+    module = cp_mgmt_package_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_security_zone.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_security_zone.py
@@ -1,0 +1,113 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_security_zone
+
+OBJECT = {
+    "name": "SZone1",
+    "comments": "My Security Zone 1",
+    "color": "yellow"
+}
+
+CREATE_PAYLOAD = {
+    "name": "SZone1",
+    "comments": "My Security Zone 1",
+    "color": "yellow"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "SZone1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "SZone1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_security_zone.api_call'
+api_call_object = 'security-zone'
+
+
+class TestCheckpointSecurityZone(object):
+    module = cp_mgmt_security_zone
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_security_zone_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_security_zone_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_security_zone_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'security-zone'
+api_call_object_plural_version = 'security-zones'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointSecurityZoneFacts(object):
+    module = cp_mgmt_security_zone_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_dce_rpc.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_dce_rpc.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_dce_rpc
+
+OBJECT = {
+    "name": "New_DCE-RPC_Service_1",
+    "interface_uuid": "97aeb460-9aea-11d5-bd16-0090272ccb30",
+    "keep_connections_open_after_policy_installation": False
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_DCE-RPC_Service_1",
+    "interface_uuid": "97aeb460-9aea-11d5-bd16-0090272ccb30",
+    "keep_connections_open_after_policy_installation": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_DCE-RPC_Service_1",
+    "color": "blue",
+    "interface_uuid": "44aeb460-9aea-11d5-bd16-009027266b30"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_DCE-RPC_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_dce_rpc.api_call'
+api_call_object = 'service-dce-rpc'
+
+
+class TestCheckpointServiceDceRpc(object):
+    module = cp_mgmt_service_dce_rpc
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_dce_rpc_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_dce_rpc_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_dce_rpc_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-dce-rpc'
+api_call_object_plural_version = 'services-dce-rpc'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceDceRpcFacts(object):
+    module = cp_mgmt_service_dce_rpc_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_group.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_group.py
@@ -1,0 +1,121 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_group
+
+OBJECT = {
+    "name": "New Service Group 1",
+    "members": [
+        "https",
+        "bootp",
+        "nisplus",
+        "HP-OpCdistm"
+    ]
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Service Group 1",
+    "members": [
+        "https",
+        "bootp",
+        "nisplus",
+        "HP-OpCdistm"
+    ]
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Service Group 1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Service Group 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_group.api_call'
+api_call_object = 'service-group'
+
+
+class TestCheckpointServiceGroup(object):
+    module = cp_mgmt_service_group
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_group_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_group_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_group_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-group'
+api_call_object_plural_version = 'service-groups'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceGroupFacts(object):
+    module = cp_mgmt_service_group_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_global_assignment.py
test_cp_mgmt_global_assignment_facts.py
test_cp_mgmt_group.py
test_cp_mgmt_group_facts.py
test_cp_mgmt_group_with_exclusion_.py
test_cp_mgmt_group_with_exclusion_facts.py
test_cp_mgmt_host.py
test_cp_mgmt_host_facts.py
test_cp_mgmt_multicast_address_range.py
test_cp_mgmt_multicast_address_range_facts.py
test_cp_mgmt_package.py
test_cp_mgmt_package_facts.py
test_cp_mgmt_security_zone.py
test_cp_mgmt_security_zone_facts.py
test_cp_mgmt_service_dce_rpc.py
test_cp_mgmt_service_dce_rpc_facts.py
test_cp_mgmt_service_group.py
test_cp_mgmt_service_group_facts.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
