### PR TITLE
VMware: vmware_guest fix multiple CDROMs issue

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -228,6 +228,49 @@
     that:
       - "cdrom_vm.changed == true"
 
+- name: Set fact of controller number and unit number - GitHub issue 62397
+  set_fact:
+    test_ctl_num: 0
+    test_unit_num: '0'
+- name: Create VM with multiple CDROMs - GitHub issue 62397
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
+    name: test_vm1
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: "{{ ds2 }}"
+    cdrom:
+    - controller_type: ide
+      controller_number: "{{ test_ctl_num }}"
+      unit_number: "{{ test_unit_num }}"
+      type: iso
+      iso_path: "[{{ ds1 }}] centos.iso"
+    - controller_type: ide
+      controller_number: 0
+      unit_number: 1
+      type: client
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "cdrom_vm.changed == true"
+
 # VCSIM fails with invalidspec exception but real vCenter PASS testcase
 # Commenting this testcase till the time
 - when: vcsim is not defined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add validation and converting "cdrom.controller_number" and "cdrom.unit_number" parameters to integer as valid value type.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ANSIBLE VERSION
ansible --version
ansible 2.9.0rc1
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/.local/lib/python2.7/site-packages/ansible
  executable location = /root/.local/bin/ansible
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
