### PR TITLE
BOTMETA: Enable automerge

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -34,7 +34,7 @@
 #           supershipit - supershipiteers can turn a shipit into a supershipit
 #
 
-automerge: False
+automerge: True
 files:
   .github/BOTMETA.yml:
     labels: botmeta


### PR DESCRIPTION
##### SUMMARY
It's been over 7 days since devel because 2.10 and automerge was disabled, therefore `version_added` should be correct for any current PRs.

Follow on from https://github.com/ansible/ansible/pull/61674

##### ISSUE TYPE
- Feature Pull Request
