### PR TITLE
nxos_bfd_global - add missing import of re

### DIFF
--- a/changelogs/fragments/nxos_bfd_global-add-missing-import.yaml
+++ b/changelogs/fragments/nxos_bfd_global-add-missing-import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nxos_bfd_global - add missing import of re

--- a/lib/ansible/modules/network/nxos/nxos_bfd_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_bfd_global.py
@@ -139,6 +139,7 @@ cmds:
 '''
 
 
+import re
 from ansible.module_utils.network.nxos.nxos import NxosCmdRef
 from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.network.nxos.nxos import load_config


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The import of `re` was removed recently but is needed by a recent commit. This is causing CI failures in `devel`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/network/nxos/nxos_bfd_global.py`