### PR TITLE
Do not PATCH Account Enabled prop if not supported

### DIFF
--- a/changelogs/fragments/62617-fix-redfish-enable-account-if-enabled-prop-missing.yaml
+++ b/changelogs/fragments/62617-fix-redfish-enable-account-if-enabled-prop-missing.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_command - fix EnableAccount if Enabled property is not present in Account resource (https://github.com/ansible/ansible/issues/59822)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -874,7 +874,7 @@ class RedfishUtils(object):
         uri = response['uri']
         data = response['data']
 
-        if data.get('Enabled'):
+        if data.get('Enabled', True):
             # account already enabled, nothing to do
             return {'ret': True, 'changed': False}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the enable_user() method to avoid PATCHing the `Enabled` property if that property is not present in the Account resource (i.e. the property is not supported).

If the property is not present (not supported), the account is assumed to be enabled by default and no action is needed to enable it.

Fixes #59822

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue #59822 for a description of the problem.

<!--- Paste verbatim command output below, e.g. before and after your change -->
After the fix, when running the `EnableUser` command on an account that does not support the `Enabled` property, the command succeeds with `changed=0`:
```paste below
$ ansible-playbook -i myinventory.yml playbooks/accounts/enable_user.yml 

PLAY [Enable User] *************************************************************

TASK [Enable user] *************************************************************
[WARNING]: Platform darwin on host mockup-localstorage is using the discovered
Python interpreter at /usr/bin/python, but future installation of another
Python interpreter could change this. See https://docs.ansible.com/ansible/deve
l/reference_appendices/interpreter_discovery.html for more information.

ok: [mockup-localstorage]

PLAY RECAP *********************************************************************
mockup-localstorage        : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
