### PR TITLE
Add proper error when trying to run on older PS versions

### DIFF
--- a/changelogs/fragments/pwsh-minimum.yaml
+++ b/changelogs/fragments/pwsh-minimum.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Windows - Add a check for the minimum PowerShell version so we can create a friendly error message on older hosts

--- a/lib/ansible/executor/powershell/bootstrap_wrapper.ps1
+++ b/lib/ansible/executor/powershell/bootstrap_wrapper.ps1
@@ -1,4 +1,10 @@
 &chcp.com 65001 > $null
+
+if ($PSVersionTable.PSVersion -lt [Version]"3.0") {
+    '{"failed":true,"msg":"Ansible requires PowerShell v3.0 or newer"}'
+    exit 1
+}
+
 $exec_wrapper_str = $input | Out-String
 $split_parts = $exec_wrapper_str.Split(@("`0`0`0`0"), 2, [StringSplitOptions]::RemoveEmptyEntries)
 If (-not $split_parts.Length -eq 2) { throw "invalid payload" }


### PR DESCRIPTION
##### SUMMARY
I'm still not sure we actually want this check in Ansible or not, I created the PR just to see if it was viable and it seems to be. This does not stop people from still using `raw` on older hosts if they have some manual install steps as `raw` does not into the `bootstrap_wrapper`. Only proper modules and `script` call that and it currently fails with a syntax error anyway.

```
win7 | FAILED! => {
    "changed": false,
    "module_stderr": "Exception calling \"Create\" with \"1\" argument(s): \"You must provide a value expression on the right-hand side of the '-' operator.\"\r\n    + CategoryInfo          : NotSpecified: (:) [
], MethodInvocationException\r\n    + FullyQualifiedErrorId : DotNetMethodException",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

Fixes https://github.com/ansible/ansible/issues/62411

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Windows