### PR TITLE
Add module ldap_attrs; deprecate ldap_attr

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -43,12 +43,16 @@ Modules removed
 
 The following modules no longer exist:
 
-* ldap_attr use :ref:`ldap_attrs <ldap_attrs_module>` instead.
 * letsencrypt use :ref:`acme_certificate <acme_certificate_module>` instead.
 
 
 Deprecation notices
 -------------------
+
+The following modules will be removed in Ansible 2.14. Please update your playbooks accordingly.
+
+* ldap_attr use :ref:`ldap_attrs <ldap_attrs_module>` instead.
+
 
 The following functionality will be removed in Ansible 2.14. Please update update your playbooks accordingly.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -43,6 +43,7 @@ Modules removed
 
 The following modules no longer exist:
 
+* ldap_attr use :ref:`ldap_attrs <ldap_attrs_module>` instead.
 * letsencrypt use :ref:`acme_certificate <acme_certificate_module>` instead.
 
 
@@ -63,6 +64,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`ec2_key <ec2_key_module>`: the ``wait`` option will be removed. It has had no effect since Ansible 2.5.
 * :ref:`ec2_key <ec2_key_module>`: the ``wait_timeout`` option will be removed. It has had no effect since Ansible 2.5.
 * :ref:`ec2_lc <ec2_lc_module>`: the ``associate_public_ip_address`` option will be removed. It has always been ignored by the module.
+
 
 The following functionality will change in Ansible 2.14. Please update update your playbooks accordingly.
 

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -36,7 +36,10 @@ notes:
     possible to see spurious changes when target and actual values are
     semantically identical but lexically distinct.
 version_added: '2.3'
-deprecated: Deprecated in 2.9. Use M(ldap_attrs) instead.
+deprecated:
+  removed_in: '2.12'
+  why: 'The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies..'
+  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.9. Use M(ldap_attrs) instead.'
 author:
   - Jiri Tyr (@jtyr)
 requirements:

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -38,7 +38,7 @@ notes:
 version_added: '2.3'
 deprecated:
   removed_in: '2.14'
-  why: 'The current "ldap_attr" module does not support LDAP attribute insertations or deletions with objectClass dependencies..'
+  why: 'The current "ldap_attr" module does not support LDAP attribute insertations or deletions with objectClass dependencies.'
   alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.10.'
 author:
   - Jiri Tyr (@jtyr)

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -38,8 +38,8 @@ notes:
 version_added: '2.3'
 deprecated:
   removed_in: '2.14'
-  why: 'The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies..'
-  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.10. Use M(ldap_attrs) instead.'
+  why: 'The current "ldap_attr" module does not support LDAP attribute insertations or deletions with objectClass dependencies..'
+  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.10.'
 author:
   - Jiri Tyr (@jtyr)
 requirements:

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -57,6 +57,7 @@ options:
       - If C(absent), all given values will be removed if present.
       - If C(exact), the set of values will be forced to exactly those provided and no others.
       - If I(state=exact) and I(value) is an empty list, all values for this attribute will be removed.
+    type: str
     choices: [ absent, exact, present ]
     default: present
   values:

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -38,7 +38,7 @@ notes:
 version_added: '2.3'
 deprecated:
   removed_in: '2.14'
-  why: 'The current "ldap_attr" module does not support LDAP attribute insertations or deletions with objectClass dependencies.'
+  why: 'The current "ldap_attr" module does not support LDAP attribute insertions or deletions with objectClass dependencies.'
   alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.10.'
 author:
   - Jiri Tyr (@jtyr)

--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -37,9 +37,9 @@ notes:
     semantically identical but lexically distinct.
 version_added: '2.3'
 deprecated:
-  removed_in: '2.12'
+  removed_in: '2.14'
   why: 'The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies..'
-  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.9. Use M(ldap_attrs) instead.'
+  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.10. Use M(ldap_attrs) instead.'
 author:
   - Jiri Tyr (@jtyr)
 requirements:

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2017, Alexander Korinek <noles@a3k.net>
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -8,18 +9,20 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['deprecated'],
+    'status': ['preview'],
     'supported_by': 'community'
 }
 
