### PR TITLE
Network and address range tests

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6288,8 +6288,6 @@ test/units/modules/network/check_point/test_checkpoint_session.py future-import-
 test/units/modules/network/check_point/test_checkpoint_session.py metaclass-boilerplate
 test/units/modules/network/check_point/test_checkpoint_task_facts.py future-import-boilerplate
 test/units/modules/network/check_point/test_checkpoint_task_facts.py metaclass-boilerplate
-test/units/modules/network/check_point/test_cp_mgmt_network.py future-import-boilerplate
-test/units/modules/network/check_point/test_cp_mgmt_network.py metaclass-boilerplate
 test/units/modules/network/cloudvision/test_cv_server_provision.py future-import-boilerplate
 test/units/modules/network/cloudvision/test_cv_server_provision.py metaclass-boilerplate
 test/units/modules/network/cumulus/test_nclu.py future-import-boilerplate

--- a/test/units/modules/network/check_point/test_cp_mgmt_address_range.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_address_range.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2019 Red Hat
-#
-# This file is part of Ansible
+# Ansible module to manage CheckPoint Firewall (c) 2019
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,9 +23,6 @@ from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleEx
 from ansible.module_utils import basic
 from ansible.modules.network.check_point import cp_mgmt_address_range
 
-function_path = 'ansible.modules.network.check_point.cp_mgmt_address_range.api_call'
-api_call_object = 'address_range'
-
 OBJECT = {
     "name": "New Address Range 1",
     "ip_address_first": "192.0.2.1",
@@ -42,19 +37,23 @@ CREATE_PAYLOAD = {
 
 UPDATE_PAYLOAD = {
     "name": "New Address Range 1",
-    "color": "orange",
+    "color": "blue",
     "ip_address_first": "192.0.2.1",
-    "ip_address_last": "192.0.2.1",
-    "groups": "New Group 1"
+    "ip_address_last": "192.0.2.1"
 }
+
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
 
 DELETE_PAYLOAD = {
     "name": "New Address Range 1",
-    'state': 'absent'
+    "state": "absent"
 }
 
+function_path = 'ansible.modules.network.check_point.cp_mgmt_address_range.api_call'
+api_call_object = 'address-range'
 
-class TestCheckpointNetwork(object):
+
+class TestCheckpointAddressRange(object):
     module = cp_mgmt_address_range
 
     @pytest.fixture(autouse=True)
@@ -69,32 +68,36 @@ class TestCheckpointNetwork(object):
     def test_create(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': True, api_call_object: OBJECT}
-        connection_mock.api_call.return_value = {'changed': True, api_call_object: OBJECT}
         result = self._run_module(CREATE_PAYLOAD)
 
         assert result['changed']
-        assert api_call_object in result
+        assert OBJECT.items() == result[api_call_object].items()
 
     def test_create_idempotent(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': False, api_call_object: OBJECT}
-        connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(CREATE_PAYLOAD)
 
         assert not result['changed']
 
     def test_update(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
-        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
-        connection_mock.send_request.return_value = (200, OBJECT)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
         result = self._run_module(UPDATE_PAYLOAD)
 
         assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
+
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
 
     def test_delete(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': True}
-        connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(DELETE_PAYLOAD)
 
         assert result['changed']
@@ -102,7 +105,6 @@ class TestCheckpointNetwork(object):
     def test_delete_idempotent(self, mocker, connection_mock):
         mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': False}
-        connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(DELETE_PAYLOAD)
 
         assert not result['changed']

--- a/test/units/modules/network/check_point/test_cp_mgmt_address_range_facts.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_address_range_facts.py
@@ -1,0 +1,82 @@
+# Ansible module to manage CheckPoint Firewall (c) 2019
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
+
+from ansible.module_utils import basic
+from ansible.modules.network.check_point import cp_mgmt_address_range_facts
+
+OBJECT = {
+    "from": 1,
+    "to": 1,
+    "total": 6,
+    "objects": [
+        "53de74b7-8f19-4cbe-99fc-a81ef0759bad"
+    ]
+}
+
+SHOW_PLURAL_PAYLOAD = {
+    'limit': 1,
+    'details_level': 'uid'
+}
+
+SHOW_SINGLE_PAYLOAD = {
+    'name': 'object_which_is_not_exist'
+}
+
+api_call_object = 'address-range'
+api_call_object_plural_version = 'address-ranges'
+failure_msg = '''{u'message': u'Requested object [object_which_is_not_exist] not found', u'code': u'generic_err_object_not_found'}'''
+
+
+class TestCheckpointAddressRangeFacts(object):
+    module = cp_mgmt_address_range_facts
+
+    @pytest.fixture(autouse=True)
+    def module_mock(self, mocker):
+        return mocker.patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+
+    @pytest.fixture
+    def connection_mock(self, mocker):
+        connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
+        return connection_class_mock.return_value
+
+    def test_show_single_object_which_is_not_exist(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (404, failure_msg)
+        try:
+            result = self._run_module(SHOW_SINGLE_PAYLOAD)
+        except Exception as e:
+            result = e.args[0]
+
+        assert result['failed']
+        assert 'Checkpoint device returned error 404 with message ' + failure_msg == result['msg']
+
+    def test_show_few_objects(self, mocker, connection_mock):
+        connection_mock.send_request.return_value = (200, OBJECT)
+        result = self._run_module(SHOW_PLURAL_PAYLOAD)
+
+        assert not result['changed']
+        assert OBJECT == result['ansible_facts'][api_call_object_plural_version]
+
+    def _run_module(self, module_args):
+        set_module_args(module_args)
+        with pytest.raises(AnsibleExitJson) as ex:
+            self.module.main()
+        return ex.value.args[0]

--- a/test/units/modules/network/check_point/test_cp_mgmt_network.py
+++ b/test/units/modules/network/check_point/test_cp_mgmt_network.py
@@ -1,6 +1,4 @@
-# Copyright (c) 2019 Red Hat
-#
-# This file is part of Ansible
+# Ansible module to manage CheckPoint Firewall (c) 2019
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,30 +14,43 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 import pytest
-from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleFailJson, AnsibleExitJson
+from units.modules.utils import set_module_args, exit_json, fail_json, AnsibleExitJson
 
 from ansible.module_utils import basic
 from ansible.modules.network.check_point import cp_mgmt_network
 
-OBJECT = {'name': 'test_network', 'nat_settings': {'auto_rule': True,
-                                                   'hide_behind': 'ip-address',
-                                                   'ip_address': '192.168.1.111'},
-          'subnet': '192.0.2.1', 'subnet_mask': '255.255.255.0', 'state': 'present'}
+OBJECT = {
+    "name": "New Network 1",
+    "subnet": "192.0.2.0",
+    "subnet_mask": "255.255.255.0"
+}
 
-CREATE_PAYLOAD = {'name': 'test_network', 'nat_settings': {'auto_rule': True,
-                                                           'hide_behind': 'ip-address',
-                                                           'ip_address': '192.168.1.111'},
-                  'subnet': '192.168.1.0', 'subnet_mask': '255.255.255.0', 'state': 'present'}
+CREATE_PAYLOAD = {
+    "name": "New Network 1",
+    "subnet": "192.0.2.0",
+    "subnet_mask": "255.255.255.0"
+}
 
-UPDATE_PAYLOAD = {'name': 'test_new_network', 'nat_settings': {'auto_rule': True,
-                                                               'hide_behind': 'ip-address',
-                                                               'ip_address': '192.168.1.111'},
-                  'subnet': '192.168.1.0', 'subnet_mask': '255.255.255.0', 'state': 'present'}
+UPDATE_PAYLOAD = {
+    "name": "New Network 1",
+    "color": "blue",
+    "subnet": "192.0.0.0",
+    "mask_length": 16
+}
 
-DELETE_PAYLOAD = {'name': 'test_new_network', 'state': 'absent'}
+OBJECT_AFTER_UPDATE = UPDATE_PAYLOAD
+
+DELETE_PAYLOAD = {
+    "name": "New Network 1",
+    "state": "absent"
+}
+
+function_path = 'ansible.modules.network.check_point.cp_mgmt_network.api_call'
+api_call_object = 'network'
 
 
 class TestCheckpointNetwork(object):
@@ -54,49 +65,46 @@ class TestCheckpointNetwork(object):
         connection_class_mock = mocker.patch('ansible.module_utils.network.checkpoint.checkpoint.Connection')
         return connection_class_mock.return_value
 
-    @pytest.fixture
-    def get_network_404(self, mocker):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
-        mock_function.return_value = (404, 'Object not found')
-        return mock_function.return_value
-
-    def test_network_create(self, mocker, connection_mock):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
-        mock_function.return_value = {'changed': True, 'network': OBJECT}
-        connection_mock.api_call.return_value = {'changed': True, 'network': OBJECT}
+    def test_create(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT}
         result = self._run_module(CREATE_PAYLOAD)
 
         assert result['changed']
-        assert 'network' in result
+        assert OBJECT.items() == result[api_call_object].items()
 
-    def test_network_create_idempotent(self, mocker, connection_mock):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
-        mock_function.return_value = {'changed': False, 'network': OBJECT}
-        connection_mock.send_request.return_value = (200, OBJECT)
+    def test_create_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT}
         result = self._run_module(CREATE_PAYLOAD)
 
         assert not result['changed']
 
-    def test_network_update(self, mocker, connection_mock):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
-        mock_function.return_value = {'changed': True, 'network': OBJECT}
-        connection_mock.send_request.return_value = (200, OBJECT)
+    def test_update(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': True, api_call_object: OBJECT_AFTER_UPDATE}
         result = self._run_module(UPDATE_PAYLOAD)
 
         assert result['changed']
+        assert OBJECT_AFTER_UPDATE.items() == result[api_call_object].items()
 
-    def test_network_delete(self, mocker, connection_mock):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
+    def test_update_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
+        mock_function.return_value = {'changed': False, api_call_object: OBJECT_AFTER_UPDATE}
+        result = self._run_module(UPDATE_PAYLOAD)
+
+        assert not result['changed']
+
+    def test_delete(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': True}
-        connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(DELETE_PAYLOAD)
 
         assert result['changed']
 
-    def test_network_delete_idempotent(self, mocker, connection_mock):
-        mock_function = mocker.patch('ansible.modules.network.check_point.cp_mgmt_network.api_call')
+    def test_delete_idempotent(self, mocker, connection_mock):
+        mock_function = mocker.patch(function_path)
         mock_function.return_value = {'changed': False}
-        connection_mock.send_request.return_value = (200, OBJECT)
         result = self._run_module(DELETE_PAYLOAD)
 
         assert not result['changed']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add and edit unit tests for check_point ansible modules

This commit adds several missing unit tests for the check_point ansible
modules.

test_cp_mgmt_network.py
test_cp_mgmt_address_range.py
test_cp_mgmt_address_range_facts.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
