### PR TITLE
azure: re-balance tests to avoid timeout

### DIFF
--- a/test/integration/targets/azure_rm_azurefirewall/aliases
+++ b/test/integration/targets/azure_rm_azurefirewall/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-shippable/azure/group4
+shippable/azure/group3
 destructive

--- a/test/integration/targets/azure_rm_manageddisk/aliases
+++ b/test/integration/targets/azure_rm_manageddisk/aliases
@@ -1,4 +1,4 @@
 cloud/azure
-shippable/azure/group3
+shippable/azure/group4
 destructive
 azure_rm_manageddisk_info


### PR DESCRIPTION
##### SUMMARY

- azure_rm_azurefirewall currently takes more than 25m to run: #62307
- azure_rm_manageddisk takes around 2 minutes

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

azure
azure_rm_azurefirewall