### PR TITLE
Backport of 62204: elasticache_info: fix a typo

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_info.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_info.py
@@ -105,7 +105,7 @@ elasticache_clusters:
               returned: always
               type: int
               sample: 6379
-        parameter_grou_status:
+        parameter_group_status:
           description: Status of the Cache Parameter Group
           returned: always
           type: str


### PR DESCRIPTION
(cherry picked from commit a72ea8440aea1b9e5b13773a3adf50faea88ee03)

##### SUMMARY
Backport of #62204 : elasticache_info: fix a typo

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
'''lib/ansible/modules/cloud/amazon/elasticache_info.py'''
