### PR TITLE
fix typos in remote_management modules

### DIFF
--- a/lib/ansible/modules/remote_management/cpm/cpm_user.py
+++ b/lib/ansible/modules/remote_management/cpm/cpm_user.py
@@ -81,7 +81,7 @@ options:
   user_accesslevel:
     description:
       - This is the access level that needs to be create/modified/deleted
-      - 0 View, 1 User, 2 SuperUser, 3 Adminstrator
+      - 0 View, 1 User, 2 SuperUser, 3 Administrator
     required: false
     choices: [ 0, 1, 2, 3 ]
   user_accessssh:

--- a/lib/ansible/modules/remote_management/foreman/_katello.py
+++ b/lib/ansible/modules/remote_management/foreman/_katello.py
@@ -187,7 +187,7 @@ EXAMPLES = '''
 
 - include: katello.yml
   vars:
-      name: Promote Contentview Environment with longer timout
+      name: Promote Contentview Environment with longer timeout
       task_timeout: 10800
       entity: content_view
       action: promote
@@ -199,10 +199,10 @@ EXAMPLES = '''
 
 # Best Practices
 
-# In Foreman, things can be done in paralell.
+# In Foreman, things can be done in parallel.
 # When a conflicting action is already running,
 # the task will fail instantly instead of waiting for the already running action to complete.
-# So you sould use a "until success" loop to catch this.
+# So you should use a "until success" loop to catch this.
 
 - name: Promote Contentview Environment with increased Timeout
   katello:

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -52,7 +52,7 @@ options:
     - The state of the boot media.
     - "no_boot: Do not boot from the device"
     - "boot_once: Boot from the device once and then notthereafter"
-    - "boot_always: Boot from the device each time the serveris rebooted"
+    - "boot_always: Boot from the device each time the server is rebooted"
     - "connect: Connect the virtual media device and set to boot_always"
     - "disconnect: Disconnects the virtual media device and set to no_boot"
     - "poweroff: Power off the server"

--- a/lib/ansible/modules/remote_management/imc/imc_rest.py
+++ b/lib/ansible/modules/remote_management/imc/imc_rest.py
@@ -247,7 +247,7 @@ input:
   sample: |
     <configConfMo><inConfig><computeRackUnit dn="sys/rack-unit-1" admin_Power="down"/></inConfig></configConfMo>
 output:
-  description: RAW XML output eceived from the Cisco IMC, with error details
+  description: RAW XML output received from the Cisco IMC, with error details
   returned: failed
   type: str
   sample: >

--- a/lib/ansible/modules/remote_management/intersight/intersight_rest_api.py
+++ b/lib/ansible/modules/remote_management/intersight/intersight_rest_api.py
@@ -27,7 +27,7 @@ options:
     required: yes
   query_params:
     description:
-    - Query parameters for the Intersight API query languange.
+    - Query parameters for the Intersight API query language.
     type: dict
   update_method:
     description:
@@ -38,7 +38,7 @@ options:
     default: patch
   api_body:
     description:
-    - The paylod for API requests used to modify resources.
+    - The payload for API requests used to modify resources.
     type: dict
   state:
     description:

--- a/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
+++ b/lib/ansible/modules/remote_management/lxca/lxca_cmms.py
@@ -48,7 +48,7 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # get all cmms info
-- name: get nodess data from LXCA
+- name: get nodes data from LXCA
   lxca_cmms:
     login_user: USERID
     login_password: Password

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_alert_profiles.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_alert_profiles.py
@@ -149,7 +149,7 @@ class ManageIQAlertProfiles(object):
         except Exception as e:
             self.module.fail_json(msg="Deleting profile failed: {error}".format(error=e))
 
-        msg = "Successfuly deleted profile {name}".format(name=profile['name'])
+        msg = "Successfully deleted profile {name}".format(name=profile['name'])
         return dict(changed=True, msg=msg)
 
     def get_alert_href(self, alert):

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
@@ -129,7 +129,7 @@ from ansible.module_utils.manageiq import ManageIQ, manageiq_argument_spec
 
 class ManageIQAlert(object):
     """ Represent a ManageIQ alert. Can be initialized with both the format
-    we recieve from the server and the format we get from the user.
+    we receive from the server and the format we get from the user.
     """
     def __init__(self, alert):
         self.description = alert['description']
@@ -257,7 +257,7 @@ class ManageIQAlerts(object):
                 # the result to the expected result.
                 if new_alert_obj == ManageIQAlert(result):
                     # success!
-                    msg = "Alert {description} upated successfully: {details}"
+                    msg = "Alert {description} updated successfully: {details}"
                     msg = msg.format(description=existing_alert['description'], details=result)
 
                     return dict(changed=True, msg=msg)

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_policies.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_policies.py
@@ -278,7 +278,7 @@ class ManageIQPolicies(object):
                 error=e)
             self.module.fail_json(msg=msg)
 
