### PR TITLE
[stable-2.9] Remove obsolete MANIFEST.in entries.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,13 +20,11 @@ recursive-include lib/ansible/config *.yml
 recursive-include licenses *.txt
 recursive-include packaging *
 recursive-include test/ansible_test *.py Makefile
-recursive-include test/cache .keep
 recursive-include test/integration *
 recursive-include test/lib/ansible_test/config *.template
 recursive-include test/lib/ansible_test/_data *.cfg *.ini *.json *.ps1 *.psd1 *.py *.sh *.txt *.yml coveragerc inventory
 recursive-include test/lib/ansible_test/_data/injector ansible ansible-config ansible-connection ansible-console ansible-doc ansible-galaxy ansible-playbook ansible-pull ansible-test ansible-vault pytest
 recursive-include test/lib/ansible_test/_data/sanity/validate-modules validate-modules
-recursive-include test/results .keep
 recursive-include test/sanity *.json *.py *.txt
 exclude test/sanity/code-smell/botmeta.*
 recursive-include test/units *


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Remove obsolete MANIFEST.in entries.

Backport of https://github.com/ansible/ansible/pull/62476

(cherry picked from commit 7d40f6d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

MANIFEST.in
