### PR TITLE
Updated nmcli.py for several versions

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -994,7 +994,7 @@ class Nmcli(object):
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
                 if key == 'connection.autoconnect':
-                    options[key] = 'false'
+                    options[key] = false
                 cmd.extend([key, to_text(value)])
 
         return cmd
@@ -1479,10 +1479,10 @@ def main():
             slavepriority=dict(type='int', default=32),
             forwarddelay=dict(type='int', default=15),
             hellotime=dict(type='int', default=2),
-            maxage=dict(type='int'),
+            maxage=dict(type='int', default=20),
             ageingtime=dict(type='int', default=300),
             hairpin=dict(type='bool', default=True),
-            path_cost=dict(type='int'),
+            path_cost=dict(type='int', default=100),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -993,8 +993,8 @@ class Nmcli(object):
             if value is not None and conn_type == 'ethernet':
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
-                if key == 'connection.autoconnect':
-                    options[key] = self.bool_to_string(False)
+                if options[key] == 'connection.autoconnect':
+                    options[key] = False
                 cmd.extend([key, to_text(value)])
 
         return cmd

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -566,7 +566,7 @@ NM_CLIENT_IMP_ERR = None
 try:
     import gi
     gi.require_version('NM', '1.0')
-    
+
     from gi.repository import NM
     HAVE_NM_CLIENT = True
 except (ImportError, ValueError):
@@ -585,6 +585,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
 from ansible.module_utils._text import to_text
+
 
 class Nmcli(object):
     """

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -48,7 +48,7 @@ options:
         default: yes
     conn_name:
         description:
-            - The name used to call the connection. Pattern is <type>[-<ifname>][-<num>].
+            - 'Where conn_name will be the name used to call the connection. when not provided a default name is generated: <type>[-<ifname>][-<num>]'
         type: str
         required: true
     ifname:
@@ -565,18 +565,26 @@ except ImportError:
 NM_CLIENT_IMP_ERR = None
 try:
     import gi
-    gi.require_version('NMClient', '1.0')
-    gi.require_version('NetworkManager', '1.0')
-
-    from gi.repository import NetworkManager, NMClient
+    gi.require_version('NM', '1.0')
+    
+    from gi.repository import NM
     HAVE_NM_CLIENT = True
 except (ImportError, ValueError):
-    NM_CLIENT_IMP_ERR = traceback.format_exc()
-    HAVE_NM_CLIENT = False
+    try:
+        import gi
+        gi.require_version('NMClient', '1.0')
+        gi.require_version('NetworkManager', '1.0')
+
+        from gi.repository import NetworkManager, NMClient
+        HAVE_NM_CLIENT = True
+    except (ImportError, ValueError):
+        NM_CLIENT_IMP_ERR = traceback.format_exc()
+        HAVE_NM_CLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 
+from ansible.module_utils._text import to_text
 
 class Nmcli(object):
     """
@@ -805,7 +813,7 @@ class Nmcli(object):
             'gw4': self.gw4,
             'ip6': self.ip6,
             'gw6': self.gw6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'ipv4.dhcp-client-id': self.dhcp_client_id,
@@ -813,7 +821,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -826,7 +834,7 @@ class Nmcli(object):
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'ipv4.dhcp-client-id': self.dhcp_client_id,
@@ -834,7 +842,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -881,7 +889,7 @@ class Nmcli(object):
             'gw4': self.gw4,
             'ip6': self.ip6,
             'gw6': self.gw6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'miimon': self.miimon,
@@ -895,7 +903,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
         return cmd
 
     def modify_connection_bond(self):
@@ -909,7 +917,7 @@ class Nmcli(object):
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'miimon': self.miimon,
@@ -922,7 +930,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -974,7 +982,7 @@ class Nmcli(object):
             'gw4': self.gw4,
             'ip6': self.ip6,
             'gw6': self.gw6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'ipv4.dhcp-client-id': self.dhcp_client_id,
@@ -982,7 +990,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -999,7 +1007,7 @@ class Nmcli(object):
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
             'ipv6.dns': self.dns6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             '802-3-ethernet.mtu': self.mtu,
@@ -1010,7 +1018,7 @@ class Nmcli(object):
             if value is not None:
                 if key == '802-3-ethernet.mtu' and conn_type != 'ethernet':
                     continue
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -1035,7 +1043,7 @@ class Nmcli(object):
             'gw4': self.gw4,
             'ip6': self.ip6,
             'gw6': self.gw6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'bridge.ageing-time': self.ageingtime,
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
@@ -1047,7 +1055,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -1063,7 +1071,7 @@ class Nmcli(object):
             'ipv4.gateway': self.gw4,
             'ipv6.address': self.ip6,
             'ipv6.gateway': self.gw6,
