### PR TITLE
[stable-2.9] Fix "JSON object must be str, bytes or bytearray, not list"

### DIFF
--- a/changelogs/fragments/62350-eapi-json-fix.yaml
+++ b/changelogs/fragments/62350-eapi-json-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed intermittent "JSON object must be str, bytes or bytearray, not list" error with EOS over httpapi

--- a/lib/ansible/plugins/httpapi/eos.py
+++ b/lib/ansible/plugins/httpapi/eos.py
@@ -68,7 +68,8 @@ class HttpApi(HttpApiBase):
 
     def send_request(self, data, **message_kwargs):
         data = to_list(data)
-        if self._become:
+        become = self._become
+        if become:
             self.connection.queue_message('vvvv', 'firing event: on_become')
             data.insert(0, {"cmd": "enable", "input": self._become_pass})
 
@@ -87,7 +88,7 @@ class HttpApi(HttpApiBase):
 
         results = handle_response(response_data)
 
-        if self._become:
+        if become:
             results = results[1:]
         if len(results) == 1:
             results = results[0]
@@ -101,7 +102,7 @@ class HttpApi(HttpApiBase):
         device_info = {}
 
         device_info['network_os'] = 'eos'
-        reply = self.send_request('show version | json')
+        reply = self.send_request('show version', output='json')
         data = json.loads(reply)
 
         device_info['network_os_version'] = data['version']


### PR DESCRIPTION
##### SUMMARY

(cherry picked from commit 84d9b3e)

Co-authored-by: Nathaniel Case <ncase@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi/eos.py