### PR TITLE
[stable-2.8] Mark ansible-test cloud credentials as sensitive.

### DIFF
--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -124,6 +124,8 @@ class AzureCloudProvider(CloudProvider):
                 RESOURCE_GROUP_SECONDARY=response['resourceGroupNames'][1],
             )
 
+            display.sensitive.add(values['AZURE_SECRET'])
+
             config = '\n'.join('%s: %s' % (key, values[key]) for key in sorted(values))
 
             config = '[default]\n' + config
@@ -144,6 +146,9 @@ class AzureCloudEnvironment(CloudEnvironment):
         :rtype: CloudEnvironmentConfig
         """
         env_vars = get_config(self.config_path)
+
+        display.sensitive.add(env_vars.get('AZURE_SECRET'))
+        display.sensitive.add(env_vars.get('AZURE_PASSWORD'))
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,

--- a/test/runner/lib/cloud/cloudscale.py
+++ b/test/runner/lib/cloud/cloudscale.py
@@ -65,6 +65,8 @@ class CloudscaleCloudEnvironment(CloudEnvironment):
             CLOUDSCALE_API_TOKEN=parser.get('default', 'cloudscale_api_token'),
         )
 
+        display.sensitive.add(env_vars['CLOUDSCALE_API_TOKEN'])
+
         ansible_vars = dict(
             cloudscale_resource_prefix=self.resource_prefix,
         )

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -200,6 +200,8 @@ class CsCloudProvider(CloudProvider):
                 SECRET=credentials['secretkey'],
             )
 
+            display.sensitive.add(values['SECRET'])
+
         config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -278,6 +280,8 @@ class CsCloudEnvironment(CloudEnvironment):
             CLOUDSTACK_SECRET=config['secret'],
             CLOUDSTACK_TIMEOUT=config['timeout'],
         )
+
+        display.sensitive.add(env_vars['CLOUDSTACK_SECRET'])
 
         ansible_vars = dict(
             cs_resource_prefix=self.resource_prefix,

--- a/test/runner/lib/cloud/hcloud.py
+++ b/test/runner/lib/cloud/hcloud.py
@@ -76,6 +76,8 @@ class HcloudCloudProvider(CloudProvider):
                 TOKEN=token,
             )
 
+            display.sensitive.add(values['TOKEN'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)
@@ -99,6 +101,8 @@ class HcloudCloudEnvironment(CloudEnvironment):
         env_vars = dict(
             HCLOUD_TOKEN=parser.get('default', 'hcloud_api_token'),
         )
+
+        display.sensitive.add(env_vars['HCLOUD_TOKEN'])
 
         ansible_vars = dict(
             hcloud_prefix=self.resource_prefix,

--- a/test/runner/lib/cloud/opennebula.py
+++ b/test/runner/lib/cloud/opennebula.py
@@ -58,6 +58,8 @@ class OpenNebulaCloudEnvironment(CloudEnvironment):
 
         ansible_vars.update(dict(parser.items('default')))
 
+        display.sensitive.add(ansible_vars.get('opennebula_password'))
+
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
         )

--- a/test/runner/lib/cloud/scaleway.py
+++ b/test/runner/lib/cloud/scaleway.py
@@ -9,7 +9,10 @@ from lib.cloud import (
     CloudEnvironmentConfig,
 )
 
-from lib.util import ConfigParser
+from lib.util import (
+    ConfigParser,
+    display,
+)
 
 
 class ScalewayCloudProvider(CloudProvider):
@@ -55,6 +58,8 @@ class ScalewayCloudEnvironment(CloudEnvironment):
             SCW_API_KEY=parser.get('default', 'key'),
             SCW_ORG=parser.get('default', 'org')
         )
+
+        display.sensitive.add(env_vars['SCW_API_KEY'])
 
         ansible_vars = dict(
             scw_org=parser.get('default', 'org'),

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -120,6 +120,8 @@ class TowerCloudProvider(CloudProvider):
                 PASSWORD=connection.password,
             )
 
+            display.sensitive.add(values['PASSWORD'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)

--- a/test/runner/lib/cloud/vultr.py
+++ b/test/runner/lib/cloud/vultr.py
@@ -9,7 +9,10 @@ from lib.cloud import (
     CloudEnvironmentConfig,
 )
 
-from lib.util import ConfigParser
+from lib.util import (
+    ConfigParser,
+    display,
+)
 
 
 class VultrCloudProvider(CloudProvider):
@@ -54,6 +57,8 @@ class VultrCloudEnvironment(CloudEnvironment):
         env_vars = dict(
             VULTR_API_KEY=parser.get('default', 'key'),
         )
+
+        display.sensitive.add(env_vars['VULTR_API_KEY'])
 
         ansible_vars = dict(
             vultr_resource_prefix=self.resource_prefix,


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Mark ansible-test cloud credentials as sensitive.

Backport of https://github.com/ansible/ansible/pull/62392

(cherry picked from commit 9f7b124a6fe616c3fd06d500c1a6f6969c57ba2d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

No changelog fragment since ansible-test is not shipped in Ansible 2.8.