### PR TITLE
package_facts: check 'vital' and 'automated' values ('pkg' manager)

### DIFF
--- a/changelogs/fragments/62766-package_facts-pkg-manager-fix-vital-value.yml
+++ b/changelogs/fragments/62766-package_facts-pkg-manager-fix-vital-value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "package_facts - fix value of ``vital`` attribute which is returned when ``pkg`` manager is used"

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -241,7 +241,7 @@ class PKG(CLIMgr):
                 pass
 
         if 'automatic' in pkg:
-            pkg['automatic'] = bool(pkg['automatic'])
+            pkg['automatic'] = bool(int(pkg['automatic']))
 
         if 'category' in pkg:
             pkg['category'] = pkg['category'].split('/', 1)[0]
@@ -258,7 +258,7 @@ class PKG(CLIMgr):
                 pkg['revision'] = '0'
 
         if 'vital' in pkg:
-            pkg['vital'] = bool(pkg['vital'])
+            pkg['vital'] = bool(int(pkg['vital']))
 
         return pkg
 

--- a/test/integration/targets/package_facts/aliases
+++ b/test/integration/targets/package_facts/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group3
-skip/freebsd
 skip/osx

--- a/test/integration/targets/package_facts/tasks/main.yml
+++ b/test/integration/targets/package_facts/tasks/main.yml
@@ -73,3 +73,43 @@
 - name: check for ansible_facts.packages exists
   assert:
     that: ansible_facts.packages is defined
+
+- name: Run package_fact tests - FreeBSD
+  block:
+    - name: Gather package facts
+      package_facts:
+        manager: pkg
+
+    - name: check for ansible_facts.packages exists
+      assert:
+        that: ansible_facts.packages is defined
+
+    - name: check there is at least one package not flagged vital nor automatic
+      command: pkg query -e "%a = 0 && %V = 0" %n
+      register: not_vital_nor_automatic
+      failed_when: not not_vital_nor_automatic.stdout
+
+    - vars:
+        pkg_name: "{{ not_vital_nor_automatic.stdout_lines[0].strip() }}"
+      block:
+        - name: check the selected package is not vital
+          assert:
+            that:
+              - 'not ansible_facts.packages[pkg_name][0].vital'
+              - 'not ansible_facts.packages[pkg_name][0].automatic'
+
+        - name: flag the selected package as vital and automatic
+          command: 'pkg set --yes -v 1 -A 1 {{ pkg_name }}'
+
+        - name: Gather package facts (again)
+          package_facts:
+
+        - name: check the selected package is flagged vital and automatic
+          assert:
+            that:
+              - 'ansible_facts.packages[pkg_name][0].vital|bool'
+              - 'ansible_facts.packages[pkg_name][0].automatic|bool'
+      always:
+        - name: restore previous flags for the selected package
+          command: 'pkg set --yes -v 0 -A 0 {{ pkg_name }}'
+  when: ansible_os_family == "FreeBSD"


### PR DESCRIPTION
##### SUMMARY
`package_facts`: check fix value of `vital` and `automatic` attributes. This attributes is returned when `pkg` manager is used (FreeBSD).

Value is converted to an integer instead of using `ansible.module_utils.parsing.convert_bool.boolean` because the only
possible values are `0` or `1`.

Integration test of `package_facts` updated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
package_facts

##### ADDITIONAL INFORMATION
[Link to pkg-set documentation](https://www.freebsd.org/cgi/man.cgi?query=pkg-set)