### PR TITLE
[stable-2.9] Stabilize nxos initiated copy for nxos_file_copy plugin

### DIFF
--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -286,7 +286,7 @@ class ActionModule(ActionBase):
             # 14) - Copy completed without issues
             # 15) - nxos_router_prompt#
             # 16) - pexpect timeout
-            possible_outcomes = ['sure you want to continue connecting \(yes/no\)\? ',
+            possible_outcomes = [r'sure you want to continue connecting \(yes/no\)\? ',
                                  '(?i)Password: ',
                                  'file existing with this name',
                                  'timed out',

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -356,7 +356,7 @@ class ActionModule(ActionBase):
             if outcome['final_prompt_detected']:
                 break
             if outcome['error'] or outcome['expect_timeout']:
-                # Error encountered, try to spawn expect session n more times up to mac_attempts - 1
+                # Error encountered, try to spawn expect session n more times up to max_attempts - 1
                 if connect_attempt < max_attempts:
                     outcome['error'] = False
                     outcome['expect_timeout'] = False

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -99,14 +99,12 @@ class ActionModule(ActionBase):
                 raise AnsibleError('Playbook parameter <remote_scp_server> required when <file_pull> is True')
 
         if playvals['remote_scp_server'] or \
-           playvals['remote_scp_server_user'] or \
-           playvals['remote_scp_server_password']:
+           playvals['remote_scp_server_user']:
 
             if None in (playvals['remote_scp_server'],
-                        playvals['remote_scp_server_user'],
-                        playvals['remote_scp_server_password']):
-                params = '<remote_scp_server>, <remote_scp_server_user>, ,remote_scp_server_password>'
-                raise AnsibleError('Playbook parameters {0} must all be set together'.format(params))
+                        playvals['remote_scp_server_user']):
+                params = '<remote_scp_server>, <remote_scp_server_user>'
+                raise AnsibleError('Playbook parameters {0} must be set together'.format(params))
 
         return playvals
 
@@ -405,7 +403,12 @@ class ActionModule(ActionBase):
                 nxos_session.sendline('yes')
                 continue
             if outcome['password_prompt_detected']:
-                nxos_session.sendline(self.playvals['remote_scp_server_password'])
+                if self.playvals.get('remote_scp_server_password'):
+                    nxos_session.sendline(self.playvals['remote_scp_server_password'])
+                else:
+                    err_msg = 'Remote scp server {0} requires a password.'.format(rserver)
+                    err_msg += ' Set the <remote_scp_server_password> playbook parameter or configure nxos device for passwordless scp'
+                    raise AnsibleError(err_msg)
                 continue
             if outcome['existing_file_with_same_name']:
                 nxos_session.sendline('y')

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -359,6 +359,7 @@ class ActionModule(ActionBase):
                     outcome['error'] = False
                     outcome['expect_timeout'] = False
                     nxos_session.close()
+                    import epdb ; epdb.serve()
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
                 self.results['failed'] = True

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -364,6 +364,7 @@ class ActionModule(ActionBase):
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
                 self.results['failed'] = True
+                re.sub(nxos_password, '', outcome['error_data'])
                 self.results['error_data'] = 'Failed to spawn expect session! ' + outcome['error_data']
                 nxos_session.close()
                 return
@@ -372,8 +373,10 @@ class ActionModule(ActionBase):
             # The after string will contain the text that was matched by the expected pattern.
             msg = 'After {0} attempts, failed to spawn pexpect session to {1}'
             msg += 'BEFORE: {2}, AFTER: {3}'
+            error_msg = msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.after)
+            re.sub(nxos_password, '', error_msg)
             nxos_session.close()
-            raise AnsibleError(msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.after))
+            raise AnsibleError(error_msg)
 
         # Create local file directory under NX-OS filesystem if
         # local_file_directory playbook parameter is set.
@@ -387,6 +390,7 @@ class ActionModule(ActionBase):
                     if outcome['error'] or outcome['expect_timeout']:
                         self.results['mkdir_cmd'] = mkdir_cmd
                         self.results['failed'] = True
