### PR TITLE
os_router: Fixes subnet and network scope through filters

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -240,7 +240,7 @@ def _needs_update(cloud, module, router, network, internal_subnet_ids, internal_
     # check external interfaces
     if module.params['external_fixed_ips']:
         for new_iface in module.params['external_fixed_ips']:
-            subnet = cloud.get_subnet(new_iface['subnet'], filters)
+            subnet = cloud.get_subnet(new_iface['subnet'])
             exists = False
 
             # compare the requested interface with existing, looking for an existing match
@@ -347,7 +347,7 @@ def _validate_subnets(module, cloud, filters=None):
                 subnet = cloud.get_subnet(iface['subnet'], filters)
                 if not subnet:
                     module.fail_json(msg='subnet %s not found' % iface['subnet'])
-                net = cloud.get_network(iface['net'])
+                net = cloud.get_network(iface['net'], filters))
                 if not net:
                     module.fail_json(msg='net %s not found' % iface['net'])
                 if "portip" not in iface:


### PR DESCRIPTION
##### SUMMARY
* When checking for external_fixed_ips, the search for the subnet was scoped with
the project for an external (shared) subnet. This only works for the project who one the external network.

* For each interface defined for the router, the search for the network wasn't scoped
to the project, which leads to "Multiple matches found for network" error if their
were multiple network with the same name.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_router

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
`ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/racciari/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/racciari/venv/ansible-test/lib/python2.7/site-packages/ansible
  executable location = /home/racciari/venv/ansible-test/bin/ansible
  python version = 2.7.5 (default, Oct 30 2018, 23:45:53) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]`
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1- Create 2 projects
2-  Create a network in each project using the same name
3 - Create a router with the network name
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
```
