### PR TITLE
Bug/ce_sflow/20190924

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_sflow.py
+++ b/lib/ansible/modules/network/cloudengine/ce_sflow.py
@@ -366,6 +366,9 @@ class Sflow(object):
         self.source_ip = self.module.params['source_ip']
         self.source_version = None
         self.export_route = self.module.params['export_route']
+        self.rate_limit = self.module.params['rate_limit']
+        self.rate_limit_slot = self.module.params['rate_limit_slot']
+        self.forward_enp_slot = self.module.params['forward_enp_slot']
         self.collector_id = self.module.params['collector_id']
         self.collector_ip = self.module.params['collector_ip']
         self.collector_version = None
@@ -886,6 +889,10 @@ class Sflow(object):
     def check_params(self):
         """Check all input params"""
 
+        if any((self.rate_limit, self.rate_limit_slot, self.forward_enp_slot)):
+            self.module.fail_json(msg="""Error: rate_limit, rate_limit_slot orforward_enp_slot are not supported by NETCONF API,
+                please use ce_command or ce_config to have a try.""")
+
         # check agent_ip
         if self.agent_ip:
             self.agent_ip = self.agent_ip.upper()
@@ -1128,9 +1135,9 @@ def main():
         source_ip=dict(required=False, type='str'),
         export_route=dict(required=False, type='str',
                           choices=['enable', 'disable']),
-        rate_limit=dict(required=False, type='str', removed_in_version='2.11'),
-        rate_limit_slot=dict(required=False, type='str', removed_in_version='2.11'),
-        forward_enp_slot=dict(required=False, type='str', removed_in_version='2.11'),
+        rate_limit=dict(required=False, type='str', removed_in_version='2.13'),
+        rate_limit_slot=dict(required=False, type='str', removed_in_version='2.13'),
+        forward_enp_slot=dict(required=False, type='str', removed_in_version='2.13'),
         collector_id=dict(required=False, type='str', choices=['1', '2']),
         collector_ip=dict(required=False, type='str'),
         collector_ip_vpn=dict(required=False, type='str'),

--- a/lib/ansible/modules/network/cloudengine/ce_sflow.py
+++ b/lib/ansible/modules/network/cloudengine/ce_sflow.py
@@ -104,6 +104,27 @@ options:
         description:
             - Configures the sFlow packets sent by the switch not to carry routing information.
         choices: ['enable', 'disable']
+    rate_limit:
+        description:
+            - Specifies the rate of sFlow packets sent from a card to the control plane.
+              The value is an integer that ranges from 100 to 1500, in pps.
+              Deprecated, will be removed in version 2.13.
+    rate_limit_slot:
+        description:
+            - Specifies the slot where the rate of output sFlow packets is limited.
+              If this parameter is not specified, the rate of sFlow packets sent from
+              all cards to the control plane is limited.
+              The value is an integer or a string of characters.
+              Deprecated, will be removed in version 2.13.
+    forward_enp_slot:
+        description:
+            - Enable the Embedded Network Processor (ENP) chip function.
+              The switch uses the ENP chip to perform sFlow sampling,
+              and the maximum sFlow sampling interval is 65535.
+              If you set the sampling interval to be larger than 65535,
+              the switch automatically restores it to 65535.
+              The value is an integer or 'all'.
+              Deprecated, will be removed in version 2.13.
     state:
         description:
             - Determines whether the config should be present or not
@@ -1107,6 +1128,9 @@ def main():
         source_ip=dict(required=False, type='str'),
         export_route=dict(required=False, type='str',
                           choices=['enable', 'disable']),
+        rate_limit=dict(required=False, type='str', removed_in_version='2.11'),
+        rate_limit_slot=dict(required=False, type='str', removed_in_version='2.11'),
+        forward_enp_slot=dict(required=False, type='str', removed_in_version='2.11'),
         collector_id=dict(required=False, type='str', choices=['1', '2']),
         collector_ip=dict(required=False, type='str'),
         collector_ip_vpn=dict(required=False, type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some params are not supprted by NETCONF API, should not be removed directly. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_sflow.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

       
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 rate_limit=dict(required=False, type='str', removed_in_version='2.13'),
 rate_limit_slot=dict(required=False, type='str', removed_in_version='2.13'),
 forward_enp_slot=dict(required=False, type='str', removed_in_version='2.13'),
```
The params( rate_limit, rate_limit_slot, forward_enp_slot ) are supported by NETCONF API, but Network_cli. Network_cli and Netconf should not be used together.So modify it.