### PR TITLE
setup_docker/rhel7: drop system python-docker

### DIFF
--- a/test/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -25,6 +25,11 @@
   args:
     warn: no
 
+- name: Remove the existing python-requests to be able to install the one wanted by docker-py
+  yum:
+    name: python-requests
+    state: absent
+
 - name: Install docker
   yum:
     name: "{{ docker_packages }}"

--- a/test/integration/targets/setup_docker/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/vars/RedHat-7.yml
@@ -4,5 +4,4 @@ docker_prereq_packages:
   - lvm2
   - libseccomp
 
-docker_pip_extra_packages:
-  - requests==2.6.0
+docker_pip_extra_packages: []


### PR DESCRIPTION
##### SUMMARY

On RHEL7.6: docker-py 4.02 wants requests 2.22.0. RHEL ships requests 2.6.0, and pip doesn't upgrade it:
`cannot uninstall  not possible (ERROR: Cannot uninstall 'requests'. It is a distutils installed project
and thus we cannot accurately determine which files belong to it which would lead to only a partial
uninstall.).`.

The problem is related to the bump to pip 19.2.3 that happens with the
default-test-container:1.9.3 image:
https://github.com/ansible/default-test-container/commits/a95c5cb27261e3d73a5d66273bb03830b68d8590

The same task before the pip upgrade:
```
04:46 TASK [setup_docker : Install Python requirements] ******************************
04:48 [0;33mchanged: [testhost] => {"changed": true, "cmd": ["/bin/pip2", "install", "-c", "/tmp/ansible.QqvrZz.test/constraints.txt", "docker", "requests==2.6.0"], "name": ["docker", "requests==2.6.0"], "requirements": null, "state": "present", "stderr": "DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support\nERROR: docker 4.0.2 has requirement requests!=2.18.0,>=2.14.2, but you'll have requests 2.6.0 which is incompatible.\n", "stderr_lines": ["DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support", "ERROR: docker 4.0.2 has requirement requests!=2.18.0,>=2.14.2, but you'll have requests 2.6.0 which is incompatible."], "stdout": "Ignoring coverage: markers 'python_version > \"3.7\"' don't match your environment\nIgnoring cryptography: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring urllib3: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring sphinx: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring wheel: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring yamllint: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring paramiko: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pytest: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pytest-forked: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring requests: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring virtualenv: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pyopenssl: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pyyaml: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pycparser: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring xmltodict: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring lxml: markers 'python_version < \"2.7\"' don't match your environment\nIgnoring pyvmomi: markers 'python_version < \"2.7\"' don't match your environment\nCollecting docker\n  Downloading https://files.pythonhosted.org/packages/95/47/5560c9cf0c92b50da24216f0e7733250fbed5a497f69e3c70e1be62143fe/docker-4.0.2-py2.py3-none-any.whl (138kB)\nRequirement already satisfied: requests==2.6.0 in /usr/lib/python2.7/site-packages (2.6.0)\nRequirement already satisfied: six>=1.4.0 in /usr/lib/python2.7/site-packages (from docker) (1.9.0)\nRequirement already satisfied: ipaddress>=1.0.16; python_version < \"3.3\" in /usr/lib/python2.7/site-packages (from docker) (1.0.16)\nRequirement already satisfied: backports.ssl-match-hostname>=3.5; python_version < \"3.5\" in /usr/lib/python2.7/site-packages (from docker) (3.5.0.1)\nCollecting websocket-client>=0.32.0 (from docker)\n  Downloading https://files.pythonhosted.org/packages/29/19/44753eab1fdb50770ac69605527e8859468f3c0fd7dc5a76dd9c4dbd7906/websocket_client-0.56.0-py2.py3-none-any.whl (200kB)\nInstalling collected packages: websocket-client, docker\nSuccessfully installed docker-4.0.2 websocket-client-0.56.0\n", "stdout_lines": ["Ignoring coverage: markers 'python_version > \"3.7\"' don't match your environment", "Ignoring cryptography: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring urllib3: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring sphinx: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring wheel: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring yamllint: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring paramiko: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pytest: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pytest-forked: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring requests: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring virtualenv: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pyopenssl: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pyyaml: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pycparser: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring xmltodict: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring lxml: markers 'python_version < \"2.7\"' don't match your environment", "Ignoring pyvmomi: markers 'python_version < \"2.7\"' don't match your environment", "Collecting docker", "  Downloading https://files.pythonhosted.org/packages/95/47/5560c9cf0c92b50da24216f0e7733250fbed5a497f69e3c70e1be62143fe/docker-4.0.2-py2.py3-none-any.whl (138kB)", "Requirement already satisfied: requests==2.6.0 in /usr/lib/python2.7/site-packages (2.6.0)", "Requirement already satisfied: six>=1.4.0 in /usr/lib/python2.7/site-packages (from docker) (1.9.0)", "Requirement already satisfied: ipaddress>=1.0.16; python_version < \"3.3\" in /usr/lib/python2.7/site-packages (from docker) (1.0.16)", "Requirement already satisfied: backports.ssl-match-hostname>=3.5; python_version < \"3.5\" in /usr/lib/python2.7/site-packages (from docker) (3.5.0.1)", "Collecting websocket-client>=0.32.0 (from docker)", "  Downloading https://files.pythonhosted.org/packages/29/19/44753eab1fdb50770ac69605527e8859468f3c0fd7dc5a76dd9c4dbd7906/websocket_client-0.56.0-py2.py3-none-any.whl (200kB)", "Installing collected packages: websocket-client, docker", "Successfully installed docker-4.0.2 websocket-client-0.56.0"], "version": null, "virtualenv": null}[0m
```

An example: https://app.shippable.com/github/ansible/ansible/runs/142789/101/console

note: on RHEL7.6, cloud-init is the only package to depends on python-requests

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

setup_docker
<!--- Write the short name of the module, plugin, task or feature below -->