### PR TITLE
Add fix for specifying current dir in collections_paths

### DIFF
--- a/changelogs/fragments/collection-prefix-basedir.yaml
+++ b/changelogs/fragments/collection-prefix-basedir.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix issue where the collection loader tracebacks if ``collections_paths = ./`` is set in the config

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -519,7 +519,7 @@ def get_collection_name_from_path(path):
             # strip off the common prefix (handle weird testing cases of nested collection roots, eg)
             collection_remnant = n_path[len(coll_path):]
             # commonprefix may include the trailing /, prepend to the remnant if necessary (eg trailing / on root)
-            if collection_remnant[0] != '/':
+            if collection_remnant and collection_remnant[0] != '/':
                 collection_remnant = '/' + collection_remnant
             # the path lives under this collection root, see if it maps to a collection
             found_collection = _N_COLLECTION_PATH_RE.search(collection_remnant)


### PR DESCRIPTION
##### SUMMARY
If you have specified `collections_paths = ./` in your config then it will fail trying to find any collection in that path because `collection_remnant` is an empty string.

A quick an easy reproducer is to have the following playbook (no need to set up the collection).

```
# main.yml
---
- hosts: localhost
  collections:  # This must be present for the get_collection_name_from_path() to be called
  - test.collection
  tasks:
  - ping:
```

```
# run the following to get an error
$ ANSIBLE_COLLECTIONS_PATHS=./ ansible-playbook main.yml -vvv
ansible-playbook 2.10.0.dev0
  config file = None
  configured module search path = ['/Users/jborean/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jborean/dev/ansible/lib/ansible
  executable location = /Users/jborean/dev/ansible/bin/ansible-playbook
  python version = 3.7.4 (default, Aug 12 2019, 11:51:58) [Clang 10.0.1 (clang-1001.0.46.4)]
No config file found; using defaults
ERROR! Unexpected Exception, this is probably a bug: string index out of range
the full traceback was:

Traceback (most recent call last):
  File "/Users/jborean/dev/ansible/bin/ansible-playbook", line 123, in <module>
    exit_code = cli.run()
  File "/Users/jborean/dev/ansible/lib/ansible/cli/playbook.py", line 95, in run
    playbook_collection = get_collection_name_from_path(b_playbook_dirs[0])
  File "/Users/jborean/dev/ansible/lib/ansible/utils/collection_loader.py", line 522, in get_collection_name_from_path
    if collection_remnant[0] != '/':
IndexError: string index out of range
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection_loader