### PR TITLE
allow setting multiple BIOS attributes at a time

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -51,14 +51,14 @@ options:
   bios_attribute_name:
     required: false
     description:
-      - name of BIOS attr to update (deprecated: use bios_attributes instead)
+      - name of BIOS attr to update (deprecated - use bios_attributes instead)
     default: 'null'
     type: str
     version_added: "2.8"
   bios_attribute_value:
     required: false
     description:
-      - value of BIOS attr to update (deprecated: use bios_attributes instead)
+      - value of BIOS attr to update (deprecated - use bios_attributes instead)
     default: 'null'
     type: str
     version_added: "2.8"

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -51,17 +51,24 @@ options:
   bios_attribute_name:
     required: false
     description:
-      - name of BIOS attribute to update
+      - name of BIOS attr to update (deprecated: use bios_attributes instead)
     default: 'null'
     type: str
     version_added: "2.8"
   bios_attribute_value:
     required: false
     description:
-      - value of BIOS attribute to update
+      - value of BIOS attr to update (deprecated: use bios_attributes instead)
     default: 'null'
     type: str
     version_added: "2.8"
+  bios_attributes:
+    required: false
+    description:
+      - dictionary of BIOS attributes to update
+    default: {}
+    type: dict
+    version_added: "2.10"
   timeout:
     description:
       - Timeout in seconds for URL requests to OOB controller
@@ -84,23 +91,25 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attribute_name: BootMode
-      bios_attribute_value: Uefi
+      bios_attributes:
+        BootMode: "Uefi"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Set BootMode to Legacy BIOS
+  - name: Set multiple BootMode attributes
     redfish_config:
       category: Systems
       command: SetBiosAttributes
-      bios_attribute_name: BootMode
-      bios_attribute_value: Bios
+      bios_attributes:
+        BootMode: "Bios"
+        OneTimeBootMode: "Enabled"
+        BootSeqRetry: "Enabled"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
 
-  - name: Enable PXE Boot for NIC1
+  - name: Enable PXE Boot for NIC1 using deprecated options
     redfish_config:
       category: Systems
       command: SetBiosAttributes
@@ -173,6 +182,7 @@ def main():
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
             bios_attribute_value=dict(default='null'),
+            bios_attributes=dict(type='dict', default={}),
             timeout=dict(type='int', default=10),
             boot_order=dict(type='list', elements='str', default=[])
         ),
@@ -190,8 +200,13 @@ def main():
     timeout = module.params['timeout']
 
     # BIOS attributes to update
-    bios_attributes = {'bios_attr_name': module.params['bios_attribute_name'],
-                       'bios_attr_value': module.params['bios_attribute_value']}
+    bios_attributes = module.params['bios_attributes']
+    if module.params['bios_attribute_name'] != 'null':
+        bios_attributes[module.params['bios_attribute_name']] = module.params[
+            'bios_attribute_value']
+        module.deprecate(msg='The bios_attribute_name/bios_attribute_value '
+                         'options are deprecated. Use bios_attributes instead',
+                         version='2.10')
 
     # boot order
     boot_order = module.params['boot_order']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added new `bios_attributes` option to the `SetBiosAttributes` command to allow specifying a dictionary of BIOS attributes to set.
Deprecated older options `bios_attribute_name` and `bios_attribute_value`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #60111

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_config.py
redfish_utils.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**Before: Playbook could only set one BIOS attribute at a time**
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: Set BootMode to Bios
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attribute_name: BootMode
      bios_attribute_value: Bios
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

**After: Playbook can now set multiple BIOS attributes at a time**
```
  - name: Set multiple BootMode attributes
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attributes:
        BootMode: "Bios"
        OneTimeBootMode: "Enabled"
        BootSeqRetry: "Enabled"
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```
