### PR TITLE
Include computer_name in VM instance facts

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
@@ -222,7 +222,7 @@ class AzureRMVirtualMachineScaleSetVMInfo(AzureRMModuleBase):
             'provisioning_state': d.get('provisioning_state', None),
             'power_state': power_state,
             'vm_id': d.get('vm_id', None),
-            'computer_name': d.get('os_profile').get('computer_name')
+            'computer_name': d.get('os_profile').get('computer_name', None)
         }
         return d
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescalesetinstance_info.py
@@ -221,7 +221,8 @@ class AzureRMVirtualMachineScaleSetVMInfo(AzureRMModuleBase):
             'name': d.get('name', None),
             'provisioning_state': d.get('provisioning_state', None),
             'power_state': power_state,
-            'vm_id': d.get('vm_id', None)
+            'vm_id': d.get('vm_id', None),
+            'computer_name': d.get('os_profile').get('computer_name')
         }
         return d
 


### PR DESCRIPTION
Implement #62564 by returning the computer name from OS profile

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #62564 by additionally returning computer_name in VM instance facts

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachinescalesetinstance_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE:

            {
                "id": "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/virtualMachineScaleSets/somevmss/virtualMachines/7",
                "instance_id": "7",
                "latest_model": true,
                "name": "somevmss_7",
                "power_state": "running",
                "provisioning_state": "Succeeded",
                "resource_group": "...",
                "tags": null,
                "vm_id": "..."
            }


AFTER:
            {
                "computer_name": "somevmss000007",
                "id": "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/virtualMachineScaleSets/somevmss/virtualMachines/7",
                "instance_id": "7",
                "latest_model": true,
                "name": "somevmss_7",
                "power_state": "running",
                "provisioning_state": "Succeeded",
                "resource_group": "...",
                "tags": null,
                "vm_id": "..."
            }
```