+                        re.sub(nxos_password, '', outcome['error_data'])
                         self.results['error_data'] = outcome['error_data']
                         return
                     local_dir_root += each + '/'
@@ -411,6 +415,8 @@ class ActionModule(ActionBase):
                 break
             if outcome['error'] or outcome['expect_timeout']:
                 self.results['failed'] = True
+                re.sub(nxos_password, '', outcome['error_data'])
+                re.sub(self.playvals['remote_scp_server_password'], '', outcome['error_data'])
                 self.results['error_data'] = outcome['error_data']
                 nxos_session.close()
                 return
@@ -419,8 +425,11 @@ class ActionModule(ActionBase):
             # The after string will contain the text that was matched by the expected pattern.
             msg = 'After {0} attempts, failed to copy file to {1}'
             msg += 'BEFORE: {2}, AFTER: {3}, CMD: {4}'
+            error_msg = msg.format(copy_attempt, nxos_hostname, nxos_session.before, nxos_session.before, copy_cmd)
+            re.sub(nxos_password, '', error_msg)
+            re.sub(self.playvals['remote_scp_server_password'], '', error_msg)
             nxos_session.close()
-            raise AnsibleError(msg.format(copy_attempt, nxos_hostname, nxos_session.before, nxos_session.before, copy_cmd))
+            raise AnsibleError(error_msg)
 
         nxos_session.close()
 

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -344,6 +344,7 @@ class ActionModule(ActionBase):
         # spawning the expect session so loop up to 24 times during the spawn process.
         max_attempts = 24
         for connect_attempt in range(max_attempts):
+            import epdb ; epdb.serve()
             outcome = process_outcomes(nxos_session)
             if outcome['user_response_required']:
                 nxos_session.sendline('yes')

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -357,11 +357,15 @@ class ActionModule(ActionBase):
             outcome = process_outcomes(nxos_session)
             if outcome['user_response_required']:
                 logit('user_response_required')
+                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 nxos_session.sendline('yes')
+                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 continue
             if outcome['password_prompt_detected']:
                 logit('password_prompt_detected')
+                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 nxos_session.sendline(nxos_password)
+                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 continue
             if outcome['final_prompt_detected']:
                 logit('final_prompt_detected')
@@ -371,6 +375,7 @@ class ActionModule(ActionBase):
                 logit('error_encountered')
                 if connect_attempt < max_attempts:
                     logit('Attempt %s to spawn ssh session' % connect_attempt)
+                    logit('%s, %s' % (nxos_session.before, nxos_session.after))
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
                 logit('final failure error ... return the info')
@@ -383,7 +388,7 @@ class ActionModule(ActionBase):
             logit('Strange error, outcome info: %s' % outcome)
             msg = 'After {0} attempts, failed to spawn pexpect session to {1}'
             msg += 'BEFORE: {2}, AFTER: {3}'
-            raise AnsibleError(msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.before))
+            raise AnsibleError(msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.after))
 
         # Create local file directory under NX-OS filesystem if
         # local_file_directory playbook parameter is set.

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -286,8 +286,8 @@ class ActionModule(ActionBase):
             # 14) - Copy completed without issues
             # 15) - nxos_router_prompt#
             # 16) - pexpect timeout
