### PR TITLE
acme_* modules: bump acme-test-container version

### DIFF
--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -45,7 +45,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.7.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.8.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Uses new test container ansible/acme-test-container#16. Needed for #60710, but kept separate so it can be backported.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/cloud/acme.py
