### PR TITLE
find - clarify description of 'contains'

### DIFF
--- a/changelogs/fragments/find-contains-docs.yaml
+++ b/changelogs/fragments/find-contains-docs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - find - clarify description of ``contains`` (https://github.com/ansible/ansible/issues/61983)

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -56,7 +56,7 @@ options:
         version_added: "2.5"
     contains:
         description:
-            - One or more regex patterns which should be matched against the file content.
+            - A regular expression or pattern which should be matched against the file content.
         type: str
     paths:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #61983 

The `contains` parameter is meant to be a single regular expression based on its use in the module code.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/files/find.py`