-            'autoconnect': self.bool_to_string(self.autoconnect),
+            'connection.autoconnect': self.bool_to_string(self.autoconnect),
             'bridge.ageing-time': self.ageingtime,
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
@@ -1075,7 +1083,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -1101,7 +1109,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -1117,7 +1125,7 @@ class Nmcli(object):
 
         for key, value in options.items():
             if value is not None:
-                cmd.extend([key, value])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 
@@ -1150,7 +1158,7 @@ class Nmcli(object):
                   'gw4': self.gw4 or '',
                   'ip6': self.ip6 or '',
                   'gw6': self.gw6 or '',
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1177,7 +1185,7 @@ class Nmcli(object):
                   'ipv6.address': self.ip6 or '',
                   'ipv6.gateway': self.gw6 or '',
                   'ipv6.dns': self.dns6 or '',
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
 
         for k, v in params.items():
@@ -1206,7 +1214,7 @@ class Nmcli(object):
         params = {'vxlan.id': self.vxlan_id,
                   'vxlan.local': self.vxlan_local,
                   'vxlan.remote': self.vxlan_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1226,7 +1234,7 @@ class Nmcli(object):
         params = {'vxlan.id': self.vxlan_id,
                   'vxlan.local': self.vxlan_local,
                   'vxlan.remote': self.vxlan_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1256,7 +1264,7 @@ class Nmcli(object):
 
         params = {'ip-tunnel.local': self.ip_tunnel_local,
                   'ip-tunnel.remote': self.ip_tunnel_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1275,7 +1283,7 @@ class Nmcli(object):
 
         params = {'ip-tunnel.local': self.ip_tunnel_local,
                   'ip-tunnel.remote': self.ip_tunnel_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1305,7 +1313,7 @@ class Nmcli(object):
 
         params = {'ip-tunnel.local': self.ip_tunnel_local,
                   'ip-tunnel.remote': self.ip_tunnel_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])
@@ -1324,7 +1332,7 @@ class Nmcli(object):
 
         params = {'ip-tunnel.local': self.ip_tunnel_local,
                   'ip-tunnel.remote': self.ip_tunnel_remote,
-                  'autoconnect': self.bool_to_string(self.autoconnect)
+                  'connection.autoconnect': self.bool_to_string(self.autoconnect)
                   }
         for k, v in params.items():
             cmd.extend([k, v])

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -993,8 +993,8 @@ class Nmcli(object):
             if value is not None and conn_type == 'ethernet':
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
-                if options[key] == 'connection.autoconnect':
-                    options[key] = False
+                if key == 'connection.autoconnect':
+                    options.update(key=False)
                 cmd.extend([key, to_text(value)])
 
         return cmd

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1049,7 +1049,7 @@ class Nmcli(object):
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
             'bridge.mac-address': self.mac,
-            #'bridge.max-age': self.maxage,
+            'bridge.max-age': self.maxage,
             'bridge.priority': self.priority,
             'bridge.stp': self.bool_to_string(self.stp)
         }
@@ -1077,7 +1077,7 @@ class Nmcli(object):
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
             'bridge.mac-address': self.mac,
-            #'bridge.max-age': self.maxage,
+            'bridge.max-age': self.maxage,
             'bridge.priority': self.priority,
             'bridge.stp': self.bool_to_string(self.stp)
         }

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -990,8 +990,11 @@ class Nmcli(object):
         }
 
         for key, value in options.items():
-            if value is not None:
+            if value is not None and conn_type == 'ethernet':
                 cmd.extend([key, to_text(value)])
+            elif value is not None and conn_type == 'generic':
+                if key is not 'connection.autoconnect':
+                    cmd.extend([key, to_text(value)])
 
         return cmd
 

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -990,11 +990,7 @@ class Nmcli(object):
         }
 
         for key, value in options.items():
-            if value is not None and conn_type == 'ethernet':
-                cmd.extend([key, to_text(value)])
-            elif value is not None and conn_type == 'generic':
-                if key == 'connection.autoconnect':
-                    options.update(key=False)
+            if value is not None:
                 cmd.extend([key, to_text(value)])
 
         return cmd
@@ -1053,7 +1049,7 @@ class Nmcli(object):
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
             'bridge.mac-address': self.mac,
-            'bridge.max-age': self.maxage,
+            #'bridge.max-age': self.maxage,
             'bridge.priority': self.priority,
             'bridge.stp': self.bool_to_string(self.stp)
         }