+
 DOCUMENTATION = r'''
 ---
-module: ldap_attr
-short_description: Add or remove LDAP attribute values
+module: ldap_attrs
+short_description: Add or remove multiple LDAP attribute values.
 description:
-  - Add or remove LDAP attribute values.
+  - Add or remove multiple LDAP attribute values.
 notes:
   - This only deals with attributes on existing entries. To add or remove
     whole entries, see M(ldap_entry).
@@ -35,34 +38,29 @@ notes:
     rules. This should work out in most cases, but it is theoretically
     possible to see spurious changes when target and actual values are
     semantically identical but lexically distinct.
-version_added: '2.3'
-deprecated: Deprecated in 2.9. Use M(ldap_attrs) instead.
+version_added: '2.9'
 author:
   - Jiri Tyr (@jtyr)
+  - Alexander Korinek (@noles)
 requirements:
   - python-ldap
 options:
-  name:
-    description:
-      - The name of the attribute to modify.
-    type: str
-    required: true
   state:
-    description:
-      - The state of the attribute values.
-      - If C(present), all given values will be added if they're missing.
-      - If C(absent), all given values will be removed if present.
-      - If C(exact), the set of values will be forced to exactly those provided and no others.
-      - If I(state=exact) and I(value) is an empty list, all values for this attribute will be removed.
-    choices: [ absent, exact, present ]
+    required: false
+    choices: [present, absent, exact]
     default: present
-  values:
     description:
-      - The value(s) to add or remove. This can be a string or a list of
-        strings. The complex argument format is required in order to pass
-        a list of strings (see examples).
-    type: raw
+      - The state of the attribute values. If C(present), all given
+        values will be added if they're missing. If C(absent), all given
+        values will be removed if present. If C(exact), the set of values
+        will be forced to exactly those provided and no others. If
+        I(state=exact) and I(value) is empty, all values for this
+        attribute will be removed.
+  attributes:
     required: true
+    description:
+      - The attribute(s) and value(s) to add or remove. The complex argument format is required in order to pass
+        a list of strings (see examples).
   params:
     description:
     - Additional module parameters.
@@ -71,56 +69,54 @@ extends_documentation_fragment:
 - ldap.documentation
 '''
 
+
 EXAMPLES = r'''
 - name: Configure directory number 1 for example.com
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcSuffix
-    values: dc=example,dc=com
+    attributes:
+        olcSuffix: dc=example,dc=com
     state: exact
 
 # The complex argument format is required here to pass a list of ACL strings.
 - name: Set up the ACL
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcAccess
-    values:
-      - >-
-        {0}to attrs=userPassword,shadowLastChange
-        by self write
-        by anonymous auth
-        by dn="cn=admin,dc=example,dc=com" write
-        by * none'
-      - >-
-        {1}to dn.base="dc=example,dc=com"
-        by dn="cn=admin,dc=example,dc=com" write
-        by * read
+    attributes:
+        olcAccess:
+          - >-
+            {0}to attrs=userPassword,shadowLastChange
+            by self write
+            by anonymous auth
+            by dn="cn=admin,dc=example,dc=com" write
+            by * none'
+          - >-
+            {1}to dn.base="dc=example,dc=com"
+            by dn="cn=admin,dc=example,dc=com" write
+            by * read
     state: exact
 
 - name: Declare some indexes
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcDbIndex
-    values: "{{ item }}"
-  with_items:
-    - objectClass eq
-    - uid eq
+    attributes:
+        olcDbIndex:
+            - objectClass eq
+            - uid eq
 
 - name: Set up a root user, which we can use later to bootstrap the directory
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: "{{ item.key }}"
-    values: "{{ item.value }}"
+    attributes:
+        olcRootDN: cn=root,dc=example,dc=com
+        olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
     state: exact
-  with_dict:
-    olcRootDN: cn=root,dc=example,dc=com
-    olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
 
 - name: Get rid of an unneeded attribute
-  ldap_attr:
+  ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
-    name: shadowExpire
-    values: []
+    attributes:
+        shadowExpire: ""
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com
@@ -135,13 +131,14 @@ EXAMPLES = r'''
 #   bind_dn: cn=admin,dc=example,dc=com
 #   bind_pw: password
 - name: Get rid of an unneeded attribute
