### PR TITLE
Fixed typo in nxos_config documentation

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -198,7 +198,7 @@ options:
       dir_path:
         description:
           - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exit it will be first
+            configuration file will be stored. If the directory does not exist it will be
             created and the filename is either the value of C(filename) or default filename
             as described in C(filename) options description. If the path value is not given
             in that case a I(backup) directory will be created in the current working directory


### PR DESCRIPTION
##### SUMMARY
Changed 'exit' to 'exist' and removed unnecessary word 'first'


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

```
