### PR TITLE
[backport/2.9/62330] nsupdate: Don't mention the Microsoft DNS server

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -24,7 +24,6 @@ module: nsupdate
 short_description: Manage DNS records.
 description:
     - Create, update and remove DNS records using DDNS updates
-    - DDNS works well with both bind and Microsoft DNS (see https://technet.microsoft.com/en-us/library/cc961412.aspx)
 version_added: "2.3"
 requirements:
   - dnspython


### PR DESCRIPTION
##### SUMMARY
Microsoft's DNS server uses GSS-TSIG to secure Dynamic DNS
updates. That is a Kerberos based form of TSIG neither supported by
the Ansible nsupdate module nor the underlying dnspython module.

Related to #57294 and #62238.

(cherry picked from commit 70a33c3140582b0855a34129343a95b9f8fde1a7)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nsupdate