### PR TITLE
Pull request for temp/backport-60947

### DIFF
--- a/changelogs/fragments/60947-check-module-names-for-collections.yaml
+++ b/changelogs/fragments/60947-check-module-names-for-collections.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Check action plugin names for network (eos, ios, iosxr, junos, netconf, nxos) modules properly load with collections.

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -38,7 +38,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'eos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'eos_config' else False
         socket_path = None
 
         if self._play_context.connection in ('network_cli', 'httpapi'):

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -38,7 +38,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'ios_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'ios_config' else False
         socket_path = None
 
         if self._play_context.connection == 'network_cli':

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -38,9 +38,10 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'iosxr_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'iosxr_config' else False
         socket_path = None
-        force_cli = self._task.action in ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
+        force_cli = module_name in ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
 
         if self._play_context.connection == 'local':
             provider = load_provider(iosxr_provider_spec, self._task.args)
@@ -77,7 +78,7 @@ class ActionModule(ActionNetworkModule):
         elif self._play_context.connection in ('netconf', 'network_cli'):
             if force_cli and self._play_context.connection != 'network_cli':
                 return {'failed': True, 'msg': 'Connection type %s is not valid for module %s' %
-                        (self._play_context.connection, self._task.action)}
+                        (self._play_context.connection, module_name)}
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using {0} and will be ignored'.format(self._play_context.connection))

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -39,7 +39,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'junos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'junos_config' else False
         socket_path = None
 
         if self._play_context.connection == 'local':
@@ -48,12 +49,12 @@ class ActionModule(ActionNetworkModule):
             pc.network_os = 'junos'
             pc.remote_addr = provider['host'] or self._play_context.remote_addr
 
-            if provider['transport'] == 'cli' and self._task.action not in CLI_SUPPORTED_MODULES:
+            if provider['transport'] == 'cli' and module_name not in CLI_SUPPORTED_MODULES:
                 return {'failed': True, 'msg': "Transport type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
-                                               % (provider['transport'], self._task.action)}
+                                               % (provider['transport'], module_name)}
 
-            if self._task.action == 'junos_netconf' or (provider['transport'] == 'cli' and self._task.action == 'junos_command'):
+            if module_name == 'junos_netconf' or (provider['transport'] == 'cli' and module_name == 'junos_command'):
                 pc.connection = 'network_cli'
                 pc.port = int(provider['port'] or self._play_context.port or 22)
             else:
@@ -83,15 +84,15 @@ class ActionModule(ActionNetworkModule):
             if any(provider.values()):
                 # for legacy reasons provider value is required for junos_facts(optional) and junos_package
                 # modules as it uses junos_eznc library to connect to remote host
-                if not (self._task.action == 'junos_facts' or self._task.action == 'junos_package'):
+                if not (module_name == 'junos_facts' or module_name == 'junos_package'):
                     display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                     del self._task.args['provider']
 
-            if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
-                    (self._play_context.connection == 'netconf' and self._task.action in CLI_SUPPORTED_MODULES[0:2]):
+            if (self._play_context.connection == 'network_cli' and module_name not in CLI_SUPPORTED_MODULES) or \
+                    (self._play_context.connection == 'netconf' and module_name in CLI_SUPPORTED_MODULES[0:2]):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
-                                               % (self._play_context.connection, self._task.action)}
+                                               % (self._play_context.connection, module_name)}
 
         if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/netconf.py
+++ b/lib/ansible/plugins/action/netconf.py
@@ -33,16 +33,17 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'netconf_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'netconf_config' else False
 
-        if self._play_context.connection not in ['netconf', 'local'] and self._task.action == 'netconf_config':
+        if self._play_context.connection not in ['netconf', 'local'] and module_name == 'netconf_config':
             return {'failed': True, 'msg': 'Connection type %s is not valid for netconf_config module. '
                                            'Valid connection type is netconf or local (deprecated)' % self._play_context.connection}
-        elif self._play_context.connection not in ['netconf'] and self._task.action != 'netconf_config':
+        elif self._play_context.connection not in ['netconf'] and module_name != 'netconf_config':
             return {'failed': True, 'msg': 'Connection type %s is not valid for %s module. '
-                                           'Valid connection type is netconf.' % (self._play_context.connection, self._task.action)}
+                                           'Valid connection type is netconf.' % (self._play_context.connection, module_name)}
 
-        if self._play_context.connection == 'local' and self._task.action == 'netconf_config':
+        if self._play_context.connection == 'local' and module_name == 'netconf_config':
             args = self._task.args
             pc = copy.deepcopy(self._play_context)
             pc.connection = 'netconf'

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -39,14 +39,15 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'nxos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'nxos_config' else False
         socket_path = None
 
         if (self._play_context.connection == 'httpapi' or self._task.args.get('provider', {}).get('transport') == 'nxapi') \
-                and self._task.action in ('nxos_file_copy', 'nxos_nxapi'):
-            return {'failed': True, 'msg': "Transport type 'nxapi' is not valid for '%s' module." % (self._task.action)}
+                and module_name in ('nxos_file_copy', 'nxos_nxapi'):
+            return {'failed': True, 'msg': "Transport type 'nxapi' is not valid for '%s' module." % (module_name)}
 
-        if self._task.action == 'nxos_file_copy':
+        if module_name == 'nxos_file_copy':
             self._task.args['host'] = self._play_context.remote_addr
             self._task.args['password'] = self._play_context.password
             if self._play_context.connection == 'network_cli':
@@ -54,7 +55,7 @@ class ActionModule(ActionNetworkModule):
             elif self._play_context.connection == 'local':
                 self._task.args['username'] = self._play_context.connection_user
 
-        if self._task.action == 'nxos_install_os':
+        if module_name == 'nxos_install_os':
             persistent_command_timeout = 0
             persistent_connect_timeout = 0
             connection = self._connection


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Stable-2.9 backport for collection loader fixes. This is because we do not properly load the action plugin when using FQCN.

https://github.com/ansible/ansible/pull/60947

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
action plugins for eos, ios, iosxr, nxos, junos, netconf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->