### PR TITLE
Fix unit test requirements path after merging #62181

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -249,7 +249,7 @@ Testing basics
 ====================
 
 These two examples will get you started with testing your module code. The :ref:`testing <developing_testing>` section has more detailed
-information, including instructions for :ref:`testing module documentation <testing_module_documentation>`, adding :ref:`integration tests <testing_integration>`, and more. The :ref:`ansible-test` documentation provides details about the flags available with the ``ansible-test`` command.
+information, including instructions for :ref:`testing module documentation <testing_module_documentation>`, adding :ref:`integration tests <testing_integration>`, and more.
 
 Sanity tests
 ------------

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -248,13 +248,13 @@ The next step in testing your new module is to consume it with an Ansible playbo
 Testing basics
 ====================
 
-These two examples will get you started with testing your module code. Please review our :ref:`testing <developing_testing>` section for more detailed
-information, including instructions for :ref:`testing module documentation <testing_module_documentation>`, adding :ref:`integration tests <testing_integration>`, and more.
+These two examples will get you started with testing your module code. The :ref:`testing <developing_testing>` section has more detailed
+information, including instructions for :ref:`testing module documentation <testing_module_documentation>`, adding :ref:`integration tests <testing_integration>`, and more. The :ref:`ansible-test` documentation provides details about the flags available with the ``ansible-test`` command.
 
 Sanity tests
 ------------
 
-You can run through Ansible's sanity checks in a container:
+You can run through the Ansible sanity checks in a container. By default the test command will run tests on all supported versions of Python. To limit your test run to a specific Python version:
 
 ``$ ansible-test sanity -v --docker --python 2.7 MODULE_NAME``
 
@@ -264,14 +264,16 @@ container for this, you can choose to use ``--venv`` instead of ``--docker``.
 Unit tests
 ----------
 
-You can add unit tests for your module in ``./test/units/modules``. You must first setup your testing environment. In this example, we're using Python 3.5.
+You can add unit tests for your module in ``./test/units/modules``. You can run these in a container as well. Be sure to set up your development environment:
 
-- Install the requirements (outside of your virtual environment): ``$ pip3 install -r ./test/units/requirements.txt``
-- To run all tests do the following: ``$ ansible-test units --python 3.5`` (you must run ``. hacking/env-setup`` prior to this)
+``. hacking/env-setup``
 
-.. note:: Ansible uses pytest for unit testing.
+Then run the unit tests in the container of your choice. These commands install any missing requirements in your container or virtual environment before exercising the tests:
 
-To run pytest against a single test module, you can do the following (provide the path to the test module appropriately):
+``ansible-test units --docker default MODULE_NAME``
+``ansible-test units --venv MODULE_NAME``
+
+Ansible uses pytest for unit testing. You can run pytest against a single test module (use the correct path for your test module):
 
 ``$ pytest -r a --cov=. --cov-report=html --fulltrace --color yes
 test/units/modules/.../test/my_test.py``

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -266,7 +266,7 @@ Unit tests
 
 You can add unit tests for your module in ``./test/units/modules``. You must first setup your testing environment. In this example, we're using Python 3.5.
 
-- Install the requirements (outside of your virtual environment): ``$ pip3 install -r ./test/lib/ansible_test/_data/requirements/units.txt``
+- Install the requirements (outside of your virtual environment): ``$ pip3 install -r ./test/units/requirements.txt``
 - To run all tests do the following: ``$ ansible-test units --python 3.5`` (you must run ``. hacking/env-setup`` prior to this)
 
 .. note:: Ansible uses pytest for unit testing.

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -274,7 +274,7 @@ Then run the unit tests in the container of your choice. These commands install 
 
 Ansible uses pytest for unit testing. You can run unit tests against a single test module (use the correct path for your test module)::
 
-  $ ansible-test units test/units/modules/.../test/my_test.py
+  $ ansible-test units test/units/modules/.../test_my_module.py
 
 Contributing back to Ansible
 ============================

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -254,9 +254,9 @@ information, including instructions for :ref:`testing module documentation <test
 Sanity tests
 ------------
 
-You can run through the Ansible sanity checks in a container. By default the test command will run tests on all supported versions of Python. To limit your test run to a specific Python version:
+You can run through the Ansible sanity checks in a container. By default the test command will run tests on all supported versions of Python. To limit your test run to a specific Python version::
 
-``$ ansible-test sanity -v --docker --python 2.7 MODULE_NAME``
+  $ ansible-test sanity -v --docker default --python 2.7 MODULE_NAME
 
 Note that this example requires Docker to be installed and running. If you'd rather not use a
 container for this, you can choose to use ``--venv`` instead of ``--docker``.
@@ -264,19 +264,18 @@ container for this, you can choose to use ``--venv`` instead of ``--docker``.
 Unit tests
 ----------
 
-You can add unit tests for your module in ``./test/units/modules``. You can run these in a container as well. Be sure to set up your development environment:
+You can add unit tests for your module in ``./test/units/modules``. You can run these in a container as well. Be sure to set up your development environment::
 
-``. hacking/env-setup``
+  ./hacking/env-setup
 
-Then run the unit tests in the container of your choice. These commands install any missing requirements in your container or virtual environment before exercising the tests:
+Then run the unit tests in the container of your choice. These commands install any missing requirements in your container or virtual environment before exercising the tests::
 
-``ansible-test units --docker default MODULE_NAME``
-``ansible-test units --venv MODULE_NAME``
+  ansible-test units --docker default MODULE_NAME
+  ansible-test units --venv MODULE_NAME
 
-Ansible uses pytest for unit testing. You can run pytest against a single test module (use the correct path for your test module):
+Ansible uses pytest for unit testing. You can run pytest against a single test module (use the correct path for your test module)::
 
-``$ pytest -r a --cov=. --cov-report=html --fulltrace --color yes
-test/units/modules/.../test/my_test.py``
+  $ pytest -r a --cov=. --cov-report=html --fulltrace --color yes test/units/modules/.../test/my_test.py
 
 Contributing back to Ansible
 ============================

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -258,8 +258,7 @@ You can run through the Ansible sanity checks in a container. By default the tes
 
   $ ansible-test sanity -v --docker default --python 2.7 MODULE_NAME
 
-Note that this example requires Docker to be installed and running. If you'd rather not use a
-container for this, you can choose to use ``--venv`` instead of ``--docker``.
+Note that this example requires Docker to be installed and running. If you prefer, you can use the Python testing wrapper by passing ``--venv`` instead of ``--docker <container_name>``.
 
 Unit tests
 ----------
@@ -273,9 +272,9 @@ Then run the unit tests in the container of your choice. These commands install 
   ansible-test units --docker default MODULE_NAME
   ansible-test units --venv MODULE_NAME
 
-Ansible uses pytest for unit testing. You can run pytest against a single test module (use the correct path for your test module)::
+Ansible uses pytest for unit testing. You can run unit tests against a single test module (use the correct path for your test module)::
 
-  $ pytest -r a --cov=. --cov-report=html --fulltrace --color yes test/units/modules/.../test/my_test.py
+  $ ansible-test units test/units/modules/.../test/my_test.py
 
 Contributing back to Ansible
 ============================


### PR DESCRIPTION
##### SUMMARY
This PR adjusts the unit tests [requirements](https://github.com/ansible/ansible/blob/devel/test/units/requirements.txt) path described in the documentation, after merging #62181

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
