### PR TITLE
Fix _validate_csr_subject and _validate_csr_signature

### DIFF
--- a/changelogs/fragments/62790-openssl_certificate_fix_assert.yml
+++ b/changelogs/fragments/62790-openssl_certificate_fix_assert.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_certificate - fix ``assertonly`` provider certificate verification, causing 'private key mismatch' and 'subject mismatch' errors."

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1861,12 +1861,10 @@ class AssertOnlyCertificateCryptography(AssertOnlyCertificateBase):
     def _validate_csr_signature(self):
         if not self.csr.is_signature_valid:
             return False
-        if self.csr.public_key().public_numbers() != self.cert.public_key().public_numbers():
-            return False
+        return self.csr.public_key().public_numbers() == self.cert.public_key().public_numbers()
 
     def _validate_csr_subject(self):
-        if self.csr.subject != self.cert.subject:
-            return False
+        return self.csr.subject == self.cert.subject
 
     def _validate_csr_extensions(self):
         cert_exts = self.cert.extensions


### PR DESCRIPTION
On python 3, if there is no explicit "return True", the
function call will be seen as "False", thus failling the module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