-        # check all entities in result to be successfull
+        # check all entities in result to be successful
         for result in response['results']:
             if not result['success']:
                 msg = "Failed to {action}: {message}".format(

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -718,7 +718,7 @@ class ManageIQProvider(object):
         # NOTE: we do not check for diff's between requested and current
         #       provider, we always submit endpoints with password or auth_keys,
         #       since we can not compare with current password or auth_key,
-        #       every edit request is sent to ManageIQ API without compareing
+        #       every edit request is sent to ManageIQ API without comparing
         #       it to current state.
 
         # clean nulls, we do not send nulls to the api
@@ -869,7 +869,7 @@ def main():
             manageiq_provider.module.fail_json(
                 msg="provider_type %s is not supported" % (provider_type))
 
-        # build "connection_configurations" objects from user requsted endpoints
+        # build "connection_configurations" objects from user requested endpoints
         # "provider" is a required endpoint, if we have it, we have endpoints
         if raw_endpoints.get("provider"):
             endpoints = manageiq_provider.build_connection_configurations(provider_type, raw_endpoints)

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
@@ -225,7 +225,7 @@ class ManageIQTags(object):
                 error=e)
             self.module.fail_json(msg=msg)
 
-        # check all entities in result to be successfull
+        # check all entities in result to be successful
         for result in response['results']:
             if not result['success']:
                 msg = "Failed to {action}: {message}".format(

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -313,7 +313,7 @@ def main():
                 changed=False,
                 msg="user %s: does not exist in manageiq" % (userid))
 
-    # user shoult exist
+    # user should exist
     if state == "present":
         # if we have a user, edit it
         if user:

--- a/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_info.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_info.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
 
 - name: Gather information about a Logical Interconnect Group by name
   oneview_logical_interconnect_group_info:
-    name: logical lnterconnect group name
+    name: logical interconnect group name
     hostname: 172.16.101.48
     username: administrator
     password: my_password

--- a/lib/ansible/modules/remote_management/redfish/redfish_info.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_info.py
@@ -378,7 +378,7 @@ def main():
                     result["firmware_update_capabilities"] = rf_utils.get_firmware_update_capabilities()
 
         elif category == "Sessions":
-            # excute only if we find SessionService resources
+            # execute only if we find SessionService resources
             resource = rf_utils._find_sessionservice_resource()
             if resource['ret'] is False:
                 module.fail_json(msg=resource['msg'])

--- a/lib/ansible/modules/remote_management/ucs/ucs_query.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_query.py
@@ -26,13 +26,13 @@ options:
     class_ids:
         description:
         - One or more UCS Manager Class IDs to query.
-        - As a comma separtated list
+        - As a comma separated list
         type: str
 
     distinguished_names:
         description:
         - One or more UCS Manager Distinguished Names to query.
-        - As a comma separtated list
+        - As a comma separated list
         type: str
 
     delegate_to:

--- a/lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
@@ -299,7 +299,7 @@ def check_storage_profile_props(ucs, module, dn):
         if mo_1.check_prop_match(**kwargs):
             props_match = True
     elif not module.params['storage_profile']:
-        # no stroage profile mo or desired state
+        # no storage profile mo or desired state
         props_match = True
 
     return props_match

--- a/lib/ansible/modules/remote_management/ucs/ucs_vlan_find.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vlan_find.py
@@ -47,7 +47,7 @@ version_added: '2.9'
 '''
 
 EXAMPLES = r'''
-- name: Get all vlans in frabric A
+- name: Get all vlans in fabric A
   ucs_vlan_find:
     hostname: 172.16.143.150
     username: admin


### PR DESCRIPTION
##### SUMMARY
fix typos in remote_management modules

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```
lib/ansible/modules/remote_management/cpm/cpm_user.py
lib/ansible/modules/remote_management/foreman/_katello.py
lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
lib/ansible/modules/remote_management/imc/imc_rest.py
lib/ansible/modules/remote_management/intersight/intersight_rest_api.py
lib/ansible/modules/remote_management/lxca/lxca_cmms.py
lib/ansible/modules/remote_management/manageiq/manageiq_alert_profiles.py
lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
lib/ansible/modules/remote_management/manageiq/manageiq_policies.py
lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
lib/ansible/modules/remote_management/manageiq/manageiq_user.py
lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_info.py
lib/ansible/modules/remote_management/redfish/redfish_info.py
lib/ansible/modules/remote_management/ucs/ucs_query.py
lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
lib/ansible/modules/remote_management/ucs/ucs_vlan_find.py
```
