### PR TITLE
VMware: Simplifying get_vm() in module_utils.vmware

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -929,12 +929,10 @@ class PyVmomi(object):
             vms = []
 
             for temp_vm_object in objects:
-                if len(temp_vm_object.propSet) != 1:
-                    continue
-                for temp_vm_object_property in temp_vm_object.propSet:
-                    if temp_vm_object_property.val == self.params['name']:
-                        vms.append(temp_vm_object.obj)
-                        break
+                if (
+                        len(temp_vm_object.propSet) == 1 and
+                        temp_vm_object.propSet[0].val == self.params['name']):
+                    vms.append(temp_vm_object.obj)
 
             # get_managed_objects_properties may return multiple virtual machine,
             # following code tries to find user desired one depending upon the folder specified.


### PR DESCRIPTION
##### SUMMARY
This PR is simplifying the code of the `get_vm()` method of the `module_utils.vmware` package. The condition:

```python
                 if len(temp_vm_object.propSet) != 1:
                     continue
```

is explicitly saying that the `temp_vm_object.propSet` must have only single item. This allows to simplify the following code by removing the `for` loop and addressing the first item of the list directly.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
`module_utils.vmware`

##### ADDITIONAL INFORMATION
N/A