### PR TITLE
backport/2.9/61959 lookup_rabbitmq pika > 1.0.0 is_closing bug fix (#61959)

### DIFF
--- a/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
+++ b/changelogs/fragments/lookup_rabbitmq-is_closing-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq lookup plugin - Fix for rabbitmq lookups failing when using pika v1.0.0 and newer.

--- a/lib/ansible/plugins/lookup/rabbitmq.py
+++ b/lib/ansible/plugins/lookup/rabbitmq.py
@@ -180,7 +180,7 @@ class LookupModule(LookupBase):
             else:
                 break
 
-        if connection.is_closing or connection.is_closed:
+        if connection.is_closed:
             return [ret]
         else:
             try:


### PR DESCRIPTION
* In pika v1.0.0 BlockingChannel.is_closing was removed.  Updating
plugin accordingly.

Ref: https://github.com/pika/pika/pull/1034

* Adding change fragment for is_closing bug.

* Updated change fragment description.

(cherry picked from commit 9b149917a63ead90f49918632cb64ea2892f50da)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixed in https://github.com/ansible/ansible/pull/61959

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/lookup/rabbitmq.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