-  ldap_attr:
+  ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
-    name: shadowExpire
-    values: []
+    attributes:
+        shadowExpire: ""
     state: exact
     params: "{{ ldap_auth }}"
 '''
+
 
 RETURN = r'''
 modlist:
@@ -167,82 +164,91 @@ except ImportError:
     HAS_LDAP = False
 
 
-class LdapAttr(LdapGeneric):
+class LdapAttrs(LdapGeneric):
     def __init__(self, module):
         LdapGeneric.__init__(self, module)
 
         # Shortcuts
-        self.name = self.module.params['name']
+        self.attrs = self.module.params['attributes']
         self.state = self.module.params['state']
 
-        # Normalize values
-        if isinstance(self.module.params['values'], list):
-            self.values = list(map(to_bytes, self.module.params['values']))
+
+        # Establish connection
+        self.connection = self._connect_to_ldap()
+
+    def _normalize_values(self, values):
+        """ Normalize attribute's values. """
+        norm_values = []
+
+        if isinstance(values, list):
+            norm_values = list(map(to_bytes, values))
         else:
-            self.values = [to_bytes(self.module.params['values'])]
+            norm_values = [to_bytes(values)]
+
+        return norm_values
 
     def add(self):
-        values_to_add = list(filter(self._is_value_absent, self.values))
-
-        if len(values_to_add) > 0:
-            modlist = [(ldap.MOD_ADD, self.name, values_to_add)]
-        else:
-            modlist = []
+        modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            for value in norm_values:
+                if self._is_value_absent(name, value):
+                    modlist.append((ldap.MOD_ADD, name, value))
 
         return modlist
 
     def delete(self):
-        values_to_delete = list(filter(self._is_value_present, self.values))
-
-        if len(values_to_delete) > 0:
-            modlist = [(ldap.MOD_DELETE, self.name, values_to_delete)]
-        else:
-            modlist = []
+        modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            for value in norm_values:
+                if self._is_value_present(name, value):
+                    modlist.append((ldap.MOD_DELETE, name, value))
 
         return modlist
 
     def exact(self):
-        try:
-            results = self.connection.search_s(
-                self.dn, ldap.SCOPE_BASE, attrlist=[self.name])
-        except ldap.LDAPError as e:
-            self.fail("Cannot search for attribute %s" % self.name, e)
-
-        current = results[0][1].get(self.name, [])
         modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            try:
+                results = self.connection.search_s(
+                    self.dn, ldap.SCOPE_BASE, attrlist=[name])
+            except ldap.LDAPError as e:
+                self.fail("Cannot search for attribute %s" % self.name, e)
 
-        if frozenset(self.values) != frozenset(current):
-            if len(current) == 0:
-                modlist = [(ldap.MOD_ADD, self.name, self.values)]
-            elif len(self.values) == 0:
-                modlist = [(ldap.MOD_DELETE, self.name, None)]
-            else:
-                modlist = [(ldap.MOD_REPLACE, self.name, self.values)]
+            current = results[0][1].get(name, [])
+
+            if frozenset(norm_values) != frozenset(current):
+                if len(current) == 0:
+                    modlist.append((ldap.MOD_ADD, name, norm_values))
+                elif len(norm_values) == 0:
+                    modlist.append((ldap.MOD_DELETE, name, None))
+                else:
+                    modlist.append((ldap.MOD_REPLACE, name, norm_values))
 
         return modlist
 
-    def _is_value_present(self, value):
+    def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
             is_present = bool(
-                self.connection.compare_s(self.dn, self.name, value))
+                self.connection.compare_s(self.dn, name, value))
         except ldap.NO_SUCH_ATTRIBUTE:
             is_present = False
 
         return is_present
 
