### PR TITLE
Zabbix: Update example document for zabbix_action module

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -359,6 +359,7 @@ EXAMPLES = '''
     event_source: 'trigger'
     state: present
     status: enabled
+    esc_period: 60
     conditions:
       - type: 'trigger_severity'
         operator: '>='
@@ -381,6 +382,7 @@ EXAMPLES = '''
     event_source: 'trigger'
     state: present
     status: enabled
+    esc_period: 60
     conditions:
       - type: 'trigger_name'
         operator: 'like'
@@ -398,6 +400,8 @@ EXAMPLES = '''
           - 'Admin'
       - type: remote_command
         command: 'systemctl restart zabbix-agent'
+        command_type: custom_script
+        execute_on: server
         run_on_hosts:
           - 0
 
@@ -411,6 +415,7 @@ EXAMPLES = '''
     event_source: 'trigger'
     state: present
     status: enabled
+    esc_period: 60
     conditions:
       - type: 'trigger_severity'
         operator: '>='


### PR DESCRIPTION
##### SUMMARY
Modify the EXAMPLE because the `esc_period` parameter has been changed to required.
In remote_command, `command_type` and `execute_on` parameters are missing, so added them to EXAMPLE.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_action
