### PR TITLE
Commands tests

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
@@ -1,0 +1,72 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_assign_global_assignment
+
+PAYLOAD = {
+    "global_domains": "Global2",
+    "dependent_domains": "domain1",
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'assign-global-assignment'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointAssignGlobalAssignment(object):
+    module = cp_mgmt_assign_global_assignment
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
@@ -1,4 +1,4 @@
- # Ansible module to manage CheckPoint Firewall (c) 2019
+# Ansible module to manage CheckPoint Firewall (c) 2019
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_assign_global_assignment.py
@@ -1,4 +1,4 @@
-# Ansible module to manage CheckPoint Firewall (c) 2019
+ # Ansible module to manage CheckPoint Firewall (c) 2019
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/units/modules/network/check_point/test_cp_mgmt_discard.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_discard.py
@@ -1,0 +1,70 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_discard
+
+PAYLOAD = {
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'discard'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointDiscard(object):
+    module = cp_mgmt_discard
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_install_policy.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_install_policy.py
@@ -1,0 +1,76 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_install_policy
+
+PAYLOAD = {
+    "access": True,
+    "targets": [
+        "corporate-gateway"
+    ],
+    "policy_package": "standard",
+    "threat_prevention": True,
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'install-policy'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointInstallPolicy(object):
+    module = cp_mgmt_install_policy
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_publish.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_publish.py
@@ -1,0 +1,70 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_publish
+
+PAYLOAD = {
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'publish'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointPublish(object):
+    module = cp_mgmt_publish
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_put_file.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_put_file.py
@@ -1,0 +1,76 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_put_file
+
+PAYLOAD = {
+    "targets": [
+        "corporate-gateway"
+    ],
+    "file_path": "/home/admin/",
+    "file_name": "vsx_conf",
+    "file_content": "vs ip 192.0.2.1\nvs2 ip 192.0.2.2",
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'put-file'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointPutFile(object):
+    module = cp_mgmt_put_file
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_run_ips_update.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_run_ips_update.py
@@ -1,0 +1,70 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_run_ips_update
+
+PAYLOAD = {
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'run-ips-update'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointRunIpsUpdate(object):
+    module = cp_mgmt_run_ips_update
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_run_script.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_run_script.py
@@ -1,0 +1,75 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_run_script
+
+PAYLOAD = {
+    "script": "ls -l /",
+    "targets": [
+        "corporate-gateway"
+    ],
+    "script_name": "Script Example: List files under / dir",
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'run-script'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointRunScript(object):
+    module = cp_mgmt_run_script
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_verify_policy.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_verify_policy.py
@@ -1,0 +1,71 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_verify_policy
+
+PAYLOAD = {
+    "policy_package": "standard",
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'verify-policy'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointVerifyPolicy(object):
+    module = cp_mgmt_verify_policy
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_assign_global_assignment.py
test_cp_mgmt_discard.py
test_cp_mgmt_install_policy.py
test_cp_mgmt_verfiy_policy.py
test_cp_mgmt_publish_.py
test_cp_mgmt_put_file.py
test_cp_mgmt_run_ips_update.py
test_cp_mgmt_run_script.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
