### PR TITLE
[stable-2.9] Pin urllib3 version for k8s test

### DIFF
--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -12,6 +12,7 @@
 
 - pip:
     name:
+      - urllib3<=1.25.3
       - openshift>=0.9.2
       - coverage
     virtualenv: "{{ virtualenv }}"


### PR DESCRIPTION
urllib3-1.25.4 breaks k8s due to this bug:
https://github.com/urllib3/urllib3/issues/1682
(cherry picked from commit d3dfea9)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
