### PR TITLE
Documents storage of task files

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_best_practices.rst
+++ b/docs/docsite/rst/user_guide/playbooks_best_practices.rst
@@ -45,6 +45,8 @@ The top level of the directory would contain files and directories like so::
     site.yml                  # master playbook
     webservers.yml            # playbook for webserver tier
     dbservers.yml             # playbook for dbserver tier
+    tasks/                    # task files included from playbooks
+        webservers-extra.yml  # <-- avoids confusing playbook with task files
 
     roles/
         common/               # this hierarchy represents a "role"


### PR DESCRIPTION
##### SUMMARY
Recommends putting task files in a tasks/ subfolder in order to avoid
confusing them with playbooks. This mirrors roles internals.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

