### PR TITLE
Add link to become plugins in become docs

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -13,6 +13,8 @@ Become
 
 Ansible allows you to 'become' another user, different from the user that logged into the machine (remote user). This is done using existing privilege escalation tools such as `sudo`, `su`, `pfexec`, `doas`, `pbrun`, `dzdo`, `ksu`, `runas`, `machinectl` and others.
 
+A full list of all become plugins that are included in Ansible can be found in the :ref:`become_plugin_list`.
+
 
 .. note:: Prior to version 1.9, Ansible mostly allowed the use of `sudo` and a limited use of `su` to allow a login/remote user to become a different user and execute tasks and create resources with the second user's permissions. As of Ansible version 1.9,  `become` supersedes the old sudo/su, while still being backwards compatible. This new implementation also makes it easier to add other privilege escalation tools, including `pbrun` (Powerbroker), `pfexec`, `dzdo` (Centrify), and others.
 
@@ -79,6 +81,11 @@ ansible_become_password
 For example, if you want to run all tasks as ``root`` on a server named ``webserver``, but you can only connect as the ``manager`` user, you could use an inventory entry like this::
 
     webserver ansible_user=manager ansible_become=yes
+
+.. note::
+    The variables defined above are generic for all become plugins but plugin specific ones can also be set instead.
+    Please see the documentation for each plugin for a list of all options the plugin has and how they can be defined.
+    A full list of become plugins in Ansible can be found at :ref:`become_plugins`.
 
 Command line options
 --------------------


### PR DESCRIPTION
##### SUMMARY
Add some helpful links in the become docs to link to the actual become plugins available in Ansible.

Fixes https://github.com/ansible/ansible/issues/62367

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
become