-    def _is_value_absent(self, value):
+    def _is_value_absent(self, name, value):
         """ True if the target attribute doesn't have the given value. """
-        return not self._is_value_present(value)
-
+        return not self._is_value_present(name, value)
 
 def main():
     module = AnsibleModule(
         argument_spec=gen_specs(
-            name=dict(type='str', required=True),
             params=dict(type='dict'),
+            attributes=dict(type='dict', required=True),
             state=dict(type='str', default='present', choices=['absent', 'exact', 'present']),
-            values=dict(type='raw', required=True),
         ),
         supports_check_mode=True,
     )
@@ -258,7 +264,7 @@ def main():
         module.params.pop('params', None)
 
     # Instantiate the LdapAttr object
-    ldap = LdapAttr(module)
+    ldap = LdapAttrs(module)
 
     state = module.params['state']
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -172,10 +172,6 @@ class LdapAttrs(LdapGeneric):
         self.attrs = self.module.params['attributes']
         self.state = self.module.params['state']
 
-
-        # Establish connection
-        self.connection = self._connect_to_ldap()
-
     def _normalize_values(self, values):
         """ Normalize attribute's values. """
         norm_values = []
@@ -242,6 +238,7 @@ class LdapAttrs(LdapGeneric):
     def _is_value_absent(self, name, value):
         """ True if the target attribute doesn't have the given value. """
         return not self._is_value_present(name, value)
+
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = r'''
 ---
 module: ldap_attrs
-short_description: Add or remove multiple LDAP attribute values.
+short_description: Add or remove multiple LDAP attribute values
 description:
   - Add or remove multiple LDAP attribute values.
 notes:

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -73,12 +73,6 @@ options:
       - If C(yes), prepend list values with X-ORDERED index numbers in all
         attributes specified in the current task. This is useful mostly with
         I(olcAccess) attribute to easily manage LDAP Access Control Lists.
-  params:
-    description:
-      - Additional module parameters. This parameter can be used to define
-        various LDAP connection options in a dictionary variable and reuse them in
-        separate Ansible tasks.
-    type: dict
 extends_documentation_fragment:
 - ldap.documentation
 '''
@@ -154,22 +148,6 @@ EXAMPLES = r'''
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com
     bind_pw: password
-
-#
-# The same as in the previous example but with the authentication details
-# stored in the ldap_auth variable:
-#
-# ldap_auth:
-#   server_uri: ldap://localhost/
-#   bind_dn: cn=admin,dc=example,dc=com
-#   bind_pw: password
-- name: Get rid of an unneeded attribute
-  ldap_attrs:
-    dn: uid=jdoe,ou=people,dc=example,dc=com
-    attributes:
-        shadowExpire: ""
-    state: exact
-    params: "{{ ldap_auth }}"
 '''
 
 
