### PR TITLE
add prefix-list to ios_bgp af-mode

### DIFF
--- a/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
+++ b/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
@@ -186,11 +186,11 @@ class AFNeighbors(CliProvider):
             return cmd
 
     def _render_prefix_list_in(self, item, config=None):
-        cmd = 'neighbor %s prefix-list %s in' % (item['neighbor'], item['prefix-list-in'])
+        cmd = 'neighbor %s prefix-list %s in' % (item['neighbor'], item['prefix_list_in'])
         if not config or cmd not in config:
             return cmd
 
     def _render_prefix_list_out(self, item, config=None):
-        cmd = 'neighbor %s prefix-list %s out' % (item['neighbor'], item['prefix-list-out'])
+        cmd = 'neighbor %s prefix-list %s out' % (item['neighbor'], item['prefix_list_out'])
         if not config or cmd not in config:
             return cmd

--- a/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
+++ b/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/neighbors.py
@@ -184,3 +184,13 @@ class AFNeighbors(CliProvider):
         cmd = 'neighbor %s maximum-prefix %s' % (item['neighbor'], item['maximum_prefix'])
         if not config or cmd not in config:
             return cmd
+
+    def _render_prefix_list_in(self, item, config=None):
+        cmd = 'neighbor %s prefix-list %s in' % (item['neighbor'], item['prefix-list-in'])
+        if not config or cmd not in config:
+            return cmd
+
+    def _render_prefix_list_out(self, item, config=None):
+        cmd = 'neighbor %s prefix-list %s out' % (item['neighbor'], item['prefix-list-out'])
+        if not config or cmd not in config:
+            return cmd

--- a/lib/ansible/modules/network/ios/ios_bgp.py
+++ b/lib/ansible/modules/network/ios/ios_bgp.py
@@ -222,6 +222,12 @@ options:
                   - Maximum number of prefixes to accept from this peer.
                   - The range is from 1 to 2147483647.
                 type: int
+              prefix_list_in:
+                description:
+                  - Name of ip prefix-list to apply to incoming prefixes.
+              prefix_list_out:
+                description:
+                  - Name of ip prefix-list to apply to outgoing prefixes.
   operation:
     description:
       - Specifies the operation to be performed on the BGP process configured on the device.

--- a/lib/ansible/modules/network/ios/ios_bgp.py
+++ b/lib/ansible/modules/network/ios/ios_bgp.py
@@ -388,7 +388,9 @@ def main():
         'next_hop_self': dict(type='bool'),
         'route_reflector_client': dict(type='bool'),
         'route_server_client': dict(type='bool'),
