### PR TITLE
test: cleanup sanity/ignore.txt to avoid A100

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1605,7 +1605,6 @@ lib/ansible/modules/cloud/openstack/os_keypair.py validate-modules:doc-missing-t
 lib/ansible/modules/cloud/openstack/os_keystone_domain.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/openstack/os_keystone_domain_info.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/openstack/os_keystone_domain_info.py validate-modules:doc-missing-type
-lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:option-incorrect-version-added
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:undocumented-parameter
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY

See: https://app.shippable.com/github/ansible/ansible/runs/143332/5/console
```
21:30 ERROR: Found 1 validate-modules issue(s) which need to be resolved:
21:30 ERROR: test/sanity/ignore.txt:1608:1: A100: Ignoring 'option-incorrect-version-added' on 'lib/ansible/modules/cloud/openstack/os_keystone_endpoint.py' is unnecessary (75%)
21:30 See documentation for help: https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/validate-modules.html
21:30 ERROR: The 1 sanity test(s) listed below (out of 1) failed.
```

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME

test/sanity/ignore.txt
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
