### PR TITLE
Fix issue where local copy try to use sshpass

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -245,6 +245,10 @@ class ActionModule(ActionBase):
         elif delegate_to is not None and delegate_to in dest_host_ids:
             dest_is_local = True
 
+        # Fix for local copy to occur without sshpass
+        if dest_is_local:
+            _tmp_args['_local_rsync_password'] = None
+
         # CHECK FOR NON-DEFAULT SSH PORT
         inv_port = task_vars.get('ansible_ssh_port', None) or C.DEFAULT_REMOTE_PORT
         if _tmp_args.get('dest_port', None) is None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set  _tmp_args['_local_rsync_password'] = None when source and remote are local so it doesn't use sshpass to do local copy
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes part of #56629

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 synchronize
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Set  _tmp_args['_local_rsync_password'] = None when source and remote are local so it doesn't use sshpass to do local copy
By doing this this fixes python 2.7 local copy with user/password used to connect to inventory_hostname but won't fixes remotes one who need sshpass and python3
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
