### PR TITLE
Master (#62626)

### DIFF
--- a/changelogs/fragments/62626-win-package-test-pathfix.yaml
+++ b/changelogs/fragments/62626-win-package-test-pathfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_packages - fixed issue where Test-Path failed to find files with special characters (https://github.com/ansible/ansible/issues/62521)


### PR DESCRIPTION
* Update win_package.ps1

Update Test-Path to use -LiteralPath instead of -Path to fix issue where powershell will not detect path with special characters such as '=' and '[]'.

* Update win_package.ps1

modified other instances of -Path and changed to -LiteralPath.  All except line L243 since it is a different function.

* added literal path to get-itemproperty

(cherry picked from commit 153a322f54d2398973286bc6f86defeb101b57ae)

##### SUMMARY
Backport for #62626 to 2.9

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
win_package

##### ADDITIONAL INFORMATION
If the path variable is contains characters such as '=' or '[]' powershell can't verify the path using Test-Path. The powershell command needs to be Test-Path -LiteralPath for it verify it correctly.
