### PR TITLE
Fix azure_rm_virtualmachinescalesetinstance_info doc error

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance.py
@@ -64,7 +64,7 @@ author:
 
 EXAMPLES = '''
   - name: Upgrade instance to the latest image
-    azure_rm_computevirtualmachinescalesetinstance:
+    azure_rm_virtualmachinescalesetinstance:
       resource_group: myResourceGroup
       vmss_name: myVMSS
       instance_id: "2"

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
@@ -47,7 +47,7 @@ author:
 
 EXAMPLES = '''
   - name: List VM instances in Virtual Machine ScaleSet
-    azure_rm_computevirtualmachinescalesetinstance_info:
+    azure_rm_virtualmachinescalesetinstance_info:
       resource_group: myResourceGroup
       vmss_name: myVMSS
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix azure_rm_virtualmachinescalesetinstance_info doc error [#310](https://github.com/Azure/azure_preview_modules/issues/310)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 azure_rm_virtualmachinescalesetinstance_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