@@ -294,7 +272,6 @@ class LdapAttrs(LdapGeneric):
 def main():
     module = AnsibleModule(
         argument_spec=gen_specs(
-            params=dict(type='dict'),
             attributes=dict(type='dict', required=True),
             ordered=dict(type='bool', default=False, required=False),
             state=dict(type='str', default='present', choices=['absent', 'exact', 'present']),
@@ -305,12 +282,6 @@ def main():
     if not HAS_LDAP:
         module.fail_json(msg=missing_required_lib('python-ldap'),
                          exception=LDAP_IMP_ERR)
-
-    # Update module parameters with user's parameters if defined
-    if 'params' in module.params and isinstance(module.params['params'], dict):
-        module.params.update(module.params['params'])
-        # Remove the params
-        module.params.pop('params', None)
 
     # Instantiate the LdapAttr object
     ldap = LdapAttrs(module)

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -153,7 +153,7 @@ EXAMPLES = r'''
   ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     attributes:
-        description: ""
+        description: []
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -43,6 +43,7 @@ version_added: '2.10'
 author:
   - Jiri Tyr (@jtyr)
   - Alexander Korinek (@noles)
+  - Maciej Delmanowski (@drybjed)
 requirements:
   - python-ldap
 options:
@@ -52,12 +53,12 @@ options:
     choices: [present, absent, exact]
     default: present
     description:
-      - The state of the attribute values. If C(present), all given
+      - The state of the attribute values. If C(present), all given attribute
         values will be added if they're missing. If C(absent), all given
-        values will be removed if present. If C(exact), the set of values
-        will be forced to exactly those provided and no others. If
-        I(state=exact) and I(value) is empty, all values for this
-        attribute will be removed.
+        attribute values will be removed if present. If C(exact), the set of
+        attribute values will be forced to exactly those provided and no others.
+        If I(state=exact) and the attribute I(value) is empty, all values for
+        this attribute will be removed.
   attributes:
     required: true
     type: dict
@@ -74,7 +75,9 @@ options:
         I(olcAccess) attribute to easily manage LDAP Access Control Lists.
   params:
     description:
-    - Additional module parameters.
+      - Additional module parameters. This parameter can be used to define
+        various LDAP connection options in a dictionary variable and reuse them in
+        separate Ansible tasks.
     type: dict
 extends_documentation_fragment:
 - ldap.documentation

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -139,11 +139,21 @@ EXAMPLES = r'''
         olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
     state: exact
 
-- name: Get rid of an unneeded attribute
+- name: Remove an attribute with a specific value
   ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     attributes:
-        shadowExpire: ""
+        description: "An example user account"
+    state: absent
+    server_uri: ldap://localhost/
+    bind_dn: cn=admin,dc=example,dc=com
+    bind_pw: password
+
+- name: Remove specified attribute(s) from an entry
+  ldap_attrs:
+    dn: uid=jdoe,ou=people,dc=example,dc=com
+    attributes:
+        description: ""
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -217,7 +217,7 @@ class LdapAttrs(LdapGeneric):
                                                                values)))))
             else:
                 norm_values = list(map(to_bytes, values))
-        elif values != "":
+        else:
             norm_values = [to_bytes(str(values))]
 
         return norm_values

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1794,10 +1794,8 @@ lib/ansible/modules/net_tools/dnsmadeeasy.py validate-modules:parameter-type-not
 lib/ansible/modules/net_tools/ip_netns.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/ipinfoio_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/ipinfoio_facts.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/net_tools/ldap/_ldap_attr.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
-lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/net_tools/ldap/ldap_passwd.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/netbox/netbox_device.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/netbox/netbox_device.py validate-modules:parameter-type-not-in-doc

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1794,7 +1794,8 @@ lib/ansible/modules/net_tools/dnsmadeeasy.py validate-modules:parameter-type-not
 lib/ansible/modules/net_tools/ip_netns.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/ipinfoio_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/ipinfoio_facts.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/net_tools/ldap/ldap_attr.py validate-modules:parameter-type-not-in-doc
+lib/ansible/modules/net_tools/ldap/_ldap_attr.py validate-modules:parameter-type-not-in-doc
+lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:doc-missing-type
 lib/ansible/modules/net_tools/ldap/ldap_entry.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/net_tools/ldap/ldap_passwd.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies. The new `ldap_attrs` module uses the same configuration parameter scheme as the `ldap_entry` module and allows easy management of the LDAP entries using Ansible.

This pull request is based on https://github.com/ansible/ansible/pull/31664

Fixes #25665

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ldap_attrs

##### ADDITIONAL INFORMATION
The new module is currently included in the [DebOps](https://github.com/debops/debops/) project and is used in production environments. Usage examples: [the 'debops.ldap' role tasks](https://github.com/debops/debops/blob/master/ansible/roles/debops.ldap/tasks/ldap_tasks.yml) and [the default configuration data](https://docs.debops.org/en/master/ansible/roles/debops.ldap/defaults/main.html#envvar-ldap__default_tasks), [the `debops.slapd` role tasks](https://github.com/debops/debops/blob/master/ansible/roles/debops.slapd/tasks/slapd_tasks.yml) and [their configuration data](https://docs.debops.org/en/master/ansible/roles/debops.slapd/defaults/main.html#envvar-slapd__default_tasks), including the `X-ORDERED` cn=config attributes.