### PR TITLE
Remove top-level arguments from network modules

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -433,9 +433,7 @@ def load_provider(spec, args):
     provider = args.get('provider') or {}
     for key, value in iteritems(spec):
         if key not in provider:
-            if key in args:
-                provider[key] = args[key]
-            elif 'fallback' in value:
+            if 'fallback' in value:
                 provider[key] = _fallback(value['fallback'])
             elif 'default' in value:
                 provider[key] = value['default']

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -430,7 +430,7 @@ def validate_prefix(prefix):
 
 
 def load_provider(spec, args):
-    provider = args.get('provider', {})
+    provider = args.get('provider') or {}
     for key, value in iteritems(spec):
         if key not in provider:
             if key in args:

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -62,20 +62,7 @@ eos_argument_spec = {
     'provider': dict(type='dict', options=eos_provider_spec),
 }
 eos_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
-
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(removed_in_version=2.9, no_log=True),
-
-    'use_ssl': dict(removed_in_version=2.9, type='bool'),
-    'validate_certs': dict(removed_in_version=2.9, type='bool'),
-    'timeout': dict(removed_in_version=2.9, type='int'),
-
-    'transport': dict(removed_in_version=2.9, choices=['cli', 'eapi'])
 }
 eos_argument_spec.update(eos_top_spec)
 

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -61,10 +61,6 @@ eos_provider_spec = {
 eos_argument_spec = {
     'provider': dict(type='dict', options=eos_provider_spec),
 }
-eos_top_spec = {
-    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-}
-eos_argument_spec.update(eos_top_spec)
 
 
 def get_provider_argspec():

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -184,23 +184,24 @@ class LocalEapi:
         self._session_support = None
         self._device_configs = {}
 
-        host = module.params['provider']['host']
-        port = module.params['provider']['port']
+        provider = module.params.get('provider', {})
+        host = provider.get('host')
+        port = provider.get('port')
 
-        self._module.params['url_username'] = self._module.params['username']
-        self._module.params['url_password'] = self._module.params['password']
+        self._module.params['url_username'] = provider.get('username')
+        self._module.params['url_password'] = provider.get('password')
 
-        if module.params['provider']['use_ssl']:
+        if provider.get('use_ssl'):
             proto = 'https'
         else:
             proto = 'http'
 
-        module.params['validate_certs'] = module.params['provider']['validate_certs']
+        module.params['validate_certs'] = provider.get('validate_certs')
 
         self._url = '%s://%s:%s/command-api' % (proto, host, port)
 
-        if module.params['auth_pass']:
-            self._enable = {'cmd': 'enable', 'input': module.params['auth_pass']}
+        if 'auth_pass' in provider:
+            self._enable = {'cmd': 'enable', 'input': provider.get('auth_pass')}
         else:
             self._enable = 'enable'
 

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -578,12 +578,10 @@ def is_json(cmd):
 
 
 def is_local_eapi(module):
-    transports = []
-    transports.append(module.params.get('transport', ""))
     provider = module.params.get('provider')
     if provider:
-        transports.append(provider.get('transport', ""))
-    return 'eapi' in transports
+        return provider.get('transport') == 'eapi'
+    return False
 
 
 def to_command(module, commands):

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -36,7 +36,6 @@ from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
 from ansible.module_utils.network.common.utils import to_list, ComplexList
-from ansible.module_utils.six import iteritems
 from ansible.module_utils.urls import fetch_url
 
 _DEVICE_CONNECTION = None
@@ -200,7 +199,7 @@ class LocalEapi:
 
         self._url = '%s://%s:%s/command-api' % (proto, host, port)
 
-        if 'auth_pass' in provider:
+        if provider.get("auth_pass"):
             self._enable = {'cmd': 'enable', 'input': provider.get('auth_pass')}
         else:
             self._enable = 'enable'

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -226,7 +226,7 @@ class LocalEapi:
         data = self._module.jsonify(body)
 
         headers = {'Content-Type': 'application/json-rpc'}
-        timeout = self._module.params['timeout']
+        timeout = self._module.params['provider']['timeout']
         use_proxy = self._module.params['provider']['use_proxy']
 
         response, headers = fetch_url(

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -184,7 +184,7 @@ class LocalEapi:
         self._session_support = None
         self._device_configs = {}
 
-        provider = module.params.get('provider', {})
+        provider = module.params.get("provider") or {}
         host = provider.get('host')
         port = provider.get('port')
 

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -67,18 +67,9 @@ def get_provider_argspec():
     return eos_provider_spec
 
 
-def load_params(module):
-    provider = module.params.get('provider') or dict()
-    for key, value in iteritems(provider):
-        if key in eos_argument_spec:
-            if module.params.get(key) is None and value is not None:
-                module.params[key] = value
-
-
 def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:
-        load_params(module)
         if is_local_eapi(module):
             conn = LocalEapi(module)
         else:

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -49,14 +49,7 @@ ios_argument_spec = {
 }
 
 ios_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(removed_in_version=2.9, no_log=True),
-    'timeout': dict(removed_in_version=2.9, type='int')
 }
 ios_argument_spec.update(ios_top_spec)
 

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -48,11 +48,6 @@ ios_argument_spec = {
     'provider': dict(type='dict', options=ios_provider_spec),
 }
 
-ios_top_spec = {
-    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-}
-ios_argument_spec.update(ios_top_spec)
-
 
 def get_provider_argspec():
     return ios_provider_spec

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -90,16 +90,6 @@ command_spec = {
     'answer': dict(default=None)
 }
 
-iosxr_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
-    'timeout': dict(removed_in_version=2.9, type='int'),
-}
-iosxr_argument_spec.update(iosxr_top_spec)
-
 CONFIG_MISPLACED_CHILDREN = [
     re.compile(r'^end-\s*(.+)$')
 ]

