### PR TITLE
k8s: apply no longer the default behaviour

### DIFF
--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -91,7 +91,7 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         argument_spec['wait_condition'] = dict(type='dict', default=None, options=self.condition_spec)
         argument_spec['validate'] = dict(type='dict', default=None, options=self.validate_spec)
         argument_spec['append_hash'] = dict(type='bool', default=False)
-        argument_spec['apply'] = dict(type='bool')
+        argument_spec['apply'] = dict(type='bool', default=False)
         return argument_spec
 
     def __init__(self, k8s_kind=None, *args, **kwargs):
@@ -124,12 +124,10 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         if self.params['merge_type']:
             if LooseVersion(self.openshift_version) < LooseVersion("0.6.2"):
                 self.fail_json(msg=missing_required_lib("openshift >= 0.6.2", reason="for merge_type"))
-        if self.params.get('apply') is not None:
+        self.apply = self.params.get('apply', False)
+        if self.apply:
             if not HAS_K8S_APPLY:
                 self.fail_json(msg=missing_required_lib("openshift >= 0.9.2", reason="for apply"))
-            self.apply = self.params['apply']
-        else:
-            self.apply = HAS_K8S_APPLY
 
         if resource_definition:
             if isinstance(resource_definition, string_types):

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -142,7 +142,6 @@ options:
     - C(apply) compares the desired resource definition with the previously supplied resource definition,
       ignoring properties that are automatically generated
     - C(apply) works better with Services than 'force=yes'
-    - C(apply) defaults to True if the openshift library is new enough to support it (0.9.0 or newer)
     - mutually exclusive with C(merge_type)
     type: bool
     version_added: "2.9"


### PR DESCRIPTION
There are too many lingering uncertainties about the correctness of
apply behaviour. All tests seem to suggest it works, and it's definitely
performed well in real world application, but it may be a breaking
and unexpected change to default to apply

We will let apply bed in during 2.9 and allow people to opt in, we
may default to it in future (or not)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
