### PR TITLE
ACME module defaults

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
+++ b/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
@@ -98,6 +98,8 @@ it easier to author playbooks making heavy use of API-based modules such as clou
 +-------+---------------------------+-----------------+
 | os    | OpenStack                 | 2.8             |
 +-------+---------------------------+-----------------+
+| acme  | ACME                      | 2.10            |
++-------+---------------------------+-----------------+
 
 Use the groups with `module_defaults` by prefixing the group name with `group/` - e.g. `group/aws`
 

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -1,3 +1,4 @@
+---
 version: '1.0'
 groupings:
   acme_account:

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -1,5 +1,17 @@
 version: '1.0'
 groupings:
+  acme_account:
+  - acme
+  acme_account_info:
+  - acme
+  acme_account_facts:
+  - acme
+  acme_certificate:
+  - acme
+  acme_certificate_revoke:
+  - acme
+  acme_inspect:
+  - acme
   aws_acm_facts:
   - aws
   aws_acm_info:


### PR DESCRIPTION
##### SUMMARY
IMO there should be more [module default groups](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups).

Note that I didn't include the `acme_challenge_cert_helper` module, since it doesn't talk to ACME servers. That module also doesn't use the `acme` docs fragment.

I wonder whether it makes sense to add a new column `Remarks` and mention this exception. (I'm also thinking of adding module defaults for the docker modules, and there `docker_stack` would also be an exception, so this could potentially affect more module groups.)

##### ISSUE TYPE
- Feature Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/config/module_defaults.yml
docs/docsite/rst/user_guide/playbooks_module_defaults.rst
acme_account
acme_account_info
acme_certificate
acme_certificate_revoke
acme_inspect
