### PR TITLE
fix for ios banner to allow content starting with white spaces without stripping them

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -89,10 +89,9 @@ commands:
     - string
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.connection import exec_command
-from ansible.module_utils.network.ios.ios import load_config
+from ansible.module_utils.network.ios.ios import get_config, load_config
 from ansible.module_utils.network.ios.ios import ios_argument_spec
-import re
+from re import search, M
 
 
 def map_obj_to_commands(updates, module):
@@ -107,7 +106,7 @@ def map_obj_to_commands(updates, module):
         if want['text'] and (want['text'] != have.get('text')):
             banner_cmd = 'banner %s' % module.params['banner']
             banner_cmd += ' @\n'
-            banner_cmd += want['text'].strip()
+            banner_cmd += want['text'].strip('\n')
             banner_cmd += '\n@'
             commands.append(banner_cmd)
 
@@ -115,17 +114,21 @@ def map_obj_to_commands(updates, module):
 
 
 def map_config_to_obj(module):
-    rc, out, err = exec_command(module, 'show banner %s' % module.params['banner'])
-    if rc == 0:
-        output = out
-    else:
-        rc, out, err = exec_command(module,
-                                    'show running-config | begin banner %s'
-                                    % module.params['banner'])
-        if out:
-            output = re.search(r'\^C(.*?)\^C', out, re.S).group(1).strip()
+    """
+    This function gets the banner config without stripping any whitespaces,
+    and then fetches the required banner from it.
+    :param module:
+    :return: banner config dict object.
+    """
+    out = get_config(module, flags='| begin banner %s' % module.params['banner'])
+    if out:
+        regex = 'banner ' + module.params['banner'] + ' ^C\n'
+        if search('banner ' + module.params['banner'], out, M):
+            output = str((out.split(regex))[1].split("^C\n")[0])
         else:
             output = None
+    else:
+        output = None
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
         obj['text'] = output
@@ -135,9 +138,6 @@ def map_config_to_obj(module):
 
 def map_params_to_obj(module):
     text = module.params['text']
-    if text:
-        text = str(text).strip()
-
     return {
         'banner': module.params['banner'],
         'text': text,

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -30,20 +30,21 @@ class TestIosBannerModule(TestIosModule):
     def setUp(self):
         super(TestIosBannerModule, self).setUp()
 
-        self.mock_exec_command = patch('ansible.modules.network.ios.ios_banner.exec_command')
-        self.exec_command = self.mock_exec_command.start()
+        self.mock_get_config = patch('ansible.modules.network.ios.ios_banner.get_config')
+        self.get_config = self.mock_get_config.start()
 
         self.mock_load_config = patch('ansible.modules.network.ios.ios_banner.load_config')
         self.load_config = self.mock_load_config.start()
 
     def tearDown(self):
         super(TestIosBannerModule, self).tearDown()
-        self.mock_exec_command.stop()
+        self.mock_get_config.stop()
         self.mock_load_config.stop()
 
     def load_fixtures(self, commands=None):
-        self.exec_command.return_value = (0, load_fixture('ios_banner_show_banner.txt').strip(), None)
-        self.load_config.return_value = dict(diff=None, session='session')
+        def load_from_file(*args, **kwargs):
+            return load_fixture('ios_banner_show_running_config_ios12.txt')
+        self.get_config.side_effect = load_from_file
 
     def test_ios_banner_create(self):
         for banner_type in ('login', 'motd', 'exec', 'incoming', 'slip-ppp'):
@@ -57,21 +58,19 @@ class TestIosBannerModule(TestIosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_ios_banner_nochange(self):
-        banner_text = load_fixture('ios_banner_show_banner.txt').strip()
+        banner_text = load_fixture('ios_banner_show_banner.txt')
         set_module_args(dict(banner='login', text=banner_text))
         self.execute_module()
 
 
 class TestIosBannerIos12Module(TestIosBannerModule):
 
-    def load_fixtures(self, commands):
-        show_banner_return_value = (1, '', None)
-        show_running_config_return_value = \
-            (0, load_fixture('ios_banner_show_running_config_ios12.txt').strip(), None)
-        self.exec_command.side_effect = [show_banner_return_value,
-                                         show_running_config_return_value]
+    def load_fixtures(self, commands=None):
+        def load_from_file(*args, **kwargs):
+            return load_fixture('ios_banner_show_running_config_ios12.txt')
+        self.get_config.side_effect = load_from_file
 
     def test_ios_banner_nochange(self):
-        banner_text = load_fixture('ios_banner_show_banner.txt').strip()
+        banner_text = load_fixture('ios_banner_show_banner.txt')
         set_module_args(dict(banner='exec', text=banner_text))
         self.execute_module()


### PR DESCRIPTION
Signed-off-by: rohitthakur2590 <rohitthakur2590@outlook.com>
ios banner allowing content starting with space  without (stripping spaces).
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #61955
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_banner
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Banner should be allowed even starting with spaces.
example : 
            WARNING
This is a private system if you
do not belong here, you should go then.
Doesn't matter even if you are a hacker.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before:
WARNING
This is a private system if you
do not belong here, you should go then.
Doesn't matter even if you are a hacker.

after
            WARNING
This is a private system if you
do not belong here, you should go then.
Doesn't matter even if you are a hacker.
```
