### PR TITLE
Third pr 18 tests

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_network.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_network.py
@@ -46,13 +46,6 @@ DELETE_PAYLOAD = {'name': 'test_new_network', 'state': 'absent'}
 class TestCheckpointNetwork(object):
     module = cp_mgmt_network
 
-    checkpoint_argument_spec_for_objects = dict(
-        auto_publish_session=dict(type='bool'),
-        wait_for_task=dict(type='bool', default=True),
-        state=dict(type='str', required=True, choices=['present', 'absent']),
-        version=dict(type='str')
-    )
-
     @pytest.fixture(autouse=True)
     def module_mock(self, mocker):
         return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
@@ -114,10 +107,3 @@ class TestCheckpointNetwork(object):
         with pytest.raises(AnsibleExitJson) as ex:
             self.module.main()
         return ex.value.args[0]
-
-    def _run_module_with_fail_json(self, module_args):
-        set_module_args(module_args)
-        with pytest.raises(AnsibleFailJson) as exc:
-            self.module.main()
-        result = exc.value.args[0]
-        return result

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_icmp.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_icmp.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_icmp
+
+OBJECT = {
+    "name": "Icmp1",
+    "icmp_type": 5,
+    "icmp_code": 7
+}
+
+CREATE_PAYLOAD = {
+    "name": "Icmp1",
+    "icmp_type": 5,
+    "icmp_code": 7
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Icmp1",
+    "icmp_type": 45,
+    "icmp_code": 13
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Icmp1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_icmp.api_call'
+api_call_object = 'service-icmp'
+
+
+class TestCheckpointServiceIcmp(object):
+    module = cp_mgmt_service_icmp
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_icmp6.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_icmp6.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_icmp6
+
+OBJECT = {
+    "name": "Icmp1",
+    "icmp_type": 5,
+    "icmp_code": 7
+}
+
+CREATE_PAYLOAD = {
+    "name": "Icmp1",
+    "icmp_type": 5,
+    "icmp_code": 7
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Icmp1",
+    "icmp_type": 45,
+    "icmp_code": 13
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Icmp1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_icmp6.api_call'
+api_call_object = 'service-icmp6'
+
+
+class TestCheckpointServiceIcmp6(object):
+    module = cp_mgmt_service_icmp6
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_icmp6_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_icmp6_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_icmp6_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-icmp6'
+api_call_object_plural_version = 'services-icmp6'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceIcmp6Facts(object):
+    module = cp_mgmt_service_icmp6_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_icmp_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_icmp_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_icmp_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-icmp'
+api_call_object_plural_version = 'services-icmp'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceIcmpFacts(object):
+    module = cp_mgmt_service_icmp_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_other.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_other.py
@@ -1,0 +1,133 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_other
+
+OBJECT = {
+    "name": "New_Service_1",
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "ip_protocol": 51,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_Service_1",
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "ip_protocol": 51,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_Service_1",
+    "color": "blue",
+    "aggressive_aging": {
+        "default_timeout": 3600
+    }
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_other.api_call'
+api_call_object = 'service-other'
+
+
+class TestCheckpointServiceOther(object):
+    module = cp_mgmt_service_other
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_other_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_other_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_other_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-other'
+api_call_object_plural_version = 'services-other'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceOtherFacts(object):
+    module = cp_mgmt_service_other_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_rpc.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_rpc.py
@@ -1,0 +1,115 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_rpc
+
+OBJECT = {
+    "name": "New_RPC_Service_1",
+    "program_number": 5669,
+    "keep_connections_open_after_policy_installation": False
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_RPC_Service_1",
+    "program_number": 5669,
+    "keep_connections_open_after_policy_installation": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_RPC_Service_1",
+    "color": "blue",
+    "program_number": 5656
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_RPC_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_rpc.api_call'
+api_call_object = 'service-rpc'
+
+
+class TestCheckpointServiceRpc(object):
+    module = cp_mgmt_service_rpc
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_rpc_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_rpc_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_rpc_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-rpc'
+api_call_object_plural_version = 'services-rpc'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceRpcFacts(object):
+    module = cp_mgmt_service_rpc_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_sctp.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_sctp.py
@@ -1,0 +1,134 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_sctp
+
+OBJECT = {
+    "name": "New_SCTP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_SCTP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_SCTP_Service_1",
+    "color": "blue",
+    "port": 5656,
+    "aggressive_aging": {
+        "default_timeout": 3600
+    }
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_SCTP_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_sctp.api_call'
+api_call_object = 'service-sctp'
+
+
+class TestCheckpointServiceSctp(object):
+    module = cp_mgmt_service_sctp
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_sctp_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_sctp_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_sctp_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-sctp'
+api_call_object_plural_version = 'services-sctp'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceSctpFacts(object):
+    module = cp_mgmt_service_sctp_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_tcp.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_tcp.py
@@ -1,0 +1,134 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_tcp
+
+OBJECT = {
+    "name": "New_TCP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_TCP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    }
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_TCP_Service_1",
+    "color": "blue",
+    "port": 5656,
+    "aggressive_aging": {
+        "default_timeout": 3600
+    }
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_TCP_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_tcp.api_call'
+api_call_object = 'service-tcp'
+
+
+class TestCheckpointServiceTcp(object):
+    module = cp_mgmt_service_tcp
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_tcp_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_tcp_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_tcp_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-tcp'
+api_call_object_plural_version = 'services-tcp'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceTcpFacts(object):
+    module = cp_mgmt_service_tcp_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_udp.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_udp.py
@@ -1,0 +1,137 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_udp
+
+OBJECT = {
+    "name": "New_UDP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    },
+    "accept_replies": False
+}
+
+CREATE_PAYLOAD = {
+    "name": "New_UDP_Service_1",
+    "port": 5669,
+    "keep_connections_open_after_policy_installation": False,
+    "session_timeout": 0,
+    "match_for_any": True,
+    "sync_connections_on_cluster": True,
+    "aggressive_aging": {
+        "enable": True,
+        "timeout": 360,
+        "use_default_timeout": False
+    },
+    "accept_replies": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New_UDP_Service_1",
+    "color": "blue",
+    "port": 5656,
+    "aggressive_aging": {
+        "default_timeout": 3600
+    },
+    "accept_replies": True
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New_UDP_Service_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_service_udp.api_call'
+api_call_object = 'service-udp'
+
+
+class TestCheckpointServiceUdp(object):
+    module = cp_mgmt_service_udp
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_service_udp_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_service_udp_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_service_udp_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'service-udp'
+api_call_object_plural_version = 'services-udp'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointServiceUdpFacts(object):
+    module = cp_mgmt_service_udp_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_simple_gateway.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_simple_gateway.py
@@ -1,0 +1,117 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_simple_gateway
+
+OBJECT = {
+    "name": "gw1",
+    "ip_address": "192.0.2.1"
+}
+
+CREATE_PAYLOAD = {
+    "name": "gw1",
+    "ip_address": "192.0.2.1"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "gw1",
+    "ips": True,
+    "application_control": True,
+    "url_filtering": True,
+    "anti_bot": True,
+    "anti_virus": True,
+    "threat_emulation": True
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "gw1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_simple_gateway.api_call'
+api_call_object = 'simple-gateway'
+
+
+class TestCheckpointSimpleGateway(object):
+    module = cp_mgmt_simple_gateway
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_simple_gateway_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_simple_gateway_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_simple_gateway_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'simple-gateway'
+api_call_object_plural_version = 'simple-gateways'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointSimpleGatewayFacts(object):
+    module = cp_mgmt_simple_gateway_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_tag.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_tag.py
@@ -1,0 +1,117 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_tag
+
+OBJECT = {
+    "name": "My New Tag1",
+    "tags": [
+        "tag1",
+        "tag2"
+    ]
+}
+
+CREATE_PAYLOAD = {
+    "name": "My New Tag1",
+    "tags": [
+        "tag1",
+        "tag2"
+    ]
+}
+
+UPDATE_PAYLOAD = {
+    "name": "My New Tag1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "My New Tag1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_tag.api_call'
+api_call_object = 'tag'
+
+
+class TestCheckpointTag(object):
+    module = cp_mgmt_tag
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_tag_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_tag_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_tag_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'tag'
+api_call_object_plural_version = 'tags'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointTagFacts(object):
+    module = cp_mgmt_tag_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_service_icmp.py
test_cp_mgmt_service_icmp_facts.py
test_cp_mgmt_service_icmp6.py
test_cp_mgmt_service_icmp6_facts.py
test_cp_mgmt_service_other_.py
test_cp_mgmt_service_other_facts.py
test_cp_mgmt_service_rpc.py
test_cp_mgmt_service_rpc_facts.py
test_cp_mgmt_service_sctp.py
test_cp_mgmt_service_sctp_facts.py
test_cp_mgmt_service_tcp.py
test_cp_mgmt_service_tcp_facts.py
test_cp_mgmt_service_udp.py
test_cp_mgmt_service_udp_facts.py
test_cp_mgmt_simple_gateway.py
test_cp_mgmt_simple_gateway_facts.py
test_cp_mgmt_tag.py
test_cp_mgmt_tag_facts.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
