### PR TITLE
big revamp on xfconf, adding array values

### DIFF
--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -21,6 +21,8 @@ short_description: Edit XFCE4 Configurations
 description:
   - This module allows for the manipulation of Xfce 4 Configuration via
     xfconf-query.  Please see the xfconf-query(1) man pages for more details.
+    
+    TO-DO: add unit tests, add a 'list' state to retrieve properties, add recursive reset
 version_added: "2.8"
 options:
   channel:
@@ -38,16 +40,21 @@ options:
     description:
     - Preference properties typically have simple values such as strings,
       integers, or lists of strings and integers. This is ignored if the state
-      is "get". See man xfconf-query(1)
+      is "get". For array mode, use a list of values. See man xfconf-query(1)
   value_type:
     description:
     - The type of value being set. This is ignored if the state is "get".
-    choices: [ int, bool, float, string ]
+      For array mode, use a list of types.
   state:
     description:
     - The action to take upon the property/value.
     choices: [ get, present, absent ]
     default: "present"
+  force_array:
+    description:
+    - Force array even if only one element
+    type: bool
+    default: 'no'
 """
 
 EXAMPLES = """
@@ -57,9 +64,19 @@ EXAMPLES = """
     property: "/Xft/DPI"
     value_type: "int"
     value: "192"
-  become: True
-  become_user: johnsmith
-
+- name: Set workspace names (4)
+  xfconf:
+    channel: xfwm4
+    property: /general/workspace_names
+    value_type: string
+    value: ['Main', 'Work1', 'Work2', 'Tmp']
+- name: Set workspace names (1)
+  xfconf:
+    channel: xfwm4
+    property: /general/workspace_names
+    value_type: string
+    value: ['Main']
+    force_array: yes
 """
 
 RETURN = '''
@@ -83,132 +100,205 @@ RETURN = '''
     returned: success
     type: str
     sample: "192"
