### PR TITLE
[yarn] Set name_version when version is not specified

### DIFF
--- a/changelogs/fragments/62348-yarn-global_install_fix.yml
+++ b/changelogs/fragments/62348-yarn-global_install_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - yarn - handle no version when installing module globally (https://github.com/ansible/ansible/issues/55097)

--- a/changelogs/fragments/62348-yarn-global_install_fix.yml
+++ b/changelogs/fragments/62348-yarn-global_install_fix.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - yarn - handle no version when installing module globally (https://github.com/ansible/ansible/issues/55097)

--- a/changelogs/fragments/62348-yarn-no_version_install_fix.yml
+++ b/changelogs/fragments/62348-yarn-no_version_install_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - yarn - handle no version when installing module by name (https://github.com/ansible/ansible/issues/55097)

--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -183,6 +183,8 @@ class Yarn(object):
 
         if kwargs['version'] and self.name is not None:
             self.name_version = self.name + '@' + str(self.version)
+        elif self.name is not None:
+            self.name_version = self.name
 
     def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):


### PR DESCRIPTION
This will default to installing the latest version available by yarn.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
As put forward in https://github.com/ansible/ansible/issues/55097#issuecomment-531162676, the `name_version` variable was not being set if version was not specified. But since `version` is not required that should not be the case.
Fixes #55097

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yarn

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml
- name: install npm modules
  yarn:
    name: nodemon
    global: yes
    state: present
```

Before:
```
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/home/smpx-170l/.nvm/versions/node/v12.7.0/bin/yarn global install --non-interactive --no-emoji", "msg": "error Invalid subcommand. Try \"add, bin, dir, ls, list, remove, upgrade, upgrade-interactive\"", "rc": 1, "stderr": "error Invalid subcommand. Try \"add, bin, dir, ls, list, remove, upgrade, upgrade-interactive\"\n", "stderr_lines": ["error Invalid subcommand. Try \"add, bin, dir, ls, list, remove, upgrade, upgrade-interactive\""], "stdout": "yarn global v1.17.3\ninfo Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.\n", "stdout_lines": ["yarn global v1.17.3", "info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command."]}
```

After:
```
changed: [localhost]
```
