### PR TITLE
[vars_plugins] Allow vars plugins configuration

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -102,9 +102,9 @@ DEFAULT_PASSWORD_CHARS = to_text(ascii_letters + digits + ".,:-_", errors='stric
 DEFAULT_REMOTE_PASS = None
 DEFAULT_SUBSET = None
 # FIXME: expand to other plugins, but never doc fragments
-CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'shell')
+CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'shell', 'vars')
 # NOTE: always update the docs/docsite/Makefile to match
-DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy', 'vars')
+DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy')
 IGNORE_FILES = ("COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES")  # ignore during module search
 INTERNAL_RESULT_KEYS = ('add_host', 'add_group')
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -18,13 +18,14 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.plugins import AnsiblePlugin
 from ansible.utils.path import basedir
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class BaseVarsPlugin(object):
+class BaseVarsPlugin(AnsiblePlugin):
 
     """
     Loads variables for groups and/or hosts
@@ -32,6 +33,7 @@ class BaseVarsPlugin(object):
 
     def __init__(self):
         """ constructor """
+        super(BaseVarsPlugin, self).__init__()
         self._display = display
 
     def get_vars(self, loader, path, entities):


### PR DESCRIPTION
##### SUMMARY
Allow `vars_plugins` to be configurable (and then use the `self.get_option(<option>)` method.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins.vars.BaseVarsPlugin

##### ADDITIONAL INFORMATION
I recently wrote a custom vars plugin and, according to the documentation, I should be able to use the `self.get_option(<option>)` method to get the value of any option described in my `DOCUMENTATION` attribute.

Unfortunately that was not working directly, I made it working doing this change.
