### PR TITLE
Invert the logic for AssertOnly certificate verification

### DIFF
--- a/changelogs/fragments/62793-openssl_certificate_fix_assert_2.yml
+++ b/changelogs/fragments/62793-openssl_certificate_fix_assert_2.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "openssl_certificate - fix assertonly provider certificate verification, causing 'extensions mismatch' errors."
+

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -1871,11 +1871,11 @@ class AssertOnlyCertificateCryptography(AssertOnlyCertificateBase):
     def _validate_csr_extensions(self):
         cert_exts = self.cert.extensions
         csr_exts = self.csr.extensions
-        if len(cert_exts) != len(csr_exts):
+        if len(cert_exts) <= len(csr_exts):
             return False
-        for cert_ext in cert_exts:
+        for csr_ext in csr_exts:
             try:
-                csr_ext = csr_exts.get_extension_for_oid(cert_ext.oid)
+                cert_ext = cert_exts.get_extension_for_oid(csr_ext.oid)
                 if cert_ext != csr_ext:
                     return False
             except cryptography.x509.ExtensionNotFound as dummy:


### PR DESCRIPTION
##### SUMMARY

Since a CA can add more extensions than what a CSR request,
we can end with a situation where the CSR used to generate
a certificate will fail the assertonly provider because the CA
did add something like subjectKeyIdentifier (2.5.29.14) which
is unlikely to be part of the CSR.

So by checking that all the CSR extensions are in present
in the certificate extension list, we can handle the case when
a CA add something without causing trouble (which seems IMHO
the right thing to do)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

