### PR TITLE
[2.9] core: Handle empty extra vars in cli

### DIFF
--- a/changelogs/fragments/extra-vars.yml
+++ b/changelogs/fragments/extra-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Handle empty extra vars in ansible cli (https://github.com/ansible/ansible/issues/61497).

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -60,6 +60,8 @@ def parse_kv(args, check_raw=False):
     if args is not None:
         try:
             vargs = split_args(args)
+        except IndexError as e:
+            raise AnsibleParserError("Unable to parse argument string", orig_exc=e)
         except ValueError as ve:
             if 'no closing quotation' in str(ve).lower():
                 raise AnsibleParserError("error parsing argument string, try quoting the entire line.", orig_exc=ve)


### PR DESCRIPTION
##### SUMMARY
Fixes: #61497

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of https://github.com/ansible/ansible/pull/61831

(cherry picked from commit a2e61f67d5810d8b33989d6f9980d1f84fe67d54)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/extra-vars.yml
lib/ansible/parsing/splitter.py
