### PR TITLE
Fix traceback error in IOS and IOSXR when ran with empty config

### DIFF
--- a/changelogs/fragments/62400-ios-iosxr-traceback-with-empty-config.yaml
+++ b/changelogs/fragments/62400-ios-iosxr-traceback-with-empty-config.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Fix traceback error in IOS and IOSXR when ran with empty config (https://github.com/ansible/ansible/pull/62400)"

--- a/lib/ansible/modules/network/ios/ios_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_interfaces.py
@@ -389,7 +389,12 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_l2_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interfaces.py
@@ -348,7 +348,12 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=L2_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = L2_Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -426,7 +426,12 @@ def main():
     Main entry point for module execution
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=L3_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = L3_Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_lacp.py
+++ b/lib/ansible/modules/network/ios/ios_lacp.py
@@ -170,7 +170,11 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',))]
+
     module = AnsibleModule(argument_spec=LacpArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Lacp(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lacp_interfaces.py
@@ -347,7 +347,12 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=Lacp_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Lacp_Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_lag_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lag_interfaces.py
@@ -374,8 +374,14 @@ def main():
     Main entry point for module execution
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=Lag_interfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
+
     result = Lag_interfaces(module).execute_module()
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/ios/ios_lldp_global.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_global.py
@@ -241,7 +241,11 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',))]
+
     module = AnsibleModule(argument_spec=Lldp_globalArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Lldp_global(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_interfaces.py
@@ -485,7 +485,12 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=Lldp_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Lldp_Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/ios/ios_vlans.py
+++ b/lib/ansible/modules/network/ios/ios_vlans.py
@@ -448,7 +448,12 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=VlansArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Vlans(module).execute_module()

--- a/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
@@ -349,7 +349,12 @@ def main():
     Main entry point for module execution
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
@@ -413,7 +413,12 @@ def main():
     Main entry point for module execution
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=L2_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = L2_Interfaces(module).execute_module()

--- a/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
@@ -408,7 +408,12 @@ def main():
     Main entry point for module execution
     :returns: the result form module invocation
     """
+    required_if = [('state', 'merged', ('config',)),
+                   ('state', 'replaced', ('config',)),
+                   ('state', 'overridden', ('config',))]
+
     module = AnsibleModule(argument_spec=L3_InterfacesArgs.argument_spec,
+                           required_if=required_if,
                            supports_check_mode=True)
 
     result = L3_Interfaces(module).execute_module()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cherry-pick from: 7a5a5e7c87daee1d343a432894ff04a2251d6349
Backport PR to fix traceback error in IOS and IOSXR when ran with empty config
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios and iosxr
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
