### PR TITLE
allow before/after to be NoneType

### DIFF
--- a/changelogs/fragments/62582-allow_diff_before_after_to_be_None.yml
+++ b/changelogs/fragments/62582-allow_diff_before_after_to_be_None.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - callbacks - Allow modules to return `None` as before/after entries for diff.
+    This should make it easier for modules to report the "not existing" state of
+    the entity they touched.

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -184,6 +184,8 @@ class CallbackBase(AnsiblePlugin):
                 for x in ['before', 'after']:
                     if isinstance(diff[x], MutableMapping):
                         diff[x] = self._serialize_diff(diff[x])
+                    elif diff[x] is None:
+                        diff[x] = ''
                 if 'before_header' in diff:
                     before_header = u"before: %s" % diff['before_header']
                 else:

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -365,6 +365,34 @@ class TestCallbackDiff(unittest.TestCase):
 
             '''))
 
+    def test_diff_before_none(self):
+        self.assertMultiLineEqual(
+            self._strip_color(self.cb._get_diff({
+                'before': None,
+                'after': 'one line\n',
+            })),
+            textwrap.dedent('''\
+                --- before
+                +++ after
+                @@ -0,0 +1 @@
+                +one line
+
+            '''))
+
+    def test_diff_after_none(self):
+        self.assertMultiLineEqual(
+            self._strip_color(self.cb._get_diff({
+                'before': 'one line\n',
+                'after': None,
+            })),
+            textwrap.dedent('''\
+                --- before
+                +++ after
+                @@ -1 +0,0 @@
+                -one line
+
+            '''))
+
 
 class TestCallbackOnMethods(unittest.TestCase):
     def _find_on_methods(self, callback):


### PR DESCRIPTION
when creating or deleting an object (e.g. via an API), before/after can
be `None` (or at least represented as such by the used library). to
avoid modules havig to do

    diff={'before': before or '', 'after': after or ''}

let's just convert `None` to an empty string that can be diffed properly

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
