### PR TITLE
Update foreman inventory to use foreman's inventory report

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -123,12 +123,46 @@ user = foreman
 password = secret
 ssl_verify = True
 
+# Foreman 1.24 introduces a new reports API to improve performance of the inventory script.
+# Note: This requires foreman_ansible plugin installed.
+# Set to False if you want to use the old API. Defaults to True.
+
+use_reports_api = True
+
 # Retrieve only hosts from the organization "Web Engineering".
 # host_filters = organization="Web Engineering"
 
 # Retrieve only hosts from the organization "Web Engineering" that are
 # also in the host collection "Apache Servers".
 # host_filters = organization="Web Engineering" and host_collection="Apache Servers"
+
+# Foreman Inventory report related configuration options.
+# Configs that default to True :
+# want_organization , want_location, want_ipv4, want_host_group, want_subnet, want_smart_proxies, want_facts
+# Configs that default to False :
+# want_ipv6, want_subnet_v6, want_content_facet_attributes, want_host_params
+
+[report]
+# want_organization = True
+# want_location = True
+# want_ipv4 = True
+# want_ipv6 = False
+# want_host_group = True
+# want_subnet = True
+# want_subnet_v6 = False
+# want_smart_proxies = True
+# want_content_facet_attributes = False
+# want_host_params = False
+
+# use this config to determine if facts are to be fetched in the report and stored on the hosts.
+# want_facts = False
+
+# Upon receiving a request to return inventory report, Foreman schedules a report generation job.
+# The script then polls the report_data endpoint repeatedly to check if the job is complete and retrieves data  
+# poll_interval allows to define the polling interval between 2 calls to the report_data endpoint while polling.
+# Defaults to 10 seconds
+
+# poll_interval = 10
 
 [ansible]
 group_patterns = ["{app}-{tier}-{color}",

--- a/test/integration/targets/inventory_foreman_script/runme.sh
+++ b/test/integration/targets/inventory_foreman_script/runme.sh
@@ -17,6 +17,7 @@ url = http://${FOREMAN_HOST}:${FOREMAN_PORT}
 user = ansible-tester
 password = secure
 ssl_verify = False
+use_reports_api = False
 FOREMAN_INI
 
 # use ansible to validate the return data


### PR DESCRIPTION
##### SUMMARY
Currently the foreman inventory script relies on API calls to foreman to fetch hosts, details and facts. This is achieved my making one call to get the list of hosts, followed by 2 calls per host to fetch details and facts. This is slow and sometimes take hours to complete.

Proposed change is to implement a report which provides all the required data from foreman (WIP here: https://github.com/theforeman/foreman_ansible/pull/299) Following this, the inventory scripts needs to API calls. First to generate the report and the second to fetch the generated data.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Foreman Inventory

##### ADDITIONAL INFORMATION
Related awx PR: https://github.com/ansible/awx/pull/4758

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Work in Progress:
Before Change: https://codebeautify.org/jsonviewer/cb1e7f3e
After Change: https://codebeautify.org/jsonviewer/cbbae5d2