### PR TITLE
nxos_l2_interfaces: fix for integration tests failing to setup layer2

### DIFF
--- a/changelogs/fragments/nxos_l2_interfaces29.yaml
+++ b/changelogs/fragments/nxos_l2_interfaces29.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nxos_l2_interfaces fix for integration tests failing to setup layer2 (https://github.com/ansible/ansible/pull/61887).

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
@@ -17,8 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport trunk native vlan 10
         interface {{ test_int2 }}
+          switchport
           switchport trunk allowed vlan 20
 
   - name: Gather l2_interfaces facts

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
@@ -11,6 +11,12 @@
   ignore_errors: yes
 
 - block:
+  - name: setup2
+    cli_config:
+      config: |
+        interface {{ test_int1 }}
+          switchport
+
   - name: Merged
     nxos_l2_interfaces: &merged
       config:

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
@@ -17,7 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport trunk allowed vlan 11
+        interface {{ test_int2 }}
+          switchport
 
   - name: Gather l2_interfaces facts
     nxos_facts: &facts

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
@@ -17,8 +17,10 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
+          switchport
           switchport access vlan 5
         interface {{ test_int2 }}
+          switchport
           switchport trunk native vlan 15
 
   - name: Gather l2_interfaces facts


### PR DESCRIPTION
(#61887)

(cherry picked from commit c0f3777fe2a41d4b8884dce82e5dc4d74c261f6b)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