--- a/lib/ansible/module_utils/network/junos/facts/facts.py
+++ b/lib/ansible/module_utils/network/junos/facts/facts.py
@@ -10,7 +10,8 @@ calls the appropriate facts gathering function
 """
 
 from ansible.module_utils.network.common.facts.facts import FactsBase
-from ansible.module_utils.network.junos.facts.legacy.base import Default, Hardware, Config, Interfaces, OFacts, HAS_PYEZ
+from ansible.module_utils.network.junos.junos import HAS_PYEZ
+from ansible.module_utils.network.junos.facts.legacy.base import Default, Hardware, Config, Interfaces, OFacts
 from ansible.module_utils.network.junos.facts.interfaces.interfaces import InterfacesFacts
 from ansible.module_utils.network.junos.facts.lacp.lacp import LacpFacts
 from ansible.module_utils.network.junos.facts.lacp_interfaces.lacp_interfaces import Lacp_interfacesFacts

--- a/lib/ansible/module_utils/network/junos/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/junos/facts/legacy/base.py
@@ -11,8 +11,8 @@ based on the configuration.
 import platform
 
 from ansible.module_utils.network.common.netconf import exec_rpc
-from ansible.module_utils.network.junos.junos import get_param, tostring
-from ansible.module_utils.network.junos.junos import get_configuration, get_capabilities
+from ansible.module_utils.network.junos.junos import tostring
+from ansible.module_utils.network.junos.junos import get_configuration, get_capabilities, get_device
 from ansible.module_utils._text import to_text
 
 
@@ -20,13 +20,6 @@ try:
     from lxml.etree import Element, SubElement
 except ImportError:
     from xml.etree.ElementTree import Element, SubElement
-
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.exception import ConnectError
-    HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
 
 
 class FactsBase(object):
@@ -184,33 +177,9 @@ class Interfaces(FactsBase):
 
 
 class OFacts(FactsBase):
-    def _connect(self, module):
-        host = get_param(module, 'host')
-
-        kwargs = {
-            'port': get_param(module, 'port') or 830,
-            'user': get_param(module, 'username')
-        }
-
-        if get_param(module, 'password'):
-            kwargs['passwd'] = get_param(module, 'password')
-
-        if get_param(module, 'ssh_keyfile'):
-            kwargs['ssh_private_key_file'] = get_param(module, 'ssh_keyfile')
-
-        kwargs['gather_facts'] = False
-        try:
-            device = Device(host, **kwargs)
-            device.open()
-            device.timeout = get_param(module, 'timeout') or 10
-        except ConnectError as exc:
-            module.fail_json('unable to connect to %s: %s' % (host, to_text(exc)))
-
-        return device
-
     def populate(self):
 
-        device = self._connect(self.module)
+        device = get_device(self.module)
         facts = dict(device.facts)
 
         if '2RE' in facts:

--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -50,16 +50,6 @@ junos_provider_spec = {
 junos_argument_spec = {
     'provider': dict(type='dict', options=junos_provider_spec),
 }
-junos_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
-    'timeout': dict(removed_in_version=2.9, type='int'),
-    'transport': dict(removed_in_version=2.9)
-}
-junos_argument_spec.update(junos_top_spec)
 
 
 def tostring(element, encoding='UTF-8'):

--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -99,7 +99,7 @@ def get_capabilities(module):
 
 
 def get_device(module):
-    provider = module.params.get("provider", {})
+    provider = module.params.get("provider") or {}
     host = provider.get('host')
 
     kwargs = {

--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -33,6 +33,13 @@ except ImportError:
     from xml.etree.ElementTree import Element, SubElement, tostring as xml_to_string
     HAS_LXML = False
 
+try:
+    from jnpr.junos import Device
+    from jnpr.junos.exception import ConnectError
+    HAS_PYEZ = True
+except ImportError:
+    HAS_PYEZ = False
+
 ACTIONS = frozenset(['merge', 'override', 'replace', 'update', 'set'])
 JSON_ACTIONS = frozenset(['merge', 'override', 'update'])
 FORMATS = frozenset(['xml', 'text', 'json'])
@@ -89,6 +96,33 @@ def get_capabilities(module):
         module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
     module._junos_capabilities = json.loads(capabilities)
     return module._junos_capabilities
+
+
+def get_device(module):
+    provider = module.params.get("provider", {})
+    host = provider.get('host')
+
+    kwargs = {
+        'port': provider.get('port') or 830,
+        'user': provider.get('username')
+    }
+
+    if 'password' in provider:
+        kwargs['passwd'] = provider.get('password')
+
+    if 'ssh_keyfile' in provider:
+        kwargs['ssh_private_key_file'] = provider.get('ssh_keyfile')
+
+    kwargs['gather_facts'] = False
+
+    try:
+        device = Device(host, **kwargs)
+        device.open()
+        device.timeout = provider.get('timeout') or 10
+    except ConnectError as exc:
+        module.fail_json('unable to connect to %s: %s' % (host, to_text(exc)))
+
+    return device
 
 
 def is_netconf(module):
@@ -240,16 +274,6 @@ def load_config(module, candidate, warnings, action='merge', format='xml'):
 
     module._junos_connection.validate()
     return get_diff(module)
-
-
-def get_param(module, key):
-    if module.params.get(key):
-        value = module.params[key]
-    elif module.params.get('provider'):
-        value = module.params['provider'].get(key)
-    else:
-        value = None
-    return value
 
 
 def map_params_to_obj(module, param_to_xpath_map, param=None):

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -83,10 +83,6 @@ nxos_provider_spec = {
 nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),
 }
-nxos_top_spec = {
-    'authorize': dict(type='bool', fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE'])),
-}
-nxos_argument_spec.update(nxos_top_spec)
 
 
 def get_provider_argspec():

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -251,13 +251,14 @@ class LocalNxapi:
         self._device_configs = {}
         self._module_context = {}
 
-        self._module.params['url_username'] = self._module.params['username']
-        self._module.params['url_password'] = self._module.params['password']
+        provider = self._module.params.get("provider")
+        self._module.params['url_username'] = provider.get('username')
+        self._module.params['url_password'] = provider.get('password')
 
-        host = self._module.params['host']
-        port = self._module.params['port']
+        host = provider.get('host')
+        port = provider.get('port')
 
-        if self._module.params['use_ssl']:
+        if provider.get('use_ssl'):
             proto = 'https'
             port = port or 443
         else:

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -89,18 +89,9 @@ def get_provider_argspec():
     return nxos_provider_spec
 
 
-def load_params(module):
-    provider = module.params.get('provider') or dict()
-    for key, value in iteritems(provider):
-        if key in nxos_provider_spec:
-            if module.params.get(key) is None and value is not None:
-                module.params[key] = value
-
-
 def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:
-        load_params(module)
         if is_local_nxapi(module):
             conn = LocalNxapi(module)
         else:
@@ -1156,10 +1147,10 @@ def is_text(cmd):
 
 
 def is_local_nxapi(module):
-    transport = module.params.get('transport')
     provider = module.params.get('provider')
-    provider_transport = provider['transport'] if provider else None
-    return 'nxapi' in (transport, provider_transport)
+    if provider:
+        return provider.get("transport") == 'nxapi'
+    return False
 
 
 def to_command(module, commands):

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -84,21 +84,7 @@ nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),
 }
 nxos_top_spec = {
-    'host': dict(type='str', removed_in_version=2.9),
-    'port': dict(type='int', removed_in_version=2.9),
-
-    'username': dict(type='str', removed_in_version=2.9),
-    'password': dict(type='str', no_log=True, removed_in_version=2.9),
-    'ssh_keyfile': dict(type='str', removed_in_version=2.9),
-
     'authorize': dict(type='bool', fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE'])),
-    'auth_pass': dict(type='str', no_log=True, removed_in_version=2.9),
-
-    'use_ssl': dict(type='bool', removed_in_version=2.9),
-    'validate_certs': dict(type='bool', removed_in_version=2.9),
-    'timeout': dict(type='int', removed_in_version=2.9),
-
-    'transport': dict(type='str', choices=['cli', 'nxapi'], removed_in_version=2.9)
 }
 nxos_argument_spec.update(nxos_top_spec)
 

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -251,7 +251,7 @@ class LocalNxapi:
         self._device_configs = {}
         self._module_context = {}
 
-        provider = self._module.params.get("provider")
+        provider = self._module.params.get("provider") or {}
         self._module.params['url_username'] = provider.get('username')
         self._module.params['url_password'] = provider.get('password')
 

--- a/lib/ansible/module_utils/network/vyos/vyos.py
+++ b/lib/ansible/module_utils/network/vyos/vyos.py
@@ -46,17 +46,6 @@ vyos_provider_spec = {
 vyos_argument_spec = {
     'provider': dict(type='dict', options=vyos_provider_spec),
 }
-vyos_top_spec = {
-    'host': dict(removed_in_version=2.9),
-    'port': dict(removed_in_version=2.9, type='int'),
-
-    'username': dict(removed_in_version=2.9),
-    'password': dict(removed_in_version=2.9, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
-
-    'timeout': dict(removed_in_version=2.9, type='int'),
-}
-vyos_argument_spec.update(vyos_top_spec)
 
 
 def get_provider_argspec():

--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -89,7 +89,7 @@ session_name:
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.eos.eos import load_config, run_commands
-from ansible.module_utils.network.eos.eos import eos_argument_spec
+from ansible.module_utils.network.eos.eos import eos_argument_spec, is_local_eapi
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_text
 
@@ -129,7 +129,7 @@ def map_config_to_obj(module):
     output = run_commands(module, ['show banner %s' % module.params['banner']])
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
-        if module.params['transport'] == 'eapi':
+        if is_local_eapi(module):
             # On EAPI we need to extract the banner text from dict key
             # 'loginBanner'
             if module.params['banner'] == 'login':

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -178,10 +178,9 @@ from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 
 def check_transport(module):
-    transport = module.params['transport']
-    provider_transport = (module.params['provider'] or {}).get('transport')
+    transport = (module.params['provider'] or {}).get('transport')
 
-    if 'eapi' in (transport, provider_transport):
+    if transport == 'eapi':
         module.fail_json(msg='eos_eapi module is only supported over cli transport')
 
 

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -101,6 +101,12 @@ options:
     type: bool
     default: 'no'
     aliases: ['enable_socket']
+  timeout:
+    description:
+      - The time (in seconds) to wait for the eAPI configuration to be
+        reflected in the running-config.
+    type: int
+    default: 30
   vrf:
     description:
       - The C(vrf) argument will configure eAPI to listen for connections
@@ -333,7 +339,7 @@ def verify_state(updates, module):
                      ('local_http', 'localHttpServer'),
                      ('socket', 'unixSocketServer')]
 
-    timeout = module.params['timeout'] or 30
+    timeout = module.params["timeout"]
     state = module.params['state']
 
     while invalid_state:
@@ -380,6 +386,7 @@ def main():
         local_http_port=dict(type='int'),
 
         socket=dict(aliases=['enable_socket'], type='bool'),
+        timeout=dict(type="int", default=30),
 
         vrf=dict(default='default'),
 

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -361,11 +361,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password'] and not module.params['configured_password']:
-        warnings.append(
-            'The "password" argument is used to authenticate the current connection. ' +
-            'To set a user password use "configured_password" instead.'
-        )
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -505,15 +505,7 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password'] and not module.params['configured_password']:
-        warnings.append(
-            'The "password" argument is used to authenticate the current connection. ' +
-            'To set a user password use "configured_password" instead.'
-        )
-
-    result = {'changed': False}
-    if warnings:
-        result['warnings'] = warnings
+    result = {'changed': False, 'warnings': warnings}
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -251,11 +251,17 @@ class PublicKeyManager(object):
     def copy_key_to_node(self, base64keyfile):
         """ Copy key to IOS-XR node. We use SFTP because older IOS-XR versions don't handle SCP very well.
         """
-        if (self._module.params['host'] is None or self._module.params['provider']['host'] is None):
+        provider = self._module.params.get("provider", {})
+        node = provider.get('host')
+        if node is None:
             return False
 
-        if (self._module.params['username'] is None or self._module.params['provider']['username'] is None):
+        user = provider.get('username')
+        if user is None:
             return False
+
+        password = provider.get('password')
+        ssh_keyfile = provider.get('ssh_keyfile')
 
         if self._module.params['aggregate']:
             name = 'aggregate'
@@ -264,11 +270,6 @@ class PublicKeyManager(object):
 
         src = base64keyfile
         dst = '/harddisk:/publickey_%s.b64' % (name)
-
-        user = self._module.params['username'] or self._module.params['provider']['username']
-        node = self._module.params['host'] or self._module.params['provider']['host']
-        password = self._module.params['password'] or self._module.params['provider']['password']
-        ssh_keyfile = self._module.params['ssh_keyfile'] or self._module.params['provider']['ssh_keyfile']
 
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -284,16 +285,17 @@ class PublicKeyManager(object):
     def addremovekey(self, command):
         """ Add or remove key based on command
         """
-        if (self._module.params['host'] is None or self._module.params['provider']['host'] is None):
+        provider = self._module.params.get("provider", {})
+        node = provider.get('host')
+        if node is None:
             return False
 
-        if (self._module.params['username'] is None or self._module.params['provider']['username'] is None):
+        user = provider.get('username')
+        if user is None:
             return False
 
-        user = self._module.params['username'] or self._module.params['provider']['username']
-        node = self._module.params['host'] or self._module.params['provider']['host']
-        password = self._module.params['password'] or self._module.params['provider']['password']
-        ssh_keyfile = self._module.params['ssh_keyfile'] or self._module.params['provider']['ssh_keyfile']
+        password = provider.get('password')
+        ssh_keyfile = provider.get('ssh_keyfile')
 
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -695,11 +695,6 @@ def main():
             )
 
     result = {'changed': False, 'warnings': []}
-    if module.params['password'] and not module.params['configured_password']:
-        result['warnings'].append(
-            'The "password" argument is used to authenticate the current connection. ' +
-            'To set a user password use "configured_password" instead.'
-        )
 
     config_object = None
     if is_cliconf(module):

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -251,7 +251,7 @@ class PublicKeyManager(object):
     def copy_key_to_node(self, base64keyfile):
         """ Copy key to IOS-XR node. We use SFTP because older IOS-XR versions don't handle SCP very well.
         """
-        provider = self._module.params.get("provider", {})
+        provider = self._module.params.get("provider") or {}
         node = provider.get('host')
         if node is None:
             return False
@@ -285,7 +285,7 @@ class PublicKeyManager(object):
     def addremovekey(self, command):
         """ Add or remove key based on command
         """
-        provider = self._module.params.get("provider", {})
+        provider = self._module.params.get("provider") or {}
         node = provider.get('host')
         if node is None:
             return False

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -114,42 +114,13 @@ EXAMPLES = """
     reboot: no
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, get_param
-from ansible.module_utils._text import to_native
+from ansible.module_utils.network.junos.junos import junos_argument_spec, get_device
 
 try:
