### PR TITLE
Backport of 62200: fix typos in identity modules

### DIFF
--- a/lib/ansible/modules/identity/cyberark/cyberark_user.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_user.py
@@ -210,7 +210,7 @@ def user_add_or_update(module, HTTPMethod):
     api_base_url = cyberark_session["api_base_url"]
     validate_certs = cyberark_session["validate_certs"]
 
-    # Prepare result, paylod, and headers
+    # Prepare result, payload, and headers
     result = {}
     payload = {}
     headers = {'Content-Type': 'application/json',

--- a/lib/ansible/modules/identity/onepassword_info.py
+++ b/lib/ansible/modules/identity/onepassword_info.py
@@ -68,7 +68,7 @@ options:
         description:
             - A dictionary containing authentication details. If this is set, M(onepassword_info) will attempt to sign in to 1Password automatically.
             - Without this option, you must have already logged in via the 1Password CLI before running Ansible.
-            - It is B(highly) recommened to store 1Password credentials in an Ansible Vault. Ensure that the key used to encrypt
+            - It is B(highly) recommended to store 1Password credentials in an Ansible Vault. Ensure that the key used to encrypt
               the Ansible Vault is equal to or greater in strength than the 1Password master password.
         suboptions:
             subdomain:


### PR DESCRIPTION
(cherry picked from commit 742eebc92c7c30d250b971c50884379d8fbc3a47)

##### SUMMARY
Backport of #62200: fix typos in identity modules

##### ISSUE TYPE
- Docs Pull Request