### PR TITLE
test: temp disable azure_rm_azurefirewall

### DIFF
--- a/test/integration/targets/azure_rm_azurefirewall/aliases
+++ b/test/integration/targets/azure_rm_azurefirewall/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group3
 destructive
+disabled # See: https://github.com/ansible/ansible/issues/62307


### PR DESCRIPTION
##### SUMMARY

Disabled `azure_rm_azurefirewall` until #62307 is fixed. The test takes more than 35 minutes to run and preventing the other tests to run.
e.g: https://app.shippable.com/github/ansible/ansible/runs/143334/122/console

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

azure_rm_azurefirewall