### PR TITLE
No traceback on eos resource modules with empty config

### DIFF
--- a/changelogs/fragments/62528-eos-no-traceback.yaml
+++ b/changelogs/fragments/62528-eos-no-traceback.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "EOS resource modules - do not traceback when run with an empty config parameter"

--- a/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
@@ -95,6 +95,9 @@ class Interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)
         if state == 'overridden':

--- a/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
@@ -96,7 +96,7 @@ class Interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)

--- a/lib/ansible/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -96,7 +96,7 @@ class L2_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)

--- a/lib/ansible/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/l2_interfaces/l2_interfaces.py
@@ -95,6 +95,9 @@ class L2_interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)
         if state == 'overridden':

--- a/lib/ansible/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
@@ -95,6 +95,9 @@ class L3_interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)
         if state == 'overridden':

--- a/lib/ansible/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/l3_interfaces/l3_interfaces.py
@@ -96,7 +96,7 @@ class L3_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)

--- a/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
@@ -95,6 +95,9 @@ class Lacp_interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)
         if state == 'overridden':

--- a/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
@@ -96,7 +96,7 @@ class Lacp_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want)
         have = param_list_to_dict(have)

--- a/lib/ansible/module_utils/network/eos/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lag_interfaces/lag_interfaces.py
@@ -96,7 +96,7 @@ class Lag_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'overridden':
             commands = self._state_overridden(want, have)

--- a/lib/ansible/module_utils/network/eos/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lag_interfaces/lag_interfaces.py
@@ -13,9 +13,8 @@ created
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils.network.common.utils import to_list, dict_diff
-
 from ansible.module_utils.network.common.cfg.base import ConfigBase
+from ansible.module_utils.network.common.utils import to_list, dict_diff
 from ansible.module_utils.network.eos.facts.facts import Facts
 from ansible.module_utils.network.eos.utils.utils import normalize_interface
 
@@ -96,6 +95,9 @@ class Lag_interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/eos/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lldp_interfaces/lldp_interfaces.py
@@ -96,7 +96,7 @@ class Lldp_interfaces(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want, remove_key=False)
         have = param_list_to_dict(have, remove_key=False)

--- a/lib/ansible/module_utils/network/eos/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lldp_interfaces/lldp_interfaces.py
@@ -95,6 +95,9 @@ class Lldp_interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want, remove_key=False)
         have = param_list_to_dict(have, remove_key=False)
         if state == 'overridden':

--- a/lib/ansible/module_utils/network/eos/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/eos/config/vlans/vlans.py
@@ -95,7 +95,7 @@ class Vlans(ConfigBase):
         """
         state = self._module.params['state']
         if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         want = param_list_to_dict(want, "vlan_id", remove_key=False)
         have = param_list_to_dict(have, "vlan_id", remove_key=False)

--- a/lib/ansible/module_utils/network/eos/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/eos/config/vlans/vlans.py
@@ -94,6 +94,9 @@ class Vlans(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(state))
+
         want = param_list_to_dict(want, "vlan_id", remove_key=False)
         have = param_list_to_dict(have, "vlan_id", remove_key=False)
         if state == 'overridden':

--- a/test/integration/targets/eos_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/merged.yaml
@@ -63,4 +63,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/merged.yaml
@@ -51,3 +51,16 @@
 - assert:
     that:
       - "expected_config|difference(ansible_facts.network_resources.interfaces)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/overridden.yaml
@@ -51,4 +51,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/overridden.yaml
@@ -39,3 +39,16 @@
 - assert:
     that:
       - "config|difference(ansible_facts.network_resources.interfaces)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
@@ -37,3 +37,16 @@
 - assert:
     that:
       - "config|difference(ansible_facts.network_resources.interfaces)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
@@ -49,4 +49,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/merged.yaml
@@ -62,4 +62,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/merged.yaml
@@ -50,3 +50,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/overridden.yaml
@@ -36,3 +36,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/overridden.yaml
@@ -48,4 +48,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
@@ -51,4 +51,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/replaced.yaml
@@ -39,3 +39,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/merged.yaml
@@ -53,3 +53,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l3_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/merged.yaml
@@ -65,4 +65,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/overridden.yaml
@@ -55,4 +55,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/overridden.yaml
@@ -43,3 +43,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l3_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/replaced.yaml
@@ -46,3 +46,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.l3_interfaces|symmetric_difference(expected_config) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/replaced.yaml
@@ -58,4 +58,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/merged.yaml
@@ -53,4 +53,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/merged.yaml
@@ -41,3 +41,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/overridden.yaml
@@ -47,4 +47,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/overridden.yaml
@@ -35,3 +35,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
@@ -38,3 +38,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
@@ -50,4 +50,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
@@ -43,3 +43,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.lag_interfaces|symmetric_difference(expected_config)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/merged.yaml
@@ -55,4 +55,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/overridden.yaml
@@ -46,4 +46,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/overridden.yaml
@@ -34,3 +34,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.lag_interfaces|symmetric_difference(config)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
@@ -42,3 +42,16 @@
 - assert:
     that:
       - "ansible_facts.network_resources.lag_interfaces|symmetric_difference(expected_config)|length == 0"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/replaced.yaml
@@ -54,4 +54,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/merged.yaml
@@ -42,3 +42,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.lldp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/merged.yaml
@@ -54,4 +54,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/overridden.yaml
@@ -32,3 +32,16 @@
 - assert:
     that:
       - "config|symmetric_difference(ansible_facts.network_resources.lldp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/overridden.yaml
@@ -44,4 +44,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/replaced.yaml
@@ -38,3 +38,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.lldp_interfaces) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/replaced.yaml
@@ -50,4 +50,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_vlans/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/merged.yaml
@@ -52,4 +52,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state merged'"
+      - "result.msg == 'value of config parameter must not be empty for state merged'"

--- a/test/integration/targets/eos_vlans/tests/cli/merged.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/merged.yaml
@@ -40,3 +40,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.vlans) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: merged
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state merged'"

--- a/test/integration/targets/eos_vlans/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/overridden.yaml
@@ -49,4 +49,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state overridden'"
+      - "result.msg == 'value of config parameter must not be empty for state overridden'"

--- a/test/integration/targets/eos_vlans/tests/cli/overridden.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/overridden.yaml
@@ -37,3 +37,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.vlans) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: overridden
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state overridden'"

--- a/test/integration/targets/eos_vlans/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/replaced.yaml
@@ -50,4 +50,4 @@
 - assert:
     that:
       - "result.failed == True"
-      - "result.msg == 'config is required for state replaced'"
+      - "result.msg == 'value of config parameter must not be empty for state replaced'"

--- a/test/integration/targets/eos_vlans/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/replaced.yaml
@@ -38,3 +38,16 @@
 - assert:
     that:
       - "expected_config|symmetric_difference(ansible_facts.network_resources.vlans) == []"
+
+- name: Ensure empty config does not traceback
+  eos_interfaces:
+    config:
+    state: replaced
+  become: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "result.failed == True"
+      - "result.msg == 'config is required for state replaced'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_interfaces
eos_l2_interfaces
eos_l3_interfaces
et al.
