### PR TITLE
[WIP] systemd - add option to hide status in default output

### DIFF
--- a/changelogs/fragments/systemd-add-option-to-hide-status-in-results.yaml
+++ b/changelogs/fragments/systemd-add-option-to-hide-status-in-results.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd - add ``hide_status`` option to hide service status in default results

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -80,6 +80,14 @@ options:
         type: bool
         default: no
         version_added: "2.3"
+    hide_status:
+        description:
+            - Do not return C(status). This makes the default output from the module less verbose.
+        type: bool
+        default: no
+        version_added: '2.10'
+        aliases:
+            - quiet_output
 notes:
     - Since 2.4, one of the following options is required 'state', 'enabled', 'masked', 'daemon_reload', ('daemon_reexec' since 2.8),
       and all except 'daemon_reload' (and 'daemon_reexec' since 2.8) also require 'name'.
@@ -334,6 +342,7 @@ def main():
             user=dict(type='bool'),
             scope=dict(type='str', choices=['system', 'user', 'global']),
             no_block=dict(type='bool', default=False),
+            hide_status=dict(type='bool', default=False, aliases=['quiet_output']),
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled', 'masked', 'daemon_reload', 'daemon_reexec']],
@@ -524,6 +533,9 @@ def main():
             else:
                 # this should not happen?
                 module.fail_json(msg="Service is in unknown state", status=result['status'])
+
+    if module.params['hide_status']:
+        result.pop('status')
 
     module.exit_json(**result)
 

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -29,14 +29,21 @@
     - name: get a list of running services
       shell: systemctl | fgrep 'running' | awk '{print $1}' | sed 's/\.service//g' | fgrep -v '.' | egrep ^[a-z]
       register: running_names
-    - debug: var=running_names
+
+    - debug:
+        var: running_names
+        verbosity: 2
 
     - name: check running state
       systemd:
-          name: "{{ running_names.stdout_lines|random }}"
+          name: "{{ running_names.stdout_lines | random }}"
           state: started
       register: systemd_test0
-    - debug: var=systemd_test0
+
+    - debug:
+        var: systemd_test0
+        verbosity: 2
+
     - name: validate results for test0
       assert:
           that:
@@ -46,5 +53,17 @@
               - 'systemd_test0.status is defined'
               - 'not systemd_test0.changed'
               - 'systemd_test0.state == "started"'
+
+    - name: Check running state without returning status
+      systemd:
+          name: "{{ running_names.stdout_lines | random }}"
+          state: started
+          hide_status: yes
+      register: systemd_test1
+
+    - name: Ensure status was not returned
+      assert:
+        that:
+          - systemd_test1['status'] is not defined
 
   when: 'systemctl_check.rc == 0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #62519

The default output of `systemd` module includes the service status, which is really verbose and pain to read when running ad-hoc commands.

Add an option to remove the status.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/systemd.py`

##### ADDITIONAL INFORMATION
I'm open to bike shedding on parameter the name.

I am also not sure if it would be better to tie this to verbosity, or if there is a way to return different data based on ad-hoc execution vs. playbook execution. When running with default verbosity in a playbook, the module results are not returned. That means we have some mechanism (probably play context?) for evaluation how a module was called.