### PR TITLE
Improved docs on docker_swarm_service

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -606,7 +606,7 @@ options:
       filename:
         description:
           - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
-          - Corresponds to the C(target) option of C(docker service create --secret).
+          - Corresponds to the C(target) key of C(docker service create --secret).
         type: str
       uid:
         description:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -605,7 +605,7 @@ options:
         required: yes
       filename:
         description:
-          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified. 
+          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
           - Corresponds to the C(target) option of C(docker service create --secret).
         type: str
       uid:

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -605,7 +605,8 @@ options:
         required: yes
       filename:
         description:
-          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified.
+          - Name of the file containing the secret. Defaults to the I(secret_name) if not specified. 
+          - Corresponds to the C(target) option of C(docker service create --secret).
         type: str
       uid:
         description:


### PR DESCRIPTION
Makes clear that the `secrets.filename` option in `docker_swarm_service` actually corresponds to the `--target` option in `docker service create`. Related to #62702.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Docker nomenclature is not `filename` so one cannot be at fault for thinking it's something else (perhaps the name of the actual file created in `/var/run/secrets`). Documentation makes it clear now.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

docker_swarm_service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
