### PR TITLE
[stable-2.8] Mark AWS credentials in ansible-test as sensitive.

### DIFF
--- a/test/runner/lib/cloud/aws.py
+++ b/test/runner/lib/cloud/aws.py
@@ -73,6 +73,9 @@ class AwsCloudProvider(CloudProvider):
                 REGION='us-east-1',
             )
 
+            display.sensitive.add(values['SECRET_KEY'])
+            display.sensitive.add(values['SECURITY_TOKEN'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -98,6 +101,9 @@ class AwsCloudEnvironment(CloudEnvironment):
         )
 
         ansible_vars.update(dict(parser.items('default')))
+
+        display.sensitive.add(ansible_vars.get('aws_secret_key'))
+        display.sensitive.add(ansible_vars.get('security_token'))
 
         env_vars = {'ANSIBLE_DEBUG_BOTOCORE_LOGS': 'True'}
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Mark AWS credentials in ansible-test as sensitive.

This avoids displaying the credentials in CI when retrying tests at maximum verbosity.

Backport of https://github.com/ansible/ansible/pull/62375

(cherry picked from commit b73e772)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
