### PR TITLE
Fix iosxr_lag_interfaces intermittent failures

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/utils/utils.py
+++ b/lib/ansible/module_utils/network/iosxr/utils/utils.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.network.common.utils import is_masklen, to_netmask
+from ansible.module_utils.network.common.utils import dict_diff, is_masklen, to_netmask
 
 
 def remove_command_from_config_list(interface, cmd, commands):
@@ -178,12 +178,10 @@ def diff_list_of_dicts(w, h):
         h = []
 
     diff = []
-    set_w = set(tuple(d.items()) for d in w)
-    set_h = set(tuple(d.items()) for d in h)
-    difference = set_w.difference(set_h)
-
-    for element in difference:
-        diff.append(dict((x, y) for x, y in element))
+    for w_item, h_item in zip(w, h):
+        d = dict_diff(h_item, w_item)
+        if d:
+            diff.append(d)
 
     return diff
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  If the dictionary is read out of order from member
   the current logic in `diff_list_of_dicts` returns
   unwanted diff. Hence use `dict_diff` utils
   function instead of sets.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_lag_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
