### PR TITLE
To fix ios_l3_interfaces resource module round trip failure backport for PR 61642

### DIFF
--- a/changelogs/fragments/61642-fix-ios-l3-interfaces-rtt-failure.yaml
+++ b/changelogs/fragments/61642-fix-ios-l3-interfaces-rtt-failure.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "To fix ios_l3_interfaces resource module round trip failure(https://github.com/ansible/ansible/pull/61642)"

--- a/lib/ansible/module_utils/network/ios/utils/utils.py
+++ b/lib/ansible/module_utils/network/ios/utils/utils.py
@@ -138,6 +138,8 @@ def validate_ipv6(value, module):
 def validate_n_expand_ipv4(module, want):
     # Check if input IPV4 is valid IP and expand IPV4 with its subnet mask
     ip_addr_want = want.get('address')
+    if len(ip_addr_want.split(' ')) > 1:
+        return ip_addr_want
     validate_ipv4(ip_addr_want, module)
     ip = ip_addr_want.split('/')
     if len(ip) == 2:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cherry-picked from: f9fd1f3626170a4370335648bba056a8d4913242
To fix ios_l3_interfaces resource module round trip failure backport for PR #61642
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l3_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
