### PR TITLE
Use long option when not creating user group with luseradd

### DIFF
--- a/changelogs/fragments/62245-rhel8_local_user_creation_without_group_fails
+++ b/changelogs/fragments/62245-rhel8_local_user_creation_without_group_fails
@@ -1,0 +1,2 @@
+bugfixes:
+  - "user.py now use the long option for creating users without user groups on RHEL/CentOS as the short option case changes between versions"

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -598,17 +598,14 @@ class User(object):
             cmd.append('-g')
             cmd.append(self.group)
         elif self.group_exists(self.name):
-            # use the -N option (no user group) if a group already
-            # exists with the same name as the user to prevent
-            # errors from useradd trying to create a group when
-            # USERGROUPS_ENAB is set in /etc/login.defs.
+            # use the --nocreategroup (-n/-N)option (no user group) 
+            # if a group already exists with the same name 
+            # as the user to prevent errors from useradd 
+            # trying to create a group when USERGROUPS_ENAB 
+            # is set in /etc/login.defs.
             if os.path.exists('/etc/redhat-release'):
-                dist = distro.linux_distribution(full_distribution_name=False)
-                major_release = int(dist[1].split('.')[0])
-                if major_release <= 5:
-                    cmd.append('-n')
-                else:
-                    cmd.append('-N')
+                # use the long command to avoid case shifting issues
+                cmd.append('--nocreategroup')
             elif os.path.exists('/etc/SuSE-release'):
                 # -N did not exist in useradd before SLE 11 and did not
                 # automatically create a group

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -598,10 +598,10 @@ class User(object):
             cmd.append('-g')
             cmd.append(self.group)
         elif self.group_exists(self.name):
-            # use the --nocreategroup (-n/-N)option (no user group) 
-            # if a group already exists with the same name 
-            # as the user to prevent errors from useradd 
-            # trying to create a group when USERGROUPS_ENAB 
+            # use the --nocreategroup (-n/-N)option (no user group)
+            # if a group already exists with the same name
+            # as the user to prevent errors from useradd
+            # trying to create a group when USERGROUPS_ENAB
             # is set in /etc/login.defs.
             if os.path.exists('/etc/redhat-release'):
                 # use the long command to avoid case shifting issues


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use the long option as the short option in luseradd for adding users without creating a user group change case between versions (-n/-N). Fixes #62245.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/system/user.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Case for the short option changes between versions, lower case (-n) in rhel/centos 5, upper case (-N) in 6 and 7 and then back to lower case in 8, the long option --nocreategroup is unchanged across all versions.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