@@ -1081,7 +1077,7 @@ class Nmcli(object):
             'bridge.forward-delay': self.forwarddelay,
             'bridge.hello-time': self.hellotime,
             'bridge.mac-address': self.mac,
-            'bridge.max-age': self.maxage,
+            #'bridge.max-age': self.maxage,
             'bridge.priority': self.priority,
             'bridge.stp': self.bool_to_string(self.stp)
         }

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -995,9 +995,7 @@ class Nmcli(object):
             elif value is not None and conn_type == 'generic':
                 if key == 'connection.autoconnect':
                     options[key] = 'false'
-                    cmd.extend([key, to_text(value)])
-                else
-                    cmd.extend([key, to_text(value)])
+                cmd.extend([key, to_text(value)])
 
         return cmd
 

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -890,7 +890,7 @@ class Nmcli(object):
             'gw4': self.gw4,
             'ip6': self.ip6,
             'gw6': self.gw6,
-            'connection.autoconnect': self.bool_to_string(self.autoconnect),
+            'autoconnect': self.bool_to_string(self.autoconnect),
             'ipv4.dns-search': self.dns4_search,
             'ipv6.dns-search': self.dns6_search,
             'miimon': self.miimon,

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -993,7 +993,8 @@ class Nmcli(object):
             if value is not None and conn_type == 'ethernet':
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
-                if key != 'connection.autoconnect':
+                if key == 'connection.autoconnect':
+                    value: 'false'
                     cmd.extend([key, to_text(value)])
 
         return cmd
@@ -1478,10 +1479,10 @@ def main():
             slavepriority=dict(type='int', default=32),
             forwarddelay=dict(type='int', default=15),
             hellotime=dict(type='int', default=2),
-            maxage=dict(type='int', default=20),
+            maxage=dict(type='int'),
             ageingtime=dict(type='int', default=300),
             hairpin=dict(type='bool', default=True),
-            path_cost=dict(type='int', default=100),
+            path_cost=dict(type='int'),
             # vlan specific vars
             vlanid=dict(type='int'),
             vlandev=dict(type='str'),

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -994,7 +994,9 @@ class Nmcli(object):
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
                 if key == 'connection.autoconnect':
-                    value: 'false'
+                    options[key] = 'false'
+                    cmd.extend([key, to_text(value)])
+                else
                     cmd.extend([key, to_text(value)])
 
         return cmd

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -993,7 +993,7 @@ class Nmcli(object):
             if value is not None and conn_type == 'ethernet':
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
-                if key is not 'connection.autoconnect':
+                if key != 'connection.autoconnect':
                     cmd.extend([key, to_text(value)])
 
         return cmd

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -994,7 +994,7 @@ class Nmcli(object):
                 cmd.extend([key, to_text(value)])
             elif value is not None and conn_type == 'generic':
                 if key == 'connection.autoconnect':
-                    options[key] = false
+                    options[key] = self.bool_to_string(False)
                 cmd.extend([key, to_text(value)])
 
         return cmd


### PR DESCRIPTION
Errors found/fixed and now working on all tested Red Hat versions:

- 7.0: nmcli too version 0.9.9.1-13.git20140326.4dba720.el7
- 7.6: nmcli tool, version 1.12.0-10.el7_6
- 7.7: nmcli tool, version 1.18.0-5.el7



1. Conversion

__Error__
```
TypeError: argument of type 'int' is not iterable
```

__Fix__

Added line 587
```
from ansible.module_utils._text import to_text
```

Replaced several lines:
```
sed -i 's/cmd.extend(\[key, value\])/cmd.extend(\[key, to_text(value)\])/g' /usr/lib/python2.7/site-packages/ansible/modules/net_tools/nmcli.py
```


2. NMCLI syntax

__Error__
```
Error: invalid <setting>.<property> 'autoconnect'.
```

__Reproduce__

Working/Not Working
```
[root@localhost ~]# nmcli con mod enp0s3 connection.autoconnect yes
[root@localhost ~]# nmcli con mod enp0s3 autoconnect yes
Error: invalid <setting>.<property> 'autoconnect'.
[root@localhost ~]# 
```

__Fix__
```
Added 'connection.autoconnect' to the nmcli.py rather than 'autoconnect'
```


3. NMCLI version and NM-glib package dependency

__Error__
```
The error was: ValueError: Namespace NMClient not available
"msg": "Failed to import the required Python library (NetworkManager glib API)"
```

__Fix__
```
try/except block code lines 566 to 582
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
