### PR TITLE
archive module documentation is misleading

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -20,10 +20,8 @@ version_added: '2.3'
 short_description: Creates a compressed archive of one or more files or trees
 extends_documentation_fragment: files
 description:
-    - Packs an archive.
-    - It is the opposite of M(unarchive).
-    - By default, it assumes the compression source exists on the target.
-    - It will not copy the source file from the local system to the target before archiving.
+    - Creates or extends an archive.
+    - The source and archive are on the remote host, and the archive I(is not) copied to the local host.
     - Source files can be deleted after archival by specifying I(remove=True).
 options:
   path:
@@ -40,7 +38,7 @@ options:
     default: gz
   dest:
     description:
-      - The file name of the destination archive.
+      - The file name of the destination archive.  The parent directory must exists on the remote host.
       - This is required when C(path) refers to multiple files by either specifying a glob, a directory or multiple paths in a list.
     type: path
   exclude_path:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
'archive' is _not_ the opposite of unarchive.  Unarchive copies a local archive to the remote host and unpacks it.  Archive just creates an archive on the remote host.  It does not copy the archive back to the local host.

There are statements in the description that make no sense.  I have removed them and added ones that are explicit about the source and destination hosts.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
'archive' is _not_ the opposite of unarchive.  Unarchive copies a local archive to the remote host and unpacks it.  Archive just creates an archive on the remote host.  It does not copy the archive back to the local host.

There are statements in the description that make no sense.  I have removed them and added ones that are explicit about the source and destination hosts.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
archive
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
