### PR TITLE
Remove check_args from eos & ios

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -84,10 +84,6 @@ def get_provider_argspec():
     return eos_provider_spec
 
 
-def check_args(module, warnings):
-    pass
-
-
 def load_params(module):
     provider = module.params.get('provider') or dict()
     for key, value in iteritems(provider):

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -90,10 +90,6 @@ def get_capabilities(module):
     return module._ios_capabilities
 
 
-def check_args(module, warnings):
-    pass
-
-
 def get_defaults_flag(module):
     connection = get_connection(module)
     try:

--- a/lib/ansible/modules/network/eos/_eos_vlan.py
+++ b/lib/ansible/modules/network/eos/_eos_vlan.py
@@ -132,7 +132,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.eos.eos import load_config, run_commands
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 
 def search_obj_in_list(vlan_id, lst):
@@ -327,7 +327,6 @@ def main():
                            mutually_exclusive=mutually_exclusive)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -89,7 +89,7 @@ session_name:
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.eos.eos import load_config, run_commands
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_text
 
@@ -174,7 +174,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -299,7 +299,6 @@ from ansible.module_utils.network.common.config import NetworkConfig, dumps
 from ansible.module_utils.network.eos.eos import get_config, load_config, get_connection
 from ansible.module_utils.network.eos.eos import run_commands
 from ansible.module_utils.network.eos.eos import eos_argument_spec
-from ansible.module_utils.network.eos.eos import check_args
 
 
 def get_candidate(module):
@@ -384,7 +383,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/eos/eos_logging.py
+++ b/lib/ansible/modules/network/eos/eos_logging.py
@@ -105,7 +105,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.eos.eos import get_config, load_config
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 
 DEST_GROUP = ['on', 'host', 'console', 'monitor', 'buffered']
@@ -386,7 +386,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -158,7 +158,7 @@ from functools import partial
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.eos.eos import get_config, load_config
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 from ansible.module_utils.six import iteritems
 
 
@@ -366,8 +366,6 @@ def main():
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -126,7 +126,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.eos.eos import load_config, run_commands
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 
 def search_obj_in_list(name, lst):
@@ -319,7 +319,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/ios/_ios_interface.py
+++ b/lib/ansible/modules/network/ios/_ios_interface.py
@@ -170,7 +170,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network.ios.ios import get_config, load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.network.common.utils import conditional, remove_default_spec
 
@@ -466,7 +466,6 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -91,7 +91,7 @@ commands:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network.ios.ios import load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 import re
 
 
@@ -163,7 +163,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -146,7 +146,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.parsing import Conditional
 from ansible.module_utils.network.common.utils import transform_commands, to_lines
 from ansible.module_utils.network.ios.ios import run_commands
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 
 def parse_commands(module, warnings):
@@ -184,7 +184,6 @@ def main():
 
     warnings = list()
     result = {'changed': False, 'warnings': warnings}
-    check_args(module, warnings)
     commands = parse_commands(module, warnings)
     wait_for = module.params['wait_for'] or list()
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -342,13 +342,11 @@ from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.network.ios.ios import run_commands, get_config
 from ansible.module_utils.network.ios.ios import get_defaults_flag, get_connection
 from ansible.module_utils.network.ios.ios import ios_argument_spec
-from ansible.module_utils.network.ios.ios import check_args as ios_check_args
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
 
 
 def check_args(module, warnings):
-    ios_check_args(module, warnings)
     if module.params['multiline_delimiter']:
         if len(module.params['multiline_delimiter']) != 1:
             module.fail_json(msg='multiline_delimiter value can only be a '

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -126,7 +126,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec, validate_ip_address
 from ansible.module_utils.network.ios.ios import get_config, load_config
 from ansible.module_utils.network.ios.ios import get_capabilities
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 
 def validate_size(value, module):
@@ -406,7 +406,6 @@ def main():
     os_version = device_info['device_info']['network_os_version']
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_ntp.py
+++ b/lib/ansible/modules/network/ios/ios_ntp.py
@@ -93,7 +93,7 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.ios.ios import get_config, load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 
 def parse_server(line, dest):
@@ -287,7 +287,6 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    check_args(module, warnings)
     if warnings:
         result['warnings'] = warnings
 

--- a/lib/ansible/modules/network/ios/ios_ping.py
+++ b/lib/ansible/modules/network/ios/ios_ping.py
@@ -103,7 +103,7 @@ rtt:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.ios.ios import run_commands
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 import re
 
 
@@ -128,7 +128,6 @@ def main():
     vrf = module.params["vrf"]
 
     warnings = list()
-    check_args(module, warnings)
 
     results = {}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -137,7 +137,7 @@ from re import findall
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec, validate_ip_address
 from ansible.module_utils.network.ios.ios import get_config, load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 
 
 def map_obj_to_commands(want, have):
@@ -290,7 +290,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -120,7 +120,7 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.ios.ios import get_config, load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.common.utils import ComplexList
 
 _CONFIGURED_VRFS = None
@@ -360,7 +360,6 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    check_args(module, warnings)
     result['warnings'] = warnings
 
     want = map_params_to_obj(module)

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -228,7 +228,7 @@ from functools import partial
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.ios.ios import get_config, load_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.six import iteritems
 
 
@@ -510,8 +510,6 @@ def main():
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -256,7 +256,7 @@ from functools import partial
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network.ios.ios import load_config, get_config
-from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
+from ansible.module_utils.network.ios.ios import ios_argument_spec
 from ansible.module_utils.network.common.config import NetworkConfig
 from ansible.module_utils.six import iteritems
 
@@ -691,7 +691,6 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    check_args(module, warnings)
     result['warnings'] = warnings
 
     want = map_params_to_obj(module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`check_args` does nothing, and has not for many releases.

See also: #62625

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request?

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos
ios