### PR TITLE
Supporing NTP Servers and Peers Module in Ansible

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_ntp_servers_peers.py
+++ b/lib/ansible/modules/network/onyx/onyx_ntp_servers_peers.py
@@ -1,0 +1,275 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: onyx_ntp_servers_peers
+version_added: "2.10"
+author: "Sara-Touqan (@sarato)"
+short_description: Configures NTP peers and servers parameters
+description:
+  - This module provides declarative management of NTP peers and servers configuration on Mellanox ONYX network devices.
+options:
+  peers:
+    type: list
+    description:
+      - List of ntp peers.
+    suboptions:
+      ip_or_name:
+        description:
+          - Configures ntp peer name or ip.
+        required: true
+        type: str
+      state_enabled:
+        description:
+          - Disables/Enables ntp peer state
+        choices: ['yes','no']
+        type: str
+      version:
+        description:
+          - version number for the ntp peer
+        choices: ['3','4']
+        type: int
+      key_id:
+        description:
+          - Used to configure the key-id for the ntp peer
+        type: int
+      delete:
+        description:
+          - Used to decide if you want to delete the given ntp peer or not.
+        choices: ['yes','no']
+        type: str
+  servers:
+    type: list
+    description:
+      - List of ntp servers.
+    suboptions:
+      ip_or_name:
+        description:
+          - Configures ntp server name or ip.
+        required: true
+        type: str
+      state_enabled:
+        description:
+          - Disables/Enables ntp server
+        choices: ['yes','no']
+        type: str
+      trusted_enable:
+        description:
+          - Disables/Enables the trusted state for the ntp server.
+        choices: ['yes','no']
+        type: str
+      version:
+        description:
+          - version number for the ntp server
+        choices: ['3','4']
+        type: int
+      key_id:
+        description:
+          - Used to configure the key-id for the ntp server
+        type: int
+      delete:
+        description:
+          - Used to decide if you want to delete the given ntp server or not.
+        choices: ['yes','no']
+        type: str
+  ntpdate:
+    description:
+      - Sets system clock once from a remote server using NTP.
+    type: str
+"""
+
+EXAMPLES = """
+- name: configure NTP peers and servers
+  onyx_ntp_peers_servers:
+    peers:
+       - ip_or_name: 1.1.1.1
+         state_enabled: yes
+         version: 4
+         key_id: 6
+         delete: yes
+    serevrs:
+       - ip_or_name: 2.2.2.2
+         state_enabled: yes
+         version: 3
+         key_id: 8
+         trusted_enable: no
+         delete: yes
+    ntpdate: 192.168.10.10
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device
+  returned: always.
+  type: list
+  sample:
+    - ntp peer 1.1.1.1 disable
+      no ntp peer 1.1.1.1 disable
+      ntp peer 1.1.1.1 keyId 6
+      ntp peer 1.1.1.1 version 4
+      no ntp peer 1.1.1.1
+      ntp server 2.2.2.2 disable
+      no ntp server 2.2.2.2 disable
+      ntp server 2.2.2.2 keyID 8
+      ntp server 2.2.2.2 version 3
+      ntp server 2.2.2.2 trusted-enable
+      no ntp server 2.2.2.2
+      ntp server 192.168.10.10
+      ntpdate 192.168.10.10
+"""
+
+from copy import deepcopy
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.network.common.utils import remove_default_spec
+
+from ansible.module_utils.network.onyx.onyx import BaseOnyxModule
+from ansible.module_utils.network.onyx.onyx import show_cmd
+
+
+class OnyxNTPServersPeersModule(BaseOnyxModule):
+
+    def init_module(self):
+        """ module initialization
+        """
+        peer_spec = dict(ip_or_name=dict(required=True),
+                         state_enabled=dict(choices=['yes', 'no']),
+                         version=dict(type='int', choices=[3, 4]),
+                         key_id=dict(type='int'),
+                         delete=dict(choices=['yes', 'no']))
+        server_spec = dict(ip_or_name=dict(required=True),
+                           state_enabled=dict(choices=['yes', 'no']),
+                           version=dict(type='int', choices=[3, 4]),
+                           trusted_enable=dict(choices=['yes', 'no']),
+                           key_id=dict(type='int'),
+                           delete=dict(choices=['yes', 'no']))
+        element_spec = dict(peers=dict(type='list', elements='dict', options=peer_spec),
+                            servers=dict(type='list', elements='dict', options=server_spec),
+                            ntpdate=dict())
+        argument_spec = dict()
+        argument_spec.update(element_spec)
+        self._module = AnsibleModule(
+            argument_spec=argument_spec,
+            supports_check_mode=True)
+
+    def get_required_config(self):
+        module_params = self._module.params
+        self._required_config = dict(module_params)
+        self.validate_param_values(self._required_config)
+
+    def _show_peers_servers_config(self):
+        cmd = "show ntp configured"
+        return show_cmd(self._module, cmd, json_fmt=True, fail_on_error=False)
+
+    def _set_servers_config(self, peers_servers_config):
+        servers = dict()
+        peers = dict()
+        if not peers_servers_config:
+            return
+        index = 0
+        for peer_server in peers_servers_config:
+            if (index == 0):
+                index += 1
+                continue
+            else:
+                header_list = peer_server.get("header").split(" ")
+                type = header_list[1]
+                if (type == 'server'):
+                    server_entry = {"version": peer_server.get("NTP version"),
+                                    "state_enabled": peer_server.get("Enabled"),
+                                    "trusted_enable": peer_server.get("Trusted"),
+                                    "key_id": peer_server.get("Key ID")}
+                    servers.update({header_list[2]: server_entry})
+                else:
+                    peer_entry = {"version": peer_server.get("NTP version"),
+                                  "state_enabled": peer_server.get("Enabled"),
+                                  "key_id": peer_server.get("Key ID")}
+                    peers.update({header_list[2]: peer_entry})
+            index += 1
+            self._current_config.update({"servers": servers})
+            self._current_config.update({"peers": peers})
+
+    def load_current_config(self):
+        self._current_config = dict()
+        peers_servers_config = self._show_peers_servers_config()
+        if peers_servers_config:
+            self._set_servers_config(peers_servers_config)
+
+    def generate_commands(self):
+        ntp_options = ["peers", "servers"]
+        for option in ntp_options:
+            option_name = "peer"
+            if option == "servers":
+                option_name = "server"
+            req_ntp = self._required_config.get(option)
+            if req_ntp is not None:
+                for ntp_peer in req_ntp:
+                    curr_name = None
+                    if self._current_config:
+                        curr_name = self._current_config.get(option).get(ntp_peer.get("ip_or_name"))
+                        if curr_name:
+                            if ntp_peer.get("delete"):
+                                if(ntp_peer.get("delete") == "yes"):
+                                    self._commands.append('no ntp {0} {1}' .format(option_name, ntp_peer.get('ip_or_name')))
+                                    continue
+                            if ntp_peer.get("state_enabled"):
+                                if (curr_name.get("state_enabled") != ntp_peer.get("state_enabled")):
+                                    if(ntp_peer.get("state_enabled") == "yes"):
+                                        self._commands.append('no ntp {0} {1} disable' .format(option_name, ntp_peer.get('ip_or_name')))
+                                    else:
+                                        self._commands.append('ntp {0} {1} disable'  .format(option_name, ntp_peer.get('ip_or_name')))
+                            if ntp_peer.get("version"):
+                                if (int(curr_name.get("version")) != ntp_peer.get("version")):
+                                    self._commands.append('ntp {0} {1} version {2}'  .format(option_name, ntp_peer.get('ip_or_name'), ntp_peer.get('version')))
+                            if ntp_peer.get("key_id"):
+                                if curr_name.get("key_id") != "none":
+                                    if (int(curr_name.get("key_id")) != ntp_peer.get("key_id")):
+                                        self._commands.append('ntp {0} {1} keyID {2}'  .format(option_name, ntp_peer.get('ip_or_name'), ntp_peer.get('key_id')))
+                                else:
+                                    self._commands.append('ntp {0} {1} keyID {2}'  .format(option_name, ntp_peer.get('ip_or_name'), ntp_peer.get('key_id')))
+                            if option_name == "server":
+                                if ntp_peer.get("trusted_enable"):
+                                    if (curr_name.get("trusted_enable") != ntp_peer.get("trusted_enable")):
+                                        if ntp_peer.get("trusted_enable") == "yes":
+                                            self._commands.append('ntp {0} {1} trusted-enable'  .format(option_name, ntp_peer.get('ip_or_name')))
+                                        else:
+                                            self._commands.append('no ntp {0} {1} trusted-enable'  .format(option_name, ntp_peer.get('ip_or_name')))
+                    else:
+                        if ntp_peer.get("delete"):
+                            if(ntp_peer.get("delete") == "yes"):
+                                continue
+                        if ntp_peer.get("state_enabled"):
+                            if(ntp_peer.get("state_enabled") == "yes"):
+                                self._commands.append('no ntp {0} {1} disable' .format(option_name, ntp_peer.get('ip_or_name')))
+                            else:
+                                self._commands.append('ntp {0} {1} disable'  .format(option_name, ntp_peer.get('ip_or_name')))
+                        else:
+                            self._commands.append('ntp {0} {1} disable'  .format(option_name, ntp_peer.get('ip_or_name')))
+                        if ntp_peer.get("version"):
+                            self._commands.append('ntp {0} {1} version {2}'  .format(option_name, ntp_peer.get('ip_or_name'), ntp_peer.get('version')))
+                        if ntp_peer.get("key_id"):
+                            self._commands.append('ntp {0} {1} keyID {2}'  .format(option_name, ntp_peer.get('ip_or_name'), ntp_peer.get('key_id')))
+
+        ntpdate = self._required_config.get("ntpdate")
+        if ntpdate is not None:
+            self._commands.append('ntpdate {0}' .format(ntpdate))
+
+
+def main():
+    """ main entry point for module execution
+    """
+    OnyxNTPServersPeersModule.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/onyx/fixtures/onyx_ntp_servers_peers_show.cfg
+++ b/test/units/modules/network/onyx/fixtures/onyx_ntp_servers_peers_show.cfg
@@ -1,0 +1,19 @@
+[
+    {
+        "NTP enabled": "yes",
+        "NTP Authentication enabled": "no"
+    },
+    {
+        "NTP version": "4",
+        "Enabled": "yes",
+        "Key ID": "none",
+        "header": "NTP peer 1.1.1.1"
+    },
+    {
+        "NTP version": "4",
+        "Enabled": "no",
+        "Trusted": "yes",
+        "Key ID": "99",
+        "header": "NTP server 2.2.2.2"
+    }
+]

--- a/test/units/modules/network/onyx/test_onyx_ntp_servers_peers.py
+++ b/test/units/modules/network/onyx/test_onyx_ntp_servers_peers.py
@@ -1,0 +1,123 @@
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.onyx import onyx_ntp_servers_peers
+from units.modules.utils import set_module_args
+from .onyx_module import TestOnyxModule, load_fixture
+
+
+class TestOnyxNtpServersPeersModule(TestOnyxModule):
+
+    module = onyx_ntp_servers_peers
+    enabled = False
+
+    def setUp(self):
+        self.enabled = False
+        super(TestOnyxNtpServersPeersModule, self).setUp()
+        self.mock_get_config = patch.object(
+            onyx_ntp_servers_peers.OnyxNTPServersPeersModule, "_show_peers_servers_config")
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch(
+            'ansible.module_utils.network.onyx.onyx.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestOnyxNtpServersPeersModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        config_file = 'onyx_ntp_servers_peers_show.cfg'
+        data = load_fixture(config_file)
+        self.get_config.return_value = data
+        self.load_config.return_value = None
+
+    def test_ntp_peer_state_no_change(self):
+        set_module_args(dict(peers=[dict(ip_or_name='1.1.1.1',
+                                         state_enabled='yes')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_peer_state_with_change(self):
+        set_module_args(dict(peers=[dict(ip_or_name='1.1.1.1',
+                                         state_enabled='no')]))
+        commands = ['ntp peer 1.1.1.1 disable']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_peer_version_no_change(self):
+        set_module_args(dict(peers=[dict(ip_or_name='1.1.1.1',
+                                         version='4')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_peer_version_with_change(self):
+        set_module_args(dict(peers=[dict(ip_or_name='1.1.1.1',
+                                         version='3')]))
+        commands = ['ntp peer 1.1.1.1 version 3']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_peer_delete_with_change(self):
+        set_module_args(dict(peers=[dict(ip_or_name='1.1.1.1',
+                                         delete='yes')]))
+        commands = ['no ntp peer 1.1.1.1']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_server_state_no_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           state_enabled='no')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_server_state_with_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           state_enabled='yes')]))
+        commands = ['no ntp server 2.2.2.2 disable']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_server_version_no_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           version='4')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_server_version_with_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           version='3')]))
+        commands = ['ntp server 2.2.2.2 version 3']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_server_keyID_no_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           key_id='99')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_server_keyID_with_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           key_id='8')]))
+        commands = ['ntp server 2.2.2.2 keyID 8']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_server_trusted_state_no_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           trusted_enable='yes')]))
+        self.execute_module(changed=False)
+
+    def test_ntp_server_trusted_state_with_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           trusted_enable='no')]))
+        commands = ['no ntp server 2.2.2.2 trusted-enable']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntp_server_delete_with_change(self):
+        set_module_args(dict(servers=[dict(ip_or_name='2.2.2.2',
+                                           delete='yes')]))
+        commands = ['no ntp server 2.2.2.2']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ntpdate_with_change(self):
+        set_module_args(dict(ntpdate='192.22.1.66'))
+        commands = ['ntpdate 192.22.1.66']
+        self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
##### SUMMARY
Supporting NTP Peers and Servers configuration in Ansible

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
onyx_ntp_servers_peers

##### ADDITIONAL INFORMATION
Here I support all configuration commands in NTP that are related to a server or to a peer.