### PR TITLE
Account for empty strings when splitting the host pattern

### DIFF
--- a/changelogs/fragments/split-host-pattern-empty-strings.yaml
+++ b/changelogs/fragments/split-host-pattern-empty-strings.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - account for empty strings in when splitting the host pattern (https://github.com/ansible/ansible/issues/61964)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -130,7 +130,7 @@ def split_host_pattern(pattern):
                 '''), pattern, re.X
             )
 
-    return [p.strip() for p in patterns]
+    return [p.strip() for p in patterns if p.strip()]
 
 
 class InventoryManager(object):

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -110,7 +110,6 @@ def split_host_pattern(pattern):
     # comma-separated list of patterns.
     if u',' in pattern:
         patterns = pattern.split(u',')
-        patterns = [p.strip() for p in patterns]
 
     # If it doesn't, it could still be a single pattern. This accounts for
     # non-separator uses of colons: IPv6 addresses and [x:y] host ranges.
@@ -130,7 +129,8 @@ def split_host_pattern(pattern):
                     )+              # occurring once or more
                 '''), pattern, re.X
             )
-    return [p for p in patterns if p]
+
+    return [p.strip() for p in patterns if p.strip()]
 
 
 class InventoryManager(object):

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -110,6 +110,7 @@ def split_host_pattern(pattern):
     # comma-separated list of patterns.
     if u',' in pattern:
         patterns = pattern.split(u',')
+        patterns = [p.strip() for p in patterns]
 
     # If it doesn't, it could still be a single pattern. This accounts for
     # non-separator uses of colons: IPv6 addresses and [x:y] host ranges.
