### PR TITLE
Fix whitespace issue in filter (backport 2.7)

### DIFF
--- a/changelogs/fragments/aci-42-filter-whitespace.yaml
+++ b/changelogs/fragments/aci-42-filter-whitespace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ACI modules - Fix a whitespace issue in filters for ACI 4.2 strict validation"

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -400,9 +400,9 @@ class ACIModule(object):
         ''' Build an APIC filter based on obj_class and key-value pairs '''
         accepted_params = dict((k, v) for (k, v) in params.items() if v is not None)
         if len(accepted_params) == 1:
-            return ','.join('eq({0}.{1}, "{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items())
+            return ','.join('eq({0}.{1},"{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items())
         elif len(accepted_params) > 1:
-            return 'and(' + ','.join(['eq({0}.{1}, "{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items()]) + ')'
+            return 'and(' + ','.join(['eq({0}.{1},"{2}")'.format(obj_class, k, v) for (k, v) in accepted_params.items()]) + ')'
 
     def construct_url(self, root_class, subclass_1=None, subclass_2=None, subclass_3=None, child_classes=None):
         """


### PR DESCRIPTION
##### SUMMARY
This fixes reported issue #60276
This is due to a more strict parsing of filters since ACI v4.2.

This is a backport of #62768

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
All ACI modules