### PR TITLE
mongodb_replicaset/test: properly kill the nodes

### DIFF
--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -89,7 +89,7 @@
   wait_for:
     path: "/proc/{{ item }}/status"
     state: absent
-  with_items: "{{ pids_of_mongod }}"
+  with_items: "{{ pids_of_mongod.pids }}"
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset1 }}"

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_replicaset.yml
@@ -36,7 +36,6 @@
     chdir: "{{ remote_tmp_dir }}"
   with_items: "{{ mongodb_nodes | sort }}"
   when: mongod_auth == True
-  ignore_errors: yes
 
 - name: Wait for mongod to start responding
   wait_for:


### PR DESCRIPTION
##### SUMMARY

The `pids` module returns the list of the PID in a `pids` key.

This change ensures we correctly wait for the end of the previous mongod
instances before we start the next ones.

In addition, we remove an unnecessary `ignore_errors`.

closes: #61938
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

mongodb_replicaset