### PR TITLE
Coll links

### DIFF
--- a/docs/docsite/rst/dev_guide/collections_tech_preview.rst
+++ b/docs/docsite/rst/dev_guide/collections_tech_preview.rst
@@ -1,0 +1,6 @@
+.. _collections:
+
+As we create the roadmap for collections, we've created separate pages for user who want to:
+
+:ref:`Develop collections <developing_collections>`
+:ref:`Use collections <using_collections>`

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -1,5 +1,5 @@
 
-.. _collections:
+.. _using_collections:
 
 *****************
 Using collections


### PR DESCRIPTION
##### SUMMARY
Search engines are still returning the old Tech Preview page for searches about ansible collections. Provide something more than a 404 there.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
collections
