### PR TITLE
[Backport/2.9/62706] *_interfaces: fixes option names in examples. from operation to state

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -151,7 +151,7 @@ EXAMPLES = """
       - name: GigabitEthernet0/3.100
         ipv4:
         - address: 192.168.0.3/24
-    operation: merged
+    state: merged
 
 # After state:
 # ------------
@@ -213,7 +213,7 @@ EXAMPLES = """
         ipv4:
         - address: 192.168.0.3/24
           secondary: True
-    operation: replaced
+    state: replaced
 
 # After state:
 # ------------
@@ -269,7 +269,7 @@ EXAMPLES = """
       - name: GigabitEthernet0/3.100
         ipv6:
         - address: autoconfig
-    operation: overridden
+    state: overridden
 
 # After state:
 # ------------
@@ -321,7 +321,7 @@ EXAMPLES = """
     config:
       - name: GigabitEthernet0/2
       - name: GigabitEthernet0/3.100
-    operation: deleted
+    state: deleted
 
 # After state:
 # -------------
@@ -374,7 +374,7 @@ EXAMPLES = """
 
 - name: "Delete L3 attributes of ALL interfaces together (NOTE: This won't delete the interface itself)"
   ios_l3_interfaces:
-    operation: deleted
+    state: deleted
 
 # After state:
 # -------------

--- a/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_l3_interfaces.py
@@ -130,7 +130,7 @@ EXAMPLES = """
         ipv4:
         - address: 192.168.2.1/24
           secondary: True
-    operation: merged
+    state: merged
 
 # After state:
 # ------------
@@ -190,7 +190,7 @@ EXAMPLES = """
         - address: 192.168.0.2/24
         - address: 192.168.2.1/24
           secondary: True
-    operation: overridden
+    state: overridden
 
 # After state:
 # -------------
@@ -247,7 +247,7 @@ EXAMPLES = """
       - name: GigabitEthernet0/0/0/4
         ipv4:
         - address: 192.168.0.2/24
-    operation: replaced
+    state: replaced
 
 # After state:
 # -------------
@@ -303,7 +303,7 @@ EXAMPLES = """
       - name: GigabitEthernet0/0/0/3
       - name: GigabitEthernet0/0/0/4
       - name: GigabitEthernet0/0/0/3.700
-    operation: deleted
+    state: deleted
 
 # After state:
 # -------------
@@ -356,7 +356,7 @@ EXAMPLES = """
 
 - name: "Delete L3 attributes of all interfaces (Note: This won't delete the interface itself)"
   iosxr_l3_interfaces:
-    operation: deleted
+    state: deleted
 
 # After state:
 # -------------

--- a/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_bfd_interfaces.py
@@ -82,7 +82,7 @@ EXAMPLES = """
 
 - name: Configure interfaces
   nxos_bfd_interfaces:
-    operation: deleted
+    state: deleted
 
 
 # Using merged
@@ -96,7 +96,7 @@ EXAMPLES = """
       - name: Ethernet1/2
         bfd: disable
         echo: disable
-    operation: merged
+    state: merged
 
 
 # Using overridden
@@ -110,7 +110,7 @@ EXAMPLES = """
       - name: Ethernet1/2
         bfd: disable
         echo: disable
-    operation: overridden
+    state: overridden
 
 
 # Using replaced
@@ -124,7 +124,7 @@ EXAMPLES = """
       - name: Ethernet1/2
         bfd: disable
         echo: disable
-    operation: replaced
+    state: replaced
 
 
 """


### PR DESCRIPTION
(cherry picked from commit 00cf6d8e9aefc894d4897f3a7da947d77ad7f7f5)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes option names in examples. 
from `operation` to `state`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ios_l3_interfaces
- nxos_l3_interfaces
- nxos_bfd_interfaces
