### PR TITLE
Backport 2.8: explicited RouterOS does not support connection: local

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_routeros.rst
+++ b/docs/docsite/rst/network/user_guide/platform_routeros.rst
@@ -29,6 +29,8 @@ Connections Available
 | **Returned Data Format**  | ``stdout[0].``                                |
 +---------------------------+-----------------------------------------------+
 
+RouterOS does not support ``ansible_connection: local``. You must use ``ansible_connection: network_cli``.
+
 Using CLI in Ansible
 ====================
 


### PR DESCRIPTION
(cherry picked from commit b8aa87bd064f6a70672b1db7b0a33207d8e29926)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
[Settings by Platform](https://docs.ansible.com/ansible/devel/network/user_guide/platform_index.html#settings-by-platform) matrix says that RouterOS does not support local connection plugin.
- Backport: #62203
So I specified that like VOSS/NOS etc Platform Options Page.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- RouterOS Platform Options