### PR TITLE
Update examples in documentation for env lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -10,34 +10,48 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: read the value of environment variables
     description:
-        - Allows you to query the environment variables available on the controller when you invoked Ansible.
+      - Allows you to query the environment variables available on the
+        controller when you invoked Ansible.
     options:
       _terms:
-        description: Environment variable or list of them to lookup the values for
+        description:
+          - Environment variable or list of them to lookup the values for.
         required: True
+      default:
+        description:
+          - Default value when the environment variable is not defined.
+        type: string
+        default: ""
+        required: False
 """
 
 EXAMPLES = """
-- debug: msg="{{ lookup('env','HOME') }} is an environment variable"
+- debug:
+    msg: "'{{ lookup('env','HOME') }}' is the HOME environment variable."
+- debug:
+    msg: "'{{ lookup('env','USERNAME', 'nobody') }}' is the user name."
 """
 
 RETURN = """
   _list:
     description:
-      - values from the environment variables.
+      - Values from the environment variables.
     type: list
 """
+
+
+import os
+
 from ansible.plugins.lookup import LookupBase
 from ansible.utils import py3compat
 
 
 class LookupModule(LookupBase):
-
-    def run(self, terms, variables, **kwargs):
-
+    def run(self, terms, variables=None, default=''):
         ret = []
+
         for term in terms:
             var = term.split()[0]
-            ret.append(py3compat.environ.get(var, ''))
+            ret.append(py3compat.environ.get(var, default))
 
         return ret

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -8,7 +8,7 @@ DOCUMENTATION = """
     lookup: env
     author: Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>
     version_added: "0.9"
-    short_description: read the value of environment variables
+    short_description: Read the value of environment variables
     description:
       - Allows you to query the environment variables available on the
         controller when you invoked Ansible.
@@ -17,19 +17,24 @@ DOCUMENTATION = """
         description:
           - Environment variable or list of them to lookup the values for.
         required: True
-      default:
-        description:
-          - Default value when the environment variable is not defined.
-        type: string
-        default: ""
-        required: False
+    notes:
+      - The module returns an empty string if the environment variable is not
+        defined. This makes it impossbile to differentiate between the case the
+        variable is not defined and the case the variable is defined but it
+        contains an empty string.
+      - The C(default) filter requires second parameter to be set to C(True)
+        in order to set a default value in the case the variable is not
+        defined (see examples).
 """
 
 EXAMPLES = """
-- debug:
-    msg: "'{{ lookup('env','HOME') }}' is the HOME environment variable."
-- debug:
-    msg: "'{{ lookup('env','USERNAME', 'nobody') }}' is the user name."
+- name: Basic usage
+  debug:
+    msg: "'{{ lookup('env', 'HOME') }}' is the HOME environment variable."
+
+- name: Example how to set default value if the variable is not defined
+  debug:
+    msg: "'{{ lookup('env', 'USR') | default('nobody', True) }}' is the user."
 """
 
 RETURN = """
@@ -40,18 +45,16 @@ RETURN = """
 """
 
 
-import os
-
 from ansible.plugins.lookup import LookupBase
 from ansible.utils import py3compat
 
 
 class LookupModule(LookupBase):
-    def run(self, terms, variables=None, default=''):
+    def run(self, terms, variables, **kwargs):
         ret = []
 
         for term in terms:
             var = term.split()[0]
-            ret.append(py3compat.environ.get(var, default))
+            ret.append(py3compat.environ.get(var, ''))
 
         return ret


### PR DESCRIPTION
##### SUMMARY
The current `env` lookup plugin is setting the default value to empty string if the variable is not defined. This is nor particularly great as it doesn't allow to use the `default()` filter if the variable is not defined. It would be great if we could change the default value from empty string to `None` but that would break the backward compatibility. This PR is keeping the current behavior (non-existing variable returns empty string) and it's adding the possibility to define custom default value. It also adds some basic unit tests.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`env` lookup plugin

##### ADDITIONAL INFORMATION

```
# This returns empty string
lookup('env', 'MYVAR')

# This returns the default value defined in the lookup plugin
lookup('env', 'MYVAR', default='myval')

# It also allows to use the default() filter if setting the default to None
lookup('env', 'MYVAR', default=None) | default('myval')
```
