### PR TITLE
[stable-2.7] Mark ansible-test cloud credentials as sensitive.

### DIFF
--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -122,6 +122,8 @@ class AzureCloudProvider(CloudProvider):
                 RESOURCE_GROUP_SECONDARY=response['resourceGroupNames'][1],
             )
 
+            display.sensitive.add(values['AZURE_SECRET'])
+
             config = '\n'.join('%s: %s' % (key, values[key]) for key in sorted(values))
 
         self._write_config(config)
@@ -141,6 +143,9 @@ class AzureCloudEnvironment(CloudEnvironment):
         :type cmd: list[str]
         """
         config = get_config(self.config_path)
+
+        display.sensitive.add(config.get('AZURE_SECRET'))
+        display.sensitive.add(config.get('AZURE_PASSWORD'))
 
         cmd.append('-e')
         cmd.append('resource_prefix=%s' % self.resource_prefix)

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -199,6 +199,8 @@ class CsCloudProvider(CloudProvider):
                 SECRET=credentials['secretkey'],
             )
 
+            display.sensitive.add(values['SECRET'])
+
         config = self._populate_config_template(config, values)
 
         self._write_config(config)

--- a/test/runner/lib/cloud/tower.py
+++ b/test/runner/lib/cloud/tower.py
@@ -117,6 +117,8 @@ class TowerCloudProvider(CloudProvider):
                 PASSWORD=connection.password,
             )
 
+            display.sensitive.add(values['PASSWORD'])
+
             config = self._populate_config_template(config, values)
 
         self._write_config(config)


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Mark ansible-test cloud credentials as sensitive.

Backport of https://github.com/ansible/ansible/pull/62392

(cherry picked from commit 9f7b124a6fe616c3fd06d500c1a6f6969c57ba2d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

No changelog fragment since ansible-test is not shipped in Ansible 2.8.