### PR TITLE
Backport of 62197: fix typos in commands modules

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -211,7 +211,7 @@ def main():
         # This should catch all insufficient versions of pexpect
         # We deem them insufficient for their lack of ability to specify
         # to not echo responses via the run/runu functions, which would
-        # potentially leak sensentive information
+        # potentially leak sensitive information
         module.fail_json(msg='Insufficient version of pexpect installed '
                              '(%s), this module requires pexpect>=3.3. '
                              'Error was %s' % (pexpect.__version__, to_native(e)))

--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -93,7 +93,7 @@ options:
   asynchronous:
     description:
     - Will run the command as a detached process and the module returns
-      immediately after starting the processs while the process continues to
+      immediately after starting the process while the process continues to
       run in the background.
     - The I(stdout) and I(stderr) return values will be null when this is set
       to C(yes).


### PR DESCRIPTION
(cherry picked from commit 6691527799256b1dcde680568a5e3a14189dd0c6)

##### SUMMARY
Backport of #62197: fix typos in commands modules

##### ISSUE TYPE
- Docs Pull Request