### PR TITLE
Fixing GcpSession.put definition to accept additional kwargs (#56326)

### DIFF
--- a/lib/ansible/module_utils/gcp_utils.py
+++ b/lib/ansible/module_utils/gcp_utils.py
@@ -105,11 +105,11 @@ class GcpSession(object):
         kwargs = {'json': body}
         return self.full_delete(url, **kwargs)
 
-    def put(self, url, body=None):
+    def put(self, url, body=None, **kwargs):
         """
         This method should be avoided in favor of full_put
         """
-        kwargs = {'json': body}
+        kwargs.update({'json': body})
         return self.full_put(url, **kwargs)
 
     def patch(self, url, body=None, **kwargs):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Allowing `GcpSession.put` to accept additional `kwargs`, similar to other methods.
Fixes #56326

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
GCP

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
`update` call in `gcp_iam_role.py` passes additional arguments to `GcpSession.put`, resulting in `TypeError` as seen in #56326
https://github.com/ansible/ansible/blob/fd7e156ccdbe6869f833fbd9d98670655becff8c/lib/ansible/modules/cloud/google/gcp_iam_role.py#L197
Fix accepts `kwargs` and passes them to `GcpSession.full_put`, similar to other methods.
