### PR TITLE
ec2_eip: Fixing check_mode and tests

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -372,12 +372,10 @@ def allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode,
 
     try:
         result = ec2.allocate_address(DryRun=check_mode, Domain=domain, aws_retry=True), True
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        if e.response['Error']['Code'] == "DryRunOperation":
-            result = "Would have allocated the Elastic IP address if not in check_mode", True
-        else:
-            module.fail_json_aws(e, msg="Couldn't allocate Elastic IP address")
-
+    except is_boto3_error_code('DryRunOperation') as e:
+        result = "Would have allocated the Elastic IP address if not in check_mode", True
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Couldn't allocate Elastic IP address")
     return result
 
 
@@ -498,11 +496,10 @@ def allocate_address_from_pool(ec2, module, domain, check_mode, public_ipv4_pool
 
     try:
         result = ec2.allocate_address(aws_retry=True, **params)
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        if e.response['Error']['Code'] == "DryRunOperation":
-            result = "Would have allocated the Elastic IP address if not in check_mode"
-        else:
-            module.fail_json_aws(e, msg="Couldn't allocate Elastic IP address")
+    except is_boto3_error_code('DryRunOperation') as e:
+        result = "Would have allocated the Elastic IP address if not in check_mode"
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Couldn't allocate Elastic IP address")
     return result
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -600,7 +600,7 @@ def main():
                     )
                 result = {'changed': changed}
                 if not module.check_mode:
-                    result['public_ip'] = address['PublicIp'],
+                    result['public_ip'] = address['PublicIp']
                     result['allocation_id'] = address['AllocationId']
         else:
             if device_id:

--- a/test/integration/targets/ec2_eip/tasks/main.yml
+++ b/test/integration/targets/ec2_eip/tasks/main.yml
@@ -20,9 +20,8 @@
 
     - assert:
         that:
-          - eip is defined
-          - eip.public_ip is defined and eip.public_ip != ""
-          - eip.allocation_id is defined and eip.allocation_id != ""
+          - eip is defined and (eip.public_ip | ipaddr)
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
 
     - name: Allocate a new eip
       ec2_eip:
@@ -33,10 +32,8 @@
 
     - assert:
         that:
