### PR TITLE
psexec - Fix kerb and interactive support

### DIFF
--- a/changelogs/fragments/psexec-kerb-and-interactive.yaml
+++ b/changelogs/fragments/psexec-kerb-and-interactive.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- psexec - Fix issue where the Kerberos package was not detected as being available.
+- psexec - Fix issue where the ``interactive`` option was not being passed down to the library.

--- a/lib/ansible/modules/commands/psexec.py
+++ b/lib/ansible/modules/commands/psexec.py
@@ -443,7 +443,7 @@ def main():
     process_timeout = module.params['process_timeout']
     stdin = module.params['stdin']
 
-    if connection_username is None or connection_password is None and \
+    if (connection_username is None or connection_password is None) and \
             not HAS_KERBEROS:
         module.fail_json(msg=missing_required_lib("gssapi"),
                          execption=KERBEROS_IMP_ERR)
@@ -476,7 +476,8 @@ def main():
     b_stdin = to_bytes(stdin, encoding='utf-8') if stdin else None
     run_args = dict(
         executable=executable, arguments=arguments, asynchronous=asynchronous,
-        load_profile=load_profile, interactive_session=interactive_session,
+        load_profile=load_profile, interactive=interactive,
+        interactive_session=interactive_session,
         run_elevated=elevated, run_limited=limited,
         username=process_username, password=process_password,
         use_system_account=use_system, working_dir=working_directory,


### PR DESCRIPTION
##### SUMMARY
Fix issue where the library would fail because the kerb optional packages were available but the if statement check was incorrect causing a failure. Also fix an issue where the `interactive` module option was not being passed down.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psexec