### PR TITLE
Fix for backup option dest key for network modules

### DIFF
--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -103,7 +103,7 @@ class ActionModule(_ActionModule):
             result['msg'] = copy_result.get('msg')
             return
 
-        result['backup_path'] = copy_result['dest']
+        result['backup_path'] = dest
         if copy_result.get('changed', False):
             result['changed'] = copy_result['changed']
 


### PR DESCRIPTION
##### SUMMARY
Fixes #57131

'dest' lives as a function level variable as defined at https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/action/network.py#L76

and in the nested dictionary in 3 different places under 2 different situations:

Under normal running (and with --diff):
```
if 'dest' in copy_result:
    result['backup_path'] = copy_result['dest']
```
When running with --check
```
if 'invocation' in copy_result and 'dest' in copy_result['invocation']:
    result['backup_path'] = copy_result['invocation']['dest']
```

And always:
```
result['backup_path'] = copy_result['invocation']['module_args']['dest']
```
This change cleans up the code a little, while using the function level variable we already had set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
action plugin, network.py