### PR TITLE
[stable-2.9] fix nxos_config tests for httpapi (#62082)

### DIFF
--- a/test/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -25,9 +25,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test cases (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local connection={{ nxapi }}"
-  with_items: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/nxos_config/tests/common/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/common/backup.yaml
@@ -66,7 +66,6 @@
     backup_options:
       filename: backup.cfg
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:
@@ -88,7 +87,6 @@
     backup: yes
     backup_options:
       filename: backup.cfg
-  become: yes
   register: result
 
 - assert:
@@ -110,7 +108,6 @@
     backup: yes
     backup_options:
       dir_path: "{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}"
-  become: yes
   register: result
 
 - assert:


### PR DESCRIPTION
* fix nxos_config tests for httpapi

* Remove become parameter

(cherry picked from commit c4894b512d17e479595d17cb525f6b69e90f3c2c)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
