### PR TITLE
Add hint for config option priority

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -452,4 +452,8 @@ Authors
     If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/modules/@{ source }@?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
 {% else %}
     If you notice any issues in this documentation, you can `edit this document <https://github.com/ansible/ansible/edit/devel/lib/ansible/plugins/@{ plugin_type }@/@{ source }@?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr>`_ to improve it.
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priorty order, for example a variable that is lower in the list will override a variable that is higher up.
 {% endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -455,5 +455,5 @@ Authors
 
 
 .. hint::
-    Configuration entries for each entry type have a low to high priorty order, for example a variable that is lower in the list will override a variable that is higher up.
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
I couldn't find a place that defined the priority order of plugin options so I've added it to the base template file so it displays it on each plugin.

Fixes https://github.com/ansible/ansible/issues/62367

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugin docs