### PR TITLE
Fix issue when setting an empty pass to no_log param (#62804) - 2.9

### DIFF
--- a/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
+++ b/changelogs/fragments/ansible_basic_no_log_empty_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.Basic - Fix issue when setting a ``no_log`` parameter to an empty string - https://github.com/ansible/ansible/issues/62613

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -700,8 +700,9 @@ namespace Ansible.Basic
                 if ((bool)v["no_log"])
                 {
                     object noLogObject = parameters.Contains(k) ? parameters[k] : null;
-                    if (noLogObject != null)
-                        noLogValues.Add(noLogObject.ToString());
+                    string noLogString = noLogObject == null ? "" : noLogObject.ToString();
+                    if (!String.IsNullOrEmpty(noLogString))
+                        noLogValues.Add(noLogString);
                 }
 
                 object removedInVersion = v["removed_in_version"];

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -735,7 +735,7 @@ test_no_log - Invoked with:
         } catch [System.Management.Automation.RuntimeException] {
             $failed = $true
             $_.Exception.Message | Assert-Equals -Expected "exit: 0"
-            $actual = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+            $actual = [Ansible.Basic.AnsibleModule]::FromJson($_test_out)
         }
         $failed | Assert-Equals -Expected $true
 


### PR DESCRIPTION
(cherry picked from commit 322e22583018a8f775c79baaa15021d799eb564e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/62804.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs