### PR TITLE
Backport/2.9/61020

### DIFF
--- a/changelogs/fragments/kubevirt-add-wait_sleep-param.yml
+++ b/changelogs/fragments/kubevirt-add-wait_sleep-param.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "kubevirt: apply wait_sleep fix from devel to not fail on missing param"

--- a/lib/ansible/module_utils/kubevirt.py
+++ b/lib/ansible/module_utils/kubevirt.py
@@ -63,6 +63,7 @@ VM_COMMON_ARG_SPEC = {
     'merge_type': {'type': 'list', 'choices': ['json', 'merge', 'strategic-merge']},
     'wait': {'type': 'bool', 'default': True},
     'wait_timeout': {'type': 'int', 'default': 120},
+    'wait_sleep': {'type': 'int', 'default': 5},
 }
 VM_COMMON_ARG_SPEC.update(VM_SPEC_DEF_ARG_SPEC)
 

--- a/lib/ansible/plugins/doc_fragments/kubevirt_common_options.py
+++ b/lib/ansible/plugins/doc_fragments/kubevirt_common_options.py
@@ -32,6 +32,11 @@ options:
             - The amount of time in seconds the module should wait for the resource to get into desired state.
         type: int
         default: 120
+    wait_sleep:
+        description:
+            - Number of seconds to sleep between checks.
+        default: 5
+        version_added: "2.9"
     memory:
         description:
             - The amount of memory to be requested by virtual machine.


### PR DESCRIPTION
##### SUMMARY
wait_sleep got added to k8s modules; this needs to be reflected in kubevirt modules for them to not break

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
kubevirt
