### PR TITLE
Fix network_cli exec_command connection init (#62344)

### DIFF
--- a/changelogs/fragments/network_execute_command_fix.yaml
+++ b/changelogs/fragments/network_execute_command_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ensure connection with remote host is created before invoking execute_command() from module side (https://github.com/ansible/ansible/issues/61596)

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -138,6 +138,10 @@ class ConnectionProcess(object):
                     if log_messages:
                         display.display("jsonrpc request: %s" % data, log_only=True)
 
+                    request = json.loads(to_text(data, errors='surrogate_or_strict'))
+                    if request.get('method') == "exec_command" and not self.connection.connected:
+                        self.connection._connect()
+
                     signal.alarm(self.connection.get_option('persistent_command_timeout'))
 
                     resp = self.srv.handle_request(data)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix network_cli exec_command connection init

Fixes https://github.com/ansible/ansible/issues/61596

*  If `exec_command` method is invoked from the module side
   on the connection object to execute the command on the target
   host check if the connection is created if not create the
   connection.

* Fix review comment

(cherry picked from commit 74e4993628bc536466542ff4cc30925bc74a0e13)

Merged to devel https://github.com/ansible/ansible/pull/62344
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/cli/scripts/ansible_connection_cli_stub.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
