### PR TITLE
Mark AWS credentials in ansible-test as sensitive.

### DIFF
--- a/test/lib/ansible_test/_internal/cloud/aws.py
+++ b/test/lib/ansible_test/_internal/cloud/aws.py
@@ -74,6 +74,9 @@ class AwsCloudProvider(CloudProvider):
                 REGION='us-east-1',
             )
 
+            display.sensitive.add(values['SECRET_KEY'])
+            display.sensitive.add(values['SECURITY_TOKEN'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -99,6 +102,9 @@ class AwsCloudEnvironment(CloudEnvironment):
         )
 
         ansible_vars.update(dict(parser.items('default')))
+
+        display.sensitive.add(ansible_vars.get('aws_secret_key'))
+        display.sensitive.add(ansible_vars.get('security_token'))
 
         if 'aws_cleanup' not in ansible_vars:
             ansible_vars['aws_cleanup'] = not self.managed


### PR DESCRIPTION
##### SUMMARY

Mark AWS credentials in ansible-test as sensitive.

This avoids displaying the credentials in CI when retrying tests at maximum verbosity.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