-        'maximum_prefix': dict(type='int')
+        'maximum_prefix': dict(type='int'),
+        'prefix_list_in': dict(),
+        'prefix_list_out': dict()
     }
 
     address_family_spec = {

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -198,7 +198,6 @@
         - "'neighbor 192.0.2.15 activate' in result.commands"
         - "'neighbor 192.0.2.15 route-reflector-client' in result.commands"
         - "'neighbor 10.10.20.20 activate' in result.commands"
-        - "'neighbor 10.10.20.20 route-reflector-client' in result.commands"
         - "'neighbor 10.10.20.20 prefix-list incoming-prefixes in' in result.commands"
         - "'neighbor 10.10.20.20 prefix-list outgoing-prefixes out' in result.commands"
 

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -86,6 +86,11 @@
             remote_as: 64511
             description: EBGP_NBR_1
             local_as: 64497
+
+          - neighbor: 10.10.20.20
+            remote_as: 65012
+            description: EBGP_NBR_2
+            ebgp_multihop: 100
     register: result
 
   - assert:

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -180,6 +180,11 @@
               - neighbor: 192.0.2.15
                 activate: yes
                 route_reflector_client: True
+
+              - neighbor: 10.10.20.20
+                activate: yes
+                prefix_list_in: incoming-prefixes
+                prefix_list_out: outgoing-prefixes
     register: result
 
   - assert:
@@ -192,6 +197,10 @@
         - "'neighbor 203.0.113.10 advertisement-interval 120' in result.commands"
         - "'neighbor 192.0.2.15 activate' in result.commands"
         - "'neighbor 192.0.2.15 route-reflector-client' in result.commands"
+        - "'neighbor 10.10.20.20 activate' in result.commands"
+        - "'neighbor 10.10.20.20 route-reflector-client' in result.commands"
+        - "'neighbor 10.10.20.20 prefix-list incoming-prefixes in' in result.commands"
+        - "'neighbor 10.10.20.20 prefix-list outgoing-prefixes out' in result.commands"
 
   - name: Configure BGP neighbors under address family mode (idempotent)
     ios_bgp: *af_nbr

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -169,6 +169,7 @@
       operation: merge
       config:
         bgp_as: 64496
+        neighbors:
           - neighbor: 10.10.20.20
             remote_as: 65012
         address_family:

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -87,10 +87,6 @@
             description: EBGP_NBR_1
             local_as: 64497
 
-          - neighbor: 10.10.20.20
-            remote_as: 65012
-            description: EBGP_NBR_2
-            ebgp_multihop: 100
     register: result
 
   - assert:
@@ -173,6 +169,8 @@
       operation: merge
       config:
         bgp_as: 64496
+          - neighbor: 10.10.20.20
+            remote_as: 65012
         address_family:
           - afi: ipv4
             safi: unicast
@@ -196,6 +194,7 @@
       that:
         - 'result.changed == true'
         - "'router bgp 64496' in result.commands"
+        - "'neighbor 10.10.20.20 remote-as 65012' in result.commands"
         - "'address-family ipv4' in result.commands"
         - "'neighbor 203.0.113.10 activate' in result.commands"
         - "'neighbor 203.0.113.10 maximum-prefix 250' in result.commands"

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -87,6 +87,10 @@
             description: EBGP_NBR_1
             local_as: 64497
 
+          - neighbor: 10.10.20.20
+            remote_as: 65012
+            description: BGP_NBR_2
+            ebgp_multihop: 100
     register: result
 
   - assert:
@@ -95,6 +99,8 @@
         - "'neighbor 203.0.113.10 remote-as 64511' in result.commands"
         - "'neighbor 203.0.113.10 description EBGP_NBR_1' in result.commands"
         - "'neighbor 203.0.113.10 local-as 64497' in result.commands"
+        - "'neighbor 10.10.20.20 remote-as 65012' in result.commands"
+        - "'neighbor 10.10.20.20 description BGP_NBR_2' in result.commands"
         - "'no neighbor 192.0.2.10' in result.commands"
 
   - name: Configure BGP neighbors with operation replace (idempotent)
@@ -169,9 +175,6 @@
       operation: merge
       config:
         bgp_as: 64496
-        neighbors:
-          - neighbor: 10.10.20.20
-            remote_as: 65012
         address_family:
           - afi: ipv4
             safi: unicast
@@ -195,7 +198,6 @@
       that:
         - 'result.changed == true'
         - "'router bgp 64496' in result.commands"
-        - "'neighbor 10.10.20.20 remote-as 65012' in result.commands"
         - "'address-family ipv4' in result.commands"
         - "'neighbor 203.0.113.10 activate' in result.commands"
         - "'neighbor 203.0.113.10 maximum-prefix 250' in result.commands"


### PR DESCRIPTION
##### SUMMARY
Add support for prefix-list in address-family mode

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ios_bgp

##### ADDITIONAL INFORMATION
Add support for prefix list for neighbors.
```
router bgp 64496
  neighbor 10.10.20.20
  address-family ipv4 unicast
  neighbor 10.10.20.20 prefix-list incoming-prefixes in
  neighbor 10.10.20.20 prefix-list outgoing-prefixes out
```
from this example task
```
- name: Configure BGP neighbors under address family mode
    ios_bgp: 
      operation: merge
      config:
        bgp_as: 64496
        address_family:
          - afi: ipv4
            safi: unicast
            neighbors:
              - neighbor: 10.10.20.20
                activate: yes
                prefix_list_in: incoming-prefixes
                prefix_list_out: outgoing-prefixes
```
