### PR TITLE
Add a representer for AnsibleUnsafeBytes

### DIFF
--- a/changelogs/fragments/62598-AnsibleDumper-representer.yaml
+++ b/changelogs/fragments/62598-AnsibleDumper-representer.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - AnsibleDumper - Add a representer for AnsibleUnsafeBytes (https://github.com/ansible/ansible/issues/62562).

--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -23,7 +23,7 @@ import yaml
 
 from ansible.module_utils.six import PY3
 from ansible.parsing.yaml.objects import AnsibleUnicode, AnsibleSequence, AnsibleMapping, AnsibleVaultEncryptedUnicode
-from ansible.utils.unsafe_proxy import AnsibleUnsafeText
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes
 from ansible.vars.hostvars import HostVars, HostVarsVars
 
 
@@ -46,8 +46,10 @@ def represent_vault_encrypted_unicode(self, data):
 
 if PY3:
     represent_unicode = yaml.representer.SafeRepresenter.represent_str
+    represent_binary = yaml.representer.SafeRepresenter.represent_binary
 else:
     represent_unicode = yaml.representer.SafeRepresenter.represent_unicode
+    represent_binary = yaml.representer.SafeRepresenter.represent_str
 
 AnsibleDumper.add_representer(
     AnsibleUnicode,
@@ -57,6 +59,11 @@ AnsibleDumper.add_representer(
 AnsibleDumper.add_representer(
     AnsibleUnsafeText,
     represent_unicode,
+)
+
+AnsibleDumper.add_representer(
+    AnsibleUnsafeBytes,
+    represent_binary,
 )
 
 AnsibleDumper.add_representer(

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -75,9 +75,16 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         result = b_text
         if PY2:
             # https://pyyaml.org/wiki/PyYAMLDocumentation#string-conversion-python-2-only
-            # pyyaml on Python 2 returns unicode and not bytes when given bytes with non-ASCII characters.
-            # Changes need to be made to the methods in Ansible to coerce the strings to behave consistently
-            # on Python 2 and Python 3.
+            # pyyaml on Python 2 can return either unicode or bytes when given byte strings.
+            # We normalize that to always return unicode on Python2 as that's right most of the
+            # time.  However, this means byte strings can round trip through yaml on Python3 but
+            # not on Python2.  To make this code work the same on Python2 and Python3 (we want
+            # the Python3 behaviour) we need to change the methods in Ansible to:
+            # (1) Let byte strings pass through yaml without being converted on Python2
+            # (2) Convert byte strings to text strings before being given to pyyaml  (Without this,
+            #       strings would end up as byte strings most of the time which would mostly be wrong)
+            # In practice, we mostly read bytes in from files and then pass that to pyyaml, for which
+            # the present behavior is correct.
             # This is a workaround for the current behavior.
             result = u'tr\xe9ma'
 

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -63,9 +63,9 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         self.assertEqual(plaintext, data_from_yaml.data)
 
     def test_bytes(self):
-        b_text = u'some bytés'.encode('utf-8')
-        f = AnsibleUnsafeBytes(b_text)
-        yaml_out = self._dump_string(f, dumper=self.dumper)
+        b_text = u'tréma'.encode('utf-8')
+        unsafe_object = AnsibleUnsafeBytes(b_text)
+        yaml_out = self._dump_string(unsafe_object, dumper=self.dumper)
 
         stream = self._build_stream(yaml_out)
         loader = self._loader(stream)
@@ -77,11 +77,10 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
 
         self.assertEqual(b_text, data_from_yaml)
 
-
     def test_unicode(self):
-        u_text = u'some unicodé'
-        f = AnsibleUnsafeText(u_text)
-        yaml_out = self._dump_string(f, dumper=self.dumper)
+        u_text = u'nöel'
+        unsafe_object = AnsibleUnsafeText(u_text)
+        yaml_out = self._dump_string(unsafe_object, dumper=self.dumper)
 
         stream = self._build_stream(yaml_out)
         loader = self._loader(stream)

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -24,6 +24,7 @@ from units.compat import unittest
 from ansible.parsing import vault
 from ansible.parsing.yaml import dumper, objects
 from ansible.parsing.yaml.loader import AnsibleLoader
+from ansible.module_utils.six import PY2
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes
 
 from units.mock.yaml_helper import YamlTestUtils
@@ -62,7 +63,7 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         self.assertEqual(plaintext, data_from_yaml.data)
 
     def test_bytes(self):
-        b_text = b'some bytes'
+        b_text = u'some bytés'.encode('utf-8')
         f = AnsibleUnsafeBytes(b_text)
         yaml_out = self._dump_string(f, dumper=self.dumper)
 
@@ -71,11 +72,14 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
 
         data_from_yaml = loader.get_single_data()
 
+        if PY2:
+            data_from_yaml = data_from_yaml.encode('utf-8')
+
         self.assertEqual(b_text, data_from_yaml)
 
 
     def test_unicode(self):
-        u_text = u'some unicode'
+        u_text = u'some unicodé'
         f = AnsibleUnsafeText(u_text)
         yaml_out = self._dump_string(f, dumper=self.dumper)
 
@@ -85,15 +89,3 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         data_from_yaml = loader.get_single_data()
 
         self.assertEqual(u_text, data_from_yaml)
-
-    def test_native_text(self):
-        n_text = 'some native text'
-        f = AnsibleUnsafeText(n_text)
-        yaml_out = self._dump_string(f, dumper=self.dumper)
-
-        stream = self._build_stream(yaml_out)
-        loader = self._loader(stream)
-
-        data_from_yaml = loader.get_single_data()
-
-        self.assertEqual(n_text, data_from_yaml)

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -72,10 +72,16 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
 
         data_from_yaml = loader.get_single_data()
 
+        result = b_text
         if PY2:
-            data_from_yaml = data_from_yaml.encode('utf-8')
+            # https://pyyaml.org/wiki/PyYAMLDocumentation#string-conversion-python-2-only
+            # pyyaml on Python 2 returns unicode and not bytes when given bytes with non-ASCII characters.
+            # Changes need to be made to the methods in Ansible to coerce the strings to behave consistently
+            # on Python 2 and Python 3.
+            # This is a workaround for the current behavior.
+            result = u'tr\xe9ma'
 
-        self.assertEqual(b_text, data_from_yaml)
+        self.assertEqual(result, data_from_yaml)
 
     def test_unicode(self):
         u_text = u'nöel'

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -87,7 +87,7 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         self.assertEqual(u_text, data_from_yaml)
 
     def test_native_text(self):
-        n_text = 'some unicode'
+        n_text = 'some native text'
         f = AnsibleUnsafeText(n_text)
         yaml_out = self._dump_string(f, dumper=self.dumper)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #62562

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/yaml/dumper.py
