### PR TITLE
[stable-2.9] Mark ansible-test cloud credentials as sensitive.

### DIFF
--- a/changelogs/fragments/ansible-test-cloud-secrets.yml
+++ b/changelogs/fragments/ansible-test-cloud-secrets.yml
@@ -1,0 +1,3 @@
+bugfixes:
+    - >
+        **security issue** - Redact cloud plugin secrets in ansible-test when running integration tests using cloud plugins. Only present in 2.9.0b1.

--- a/test/lib/ansible_test/_internal/cloud/azure.py
+++ b/test/lib/ansible_test/_internal/cloud/azure.py
@@ -125,6 +125,8 @@ class AzureCloudProvider(CloudProvider):
                 RESOURCE_GROUP_SECONDARY=response['resourceGroupNames'][1],
             )
 
+            display.sensitive.add(values['AZURE_SECRET'])
+
             config = '\n'.join('%s: %s' % (key, values[key]) for key in sorted(values))
 
             config = '[default]\n' + config
@@ -145,6 +147,9 @@ class AzureCloudEnvironment(CloudEnvironment):
         :rtype: CloudEnvironmentConfig
         """
         env_vars = get_config(self.config_path)
+
+        display.sensitive.add(env_vars.get('AZURE_SECRET'))
+        display.sensitive.add(env_vars.get('AZURE_PASSWORD'))
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,

--- a/test/lib/ansible_test/_internal/cloud/cloudscale.py
+++ b/test/lib/ansible_test/_internal/cloud/cloudscale.py
@@ -66,6 +66,8 @@ class CloudscaleCloudEnvironment(CloudEnvironment):
             CLOUDSCALE_API_TOKEN=parser.get('default', 'cloudscale_api_token'),
         )
 
+        display.sensitive.add(env_vars['CLOUDSCALE_API_TOKEN'])
+
         ansible_vars = dict(
             cloudscale_resource_prefix=self.resource_prefix,
         )

--- a/test/lib/ansible_test/_internal/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/cloud/cs.py
@@ -201,6 +201,8 @@ class CsCloudProvider(CloudProvider):
                 SECRET=credentials['secretkey'],
             )
 
+            display.sensitive.add(values['SECRET'])
+
         config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -279,6 +281,8 @@ class CsCloudEnvironment(CloudEnvironment):
             CLOUDSTACK_SECRET=config['secret'],
             CLOUDSTACK_TIMEOUT=config['timeout'],
         )
+
+        display.sensitive.add(env_vars['CLOUDSTACK_SECRET'])
 
         ansible_vars = dict(
             cs_resource_prefix=self.resource_prefix,

--- a/test/lib/ansible_test/_internal/cloud/hcloud.py
+++ b/test/lib/ansible_test/_internal/cloud/hcloud.py
@@ -77,6 +77,8 @@ class HcloudCloudProvider(CloudProvider):
                 TOKEN=token,
             )
 
+            display.sensitive.add(values['TOKEN'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -103,6 +105,8 @@ class HcloudCloudEnvironment(CloudEnvironment):
         env_vars = dict(
             HCLOUD_TOKEN=parser.get('default', 'hcloud_api_token'),
         )
+
+        display.sensitive.add(env_vars['HCLOUD_TOKEN'])
 
         ansible_vars = dict(
             hcloud_prefix=self.resource_prefix,

--- a/test/lib/ansible_test/_internal/cloud/opennebula.py
+++ b/test/lib/ansible_test/_internal/cloud/opennebula.py
@@ -59,6 +59,8 @@ class OpenNebulaCloudEnvironment(CloudEnvironment):
 
         ansible_vars.update(dict(parser.items('default')))
 
+        display.sensitive.add(ansible_vars.get('opennebula_password'))
+
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
         )

--- a/test/lib/ansible_test/_internal/cloud/scaleway.py
+++ b/test/lib/ansible_test/_internal/cloud/scaleway.py
@@ -10,7 +10,10 @@ from . import (
     CloudEnvironmentConfig,
 )
 
-from ..util import ConfigParser
+from ..util import (
+    ConfigParser,
+    display,
+)
 
 
 class ScalewayCloudProvider(CloudProvider):
@@ -56,6 +59,8 @@ class ScalewayCloudEnvironment(CloudEnvironment):
             SCW_API_KEY=parser.get('default', 'key'),
             SCW_ORG=parser.get('default', 'org')
         )
+
+        display.sensitive.add(env_vars['SCW_API_KEY'])
 
         ansible_vars = dict(
             scw_org=parser.get('default', 'org'),

--- a/test/lib/ansible_test/_internal/cloud/tower.py
+++ b/test/lib/ansible_test/_internal/cloud/tower.py
@@ -124,6 +124,8 @@ class TowerCloudProvider(CloudProvider):
                 PASSWORD=connection.password,
             )
 
+            display.sensitive.add(values['PASSWORD'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -257,6 +257,10 @@ class VcenterEnvironment(CloudEnvironment):
                 vcsim=self._get_cloud_config('vcenter_host'),
             )
 
+        for key, value in ansible_vars.items():
+            if key.endswith('_password'):
+                display.sensitive.add(value)
+
         return CloudEnvironmentConfig(
             env_vars=env_vars,
             ansible_vars=ansible_vars,

--- a/test/lib/ansible_test/_internal/cloud/vultr.py
+++ b/test/lib/ansible_test/_internal/cloud/vultr.py
@@ -10,7 +10,10 @@ from . import (
     CloudEnvironmentConfig,
 )
 
-from ..util import ConfigParser
+from ..util import (
+    ConfigParser,
+    display,
+)
 
 
 class VultrCloudProvider(CloudProvider):
@@ -55,6 +58,8 @@ class VultrCloudEnvironment(CloudEnvironment):
         env_vars = dict(
             VULTR_API_KEY=parser.get('default', 'key'),
         )
+
+        display.sensitive.add(env_vars['VULTR_API_KEY'])
 
         ansible_vars = dict(
             vultr_resource_prefix=self.resource_prefix,


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Mark ansible-test cloud credentials as sensitive.

Backport of https://github.com/ansible/ansible/pull/62392

(cherry picked from commit 9f7b124a6fe616c3fd06d500c1a6f6969c57ba2d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
