### PR TITLE
[2.9 backport] Fix plugin names for collection plugins. (#60317)

### DIFF
--- a/changelogs/fragments/collection_loader_import_fixes.yml
+++ b/changelogs/fragments/collection_loader_import_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - collection loader - fixed relative imports on Python 2.7, ensure pluginloader caches use full name to prevent names from being clobbered (https://github.com/ansible/ansible/pull/60317)

--- a/test/integration/targets/collections_plugin_namespace/aliases
+++ b/test/integration/targets/collections_plugin_namespace/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+skip/python2.6

--- a/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/filter/test_filter.py
+++ b/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/filter/test_filter.py
@@ -1,0 +1,15 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def filter_name(a):
+    return __name__
+
+
+class FilterModule(object):
+    def filters(self):
+        filters = {
+            'filter_name': filter_name,
+        }
+
+        return filters

--- a/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_name.py
+++ b/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_name.py
@@ -1,0 +1,9 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__name__]

--- a/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_no_future_boilerplate.py
+++ b/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_no_future_boilerplate.py
@@ -1,0 +1,10 @@
+# do not add future boilerplate to this plugin
+# specifically, do not add absolute_import, as the purpose of this plugin is to test implicit relative imports on Python 2.x
+__metaclass__ = type
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return [__name__]

--- a/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/test/test_test.py
+++ b/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/test/test_test.py
@@ -1,0 +1,13 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def test_name_ok(value):
+    return __name__ == 'ansible_collections.my_ns.my_col.plugins.test.test_test'
+
+
+class TestModule:
+    def tests(self):
+        return {
+            'test_name_ok': test_name_ok,
+        }

--- a/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
+++ b/test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/roles/test/tasks/main.yml
@@ -1,0 +1,12 @@
+- set_fact:
+    filter_name: "{{ 1 | my_ns.my_col.filter_name }}"
+    lookup_name: "{{ lookup('my_ns.my_col.lookup_name') }}"
+    lookup_no_future_boilerplate: "{{ lookup('my_ns.my_col.lookup_no_future_boilerplate') }}"
+    test_name_ok: "{{ 1 is my_ns.my_col.test_name_ok }}"
+
+- assert:
+    that:
+      - filter_name == 'ansible_collections.my_ns.my_col.plugins.filter.test_filter'
+      - lookup_name == 'ansible_collections.my_ns.my_col.plugins.lookup.lookup_name'
+      - lookup_no_future_boilerplate == 'ansible_collections.my_ns.my_col.plugins.lookup.lookup_no_future_boilerplate'
+      - test_name_ok

--- a/test/integration/targets/collections_plugin_namespace/runme.sh
+++ b/test/integration/targets/collections_plugin_namespace/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_COLLECTIONS_PATHS="${PWD}/collection_root" ansible-playbook test.yml -i ../../inventory "$@"

--- a/test/integration/targets/collections_plugin_namespace/test.yml
+++ b/test/integration/targets/collections_plugin_namespace/test.yml
@@ -1,0 +1,3 @@
+- hosts: testhost
+  roles:
+    - my_ns.my_col.test

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5951,6 +5951,7 @@ test/integration/targets/async_fail/library/async_test.py future-import-boilerpl
 test/integration/targets/async_fail/library/async_test.py metaclass-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py future-import-boilerplate
 test/integration/targets/aws_lambda/files/mini_lambda.py metaclass-boilerplate
+test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_no_future_boilerplate.py future-import-boilerplate
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util2.py pylint:relative-beyond-top-level
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/my_util3.py pylint:relative-beyond-top-level
 test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/my_module.py pylint:relative-beyond-top-level


### PR DESCRIPTION
Backport of #60317 to 2.9

* Fix plugin names for collection plugins.

Add an integration test to verify plugin __name__ is correct for collection plugins.

* Fix collection loader PEP 302 compliance.

The `find_module` function now returns `None` if the module cannot be found. Previously it would return `self` for modules which did not exist.

Returning a loader from `find_module` which cannot find the module will result in import errors on Python 2.x when using implicit relative imports.

* add changelog

* sanity/units/merge fixes

(cherry picked from commit 1c64dba3c9800deabb45b75bfd17b951b66e0eee)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
