### PR TITLE
VMware: Add associable_object_types in vmware_category

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_category.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_category.py
@@ -68,6 +68,28 @@ options:
       default: 'present'
       choices: [ 'present', 'absent' ]
       type: str
+    associable_object_types:
+      description:
+      - List of object types that can be associated with the given category.
+      choices:
+      - All objects
+      - Cluster
+      - Content Library
+      - Datacenter
+      - Datastore
+      - Datastore Cluster
+      - Distributed Port Group
+      - Distributed Switch
+      - Folder
+      - Host
+      - Library item
+      - Network
+      - Resource Pool
+      - vApp
+      - Virtual Machine
+      version_added: '2.10'
+      type: list
+      elements: str
 extends_documentation_fragment: vmware_rest_client.documentation
 '''
 
@@ -107,6 +129,19 @@ EXAMPLES = r'''
     password: "{{ vcenter_pass }}"
     category_name: Sample_Category_0002
     state: absent
+
+- name: Create category with 2 associable object types
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: 'Sample_Category_0003'
+    category_description: 'sample description'
+    associable_object_types:
+    - Datastore
+    - Cluster
+    state: present
 '''
 
 RETURN = r'''
@@ -163,7 +198,18 @@ class VmwareCategory(VmwareRestClient):
         else:
             category_spec.cardinality = CategoryModel.Cardinality.MULTIPLE
 
-        category_spec.associable_types = set()
+        associable_object_types = self.params.get('associable_object_types')
+
+        obj_types_set = []
+        if associable_object_types:
+            for obj_type in associable_object_types:
+                if obj_type.lower() == 'all objects':
+                    obj_types_set = []
+                    break
+                else:
+                    obj_types_set.append(obj_type)
+
+        category_spec.associable_types = set(obj_types_set)
 
         try:
             category_id = self.category_service.create(category_spec)
@@ -262,6 +308,17 @@ def main():
         category_cardinality=dict(type='str', choices=["multiple", "single"], default="multiple"),
         new_category_name=dict(type='str'),
         state=dict(type='str', choices=['present', 'absent'], default='present'),
+        associable_object_types=dict(
+            type='list',
+            choices=[
+                'All objects', 'Folder', 'Cluster',
+                'Datacenter', 'Datastore', 'Datastore Cluster',
+                'Distributed Port Group', 'Distributed Switch',
+                'Host', 'Content Library', 'Library item', 'Network',
+                'Resource Pool', 'vApp', 'Virtual Machine',
+            ],
+            elements=str,
+        ),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 

--- a/test/integration/targets/vmware_category/aliases
+++ b/test/integration/targets/vmware_category/aliases
@@ -1,0 +1,3 @@
+shippable/vcenter/group1
+cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_category/tasks/associable_obj_types.yml
+++ b/test/integration/targets/vmware_category/tasks/associable_obj_types.yml
@@ -1,0 +1,92 @@
+# Test code for the vmware_category Operations.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+    - name: Create different types of category with associable object types
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        category_name: '{{ item }} name'
+        category_description: '{{ item }} description'
+        associable_object_types:
+          - "{{ item }}"
+        state: present
+      with_items:
+        - All objects
+        - Folder
+        - Cluster
+        - Datacenter
+        - Datastore
+        - Datastore Cluster
+        - Distributed Port Group
+        - Distributed Switch
+        - Host
+        - Content Library
+        - Library item
+        - Network
+        - Resource Pool
+        - vApp
+        - Virtual Machine
+    
+    - name: Delete different types of category with associable object types
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        category_name: '{{ item }} name'
+        state: absent
+      with_items:
+        - All objects
+        - Folder
+        - Cluster
+        - Datacenter
+        - Datastore
+        - Datastore Cluster
+        - Distributed Port Group
+        - Distributed Switch
+        - Host
+        - Content Library
+        - Library item
+        - Network
+        - Resource Pool
+        - vApp
+        - Virtual Machine
+
+    - name: Create category with 2 associable object types
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        category_name: 'Sample_cate_0001'
+        category_description: 'sample description'
+        associable_object_types:
+        - Datastore
+        - Cluster
+        state: present
+      register: category_change
+
+    - name: Assert change is made
+      assert:
+        that:
+          - category_change.changed
+
+    - name: Delete category with 2 associable object types
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+        category_name: 'Sample_cate_0001'
+        state: absent
+      register: category_change
+
+    - name: Assert change is made
+      assert:
+        that:
+          - category_change.changed

--- a/test/integration/targets/vmware_category/tasks/main.yml
+++ b/test/integration/targets/vmware_category/tasks/main.yml
@@ -1,0 +1,5 @@
+# Test code for the vmware_category Operations.
+# Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- include: associable_obj_types.yml


### PR DESCRIPTION
##### SUMMARY
User can specify associable object types while creating the categories.
VMware API does not allow to modify associable object types after creation of
category.

Fixes: #61220

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_category.py
test/integration/targets/vmware_category/aliases
test/integration/targets/vmware_category/tasks/associable_obj_types.yml
test/integration/targets/vmware_category/tasks/main.yml