### PR TITLE
Always specify header of connection keep-alive regardless of python v…

### DIFF
--- a/changelogs/fragments/62218-fix-to-entrust-api.yml
+++ b/changelogs/fragments/62218-fix-to-entrust-api.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "openssl_certificate - When provider is ``entrust``, use a ``connection: keep-alive`` header for ECS API connections."
+- "ecs_certificate - Always specify header ``connection: keep-alive`` for ECS API connections."

--- a/lib/ansible/module_utils/ecs/api.py
+++ b/lib/ansible/module_utils/ecs/api.py
@@ -241,7 +241,10 @@ class ECSSession(object):
         return resource
 
     def _set_config(self, name, **kwargs):
-        headers = {"Content-Type": "application/json"}
+        headers = {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+        }
         self.request = Request(headers=headers, timeout=60)
 
         configurators = [self._read_config_vars]


### PR DESCRIPTION
…… (#62218)

* Always specify header of connection keep-alive regardless of python version.

* Add chgangelog fragment

* Fixes to changelog fragment

(cherry picked from commit 606e13919ee028a8c33e6e1e65980a8488c971fa)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/62218

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ecs_certificate
openssl_certificate
module_utils/ecs/api