### PR TITLE
Improve dconf documentation to include conversion problems

### DIFF
--- a/lib/ansible/modules/system/dconf.py
+++ b/lib/ansible/modules/system/dconf.py
@@ -39,6 +39,10 @@ notes:
     wanted to provide a string value, the correct syntax would be
     C(value="'myvalue'") - with single quotes as part of the Ansible parameter
     value.
+  - When using loops in combination with a value like
+    :code:`"[('xkb', 'us'), ('xkb', 'se')]"`, you need to be aware of possible
+    type conversions. Applying a filter :code:`"{{ item.value | string }}"`
+    to the parameter variable can avoid potential conversion problems.
   - The easiest way to figure out exact syntax/value you need to provide for a
     key is by making the configuration change in application affected by the
     key, and then having a look at value set via commands C(dconf dump


### PR DESCRIPTION
##### SUMMARY
When applying multiple dconf settings in a loop, implicit conversions can cause problems and are not well documented.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dconf

##### ADDITIONAL INFORMATION

Example configuration:
```
dconf_settings:
  - key: "/org/gnome/desktop/input-sources/sources"
    value: "[('xkb', 'us'), ('xkb', 'de')]"
```
```
- name: set custom dconf settings
  dconf:
    key: "{{ item.key }}"
    value: "{{ item.value }}"
    state: "{{ item.state | default(omit) }}"
  loop: "{{ dconf_settings }}"
```
will trigger the following warning
>  [WARNING]: The value [['xkb', 'us'], ['xkb', 'de']] (type list) in a string field was converted to "[['xkb', 'us'], ['xkb', 'de']]"
(type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

and adds `[['xkb', 'us'], ['xkb', 'de']]` instead of `[('xkb', 'us'), ('xkb', 'de')]` into dconf, which breaks the configuration.

when setting
```
    value: "{{ item.value | string }}"
```
the setting is written correctly and works as expected.