### PR TITLE
cloudformation_info - fix KeyError

### DIFF
--- a/changelogs/fragments/62290-fix-cloudformation_info-KeyError.yaml
+++ b/changelogs/fragments/62290-fix-cloudformation_info-KeyError.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudformation_info - Fix a KeyError returning information about the stack(s).

--- a/lib/ansible/modules/cloud/amazon/cloudformation_info.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_info.py
@@ -295,7 +295,10 @@ def main():
 
     service_mgr = CloudFormationServiceManager(module)
 
-    result = {'ansible_facts': {'cloudformation': {}}}
+    if is_old_facts:
+        result = {'ansible_facts': {'cloudformation': {}}}
+    else:
+        result = {'cloudformation': {}}
 
     for stack_description in service_mgr.describe_stacks(module.params.get('stack_name')):
         facts = {'stack_description': stack_description}


### PR DESCRIPTION
##### SUMMARY
I noticed that cloudformation_info was unusable. Looks like the only place this happened for the AWS _facts -> _info renames though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudformation_info