-...
+  previous_value:
+    description: The value of the preference key before executing the module (None for "get" state)
+    returned: success
+    type: str
+    sample: "96"
 '''
-
-import sys
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
 
-class XfconfPreference(object):
-    def __init__(self, module, channel, property, value_type, value):
+class XfConfException(Exception):
+    pass
+
+
+class XfConfProperty(object):
+    SET = "present"
+    GET = "get"
+    RESET = "absent"
+    VALID_STATES = (SET, GET, RESET)
+    VALID_VALUE_TYPES = ('int', 'bool', 'float', 'string')
+    previous_value = None
+    is_array = None
+
+    def __init__(self, module):
         self.module = module
-        self.channel = channel
-        self.property = property
-        self.value_type = value_type
-        self.value = value
+        self.channel = module.params['channel']
+        self.property = module.params['property']
+        self.value_type = module.params['value_type']
+        self.value = module.params['value']
+        self.force_array = module.params['force_array']
 
-    def call(self, call_type, fail_onerr=True):
-        """ Helper function to perform xfconf-query operations """
-        changed = False
-        out = ''
+        self.cmd = "{0} --channel {1} --property {2}".format(
+                module.get_bin_path('xfconf-query', True),
+                shlex_quote(self.channel),
+                shlex_quote(self.property)
+        )
+        self.method_map = dict(zip((self.SET, self.GET, self.RESET),
+                                   (self.set, self.get, self.reset)))
 
-        # Execute the call
-        cmd = "{0} --channel {1} --property {2}".format(self.module.get_bin_path('xfconf-query', True),
-                                                        shlex_quote(self.channel),
-                                                        shlex_quote(self.property))
+        # @TODO This will not work with non-English translations, but xfconf-query does not return
+        #       distinct result codes for distinct outcomes.
+        self.does_not = 'Property "{0}" does not exist on channel "{1}".'.format(self.property, self.channel)
+
+        def run(cmd):
+            return module.run_command(cmd, check_rc=False)
+        self._run = run
+
+    def _execute_xfconf_query(self, args=None):
         try:
-            if call_type == 'set':
-                cmd += " --type {0} --create --set {1}".format(shlex_quote(self.value_type),
-                                                               shlex_quote(self.value))
-            elif call_type == 'unset':
-                cmd += " --reset"
+            cmd = self.cmd
+            if args:
+                cmd = "{0} {1}".format(cmd, args)
 
-            # Start external command
-            rc, out, err = self.module.run_command(cmd, check_rc=False)
+            self.module.debug("Running cmd={0}".format(cmd))
+            rc, out, err = self._run(cmd)
+            if err.rstrip() == self.does_not:
+                return None
+            if rc or len(err):
+                raise XfConfException('xfconf-query failed with error (rc={0}): {1}'.format(rc, err))
 
-            if rc != 0 or len(err) > 0:
-                if fail_onerr:
-                    self.module.fail_json(msg='xfconf-query failed with error: %s' % (str(err)))
-            else:
-                changed = True
+            return out.rstrip()
 
         except OSError as exception:
-            self.module.fail_json(msg='xfconf-query failed with exception: %s' % exception)
-        return changed, out.rstrip()
+            XfConfException('xfconf-query failed with exception: {0}'.format(exception))
+
+    def get(self):
+        previous_value = self._execute_xfconf_query()
+        if previous_value is None:
+            return
+
+        if "Value is an array with" in previous_value:
+            previous_value = previous_value.split("\n")
+            previous_value.pop(0)
+            previous_value.pop(0)
+
+        return previous_value
+
+    def reset(self):
+        self._execute_xfconf_query("--reset")
+        return None
+        
+    @staticmethod
+    def _fix_bool(value):
+        if value.lower() in ("true", "false"):
+            value = value.lower()
+        return value
+
+    def _make_value_args(self, value, value_type):
+        if value_type == 'bool':
+            value = self._fix_bool(value)
+        return " --type '{1}' --set '{0}'".format(shlex_quote(value), shlex_quote(value_type))
+
+    def set(self):
+        args = "--create"
+        if self.is_array:
+            args += " --force-array"
+            for v in zip(self.value, self.value_type):
+                args += self._make_value_args(*v)
+        else:
+            args += self._make_value_args(self.value, self.value_type)
+        self._execute_xfconf_query(args)
+        return self.value
+
+    def call(self, state):
+        return self.method_map[state]()
+
+    def sanitize(self):
+        self.previous_value = self.get()
+
+        if self.value is None and self.value_type is None:
+            return
+        if (self.value is None) ^ (self.value_type is None):
+            raise XfConfException('Must set both "value" and "value_type"')
+
+        # Check for invalid value types
+        for v in self.value_type:
+            if v not in self.VALID_VALUE_TYPES:
+                raise XfConfException('value_type {0} is not supported'.format(v))
+
+        # stringify all values - in the CLI they will all be happy strings anyway
+        # and by doing this here the rest of the code can be agnostic to it
+        self.value = [str(v) for v in self.value]
+
+        values_len = len(self.value)
+        types_len = len(self.value_type)
+
+        if types_len == 1:
+            # use one single type for the entire list
+            self.value_type = self.value_type * values_len
+        elif types_len != values_len:
+            # or complain if lists' lengths are different
+            raise XfConfException('Same number of "value" and "value_type" needed')
+
+        # fix boolean values
+        self.value = [self._fix_bool(v[0]) if v[1] == 'bool' else v[0] for v in zip(self.value, self.value_type)]
+
+        # calculates if it is an array
+        self.is_array = self.force_array or isinstance(self.previous_value, list) or values_len > 1
+        if not self.is_array:
+            self.value = self.value[0]
+            self.value_type = self.value_type[0]
 
 
 def main():
+    module_name = "xfconf"
     # Setup the Ansible module
     module = AnsibleModule(
         argument_spec=dict(
             channel=dict(required=True, type='str'),
             property=dict(required=True, type='str'),
-            value_type=dict(required=False,
-                            choices=['int', 'bool', 'float', 'string'],
-                            type='str'),
-            value=dict(required=False, default=None, type='str'),
-            state=dict(default='present',
-                       choices=['present', 'get', 'absent'],
-                       type='str')
+            value_type=dict(required=False, type='list'),
+            value=dict(required=False, type='list'),
+            state=dict(default=XfConfProperty.SET,
+                       choices=XfConfProperty.VALID_STATES,
+                       type='str'),
+            force_array=dict(default=False, type='bool', aliases=['array']),
         ),
         supports_check_mode=True
     )
 
-    state_values = {"present": "set", "absent": "unset", "get": "get"}
+    state = module.params['state']
 
-    # Assign module values to dictionary values
-    channel = module.params['channel']
-    property = module.params['property']
-    value_type = module.params['value_type']
-    if module.params['value'].lower() == "true":
-        value = "true"
-    elif module.params['value'] == "false":
-        value = "false"
-    else:
-        value = module.params['value']
+    if state == XfConfProperty.SET:
+        if not module.params.get('value'):
+            module.fail_json(msg='State {0} requires "value" to be set'.format(state))
+        elif not module.params.get('value_type'):
+            module.fail_json(msg='State {0} requires "value_type" to be set'.format(state))
 
-    state = state_values[module.params['state']]
+    try:
+        # Create a Xfconf preference
+        xfconf = XfConfProperty(module)
+        xfconf.sanitize()
 
-    # Initialize some variables for later
-    change = False
-    new_value = ''
+        previous_value = xfconf.get()
+        facts = {
+            module_name: dict(
+                channel=xfconf.channel,
+                property=xfconf.property,
+                value_type=xfconf.value_type,
+                value=previous_value,)}
 
-    if state != "get":
-        if value is None or value == "":
-            module.fail_json(msg='State %s requires "value" to be set'
-                             % str(state))
-        elif value_type is None or value_type == "":
-            module.fail_json(msg='State %s requires "value_type" to be set'
-                             % str(state))
+        if state == XfConfProperty.GET \
+                or (previous_value is not None
+                    and (state, set(previous_value)) == (XfConfProperty.SET, set(xfconf.value))):
+            module.exit_json(changed=False, ansible_facts=facts)
+            return
 
-    # Create a Xfconf preference
-    xfconf = XfconfPreference(module,
-                              channel,
-                              property,
-                              value_type,
-                              value)
-    # Now we get the current value, if not found don't fail
-    dummy, current_value = xfconf.call("get", fail_onerr=False)
-
-    # Check if the current value equals the value we want to set.  If not, make
-    # a change
-    if current_value != value:
         # If check mode, we know a change would have occurred.
         if module.check_mode:
-            # So we will set the change to True
-            change = True
-            # And set the new_value to the value that would have been set
-            new_value = value
-        # If not check mode make the change.
+            new_value = xfconf.value
         else:
-            change, new_value = xfconf.call(state)
-    # If the value we want to set is the same as the current_value, we will
-    # set the new_value to the current_value for reporting
-    else:
-        new_value = current_value
+            new_value = xfconf.call(state)
 
-    facts = dict(xfconf={'changed': change,
-                         'channel': channel,
-                         'property': property,
-                         'value_type': value_type,
-                         'new_value': new_value,
-                         'previous_value': current_value,
-                         'playbook_value': module.params['value']})
+        facts[module_name].update(value=new_value, previous_value=previous_value)
+        module.exit_json(changed=True, ansible_facts=facts)
 
-    module.exit_json(changed=change, ansible_facts=facts)
+    except Exception as e:
+        module.fail_json(msg="Failed with exception: {0}".format(e))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -22,7 +22,7 @@ description:
   - This module allows for the manipulation of Xfce 4 Configuration via xfconf-query.
   - Please see the xfconf-query(1) man pages for more details.
   - "TO-DO: unit tests, list state to retrieve properties, recursive reset."
-version_added: "2.8"
+version_added: "2.10"
 options:
   channel:
     description:

--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -22,7 +22,7 @@ description:
   - This module allows for the manipulation of Xfce 4 Configuration via xfconf-query.
   - Please see the xfconf-query(1) man pages for more details.
   - "TO-DO: unit tests, list state to retrieve properties, recursive reset."
-version_added: "2.10"
+version_added: "2.8"
 options:
   channel:
     description:
@@ -56,6 +56,7 @@ options:
     default: 'no'
     aliases:
     - array
+    version_added: "2.10"
 seealso:
   - name: XFCE documentation on xfconf-query
     description: Manual page for the command

--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -19,10 +19,9 @@ author:
     - "Joseph Benden (@jbenden)"
 short_description: Edit XFCE4 Configurations
 description:
-  - This module allows for the manipulation of Xfce 4 Configuration via
-    xfconf-query.  Please see the xfconf-query(1) man pages for more details.
-    
-    TO-DO: add unit tests, add a 'list' state to retrieve properties, add recursive reset
+  - This module allows for the manipulation of Xfce 4 Configuration via xfconf-query.
+  - Please see the xfconf-query(1) man pages for more details.
+  - "TO-DO: unit tests, list state to retrieve properties, recursive reset."
 version_added: "2.8"
 options:
   channel:
@@ -55,6 +54,12 @@ options:
     - Force array even if only one element
     type: bool
     default: 'no'
+    aliases:
+    - array
+seealso:
+  - name: XFCE documentation on xfconf-query
+    description: Manual page for the command
+    link: https://docs.xfce.org/xfce/xfconf/xfconf-query
 """
 
 EXAMPLES = """
@@ -133,9 +138,9 @@ class XfConfProperty(object):
         self.force_array = module.params['force_array']
 
         self.cmd = "{0} --channel {1} --property {2}".format(
-                module.get_bin_path('xfconf-query', True),
-                shlex_quote(self.channel),
-                shlex_quote(self.property)
+            module.get_bin_path('xfconf-query', True),
+            shlex_quote(self.channel),
+            shlex_quote(self.property)
         )
         self.method_map = dict(zip((self.SET, self.GET, self.RESET),
                                    (self.set, self.get, self.reset)))
@@ -181,7 +186,7 @@ class XfConfProperty(object):
     def reset(self):
         self._execute_xfconf_query("--reset")
         return None
-        
+
     @staticmethod
     def _fix_bool(value):
         if value.lower() in ("true", "false"):

--- a/lib/ansible/modules/system/xfconf.py
+++ b/lib/ansible/modules/system/xfconf.py
@@ -167,7 +167,7 @@ class XfConfProperty(object):
     @property
     def previous_value(self):
         if not self._previous_value_set:
-            self._previous_value, _ = self.get()
+            self._previous_value, changed = self.get()
         return self._previous_value
 
     def _execute_xfconf_query(self, args=None, check_mode_aware=True, **kwargs):
@@ -178,7 +178,7 @@ class XfConfProperty(object):
 
             self.module.debug("Running cmd={0}".format(cmd))
             if check_mode_aware and self.module.check_mode:
-                return 'Would have executed: {}'.format(cmd)
+                return 'Would have executed: {0}'.format(cmd)
 
             rc, out, err = self._run(cmd)
             if err.rstrip() == self.does_not:
@@ -221,7 +221,7 @@ class XfConfProperty(object):
 
         rec = "--recursive" if self.recursive else ""
 
-        self._execute_xfconf_query("--reset {}".format(rec), check_mode_aware=check_mode_aware)
+        self._execute_xfconf_query("--reset {0}".format(rec), check_mode_aware=check_mode_aware)
         return None, True
 
     @staticmethod
@@ -315,7 +315,7 @@ def main():
                        choices=XfConfProperty.VALID_STATES,
                        type='str'),
             force_array=dict(default=False, type='bool', aliases=['array']),
-            recursive=dict(default=False, type=bool),
+            recursive=dict(default=False, type='bool'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds arrays support for xfconf module. There is another PR already open adding that feature (https://github.com/ansible/ansible/pull/50108). However, in that PR, the maintainer of the xfconf module asked if anyone is interested in taking over the module (https://github.com/ansible/ansible/pull/50108#issuecomment-471218315).
So, I have contacted him and I am creating this PR after his instructions.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/46308
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
xfconf
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is largely based on the previous PR, so the examples found there apply. On top of that, it handles a couple of other cases. See below:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: Configure single workspace
    xfconf:
      channel: xfwm4
      property: "{{ item.property }}"
      value_type: "{{ item.type }}"
      value: "{{ item.value }}"
      state: present
    with_items:
    - { property: /general/workspace_count, type: int, value: 1 }
    - { property: /general/workspace_names, type: string, value: Main }
      # ^ assumed as an array because the existing property is an array

  - name: Configure four workspaces
    xfconf:
      channel: xfwm4
      property: "{{ item.property }}"
      value_type: "{{ item.type }}"
      value: "{{ item.value }}"
      state: present
    with_items:
    - { property: /general/workspace_count, type: int, value: 4 }
    - { property: /general/workspace_names, type: string, value: ['Main', 'Work1', 'Work2', 'Tmp'] }
      # ^ assumed as an array because length of "value" is > 1
      # ^ type can be a single element, which is then used on all the elements of "value"

  - name: New property forced to be an array (dummy example)
    xfconf:
      channel: xfwm4
      property: /my/new/one_element_array
      value_type: string
      value: potatoes
      force_array: yes
      state: present
      # ^ assumed as an array only because "force_array" is yes

  - name: Array with mixed types (dummy example)
    xfconf:
      channel: xfwm4
      property: /my/mixed_array
      value_type: [ int, string ]
      value: [ 42, potatoes ]
      state: present
      # for mixed-type arrays the value type must list the type for each item
```
