### PR TITLE
inter-related collection loader fixes

### DIFF
--- a/changelogs/fragments/collection_loader_fixes.yml
+++ b/changelogs/fragments/collection_loader_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- collections - various relative import and caching fixes (https://github.com/ansible/ansible/pull/62470)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -352,9 +352,9 @@ class JinjaPluginIntercept(MutableMapping):
                 fq_name = '.'.join((parent_prefix, f[0]))
                 self._collection_jinja_func_cache[fq_name] = f[1]
 
-            function_impl = self._collection_jinja_func_cache[key]
-
         # FIXME: detect/warn on intra-collection function name collisions
+
+        function_impl = self._collection_jinja_func_cache[key]
 
         return function_impl
 

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -104,8 +104,19 @@ class AnsibleCollectionLoader(with_metaclass(Singleton, object)):
 
     def find_module(self, fullname, path=None):
         # this loader is only concerned with items under the Ansible Collections namespace hierarchy, ignore others
-        if fullname and fullname.split('.', 1)[0] == 'ansible_collections':
-            return self
+        if fullname and fullname.split('.', 1)[0] != 'ansible_collections':
+            return None
+
+        # PEP302 says we can only return ourselves as the loader if we can load something, so just try to load it
+        # FUTURE: optimize away some of the actual loading work?
+        try:
+            mod = self.load_module(fullname)
+            if mod:
+                return self
+        except ImportError:
+            pass
+        except KeyError:
+            pass
 
         return None
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/filter/test_filter.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/filter/test_filter.py
@@ -1,0 +1,15 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def filter_name(a):
+    return __name__
+
+
+class FilterModule(object):
+    def filters(self):
+        filters = {
+            'filter_name': filter_name,
+        }
+
+        return filters

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/lookup/lookup_name.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/lookup/lookup_name.py
@@ -1,0 +1,9 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__name__]

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/lookup/lookup_no_future_boilerplate.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/lookup/lookup_no_future_boilerplate.py
@@ -1,0 +1,10 @@
+# do not add future boilerplate to this plugin
+# specifically, do not add absolute_import, as the purpose of this plugin is to test implicit relative imports on Python 2.x
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__name__]

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/test/test_test.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/test/test_test.py
@@ -1,0 +1,13 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def test_name_ok(value):
+    return __name__ == 'ansible_collections.testns.testcoll.plugins.test.test_test'
+
+
+class TestModule:
+    def tests(self):
+        return {
+            'test_name_ok': test_name_ok,
+        }

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -369,9 +369,56 @@
       # ensure that the connection var we overrode above made it into the running config
       - connection_out.stderr == "connectionvar is from_play"
 
-- hosts: testhost
+- hosts: localhost
+  tasks:
+    - assert:
+        that:
+        - hostvars['dynamic_host_a'] is defined
+        - hostvars['dynamic_host_a'].connection_out.stdout == "localconn ran echo 'hello world'"
+
+- hosts: localhost
+  tasks:
+  # create a couple of dynamic hosts to exercise collection-hosted connection plugin config/delegation
+  - add_host:
+      name: localconn_main
+      ansible_connection: testns.testcoll.localconn
+      ansible_localconn_connectionvar: main hostvar
+  - add_host:
+      name: localconn_delegated
+      ansible_connection: testns.testcoll.localconn
+      ansible_localconn_connectionvar: delegated hostvar
+
+- hosts: localconn_main
+  tasks:
+    - raw: main value
+      register: main_out
+    - raw: delegated value
+      delegate_to: localconn_delegated
+      register: delegated_out
+
+- hosts: localhost
   tasks:
   - assert:
       that:
-      - hostvars['dynamic_host_a'] is defined
-      - hostvars['dynamic_host_a'].connection_out.stdout == "localconn ran echo 'hello world'"
+      - hostvars['localconn_main'].main_out.stdout == "localconn ran main value"
+      - hostvars['localconn_main'].delegated_out.stdout == "localconn ran delegated value"
+
+
+# ensure that plugins are loaded/stored under their qualified name to prevent cross-collection clobbering
+- name: validate fully qualified plugin names
+  hosts: testhost
+  tasks:
+  - name: store loaded plugin names
+    set_fact:
+      filter_name: "{{ 1 | testns.testcoll.filter_name }}"
+      lookup_name: "{{ lookup('testns.testcoll.lookup_name') }}"
+      lookup_no_future_boilerplate: "{{ lookup('testns.testcoll.lookup_no_future_boilerplate') }}"
+      test_name_ok: "{{ 1 is testns.testcoll.test_name_ok }}"
+
+  - name: validate loaded plugin names are properly qualified
+    assert:
+      that:
+        - filter_name == 'ansible_collections.testns.testcoll.plugins.filter.test_filter'
+        - lookup_name == 'ansible_collections.testns.testcoll.plugins.lookup.lookup_name'
+        - lookup_no_future_boilerplate == 'ansible_collections.testns.testcoll.plugins.lookup.lookup_no_future_boilerplate'
+        - test_name_ok

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/connection/relimp_conn.py
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/connection/relimp_conn.py
@@ -1,0 +1,43 @@
+from __future__ import (division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils._text import to_native
+from ansible.plugins.connection import ConnectionBase
+from ..module_utils.my_util1 import one
+
+DOCUMENTATION = """
+    connection: localconn
+    short_description: do stuff local
+    description:
+        - does stuff
+    options:
+      connectionvar:
+        description:
+            - something we set
+        default: the_default
+        vars:
+            - name: ansible_localconn_connectionvar
+"""
+
+
+class Connection(ConnectionBase):
+    transport = 'local'
+    has_pipelining = True
+
+    def _connect(self):
+        return self
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        one()
+        stdout = 'localconn ran {0}'.format(to_native(cmd))
+        stderr = 'connectionvar is {0}'.format(to_native(self.get_option('connectionvar')))
+        return (0, stdout, stderr)
+
+    def put_file(self, in_path, out_path):
+        raise NotImplementedError('just a test')
+
+    def fetch_file(self, in_path, out_path):
+        raise NotImplementedError('just a test')
+
+    def close(self):
+        self._connected = False

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
@@ -2,3 +2,14 @@
   my_ns.my_col.my_module:
 - name: collection relative module usage with relative imports
   my_module:
+- name: make a host using a connection with a relative import and no absolute_import boilerplate
+  add_host:
+    name: relimp_conn_testhost
+    ansible_connection: my_ns.my_col.relimp_conn
+- name: exercise the relative import connection
+  raw: some stuff
+  delegate_to: relimp_conn_testhost
+  register: relimp_conn_out
+- assert:
+    that:
+    - relimp_conn_out.stdout == 'localconn ran some stuff'


### PR DESCRIPTION
##### SUMMARY
* fix for relative imports (PEP302 compliance- verifying our loader can find a module before returning itself to do so)
* ensure that internal pluginloader caches use the full name of the code object so same-named objects in different collections can't clobber each other
* ensure that Jinja2 plugin loader doesn't look things up in function cache before it's fully-populated
* add relative import tests for controller-hosted plugins (JInja2 plugins, connections)
* supersedes #60317

needs backport to 2.9

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
collection_loader

##### ADDITIONAL INFORMATION
