### PR TITLE
Backport of  62201: fix typos in net_tools_modules

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -224,7 +224,7 @@ EXAMPLES = r'''
     dest: /tmp/afilecopy.txt
 
 - name: < Fetch file that requires authentication.
-        username/password only availabe since 2.8, in older versions you need to use url_username/url_password
+        username/password only available since 2.8, in older versions you need to use url_username/url_password
   get_url:
     url: http://example.com/path/file.conf
     dest: /etc/foo.conf

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -468,7 +468,7 @@ def form_urlencoded(body):
 
     if isinstance(body, (Mapping, Sequence)):
         result = []
-        # Turn a list of lists into a list of tupples that urlencode accepts
+        # Turn a list of lists into a list of tuples that urlencode accepts
         for key, values in kv_list(body):
             if isinstance(values, string_types) or not isinstance(values, (Mapping, Sequence)):
                 values = [values]

--- a/lib/ansible/modules/net_tools/infinity/infinity.py
+++ b/lib/ansible/modules/net_tools/infinity/infinity.py
@@ -151,7 +151,7 @@ class Infinity(object):
             params=None,
             payload_data=None):
         """
-        Perform the HTTPS request by using anible get/delete method
+        Perform the HTTPS request by using ansible get/delete method
         """
         stat_codes = [200] if stat_codes is None else stat_codes
         request_url = str(self.base_url) + str(resource_url)

--- a/lib/ansible/modules/net_tools/nios/nios_fixed_address.py
+++ b/lib/ansible/modules/net_tools/nios/nios_fixed_address.py
@@ -19,7 +19,7 @@ short_description: Configure Infoblox NIOS DHCP Fixed Address
 description:
   - A fixed address is a specific IP address that a DHCP server
     always assigns when a lease request comes from a particular
-    MAC address of the clien.
+    MAC address of the client.
   - Supports both IPV4 and IPV6 internet protocols
 requirements:
   - infoblox-client


### PR DESCRIPTION
(cherry picked from commit 6936187bbe6ab55f1daf3acd9e5e0ca9ee68ec02)

##### SUMMARY
Backport of  #62201: fix typos in net_tools_modules

##### ISSUE TYPE
- Docs Pull Request