@@ -129,8 +130,7 @@ def split_host_pattern(pattern):
                     )+              # occurring once or more
                 '''), pattern, re.X
             )
-
-    return [p.strip() for p in patterns if p.strip()]
+    return [p for p in patterns if p]
 
 
 class InventoryManager(object):

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -13,14 +13,6 @@ cleanup() {
 
 trap 'cleanup' EXIT
 
-# https://github.com/ansible/ansible/issues/61964
-ansible-playbook -i ../../inventory --limit testhost,, playbook.yml
-empty_inventory_exit_code="$?"
-if [ "$empty_inventory_exit_code" != "0" ]; then
-    echo "Inventory limit failed"
-    exit 1
-fi
-
 # https://github.com/ansible/ansible/issues/52152
 # Ensure that non-matching limit causes failure with rc 1
 ansible-playbook -i ../../inventory --limit foo playbook.yml

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -13,6 +13,14 @@ cleanup() {
 
 trap 'cleanup' EXIT
 
+# https://github.com/ansible/ansible/issues/61964
+ansible-playbook -i ../../inventory --limit testhost,, playbook.yml
+empty_inventory_exit_code="$?"
+if [ "$empty_inventory_exit_code" != "0" ]; then
+    echo "Inventory limit failed"
+    exit 1
+fi
+
 # https://github.com/ansible/ansible/issues/52152
 # Ensure that non-matching limit causes failure with rc 1
 ansible-playbook -i ../../inventory --limit foo playbook.yml

--- a/test/integration/targets/inventory_limit/aliases
+++ b/test/integration/targets/inventory_limit/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group4

--- a/test/integration/targets/inventory_limit/hosts.yml
+++ b/test/integration/targets/inventory_limit/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    host1:
+    host2:
+    host3:

--- a/test/integration/targets/inventory_limit/runme.sh
+++ b/test/integration/targets/inventory_limit/runme.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eux
+
+trap 'echo "Host pattern limit test failed"' ERR
+
+# https://github.com/ansible/ansible/issues/61964
+
+# These tests should return all hosts
+ansible -i hosts.yml all --limit ,, --list-hosts | grep -q 'hosts (3)'
+ansible -i hosts.yml ,, --list-hosts | grep -q 'hosts (3)'
+ansible -i hosts.yml , --list-hosts | grep -q 'hosts (3)'
+ansible -i hosts.yml all --limit , --list-hosts | grep -q 'hosts (3)'
+ansible -i hosts.yml all --limit '' --list-hosts | grep -q 'hosts (3)'
+
+
+# Only one host
+ansible -i hosts.yml all --limit ,,host1 --list-hosts | grep -q 'hosts (1)'
+ansible -i hosts.yml ,,host1 --list-hosts | grep -q 'hosts (1)'
+
+ansible -i hosts.yml all --limit host1,, --list-hosts | grep -q 'hosts (1)'
+ansible -i hosts.yml host1,, --list-hosts | grep -q 'hosts (1)'
+
+
+# Only two hosts
+ansible -i hosts.yml all --limit host1,,host3 --list-hosts | grep -q 'hosts (2)'
+ansible -i hosts.yml host1,,host3 --list-hosts | grep -q 'hosts (2)'
+
+ansible -i hosts.yml all --limit 'host1, ,    ,host3' --list-hosts | grep -q 'hosts (2)'
+ansible -i hosts.yml 'host1, ,    ,host3' --list-hosts | grep -q 'hosts (2)'
+

--- a/test/integration/targets/inventory_limit/runme.sh
+++ b/test/integration/targets/inventory_limit/runme.sh
@@ -7,25 +7,25 @@ trap 'echo "Host pattern limit test failed"' ERR
 # https://github.com/ansible/ansible/issues/61964
 
 # These tests should return all hosts
-ansible -i hosts.yml all --limit ,, --list-hosts | grep -q 'hosts (3)'
-ansible -i hosts.yml ,, --list-hosts | grep -q 'hosts (3)'
-ansible -i hosts.yml , --list-hosts | grep -q 'hosts (3)'
-ansible -i hosts.yml all --limit , --list-hosts | grep -q 'hosts (3)'
-ansible -i hosts.yml all --limit '' --list-hosts | grep -q 'hosts (3)'
+ansible -i hosts.yml all --limit ,, --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml ,, --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml , --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml all --limit , --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml all --limit '' --list-hosts | tee out ; grep -q 'hosts (3)' out
 
 
 # Only one host
-ansible -i hosts.yml all --limit ,,host1 --list-hosts | grep -q 'hosts (1)'
-ansible -i hosts.yml ,,host1 --list-hosts | grep -q 'hosts (1)'
+ansible -i hosts.yml all --limit ,,host1 --list-hosts | tee out ; grep -q 'hosts (1)' out
+ansible -i hosts.yml ,,host1 --list-hosts | tee out ; grep -q 'hosts (1)' out
 
-ansible -i hosts.yml all --limit host1,, --list-hosts | grep -q 'hosts (1)'
-ansible -i hosts.yml host1,, --list-hosts | grep -q 'hosts (1)'
+ansible -i hosts.yml all --limit host1,, --list-hosts | tee out ; grep -q 'hosts (1)' out
+ansible -i hosts.yml host1,, --list-hosts | tee out ; grep -q 'hosts (1)' out
 
 
 # Only two hosts
-ansible -i hosts.yml all --limit host1,,host3 --list-hosts | grep -q 'hosts (2)'
-ansible -i hosts.yml host1,,host3 --list-hosts | grep -q 'hosts (2)'
+ansible -i hosts.yml all --limit host1,,host3 --list-hosts | tee out ; grep -q 'hosts (2)' out
+ansible -i hosts.yml host1,,host3 --list-hosts | tee out ; grep -q 'hosts (2)' out
 
-ansible -i hosts.yml all --limit 'host1, ,    ,host3' --list-hosts | grep -q 'hosts (2)'
-ansible -i hosts.yml 'host1, ,    ,host3' --list-hosts | grep -q 'hosts (2)'
+ansible -i hosts.yml all --limit 'host1, ,    ,host3' --list-hosts | tee out ; grep -q 'hosts (2)' out
+ansible -i hosts.yml 'host1, ,    ,host3' --list-hosts | tee out ; grep -q 'hosts (2)' out
 

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -51,6 +51,8 @@ class TestInventory(unittest.TestCase):
         'foo:bar:baz[1:2]': ['foo', 'bar', 'baz[1:2]'],
         'a,,b': ['a', 'b'],
         'a,  ,b,,c, ,': ['a', 'b', 'c'],
+        ',': [],
+        '': [],
     }
 
     pattern_lists = [

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -49,6 +49,8 @@ class TestInventory(unittest.TestCase):
         'a:b': ['a', 'b'],
         ' a : b ': ['a', 'b'],
         'foo:bar:baz[1:2]': ['foo', 'bar', 'baz[1:2]'],
+        'a,,b': ['a', 'b'],
+        'a,  ,b,,c, ,': ['a', 'b', 'c'],
     }
 
     pattern_lists = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Filter out empty strings when returning the list of hosts from `split_host_pattern()`.
Fixes #61964
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/inventory/manager.py`