### PR TITLE
Fix issue when setting an empty pass to no_log param

### DIFF
--- a/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
+++ b/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.Basic - Fix issue when setting a ``no_log`` parameter to an empty string - https://github.com/ansible/ansible/issues/62613

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -700,8 +700,9 @@ namespace Ansible.Basic
                 if ((bool)v["no_log"])
                 {
                     object noLogObject = parameters.Contains(k) ? parameters[k] : null;
-                    if (noLogObject != null)
-                        noLogValues.Add(noLogObject.ToString());
+                    string noLogString = noLogObject == null ? "" : noLogObject.toString();
+                    if (!String.IsNullOrEmpty(noLogString))
+                        noLogValues.Add(noLogString);
                 }
 
                 object removedInVersion = v["removed_in_version"];

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -700,7 +700,7 @@ namespace Ansible.Basic
                 if ((bool)v["no_log"])
                 {
                     object noLogObject = parameters.Contains(k) ? parameters[k] : null;
-                    string noLogString = noLogObject == null ? "" : noLogObject.toString();
+                    string noLogString = noLogObject == null ? "" : noLogObject.ToString();
                     if (!String.IsNullOrEmpty(noLogString))
                         noLogValues.Add(noLogString);
                 }


### PR DESCRIPTION
##### SUMMARY
Fix issue when setting a param that had `no_log=True` as an empty string for PowerShell modules.

Fixes https://github.com/ansible/ansible/issues/62613

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs