### PR TITLE
Change enable to enabled for junos_interfaces and junos_lldp_interfaces module (#62321)

### DIFF
--- a/changelogs/fragments/junos_rm_modules_enable_option_fix.yaml
+++ b/changelogs/fragments/junos_rm_modules_enable_option_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Change enable to enabled for junos_interfaces and junos_lldp_interfaces module (https://github.com/ansible/ansible/issues/62319)

--- a/lib/ansible/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -42,7 +42,7 @@ class InterfacesArgs(object):
                                                                    'full-duplex',
                                                                    'half-duplex'],
                                                        'type': 'str'},
-                                            'enable': {'default': True, 'type': 'bool'},
+                                            'enabled': {'default': True, 'type': 'bool'},
                                             'hold_time': {'options': {'down': {'type': 'int'},
                                                                       'up': {'type': 'int'}},
                                                           'required_together': [['down', 'up']],

--- a/lib/ansible/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
@@ -37,7 +37,7 @@ class Lldp_interfacesArgs(object):
         pass
 
     argument_spec = {'config': {'elements': 'dict',
-                                'options': {'enable': {'type': 'bool'},
+                                'options': {'enabled': {'type': 'bool'},
                                             'name': {'required': True, 'type': 'str'}},
                                 'type': 'list'},
                      'state': {'choices': ['merged', 'replaced', 'deleted', 'overridden'],

--- a/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
@@ -184,7 +184,7 @@ class Interfaces(ConfigBase):
             if config.get('duplex'):
                 build_child_xml_node(intf, 'link-mode', config['duplex'])
 
-            if config.get('enable') is False:
+            if config.get('enabled') is False:
                 build_child_xml_node(intf, 'disable')
 
             holdtime = config.get('hold_time')

--- a/lib/ansible/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
@@ -172,8 +172,8 @@ class Lldp_interfaces(ConfigBase):
             if config.get('name'):
                 build_child_xml_node(lldp_intf_root, 'name', config['name'])
 
-            if config.get('enable') is not None:
-                if config['enable'] is False:
+            if config.get('enabled') is not None:
+                if config['enabled'] is False:
                     build_child_xml_node(lldp_intf_root, 'disable')
                 else:
                     build_child_xml_node(lldp_intf_root, 'disable', None, {'delete': 'delete'})

--- a/lib/ansible/module_utils/network/junos/facts/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/facts/interfaces/interfaces.py
@@ -105,7 +105,7 @@ class InterfacesFacts(object):
         config['hold_time']['up'] = utils.get_xml_conf_arg(conf, 'hold-time/up')
         disable = utils.get_xml_conf_arg(conf, 'disable', data='tag')
         if disable:
-            config['enable'] = False
+            config['enabled'] = False
         else:
-            config['enable'] = True
+            config['enabled'] = True
         return utils.remove_empties(config)

--- a/lib/ansible/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
@@ -100,5 +100,5 @@ class Lldp_interfacesFacts(object):
         config = deepcopy(spec)
         config['name'] = utils.get_xml_conf_arg(conf, 'name')
         if utils.get_xml_conf_arg(conf, 'disable', data='tag'):
-            config['enable'] = False
+            config['enabled'] = False
         return utils.remove_empties(config)

--- a/lib/ansible/modules/network/junos/junos_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_interfaces.py
@@ -60,11 +60,11 @@ options:
           full duplex or in automatic state which negotiates the duplex automatically.
         type: str
         choices: ['automatic', 'full-duplex', 'half-duplex']
-      enable:
+      enabled:
         default: True
         description:
         - Administrative state of the interface.
-        - Set the value to C(true) to administratively enable the interface or C(false) to disable it.
+        - Set the value to C(true) to administratively enabled the interface or C(false) to disable it.
         type: bool
       hold_time:
         description:
@@ -161,11 +161,11 @@ EXAMPLES = """
     config:
       - name: ge-0/0/1
         description: 'Configured by Ansible-1'
-        enable: True
+        enabled: True
         mtu: 1800
       - name: ge-0/0/2
         description: 'Configured by Ansible-2'
-        enable: False
+        enabled: False
     state: merged
 
 # After state:
@@ -208,7 +208,7 @@ EXAMPLES = """
     config:
       - name: ge-0/0/2
         description: 'Configured by Ansible-2'
-        enable: False
+        enabled: False
         mtu: 2800
       - name: ge-0/0/3
         description: 'Configured by Ansible-3'
@@ -255,7 +255,7 @@ EXAMPLES = """
     config:
       - name: ge-0/0/2
         description: 'Configured by Ansible-2'
-        enable: False
+        enabled: False
         mtu: 2800
       - name: ge-0/0/3
         description: 'Configured by Ansible-3'

--- a/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_lldp_interfaces.py
@@ -54,7 +54,7 @@ options:
           - Name of the interface LLDP needs to be configured on.
         type: str
         required: True
-      enable:
+      enabled:
         description:
           - This is a boolean value to control disabling of LLDP on the interface C(name)
         type: bool
@@ -82,7 +82,7 @@ EXAMPLES = """
     config:
       - name: ge-0/0/1
       - name: ge-0/0/2
-        enable: False
+        enabled: False
     state: merged
 
 # After state:
@@ -112,7 +112,7 @@ EXAMPLES = """
       - name: ge-0/0/2
         disable: False
       - name: ge-0/0/3
-        enable: False
+        enabled: False
     state: replaced
 
 # After state:
@@ -141,7 +141,7 @@ EXAMPLES = """
   junos_lldp_interfaces:
     config:
       - name: ge-0/0/2
-        enable: False
+        enabled: False
     state: overridden
 
 # After state:

--- a/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
@@ -7,7 +7,7 @@
 - set_fact:
     expected_deleted_output:
       - name: fxp0
-        enable: true
+        enabled: true
 
 - block:
     - name: Configure initial state for interface
@@ -17,7 +17,7 @@
             description: "Configured by Ansible - Interface 1"
             mtu: 1024
             speed: 100m
-            enable: False
+            enabled: False
             duplex: full-duplex
             hold_time:
               up: 2000

--- a/test/integration/targets/junos_interfaces/tests/netconf/groups.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/groups.yaml
@@ -8,12 +8,12 @@
     expected_group_output:
       - name: ge-0/0/11
         description: "within test group"
-        enable: true
+        enabled: true
       - name: ge-0/0/12
         description: "global interface config"
-        enable: true
+        enabled: true
       - name: fxp0
-        enable: true
+        enabled: true
 
 - name: "Teardown delete interface configuration"
   junos_config: &delete_interface_config

--- a/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
@@ -10,7 +10,7 @@
         description: "Configured by Ansible - Interface 1"
         mtu: 1024
         speed: 100m
-        enable: false
+        enabled: false
         duplex: full-duplex
         hold_time:
           up: 2000
@@ -19,12 +19,12 @@
         description: "Configured by Ansible - Interface 2"
         mtu: 2048
         speed: 10m
-        enable: true
+        enabled: true
         hold_time:
           up: 3000
           down: 3200
       - name: fxp0
-        enable: true
+        enabled: true
 
 - block:
     - name: Merge the provided configuration with the exisiting running configuration
@@ -34,7 +34,7 @@
             description: "Configured by Ansible - Interface 1"
             mtu: 1024
             speed: 100m
-            enable: False
+            enabled: False
             duplex: full-duplex
             hold_time:
               up: 2000

--- a/test/integration/targets/junos_interfaces/tests/netconf/overridden.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/overridden.yaml
@@ -8,9 +8,9 @@
     expected_overridden_output:
       - name: ge-0/0/1
         description: "Overridden by Ansible - Interface 1"
-        enable: true
+        enabled: true
       - name: fxp0
-        enable: true
+        enabled: true
 
 - block:
     - name: Configure initial state for interface
@@ -20,7 +20,7 @@
             description: "Configured by Ansible - Interface 1"
             mtu: 1024
             speed: 100m
-            enable: False
+            enabled: False
             duplex: full-duplex
             hold_time:
               up: 2000

--- a/test/integration/targets/junos_interfaces/tests/netconf/replaced.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/replaced.yaml
@@ -10,17 +10,17 @@
         description: "Replaced by Ansible - Interface 1"
         mtu: 2048
         speed: 10m
-        enable: true
+        enabled: true
       - name: ge-0/0/2
         description: "Configured by Ansible - Interface 2"
         mtu: 2048
         speed: 10m
-        enable: true
+        enabled: true
         hold_time:
           up: 3000
           down: 3200
       - name: fxp0
-        enable: true
+        enabled: true
 
 - block:
     - name: Configure initial state for interface
@@ -30,7 +30,7 @@
             description: "Configured by Ansible - Interface 1"
             mtu: 1024
             speed: 100m
-            enable: False
+            enabled: False
             duplex: full-duplex
             hold_time:
               up: 2000
@@ -52,7 +52,7 @@
             description: "Replaced by Ansible - Interface 1"
             mtu: 2048
             speed: 10m
-            enable: True
+            enabled: True
         state: replaced
       register: result
 

--- a/test/integration/targets/junos_interfaces/tests/netconf/rtt.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/rtt.yaml
@@ -10,7 +10,7 @@
         description: "Configured by Ansible - Interface 1"
         mtu: 1024
         speed: 100m
-        enable: false
+        enabled: false
         duplex: full-duplex
         hold_time:
           up: 2000
@@ -19,12 +19,12 @@
         description: "Configured by Ansible - Interface 2"
         mtu: 2048
         speed: 10m
-        enable: true
+        enabled: true
         hold_time:
           up: 3000
           down: 3200
       - name: fxp0
-        enable: true
+        enabled: true
 
 - block:
     - name: Apply the provided configuration (base config)
@@ -34,7 +34,7 @@
             description: "Configured by Ansible - Interface 1"
             mtu: 1024
             speed: 100m
-            enable: False
+            enabled: False
             duplex: full-duplex
             hold_time:
               up: 2000
@@ -43,7 +43,7 @@
             description: "Configured by Ansible - Interface 2"
             mtu: 2048
             speed: 10m
-            enable: True
+            enabled: True
             hold_time:
               up: 3000
               down: 3200
@@ -64,7 +64,7 @@
             description: "Configured by Ansible - Interface 1 modified"
             mtu: 3048
             speed: 10m
-            enable: True
+            enabled: True
             duplex: half-duplex
             hold_time:
               up: 3000
@@ -73,7 +73,7 @@
             description: "Configured by Ansible - Interface 2 modified"
             mtu: 4048
             speed: 100m
-            enable: False
+            enabled: False
             hold_time:
               up: 4000
               down: 5200

--- a/test/integration/targets/junos_lldp_interfaces/tests/netconf/deleted.yaml
+++ b/test/integration/targets/junos_lldp_interfaces/tests/netconf/deleted.yaml
@@ -30,7 +30,7 @@
         config:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
         state: merged
       register: result
 

--- a/test/integration/targets/junos_lldp_interfaces/tests/netconf/merged.yaml
+++ b/test/integration/targets/junos_lldp_interfaces/tests/netconf/merged.yaml
@@ -25,14 +25,14 @@
         expected_merged_output:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
 
     - name: Merge the provided configuration with the exisiting running configuration
       junos_lldp_interfaces: &merged
         config:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
         state: merged
       register: result
 

--- a/test/integration/targets/junos_lldp_interfaces/tests/netconf/overridden.yaml
+++ b/test/integration/targets/junos_lldp_interfaces/tests/netconf/overridden.yaml
@@ -30,7 +30,7 @@
         config:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
         state: merged
       register: result
 

--- a/test/integration/targets/junos_lldp_interfaces/tests/netconf/replaced.yaml
+++ b/test/integration/targets/junos_lldp_interfaces/tests/netconf/replaced.yaml
@@ -24,23 +24,23 @@
     - set_fact:
         expected_replaced_output:
           - name: ge-0/0/1
-            enable: False
+            enabled: False
           - name: ge-0/0/2
-            enable: False
+            enabled: False
 
     - name: Configure initial state for interface
       junos_lldp_interfaces:
         config:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
       register: result
 
     - name: Replace the provided configuration with the exisiting running configuration
       junos_lldp_interfaces: &replaced
         config:
           - name: ge-0/0/1
-            enable: False
+            enabled: False
         state: replaced
       register: result
 

--- a/test/integration/targets/junos_lldp_interfaces/tests/netconf/rtt.yaml
+++ b/test/integration/targets/junos_lldp_interfaces/tests/netconf/rtt.yaml
@@ -25,14 +25,14 @@
         expected_revert_output:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
 
     - name: Apply the provided configuration (base config)
       junos_lldp_interfaces:
         config:
           - name: ge-0/0/1
           - name: ge-0/0/2
-            enable: False
+            enabled: False
         state: merged
       register: base_config
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #62319

Change `enable` option to `enabled` in junos_interfaces
and junos_lldp_interfaces
data model to be in sync with other network platform
resource modules added in 2.9 version.

(cherry picked from commit a9a5f4e40dab088c6abbfcb5be2274e47ffacb72)
Merged to devel https://github.com/ansible/ansible/pull/62321
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_interfaces
junos_l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
