### PR TITLE
nsupdate: Use authoritative server for zone lookup

### DIFF
--- a/changelogs/fragments/62329-nsupdate-lookup-internal-zones.yaml
+++ b/changelogs/fragments/62329-nsupdate-lookup-internal-zones.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Fix zone name lookup of internal/private zones (https://github.com/ansible/ansible/issues/62052)


### PR DESCRIPTION
##### SUMMARY

Using a regular recursive resolver to lookup the zone name might not
work when the zone in question belong to a private/internal
domain. The authoritative server being used on the other hand will
definitely know about the zone(s) it's serving.

This approach is also consistent with the nsupdate module already
querying the specified authoritative server for TTL values.

The reason for the implementation having to loop until finding a
direct match is to account for different SOA responses triggered by
CNAMEs and DNAMEs. The previously used `dns.resolver.zone_for_name()`
function does the same.

Resolves #62052

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nsupdate