### PR TITLE
[Backport/2.9/62616] VMware: Fix documentation of vmware_cluster_ha

### DIFF
--- a/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
+++ b/changelogs/fragments/62616-vmware_cluster_ha-fix-documentation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_ha - Remove a wrong parameter from an example in the documentation.

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster_ha.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster_ha.py
@@ -197,7 +197,6 @@ EXAMPLES = r"""
     cluster_name: "{{ cluster_name }}"
     enable_ha: True
     ha_vm_monitoring: vmMonitoringOnly
-    enable_vsan: True
   delegate_to: localhost
 
 - name: Enable HA with admission control reserving 50% of resources for HA


### PR DESCRIPTION
##### SUMMARY
There is a C&P error in the example section of the documentation: enable_vsan isn't a valid parameter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_cluster_ha

##### ADDITIONAL INFORMATION

Backport of PR #62616