### PR TITLE
Fix issue when setting an empty pass to no_log param (#62804) - 2.8

### DIFF
--- a/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
+++ b/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.Basic - Fix issue when setting a ``no_log`` parameter to an empty string - https://github.com/ansible/ansible/issues/62613

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -700,8 +700,9 @@ namespace Ansible.Basic
                 if ((bool)v["no_log"])
                 {
                     object noLogObject = parameters.Contains(k) ? parameters[k] : null;
-                    if (noLogObject != null)
-                        noLogValues.Add(noLogObject.ToString());
+                    string noLogString = noLogObject == null ? "" : noLogObject.ToString();
+                    if (!String.IsNullOrEmpty(noLogString))
+                        noLogValues.Add(noLogString);
                 }
 
                 object removedInVersion = v["removed_in_version"];

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -709,6 +709,48 @@ test_no_log - Invoked with:
         $actual_event | Assert-DictionaryEquals -Expected $expected_event
     }
 
+    "No log value with an empty string" = {
+        $spec = @{
+            options = @{
+                password1 = @{type = "str"; no_log = $true}
+                password2 = @{type = "str"; no_log = $true}
+            }
+        }
+        $complex_args = @{
+            _ansible_module_name = "test_no_log"
+            password1 = ""
+        }
+
+        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        $m.Result.data = $complex_args.dict
+
+        # verify params internally aren't masked
+        $m.Params.password1 | Assert-Equals -Expected ""
+        $m.Params.password2 | Assert-Equals -Expected $null
+
+        $failed = $false
+        try {
+            $m.ExitJson()
+        } catch [System.Management.Automation.RuntimeException] {
+            $failed = $true
+            $_.Exception.Message | Assert-Equals -Expected "exit: 0"
+            $actual = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+        }
+        $failed | Assert-Equals -Expected $true
+
+        $expected = @{
+            invocation = @{
+                module_args = @{
+                    password1 = ""
+                    password2 = $null
+                }
+            }
+            changed = $false
+            data = $complex_args.dict
+        }
+        $actual | Assert-DictionaryEquals -Expected $expected
+    }
+
     "Removed in version" = {
         $spec = @{
             options = @{

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -734,7 +734,7 @@ test_no_log - Invoked with:
         } catch [System.Management.Automation.RuntimeException] {
             $failed = $true
             $_.Exception.Message | Assert-Equals -Expected "exit: 0"
-            $actual = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+            $actual = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
         }
         $failed | Assert-Equals -Expected $true
 


### PR DESCRIPTION
(cherry picked from commit 322e22583018a8f775c79baaa15021d799eb564e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/62804.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs