### PR TITLE
backport/2.9/61960 rabbitmq_publish fix for incorrectly stating message was not publishe…

### DIFF
--- a/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
+++ b/changelogs/fragments/55919-rabbitmq_publish-fix-for-recent-pika-versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rabbitmq_publish - Fix to ensure the module works correctly for pika v1.0.0 and later. (https://github.com/ansible/ansible/pull/61960)

--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -18,6 +18,7 @@ import traceback
 PIKA_IMP_ERR = None
 try:
     import pika
+    import pika.exceptions
     from pika import spec
     HAS_PIKA = True
 except ImportError:
@@ -193,4 +194,8 @@ class RabbitClient():
         if args['exchange'] is None:
             args['exchange'] = ''
 
-        return self.conn_channel.basic_publish(**args)
+        try:
+            self.conn_channel.basic_publish(**args)
+            return True
+        except pika.exceptions.UnroutableError:
+            return False


### PR DESCRIPTION
…d to the queue (#61960)

* Pika v1.0.0 and above were causing issues for publish_message.  Updated
to ensure publish_message works with pika 0.13.1 and 1.0.0 and above.

* Adding changelog fragment for rabbitmq_publish fix.

* Updating return value.

(cherry picked from commit 1b2fd2cb5ffd8c7b909ac178f81f764669dc49d8)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixed in: https://github.com/ansible/ansible/pull/61960

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_publish.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
