### PR TITLE
IOS-XR: Fail with a better message when config is not provided

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/interfaces/interfaces.py
@@ -100,6 +100,8 @@ class Interfaces(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'overridden':
             commands = self._state_overridden(want, have)

--- a/lib/ansible/module_utils/network/iosxr/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/l2_interfaces/l2_interfaces.py
@@ -96,6 +96,10 @@ class L2_Interfaces(ConfigBase):
         commands = []
 
         state = self._module.params['state']
+
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have, self._module)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/iosxr/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/l3_interfaces/l3_interfaces.py
@@ -97,6 +97,10 @@ class L3_Interfaces(ConfigBase):
         commands = []
 
         state = self._module.params['state']
+
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have, self._module)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/iosxr/config/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/iosxr/config/lacp/lacp.py
@@ -107,6 +107,8 @@ class Lacp(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'deleted':
             commands = self._state_deleted(want, have)

--- a/lib/ansible/module_utils/network/iosxr/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/lacp_interfaces/lacp_interfaces.py
@@ -105,6 +105,9 @@ class Lacp_interfaces(ConfigBase):
         commands = []
         state = self._module.params['state']
 
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands.extend(
                 Lacp_interfaces._state_overridden(

--- a/lib/ansible/module_utils/network/iosxr/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/lag_interfaces/lag_interfaces.py
@@ -128,6 +128,9 @@ class Lag_interfaces(ConfigBase):
         state = self._module.params['state']
         commands = []
 
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands.extend(self._state_overridden(want, have))
 

--- a/lib/ansible/module_utils/network/iosxr/config/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/iosxr/config/lldp_global/lldp_global.py
@@ -104,6 +104,8 @@ class Lldp_global(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'deleted':
             commands = self._state_deleted(want, have)

--- a/lib/ansible/module_utils/network/iosxr/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/config/lldp_interfaces/lldp_interfaces.py
@@ -102,6 +102,8 @@ class Lldp_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         commands = []
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'overridden':
             commands.extend(

--- a/test/integration/targets/iosxr_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/iosxr_l2_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_l2_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_l2_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_l2_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_l2_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_l2_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/iosxr_l3_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_l3_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_l3_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_l3_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_l3_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_l3_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/iosxr_lacp/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_lacp/tests/cli/empty_config.yaml
@@ -1,0 +1,25 @@
+---
+- debug:
+      msg: "START iosxr_lacp empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_lacp:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_lacp:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'

--- a/test/integration/targets/iosxr_lacp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_lacp_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_lacp_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_lacp_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_lacp_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_lacp_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/iosxr_lag_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_lag_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_lag_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_lag_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_lag_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_lag_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/iosxr_lldp_global/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_lldp_global/tests/cli/empty_config.yaml
@@ -1,0 +1,25 @@
+---
+- debug:
+      msg: "START iosxr_lldp_global empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_lldp_global:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_lldp_global:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'

--- a/test/integration/targets/iosxr_lldp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/iosxr_lldp_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START iosxr_lldp_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  iosxr_lldp_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  iosxr_lldp_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  iosxr_lldp_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible/pull/62998
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- No more traceback on empty config when state is 'merged', 'replaced' or 'overridden'.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_interfaces.py
iosxr_l2_interfaces.py
iosxr_l3_interfaces.py
iosxr_lacp.py
iosxr_lag_interfaces.py
iosxr_lacp_interfaces.py
iosxr_lldp_global.py
iosxr_lldp_interfaces.py