### PR TITLE
postgresql_table: add reference to postgresql_idx in seealso

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_table.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_table.py
@@ -106,6 +106,7 @@ notes:
 - Unlogged tables are available from PostgreSQL server version 9.1.
 seealso:
 - module: postgresql_sequence
+- module: postgresql_idx
 - module: postgresql_info
 - module: postgresql_tablespace
 - module: postgresql_owner


### PR DESCRIPTION
##### SUMMARY
postgresql_table: add reference to postgresql_idx in seealso

relates to https://github.com/ansible/ansible/pull/62356

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_table.py```
