### PR TITLE
Forth pr 18 tests

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_access_layer.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_layer.py
@@ -1,0 +1,110 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_layer
+
+OBJECT = {
+    "name": "New Layer 1"
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Layer 1"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Layer 1",
+    "applications_and_url_filtering": False
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Layer 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_access_layer.api_call'
+api_call_object = 'access-layer'
+
+
+class TestCheckpointAccessLayer(object):
+    module = cp_mgmt_access_layer
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_access_layer_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_layer_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_layer_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'access-layer'
+api_call_object_plural_version = 'access-layers'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointAccessLayerFacts(object):
+    module = cp_mgmt_access_layer_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_access_role.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_role.py
@@ -1,0 +1,119 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_role
+
+OBJECT = {
+    "name": "New Access Role 1",
+    "networks": "any",
+    "users": "any",
+    "machines": "all identified",
+    "remote_access_clients": "any"
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Access Role 1",
+    "networks": "any",
+    "users": "any",
+    "machines": "all identified",
+    "remote_access_clients": "any"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Access Role 1",
+    "users": "all identified",
+    "machines": "any"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Access Role 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_access_role.api_call'
+api_call_object = 'access-role'
+
+
+class TestCheckpointAccessRole(object):
+    module = cp_mgmt_access_role
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_access_role_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_role_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_role_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'access-role'
+api_call_object_plural_version = 'access-roles'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointAccessRoleFacts(object):
+    module = cp_mgmt_access_role_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_administrator.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_administrator.py
@@ -1,0 +1,123 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_administrator
+
+OBJECT = {
+    "name": "admin",
+    "password": "secret",
+    "email": "admin@gmail.com",
+    "must_change_password": False,
+    "phone_number": "1800-800-800",
+    "authentication_method": "undefined",
+    "permissions_profile": "read write all"
+}
+
+CREATE_PAYLOAD = {
+    "name": "admin",
+    "password": "secret",
+    "email": "admin@gmail.com",
+    "must_change_password": False,
+    "phone_number": "1800-800-800",
+    "authentication_method": "undefined",
+    "permissions_profile": "read write all"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "admin",
+    "password": "bew secret",
+    "permissions_profile": "read only profile"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "admin",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_administrator.api_call'
+api_call_object = 'administrator'
+
+
+class TestCheckpointAdministrator(object):
+    module = cp_mgmt_administrator
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_administrator_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_administrator_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_administrator_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'administrator'
+api_call_object_plural_version = 'administrators'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointAdministratorFacts(object):
+    module = cp_mgmt_administrator_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site.py
@@ -1,0 +1,136 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site
+
+OBJECT = {
+    "name": "New Application Site 1",
+    "description": "My Application Site",
+    "primary_category": "Social Networking",
+    "additional_categories": [
+        "Instant Chat",
+        "Supports Streaming",
+        "New Application Site Category 1"
+    ],
+    "url_list": [
+        "www.cnet.com",
+        "www.stackoverflow.com"
+    ],
+    "urls_defined_as_regular_expression": False
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Application Site 1",
+    "description": "My Application Site",
+    "primary_category": "Social Networking",
+    "additional_categories": [
+        "Instant Chat",
+        "Supports Streaming",
+        "New Application Site Category 1"
+    ],
+    "url_list": [
+        "www.cnet.com",
+        "www.stackoverflow.com"
+    ],
+    "urls_defined_as_regular_expression": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Application Site 1",
+    "description": "My New Application Site",
+    "primary_category": "Instant Chat",
+    "urls_defined_as_regular_expression": True
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Application Site 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_application_site.api_call'
+api_call_object = 'application-site'
+
+
+class TestCheckpointApplicationSite(object):
+    module = cp_mgmt_application_site
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site_category.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site_category.py
@@ -1,0 +1,112 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site_category
+
+OBJECT = {
+    "name": "New Application Site Category 1",
+    "description": "My Application Site category"
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Application Site Category 1",
+    "description": "My Application Site category"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Application Site Category 1",
+    "description": "My new Application Site category"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Application Site Category 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_application_site_category.api_call'
+api_call_object = 'application-site-category'
+
+
+class TestCheckpointApplicationSiteCategory(object):
+    module = cp_mgmt_application_site_category
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site_category_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site_category_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site_category_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'application-site-category'
+api_call_object_plural_version = 'application-site-categories'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointApplicationSiteCategoryFacts(object):
+    module = cp_mgmt_application_site_category_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'application-site'
+api_call_object_plural_version = 'application-sites'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointApplicationSiteFacts(object):
+    module = cp_mgmt_application_site_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site_group.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site_group.py
@@ -1,0 +1,121 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site_group
+
+OBJECT = {
+    "name": "New Application Site Group 1",
+    "members": [
+        "facebook",
+        "Social Networking",
+        "New Application Site 1",
+        "New Application Site Category 1"
+    ]
+}
+
+CREATE_PAYLOAD = {
+    "name": "New Application Site Group 1",
+    "members": [
+        "facebook",
+        "Social Networking",
+        "New Application Site 1",
+        "New Application Site Category 1"
+    ]
+}
+
+UPDATE_PAYLOAD = {
+    "name": "New Application Site Group 1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Application Site Group 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_application_site_group.api_call'
+api_call_object = 'application-site-group'
+
+
+class TestCheckpointApplicationSiteGroup(object):
+    module = cp_mgmt_application_site_group
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_application_site_group_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_application_site_group_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_application_site_group_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'application-site-group'
+api_call_object_plural_version = 'application-site-groups'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointApplicationSiteGroupFacts(object):
+    module = cp_mgmt_application_site_group_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_dns_domain.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_dns_domain.py
@@ -1,0 +1,112 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_dns_domain
+
+OBJECT = {
+    "name": ".www.example.com",
+    "is_sub_domain": False
+}
+
+CREATE_PAYLOAD = {
+    "name": ".www.example.com",
+    "is_sub_domain": False
+}
+
+UPDATE_PAYLOAD = {
+    "name": ".www.example.com",
+    "is_sub_domain": True
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": ".www.example.com",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_dns_domain.api_call'
+api_call_object = 'dns-domain'
+
+
+class TestCheckpointDnsDomain(object):
+    module = cp_mgmt_dns_domain
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_dns_domain_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_dns_domain_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_dns_domain_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'dns-domain'
+api_call_object_plural_version = 'dns-domains'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointDnsDomainFacts(object):
+    module = cp_mgmt_dns_domain_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_dynamic_object.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_dynamic_object.py
@@ -1,0 +1,113 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_dynamic_object
+
+OBJECT = {
+    "name": "Dynamic_Object_1",
+    "comments": "My Dynamic Object 1",
+    "color": "yellow"
+}
+
+CREATE_PAYLOAD = {
+    "name": "Dynamic_Object_1",
+    "comments": "My Dynamic Object 1",
+    "color": "yellow"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Dynamic_Object_1"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Dynamic_Object_1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_dynamic_object.api_call'
+api_call_object = 'dynamic-object'
+
+
+class TestCheckpointDynamicObject(object):
+    module = cp_mgmt_dynamic_object
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_dynamic_object_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_dynamic_object_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_dynamic_object_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'dynamic-object'
+api_call_object_plural_version = 'dynamic-objects'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointDynamicObjectFacts(object):
+    module = cp_mgmt_dynamic_object_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_exception_group.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_exception_group.py
@@ -1,0 +1,113 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_exception_group
+
+OBJECT = {
+    "name": "exception_group_2",
+    "apply_on": "manually-select-threat-rules"
+}
+
+CREATE_PAYLOAD = {
+    "name": "exception_group_2",
+    "apply_on": "manually-select-threat-rules"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "exception_group_2",
+    "tags": "tag3",
+    "apply_on": "all-threat-rules"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "exception_group_2",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_exception_group.api_call'
+api_call_object = 'exception-group'
+
+
+class TestCheckpointExceptionGroup(object):
+    module = cp_mgmt_exception_group
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_exception_group_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_exception_group_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_exception_group_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'exception-group'
+api_call_object_plural_version = 'exception-groups'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointExceptionGroupFacts(object):
+    module = cp_mgmt_exception_group_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_network.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_network.py
@@ -46,13 +46,6 @@ DELETE_PAYLOAD = {'name': 'test_new_network', 'state': 'absent'}
 class TestCheckpointNetwork(object):
     module = cp_mgmt_network
 
-    checkpoint_argument_spec_for_objects = dict(
-        auto_publish_session=dict(type='bool'),
-        wait_for_task=dict(type='bool', default=True),
-        state=dict(type='str', required=True, choices=['present', 'absent']),
-        version=dict(type='str')
-    )
-
     @pytest.fixture(autouse=True)
     def module_mock(self, mocker):
         return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
@@ -114,10 +107,3 @@ class TestCheckpointNetwork(object):
         with pytest.raises(AnsibleExitJson) as ex:
             self.module.main()
         return ex.value.args[0]
-
-    def _run_module_with_fail_json(self, module_args):
-        set_module_args(module_args)
-        with pytest.raises(AnsibleFailJson) as exc:
-            self.module.main()
-        result = exc.value.args[0]
-        return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_access_layer.py
test_cp_mgmt_access_layer_facts.py
test_cp_mgmt_access_role.py
test_cp_mgmt_access_role_facts.py
test_cp_mgmt_administrator_.py
test_cp_mgmt_administrator_facts.py
test_cp_mgmt_application_site.py
test_cp_mgmt_application_site_facts.py
test_cp_mgmt_application_site_catagory.py
test_cp_mgmt_application_site_catagory_facts.py
test_cp_mgmt_application_group.py
test_cp_mgmt_application_group_facts.py
test_cp_mgmt_dns_domain.py
test_cp_mgmt_dns_domain_facts.py
test_cp_mgmt_dynamic_object.py
test_cp_mgmt_dynamic_object_facts.py
test_cp_mgmt_exception_group.py
test_cp_mgmt_exception_group_facts.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
