### PR TITLE
Always specify header of connection keep-alive regardless of python v…

### DIFF
--- a/changelogs/fragments/62218-fix-to-entrust-api.yml
+++ b/changelogs/fragments/62218-fix-to-entrust-api.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - openssl_certificate - When provider is ``entrust``, use a ``connection: keep-alive`` header for ECS API connections.
-  - ecs_certificate - Always specify header ``connection: keep-alive`` for ECS API connections.
+- "openssl_certificate - When provider is ``entrust``, use a ``connection: keep-alive`` header for ECS API connections."
+- "ecs_certificate - Always specify header ``connection: keep-alive`` for ECS API connections."

--- a/changelogs/fragments/62218-fix-to-entrust-api.yml
+++ b/changelogs/fragments/62218-fix-to-entrust-api.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - openssl_certificate - When provider is ``entrust``, use a ``connection: keep-alive`` header for ECS API connections.
+  - ecs_certificate - Always specify header ``connection: keep-alive`` for ECS API connections.

--- a/lib/ansible/module_utils/ecs/api.py
+++ b/lib/ansible/module_utils/ecs/api.py
@@ -241,7 +241,10 @@ class ECSSession(object):
         return resource
 
     def _set_config(self, name, **kwargs):
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+        }
         self.request = Request(headers=headers, timeout=60)
 
         configurators = [self._read_config_vars]


### PR DESCRIPTION
##### SUMMARY
One of our testers found that Python seems to be inconsistent with connection headers depending on version of Python/libraries.

The REST API doesn't work well with "connection: close", so this bugfix is to always set a connection keep-alive header (this drastically improves performance).


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
ecs_certificate
module_utils/ecs/api