### PR TITLE
[2.9 backport] fix collection jinja2 cache issue (#62543)

### DIFF
--- a/changelogs/fragments/collection_jinja_cache_fix.yml
+++ b/changelogs/fragments/collection_jinja_cache_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - collection loader - ensure Jinja function cache is fully-populated before lookup

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -350,12 +350,10 @@ class JinjaPluginIntercept(MutableMapping):
 
             for f in iteritems(method_map()):
                 fq_name = '.'.join((parent_prefix, f[0]))
+                # FIXME: detect/warn on intra-collection function name collisions
                 self._collection_jinja_func_cache[fq_name] = f[1]
 
-            function_impl = self._collection_jinja_func_cache[key]
-
-        # FIXME: detect/warn on intra-collection function name collisions
-
+        function_impl = self._collection_jinja_func_cache[key]
         return function_impl
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
##### SUMMARY
Backport #62543 to 2.9

* prevents premature lookup (and potential KeyError) of Jinja filter/test function cache that's not fully populated

(cherry picked from commit d0c7b42e58fbae1832eaed699865fdd2f27b07cc)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
