### PR TITLE
test: disable hcloud_floating_ip_info

### DIFF
--- a/test/integration/targets/hcloud_floating_ip_info/aliases
+++ b/test/integration/targets/hcloud_floating_ip_info/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled # See: https://github.com/ansible/ansible/issues/62414


### PR DESCRIPTION
##### SUMMARY

Temporarily disable `hcloud_floating_ip_info`, this until #62414 is
resolved.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

hcloud_floating_ip_info
<!--- Write the short name of the module, plugin, task or feature below -->