### PR TITLE
cron - Only run get_bin_path() once

### DIFF
--- a/changelogs/fragments/cron-only-get-bin-path-once.yaml
+++ b/changelogs/fragments/cron-only-get-bin-path-once.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron cronvar - only run ``get_bin_path()`` once

--- a/lib/ansible/modules/system/cronvar.py
+++ b/lib/ansible/modules/system/cronvar.py
@@ -126,6 +126,7 @@ class CronVar(object):
         self.user = user
         self.lines = None
         self.wordchars = ''.join(chr(x) for x in range(128) if chr(x) not in ('=', "'", '"',))
+        self.cron_cmd = self.module.get_bin_path('cronvar', required=True)
 
         if cron_file:
             self.cron_file = ""
@@ -290,32 +291,31 @@ class CronVar(object):
         """
         Returns the command line for reading a crontab
         """
-        cron_cmd = self.module.get_bin_path('crontab', required=True)
         user = ''
 
         if self.user:
             if platform.system() == 'SunOS':
-                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(cron_cmd))
+                return "su %s -c '%s -l'" % (shlex_quote(self.user), shlex_quote(self.cron_cmd))
             elif platform.system() == 'AIX':
-                return "%s -l %s" % (shlex_quote(cron_cmd), shlex_quote(self.user))
+                return "%s -l %s" % (shlex_quote(self.cron_cmd), shlex_quote(self.user))
             elif platform.system() == 'HP-UX':
-                return "%s %s %s" % (cron_cmd, '-l', shlex_quote(self.user))
+                return "%s %s %s" % (self.cron_cmd, '-l', shlex_quote(self.user))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (cron_cmd, user, '-l')
+        return "%s %s %s" % (self.cron_cmd, user, '-l')
 
     def _write_execute(self, path):
         """
         Return the command line for writing a crontab
         """
-        cron_cmd = self.module.get_bin_path('crontab', required=True)
         user = ''
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
-                return "chown %s %s ; su '%s' -c '%s %s'" % (shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), cron_cmd, shlex_quote(path))
+                return "chown %s %s ; su '%s' -c '%s %s'" % (
+                    shlex_quote(self.user), shlex_quote(path), shlex_quote(self.user), self.cron_cmd, shlex_quote(path))
             elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % shlex_quote(self.user)
-        return "%s %s %s" % (cron_cmd, user, shlex_quote(path))
+        return "%s %s %s" % (self.cron_cmd, user, shlex_quote(path))
 
 
 # ==================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Per @abadger's suggestion [here](https://github.com/ansible/ansible/pull/62544#pullrequestreview-290182966), only run `get_bin_path()` once.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/cron.py`
`lib/ansible/modules/system/cronvar.py`