### PR TITLE
Unique tests

### DIFF
--- a/test/units/modules/network/check_point/test_cp_mgmt_access_rule.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_rule.py
@@ -1,0 +1,124 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_rule
+
+OBJECT = {
+    "layer": "Network",
+    "name": "Rule 1",
+    "service": [
+        "SMTP",
+        "AOL"
+    ]
+}
+
+CREATE_PAYLOAD = {
+    "layer": "Network",
+    "name": "Rule 1",
+    "service": [
+        "SMTP",
+        "AOL"
+    ]
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Rule 1",
+    "layer": "Network",
+    "action_settings": {
+        "limit": "Upload_1Gbps",
+        "enable_identity_captive_portal": True
+    }
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Rule 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_access_rule.api_call'
+api_call_object = 'access-rule'
+
+
+class TestCheckpointAccessRule(object):
+    module = cp_mgmt_access_rule
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_access_rule_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_access_rule_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_access_rule_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'access-rule'
+api_call_object_plural_version = 'access-rulebase'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointAccessRuleFacts(object):
+    module = cp_mgmt_access_rule_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_threat_exception.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_threat_exception.py
@@ -1,0 +1,119 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_threat_exception
+
+OBJECT = {
+    "layer": "New Layer 1",
+    "name": "Exception Rule",
+    "track": "Log",
+    "rule_name": "First rule",
+    "protected_scope": "All_Internet"
+}
+
+CREATE_PAYLOAD = {
+    "layer": "New Layer 1",
+    "name": "Exception Rule",
+    "track": "Log",
+    "rule_name": "First rule",
+    "protected_scope": "All_Internet"
+}
+
+UPDATE_PAYLOAD = {
+    "name": "Exception Rule",
+    "layer": "New Layer 1",
+    "rule_name": "First rule",
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "Exception Rule",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_threat_exception.api_call'
+api_call_object = 'threat-exception'
+
+
+class TestCheckpointThreatException(object):
+    module = cp_mgmt_threat_exception
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_threat_exception_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_threat_exception_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_threat_exception_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'threat-exception'
+api_call_object_plural_version = 'threat-rule-exception-rulebase'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointThreatExceptionFacts(object):
+    module = cp_mgmt_threat_exception_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_threat_protection_override.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_threat_protection_override.py
@@ -1,0 +1,79 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_threat_protection_override
+
+PAYLOAD = {
+    "name": "FTP Commands",
+    "overrides": [
+        {
+            "profile": "New Profile 1",
+            "action": "inactive",
+            "track": "None",
+            "capture-packets": True
+        }
+    ],
+    "wait_for_task": False
+}
+
+RETURN_PAYLOAD = {
+    "task-id": "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+}
+
+command = 'set-threat-protection'
+failure_msg = '{command failed}'
+
+
+class TestCheckpointThreatProtectionOverride(object):
+    module = cp_mgmt_threat_protection_override
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_command(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, RETURN_PAYLOAD)
+        result = self._run_module(PAYLOAD)
+
+        assert result['changed']
+        assert RETURN_PAYLOAD == result[command]
+
+    def test_command_fail(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_threat_rule.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_threat_rule.py
@@ -1,0 +1,124 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_threat_rule
+
+OBJECT = {
+    "layer": "New Layer 1",
+    "name": "First threat rule",
+    "comments": "",
+    "track": "None",
+    "protected_scope": "All_Internet",
+    "install_on": "Policy Targets"
+}
+
+CREATE_PAYLOAD = {
+    "layer": "New Layer 1",
+    "name": "First threat rule",
+    "comments": "",
+    "track": "None",
+    "protected_scope": "All_Internet",
+    "install_on": "Policy Targets"
+}
+
+UPDATE_PAYLOAD = {
+    "layer": "New Layer 1",
+    "comments": "commnet for the first rule",
+    "action": "New Profile 1",
+    "name": "First threat rule",
+    "protected_scope": "All_Internet",
+    "install_on": "Policy Targets"
+}
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "First threat rule",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_threat_rule.api_call'
+api_call_object = 'threat-rule'
+
+
+class TestCheckpointThreatRule(object):
+    module = cp_mgmt_threat_rule
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT.items() == result[api_call_object].items()
+
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
+        result = self._run_module(CREATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert result['changed']
+
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False}
+        result = self._run_module(DELETE_PAYLOAD)
+
+        assert not result['changed']
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_threat_rule_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_threat_rule_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_threat_rule_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'threat-rule'
+api_call_object_plural_version = 'threat-rulebase'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointThreatRuleFacts(object):
+    module = cp_mgmt_threat_rule_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_access_rule.py
test_cp_mgmt_access_rule_facts.py
test_cp_mgmt_threat_rule.py
test_cp_mgmt_threat_rule_facts.py
test_cp_mgmt_threat_exception.py
test_cp_mgmt_threat_exception_facts.py
test_cp_mgmt_threat_protection_override.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
