### PR TITLE
[stable-2.9] Redact sensitive values by default in ansible-test

### DIFF
--- a/changelogs/fragments/ansible-test-redact.yml
+++ b/changelogs/fragments/ansible-test-redact.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test defaults to redacting sensitive values (disable with the ``--no-redact`` option)

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -206,7 +206,14 @@ def parse_args():
     common.add_argument('--redact',
                         dest='redact',
                         action='store_true',
+                        default=True,
                         help='redact sensitive values in output')
+
+    common.add_argument('--no-redact',
+                        dest='redact',
+                        action='store_false',
+                        default=False,
+                        help='show sensitive values in output')
 
     common.add_argument('--check-python',
                         choices=SUPPORTED_PYTHON_VERSIONS,

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -617,6 +617,7 @@ def filter_options(args, argv, options, exclude, require):
     options['--requirements'] = 0
     options['--truncate'] = 1
     options['--redact'] = 0
+    options['--no-redact'] = 0
 
     if isinstance(args, TestConfig):
         options.update({
@@ -681,3 +682,5 @@ def filter_options(args, argv, options, exclude, require):
 
     if args.redact:
         yield '--redact'
+    else:
+        yield '--no-redact'

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -636,7 +636,7 @@ class Display:
         self.rows = 0
         self.columns = 0
         self.truncate = 0
-        self.redact = False
+        self.redact = True
         self.sensitive = set()
 
         if os.isatty(0):
@@ -703,6 +703,9 @@ class Display:
         """
         if self.redact and self.sensitive:
             for item in self.sensitive:
+                if not item:
+                    continue
+
                 message = message.replace(item, '*' * len(item))
 
         if truncate:

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -95,9 +95,6 @@ class CommonConfig:
         self.truncate = args.truncate  # type: int
         self.redact = args.redact  # type: bool
 
-        if is_shippable():
-            self.redact = True
-
         self.cache = {}
 
     def get_ansible_config(self):  # type: () -> str


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Redact sensitive values by default in ansible-test

Backport of https://github.com/ansible/ansible/pull/62391

(cherry picked from commit 0631e057e9124af1d1676def456d49c6e0c16404)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
