### PR TITLE
hcloud_volume: clarify volume size units

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
@@ -41,7 +41,7 @@ options:
         type: str
     size:
         description:
-            - The size of the Block Volume.
+            - The size of the Block Volume in GB.
             - Required if volume does not yet exists.
         type: int
     automount:
@@ -126,7 +126,7 @@ hcloud_volume:
             returned: Always
             sample: my-volume
         size:
-            description: Size in MB of the volume
+            description: Size in GB of the volume
             type: int
             returned: Always
             sample: 1337


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

According to the [API documentation](https://docs.hetzner.cloud/#volumes) the volume size is given and returned in GB. Mention the size in the input parameter and fix the unit in the return parameter.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_volume
