### PR TITLE
mysql_replication: add master_use_gtid parameter

### DIFF
--- a/changelogs/fragments/62648-mysql_replication_add_master_use_gtid_param.yml
+++ b/changelogs/fragments/62648-mysql_replication_add_master_use_gtid_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``master_use_gtid`` parameter (https://github.com/ansible/ansible/pull/62648).

--- a/test/integration/targets/mariadb_replication/tasks/main.yml
+++ b/test/integration/targets/mariadb_replication/tasks/main.yml
@@ -4,3 +4,8 @@
 # Initial CI tests of mysql_replication module
 - import_tasks: mariadb_replication_initial.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'
+
+# Tests of master_use_gtid parameter
+# https://github.com/ansible/ansible/pull/62648
+- import_tasks: mariadb_master_use_gtid.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mariadb_replication/tasks/mariadb_master_use_gtid.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_master_use_gtid.yml
@@ -1,0 +1,149 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Tests for master_use_gtid parameter.
+# https://github.com/ansible/ansible/pull/62648
+
+#############################
+# master_use_gtid: "disabled"
+#############################
+
+# Auxiliary step:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+# Set master_use_gtid disabled:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+    master_use_gtid: disabled
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
+- name: Run replication via shell
+  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Using_Gtid == 'No'
+
+- name: Stop replication via shell
+  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+################################
+# master_use_gtid: "current_pos"
+################################
+
+# Auxiliary step:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+# Set master_use_gtid current_pos:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+    master_use_gtid: current_pos
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
+- name: Run replication via shell
+  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Using_Gtid == 'Current_Pos'
+
+- name: Stop replication via shell
+  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+##############################
+# master_use_gtid: "slave_pos"
+##############################
+
+# Auxiliary step:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+# Set master_use_gtid slave_pos:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+    master_use_gtid: slave_pos
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
+- name: Run replication via shell
+  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Using_Gtid == 'Slave_Pos'
+
+- name: Stop replication via shell
+  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'

--- a/test/integration/targets/mariadb_replication/tasks/mariadb_master_use_gtid.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_master_use_gtid.yml
@@ -35,8 +35,12 @@
     that:
     - result is changed
 
-- name: Run replication via shell
-  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Start standby for further tests:
+- name: Start standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: startslave
 
 - name: Get standby status
   mysql_replication:
@@ -49,8 +53,12 @@
     that:
     - slave_status.Using_Gtid == 'No'
 
-- name: Stop replication via shell
-  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Stop standby for further tests:
+- name: Stop standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
 
 ################################
 # master_use_gtid: "current_pos"
@@ -83,8 +91,12 @@
     that:
     - result is changed
 
-- name: Run replication via shell
-  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Start standby for further tests:
+- name: Start standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: startslave
 
 - name: Get standby status
   mysql_replication:
@@ -97,8 +109,12 @@
     that:
     - slave_status.Using_Gtid == 'Current_Pos'
 
-- name: Stop replication via shell
-  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Stop standby for further tests:
+- name: Stop standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
 
 ##############################
 # master_use_gtid: "slave_pos"
@@ -131,8 +147,12 @@
     that:
     - result is changed
 
-- name: Run replication via shell
-  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Start standby for further tests:
+- name: Start standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: startslave
 
 - name: Get standby status
   mysql_replication:
@@ -145,5 +165,9 @@
     that:
     - slave_status.Using_Gtid == 'Slave_Pos'
 
-- name: Stop replication via shell
-  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Stop standby for further tests:
+- name: Stop standby
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave


### PR DESCRIPTION
##### SUMMARY
Add MariadDB GTID support to mysql_replication module
rewrites #20630

Also the CI tests were updated to use later version of MariaDB

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```mysql_replication```
