### PR TITLE
Backport of 62320: fix typos in network modules

### DIFF
--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -100,7 +100,7 @@ options:
     aliases: [ policy_group_name ]
   interface_type:
     description:
-    - The type of interface for the static EPG deployement.
+    - The type of interface for the static EPG deployment.
     type: str
     choices: [ breakout, fex, port_channel, switch_port, vpc ]
     default: switch_port
@@ -327,7 +327,7 @@ def main():
     interface_type = module.params['interface_type']
     state = module.params['state']
 
-    # Build child_configs dyanmically
+    # Build child_configs dynamically
     child_configs = [dict(
         infraPortBlk=dict(
             attributes=dict(

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -41,7 +41,7 @@ options:
   mask:
     description:
     - The subnet mask for the Subnet.
-    - This is the number assocated with CIDR notation.
+    - This is the number associated with CIDR notation.
     - For IPv4 addresses, accepted values range between C(0) and C(32).
     - For IPv6 addresses, accepted Values range between C(0) and C(128).
     type: int
@@ -62,7 +62,7 @@ options:
     type: str
   route_profile_l3_out:
     description:
-    - The L3 Out that contains the assocated Route Profile.
+    - The L3 Out that contains the associated Route Profile.
     type: str
   scope:
     description:
@@ -82,7 +82,7 @@ options:
     description:
     - Determines the Subnet's Control State.
     - The C(querier_ip) option is used to treat the gateway_ip as an IGMP querier source IP.
-    - The C(nd_ra) option is used to treate the gateway_ip address as a Neighbor Discovery Router Advertisement Prefix.
+    - The C(nd_ra) option is used to treat the gateway_ip address as a Neighbor Discovery Router Advertisement Prefix.
     - The C(no_gw) option is used to remove default gateway functionality from the gateway address.
     - The APIC defaults to C(nd_ra) when unset during creation.
     type: str
@@ -382,7 +382,7 @@ def main():
     gateway = module.params['gateway']
     mask = module.params['mask']
     if mask is not None and mask not in range(0, 129):
-        # TODO: split checkes between IPv4 and IPv6 Addresses
+        # TODO: split checks between IPv4 and IPv6 Addresses
         module.fail_json(msg='Valid Subnet Masks are 0 to 32 for IPv4 Addresses and 0 to 128 for IPv6 addresses')
     if gateway is not None:
         gateway = '{0}/{1}'.format(gateway, str(mask))

--- a/lib/ansible/modules/network/aci/aci_domain.py
+++ b/lib/ansible/modules/network/aci/aci_domain.py
@@ -48,7 +48,7 @@ options:
     choices: [ unknown, vlan, vxlan ]
   multicast_address:
     description:
-    - The muticast IP address to use for the virtual switch.
+    - The multicast IP address to use for the virtual switch.
     type: str
   state:
     description:

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -54,9 +54,9 @@ options:
     type: int
   encap_mode:
     description:
-    - The ecapsulataion method to be used.
+    - The encapsulation method to be used.
     - The APIC defaults to C(auto) when unset during creation.
-    - If vxlan is slected, switching_mode must be "AVE".
+    - If vxlan is selected, switching_mode must be "AVE".
     type: str
     choices: [ auto, vlan, vxlan ]
   switching_mode:
@@ -337,7 +337,7 @@ def main():
         if encap in range(1, 4097):
             encap = 'vlan-{0}'.format(encap)
         else:
-            module.fail_json(msg='Valid VLAN assigments are from 1 to 4096')
+            module.fail_json(msg='Valid VLAN assignments are from 1 to 4096')
     encap_mode = module.params['encap_mode']
     switching_mode = module.params['switching_mode']
     epg = module.params['epg']
@@ -347,7 +347,7 @@ def main():
         if primary_encap in range(1, 4097):
             primary_encap = 'vlan-{0}'.format(primary_encap)
         else:
-            module.fail_json(msg='Valid VLAN assigments are from 1 to 4096')
+            module.fail_json(msg='Valid VLAN assignments are from 1 to 4096')
     resolution_immediacy = module.params['resolution_immediacy']
     state = module.params['state']
     tenant = module.params['tenant']

--- a/lib/ansible/modules/network/aci/aci_fabric_scheduler.py
+++ b/lib/ansible/modules/network/aci/aci_fabric_scheduler.py
@@ -58,7 +58,7 @@ options:
        - This set the hour of execution
   minute:
     description:
-       - This sets the minute of execution, used in conjuntion with hour
+       - This sets the minute of execution, used in conjunction with hour
   day:
     description:
        - This sets the day when execution will take place

--- a/lib/ansible/modules/network/aci/aci_firmware_policy.py
+++ b/lib/ansible/modules/network/aci/aci_firmware_policy.py
@@ -32,7 +32,7 @@ options:
         required: true
     version:
         description:
-            - The version of the firmware assoicated with this policy. This value is very import as well as constructing
+            - The version of the firmware associated with this policy. This value is very import as well as constructing
             - it correctly. The syntax for this field is n9000-xx.x. If you look at the firmware repository using the UI
             - each version will have a "Full Version" column, this is the value you need to use. So, if the Full Version
             - is 13.1(1i), the value for this field would be n9000-13.1(1i)

--- a/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
+++ b/lib/ansible/modules/network/aci/aci_interface_policy_ospf.py
@@ -109,7 +109,7 @@ options:
     description:
     - The interval between LSA retransmissions.
     - The retransmit interval occurs while the router is waiting for an acknowledgement from the neighbor router that it received the LSA.
-    - If no acknowlegment is received at the end of the interval, then the LSA is resent.
+    - If no acknowledgment is received at the end of the interval, then the LSA is resent.
     - Accepted values range between C(1) and C(65535).
     - The APIC defaults to C(5) when unset during creation.
     type: int

--- a/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
+++ b/lib/ansible/modules/network/aci/aci_l3out_route_tag_policy.py
@@ -186,7 +186,7 @@ from ansible.module_utils.network.aci.aci import ACIModule, aci_argument_spec
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
-        tenant=dict(type='str', aliases=['tenant_name']),  # Not required for quering all objects
+        tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         rtp=dict(type='str', aliases=['name', 'rtp_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         tag=dict(type='int'),

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -50,7 +50,7 @@ options:
     type: raw
   src:
     description:
-    - Name of the absolute path of the filname that includes the body
+    - Name of the absolute path of the filename that includes the body
       of the HTTP request being sent to the ACI fabric.
     - If you require a templated payload, use the C(content) parameter
       together with the C(template) lookup plugin, or use M(template).
@@ -107,7 +107,7 @@ EXAMPLES = r'''
       fvTenant:
         attributes:
           name: Sales
-          descr: Sales departement
+          descr: Sales department
   delegate_to: localhost
 
 - name: Add a tenant using a JSON string
@@ -123,7 +123,7 @@ EXAMPLES = r'''
         "fvTenant": {
           "attributes": {
             "name": "Sales",
-            "descr": "Sales departement"
+            "descr": "Sales department"
           }
         }
       }

--- a/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
+++ b/lib/ansible/modules/network/aci/aci_static_binding_to_epg.py
@@ -56,7 +56,7 @@ options:
     aliases: [ primary_vlan, primary_vlan_id ]
   deploy_immediacy:
     description:
-    - The Deployement Immediacy of Static EPG on PC, VPC or Interface.
+    - The Deployment Immediacy of Static EPG on PC, VPC or Interface.
     - The APIC defaults to C(lazy) when unset during creation.
     type: str
     choices: [ immediate, lazy ]
@@ -72,7 +72,7 @@ options:
     aliases: [ interface_mode_name, mode ]
   interface_type:
     description:
-    - The type of interface for the static EPG deployement.
+    - The type of interface for the static EPG deployment.
     type: str
     choices: [ fex, port_channel, switch_port, vpc ]
     default: switch_port

--- a/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_ep_retention_policy.py
@@ -66,7 +66,7 @@ options:
     type: int
   description:
     description:
-    - Description for the End point rentention policy.
+    - Description for the End point retention policy.
     type: str
     aliases: [ descr ]
   state:

--- a/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_span_src_group_to_dst_group.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: aci_tenant_span_src_group_to_dst_group
 short_description: Bind SPAN source groups to destination groups (span:SpanLbl)
 description:
-- Bind SPAN source groups to associated destinaton groups on Cisco ACI fabrics.
+- Bind SPAN source groups to associated destination groups on Cisco ACI fabrics.
 version_added: '2.4'
 options:
   description:

--- a/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_domain.py
+++ b/lib/ansible/modules/network/aci/mso_schema_site_anp_epg_domain.py
@@ -105,7 +105,7 @@ options:
     type: str
   enhanced_lagpolicy_dn:
     description:
-    - Distingushied name of EPG lagpolicy. This attribute can only be used with vmmDomain domain association.
+    - Distinguished name of EPG lagpolicy. This attribute can only be used with vmmDomain domain association.
     type: str
   state:
     description:
@@ -328,7 +328,7 @@ def main():
             microSegVlan = dict(vlanType=micro_seg_vlan_type, vlan=micro_seg_vlan)
             vmmDomainProperties['microSegVlan'] = microSegVlan
         elif not micro_seg_vlan_type and micro_seg_vlan:
-            mso.fail_json(msg="micro_seg_vlan_type is required when micro_seg_vlan is provied.")
+            mso.fail_json(msg="micro_seg_vlan_type is required when micro_seg_vlan is provided.")
         elif micro_seg_vlan_type and not micro_seg_vlan:
             mso.fail_json(msg="micro_seg_vlan is required when micro_seg_vlan_type is provided.")
 
@@ -336,7 +336,7 @@ def main():
             portEncapVlan = dict(vlanType=port_encap_vlan_type, vlan=port_encap_vlan)
             vmmDomainProperties['portEncapVlan'] = portEncapVlan
         elif not port_encap_vlan_type and port_encap_vlan:
-            mso.fail_json(msg="port_encap_vlan_type is required when port_encap_vlan is provied.")
+            mso.fail_json(msg="port_encap_vlan_type is required when port_encap_vlan is provided.")
         elif port_encap_vlan_type and not port_encap_vlan:
             mso.fail_json(msg="port_encap_vlan is required when port_encap_vlan_type is provided.")
 
@@ -355,9 +355,9 @@ def main():
             epgLagPol = dict(enhancedLagPol=enhancedLagPol)
             vmmDomainProperties['epgLagPol'] = epgLagPol
         elif not enhanced_lagpolicy_name and enhanced_lagpolicy_dn:
-            mso.fail_json(msg="enhanced_lagpolicy_name is required when enhanced_lagpolicy_dn is provied.")
+            mso.fail_json(msg="enhanced_lagpolicy_name is required when enhanced_lagpolicy_dn is provided.")
         elif enhanced_lagpolicy_name and not enhanced_lagpolicy_dn:
-            mso.fail_json(msg="enhanced_lagpolicy_dn is required when enhanced_lagpolicy_name is provied.")
+            mso.fail_json(msg="enhanced_lagpolicy_dn is required when enhanced_lagpolicy_name is provided.")
 
         payload = dict(
             dn=domain_dn,

--- a/lib/ansible/modules/network/aci/mso_schema_template_anp_epg.py
+++ b/lib/ansible/modules/network/aci/mso_schema_template_anp_epg.py
@@ -131,7 +131,7 @@ options:
     choices: [ enforced, unenforced ]
   intersite_multicaste_source:
     description:
-    - Whether intersite multicase source is enabled.
+    - Whether intersite multicast source is enabled.
     - When not specified, this parameter defaults to C(no).
     type: bool
   preferred_group:

--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -79,7 +79,7 @@ options:
         against the contents of source.  There are times when it is not
         desirable to have the task get the current running-config for
         every task in a playbook.  The I(config) argument allows the
-        implementer to pass in the configuruation to use as the base
+        implementer to pass in the configuration to use as the base
         config for comparison.
 """
 

--- a/lib/ansible/modules/network/avi/avi_analyticsprofile.py
+++ b/lib/ansible/modules/network/avi/avi_analyticsprofile.py
@@ -69,7 +69,7 @@ options:
     apdex_rum_threshold:
         description:
             - If a client is able to load a page in less than the satisfactory latency threshold, the pageload is considered satisfied.
-            - It is considered tolerated if it is greater than satisfied but less than the tolerated latency multiplied by satisifed latency.
+            - It is considered tolerated if it is greater than satisfied but less than the tolerated latency multiplied by satisfied latency.
             - Greater than this number and the client's request is considered frustrated.
             - A pageload includes the time for dns lookup, download of all http objects, and page render time.
             - Allowed values are 1-30000.
@@ -128,7 +128,7 @@ options:
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_lossy_zero_win_size_event_threshold:
         description:
-            - A client connection is considered lossy when percentage of times a packet could not be trasmitted due to tcp zero window is above this threshold.
+            - A client connection is considered lossy when percentage of times a packet could not be transmitted due to tcp zero window is above this threshold.
             - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     conn_server_lossy_ooo_threshold:
@@ -148,7 +148,7 @@ options:
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_server_lossy_zero_win_size_event_threshold:
         description:
-            - A server connection is considered lossy when percentage of times a packet could not be trasmitted due to tcp zero window is above this threshold.
+            - A server connection is considered lossy when percentage of times a packet could not be transmitted due to tcp zero window is above this threshold.
             - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     description:

--- a/lib/ansible/modules/network/avi/avi_gslb.py
+++ b/lib/ansible/modules/network/avi/avi_gslb.py
@@ -200,7 +200,7 @@ EXAMPLES = """
       username: "{{ username }}"
       password: "{{ password }}"
       controller: "{{ controller }}"
-    # On basis of cluster leader uuid dns_configs is set for that perticular leader cluster
+    # On basis of cluster leader uuid dns_configs is set for that particular leader cluster
     leader_cluster_uuid: "cluster-84aa795f-8f09-42bb-97a4-5103f4a53da9"
     name: "test-gslb"
     avi_api_update_method: patch
@@ -228,7 +228,7 @@ EXAMPLES = """
       username: "{{ username }}"
       password: "{{ password }}"
       controller: "{{ controller }}"
-    # On basis of cluster leader uuid dns_configs is set for that perticular leader cluster
+    # On basis of cluster leader uuid dns_configs is set for that particular leader cluster
     leader_cluster_uuid: "cluster-84aa795f-8f09-42bb-97a4-5103f4a53da9"
     name: "test-gslb"
     avi_api_update_method: patch

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -76,7 +76,7 @@ options:
     autoscale_launch_config_ref:
         description:
             - If configured then avi will trigger orchestration of pool server creation and deletion.
-            - It is only supported for container clouds like mesos, opensift, kubernates, docker etc.
+            - It is only supported for container clouds like mesos, openshift, kubernetes, docker, etc.
             - It is a reference to an object of type autoscalelaunchconfig.
     autoscale_networks:
         description:
@@ -105,7 +105,7 @@ options:
             - It is a reference to an object of type cloud.
     conn_pool_properties:
         description:
-            - Connnection pool properties.
+            - Connection pool properties.
             - Field introduced in 18.2.1.
         version_added: "2.9"
     connection_ramp_duration:
@@ -213,7 +213,7 @@ options:
             - Http header name to be used for the hash key.
     lb_algorithm_core_nonaffinity:
         description:
-            - Degree of non-affinity for core afffinity based server selection.
+            - Degree of non-affinity for core affinity based server selection.
             - Allowed values are 1-65535.
             - Field introduced in 17.1.3.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
@@ -367,7 +367,7 @@ options:
         description:
             - Virtual routing context that the pool is bound to.
             - This is used to provide the isolation of the set of networks the pool is attached to.
-            - The pool inherits the virtual routing conext of the virtual service, and this field is used only internally, and is set by pb-transform.
+            - The pool inherits the virtual routing context of the virtual service, and this field is used only internally, and is set by pb-transform.
             - It is a reference to an object of type vrfcontext.
 extends_documentation_fragment:
     - avi

--- a/lib/ansible/modules/network/avi/avi_serviceenginegroup.py
+++ b/lib/ansible/modules/network/avi/avi_serviceenginegroup.py
@@ -417,7 +417,7 @@ options:
             - Instance/flavor name for se instance.
     iptables:
         description:
-            - Iptable rules.
+            - Iptables rules.
     least_load_core_selection:
         description:
             - Select core with least load for new flow.
@@ -925,7 +925,7 @@ options:
     waf_learning_memory:
         description:
             - Amount of memory reserved on se for waf learning.
-            - This can be atmost 5% of se memory.
+            - Cannot exceed 5% of se memory.
             - Field deprecated in 18.2.3.
             - Field introduced in 18.1.2.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -306,7 +306,7 @@ options:
         version_added: "2.4"
     performance_limits:
         description:
-            - Optional settings that determine performance limits like max connections or bandwdith etc.
+            - Optional settings that determine performance limits like max connections or bandwidth etc.
     pool_group_ref:
         description:
             - The pool group is an object that contains pools.

--- a/lib/ansible/modules/network/check_point/checkpoint_access_rule.py
+++ b/lib/ansible/modules/network/check_point/checkpoint_access_rule.py
@@ -54,7 +54,7 @@ options:
     type: str
   destination:
     description:
-      - Destionation object of the access rule.
+      - Destination object of the access rule.
     type: str
   action:
     description:

--- a/lib/ansible/modules/network/check_point/cp_mgmt_threat_profile.py
+++ b/lib/ansible/modules/network/check_point/cp_mgmt_threat_profile.py
@@ -77,7 +77,7 @@ options:
         choices: ['Inactive', 'Ask', 'Prevent', 'Detect']
       indicator:
         description:
-          - The indicator whose action is to be overriden.
+          - The indicator whose action is to be overridden.
         type: str
   ips_settings:
     description:

--- a/lib/ansible/modules/network/cloudengine/ce_aaa_server.py
+++ b/lib/ansible/modules/network/cloudengine/ce_aaa_server.py
@@ -1116,7 +1116,7 @@ class AaaServer(object):
         xml = self.netconf_set_config(module=module, conf_str=conf_str)
 
         if "<ok/>" not in xml:
-            module.fail_json(msg='Error: Delete authorization domian failed.')
+            module.fail_json(msg='Error: Delete authorization domain failed.')
 
         cmds = []
         cmd = "undo authorization-scheme"

--- a/lib/ansible/modules/network/cloudengine/ce_dldp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp.py
@@ -34,10 +34,10 @@ notes:
     - The relevant configurations will be deleted if DLDP is disabled using enable=disable.
     - When using auth_mode=none, it will restore the default DLDP authentication mode. By default,
       DLDP packets are not authenticated.
-    - By default, the working mode of DLDP is enhance, so you are advised to use work_mode=enhance to restore defualt
+    - By default, the working mode of DLDP is enhance, so you are advised to use work_mode=enhance to restore default
       DLDP working mode.
     - The default interval for sending Advertisement packets is 5 seconds, so you are advised to use time_interval=5 to
-      restore defualt DLDP interval.
+      restore default DLDP interval.
 options:
     enable:
         description:
@@ -125,7 +125,7 @@ proposed:
                 "work_mode": "normal"
             }
 existing:
-    description: k/v pairs of existing global DLDP configration
+    description: k/v pairs of existing global DLDP configuration
     returned: always
     type: dict
     sample: {
@@ -135,7 +135,7 @@ existing:
                 "work_mode": "enhance"
             }
 end_state:
-    description: k/v pairs of global DLDP configration after module execution
+    description: k/v pairs of global DLDP configuration after module execution
     returned: always
     type: dict
     sample: {
@@ -204,14 +204,14 @@ CE_NC_MERGE_DLDP_GLOBAL_CONFIG_TAIL = """
 
 
 class Dldp(object):
-    """Manage global dldp configration"""
+    """Manage global dldp configuration"""
 
     def __init__(self, argument_spec):
         self.spec = argument_spec
         self.module = None
         self.init_module()
 
-        # DLDP global configration info
+        # DLDP global configuration info
         self.enable = self.module.params['enable'] or None
         self.work_mode = self.module.params['work_mode'] or None
         self.internal = self.module.params['time_interval'] or None
@@ -324,7 +324,7 @@ class Dldp(object):
         topo = root.find("dldp/dldpSys")
         if not topo:
             self.module.fail_json(
-                msg="Error: Get current DLDP configration failed.")
+                msg="Error: Get current DLDP configuration failed.")
 
         for eles in topo:
             if eles.tag in ["dldpEnable", "dldpInterval", "dldpWorkMode", "dldpAuthMode"]:

--- a/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
@@ -32,7 +32,7 @@ author:
     - Zhou Zhijin (@QijunPan)
 notes:
     - If C(state=present, enable=disable), interface DLDP enable will be turned off and
-      related interface DLDP confuration will be cleared.
+      related interface DLDP configuration will be cleared.
     - If C(state=absent), only local_mac is supported to configure.
 options:
     interface:
@@ -106,7 +106,7 @@ EXAMPLES = '''
       reset: enable
       provider: "{{ cli }}"
 
-  - name: "Unconfigure interface DLDP local mac addreess when C(state=absent)"
+  - name: "Unconfigure interface DLDP local mac address when C(state=absent)"
     ce_dldp_interface:
       interface: 40GE2/0/1
       state: absent
@@ -127,7 +127,7 @@ proposed:
                 "reset": "enable"
             }
 existing:
-    description: k/v pairs of existing interface DLDP configration
+    description: k/v pairs of existing interface DLDP configuration
     returned: always
     type: dict
     sample: {
@@ -138,7 +138,7 @@ existing:
                 "reset": "disable"
             }
 end_state:
-    description: k/v pairs of interface DLDP configration after module execution
+    description: k/v pairs of interface DLDP configuration after module execution
     returned: always
     type: dict
     sample: {
@@ -309,14 +309,14 @@ def get_interface_type(interface):
 
 
 class DldpInterface(object):
-    """Manage interface dldp configration"""
+    """Manage interface dldp configuration"""
 
     def __init__(self, argument_spec):
         self.spec = argument_spec
         self.module = None
         self.init_module()
 
-        # DLDP interface configration info
+        # DLDP interface configuration info
         self.interface = self.module.params['interface']
         self.enable = self.module.params['enable'] or None
         self.reset = self.module.params['reset'] or None
@@ -457,7 +457,7 @@ class DldpInterface(object):
         topo = root.find("dldp/dldpInterfaces/dldpInterface")
         if topo is None:
             self.module.fail_json(
-                msg="Error: Get current DLDP configration failed.")
+                msg="Error: Get current DLDP configuration failed.")
         for eles in topo:
             if eles.tag in ["dldpEnable", "dldpCompatibleEnable", "dldpLocalMac"]:
                 if not eles.text:
@@ -561,7 +561,7 @@ class DldpInterface(object):
                              reset=self.reset, state=self.state)
 
     def get_update_cmd(self):
-        """Get updatede commands"""
+        """Get updated commands"""
 
         if self.same_conf:
             return
@@ -624,7 +624,7 @@ class DldpInterface(object):
         self.module.exit_json(**self.results)
 
     def work(self):
-        """Excute task"""
+        """Execute task"""
 
         self.dldp_intf_conf = self.get_dldp_intf_exist_config()
         self.check_params()

--- a/lib/ansible/modules/network/cloudengine/ce_eth_trunk.py
+++ b/lib/ansible/modules/network/cloudengine/ce_eth_trunk.py
@@ -399,7 +399,7 @@ class EthTrunk(object):
         return False
 
     def get_mode_xml_str(self):
-        """trunk mode netconf xml fromat string"""
+        """trunk mode netconf xml format string"""
 
         return MODE_CLI2XML.get(self.mode)
 

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_bd_vni.py
@@ -424,7 +424,7 @@ def is_valid_value(vrf_targe_value):
 
 
 class EvpnBd(object):
-    """Manange evpn instance in BD view"""
+    """Manage evpn instance in BD view"""
 
     def __init__(self, argument_spec, ):
         self.spec = argument_spec
@@ -953,19 +953,19 @@ class EvpnBd(object):
             for ele in self.vpn_target_import:
                 if ele not in self.evpn_info['vpn_target_import'] and ele not in self.evpn_info['vpn_target_both']:
                     self.module.fail_json(
-                        msg='Error: VPN target import attribute value %s doesnot exist.' % ele)
+                        msg='Error: VPN target import attribute value %s does not exist.' % ele)
 
         if self.vpn_target_export:
             for ele in self.vpn_target_export:
                 if ele not in self.evpn_info['vpn_target_export'] and ele not in self.evpn_info['vpn_target_both']:
                     self.module.fail_json(
-                        msg='Error: VPN target export attribute value %s doesnot exist.' % ele)
+                        msg='Error: VPN target export attribute value %s does not exist.' % ele)
 
         if self.vpn_target_both:
             for ele in self.vpn_target_both:
                 if ele not in self.evpn_info['vpn_target_both']:
                     self.module.fail_json(
-                        msg='Error: VPN target export and import attribute value %s doesnot exist.' % ele)
+                        msg='Error: VPN target export and import attribute value %s does not exist.' % ele)
 
     def check_params(self):
         """Check all input params"""
@@ -990,7 +990,7 @@ class EvpnBd(object):
             if self.route_distinguisher:
                 if not self.evpn_info['route_distinguisher']:
                     self.module.fail_json(
-                        msg='Error: Route distinguisher doesnot have been configured.')
+                        msg='Error: Route distinguisher has not been configured.')
                 else:
                     if self.route_distinguisher != self.evpn_info['route_distinguisher']:
                         self.module.fail_json(
@@ -1014,7 +1014,7 @@ class EvpnBd(object):
                 msg='Error: The vxlan vni is not configured or the bridge domain id is invalid.')
 
     def work(self):
-        """Excute task"""
+        """Execute task"""
 
         self.get_evpn_instance_info()
         self.process_input_params()

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_bgp_rr.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_bgp_rr.py
@@ -182,7 +182,7 @@ def is_config_exist(cmp_cfg, test_cfg):
 
 
 class EvpnBgpRr(object):
-    """Manange RR in BGP-EVPN address family view"""
+    """Manage RR in BGP-EVPN address family view"""
 
     def __init__(self, argument_spec):
         self.spec = argument_spec
@@ -462,7 +462,7 @@ class EvpnBgpRr(object):
         """Check all input params"""
 
         if self.cur_config['bgp_exist'] == 'false':
-            self.module.fail_json(msg="Error: BGP view doesnot exist.")
+            self.module.fail_json(msg="Error: BGP view does not exist.")
 
         if self.bgp_instance:
             if len(self.bgp_instance) < 1 or len(self.bgp_instance) > 31:
@@ -491,7 +491,7 @@ class EvpnBgpRr(object):
                     msg='Error: Ip address cannot be configured as group-name.')
 
     def work(self):
-        """Excute task"""
+        """Execute task"""
 
         self.get_current_config()
         self.check_params()

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
@@ -107,7 +107,7 @@ from ansible.module_utils.network.cloudengine.ce import ce_argument_spec
 
 
 class EvpnGlobal(object):
-    """Manange global configuration of EVPN"""
+    """Manage global configuration of EVPN"""
 
     def __init__(self, argument_spec, ):
         self.spec = argument_spec
@@ -150,7 +150,7 @@ class EvpnGlobal(object):
             self.updates_cmd.append(cmd)   # show updates result
 
     def get_evpn_global_info(self):
-        """ get current EVPN global configration"""
+        """ get current EVPN global configuration"""
 
         self.global_info['evpnOverLay'] = 'disable'
         flags = list()
@@ -196,7 +196,7 @@ class EvpnGlobal(object):
         return False
 
     def config_evnp_global(self):
-        """ set global EVPN configration"""
+        """ set global EVPN configuration"""
         if not self.conf_exist:
             if self.overlay_enable == 'enable':
                 self.cli_add_command('evpn-overlay enable')
@@ -208,7 +208,7 @@ class EvpnGlobal(object):
                 self.changed = True
 
     def work(self):
-        """excute task"""
+        """execute task"""
         self.get_evpn_global_info()
         self.get_existing()
         self.get_proposed()

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -335,7 +335,7 @@ class FileCopy(object):
         return False
 
     def work(self):
-        """Excute task """
+        """Execute task """
 
         if not HAS_SCP:
             self.module.fail_json(

--- a/lib/ansible/modules/network/cloudengine/ce_mlag_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_mlag_interface.py
@@ -754,7 +754,7 @@ class MlagInterface(object):
             self.changed = True
 
     def set_mlag_interface(self):
-        """set mlag interface atrribute info"""
+        """set mlag interface attribute info"""
 
         if self.is_mlag_interface_info_change():
             mlag_port = "Eth-Trunk"
@@ -768,7 +768,7 @@ class MlagInterface(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set mlag interface atrribute info failed.')
+                    msg='Error: set mlag interface attribute info failed.')
 
             self.updates_cmd.append("interface %s" % mlag_port)
             if self.mlag_priority_id:
@@ -815,7 +815,7 @@ class MlagInterface(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set mlag interface atrribute info failed.')
+                    msg='Error: set mlag interface attribute info failed.')
 
             if self.mlag_priority_id:
                 self.updates_cmd.append(

--- a/lib/ansible/modules/network/cloudengine/ce_mtu.py
+++ b/lib/ansible/modules/network/cloudengine/ce_mtu.py
@@ -46,7 +46,7 @@ options:
               and 1536 to 12288 for ToR switches.
     jumbo_min:
         description:
-            - Non-jumbo frame size threshod. The default value is 1518.
+            - Non-jumbo frame size threshold. The default value is 1518.
               The value is an integer that ranges from 1518 to jumbo_max, in bytes.
     state:
         description:

--- a/lib/ansible/modules/network/cloudengine/ce_netstream_export.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netstream_export.py
@@ -216,7 +216,7 @@ def is_config_exist(cmp_cfg, test_cfg):
 
 
 class NetstreamExport(object):
-    """Manange NetStream export"""
+    """Manage NetStream export"""
 
     def __init__(self, argument_spec):
         self.spec = argument_spec
@@ -519,7 +519,7 @@ class NetstreamExport(object):
             self.config_nets_export_ip_ver()
 
     def work(self):
-        """excute task"""
+        """execute task"""
 
         self.check_params()
         self.get_proposed()

--- a/lib/ansible/modules/network/cloudengine/ce_ntp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_ntp.py
@@ -250,7 +250,7 @@ class Ntp(object):
         self.mutually_exclusive = [('server', 'peer')]
         self.init_module()
 
-        # ntp configration info
+        # ntp configuration info
         self.server = self.module.params['server'] or None
         self.peer = self.module.params['peer'] or None
         self.key_id = self.module.params['key_id']
@@ -362,7 +362,7 @@ class Ntp(object):
         if self.vpn_name:
             if (len(self.vpn_name) < 1) or (len(self.vpn_name) > 31):
                 self.module.fail_json(
-                    msg='Error: VPN name length is beetween 1 and 31.')
+                    msg='Error: VPN name length is between 1 and 31.')
 
         if self.address:
             self.check_ipaddr_validate()
@@ -579,7 +579,7 @@ class Ntp(object):
         self.updates_cmd.append(cli_str)
 
     def work(self):
-        """Excute task"""
+        """Execute task"""
 
         self.get_existing()
         self.get_proposed()

--- a/lib/ansible/modules/network/cloudengine/ce_ntp_auth.py
+++ b/lib/ansible/modules/network/cloudengine/ce_ntp_auth.py
@@ -207,7 +207,7 @@ class NtpAuth(object):
         self.module = None
         self.init_module()
 
-        # ntp_auth configration info
+        # ntp_auth configuration info
         self.key_id = self.module.params['key_id']
         self.password = self.module.params['auth_pwd'] or None
         self.auth_mode = self.module.params['auth_mode'] or None
@@ -483,7 +483,7 @@ class NtpAuth(object):
         self.module.exit_json(**self.results)
 
     def work(self):
-        """Excute task"""
+        """Execute task"""
 
         self.get_existing()
         self.get_proposed()

--- a/lib/ansible/modules/network/cloudengine/ce_snmp_community.py
+++ b/lib/ansible/modules/network/cloudengine/ce_snmp_community.py
@@ -147,7 +147,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import get_nc_config, set_nc_config, ce_argument_spec
 
 
-# get snmp commutiny
+# get snmp community
 CE_GET_SNMP_COMMUNITY_HEADER = """
     <filter type="subtree">
       <snmp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
@@ -162,7 +162,7 @@ CE_GET_SNMP_COMMUNITY_TAIL = """
       </snmp>
     </filter>
 """
-# merge snmp commutiny
+# merge snmp community
 CE_MERGE_SNMP_COMMUNITY_HEADER = """
     <config>
       <snmp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
@@ -177,7 +177,7 @@ CE_MERGE_SNMP_COMMUNITY_TAIL = """
       </snmp>
     </config>
 """
-# create snmp commutiny
+# create snmp community
 CE_CREATE_SNMP_COMMUNITY_HEADER = """
     <config>
       <snmp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
@@ -192,7 +192,7 @@ CE_CREATE_SNMP_COMMUNITY_TAIL = """
       </snmp>
     </config>
 """
-# delete snmp commutiny
+# delete snmp community
 CE_DELETE_SNMP_COMMUNITY_HEADER = """
     <config>
       <snmp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">

--- a/lib/ansible/modules/network/cloudengine/ce_stp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_stp.py
@@ -579,7 +579,7 @@ class Stp(object):
 
         cmds = list()
 
-        # cofig stp global
+        # config stp global
         if self.stp_mode:
             if self.stp_mode != self.cur_cfg["stp_mode"]:
                 cmd = "stp mode %s" % self.stp_mode

--- a/lib/ansible/modules/network/cloudengine/ce_switchport.py
+++ b/lib/ansible/modules/network/cloudengine/ce_switchport.py
@@ -858,7 +858,7 @@ class SwitchPort(object):
 
         if not self.is_l2switchport():
             self.module.fail_json(
-                msg='Error: Interface is not layer2 swtich port.')
+                msg='Error: Interface is not layer2 switch port.')
         if self.state == "unconfigured":
             if any([self.mode, self.default_vlan, self.pvid_vlan, self.trunk_vlans, self.untagged_vlans, self.tagged_vlans]):
                 self.module.fail_json(

--- a/lib/ansible/modules/network/cloudengine/ce_vrf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf.py
@@ -160,7 +160,7 @@ def build_config_xml(xmlstr):
 
 
 class Vrf(object):
-    """Manange vpn instance"""
+    """Manage vpn instance"""
 
     def __init__(self, argument_spec, ):
         self.spec = argument_spec

--- a/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrf_interface.py
@@ -260,7 +260,7 @@ def get_interface_type(interface):
 
 
 class VrfInterface(object):
-    """Manange vpn instance"""
+    """Manage vpn instance"""
 
     def __init__(self, argument_spec):
         self.spec = argument_spec
@@ -483,7 +483,7 @@ class VrfInterface(object):
             self.changed = True
 
     def work(self):
-        """excute task"""
+        """execute task"""
 
         self.get_intf_conf_info()
         self.check_params()

--- a/lib/ansible/modules/network/cloudengine/ce_vrrp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vrrp.py
@@ -816,7 +816,7 @@ class Vrrp(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set vrrp global atrribute info failed.')
+                    msg='Error: set vrrp global attribute info failed.')
 
             if self.gratuitous_arp_interval:
                 self.updates_cmd.append(
@@ -860,7 +860,7 @@ class Vrrp(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set vrrp global atrribute info failed.')
+                    msg='Error: set vrrp global attribute info failed.')
             if self.gratuitous_arp_interval:
                 self.updates_cmd.append("undo vrrp gratuitous-arp interval")
 
@@ -912,7 +912,7 @@ class Vrrp(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set vrrp group atrribute info failed.')
+                    msg='Error: set vrrp group attribute info failed.')
             if self.interface and self.vrid:
                 self.updates_cmd.append("interface %s" % self.interface)
                 if self.vrrp_type == "admin":
@@ -1021,7 +1021,7 @@ class Vrrp(object):
             recv_xml = set_nc_config(self.module, conf_str)
             if "<ok/>" not in recv_xml:
                 self.module.fail_json(
-                    msg='Error: set vrrp global atrribute info failed.')
+                    msg='Error: set vrrp global attribute info failed.')
             if self.interface and self.vrid:
                 self.updates_cmd.append("interface %s" % self.interface)
                 if self.vrrp_type == "admin":

--- a/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
+++ b/lib/ansible/modules/network/cloudengine/ce_vxlan_vap.py
@@ -79,7 +79,7 @@ EXAMPLES = '''
 
   tasks:
 
-  - name: Create a papping between a VLAN and a BD
+  - name: Create a mapping between a VLAN and a BD
     ce_vxlan_vap:
       bridge_domain_id: 100
       bind_vlan_id: 99

--- a/lib/ansible/modules/network/cnos/cnos_backup.py
+++ b/lib/ansible/modules/network/cnos/cnos_backup.py
@@ -151,7 +151,7 @@ msg:
   description: Success or failure message
   returned: always
   type: str
-  sample: "Config file tranferred to server"
+  sample: "Config file transferred to server"
 '''
 
 import sys
@@ -171,7 +171,7 @@ from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 
 
-# Utility Method to back up the running config or start up copnfig
+# Utility Method to back up the running config or start up config
 # This method supports only SCP or SFTP or FTP or TFTP
 # Tuning of timeout parameter is pending
 def doConfigBackUp(module, prompt, answer):
@@ -266,7 +266,7 @@ def main():
     # Logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="Config file tranferred to server")
+        module.exit_json(changed=True, msg="Config file transferred to server")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/cnos/cnos_bgp.py
+++ b/lib/ansible/modules/network/cnos/cnos_bgp.py
@@ -125,7 +125,7 @@ options:
                   backdoor,route-map, Name of the route map ]
     bgpArg8:
         description:
-            - This is an overloaded bgp eigth argument. Usage of this argument
+            - This is an overloaded bgp eight argument. Usage of this argument
              can be found is the User Guide referenced above.
         required: No
         default: Null

--- a/lib/ansible/modules/network/cnos/cnos_image.py
+++ b/lib/ansible/modules/network/cnos/cnos_image.py
@@ -116,7 +116,7 @@ msg:
   description: Success or failure message
   returned: always
   type: str
-  sample: "Image file tranferred to device"
+  sample: "Image file transferred to device"
 '''
 
 import sys
@@ -231,7 +231,7 @@ def main():
     # Logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="Image file tranferred to device")
+        module.exit_json(changed=True, msg="Image file transferred to device")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/cnos/cnos_rollback.py
+++ b/lib/ansible/modules/network/cnos/cnos_rollback.py
@@ -152,7 +152,7 @@ msg:
   description: Success or failure message
   returned: always
   type: str
-  sample: "Config file tranferred to Device"
+  sample: "Config file transferred to Device"
 '''
 
 import sys
@@ -172,7 +172,7 @@ from ansible.module_utils.basic import AnsibleModule
 from collections import defaultdict
 
 
-# Utility Method to rollback the running config or start up copnfig
+# Utility Method to rollback the running config or start up config
 # This method supports only SCP or SFTP or FTP or TFTP
 def doConfigRollBack(module, prompt, answer):
     host = module.params['host']
@@ -275,7 +275,7 @@ def main():
     # need to add logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="Config file tranferred to Device")
+        module.exit_json(changed=True, msg="Config file transferred to Device")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -396,7 +396,7 @@ def main():
     flags = ['all'] if module.params['defaults'] else []
     connection = get_connection(module)
 
-    # Refuse to diff_against: session if essions are disabled
+    # Refuse to diff_against: session if sessions are disabled
     if module.params['diff_against'] == 'session' and not connection.supports_sessions:
         module.fail_json(msg="Cannot diff against sessions when sessions are disabled. Please change diff_against to another value")
 

--- a/lib/ansible/modules/network/exos/exos_lldp_global.py
+++ b/lib/ansible/modules/network/exos/exos_lldp_global.py
@@ -39,7 +39,7 @@ DOCUMENTATION = """
 ---
 module: exos_lldp_global
 version_added: 2.9
-short_description: Configure and manage Link Layer Discovery Protocol(LLDP) attribures on EXOS platforms.
+short_description: Configure and manage Link Layer Discovery Protocol(LLDP) attributes on EXOS platforms.
 description: This module configures and manages the Link Layer Discovery Protocol(LLDP) attributes on Extreme Networks EXOS platforms.
 author: Ujwal Komarla (@ujwalkomarla)
 notes:

--- a/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
+++ b/lib/ansible/modules/network/f5/bigip_appsvcs_extension.py
@@ -445,7 +445,7 @@ class ModuleManager(object):
 
         # This deals with cases where you're comparing a passphrase.
         #
-        # Passphrases will always cause an idepotent operation to register
+        # Passphrases will always cause an idempotent operation to register
         # a change. Therefore, by specifying "force", you are instructing
         # the module to **not** ignore the passphrase.
         #

--- a/lib/ansible/modules/network/f5/bigip_asm_dos_application.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_dos_application.py
@@ -77,7 +77,7 @@ options:
       latency_threshold:
         description:
           - Specifies the latency threshold for automatic heavy URL detection.
-          - The accepted range is between 0 and 4294967295 miliseconds inclusive.
+          - The accepted range is between 0 and 4294967295 milliseconds inclusive.
         type: int
       exclude:
         description:

--- a/lib/ansible/modules/network/f5/bigip_device_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_device_certificate.py
@@ -17,7 +17,7 @@ DOCUMENTATION = r'''
 module: bigip_device_certificate
 short_description: Manage self-signed device certificates
 description:
-  - Module used to create and/or renew self-signed defice certificates for BIG-IP.
+  - Module used to create and/or renew self-signed device certificates for BIG-IP.
 version_added: 2.9
 options:
   days_valid:

--- a/lib/ansible/modules/network/f5/bigip_device_info.py
+++ b/lib/ansible/modules/network/f5/bigip_device_info.py
@@ -1932,37 +1932,37 @@ gtm_pools:
       type: int
     qos_lcs:
       description:
-        - Weight assign to the Link Capacity performance factor when load balacing option
+        - Weight assign to the Link Capacity performance factor when load balancing option
           is QoS.
       returned: queried
       type: int
     qos_packet_rate:
       description:
-        - Weight assign to the Packet Rate performance factor when load balacing option
+        - Weight assign to the Packet Rate performance factor when load balancing option
           is QoS.
       returned: queried
       type: int
     qos_rtt:
       description:
-        - Weight assign to the Round Trip Time performance factor when load balacing option
+        - Weight assign to the Round Trip Time performance factor when load balancing option
           is QoS.
       returned: queried
       type: int
     qos_topology:
       description:
-        - Weight assign to the Topology performance factor when load balacing option
+        - Weight assign to the Topology performance factor when load balancing option
           is QoS.
       returned: queried
       type: int
     qos_vs_capacity:
       description:
-        - Weight assign to the Virtual Server performance factor when load balacing option
+        - Weight assign to the Virtual Server performance factor when load balancing option
           is QoS.
       returned: queried
       type: int
     qos_vs_score:
       description:
-        - Weight assign to the Virtual Server Score performance factor when load balacing
+        - Weight assign to the Virtual Server Score performance factor when load balancing
           option is QoS.
       returned: queried
       type: int
@@ -6070,7 +6070,7 @@ udp_profiles:
       description:
         - The Quality of Service level that the system assigns to
           UDP packets when sending them to clients.
-        - May be either numberic, or the value C(pass-through).
+        - May be either numeric, or the value C(pass-through).
       returned: queried
       type: str
       sample: pass-through

--- a/lib/ansible/modules/network/f5/bigip_gtm_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_pool.py
@@ -254,7 +254,7 @@ fallback_lb_method:
   type: str
   sample: fewest-hops
 fallback_ip:
-  description: New fallback IP used when load balacing using the C(fallback_ip) method.
+  description: New fallback IP used when load balancing using the C(fallback_ip) method.
   returned: changed
   type: str
   sample: 10.10.10.10

--- a/lib/ansible/modules/network/f5/bigip_lx_package.py
+++ b/lib/ansible/modules/network/f5/bigip_lx_package.py
@@ -27,7 +27,7 @@ options:
         and you intend to use this module in a C(role), it is recommended that you use
         the C({{ role_path }}) variable. An example is provided in the C(EXAMPLES) section.
       - When C(state) is C(absent), it is not necessary for the package to exist on the
-        Ansible controller. If the full path to the package is provided, the fileame will
+        Ansible controller. If the full path to the package is provided, the filename will
         specifically be cherry picked from it to properly remove the package.
     type: path
   state:

--- a/lib/ansible/modules/network/f5/bigip_policy_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_policy_rule.py
@@ -198,7 +198,7 @@ EXAMPLES = r'''
         - type: http_uri
           path_starts_with: /HomePage/
 
-- name: Remove all rules and confitions from the rule
+- name: Remove all rules and conditions from the rule
   bigip_policy_rule:
     policy: Policy-Foo
     name: rule1

--- a/lib/ansible/modules/network/f5/bigip_profile_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_tcp.py
@@ -335,7 +335,7 @@ class ModuleParameters(Parameters):
         if 0 <= self._values['syn_rto_base'] <= 5000:
             return self._values['syn_rto_base']
         raise F5ModuleError(
-            "Valid 'syn_rto_base' must be in range 0 - 5000 miliseconds."
+            "Valid 'syn_rto_base' must be in range 0 - 5000 milliseconds."
         )
 
 

--- a/lib/ansible/modules/network/f5/bigip_provision.py
+++ b/lib/ansible/modules/network/f5/bigip_provision.py
@@ -85,7 +85,7 @@ options:
         level provided that there are sufficient resources on the device (such
         as physical RAM) to support the provisioned module.
       - When C(absent), de-provision the module.
-      - C(absent), is not a relevent option to C(mgmt) module as module can not be de-provisioned.
+      - C(absent), is not a relevant option to C(mgmt) module as module can not be de-provisioned.
     type: str
     choices:
       - present

--- a/lib/ansible/modules/network/fortios/fortios_address.py
+++ b/lib/ansible/modules/network/fortios/fortios_address.py
@@ -38,7 +38,7 @@ options:
   value:
     description:
       - Address value, based on type.
-        If type=fqdn, somthing like www.google.com.
+        If type=fqdn, something like www.google.com.
         If type=ipmask, you can use simple ip (192.168.0.1), ip+mask (192.168.0.1 255.255.255.0) or CIDR (192.168.0.1/32).
   start_ip:
     description:

--- a/lib/ansible/modules/network/fortios/fortios_facts.py
+++ b/lib/ansible/modules/network/fortios/fortios_facts.py
@@ -121,7 +121,7 @@ EXAMPLES = '''
       gather_subset:
         - fact: 'system_status_select'
 
-  - name: gather all pysical interfaces status facts
+  - name: gather all physical interfaces status facts
     fortios_facts:
       host:  "{{ host }}"
       username: "{{ username }}"
@@ -130,7 +130,7 @@ EXAMPLES = '''
       gather_subset:
         - fact: 'system_interface_select'
 
-  - name: gather gather all pysical and vlan interfaces status facts
+  - name: gather gather all physical and vlan interfaces status facts
     fortios_facts:
       host:  "{{ host }}"
       username: "{{ username }}"

--- a/lib/ansible/modules/network/fortios/fortios_report_chart.py
+++ b/lib/ansible/modules/network/fortios/fortios_report_chart.py
@@ -183,7 +183,7 @@ options:
                                 type: int
                             op:
                                 description:
-                                    - Comparision operater.
+                                    - Comparison operator.
                                 type: str
                                 choices:
                                     - none

--- a/lib/ansible/modules/network/fortios/fortios_report_theme.py
+++ b/lib/ansible/modules/network/fortios/fortios_report_theme.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: fortios_report_theme
-short_description: Report themes configuratio in Fortinet's FortiOS and FortiGate.
+short_description: Report themes configuration in Fortinet's FortiOS and FortiGate.
 description:
     - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
       user to set and modify report feature and theme category.

--- a/lib/ansible/modules/network/fortios/fortios_system_central_management.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_central_management.py
@@ -161,8 +161,8 @@ options:
                 type: str
             server_list:
                 description:
-                    - Additional severs that the FortiGate can use for updates (for AV, IPS, updates) and ratings (for web filter and antispam ratings)
-                       servers.
+                    - Additional servers that the FortiGate can use for updates (for AV, IPS, updates) and ratings (for web filter and antispam ratings)
+                      servers.
                 type: list
                 suboptions:
                     addr_type:

--- a/lib/ansible/modules/network/fortios/fortios_system_cluster_sync.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_cluster_sync.py
@@ -120,8 +120,8 @@ options:
                 suboptions:
                     custom_service:
                         description:
-                            - Only sessions using these custom services are synchronized. Use source and destination port ranges to define these custome
-                               services.
+                            - Only sessions using these custom services are synchronized. Use source and destination port ranges to define these custom
+                              services.
                         type: list
                         suboptions:
                             dst_port_range:

--- a/lib/ansible/modules/network/fortios/fortios_system_mobile_tunnel.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_mobile_tunnel.py
@@ -153,7 +153,7 @@ options:
                 type: int
             renew_interval:
                 description:
-                    - Time before lifetime expiraton to send NMMO HA re-registration (5 - 60).
+                    - Time before lifetime expiration to send NMMO HA re-registration (5 - 60).
                 type: int
             roaming_interface:
                 description:
@@ -168,7 +168,7 @@ options:
                     - enable
             tunnel_mode:
                 description:
-                    - NEMO tunnnel mode (GRE tunnel).
+                    - NEMO tunnel mode (GRE tunnel).
                 type: str
                 choices:
                     - gre

--- a/lib/ansible/modules/network/fortios/fortios_user_group.py
+++ b/lib/ansible/modules/network/fortios/fortios_user_group.py
@@ -209,7 +209,7 @@ options:
                 type: int
             member:
                 description:
-                    - Names of users, peers, LDAP severs, or RADIUS servers to add to the user group.
+                    - Names of users, peers, LDAP servers, or RADIUS servers to add to the user group.
                 type: list
                 suboptions:
                     name:

--- a/lib/ansible/modules/network/fortios/fortios_user_radius.py
+++ b/lib/ansible/modules/network/fortios/fortios_user_radius.py
@@ -227,7 +227,7 @@ options:
                 type: int
             rsso_endpoint_attribute:
                 description:
-                    - RADIUS attributes used to extract the user end point identifer from the RADIUS Start record.
+                    - RADIUS attributes used to extract the user end point identifier from the RADIUS Start record.
                 type: str
                 choices:
                     - User-Name

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_ap_status.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_ap_status.py
@@ -101,7 +101,7 @@ options:
                 type: str
             status:
                 description:
-                    - "Access Point's (AP's) status: rogue, accepted, or supressed."
+                    - "Access Point's (AP's) status: rogue, accepted, or suppressed."
                 type: str
                 choices:
                     - rogue

--- a/lib/ansible/modules/network/fortios/fortios_wireless_controller_bonjour_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_wireless_controller_bonjour_profile.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: fortios_wireless_controller_bonjour_profile
-short_description: Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connnect
+short_description: Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connect
    to networks using Bonjour in Fortinet's FortiOS and FortiGate.
 description:
     - This module is able to configure a FortiGate or FortiOS (FOS) device by allowing the
@@ -83,7 +83,7 @@ options:
             - absent
     wireless_controller_bonjour_profile:
         description:
-            - Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connnect to
+            - Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connect to
                networks using Bonjour.
         default: null
         type: dict
@@ -146,7 +146,7 @@ EXAMPLES = '''
    vdom: "root"
    ssl_verify: "False"
   tasks:
-  - name: Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connnect to
+  - name: Configure Bonjour profiles. Bonjour is Apple's zero configuration networking protocol. Bonjour profiles allow APs and FortiAPs to connect to
      networks using Bonjour.
     fortios_wireless_controller_bonjour_profile:
       host:  "{{ host }}"

--- a/lib/ansible/modules/network/icx/icx_banner.py
+++ b/lib/ansible/modules/network/icx/icx_banner.py
@@ -52,7 +52,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden,
+       Module will use environment variable value(default:True), unless it is overridden,
        by specifying it as module parameter.
     type: bool
     default: yes

--- a/lib/ansible/modules/network/icx/icx_interface.py
+++ b/lib/ansible/modules/network/icx/icx_interface.py
@@ -184,7 +184,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-          - Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+          - Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
       power:
         description:
@@ -215,7 +215,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-      - Module will use environment variable value(default:True), unless it is overriden,
+      - Module will use environment variable value(default:True), unless it is overridden,
        by specifying it as module parameter.
     default: yes
     type: bool

--- a/lib/ansible/modules/network/icx/icx_l3_interface.py
+++ b/lib/ansible/modules/network/icx/icx_l3_interface.py
@@ -104,7 +104,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
   state:
     description:
@@ -116,7 +116,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/icx/icx_linkagg.py
+++ b/lib/ansible/modules/network/icx/icx_linkagg.py
@@ -51,7 +51,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
   aggregate:
@@ -85,7 +85,7 @@ options:
      check_running_config:
        description:
          - Check running configuration. This can be set as environment variable.
-          Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+          Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
        type: bool
   purge:
     description:

--- a/lib/ansible/modules/network/icx/icx_lldp.py
+++ b/lib/ansible/modules/network/icx/icx_lldp.py
@@ -40,7 +40,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
   state:

--- a/lib/ansible/modules/network/icx/icx_logging.py
+++ b/lib/ansible/modules/network/icx/icx_logging.py
@@ -87,7 +87,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
   state:
     description:
@@ -98,7 +98,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/icx/icx_ping.py
+++ b/lib/ansible/modules/network/icx/icx_ping.py
@@ -158,7 +158,7 @@ def parse_ping(ping_stats):
     """
     Function used to parse the statistical information from the ping response.
     Example: "Success rate is 100 percent (5/5), round-trip min/avg/max=40/51/55 ms."
-    Returns the percent of packet loss, recieved packets, transmitted packets, and RTT dict.
+    Returns the percent of packet loss, received packets, transmitted packets, and RTT dict.
     """
     if ping_stats.startswith('Success'):
         rate_re = re.compile(r"^\w+\s+\w+\s+\w+\s+(?P<pct>\d+)\s+\w+\s+\((?P<rx>\d+)/(?P<tx>\d+)\)")

--- a/lib/ansible/modules/network/icx/icx_static_route.py
+++ b/lib/ansible/modules/network/icx/icx_static_route.py
@@ -67,7 +67,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
   purge:
     description:
@@ -83,7 +83,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/icx/icx_system.py
+++ b/lib/ansible/modules/network/icx/icx_system.py
@@ -54,7 +54,7 @@ options:
     suboptions:
       type:
         description:
-          - specifiy the type of the server
+          - specify the type of the server
         type: str
         choices: ['radius','tacacs']
       hostname:
@@ -101,7 +101,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/icx/icx_user.py
+++ b/lib/ansible/modules/network/icx/icx_user.py
@@ -79,7 +79,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
   name:
     description:
@@ -135,7 +135,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/icx/icx_vlan.py
+++ b/lib/ansible/modules/network/icx/icx_vlan.py
@@ -91,7 +91,7 @@ options:
     suboptions:
       type:
         description:
-          - Specifiy the type of spanning-tree
+          - Specify the type of spanning-tree
         type: str
         default: 802-1w
         choices: ['802-1w','rstp']
@@ -166,7 +166,7 @@ options:
         suboptions:
           type:
             description:
-              - Specifiy the type of spanning-tree
+              - Specify the type of spanning-tree
             type: str
             default: 802-1w
             choices: ['802-1w','rstp']
@@ -189,7 +189,7 @@ options:
       check_running_config:
         description:
           - Check running configuration. This can be set as environment variable.
-           Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+           Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
         type: bool
       associated_interfaces:
         description:
@@ -217,7 +217,7 @@ options:
   check_running_config:
     description:
       - Check running configuration. This can be set as environment variable.
-       Module will use environment variable value(default:True), unless it is overriden, by specifying it as module parameter.
+       Module will use environment variable value(default:True), unless it is overridden, by specifying it as module parameter.
     type: bool
     default: yes
 """

--- a/lib/ansible/modules/network/illumos/dladm_iptun.py
+++ b/lib/ansible/modules/network/illumos/dladm_iptun.py
@@ -42,7 +42,7 @@ options:
         aliases: ['tunnel_type']
     local_address:
         description:
-            - Literat IP address or hostname corresponding to the tunnel source.
+            - Literal IP address or hostname corresponding to the tunnel source.
         required: false
         aliases: [ "local" ]
     remote_address:

--- a/lib/ansible/modules/network/illumos/ipadm_ifprop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_ifprop.py
@@ -29,7 +29,7 @@ options:
         aliases: [nic]
     protocol:
         description:
-            - Specifies the procotol for which we want to manage properties.
+            - Specifies the protocol for which we want to manage properties.
         required: true
     property:
         description:

--- a/lib/ansible/modules/network/illumos/ipadm_prop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_prop.py
@@ -24,7 +24,7 @@ author: Adam Števko (@xen0l)
 options:
     protocol:
         description:
-            - Specifies the procotol for which we want to manage properties.
+            - Specifies the protocol for which we want to manage properties.
         required: true
     property:
         description:

--- a/lib/ansible/modules/network/ingate/ig_config.py
+++ b/lib/ansible/modules/network/ingate/ig_config.py
@@ -386,7 +386,7 @@ return_rowid:
   type: list
   sample: [1, 3]
 download:
-  description: Configuraton database and meta data
+  description: Configuration database and meta data
   returned: when C(download) is yes and success
   type: complex
   contains:

--- a/lib/ansible/modules/network/ios/ios_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_interfaces.py
@@ -365,12 +365,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/ios/ios_l2_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interfaces.py
@@ -323,12 +323,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will always be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will always be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -403,12 +403,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/ios/ios_lag_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_lag_interfaces.py
@@ -351,12 +351,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/ios/ios_lldp_global.py
+++ b/lib/ansible/modules/network/ios/ios_lldp_global.py
@@ -217,12 +217,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: dict
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: dict
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/ios/ios_ntp.py
+++ b/lib/ansible/modules/network/ios/ios_ntp.py
@@ -41,7 +41,7 @@ options:
             - md5 NTP authentication key of tye 7.
     key_id:
         description:
-            - auth_key id. Datat type string
+            - auth_key id. Data type string
     state:
         description:
             - Manage the state of the resource.

--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -185,7 +185,7 @@ def parse_ping(ping_stats):
     """
     Function used to parse the statistical information from the ping response.
     Example: "Success rate is 100 percent (5/5), round-trip min/avg/max = 1/2/8 ms"
-    Returns the percent of packet loss, recieved packets, transmitted packets, and RTT dict.
+    Returns the percent of packet loss, received packets, transmitted packets, and RTT dict.
     """
     rate_re = re.compile(r"^\w+\s+\w+\s+\w+\s+(?P<pct>\d+)\s+\w+\s+\((?P<rx>\d+)/(?P<tx>\d+)\)")
     rtt_re = re.compile(r".*,\s+\S+\s+\S+\s+=\s+(?P<min>\d+)/(?P<avg>\d+)/(?P<max>\d+)\s+\w+\s*$|.*\s*$")

--- a/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interfaces.py
@@ -326,12 +326,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l2_interfaces.py
@@ -390,12 +390,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
@@ -384,12 +384,12 @@ before:
   description: The configuration as structured data prior to module invocation.
   returned: always
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 after:
   description: The configuration as structured data after module completion.
   returned: when changed
   type: list
-  sample: The configuration returned will alwys be in the same format of the paramters above.
+  sample: The configuration returned will always be in the same format of the parameters above.
 commands:
   description: The set of commands pushed to the remote device
   returned: always

--- a/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_lacp_interfaces.py
@@ -348,7 +348,7 @@ EXAMPLES = """
 #
 #
 
- - name: Overridde all interface LACP configuration with provided configuration
+ - name: Override all interface LACP configuration with provided configuration
    iosxr_lacp_interfaces:
     config:
       - name: Bundle-Ether12

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -74,7 +74,7 @@ options:
       - Configures the groups for the username in the device running
         configuration. The argument accepts a list of group names.
         This argument does not check if the group has been configured
-        on the device. It is similar to the aggregrate command for
+        on the device. It is similar to the aggregate command for
         usernames, but lets you configure multiple groups for the user(s).
   purge:
     description:

--- a/lib/ansible/modules/network/junos/_junos_interface.py
+++ b/lib/ansible/modules/network/junos/_junos_interface.py
@@ -80,7 +80,7 @@ options:
     description: List of Interfaces definitions.
   state:
     description:
-      - State of the Interface configuration, C(up) idicates present and
+      - State of the Interface configuration, C(up) indicates present and
         operationally up and C(down) indicates present and operationally C(down)
     default: present
     choices: ['present', 'absent', 'up', 'down']

--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -34,8 +34,8 @@ options:
         all, hardware, config, and interfaces.  Can specify a list of
         values to include a larger subset.  Values can also be used
         with an initial C(M(!)) to specify that a specific subset should
-        not be collected. To maintain backward compatbility old style facts
-        can be retrieved by explicilty adding C(ofacts)  to value, this reqires
+        not be collected. To maintain backward compatibility old style facts
+        can be retrieved by explicitly adding C(ofacts)  to value, this requires
         junos-eznc to be installed as a prerequisite. Valid value of gather_subset
         are default, hardware, config, interfaces, ofacts. If C(ofacts) is present in the
         list it fetches the old style facts (fact keys without 'ansible_' prefix) and it requires

--- a/lib/ansible/modules/network/junos/junos_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_interfaces.py
@@ -182,7 +182,7 @@ EXAMPLES = """
 # }
 
 
-# Using overriden
+# Using overridden
 
 # Before state:
 # -------------
@@ -212,7 +212,7 @@ EXAMPLES = """
         mtu: 2800
       - name: ge-0/0/3
         description: 'Configured by Ansible-3'
-    state: overriden
+    state: overridden
 
 # After state:
 # ------------

--- a/lib/ansible/modules/network/junos/junos_l3_interfaces.py
+++ b/lib/ansible/modules/network/junos/junos_l3_interfaces.py
@@ -271,7 +271,7 @@ EXAMPLES = """
 #     }
 # }
 # ge-0/0/2 {
-#     description "L3 interface whith ipv6";
+#     description "L3 interface with ipv6";
 #     unit 0 {
 #         family inet6 {
 #             address 2001:db8:3000::/64;

--- a/lib/ansible/modules/network/junos/junos_scp.py
+++ b/lib/ansible/modules/network/junos/junos_scp.py
@@ -27,7 +27,7 @@ options:
   src:
     description:
       - The C(src) argument takes a single path, or a list of paths to be
-        transfered. The argument C(recursive) must be C(true) to transfer
+        transferred. The argument C(recursive) must be C(true) to transfer
         directories.
     required: true
   dest:

--- a/lib/ansible/modules/network/meraki/meraki_admin.py
+++ b/lib/ansible/modules/network/meraki/meraki_admin.py
@@ -225,7 +225,7 @@ data:
                      type: str
                      sample: read-only
         tags:
-            description: Tags the adminsitrator has access on.
+            description: Tags the administrator has access on.
             returned: success
             type: complex
             contains:

--- a/lib/ansible/modules/network/meraki/meraki_device.py
+++ b/lib/ansible/modules/network/meraki/meraki_device.py
@@ -179,7 +179,7 @@ EXAMPLES = r'''
     tags: recently-added
   delegate_to: localhost
 
-- name: Claim a deivce into a network.
+- name: Claim a device into a network.
   meraki_device:
     auth_key: abc123
     org_name: YourOrg

--- a/lib/ansible/modules/network/meraki/meraki_switchport.py
+++ b/lib/ansible/modules/network/meraki/meraki_switchport.py
@@ -136,7 +136,7 @@ EXAMPLES = r'''
     voice_vlan: 11
   delegate_to: localhost
 
-- name: Check access port for idempotenty
+- name: Check access port for idempotency
   meraki_switchport:
     auth_key: abc12345
     state: present

--- a/lib/ansible/modules/network/meraki/meraki_vlan.py
+++ b/lib/ansible/modules/network/meraki/meraki_vlan.py
@@ -74,7 +74,7 @@ options:
       type: str
     fixed_ip_assignments:
       description:
-      - Static IP address assignements to be distributed via DHCP by MAC address.
+      - Static IP address assignments to be distributed via DHCP by MAC address.
       type: list
 author:
 - Kevin Breit (@kbreit)

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -91,7 +91,7 @@ options:
     version_added: "2.7"
   error_option:
     description:
-    - This option control the netconf server action after a error is occured while editing the configuration.
+    - This option controls the netconf server action after an error occurs while editing the configuration.
       If the value is I(stop-on-error) abort the config edit on first error, if value is I(continue-on-error)
       it continues to process configuration data on error, error is recorded and negative response is generated
       if any errors occur. If value is C(rollback-on-error) it rollback to the original configuration in case
@@ -135,7 +135,7 @@ options:
   validate:
     description:
       - This boolean flag if set validates the content of datastore given in C(target) option.
-        For this option to work remote Netconf server shoule support :validate capability.
+        For this option to work remote Netconf server should support :validate capability.
     type: bool
     default: False
     version_added: "2.7"

--- a/lib/ansible/modules/network/netconf/netconf_get.py
+++ b/lib/ansible/modules/network/netconf/netconf_get.py
@@ -98,7 +98,7 @@ EXAMPLES = """
     display: xml
     filter: /netconf-state/schemas/schema
 
-- name: get interface confiugration with filter (iosxr)
+- name: get interface configuration with filter (iosxr)
   netconf_get:
     display: pretty
     filter: <interface-configurations xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-ifmgr-cfg"></interface-configurations>
@@ -138,7 +138,7 @@ output:
                or pretty XML string response (human-readable) or response with
                namespace removed from XML string.
   returned: when the display format is selected as JSON it is returned as dict type, if the
-            display format is xml or pretty pretty it is retured as a string apart from low-level
+            display format is xml or pretty pretty it is returned as a string apart from low-level
             errors (such as action plugin).
   type: complex
   contains:

--- a/lib/ansible/modules/network/netconf/netconf_rpc.py
+++ b/lib/ansible/modules/network/netconf/netconf_rpc.py
@@ -137,7 +137,7 @@ output:
                or pretty XML string response (human-readable) or response with
                namespace removed from XML string.
   returned: when the display format is selected as JSON it is returned as dict type, if the
-            display format is xml or pretty pretty it is retured as a string apart from low-level
+            display format is xml or pretty pretty it is returned as a string apart from low-level
             errors (such as action plugin).
   type: complex
   contains:

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
@@ -287,7 +287,7 @@ options:
     cookiename:
         description:
             - >-
-                Use this parameter to specify the cookie name for C(COOKIE) peristence type. It specifies the name of
+                Use this parameter to specify the cookie name for C(COOKIE) persistence type. It specifies the name of
                 cookie with a maximum of 32 characters. If not specified, cookie name is internally generated.
 
 

--- a/lib/ansible/modules/network/netscaler/netscaler_nitro_request.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_nitro_request.py
@@ -241,7 +241,7 @@ EXAMPLES = '''
 
 RETURN = '''
 nitro_errorcode:
-    description: A numeric value containing the return code of the NITRO operation. When 0 the operation is succesful. Any non zero value indicates an error.
+    description: A numeric value containing the return code of the NITRO operation. When 0 the operation is successful. Any non zero value indicates an error.
     returned: always
     type: int
     sample: 0
@@ -285,7 +285,7 @@ nitro_object:
             state: "ENABLED"
 
 nitro_auth_token:
-    description: The token returned by the C(mas_login) operation when succesful.
+    description: The token returned by the C(mas_login) operation when successful.
     returned: when applicable
     type: str
     sample: "##E8D7D74DDBD907EE579E8BB8FF4529655F22227C1C82A34BFC93C9539D66"

--- a/lib/ansible/modules/network/netscaler/netscaler_save_config.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_save_config.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: netscaler_save_config
 short_description: Save Netscaler configuration.
 description:
-    - This module uncoditionally saves the configuration on the target netscaler node.
+    - This module unconditionally saves the configuration on the target netscaler node.
     - This module does not support check mode.
     - This module is intended to run either on the ansible  control node or a bastion (jumpserver) with access to the actual netscaler instance.
 

--- a/lib/ansible/modules/network/netscaler/netscaler_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_service.py
@@ -863,7 +863,7 @@ def main():
         'weight',
     ]
 
-    # Translate module arguments to correspondign config oject attributes
+    # Translate module arguments to correspondign config object attributes
     if module.params['ip'] is None:
         module.params['ip'] = module.params['ipaddress']
 

--- a/lib/ansible/modules/network/netscaler/netscaler_ssl_certkey.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_ssl_certkey.py
@@ -16,9 +16,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: netscaler_ssl_certkey
-short_description: Manage ssl cerificate keys.
+short_description: Manage ssl certificate keys.
 description:
-    - Manage ssl cerificate keys.
+    - Manage ssl certificate keys.
 
 version_added: "2.4.0"
 

--- a/lib/ansible/modules/network/netvisor/pn_ipv6security_raguard.py
+++ b/lib/ansible/modules/network/netvisor/pn_ipv6security_raguard.py
@@ -74,7 +74,7 @@ EXAMPLES = """
     pn_name: "foo1"
     pn_device: "host"
     pn_access_list: "sample"
-    pn_prefix_list: "sampe"
+    pn_prefix_list: "sample"
     pn_router_priority: "low"
 
 - name: ipv6 security ragurad modify

--- a/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
+++ b/lib/ansible/modules/network/netvisor/pn_port_cos_bw.py
@@ -54,7 +54,7 @@ options:
     choices: ['priority', 'no-priority']
   pn_min_bw_guarantee:
     description:
-      - Minimum b/w in precentage.
+      - Minimum b/w in percentage.
     required: False
     type: str
 """

--- a/lib/ansible/modules/network/netvisor/pn_vtep.py
+++ b/lib/ansible/modules/network/netvisor/pn_vtep.py
@@ -18,7 +18,7 @@ author: "Pluribus Networks (@rajaspachipulusu17)"
 version_added: "2.9"
 short_description: CLI command to create/delete vtep
 description:
-  - This module can be used to create a vtep and delte a vtep.
+  - This module can be used to create a vtep and delete a vtep.
 options:
   pn_cliswitch:
     description:

--- a/lib/ansible/modules/network/nso/nso_verify.py
+++ b/lib/ansible/modules/network/nso/nso_verify.py
@@ -146,7 +146,7 @@ class NsoVerify(object):
                 n_value = normalize_value(
                     expected_value.value, value, expected_value.path)
                 if n_value != expected_value.value:
-                    # if the value comparision fails, try mapping identityref
+                    # if the value comparison fails, try mapping identityref
                     value_type = value_builder.get_type(expected_value.path)
                     if value_type is not None and 'identityref' in value_type:
                         n_value, t_value = self.get_prefix_name(value)

--- a/lib/ansible/modules/network/nxos/_nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/_nxos_interface.py
@@ -158,7 +158,7 @@ EXAMPLES = """
 
 - name: Admin down all loopback interfaces
   nxos_interface:
-    name: looback 0-1023
+    name: loopback 0-1023
     admin_state: down
 
 - name: Check neighbors intent arguments

--- a/lib/ansible/modules/network/nxos/nxos_acl_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl_interface.py
@@ -84,7 +84,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def check_for_acl_int_present(module, name, intf, direction):
-    # Need to Captitalize the interface name as the nxos
+    # Need to Capitalize the interface name as the nxos
     # output has capitalization
     command = [{
         'command': 'show running-config aclmgr | section {0}'.format(intf.title()),

--- a/lib/ansible/modules/network/nxos/nxos_bgp.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp.py
@@ -38,7 +38,7 @@ notes:
       C(vrf=default) or the whole VRF instance within the BGP process when
       using a different VRF.
     - Default when supported restores params default value.
-    - Configuring global parmas is only permitted if C(vrf=default).
+    - Configuring global params is only permitted if C(vrf=default).
 options:
     asn:
         description:

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -184,7 +184,7 @@ remote_scp_server:
     type: str
     sample: 'fileserver.example.com'
 changed:
-    description: Indicates wheather or not the file was copied.
+    description: Indicates whether or not the file was copied.
     returned: success
     type: bool
     sample: true

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -136,7 +136,7 @@ options:
               is a list of dict where each dict has source and prefix defined or just
               prefix if source is not needed. The specified values will be configured
               on the device and if any previous prefix/sources exist, they will be removed.
-              Keyword 'default' is also accpted which removes all existing prefix/sources.
+              Keyword 'default' is also accepted which removes all existing prefix/sources.
         version_added: 2.6
     restart:
         description:

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -356,12 +356,12 @@ def massage_install_data(data):
 def build_install_cmd_set(issu, image, kick, type, force=True):
     commands = ['terminal dont-ask']
 
-    # Different NX-OS plaforms behave differently for
+    # Different NX-OS platforms behave differently for
     # disruptive and non-disruptive upgrade paths.
     #
     # 1) Combined kickstart/system image:
     #    * Use option 'non-disruptive' for issu.
-    #    * Omit option non-disruptive' for distruptive upgrades.
+    #    * Omit option 'non-disruptive' for disruptive upgrades.
     # 2) Separate kickstart + system images.
     #    * Omit hidden 'force' option for issu.
     #    * Use hidden 'force' option for disruptive upgrades.
@@ -415,7 +415,7 @@ def check_mode_legacy(module, issu, image, kick=None):
         command so we need to use a different method."""
     current = execute_show_command(module, 'show version', 'json')[0]
     # Call parse_show_data on empty string to create the default upgrade
-    # data stucture dictionary
+    # data structure dictionary
     data = parse_show_install('')
     upgrade_msg = 'No upgrade required'
 

--- a/lib/ansible/modules/network/nxos/nxos_lldp_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_lldp_global.py
@@ -60,7 +60,7 @@ options:
         choices: [0, 1]
       reinit:
         description:
-          - Amount of time to delay the intialization of LLDP on any interface (in seconds)
+          - Amount of time to delay the initialization of LLDP on any interface (in seconds)
         type: int
       timer:
         description:

--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -47,7 +47,7 @@ options:
     aliases: ['level']
   facility_level:
     description:
-      - Set logging serverity levels for facility based log messages.
+      - Set logging severity levels for facility based log messages.
   aggregate:
     description: List of logging definitions.
   state:

--- a/lib/ansible/modules/network/nxos/nxos_telemetry.py
+++ b/lib/ansible/modules/network/nxos/nxos_telemetry.py
@@ -263,7 +263,7 @@ EXAMPLES = """
 
 # Using replaced
 # This action will replace telemetry configuration on the device with the
-# telmetry configuration defined in the playbook.
+# telemetry configuration defined in the playbook.
 
 - name: Override Telemetry Configuration
   nxos_telemetry:

--- a/lib/ansible/modules/network/nxos/nxos_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf.py
@@ -136,7 +136,7 @@ EXAMPLES = '''
       - Ethernet2/3
       - Ethernet2/5
 
-- name: Check interfaces assigend to VRF
+- name: Check interfaces assigned to VRF
   nxos_vrf:
     name: test1
     associated_interfaces:

--- a/lib/ansible/modules/network/onyx/onyx_facts.py
+++ b/lib/ansible/modules/network/onyx/onyx_facts.py
@@ -59,7 +59,7 @@ ansible_net_gather_subset:
   type: list
 # version
 ansible_net_version:
-  description: A hash of all curently running system image information
+  description: A hash of all currently running system image information
   returned: when version is configured or when no gather_subset is provided
   type: dict
 # modules
@@ -117,7 +117,7 @@ class OnyxFactsModule(BaseOnyxModule):
         return runable_subsets
 
     def init_module(self):
-        """ module intialization
+        """ module initialization
         """
         argument_spec = dict(
             gather_subset=dict(default=['version'], type='list')

--- a/lib/ansible/modules/network/onyx/onyx_igmp.py
+++ b/lib/ansible/modules/network/onyx/onyx_igmp.py
@@ -15,7 +15,7 @@ DOCUMENTATION = """
 module: onyx_igmp
 version_added: "2.7"
 author: "Samer Deeb (@samerd)"
-short_description: Configures IGMP globl parameters
+short_description: Configures IGMP global parameters
 description:
   - This module provides declarative management of IGMP protocol params
     on Mellanox ONYX network devices.

--- a/lib/ansible/modules/network/onyx/onyx_igmp_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_igmp_interface.py
@@ -34,7 +34,7 @@ options:
 """
 
 EXAMPLES = """
-- name: configure igmp interfcae
+- name: configure igmp interface
   onyx_igmp_interface:
     state: enabled
     name: Eth1/1

--- a/lib/ansible/modules/network/onyx/onyx_interface.py
+++ b/lib/ansible/modules/network/onyx/onyx_interface.py
@@ -259,7 +259,7 @@ class OnyxInterfaceModule(BaseOnyxModule):
                 self._interface_type = if_type
             elif self._interface_type != if_type:
                 self._module.fail_json(
-                    msg='Cannot aggreagte interfaces from different types')
+                    msg='Cannot aggregate interfaces from different types')
             self._check_supported_attrs(if_obj)
 
     def get_required_config(self):

--- a/lib/ansible/modules/network/onyx/onyx_ospf.py
+++ b/lib/ansible/modules/network/onyx/onyx_ospf.py
@@ -35,7 +35,7 @@ options:
     suboptions:
       name:
         description:
-          - Intrface name.
+          - Interface name.
         required: true
       area:
         description:

--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -42,7 +42,7 @@ options:
     record:
         required: true
         description:
-            - Identifies the recoard in the table.
+            - Identifies the record in the table.
     col:
         required: true
         description:

--- a/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interfaces.py
@@ -98,7 +98,7 @@ options:
                 type: str
           ipv6:
             description:
-              - List of IPv6 addresses of the virual interface.
+              - List of IPv6 addresses of the virtual interface.
             type: list
             elements: dict
             suboptions:


### PR DESCRIPTION
* fix typos in network modules
(cherry picked from commit f11429a80db74a87f28473623889527c1d93964e)

##### SUMMARY
Backport of 62320: fix typos in network modules

##### ISSUE TYPE
- Docs Pull Request