### PR TITLE
Backport/2.9/62587  module_utils/network/cloudengine:fix get_nc_next.

### DIFF
--- a/changelogs/fragments/60569-plugins-netconf-ce.yml
+++ b/changelogs/fragments/60569-plugins-netconf-ce.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugins-netconf-ce - to get attribute 'set-id' from rpc-reply.

--- a/changelogs/fragments/62587-module_utils-network-cloudengine.yml
+++ b/changelogs/fragments/62587-module_utils-network-cloudengine.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Cloudengine module_utils - the ``set-id`` (RPC-REPLY XML attribute) may change over the time althougth ``set-id`` is the identity of the next RPC packet."
+  - "Cloudengine netconf plugin - add a dispatch RPC function,just return original RPC-REPLY, the function is used by ``Cloudengine module_utils``."

--- a/lib/ansible/module_utils/network/cloudengine/ce.py
+++ b/lib/ansible/module_utils/network/cloudengine/ce.py
@@ -357,12 +357,13 @@ def get_nc_next(module, xml_str):
         response = conn.get(xml_str, if_rpc_reply=True)
         result = response.find('./*')
         set_id = response.get('set-id')
-        fetch_node = new_ele_ns('get-next', 'http://www.huawei.com/netconf/capability/base/1.0', {'set-id': set_id})
-        while True:
+        while True and set_id is not None:
             try:
-                next = conn.dispatch(etree.tostring(fetch_node))
-                if next is not None:
-                    result.extend(next)
+                fetch_node = new_ele_ns('get-next', 'http://www.huawei.com/netconf/capability/base/1.0', {'set-id': set_id})
+                next_xml = conn.dispatch_rpc(etree.tostring(fetch_node))
+                if next_xml is not None:
+                    result.extend(next_xml.find('./*'))
+                set_id = next_xml.get('set-id')
             except ConnectionError:
                 break
     if result is not None:

--- a/lib/ansible/plugins/netconf/ce.py
+++ b/lib/ansible/plugins/netconf/ce.py
@@ -167,6 +167,9 @@ class Netconf(NetconfBase):
     @ensure_connected
     def get(self, *args, **kwargs):
         try:
+            if_rpc_reply = kwargs.pop('if_rpc_reply', False)
+            if if_rpc_reply:
+                return self.m.get(*args, **kwargs).xml
             return self.m.get(*args, **kwargs).data_xml
         except RPCError as exc:
             raise Exception(to_xml(exc.xml))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The NETCONF client can interact with the device using the <get-next> action,when the query returns more than 30K.The 'set-id' may change over the time althougth  'set-id' is the indentify of next rpc packet and also RPC xml attribute. So fix it.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/network/cloudengine/ce.py
lib/ansible/plugins/netconf/ce.py
changelogs/fragments/60569-plugins-netconf-ce.yml
changelogs/fragments/62587-module_utils-network-cloudengine.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The PR has been validated many times on real devices befor it was ready for review.
```
### RPC requset
```
<rpc message-id="103" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <get-next xmlns="http://www.huawei.com/netconf/capability/base/1.0" set-id="989"> 
  </get-next>
</rpc>
```
### RPC reply
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply message-id="103" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" set-id="989">
  <data>
    <ifm xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
      <interfaces>
        <interface>
          <ifIndex>3</ifIndex>
          <ifName>Virtual-Template1</ifName>
          <ifPhyType>Virtual-Template</ifPhyType>
     <!-- additional <user> elements appear here... --> 
        </interface>
      </interfaces>
    </ifm>
  </data>
</rpc-reply>
```
### set-id changed in next reply

