### PR TITLE
[stable-2.9] cron - Use get_bin_path() to find executable (#59765)

### DIFF
--- a/changelogs/fragments/59765-cron-cronvar-use-get-bin-path.yaml
+++ b/changelogs/fragments/59765-cron-cronvar-use-get-bin-path.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron and cronvar - use get_bin_path utility to locate the default crontab executable instead of the hardcoded /usr/bin/crontab. (https://github.com/ansible/ansible/pull/59765)

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -216,9 +216,6 @@ from ansible.module_utils.basic import AnsibleModule, get_platform
 from ansible.module_utils.six.moves import shlex_quote
 
 
-CRONCMD = "/usr/bin/crontab"
-
-
 class CronTabError(Exception):
     pass
 
@@ -512,28 +509,30 @@ class CronTab(object):
         Returns the command line for reading a crontab
         """
         user = ''
+        cron_cmd = self.module.get_bin_path('crontab', required=True)
         if self.user:
             if platform.system() == 'SunOS':
-                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(CRONCMD))
+                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(cron_cmd))
             elif platform.system() == 'AIX':
-                return "%s -l %s" % (shlex_quote(CRONCMD), shlex_quote(self.user))
+                return "%s -l %s" % (shlex_quote(cron_cmd), shlex_quote(self.user))
             elif platform.system() == 'HP-UX':
-                return "%s %s %s" % (CRONCMD, '-l', shlex_quote(self.user))
+                return "%s %s %s" % (cron_cmd, '-l', shlex_quote(self.user))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (CRONCMD, user, '-l')
+        return "%s %s %s" % (cron_cmd, user, '-l')
 
     def _write_execute(self, path):
         """
         Return the command line for writing a crontab
         """
+        cron_cmd = self.module.get_bin_path('crontab', required=True)
         user = ''
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
-                return "chown %s %s ; su '%s' -c '%s %s'" % (shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), CRONCMD, shlex_quote(path))
+                return "chown %s %s ; su '%s' -c '%s %s'" % (shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), cron_cmd, shlex_quote(path))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (CRONCMD, user, shlex_quote(path))
+        return "%s %s %s" % (cron_cmd, user, shlex_quote(path))
 
 
 def main():

--- a/lib/ansible/modules/system/cronvar.py
+++ b/lib/ansible/modules/system/cronvar.py
@@ -108,8 +108,6 @@ import tempfile
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
-CRONCMD = "/usr/bin/crontab"
-
 
 class CronVarError(Exception):
     pass
@@ -292,30 +290,32 @@ class CronVar(object):
         """
         Returns the command line for reading a crontab
         """
+        cron_cmd = self.module.get_bin_path('crontab', required=True)
         user = ''
 
         if self.user:
             if platform.system() == 'SunOS':
-                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(CRONCMD))
+                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(cron_cmd))
             elif platform.system() == 'AIX':
-                return "%s -l %s" % (shlex_quote(CRONCMD), shlex_quote(self.user))
+                return "%s -l %s" % (shlex_quote(cron_cmd), shlex_quote(self.user))
             elif platform.system() == 'HP-UX':
-                return "%s %s %s" % (CRONCMD, '-l', shlex_quote(self.user))
+                return "%s %s %s" % (cron_cmd, '-l', shlex_quote(self.user))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (CRONCMD, user, '-l')
+        return "%s %s %s" % (cron_cmd, user, '-l')
 
     def _write_execute(self, path):
         """
         Return the command line for writing a crontab
         """
+        cron_cmd = self.module.get_bin_path('crontab', required=True)
         user = ''
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
-                return "chown %s %s ; su '%s' -c '%s %s'" % (shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), CRONCMD, shlex_quote(path))
+                return "chown %s %s ; su '%s' -c '%s %s'" % (shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), cron_cmd, shlex_quote(path))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (CRONCMD, user, shlex_quote(path))
+        return "%s %s %s" % (cron_cmd, user, shlex_quote(path))
 
 
 # ==================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #59765 for Ansible 2.9
(cherry picked from commit 951a80c8b0)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/cron.py`