### PR TITLE
ec2_vpc_subnet: Rename resource_tags > tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -89,7 +89,7 @@ EXAMPLES = '''
     state: present
     vpc_id: vpc-123456
     cidr: 10.0.1.16/28
-    resource_tags:
+    tags:
       Name: Database Subnet
   register: database_subnet
 


### PR DESCRIPTION
##### SUMMARY

Most of the AWS module documentation refers to `tags` and not
`resource_tags`. This patch updates the documentation to match
other AWS module documentation. 😉

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

`ec2_vpc_subnet`

##### ADDITIONAL INFORMATION

This is just a small documentation change for `resource_tags` to `tags`.
