### PR TITLE
Adding reboot action for os_server_action module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -44,7 +44,7 @@ options:
        - Perform the given action. The lock and unlock actions always return
          changed as the servers API does not provide lock status.
      choices: [stop, start, pause, unpause, lock, unlock, suspend, resume,
-               rebuild]
+               rebuild, reboot]
      default: present
    image:
      description:

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -246,7 +246,7 @@ def main():
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)
 
-         elif action == 'reboot':
+        elif action == 'reboot':
             if not _reboot_state(status):
                 module.exit_json(changed=False)
                 
@@ -255,7 +255,7 @@ def main():
                 json={'reboot': {'type':'HARD'}})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
-                module.exit_json(changed=True)
+            module.exit_json(changed=True)
 
     except sdk.exceptions.OpenStackCloudException as e:
         module.fail_json(msg=str(e), extra_data=e.extra_data)

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -116,6 +116,7 @@ def _system_state_change(action, status):
         return False
     return True
 
+
 def _reboot_state(status):
     """Check if system state is suitable for HARD reboot"""
     if status in _reboot_states:

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -250,10 +250,10 @@ def main():
         elif action == 'reboot':
             if not _reboot_state(status):
                 module.exit_json(changed=False)
-                
+
             cloud.compute.post(
                 _action_url(server.id),
-                json={'reboot': {'type':'HARD'}})
+                json={'reboot': {'type': 'HARD'}})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
             module.exit_json(changed=True)

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -129,7 +129,7 @@ def main():
         server=dict(required=True),
         action=dict(required=True, choices=['stop', 'start', 'pause', 'unpause',
                                             'lock', 'unlock', 'suspend', 'resume',
-                                            'rebuild']),
+                                            'rebuild', 'reboot']),
         image=dict(required=False),
     )
 

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: os_server_action
 short_description: Perform actions on Compute Instances from OpenStack
 extends_documentation_fragment: openstack
-version_added: "2.0"
+version_added: "2.10"
 author: "Jesse Keating (@omgjlk)"
 description:
    - Perform server actions on an existing compute instance from OpenStack.

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: os_server_action
 short_description: Perform actions on Compute Instances from OpenStack
 extends_documentation_fragment: openstack
-version_added: "2.10"
+version_added: "2.0"
 author: "Jesse Keating (@omgjlk)"
 description:
    - Perform server actions on an existing compute instance from OpenStack.
@@ -51,6 +51,7 @@ options:
        - The type of reboot which should be executed.
      choices: [soft, hard]
      default: soft
+     version_added: "2.10"
    image:
      description:
        - Image the server should be rebuilt with

--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -46,6 +46,11 @@ options:
      choices: [stop, start, pause, unpause, lock, unlock, suspend, resume,
                rebuild, reboot]
      default: present
+   reboot_type:
+     description:
+       - The type of reboot which should be executed.
+     choices: [soft, hard]
+     default: soft
    image:
      description:
        - Image the server should be rebuilt with


### PR DESCRIPTION
##### SUMMARY

This enables the reboot action within the os_server_action module. Since there are two types of reboot actions currently supported by Openstack API, a new argument `reboot_type` has been added in order to be able to select between these two options. The action is defaulted to soft reboot.

Reboot states references: https://docs.openstack.org/api-ref/compute/?expanded=reboot-server-reboot-action-detail

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

reboot action for os_server_action module

##### ADDITIONAL INFORMATION

```
TASK [Reboot VM] *********************************************************************************************************************************************************************************************
task path: /ansible/playbooks/test_reboot.yml:50
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555 `" && echo ansible-tmp-1569413986.96-138881467066555="` echo $HOME/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555 `" ) && sleep 0'
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/basic.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/openstack.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/_text.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/parsing/convert_bool.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/parsing/__init__.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/pycompat24.py
Using module_utils file /usr/lib/python2.7/site-packages/ansible/module_utils/six/__init__.py
Using module file /usr/lib/python2.7/site-packages/ansible/modules/cloud/openstack/os_server_action.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-569NxyXFX/tmpvjy2pC TO /root/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555/os_server_action.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555/ /root/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555/os_server_action.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'OS_PROJECT_NAME=Redacted OS_USERNAME=Redacted OS_USER_DOMAIN_NAME=Redacted OS_AUTH_URL=Redacted OS_PASSWORD=Redacted OS_PROJECT_DOMAIN_NAME=Redacted /usr/bin/python2 /root/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555/os_server_action.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1569413986.96-138881467066555/ > /dev/null 2>&1 && sleep 0'
changed: [test-vm.internal -> 127.0.0.1] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "action": "reboot",
            "api_timeout": null,
            "auth": null,
            "auth_type": null,
            "availability_zone": null,
            "cacert": null,
            "cert": null,
            "image": null,
            "interface": "public",
            "key": null,
            "region_name": null,
            "server": "test-vm.internal",
            "timeout": 180,
            "verify": null,
            "wait": true
        }
    }
}
```