-    from jnpr.junos import Device
     from jnpr.junos.utils.sw import SW
-    from jnpr.junos.exception import ConnectError
     HAS_PYEZ = True
 except ImportError:
     HAS_PYEZ = False
-
-
-def connect(module):
-    host = get_param(module, 'host')
-
-    kwargs = {
-        'port': get_param(module, 'port') or 830,
-        'user': get_param(module, 'username')
-    }
-
-    if get_param(module, 'password'):
-        kwargs['passwd'] = get_param(module, 'password')
-
-    if get_param(module, 'ssh_keyfile'):
-        kwargs['ssh_private_key_file'] = get_param(module, 'ssh_keyfile')
-
-    kwargs['gather_facts'] = False
-
-    try:
-        device = Device(host, **kwargs)
-        device.open()
-        device.timeout = get_param(module, 'timeout') or 10
-    except ConnectError as exc:
-        module.fail_json(msg='unable to connect to %s: %s' % (host, to_native(exc)))
-
-    return device
 
 
 def install_package(module, device):
@@ -208,7 +179,7 @@ def main():
 
     do_upgrade = module.params['force'] or False
 
-    device = connect(module)
+    device = get_device(module)
 
     if not module.params['force']:
         device.facts_refresh()

--- a/lib/ansible/modules/network/junos/junos_scp.py
+++ b/lib/ansible/modules/network/junos/junos_scp.py
@@ -82,42 +82,14 @@ changed:
   type: bool
 """
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.junos.junos import junos_argument_spec, get_param
+from ansible.module_utils.network.junos.junos import junos_argument_spec, get_device
 from ansible.module_utils._text import to_native
 
 try:
-    from jnpr.junos import Device
     from jnpr.junos.utils.scp import SCP
-    from jnpr.junos.exception import ConnectError
     HAS_PYEZ = True
 except ImportError:
     HAS_PYEZ = False
-
-
-def connect(module):
-    host = get_param(module, 'host')
-
-    kwargs = {
-        'port': get_param(module, 'port') or 830,
-        'user': get_param(module, 'username')
-    }
-
-    if get_param(module, 'password'):
-        kwargs['passwd'] = get_param(module, 'password')
-
-    if get_param(module, 'ssh_keyfile'):
-        kwargs['ssh_private_key_file'] = get_param(module, 'ssh_keyfile')
-
-    kwargs['gather_facts'] = False
-
-    try:
-        device = Device(host, **kwargs)
-        device.open()
-        device.timeout = get_param(module, 'timeout') or 10
-    except ConnectError as exc:
-        module.fail_json('unable to connect to %s: %s' % (host, to_native(exc)))
-
-    return device
 
 
 def transfer_files(module, device):
@@ -162,7 +134,7 @@ def main():
     if not module.check_mode:
         # open pyez connection and transfer files via SCP
         try:
-            device = connect(module)
+            device = get_device(module)
             transfer_files(module, device)
         except Exception as ex:
             module.fail_json(

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -76,7 +76,6 @@ EXAMPLES = r'''
     priority: 150
     interface: vlan10
     preempt: enabled
-    host: 68.170.147.165
 
 - name: Ensure HSRP is configured with following params on a SVI
         with clear text authentication
@@ -86,7 +85,6 @@ EXAMPLES = r'''
     priority: 150
     interface: vlan10
     preempt: enabled
-    host: 68.170.147.165
     auth_type: text
     auth_string: CISCO
 
@@ -98,7 +96,6 @@ EXAMPLES = r'''
     priority: 150
     interface: vlan10
     preempt: enabled
-    host: 68.170.147.165
     auth_type: md5
     auth_string: "0 1234"
 
@@ -110,7 +107,6 @@ EXAMPLES = r'''
     priority: 150
     interface: vlan10
     preempt: enabled
-    host: 68.170.147.165
     auth_type: md5
     auth_string: "7 1234"
 
@@ -119,7 +115,6 @@ EXAMPLES = r'''
     group: 10
     interface: vlan10
     vip: 10.1.1.1
-    host: 68.170.147.165
     state: absent
 '''
 

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -306,15 +306,7 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password'] and not module.params['configured_password']:
-        warnings.append(
-            'The "password" argument is used to authenticate the current connection. ' +
-            'To set a user password use "configured_password" instead.'
-        )
-
-    result = {'changed': False}
-    if warnings:
-        result['warnings'] = warnings
+    result = {'changed': False, 'warnings': warnings}
 
     want = map_params_to_obj(module)
     have = config_to_dict(module)

--- a/lib/ansible/plugins/doc_fragments/eos.py
+++ b/lib/ansible/plugins/doc_fragments/eos.py
@@ -9,32 +9,6 @@ class ModuleDocFragment(object):
     # Standard files documentation fragment
     DOCUMENTATION = r'''
 options:
-  authorize:
-    description:
-      - B(Deprecated)
-      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes)."
-      - This option is only required if you are using eAPI.
-      - For more information please see the L(EOS Platform Options guide, ../network/user_guide/platform_eos.html).
-      - HORIZONTALLINE
-      - Instructs the module to enter privileged mode on the remote device
-        before sending any commands.  If not specified, the device will
-        attempt to execute all commands in non-privileged mode. If the value
-        is not specified in the task, the value of environment variable
-        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
-    type: bool
-    default: no
-  auth_pass:
-    description:
-      - B(Deprecated)
-      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes) with C(become_pass)."
-      - This option is only required if you are using eAPI.
-      - For more information please see the L(EOS Platform Options guide, ../network/user_guide/platform_eos.html).
-      - HORIZONTALLINE
-      - Specifies the password to use if required to enter privileged mode
-        on the remote device.  If I(authorize) is false, then this argument
-        does nothing. If the value is not specified in the task, the value of
-        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
-    type: str
   provider:
     description:
       - B(Deprecated)

--- a/lib/ansible/plugins/doc_fragments/ios.py
+++ b/lib/ansible/plugins/doc_fragments/ios.py
@@ -9,30 +9,6 @@ class ModuleDocFragment(object):
     # Standard files documentation fragment
     DOCUMENTATION = r'''
 options:
-  authorize:
-    description:
-      - B(Deprecated)
-      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes)."
-      - For more information please see the L(IOS Platform Options guide, ../network/user_guide/platform_ios.html).
-      - HORIZONTALLINE
-      - Instructs the module to enter privileged mode on the remote device
-        before sending any commands.  If not specified, the device will
-        attempt to execute all commands in non-privileged mode. If the value
-        is not specified in the task, the value of environment variable
-        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
-    type: bool
-    default: no
-  auth_pass:
-    description:
-      - B(Deprecated)
-      - "Starting with Ansible 2.5 we recommend using C(connection: network_cli) and C(become: yes) with C(become_pass)."
-      - For more information please see the L(IOS Platform Options guide, ../network/user_guide/platform_ios.html).
-      - HORIZONTALLINE
-      - Specifies the password to use if required to enter privileged mode
-        on the remote device.  If I(authorize) is false, then this argument
-        does nothing. If the value is not specified in the task, the value of
-        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
-    type: str
   provider:
     description:
       - B(Deprecated)

--- a/test/integration/targets/eos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/eos_interface/tests/cli/intent.yaml
@@ -12,7 +12,6 @@
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
-    authorize: yes
   become: yes
   register: result
 

--- a/test/integration/targets/eos_interface/tests/eapi/intent.yaml
+++ b/test/integration/targets/eos_interface/tests/eapi/intent.yaml
@@ -17,7 +17,6 @@
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
-    authorize: yes
   become: yes
   register: result
 

--- a/test/integration/targets/eos_linkagg/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_linkagg/tests/cli/basic.yaml
@@ -6,7 +6,6 @@
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -14,7 +13,6 @@
   eos_config:
     lines:
       - no channel-group 20
-    authorize: yes
     provider: "{{ cli }}"
     parents: "{{ item }}"
   loop:
@@ -26,7 +24,6 @@
   eos_linkagg: &create
     group: 20
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -52,7 +49,6 @@
     members:
       - Ethernet1
       - Ethernet2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -80,7 +76,6 @@
     mode: active
     members:
       - Ethernet2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -104,7 +99,6 @@
   eos_linkagg: &remove
     group: 20
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -128,7 +122,6 @@
     aggregate:
       - { group: 20, min_links: 3 }
       - { group: 100, min_links: 4 }
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -155,7 +148,6 @@
     aggregate:
       - { group: 20, min_links: 3 }
       - { group: 100, min_links: 4 }
-    authorize: yes
     provider: "{{ cli }}"
     state: absent
   become: yes
@@ -181,7 +173,6 @@
     lines:
       - no interface port-channel 20
       - no interface port-channel 100
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -189,7 +180,6 @@
   eos_config:
     lines:
       - no channel-group 20
-    authorize: yes
     provider: "{{ cli }}"
     parents: "{{ item }}"
   become: yes

--- a/test/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/eos_smoke/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: network_cli
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: local

--- a/test/integration/targets/eos_smoke/tasks/eapi.yaml
+++ b/test/integration/targets/eos_smoke/tasks/eapi.yaml
@@ -3,8 +3,8 @@
   find:
     paths: "{{ role_path }}/tests/eapi"
     patterns: "{{ testcase }}.yaml"
-  delegate_to: localhost
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: httpapi
 
-- name: run test case (connection=local)
+- name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: local

--- a/test/integration/targets/eos_smoke/tests/cli/common_utils.yaml
+++ b/test/integration/targets/eos_smoke/tests/cli/common_utils.yaml
@@ -10,7 +10,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -19,7 +18,6 @@
     address: 192.168.3.0/24
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -34,7 +32,6 @@
     address: 192.168.3.0/250
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -48,7 +45,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -65,7 +61,6 @@
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result

--- a/test/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
+++ b/test/integration/targets/eos_smoke/tests/eapi/common_utils.yaml
@@ -10,7 +10,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ eapi }}"
   become: yes
 
@@ -19,7 +18,6 @@
     address: 192.168.3.0/24
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ eapi }}"
   become: yes
   register: result
@@ -34,7 +32,6 @@
     address: 192.168.3.0/250
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ eapi }}"
   become: yes
   register: result
@@ -48,7 +45,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ eapi }}"
   become: yes
 
@@ -65,7 +61,6 @@
     state: up
     tx_rate: ge(0)
     rx_rate: ge(0)
-    authorize: yes
     provider: "{{ eapi }}"
   become: yes
   register: result

--- a/test/integration/targets/eos_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_static_route/tests/cli/basic.yaml
@@ -7,7 +7,6 @@
     - no ip route 192.168.3.0/24 192.168.0.1
     - no ip route 192.168.4.0/24 192.168.0.1
     - no ip route 192.168.5.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -16,7 +15,6 @@
     address: 192.168.3.0/24
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -40,7 +38,6 @@
     address: 192.168.3.0/24
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ cli }}"
     state: absent
   become: yes
@@ -65,7 +62,6 @@
     aggregate:
       - { address: 192.168.4.0/24, next_hop: 192.168.0.1 }
       - { address: 192.168.5.0/24, next_hop: 192.168.0.1 }
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -90,7 +86,6 @@
     aggregate:
       - { address: 192.168.4.0/24, next_hop: 192.168.0.1 }
       - { address: 192.168.5.0/24, next_hop: 192.168.0.1 }
-    authorize: yes
     state: absent
     provider: "{{ cli }}"
   become: yes
@@ -117,7 +112,6 @@
     - no ip route 192.168.3.0/24 192.168.0.1
     - no ip route 192.168.4.0/24 192.168.0.1
     - no ip route 192.168.5.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 

--- a/test/integration/targets/eos_static_route/tests/cli/net_static_route.yaml
+++ b/test/integration/targets/eos_static_route/tests/cli/net_static_route.yaml
@@ -8,7 +8,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -17,7 +16,6 @@
     address: 192.168.3.0/24
     next_hop: 192.168.0.1
     admin_distance: 2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -31,7 +29,6 @@
   eos_config:
     lines:
     - no ip route 192.168.3.0/24 192.168.0.1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 

--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -6,7 +6,6 @@
       privilege: 15
       role: network-operator
       state: present
-      authorize: yes
       provider: "{{ cli }}"
       configured_password: pass123
     become: yes
@@ -36,6 +35,5 @@
       name: auth_user
       state: absent
       provider: "{{ cli }}"
-      authorize: yes
     become: yes
     register: result

--- a/test/integration/targets/eos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_user/tests/cli/basic.yaml
@@ -18,7 +18,6 @@
     role: network-operator
     state: present
     configured_password: test1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -37,7 +36,6 @@
     privilege: 15
     state: present
     configured_password: test1
-    authorize: yes
     update_password: on_create
     provider: "{{ cli }}"
   become: yes
@@ -55,7 +53,6 @@
     aggregate:
       - { name: ansibletest2, configured_password: test2 }
       - { name: ansibletest3, configured_password: test3 }
-    authorize: yes
     state: present
     role: network-operator
     provider: "{{ cli }}"
@@ -77,7 +74,6 @@
     name: faileduser1
     privilege: 15
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   ignore_errors: yes
@@ -97,5 +93,4 @@
       - no username ansibletest3
       - no username ansibletest4
     provider: "{{ cli }}"
-    authorize: yes
   become: yes

--- a/test/integration/targets/eos_user/tests/cli/net_user.yaml
+++ b/test/integration/targets/eos_user/tests/cli/net_user.yaml
@@ -18,7 +18,6 @@
     role: network-operator
     state: present
     configured_password: test1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result

--- a/test/integration/targets/eos_vlan/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vlan/tests/cli/basic.yaml
@@ -6,7 +6,6 @@
       - no vlan 4000
       - no vlan 4001
       - no vlan 4002
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -16,7 +15,6 @@
       - switchport
       - no switchport access vlan 4000
     parents: interface Ethernet1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -26,7 +24,6 @@
       - switchport
       - no switchport access vlan 4000
     parents: interface Ethernet2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -35,7 +32,6 @@
     vlan_id: 4000
     name: vlan-4000
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -53,7 +49,6 @@
     vlan_id: 4000
     name: vlan-4000
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -70,7 +65,6 @@
     vlan_id: 4000
     name: vlan-4000-new
     state: suspend
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -89,7 +83,6 @@
     vlan_id: 4000
     name: vlan-4000-new
     state: suspend
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -105,7 +98,6 @@
   eos_vlan:
     vlan_id: 4000
     state: active
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -128,7 +120,6 @@
     associated_interfaces:
       - Ethernet1
       - Ethernet2
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -151,7 +142,6 @@
     interfaces:
       - Ethernet 1   # interface name space scenario
       - Ethernet 2   # interface name space scenario
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -169,7 +159,6 @@
     state: present
     associated_interfaces:
       - test
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -185,7 +174,6 @@
     state: present
     interfaces:
       - Ethernet1
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -205,7 +193,6 @@
     state: present
     interfaces:
       - Ethernet 1 # space scenario
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -223,7 +210,6 @@
       - {vlan_id: 4000, state: absent}
       - {vlan_id: 4001, name: vlan-4001}
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -243,7 +229,6 @@
       - {vlan_id: 4000, state: absent}
       - {vlan_id: 4001, name: vlan-4001}
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -262,7 +247,6 @@
     name: vlan-4002
     state: present
     purge: yes
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -283,7 +267,6 @@
     name: vlan-4002
     state: present
     purge: yes
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result

--- a/test/integration/targets/eos_vlan/tests/cli/net_vlan.yaml
+++ b/test/integration/targets/eos_vlan/tests/cli/net_vlan.yaml
@@ -8,7 +8,6 @@
   eos_config:
     lines:
       - no vlan 4000
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -17,7 +16,6 @@
     vlan_id: 4000
     name: vlan-4000
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -34,7 +32,6 @@
   eos_config:
     lines:
       - no vlan 4000
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 

--- a/test/integration/targets/eos_vrf/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vrf/tests/cli/basic.yaml
@@ -4,7 +4,6 @@
   eos_vrf:
     name: "{{ item }}"
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   with_items:
@@ -20,7 +19,6 @@
     name: test
     rd: 1:200
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -38,7 +36,6 @@
     name: test
     rd: 1:200
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -55,7 +52,6 @@
     name: test
     rd: 1:201
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -73,7 +69,6 @@
     name: test
     rd: 1:201
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -90,7 +85,6 @@
     name: test
     rd: 1:201
     state: present
-    authorize: yes
     interfaces:
       - Ethernet2
     associated_interfaces:
@@ -112,7 +106,6 @@
     name: test
     rd: 1:201
     state: present
-    authorize: yes
     interfaces:
       - ethernet 2  # interface name modified to test case insensitive and space scenario
     provider: "{{ cli }}"
@@ -130,7 +123,6 @@
   eos_vrf:
     name: test
     state: present
-    authorize: yes
     associated_interfaces:
       - test
     provider: "{{ cli }}"
@@ -147,7 +139,6 @@
     name: test1
     rd: 1:202
     state: present
-    authorize: yes
     interfaces:
       - loopback10
       - loopback11
@@ -184,7 +175,6 @@
     name: test1
     rd: 1:202
     state: present
-    authorize: yes
     interfaces:
       - loopback10
       - loopback11
@@ -206,7 +196,6 @@
   eos_vrf:
     name: "{{ item }}"
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   with_items:
@@ -220,7 +209,6 @@
       - { name: test2, rd: "1:202" }
       - { name: test3, rd: "1:203" }
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -241,7 +229,6 @@
       - { name: test2, rd: "1:202" }
       - { name: test3, rd: "1:203" }
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -260,7 +247,6 @@
       - { name: test5, rd: "1:205" }
     state: present
     purge: yes
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -282,7 +268,6 @@
   eos_vrf:
     name: test
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -290,7 +275,6 @@
   eos_vrf:
     name: test
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -303,7 +287,6 @@
       - { name: test4 }
       - { name: test5 }
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -316,7 +299,6 @@
       - { name: test4 }
       - { name: test5 }
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 

--- a/test/integration/targets/eos_vrf/tests/cli/net_vrf.yaml
+++ b/test/integration/targets/eos_vrf/tests/cli/net_vrf.yaml
@@ -8,7 +8,6 @@
   net_vrf:
     name: test
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 
@@ -17,7 +16,6 @@
     name: test
     rd: 1:200
     state: present
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
   register: result
@@ -34,7 +32,6 @@
   net_vrf:
     name: test
     state: absent
-    authorize: yes
     provider: "{{ cli }}"
   become: yes
 

--- a/test/integration/targets/ios_ping/tests/cli/ping.yaml
+++ b/test/integration/targets/ios_ping/tests/cli/ping.yaml
@@ -31,7 +31,6 @@
 - name: unexpected unsuccessful ping
   ios_ping: &invalid_ip
     dest: '10.255.255.250'
-    timeout: 45
     provider: "{{ cli }}"
   register: uup
   ignore_errors: yes

--- a/test/units/modules/network/eos/test_eos_banner.py
+++ b/test/units/modules/network/eos/test_eos_banner.py
@@ -22,6 +22,9 @@ from ansible.modules.network.eos import eos_banner
 from units.modules.utils import set_module_args
 from .eos_module import TestEosModule, load_fixture
 
+CLI = dict(transport="cli")
+EAPI = dict(transport="eapi")
+
 
 class TestEosBannerModule(TestEosModule):
 
@@ -51,34 +54,32 @@ class TestEosBannerModule(TestEosModule):
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_eos_banner_create_with_cli_transport(self):
-        set_module_args(dict(banner='login', text='test\nbanner\nstring',
-                             transport='cli'))
+        set_module_args(dict(banner='login', text='test\nbanner\nstring', provider=CLI))
         commands = ['banner login', 'test', 'banner', 'string', 'EOF']
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_banner_remove_with_cli_transport(self):
-        set_module_args(dict(banner='login', state='absent', transport='cli'))
+        set_module_args(dict(banner='login', state='absent', provider=CLI))
         commands = ['no banner login']
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_banner_create_with_eapi_transport(self):
-        set_module_args(dict(banner='login', text='test\nbanner\nstring',
-                             transport='eapi'))
+        set_module_args(dict(banner='login', text='test\nbanner\nstring', provider=EAPI))
         commands = ['banner login']
         inputs = ['test\nbanner\nstring']
         self.execute_module(changed=True, commands=commands, inputs=inputs, transport='eapi')
 
     def test_eos_banner_remove_with_eapi_transport(self):
-        set_module_args(dict(banner='login', state='absent', transport='eapi'))
+        set_module_args(dict(banner='login', state='absent', provider=EAPI))
         commands = ['no banner login']
         self.execute_module(changed=True, commands=commands, transport='eapi')
 
     def test_eos_banner_nochange_with_cli_transport(self):
         banner_text = load_fixture('eos_banner_show_banner.txt').strip()
-        set_module_args(dict(banner='login', text=banner_text, transport='cli'))
+        set_module_args(dict(banner='login', text=banner_text, provider=CLI))
         self.execute_module()
 
     def test_eos_banner_nochange_with_eapi_transport(self):
         banner_text = load_fixture('eos_banner_show_banner.txt').strip()
-        set_module_args(dict(banner='login', text=banner_text, transport='eapi'))
+        set_module_args(dict(banner='login', text=banner_text, provider=EAPI))
         self.execute_module(transport='eapi')

--- a/test/units/modules/network/ios/test_ios_ping.py
+++ b/test/units/modules/network/ios/test_ios_ping.py
@@ -59,7 +59,7 @@ class TestIosPingModule(TestIosModule):
 
     def test_ios_ping_expected_failure(self):
         ''' Test for unsuccessful pings when destination should not be reachable '''
-        set_module_args(dict(count=2, dest="10.255.255.250", state="absent", timeout=45))
+        set_module_args(dict(count=2, dest="10.255.255.250", state="absent"))
         self.execute_module()
 
     def test_ios_ping_unexpected_success(self):
@@ -69,5 +69,5 @@ class TestIosPingModule(TestIosModule):
 
     def test_ios_ping_unexpected_failure(self):
         ''' Test for unsuccessful pings when destination should be reachable - FAIL. '''
-        set_module_args(dict(count=2, dest="10.255.255.250", timeout=45))
+        set_module_args(dict(count=2, dest="10.255.255.250"))
         self.execute_module(failed=True)

--- a/test/units/modules/network/junos/test_junos_package.py
+++ b/test/units/modules/network/junos/test_junos_package.py
@@ -37,15 +37,9 @@ module_patcher.start()
 from ansible.modules.network.junos import junos_package
 
 
-class TestJunosCommandModule(TestJunosModule):
+class TestJunosPackageModule(TestJunosModule):
 
     module = junos_package
-
-    def setUp(self):
-        super(TestJunosCommandModule, self).setUp()
-
-    def tearDown(self):
-        super(TestJunosCommandModule, self).tearDown()
 
     def test_junos_package_src(self):
         set_module_args(dict(src='junos-vsrx-12.1X46-D10.2-domestic.tgz'))

--- a/test/units/modules/network/nxos/test_nxos_hsrp.py
+++ b/test/units/modules/network/nxos/test_nxos_hsrp.py
@@ -55,7 +55,7 @@ class TestNxosHsrpModule(TestNxosModule):
                              priority='150',
                              interface='Ethernet1/2',
                              preempt='enabled',
-                             host='192.0.2.1'))
+                             ))
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result['commands']), sorted(['config t',
                                                              'interface ethernet1/2',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
~~Does anyone know why `authorize` isn't marked for removal?~~

`timeout` had dual meaning in `eos_eapi`. Removing it from common args means we have to add it back to the module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request?

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos
ios
iosxr
junos
nxos
vyos