### PR TITLE
VMware: added path for non unique objects

### DIFF
--- a/changelogs/fragments/vmware_object_role_permission.yml
+++ b/changelogs/fragments/vmware_object_role_permission.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Added a object parent to adress non unique object names.

--- a/lib/ansible/modules/cloud/vmware/vmware_object_role_permission.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_object_role_permission.py
@@ -25,6 +25,7 @@ version_added: 2.8
 author:
 - Derek Rushing (@kryptsi)
 - Joseph Andreatta (@vmwjoseph)
+- Jan Meerkamp (@meerkampdvv)
 notes:
     - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
@@ -58,6 +59,7 @@ options:
     - The name of the parent object or a Path for non uniqe Object names.
     type: str
     required: False
+    version_added: "2.10"
   object_type:
     description:
     - The object type being targeted.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a object parent for non unique object names.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_object_role_permission

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
currently it is not possible to set permissions for object with non unique names.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
