### PR TITLE
[2.9] acme_* modules: bump acme-test-container version

### DIFF
--- a/changelogs/fragments/62381-acme-test-container.yml
+++ b/changelogs/fragments/62381-acme-test-container.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - Bump version of ACME test container to 1.8.0. Fixes a typo in the API and adds a newer Pebble version."

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -45,7 +45,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.7.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.8.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Backport of #62381 to stable-2.9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/cloud/acme.py