-            possible_outcomes = ['yes',
-                                 '(?i)Password',
+            possible_outcomes = ['sure you want to continue connecting \(yes/no\)\? ',
+                                 '(?i)Password: ',
                                  'file existing with this name',
                                  'timed out',
                                  '(?i)No space.*#',

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -368,6 +368,7 @@ class ActionModule(ActionBase):
         else:
             # The before property will contain all text up to the expected string pattern.
             # The after string will contain the text that was matched by the expected pattern.
+            import epdb ; epdb.serve()
             msg = 'After {0} attempts, failed to spawn pexpect session to {1}'
             msg += 'BEFORE: {2}, AFTER: {3}'
             raise AnsibleError(msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.after))

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -364,7 +364,7 @@ class ActionModule(ActionBase):
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
                 self.results['failed'] = True
-                re.sub(nxos_password, '', outcome['error_data'])
+                outcome['error_data'] = re.sub(nxos_password, '', outcome['error_data'])
                 self.results['error_data'] = 'Failed to spawn expect session! ' + outcome['error_data']
                 nxos_session.close()
                 return
@@ -390,7 +390,7 @@ class ActionModule(ActionBase):
                     if outcome['error'] or outcome['expect_timeout']:
                         self.results['mkdir_cmd'] = mkdir_cmd
                         self.results['failed'] = True
-                        re.sub(nxos_password, '', outcome['error_data'])
+                        outcome['error_data'] = re.sub(nxos_password, '', outcome['error_data'])
                         self.results['error_data'] = outcome['error_data']
                         return
                     local_dir_root += each + '/'
@@ -415,8 +415,8 @@ class ActionModule(ActionBase):
                 break
             if outcome['error'] or outcome['expect_timeout']:
                 self.results['failed'] = True
-                re.sub(nxos_password, '', outcome['error_data'])
-                re.sub(self.playvals['remote_scp_server_password'], '', outcome['error_data'])
+                outcome['error_data'] = re.sub(nxos_password, '', outcome['error_data'])
+                outcome['error_data'] = re.sub(self.playvals['remote_scp_server_password'], '', outcome['error_data'])
                 self.results['error_data'] = outcome['error_data']
                 nxos_session.close()
                 return

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -22,12 +22,6 @@ import hashlib
 import os
 import re
 
-import datetime
-def logit(msg):
-    with open('/tmp/alog.txt', 'a') as of:
-        d = datetime.datetime.now().replace(microsecond=0).isoformat()
-        of.write("---- %s ----\n%s\n" % (d,msg))
-
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.connection import Connection
@@ -345,49 +339,34 @@ class ActionModule(ActionBase):
             return outcome
 
         # Spawn pexpect connection to NX-OS device.
-        logit('Initial attempt to spawn ssh session')
-        logit('nxos_username: %s' % nxos_username)
-        logit('nxos_hostname: %s' % nxos_hostname)
-        logit('port: %s' % str(port))
         nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
         # There might be multiple user_response_required prompts or intermittent timeouts
-        # spawning the expect session so loop up to 5 times during the spwan process.
-        max_attempts = 20
+        # spawning the expect session so loop up to 24 times during the spawn process.
+        max_attempts = 24
         for connect_attempt in range(max_attempts):
             outcome = process_outcomes(nxos_session)
             if outcome['user_response_required']:
-                logit('user_response_required')
-                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 nxos_session.sendline('yes')
-                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 continue
             if outcome['password_prompt_detected']:
-                logit('password_prompt_detected')
-                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 nxos_session.sendline('%s' % nxos_password)
-                logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 continue
             if outcome['final_prompt_detected']:
-                logit('final_prompt_detected')
                 break
             if outcome['error'] or outcome['expect_timeout']:
                 # Error encountered, try to spawn expect session n more times up to mac_attempts - 1
-                logit('error_encountered')
                 if connect_attempt < max_attempts:
-                    logit('Attempt %s to spawn ssh session' % connect_attempt)
-                    logit('%s, %s' % (nxos_session.before, nxos_session.after))
-                    logit('close old session first')
+                    outcome['error'] = False
+                    outcome['expect_timeout'] = False
                     nxos_session.close()
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
-                logit('final failure error ... return the info')
                 self.results['failed'] = True
                 self.results['error_data'] = 'Failed to spawn expect session! ' + outcome['error_data']
                 return
         else:
             # The before property will contain all text up to the expected string pattern.
             # The after string will contain the text that was matched by the expected pattern.
-            logit('Strange error, outcome info: %s' % outcome)
             msg = 'After {0} attempts, failed to spawn pexpect session to {1}'
             msg += 'BEFORE: {2}, AFTER: {3}'
             raise AnsibleError(msg.format(connect_attempt, nxos_hostname, nxos_session.before, nxos_session.after))

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -352,7 +352,7 @@ class ActionModule(ActionBase):
         nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
         # There might be multiple user_response_required prompts or intermittent timeouts
         # spawning the expect session so loop up to 5 times during the spwan process.
-        max_attempts = 6
+        max_attempts = 20
         for connect_attempt in range(max_attempts):
             outcome = process_outcomes(nxos_session)
             if outcome['user_response_required']:
@@ -376,6 +376,7 @@ class ActionModule(ActionBase):
                 if connect_attempt < max_attempts:
                     logit('Attempt %s to spawn ssh session' % connect_attempt)
                     logit('%s, %s' % (nxos_session.before, nxos_session.after))
+                    logit('close old session first')
                     nxos_session.close()
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -419,7 +419,8 @@ class ActionModule(ActionBase):
             if outcome['error'] or outcome['expect_timeout']:
                 self.results['failed'] = True
                 outcome['error_data'] = re.sub(nxos_password, '', outcome['error_data'])
-                outcome['error_data'] = re.sub(self.playvals['remote_scp_server_password'], '', outcome['error_data'])
+                if self.playvals.get('remote_scp_server_password'):
+                    outcome['error_data'] = re.sub(self.playvals['remote_scp_server_password'], '', outcome['error_data'])
                 self.results['error_data'] = outcome['error_data']
                 nxos_session.close()
                 return
@@ -430,7 +431,8 @@ class ActionModule(ActionBase):
             msg += 'BEFORE: {2}, AFTER: {3}, CMD: {4}'
             error_msg = msg.format(copy_attempt, nxos_hostname, nxos_session.before, nxos_session.before, copy_cmd)
             re.sub(nxos_password, '', error_msg)
-            re.sub(self.playvals['remote_scp_server_password'], '', error_msg)
+            if self.playvals.get('remote_scp_server_password'):
+                re.sub(self.playvals['remote_scp_server_password'], '', error_msg)
             nxos_session.close()
             raise AnsibleError(error_msg)
 

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -364,7 +364,7 @@ class ActionModule(ActionBase):
             if outcome['password_prompt_detected']:
                 logit('password_prompt_detected')
                 logit('%s, %s' % (nxos_session.before, nxos_session.after))
-                nxos_session.sendline(nxos_password)
+                nxos_session.sendline('%s' % nxos_password)
                 logit('%s, %s' % (nxos_session.before, nxos_session.after))
                 continue
             if outcome['final_prompt_detected']:
@@ -376,6 +376,7 @@ class ActionModule(ActionBase):
                 if connect_attempt < max_attempts:
                     logit('Attempt %s to spawn ssh session' % connect_attempt)
                     logit('%s, %s' % (nxos_session.before, nxos_session.after))
+                    nxos_session.close()
                     nxos_session = pexpect.spawn('ssh ' + nxos_username + '@' + nxos_hostname + ' -p' + str(port))
                     continue
                 logit('final failure error ... return the info')

--- a/test/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/input_validation.yaml
@@ -60,6 +60,6 @@
 
 - assert:
     that:
-      - result is search('Playbook parameters <remote_scp_server>, <remote_scp_server_user>, ,remote_scp_server_password> must all be set together')
+      - result is search('Playbook parameters <remote_scp_server>, <remote_scp_server_user> must be set together')
 
 - debug: msg="END nxos_file_copy input_validation test"


### PR DESCRIPTION
##### SUMMARY
This PR stabilizes the expect session that gets spawned to initiate file copies from the nxos device.  There is an intermittent issue where the spawn attempt will fail and this fix resolves that.

This also removes the requirement to supply the `remote_scp_server_password` when initiating file copies from the nxos device.  This is needed when passwordless scp is enabled.
  
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_file_copy