### PR TITLE
Fix display of sanity test doc links.

### DIFF
--- a/changelogs/fragments/ansible-test-doc-links.yml
+++ b/changelogs/fragments/ansible-test-doc-links.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now shows sanity test doc links when installed (previously the links were only visible when running from source)

--- a/test/lib/ansible_test/_internal/test.py
+++ b/test/lib/ansible_test/_internal/test.py
@@ -364,6 +364,8 @@ class TestFailure(TestResult):
         """
         :rtype: str
         """
+        if self.command != 'sanity':
+            return None  # only sanity tests have docs links
 
         # Use the major.minor version for the URL only if this a release that
         # matches the pattern 2.4.0, otherwise, use 'devel'
@@ -373,19 +375,13 @@ class TestFailure(TestResult):
             url_version = '.'.join(ansible_version.split('.')[:2])
 
         testing_docs_url = 'https://docs.ansible.com/ansible/%s/dev_guide/testing' % url_version
-        testing_docs_dir = 'docs/docsite/rst/dev_guide/testing'
 
         url = '%s/%s/' % (testing_docs_url, self.command)
-        path = os.path.join(testing_docs_dir, self.command)
 
         if self.test:
             url += '%s.html' % self.test
-            path = os.path.join(path, '%s.rst' % self.test)
 
-        if os.path.exists(path):
-            return url
-
-        return None
+        return url
 
     def format_title(self, help_link=None):
         """


### PR DESCRIPTION
##### SUMMARY

The documentation links are now displayed when running from an install.

Previously the links were only displayed when running from source. This was due to ansible-test checking for the presence of documentation files locally, which are only present when running from source. The check is no longer necessary since there is a sanity test in place to enforce the presence of documentation for all sanity tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
