### PR TITLE
Remove unsed / duplicate imports for iosxr module_utils (#61385)

### DIFF
--- a/changelogs/fragments/62541-remove-unsed-import.yaml
+++ b/changelogs/fragments/62541-remove-unsed-import.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove unused import from iosxr l3_interfaces facts library.

--- a/lib/ansible/module_utils/network/iosxr/facts/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/iosxr/facts/l3_interfaces/l3_interfaces.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 from copy import deepcopy
 import re
 from ansible.module_utils.network.common import utils
-from ansible.module_utils.network.iosxr.utils.utils import get_interface_type, normalize_interface
+from ansible.module_utils.network.iosxr.utils.utils import get_interface_type
 from ansible.module_utils.network.iosxr.argspec.l3_interfaces.l3_interfaces import L3_InterfacesArgs
 
 


### PR DESCRIPTION
(cherry picked from commit 5a60bdd3083103167c5ec9e5a597edf94dc89631)
Signed-off-by: Paul Belanger <pabelanger@redhat.com>