### PR TITLE
Update pip module docs

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,7 +101,9 @@ options:
         in the system and you want to run pip for the Python 3.3 installation.
         It cannot be specified together with the 'virtualenv' parameter (added in 2.1).
         By default, it will take the appropriate version for the python interpreter
-        use by ansible, e.g. pip3 on python 3, and pip2 or pip on python 2.
+        use by ansible, e.g. pip3 on python 3, and pip2 or pip on python 2. Note that
+        the setuptools requirement is for the Python interpreter used by ansible, not
+        by the version of Python used by the specified executable.
     type: path
     version_added: "1.3"
   umask:
@@ -119,6 +121,8 @@ notes:
      the virtualenv needs to be created.
    - By default, this module will use the appropriate version of pip for the
      interpreter used by ansible (e.g. pip3 when using python 3, pip2 otherwise)
+   - The interpreter used by ansible requires the setuptools package, regardless
+     of the version of pip set with the executable option.
 requirements:
 - pip
 - virtualenv

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,8 +101,8 @@ options:
         in the system and you want to run pip for the Python 3.3 installation.
       - Mutually exclusive with I(virtualenv) (added in 2.1).
       - Does not affect the Ansible Python interpreter.
-      - The setuptools package must be installed for the Ansible Python interpreter,
-        not for the version of Python specified by this option.
+      - The setuptools package must be installed for both the Ansible Python interpreter
+        and for the version of Python specified by this option.
     type: path
     version_added: "1.3"
   umask:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -121,8 +121,10 @@ notes:
      the virtualenv needs to be created.
    - By default, this module will use the appropriate version of pip for the
      interpreter used by ansible (e.g. pip3 when using python 3, pip2 otherwise)
-   - The interpreter used by ansible requires the setuptools package, regardless
-     of the version of pip set with the executable option.
+   - The interpreter used by ansible
+     (see :ref:`ansible_python_interpreter<ansible_python_interpreter>`)
+     requires the setuptools package, regardless of the version of pip set with
+     the executable option.
 requirements:
 - pip
 - virtualenv

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -95,15 +95,14 @@ options:
     version_added: "1.3"
   executable:
     description:
-      - The explicit executable or a pathname to the executable to be used to
-        run pip for a specific version of Python installed in the system. For
+      - The explicit executable or pathname for the pip executable,
+        if different from the Ansible Python interpreter. For
         example C(pip-3.3), if there are both Python 2.7 and 3.3 installations
         in the system and you want to run pip for the Python 3.3 installation.
-        It cannot be specified together with the 'virtualenv' parameter (added in 2.1).
-        By default, it will take the appropriate version for the python interpreter
-        use by ansible, e.g. pip3 on python 3, and pip2 or pip on python 2. Note that
-        the setuptools requirement is for the Python interpreter used by ansible, not
-        by the version of Python used by the specified executable.
+      - Mutually exclusive with I(virtualenv) (added in 2.1).
+      - Does not affect the Ansible Python interpreter.
+      - The setuptools package must be installed for the Ansible Python interpreter,
+        not for the version of Python specified by this option.
     type: path
     version_added: "1.3"
   umask:
@@ -116,15 +115,16 @@ options:
     type: str
     version_added: "2.1"
 notes:
-   - Please note that virtualenv (U(http://www.virtualenv.org/)) must be
+   - The virtualenv (U(http://www.virtualenv.org/)) must be
      installed on the remote host if the virtualenv parameter is specified and
      the virtualenv needs to be created.
-   - By default, this module will use the appropriate version of pip for the
-     interpreter used by ansible (e.g. pip3 when using python 3, pip2 otherwise)
-   - The interpreter used by ansible
+   - Although it executes using the Ansible Python interpreter, the pip module shells out to
+     run the actual pip command, so it can use any pip version you specify with I(executable).
+     By default, it uses the pip version for the Ansible Python interpreter. For example, pip3 on python 3, and pip2 or pip on python 2.
+   - The interpreter used by Ansible
      (see :ref:`ansible_python_interpreter<ansible_python_interpreter>`)
      requires the setuptools package, regardless of the version of pip set with
-     the executable option.
+     the I(executable) option.
 requirements:
 - pip
 - virtualenv


### PR DESCRIPTION
##### SUMMARY
Based on #61877.

Clarifies how the `executable` option for the `pip` module works, and which Python installation requires the `setuptools` package.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
pip module
docs.ansible.com
