### PR TITLE
Remove BOTMETA notifications for joshsouza

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -45,7 +45,7 @@ files:
   $modules:
     ignored: ryansb
   $modules/cloud/amazon/:
-    ignored: erydo seiffert simplesteph nadirollo tedder
+    ignored: erydo seiffert simplesteph nadirollo tedder joshsouza
   $modules/cloud/amazon/aws_kms.py:
     ignored: tedder
   $modules/cloud/amazon/cloudformation.py:


### PR DESCRIPTION
##### SUMMARY
I no longer desire to be mentioned on AWS changes, as my level of use of Ansible has steeply declined, and I do not feel I am qualified to review the codebase as I become more detached from regular use. I'm still willing to be notified on the one module I have contributed, but the notification volume has been sufficient that I've let even those messages slip through the cracks.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
botmeta

##### ADDITIONAL INFORMATION
I'm also ok with handing off `modules/cloud/amazon/iam_user.py` to a more active maintainer if someone wishes to step up.
