### PR TITLE
vyosnoconfig tracebackfix

### DIFF
--- a/lib/ansible/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py
@@ -107,6 +107,8 @@ class Lag_interfaces(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+        if state in ('merged', 'replaced', 'overridden') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
         if state == 'overridden':
             commands.extend(self._state_overridden(want, have))
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/vyos/config/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/vyos/config/lldp_global/lldp_global.py
@@ -100,6 +100,8 @@ class Lldp_global(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+        if state in ('merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
         if state == 'deleted':
             commands.extend(self._state_deleted(want=None, have=have))
         elif state == 'merged':

--- a/lib/ansible/module_utils/network/vyos/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/vyos/config/lldp_interfaces/lldp_interfaces.py
@@ -110,6 +110,8 @@ class Lldp_interfaces(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+        if state in ('merged', 'replaced', 'overridden') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
         if state == 'overridden':
             commands.extend(self._state_overridden(want=want, have=have))
         elif state == 'deleted':

--- a/test/integration/targets/vyos_lag_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_lag_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START vyos_lag_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  vyos_lag_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  vyos_lag_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  vyos_lag_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state overridden'

--- a/test/integration/targets/vyos_lldp_global/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_lldp_global/tests/cli/empty_config.yaml
@@ -23,4 +23,3 @@
 - assert:
     that:
       - result.msg == 'config is required for state replaced'
-

--- a/test/integration/targets/vyos_lldp_global/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_lldp_global/tests/cli/empty_config.yaml
@@ -1,0 +1,26 @@
+---
+- debug:
+      msg: "START vyos_lldp_global empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  vyos_lldp_global:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  vyos_lldp_global:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state replaced'
+

--- a/test/integration/targets/vyos_lldp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_lldp_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START vyos_lldp_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  vyos_lldp_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  vyos_lldp_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  vyos_lldp_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'config is required for state overridden'


### PR DESCRIPTION
Signed-off-by: rohitthakur2590 <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
vyos traceback fix when config in none
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- vyos_lldp_interfaces
- vyos_lldp_global
-vyos_lag_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before 
  File 

fatal: [192.168.56.101]: FAILED! => {
    "changed": false, 
ule_utils/network/vyos/config/lag_interfaces/lag_interfaces.py\", line 64, in execute_module\n  File \"/tmp/ansible_vyos_lag_interfaces_payload_xOAAjj/ansible_vyos_lag_interfaces_payload.zip/ansible/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py\", line 96, in set_config\n  File \"/tmp/ansible_vyos_lag_interfaces_payload_xOAAjj/ansible_vyos_lag_interfaces_payload.zip/ansible/module_utils/network/vyos/config/lag_interfaces/lag_interfaces.py\", line 122, in set_state\nTypeError: 'NoneType' object is not iterable\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}

after
fatal: [192.168.56.101]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "config": null, 
            "state": "merged"
        }
    }, 
    "msg": "config is required for state merged"
}


```
