### PR TITLE
Ensure k8s apply works with check mode (#60572)

### DIFF
--- a/changelogs/fragments/60510-k8s-apply-check-mode.yml
+++ b/changelogs/fragments/60510-k8s-apply-check-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - k8s - ensure that apply works with check mode. Bumps minimum openshift version for apply to 0.9.2.

--- a/test/integration/targets/k8s/tasks/apply.yml
+++ b/test/integration/targets/k8s/tasks/apply.yml
@@ -55,6 +55,27 @@
         that:
           - k8s_configmap_2 is not changed
 
+    - name: add same configmap again with check mode on
+      k8s:
+        definition:
+          kind: ConfigMap
+          apiVersion: v1
+          metadata:
+            name: "apply-configmap"
+            namespace: "{{ apply_namespace }}"
+          data:
+            one: "1"
+            two: "2"
+            three: "3"
+        apply: yes
+      check_mode: yes
+      register: k8s_configmap_check
+
+    - name: check nothing changed
+      assert:
+        that:
+          - k8s_configmap_check is not changed
+
     - name: add same configmap again but using name and namespace args
       k8s:
         name: "apply-configmap"

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - pip:
     name:
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -25,13 +25,14 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Test validate with kubernetes-validate
 
 - pip:
     name:
       - kubernetes-validate==1.12.0
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -45,6 +46,7 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Test graceful failure for older versions of openshift
 
@@ -66,12 +68,13 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes
 
 # Run full test suite
 
 - pip:
     name:
-      - 'openshift>=0.9.0'
+      - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -86,3 +89,4 @@
 - file:
     path: "{{ virtualenv }}"
     state: absent
+  no_log: yes

--- a/test/integration/targets/k8s/tasks/older_openshift_fail.yml
+++ b/test/integration/targets/k8s/tasks/older_openshift_fail.yml
@@ -66,4 +66,4 @@
       assert:
         that:
           - k8s_apply is failed
-          - "k8s_apply.msg.startswith('Failed to import the required Python library (openshift >= 0.9.0)')"
+          - "k8s_apply.msg.startswith('Failed to import the required Python library (openshift >= 0.9.2)')"


### PR DESCRIPTION
##### SUMMARY
* Ensure k8s apply works with check mode

Update the new predicted object with fields from the previous object
before applying in check mode

Don't log output of `file` with `state: absent` on huge virtualenvs!

Fixes #60510

* Use openshift client fix to improve apply for check mode

Use new apply_object method to get a better approximation
of the expected object in check mode.

Requires released upgrade to openshift

* Add changelog fragment for k8s apply check mode fix

* Update changelogs/fragments/60510-k8s-apply-check-mode.yml

Co-Authored-By: Felix Fontein <felix@fontein.de>
(cherry picked from commit a684bb9f5b70fb666e26cb2d0f2b357760565951)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/k8s/raw.py
