### PR TITLE
Fix ios terminal regex for privilege escalation (#62479)

### DIFF
--- a/changelogs/fragments/ios_terminal_regex_fix.yaml
+++ b/changelogs/fragments/ios_terminal_regex_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix ios terminal regex for privilege escalation (https://github.com/ansible/ansible/issues/61726)

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -76,7 +76,7 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n](?:Local_)?[Pp]assword: ?$", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]?(?:Local[_| ])?[Pp]assword: ?$", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
             cmd[u'prompt_retry_check'] = True
         try:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/61726

*  On some ios versions the password prompt for enable
   command differs. Modify the regex to work with multiple
   password prompt patterns
   1) password:
   2) Password:
   3) Local_Password:
   4) Enter Local Password:

(cherry picked from commit bd8097ea91589c09a5341058b43beae905c716b2)
Merged to devel https://github.com/ansible/ansible/pull/62479
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/plugins/terminal/ios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
