### PR TITLE
[WIP] VMware: Fix fragile sort order in vmware_vcenter_statistics

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vcenter_statistics.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vcenter_statistics.py
@@ -130,13 +130,11 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 from ansible.module_utils._text import to_native
-from functools import total_ordering
 
 
 # This is a helper class to sort the changes in a valid order
 # "Greater than" means a change has to happen after another one.
 # As an example, let's say self is daily (key == 1) and other is weekly (key == 2)
-@total_ordering
 class ChangeHelper:
     def __init__(self, old, new):
         self.key = new.key
@@ -160,6 +158,15 @@ class ChangeHelper:
                 return self.new.level < other.old.level
         else:
             return not (other > self)
+
+    def __ge__(self, other):
+        return (self > other) or (self == other)
+
+    def __lt__(self, other):
+        return not (self >= other)
+
+    def __le__(self, other):
+        return not (self > other)
 
 
 class VmwareVcenterStatistics(PyVmomi):

--- a/lib/ansible/modules/cloud/vmware/vmware_vcenter_statistics.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vcenter_statistics.py
@@ -130,16 +130,22 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import PyVmomi, vmware_argument_spec
 from ansible.module_utils._text import to_native
+from functools import total_ordering
 
 
 # This is a helper class to sort the changes in a valid order
 # "Greater than" means a change has to happen after another one.
 # As an example, let's say self is daily (key == 1) and other is weekly (key == 2)
+@total_ordering
 class ChangeHelper:
     def __init__(self, old, new):
         self.key = new.key
         self.old = old
         self.new = new
+
+    def __eq__(self, other):
+        return ((self.key, self.new.enabled, self.new.level) ==
+                (other.key, other.new.enabled, other.new.level))
 
     def __gt__(self, other):
         if self.key < other.key:
@@ -153,7 +159,7 @@ class ChangeHelper:
             else:
                 return self.new.level < other.old.level
         else:
-            return not (self.old > self.new)
+            return not (other > self)
 
 
 class VmwareVcenterStatistics(PyVmomi):


### PR DESCRIPTION
##### SUMMARY
As pointed out from @abadger in PR #62088, bringing the changes into the right order is fragile as it depends on the implementation of `sort()` only using greater then. This PR tries to make it more stable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vcenter_statistics

