### PR TITLE
passwordstore: Improve userpass splitting

### DIFF
--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -156,7 +156,7 @@ class LookupModule(LookupBase):
             # next parse the optional parameters in keyvalue pairs
             try:
                 for param in params[1:]:
-                    name, value = param.split('=')
+                    name, value = param.split('=', 1)
                     if name not in self.paramvals:
                         raise AnsibleAssertionError('%s not in paramvals' % name)
                     self.paramvals[name] = value

--- a/test/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -47,3 +47,21 @@
   assert:
     that:
       - readpass == newpass
+
+- name: Set a predefined value to be used as a new password
+  set_fact:
+    predefinedpass: "Zm9vYmFyMQ=="
+
+- name: Create password based on predefined value
+  set_fact:
+    newpredefinedpass: "{{ lookup('passwordstore', 'predefined-pass create=yes userpass={{ predefinedpass }}') }}"
+
+- name: Read password based on predefined value
+  set_fact:
+    readpredefinedpass: "{{ lookup('passwordstore', 'predefined-pass') }}"
+
+- name: Verify password based on predefined value
+  assert:
+    that:
+      - predefinedpass == newpredefinedpass
+      - predefinedpass == readpredefinedpass


### PR DESCRIPTION
Small change to the lookup plugin passwordstore to enable saving strings with '=' symbols, like base64 encoded strings

##### SUMMARY
Userpass splitting would fail if there's an '=' symbol in the value (like a base64 encoded string, which ends with == and would break) with an error about .

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
passwordstore (lookup plugin)

