### PR TITLE
Fix broken link to powershell resources

### DIFF
--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -64,7 +64,7 @@ options:
     required: true
 notes:
 - By default there are a few builtin resources that come with PowerShell 5.0,
-  see U(https://docs.microsoft.com/en-us/powershell/dsc/builtinresource) for
+  see U(https://docs.microsoft.com/en-us/powershell/dsc/resources/resources) for
   more information on these resources.
 - Custom DSC resources can be installed with M(win_psmodule) using the I(name)
   option.


### PR DESCRIPTION
##### SUMMARY
The previous link (https://docs.microsoft.com/en-us/powershell/dsc/builtinresource ) is a 404 . MS has a new link https://docs.microsoft.com/en-us/powershell/dsc/resources/resources  with the same content

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The previous link is a 404, just fixing it with the new non-404'ing link.

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
win_dsc