-          - new_eip is defined
-          - new_eip is changed
-          - new_eip.public_ip is defined and new_eip.public_ip is match("^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
-          - new_eip.allocation_id is defined and new_eip.allocation_id is match("^eipalloc-.*")
+          - new_eip is defined and (new_eip.public_ip | ipaddr)
+          - new_eip.allocation_id is defined and new_eip.allocation_id.startswith("eipalloc-")
 
     - name: Match an existing eip (changed == false)
       ec2_eip:
@@ -48,10 +45,8 @@
 
     - assert:
         that:
-          - existing_eip is defined
-          - existing_eip is not changed
-          - existing_eip.public_ip is defined and existing_eip.public_ip != ""
-          - existing_eip.allocation_id is defined and existing_eip.allocation_id != ""
+          - existing_eip is defined and (existing_eip.public_ip == eip.public_ip)
+          - existing_eip.allocation_id is defined and (existing_eip.allocation_id == eip.allocation_id)
 
     - name: attempt reusing an existing eip with a tag (or allocate a new one)
       ec2_eip:
@@ -64,9 +59,8 @@
 
     - assert:
         that:
-          - tagged_eip is defined
-          - tagged_eip.public_ip is defined and tagged_eip.public_ip != ""
-          - tagged_eip.allocation_id is defined and tagged_eip.allocation_id != ""
+          - tagged_eip is defined and (tagged_eip.public_ip | ipaddr)
+          - tagged_eip.allocation_id is defined and tagged_eip.allocation_id.startswith("eipalloc-")
 
     - name: attempt reusing an existing eip with a tag and it's value (or allocate a new one)
       ec2_eip:
@@ -81,9 +75,8 @@
 
     - assert:
         that:
-          - backend_eip is defined
-          - backend_eip.public_ip is defined and backend_eip.public_ip != ""
-          - backend_eip.allocation_id is defined and backend_eip.allocation_id != ""
+          - backend_eip is defined and (backend_eip.public_ip == eip.public_ip)
+          - backend_eip.allocation_id is defined and (backend_eip.allocation_id == eip.allocation_id)
 
     - name: attempt reusing an existing eip with a tag and it's value (or allocate a new one from pool)
       ec2_eip:
@@ -98,9 +91,8 @@
 
     - assert:
         that:
-          - amazon_eip is defined
-          - amazon_eip.public_ip is defined and amazon_eip.public_ip != ""
-          - amazon_eip.allocation_id is defined and amazon_eip.allocation_id != ""
+          - amazon_eip is defined and (amazon_eip.public_ip | ipaddr)
+          - amazon_eip.allocation_id is defined and amazon_eip.allocation_id.startswith("eipalloc-")
 
     - name: allocate a new eip from a pool
       ec2_eip:
@@ -112,10 +104,8 @@
 
     - assert:
         that:
-          - pool_eip is defined
-          - pool_eip is changed
-          - pool_eip.public_ip is defined and pool_eip.public_ip != ""
-          - pool_eip.allocation_id is defined and pool_eip.allocation_id != ""
+          - pool_eip is defined and (pool_eip.public_ip | ipaddr)
+          - pool_eip.allocation_id is defined and pool_eip.allocation_id.startswith("eipalloc-")
 
     - name: Gather existing eips before check_mode allocation
       ec2_eip_info:

--- a/test/integration/targets/ec2_eip/tasks/main.yml
+++ b/test/integration/targets/ec2_eip/tasks/main.yml
@@ -43,7 +43,7 @@
         state: present
         in_vpc: yes
         <<: *aws_connection_info
-        public_ip: "{{ eip.public_ip }}"
+        public_ip: "{{ eip.public_ip[0] }}"
       register: existing_eip
 
     - assert:
@@ -73,7 +73,7 @@
         state: present
         in_vpc: yes
         <<: *aws_connection_info
-        public_ip: "{{ eip.public_ip }}"
+        public_ip: "{{ eip.public_ip[0] }}"
         reuse_existing_ip_allowed: yes
         tag_name: Team
         tag_value: Backend
@@ -116,6 +116,37 @@
           - pool_eip is changed
           - pool_eip.public_ip is defined and pool_eip.public_ip != ""
           - pool_eip.allocation_id is defined and pool_eip.allocation_id != ""
+
+    - name: Gather existing eips before check_mode allocation
+      ec2_eip_info:
+        <<: *aws_connection_info
+      register: eip_info_before
+    - assert:
+        that:
+          - eip_info_before is defined
+
+    - name: Allocate eip in check_mode
+      ec2_eip:
+        state: present
+        in_vpc: yes
+        <<: *aws_connection_info
+      check_mode: yes
+      register: check_mode_eip
+    - assert:
+        that:
+          - check_mode_eip is defined
+          - check_mode_eip.allocation_id is not defined
+          - check_mode_eip.public_ip is not defined
+
+    - name: Ensure check_mode hasnt allocated a new eip
+      ec2_eip_info:
+        <<: *aws_connection_info
+      register: eip_info_after
+    - assert:
+        that:
+          - eip_info_after is defined
+          - ( eip_info_before | length ) == ( eip_info_after | length )
+            
   always:
     - debug:
         msg: "{{ item }}"
@@ -130,7 +161,7 @@
     - name: Cleanup newly allocated eip
       ec2_eip:
         state: absent
-        public_ip: "{{ item.public_ip }}"
+        public_ip: "{{ item.public_ip[0] }}"
         in_vpc: yes
         <<: *aws_connection_info
       when: item is defined and item is changed and item.public_ip is defined and item.public_ip != ""
@@ -141,4 +172,3 @@
         - "{{ tagged_eip }}"
         - "{{ backend_eip }}"
         - "{{ amazon_eip }}"
-...

--- a/test/integration/targets/ec2_eip/tasks/main.yml
+++ b/test/integration/targets/ec2_eip/tasks/main.yml
@@ -35,15 +35,15 @@
         that:
           - new_eip is defined
           - new_eip is changed
-          - new_eip.public_ip is defined and new_eip.public_ip != ""
-          - new_eip.allocation_id is defined and new_eip.allocation_id != ""
+          - new_eip.public_ip is defined and new_eip.public_ip is match("^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
+          - new_eip.allocation_id is defined and new_eip.allocation_id is match("^eipalloc-.*")
 
     - name: Match an existing eip (changed == false)
       ec2_eip:
         state: present
         in_vpc: yes
         <<: *aws_connection_info
-        public_ip: "{{ eip.public_ip[0] }}"
+        public_ip: "{{ eip.public_ip }}"
       register: existing_eip
 
     - assert:
@@ -73,7 +73,7 @@
         state: present
         in_vpc: yes
         <<: *aws_connection_info
-        public_ip: "{{ eip.public_ip[0] }}"
+        public_ip: "{{ eip.public_ip }}"
         reuse_existing_ip_allowed: yes
         tag_name: Team
         tag_value: Backend
@@ -161,7 +161,7 @@
     - name: Cleanup newly allocated eip
       ec2_eip:
         state: absent
-        public_ip: "{{ item.public_ip[0] }}"
+        public_ip: "{{ item.public_ip }}"
         in_vpc: yes
         <<: *aws_connection_info
       when: item is defined and item is changed and item.public_ip is defined and item.public_ip != ""


### PR DESCRIPTION
##### SUMMARY

Fixes #62318    

1. Adds check_mode for the ec2.allocate_address call.
2. Adds tests related to this fix
3. Fixes existing ec2_eip tests (array was assigned to the "public_ip" param instead of a string)

##### ISSUE TYPE     

- Bugfix Pull Request  

##### COMPONENT NAME
cloud/amazon/ec2_eip

##### ADDITIONAL INFORMATION
Reference of the exception triggered for 3:

```
TASK [ec2_eip : attempt reusing an existing eip with a tag and it's value (or allocate a new one)] *******************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (InvalidParameterValue) when calling the DescribeAddresses operation: Invalid value '['3.226.X.X']' for PublicIp. Not a valid IPv4 address.
 [WARNING]: The value ['3.226.X.X'] (type list) in a string field was converted to u"['3.229.229.85']" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

fatal: [localhost]: FAILED! => {"boto3_version": "1.9.228", "botocore_version": "1.12.228", "changed": false, "msg": "An error occurred (InvalidParameterValue) when calling the DescribeAddresses operation: Invalid value '['3.226.X.X']' for PublicIp. Not a valid IPv4 address."}

[...]
TASK [ec2_eip : Cleanup newly allocated eip] *************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (InvalidParameterValue) when calling the DescribeAddresses operation: Invalid value '['3.226.X.X']' for PublicIp. Not a valid IPv4 address.
 [WARNING]: The value ['3.226.X.X'] (type list) in a string field was converted to u"['3.226.20.97']" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```