### PR TITLE
Fix os_keystone_endpoint endpoint_interface docs

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py
@@ -29,7 +29,7 @@ options:
      description:
         - Name or id of the service.
      required: true
-   interface:
+   endpoint_interface:
      description:
         - Interface of the service.
      choices: [admin, public, internal]

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1605,8 +1605,8 @@ lib/ansible/modules/cloud/openstack/os_keypair.py validate-modules:doc-missing-t
 lib/ansible/modules/cloud/openstack/os_keystone_domain.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/openstack/os_keystone_domain_info.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/openstack/os_keystone_domain_info.py validate-modules:doc-missing-type
+lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:option-incorrect-version-added
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:undocumented-parameter
-lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/openstack/os_keystone_role.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
The os_keystone_endpoint module has two interface arguments -
'interface' for authentication, and 'endpoint_interface' for the
endpoint being registered. Currently the module documentation only
covers 'interface', when in fact it should cover 'endpoint_interface'
and pick up 'interface' from the standard OpenStack module parameter
documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
os_keystone_endpoint
