### PR TITLE
[stable-2.8] Redact sensitive values by default in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-redact.yml
+++ b/changelogs/fragments/ansible-test-redact.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test defaults to redacting sensitive values (disable with the ``--no-redact`` option)

--- a/test/runner/lib/cli.py
+++ b/test/runner/lib/cli.py
@@ -180,7 +180,14 @@ def parse_args():
     common.add_argument('--redact',
                         dest='redact',
                         action='store_true',
+                        default=True,
                         help='redact sensitive values in output')
+
+    common.add_argument('--no-redact',
+                        dest='redact',
+                        action='store_false',
+                        default=False,
+                        help='show sensitive values in output')
 
     test = argparse.ArgumentParser(add_help=False, parents=[common])
 

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -492,6 +492,7 @@ def filter_options(args, argv, options, exclude, require):
     options['--requirements'] = 0
     options['--truncate'] = 1
     options['--redact'] = 0
+    options['--no-redact'] = 0
 
     if isinstance(args, TestConfig):
         options.update({
@@ -551,3 +552,5 @@ def filter_options(args, argv, options, exclude, require):
 
     if args.redact:
         yield '--redact'
+    else:
+        yield '--no-redact'

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -662,7 +662,7 @@ class Display(object):
         self.rows = 0
         self.columns = 0
         self.truncate = 0
-        self.redact = False
+        self.redact = True
         self.sensitive = set()
 
         if os.isatty(0):
@@ -729,6 +729,9 @@ class Display(object):
         """
         if self.redact and self.sensitive:
             for item in self.sensitive:
+                if not item:
+                    continue
+
                 message = message.replace(item, '*' * len(item))
 
         if truncate:
@@ -814,9 +817,6 @@ class CommonConfig(object):
         self.debug = args.debug  # type: bool
         self.truncate = args.truncate  # type: int
         self.redact = args.redact  # type: bool
-
-        if is_shippable():
-            self.redact = True
 
         self.cache = {}
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Redact sensitive values by default in ansible-test.

Backport of https://github.com/ansible/ansible/pull/62391

(cherry picked from commit 0631e057e9124af1d1676def456d49c6e0c16404)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
