### PR TITLE
datadog_monitor - Add api_host parameter

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -29,6 +29,13 @@ options:
           - Your Datadog API key.
         required: true
         type: str
+    api_host:
+        description:
+          - The URL to the Datadog API. Default value is C(https://api.datadoghq.com).
+          - This value can also be set with the C(DATADOG_HOST) environment variable.
+        required: false
+        type: str
+        version_added: '2.10'
     app_key:
         description:
           - Your Datadog app key.
@@ -172,6 +179,14 @@ EXAMPLES = '''
     state: "unmute"
     api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
     app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
+
+# Use datadoghq.eu platform instead of datadoghq.com
+- datadog_monitor:
+    name: "Test monitor"
+    state: "absent"
+    api_host: https://api.datadoghq.eu
+    api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
+    app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
 '''
 import traceback
 
@@ -192,6 +207,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             api_key=dict(required=True, no_log=True),
+            api_host=dict(required=False),
             app_key=dict(required=True, no_log=True),
             state=dict(required=True, choices=['present', 'absent', 'mute', 'unmute']),
             type=dict(required=False, choices=['metric alert', 'service check', 'event alert', 'process alert']),
@@ -221,6 +237,7 @@ def main():
 
     options = {
         'api_key': module.params['api_key'],
+        'api_host': module.params['api_host'],
         'app_key': module.params['app_key']
     }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `api_host` parameter to the `datadog_monitor` module to be able to select the API endpoint (`https://api.datadoghq.com` or `https://api.datadoghq.eu`) used to manage Datadog monitors. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
datadog_monitor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The problem can be reproduced when using the module with a datadoghq.eu account and the following playbook:

```yaml
# test.yml

- hosts: localhost
  connection: local
  tasks:
    - datadog_monitor:
        type: 'metric alert'
        name: 'test'
        state: present
        query: 'avg(last_5m):avg:network.http.cant_connect{*} by {host} >= 0.8'
        message: "Message"
        api_key: '...'
        app_key: '...'
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the fix:

```paste below
ansible-playbook -i localhost, test.yml
 [WARNING]: Unable to parse localhost, as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'


PLAY [localhost] *******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [datadog_monitor] *************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to connect Datadog server using given app_key and api_key : Invalid API key or Application key"}

NO MORE HOSTS LEFT *****************************************************************************************************

PLAY RECAP *************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```

After applying the fix and adding `api_host: https://api.datadoghq.eu` to the module parameters in the test.yml playbook:

```
ansible-playbook -i localhost, test.yml
[WARNING]: Unable to parse localhost, as an inventory source

[WARNING]: No inventory was parsed, only implicit localhost is available

[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match
'all'


PLAY [localhost] *******************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [localhost]

TASK [datadog_monitor] *************************************************************************************************
changed: [localhost]

PLAY RECAP *************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
