### PR TITLE
Fix traceback empty config error to meaningful msg for IOS 

### DIFF
--- a/changelogs/fragments/62538-fix-taceback-with-empty-config.yaml
+++ b/changelogs/fragments/62538-fix-taceback-with-empty-config.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Fix traceback with empty config error msg(https://github.com/ansible/ansible/pull/62538)"

--- a/lib/ansible/module_utils/network/ios/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/interfaces/interfaces.py
@@ -105,7 +105,10 @@ class Interfaces(ConfigBase):
                   to the deisred configuration
         """
         commands = []
+
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'overridden':
             commands = self._state_overridden(want, have)

--- a/lib/ansible/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l2_interfaces/l2_interfaces.py
@@ -100,6 +100,9 @@ class L2_Interfaces(ConfigBase):
         commands = []
 
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have, self._module)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -96,6 +96,9 @@ class L3_Interfaces(ConfigBase):
         commands = []
 
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have, self._module)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/ios/config/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/ios/config/lacp/lacp.py
@@ -102,6 +102,9 @@ class Lacp(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'deleted':
             commands = self._state_deleted(want, have)
         elif state == 'merged':

--- a/lib/ansible/module_utils/network/ios/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/lacp_interfaces/lacp_interfaces.py
@@ -104,7 +104,12 @@ class Lacp_Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
+        commands = []
+
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/ios/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/lag_interfaces/lag_interfaces.py
@@ -104,6 +104,9 @@ class Lag_interfaces(ConfigBase):
         """
 
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         module = self._module
         if state == 'overridden':
             commands = self._state_overridden(want, have, module)

--- a/lib/ansible/module_utils/network/ios/config/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/ios/config/lldp_global/lldp_global.py
@@ -109,6 +109,8 @@ class Lldp_global(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+        if state in ('merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
 
         if state == 'overridden':
             commands = self._state_overridden(want, have)

--- a/lib/ansible/module_utils/network/ios/config/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/lldp_interfaces/lldp_interfaces.py
@@ -105,6 +105,9 @@ class Lldp_Interfaces(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/ios/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/ios/config/vlans/vlans.py
@@ -100,6 +100,9 @@ class Vlans(ConfigBase):
                   to the desired configuration
         """
         state = self._module.params['state']
+        if state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands = self._state_overridden(want, have, state)
         elif state == 'deleted':

--- a/lib/ansible/module_utils/network/ios/facts/lldp_interfaces/lldp_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/lldp_interfaces/lldp_interfaces.py
@@ -85,7 +85,9 @@ class Lldp_InterfacesFacts(object):
         """
         config = deepcopy(spec)
         match = re.search(r'^(\S+)(:)', conf)
-        intf = match.group(1)
+        intf = ''
+        if match:
+            intf = match.group(1)
 
         if get_interface_type(intf) == 'unknown':
             return {}

--- a/test/integration/targets/ios_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START ios_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  ios_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  ios_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  ios_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/ios_l2_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_l2_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START ios_l2_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  ios_l2_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  ios_l2_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  ios_l2_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START ios_l3_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  ios_l3_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  ios_l3_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  ios_l3_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/ios_lacp/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_lacp/tests/cli/empty_config.yaml
@@ -1,0 +1,27 @@
+---
+- debug:
+      msg: "START ios_lacp empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- block:
+    - name: Merged with empty config should give appropriate error message
+      ios_lacp:
+        config:
+        state: merged
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state merged'
+
+    - name: Replaced with empty config should give appropriate error message
+      ios_lacp:
+        config:
+        state: replaced
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state replaced'
+  when: ansible_net_version != "15.6(2)T"

--- a/test/integration/targets/ios_lacp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_lacp_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,38 @@
+---
+- debug:
+      msg: "START ios_lacp_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- block:
+    - name: Merged with empty config should give appropriate error message
+      ios_lacp_interfaces:
+        config:
+        state: merged
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state merged'
+
+    - name: Replaced with empty config should give appropriate error message
+      ios_lacp_interfaces:
+        config:
+        state: replaced
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state replaced'
+
+    - name: Overridden with empty config should give appropriate error message
+      ios_lacp_interfaces:
+        config:
+        state: overridden
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state overridden'
+  when: ansible_net_version != "15.6(2)T"

--- a/test/integration/targets/ios_lag_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_lag_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,38 @@
+---
+- debug:
+      msg: "START ios_lag_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- block:
+    - name: Merged with empty config should give appropriate error message
+      ios_lag_interfaces:
+        config:
+        state: merged
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state merged'
+
+    - name: Replaced with empty config should give appropriate error message
+      ios_lag_interfaces:
+        config:
+        state: replaced
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state replaced'
+
+    - name: Overridden with empty config should give appropriate error message
+      ios_lag_interfaces:
+        config:
+        state: overridden
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state overridden'
+  when: ansible_net_version != "15.6(2)T"

--- a/test/integration/targets/ios_lldp_global/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_lldp_global/tests/cli/empty_config.yaml
@@ -1,0 +1,25 @@
+---
+- debug:
+      msg: "START ios_lldp_global empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  ios_lldp_global:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  ios_lldp_global:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'

--- a/test/integration/targets/ios_lldp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_lldp_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START ios_lldp_interfaces empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  ios_lldp_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  ios_lldp_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  ios_lldp_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/ios_vlans/tests/cli/empty_config.yaml
+++ b/test/integration/targets/ios_vlans/tests/cli/empty_config.yaml
@@ -1,0 +1,38 @@
+---
+- debug:
+      msg: "START ios_vlans empty_config.yaml integration tests on connection={{ ansible_connection }}"
+
+- block:
+    - name: Merged with empty config should give appropriate error message
+      ios_vlans:
+        config:
+        state: merged
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state merged'
+
+    - name: Replaced with empty config should give appropriate error message
+      ios_vlans:
+        config:
+        state: replaced
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state replaced'
+
+    - name: Overridden with empty config should give appropriate error message
+      ios_vlans:
+        config:
+        state: overridden
+      register: result
+      ignore_errors: True
+
+    - assert:
+        that:
+          - result.msg == 'value of config parameter must not be empty for state overridden'
+  when: ansible_net_version != "15.6(2)T"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cherry-pick: 35463d45f4abc04f369f1654678f104d82e33201
Backport PR to fix traceback empty config error to meaningful msg for IOS #62538
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
