### PR TITLE
[stable-2.9] Account for empty strings when splitting the host pattern (#62442)

### DIFF
--- a/changelogs/fragments/split-host-pattern-empty-strings.yaml
+++ b/changelogs/fragments/split-host-pattern-empty-strings.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - account for empty strings in when splitting the host pattern (https://github.com/ansible/ansible/issues/61964)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -130,7 +130,7 @@ def split_host_pattern(pattern):
                 '''), pattern, re.X
             )
 
-    return [p.strip() for p in patterns]
+    return [p.strip() for p in patterns if p.strip()]
 
 
 class InventoryManager(object):

--- a/test/integration/targets/inventory_limit/aliases
+++ b/test/integration/targets/inventory_limit/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group4

--- a/test/integration/targets/inventory_limit/hosts.yml
+++ b/test/integration/targets/inventory_limit/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    host1:
+    host2:
+    host3:

--- a/test/integration/targets/inventory_limit/runme.sh
+++ b/test/integration/targets/inventory_limit/runme.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eux
+
+trap 'echo "Host pattern limit test failed"' ERR
+
+# https://github.com/ansible/ansible/issues/61964
+
+# These tests should return all hosts
+ansible -i hosts.yml all --limit ,, --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml ,, --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml , --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml all --limit , --list-hosts | tee out ; grep -q 'hosts (3)' out
+ansible -i hosts.yml all --limit '' --list-hosts | tee out ; grep -q 'hosts (3)' out
+
+
+# Only one host
+ansible -i hosts.yml all --limit ,,host1 --list-hosts | tee out ; grep -q 'hosts (1)' out
+ansible -i hosts.yml ,,host1 --list-hosts | tee out ; grep -q 'hosts (1)' out
+
+ansible -i hosts.yml all --limit host1,, --list-hosts | tee out ; grep -q 'hosts (1)' out
+ansible -i hosts.yml host1,, --list-hosts | tee out ; grep -q 'hosts (1)' out
+
+
+# Only two hosts
+ansible -i hosts.yml all --limit host1,,host3 --list-hosts | tee out ; grep -q 'hosts (2)' out
+ansible -i hosts.yml host1,,host3 --list-hosts | tee out ; grep -q 'hosts (2)' out
+
+ansible -i hosts.yml all --limit 'host1, ,    ,host3' --list-hosts | tee out ; grep -q 'hosts (2)' out
+ansible -i hosts.yml 'host1, ,    ,host3' --list-hosts | tee out ; grep -q 'hosts (2)' out
+

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -49,6 +49,10 @@ class TestInventory(unittest.TestCase):
         'a:b': ['a', 'b'],
         ' a : b ': ['a', 'b'],
         'foo:bar:baz[1:2]': ['foo', 'bar', 'baz[1:2]'],
+        'a,,b': ['a', 'b'],
+        'a,  ,b,,c, ,': ['a', 'b', 'c'],
+        ',': [],
+        '': [],
     }
 
     pattern_lists = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #62442 for Ansible 2.9
(cherry picked from commit 987265a6ef)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/inventory/manager.py`