### PR TITLE
Support instance_uuid to find the vm for vmware_guest_network module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -39,6 +39,12 @@ options:
      - UUID of the instance to gather info if known, this is VMware's unique identifier.
      - This is a required parameter, if parameter C(name) or C(moid) is not supplied.
      type: str
+   use_instance_uuid:
+     description:
+     - Whether to use the VMware instance UUID rather than the BIOS UUID.
+     default: False
+     type: bool
+     version_added: '2.10'
    moid:
      description:
      - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
@@ -149,6 +155,21 @@ EXAMPLES = '''
     datacenter: "{{ datacenter_name }}"
     validate_certs: no
     moid: vm-42
+    gather_network_info: false
+    networks:
+      - state: absent
+        mac: "00:50:56:44:55:77"
+  delegate_to: localhost
+
+- name: Change network adapter settings of virtual machine using instance UUID
+  vmware_guest_network:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    validate_certs: no
+    uuid: 5003b4f5-c705-2f37-ccf6-dfc0b40afeb7
+    use_instance_uuid: True
     gather_network_info: false
     networks:
       - state: absent
@@ -453,6 +474,7 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
+        use_instance_uuid=dict(type='bool', default=False),
         moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', default='ha-datacenter'),

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -71,8 +71,10 @@
           state: new
           device_type: e1000e
           manual_mac: "aa:50:56:58:59:60"
+          connected: True
         - name: "VM Network"
           state: new
+          connected: True
           device_type: vmxnet3
           manual_mac: "aa:50:56:58:59:61"
     register: add_netadapter
@@ -82,7 +84,7 @@
   - name: assert the new netowrk adapters were added to VM
     assert:
       that:
-        - "add_netadapter.changed == true"
+        - add_netadapter is changed
         - "{{ add_netadapter.network_data | length | int }} == {{ netadapter_num | int + 2 }}"
 
   - name: delete one specified network adapter
@@ -102,8 +104,64 @@
   - name: assert the network adapter was removed
     assert:
       that:
-        - "del_netadapter.changed == true"
+        - del_netadapter is changed
         - "{{ del_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
+
+  - name: get instance uuid of virtual machines
+    vmware_guest_info:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines[0].name }}"
+      datacenter: '{{ dc1 }}'
+    register: guest_info
+
+  - set_fact: vm1_instance_uuid="{{ guest_info['instance']['instance_uuid'] }}"
+
+  - name: add new network adapters to virtual machine with instance uuid
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      uuid: "{{ vm1_instance_uuid }}"
+      use_instance_uuid: True
+      networks:
+        - name: "VM Network"
+          state: new
+          connected: True
+          device_type: e1000e
+          manual_mac: "00:50:56:58:59:60"
+    register: add_netadapter_instanceuuid
+
+  - debug: var=add_netadapter_instanceuuid
+
+  - name: assert the new netowrk adapters were added to VM
+    assert:
+      that:
+        - add_netadapter_instanceuuid is changed
+        - "{{ add_netadapter_instanceuuid.network_data | length | int }} == {{ netadapter_num | int + 2 }}"
+
+  - name: delete again one specified network adapter
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines[0].name }}"
+      networks:
+        - state: absent
+          mac: "00:50:56:58:59:60"
+    register: del_again_netadapter
+
+  - debug: var=del_again_netadapter
+
+  - name: assert the network adapter was removed
+    assert:
+      that:
+        - del_again_netadapter is changed
+        - "{{ del_again_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
 
   - name: disconnect one specified network adapter
     vmware_guest_network:
@@ -123,7 +181,7 @@
   - name: assert the network adapter was disconnected
     assert:
       that:
-        - "disc_netadapter.changed == true"
+        - disc_netadapter is changed
         - "{{ disc_netadapter.network_data[netadapter_num]['connected'] }} == false"
 
   - name: Check if network does not exists
@@ -145,5 +203,5 @@
   - name: Check if network does not exists
     assert:
       that:
-        - not no_nw_details.changed
+        - not (no_nw_details is changed)
         - no_nw_details.failed


### PR DESCRIPTION
##### SUMMARY
Support instance_uuid to find the vm for vmware_guest_network module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
fix https://github.com/ansible/ansible/issues/62784

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/vmware/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vmware/Ansible/ansible/lib/ansible
  executable location = /home/vmware/Ansible/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```
