### PR TITLE
[stable-2.8] Remove leading space in warning messages (#62002)

### DIFF
--- a/changelogs/fragments/display-warning-remove-erroneous-space.yaml
+++ b/changelogs/fragments/display-warning-remove-erroneous-space.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display - remove leading space when displaying WARNING messages

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -234,7 +234,7 @@ class Display(with_metaclass(Singleton, object)):
     def warning(self, msg, formatted=False):
 
         if not formatted:
-            new_msg = "\n[WARNING]: %s" % msg
+            new_msg = "[WARNING]: %s" % msg
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = "\n".join(wrapped) + "\n"
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #62002 for Ansible 2.8
(cherry picked from commit ea6e96985a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/utils/display.py`