### PR TITLE
Update vmware ansible modules requirements section

### DIFF
--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
@@ -23,6 +23,11 @@ and vCenter infrastructure. You can install pyVmomi using pip:
 
     $ pip install pyvmomi
 
+Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphere Automation Python SDK <https://github.com/vmware/vsphere-automation-sdk-python>`__. The vSphere Automation Python SDK also have client libraries, documentation and sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs and NSX-T APIs. You can install vSphere Automation Python SDK using pip:
+
+.. code-block:: bash
+
+     $ pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 
 vmware_guest module
 ===================

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
@@ -29,6 +29,9 @@ Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphe
 
      $ pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 
+Note:
+   Installing vSphere Automation Python SDK also installs pyvmomi. A separate installation of pyvmomi is not required.
+   
 vmware_guest module
 ===================
 

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
@@ -23,7 +23,7 @@ and vCenter infrastructure. You can install pyVmomi using pip:
 
     $ pip install pyvmomi
 
-Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphere Automation Python SDK <https://github.com/vmware/vsphere-automation-sdk-python>`__. The vSphere Automation Python SDK also have client libraries, documentation and sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs and NSX-T APIs. You can install vSphere Automation Python SDK using pip:
+Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphere Automation Python SDK <https://github.com/vmware/vsphere-automation-sdk-python>`__. The vSphere Automation Python SDK also has client libraries, documentation , sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs and NSX-T APIs. You can install vSphere Automation Python SDK using pip:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_intro.rst
@@ -23,14 +23,16 @@ and vCenter infrastructure. You can install pyVmomi using pip:
 
     $ pip install pyvmomi
 
-Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphere Automation Python SDK <https://github.com/vmware/vsphere-automation-sdk-python>`__. The vSphere Automation Python SDK also has client libraries, documentation , sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs and NSX-T APIs. You can install vSphere Automation Python SDK using pip:
+Ansible VMware modules leveraging latest vSphere(6.0+) features are using `vSphere Automation Python SDK <https://github.com/vmware/vsphere-automation-sdk-python>`_. The vSphere Automation Python SDK also has client libraries, documentation, and sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs, NSX-T APIs.
+
+You can install vSphere Automation Python SDK using pip:
 
 .. code-block:: bash
 
      $ pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
 
 Note:
-   Installing vSphere Automation Python SDK also installs pyvmomi. A separate installation of pyvmomi is not required.
+   Installing vSphere Automation Python SDK also installs ``pyvmomi``. A separate installation of ``pyvmomi`` is not required.
    
 vmware_guest module
 ===================


### PR DESCRIPTION
##### SUMMARY
Some of the recent vmware modules like content library, tagging is using vsphere automation sdk. 
All the new features(APIs) from vsphere 6.0 are available only in vSphere Automation SDKs.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation Update

##### ADDITIONAL INFORMATION
Added a documentation section as below:

```
Ansible VMware modules leveraging latest vSphere(6.0+) features are using vSphere Automation Python SDK. The vSphere Automation Python SDK also have client libraries, documentation and sample code for VMware Cloud on AWS Console APIs, NSX VMware Cloud on AWS integration APIs, VMware Cloud on AWS site recovery APIs and NSX-T APIs. You can install vSphere Automation Python SDK using pip:

$ pip install --upgrade git+https://github.com/vmware/vsphere-automation-sdk-python.git
Note:
Installing vSphere Automation Python SDK also installs pyvmomi. A separate installation of pyvmomi is not required.

```
