### PR TITLE
Fix access to exception using Python 3 scoping rules

### DIFF
--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -286,9 +286,9 @@ class TestTemplarMisc(BaseTemplar, unittest.TestCase):
         # FIXME Use assertRaises() as a context manager (added in 2.7) once we do not run tests on Python 2.6 anymore.
         try:
             templar.available_variables = "foo=bam"
-        except AssertionError as e:
+        except AssertionError:
             pass
-        except Exception:
+        except Exception as e:
             self.fail(e)
 
     def test_templar_escape_backslashes(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Current code will raise __NameError__ instead of the expected exception because of Python 3 scoping rules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
