### PR TITLE
nxos_lacp_interfaces: fix integration test dependencies (#61947)

### DIFF
--- a/changelogs/fragments/nxos_lacp_interfaces29.yaml
+++ b/changelogs/fragments/nxos_lacp_interfaces29.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_lacp_interfaces fix integration test dependencies (https://github.com/ansible/ansible/pull/61947).

--- a/test/integration/targets/nxos_lacp_interfaces/meta/main.yml
+++ b/test/integration/targets/nxos_lacp_interfaces/meta/main.yml
@@ -1,1 +1,2 @@
-dependencies: []
+dependencies:
+  - prepare_nxos_tests

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Start nxos_lacp_interfaces deleted integration tests connection={{ ansible_connection }}"
 
+- set_fact:
+    mode: delay
+  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+
 - name: setup1
   cli_config: &cleanup
     config: |
@@ -15,9 +19,17 @@
       config: |
         feature lacp
         interface port-channel5
-        lacp min-links 5
+          lacp min-links 5
         interface port-channel10
-        lacp mode delay
+          lacp max-bundle 10
+
+  - name: setup3 - L2 for mode command
+    cli_config:
+      config: |
+        interface port-channel10
+          switchport
+          lacp mode delay
+    when: mode is defined
 
   - name: Gather lacp_interfaces facts
     nxos_facts: &facts
@@ -39,8 +51,13 @@
         - "'interface port-channel5' in result.commands"
         - "'no lacp min-links' in result.commands"
         - "'interface port-channel10' in result.commands"
+        - "'no lacp max-bundle' in result.commands"
+
+  - assert:
+      that:
         - "'no lacp mode delay' in result.commands"
-        - "result.commands|length == 4"
+        - "result.commands|length == 5"
+    when: mode is defined
 
   - name: Idempotence - deleted
     nxos_lacp_interfaces: *deleted

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Start nxos_lacp_interfaces merged integration tests connection={{ ansible_connection }}"
 
+- set_fact:
+    mode: delay
+  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+
 - name: setup1
   cli_config: &cleanup
     config: |
@@ -15,6 +19,13 @@
       config: |
         feature lacp
 
+  - name: setup3 - L2 for mode command
+    cli_config:
+      config: |
+        interface port-channel5
+          switchport
+    when: mode is defined
+
   - name: Merged
     nxos_lacp_interfaces: &merged
       config:
@@ -22,7 +33,9 @@
           links:
             min: 5
         - name: port-channel5
-          mode: delay
+          mode: "{{ mode | default(omit) }}"
+          links:
+            max: 10
       state:  merged
     register: result
 
@@ -33,8 +46,13 @@
         - "'interface port-channel10' in result.commands"
         - "'lacp min-links 5' in result.commands"
         - "'interface port-channel5' in result.commands"
+        - "'lacp max-bundle 10' in result.commands"
+
+  - assert:
+      that:
         - "'lacp mode delay' in result.commands"
-        - "result.commands|length == 4"
+        - "result.commands|length == 5"
+    when: mode is defined
 
   - name: Gather lacp_interfaces facts
     nxos_facts:

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
@@ -2,13 +2,17 @@
 - debug:
     msg: "Start nxos_lacp_interfaces overridden integration tests connection={{ ansible_connection }}"
 
+- set_fact:
+    mode: delay
+  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+
 - name: setup1
   cli_config: &cleanup
     config: |
       no interface port-channel5
       no interface port-channel10
       no interface port-channel11
-      no feature lacp 
+      no feature lacp
 
 - block:
   - name: setup2
@@ -16,9 +20,16 @@
       config: |
         feature lacp
         interface port-channel10
-        lacp min-links 5
+          lacp min-links 5
         interface port-channel5
-        lacp max-bundle 10
+          lacp max-bundle 10
+
+  - name: setup3 - L2 for mode command
+    cli_config:
+      config: |
+        interface port-channel11
+          switchport
+    when: mode is defined
 
   - name: Gather lacp_interfaces facts
     nxos_facts: &facts
@@ -31,7 +42,9 @@
     nxos_lacp_interfaces: &overridden
       config:
         - name: port-channel11
-          mode: delay
+          links:
+            min: 4
+          mode: "{{ mode | default(omit) }}"
       state: overridden
     register: result
 
@@ -44,8 +57,12 @@
         - "'interface port-channel5' in result.commands"
         - "'no lacp max-bundle' in result.commands"
         - "'interface port-channel11' in result.commands"
+
+  - assert:
+      that:
         - "'lacp mode delay' in result.commands"
-        - "result.commands|length == 6"
+        - "result.commands|length == 7"
+    when: mode is defined
 
   - name: Gather lacp_interfaces post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
@@ -2,6 +2,10 @@
 - debug:
     msg: "Start nxos_lacp_interfaces replaced integration tests connection={{ ansible_connection }}"
 
+- set_fact:
+    mode: delay
+  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+
 - name: setup1
   cli_config: &cleanup
     config: |
@@ -14,7 +18,8 @@
       config: |
         feature lacp
         interface port-channel10
-        lacp min-links 5
+          switchport
+          lacp min-links 5
 
   - name: Gather lacp_interfaces facts
     nxos_facts: &facts
@@ -29,6 +34,7 @@
         - name: port-channel10
           links:
             max: 10
+          mode: "{{ mode | default(omit) }}"
       state: replaced
     register: result
 
@@ -39,7 +45,12 @@
         - "'interface port-channel10' in result.commands"
         - "'no lacp min-links' in result.commands"
         - "'lacp max-bundle 10' in result.commands"
-        - "result.commands|length == 3"
+
+  - assert:
+      that:
+        - "'lacp mode delay' in result.commands"
+        - "result.commands|length == 4"
+    when: mode is defined
 
   - name: Gather lacp_interfaces post facts
     nxos_facts: *facts


### PR DESCRIPTION
* nxos_lacp_interfaces: fix integration test dependencies

* Add conditional mode test to m/d/r tests

(cherry picked from commit 6e72893d78a71c1f70dcbe9e25fae746d3240822)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

