### PR TITLE
[Docs] revert back to contiguous

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_subnetwork.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_subnetwork.py
@@ -40,7 +40,7 @@ description:
   other resources to communicate with each other via internal, private IP addresses.
 - Each VPC network is subdivided into subnets, and each subnet is contained within
   a single region. You can have more than one subnet in a region for a given VPC network.
-  Each subnet has a continuous private RFC1918 IP space. You create instances, containers,
+  Each subnet has a contiguous private RFC1918 IP space. You create instances, containers,
   and the like in these subnets.
 - When you create an instance, you must create it in a subnet, and the instance draws
   its internal IP address from that subnet.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
IP addresses within a subnet are usually referred to as contiguous, not continuous. Reverting back to the original wording.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Reverses a spelling change from  #62194
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
