### PR TITLE
luks_device: ansibot wasn't able to extract author

### DIFF
--- a/lib/ansible/modules/crypto/luks_device.py
+++ b/lib/ansible/modules/crypto/luks_device.py
@@ -132,8 +132,7 @@ requirements:
     - "lsblk"
     - "blkid (when I(label) or I(uuid) options are used)"
 
-author:
-    "Jan Pokorny (@japokorn)"
+author: Jan Pokorny (@japokorn)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Ansibullbot [ignores lines without `author` or dash](https://github.com/ansible/ansibullbot/blob/02ae638641c0ac9d6331b768592eeaac446fa80d/ansibullbot/utils/moduletools.py#L828)

The following command allows to check that no other module is impacted:

    rgrep -A1 -P "^author:[[:space:]]*$" lib/ansible/modules/ |grep -P "\.py-[[:space:]]*[^-][[:space:]A-Za-z\"'@()]+$" -B1

It would be better to improve Ansibullbot in order to handle this formatting but an update recently ignored it (ansible/ansibullbot#1106), hence this proposal.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
luks_device