### PR TITLE
docker_login: fix Python 3 problem in #60381

### DIFF
--- a/changelogs/fragments/62621-docker_login-fix-60381.yaml
+++ b/changelogs/fragments/62621-docker_login-fix-60381.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - correct broken fix for https://github.com/ansible/ansible/pull/60381 which crashes for Python 3."

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -224,9 +224,9 @@ class LoginManager(DockerBaseClass):
         (rc, out, err) = self.client.module.run_command(cmd)
         if rc != 0:
             self.fail("Could not log out: %s" % err)
-        if b'Not logged in to ' in out:
+        if 'Not logged in to ' in out:
             self.results['changed'] = False
-        elif b'Removing login credentials for ' in out:
+        elif 'Removing login credentials for ' in out:
             self.results['changed'] = True
         else:
             self.client.module.warn('Unable to determine whether logout was successful.')


### PR DESCRIPTION
##### SUMMARY
Fixes #62484. This fixes a bug in #60381, which originally fixed #59232. The fix worked for Python 2, but not for Python 3. With this change, it should work fine for both Python 2 and 3.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_login
