### PR TITLE
test: disable hcloud_floating_ip_info

### DIFF
--- a/test/integration/targets/hcloud_floating_ip_info/aliases
+++ b/test/integration/targets/hcloud_floating_ip_info/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled # See: https://github.com/ansible/ansible/issues/62414


### PR DESCRIPTION
##### SUMMARY

Temporarily disable `hcloud_floating_ip_info`, this until #62414 is
resolved.

(cherry picked from commit edf15b346f4929ce0474e44cdeaa9fed9b375458)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

hcloud_floating_ip_info