### PR TITLE
Update redhat_subscription.py

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -776,7 +776,7 @@ def main():
             'username': {},
             'password': {'no_log': True},
             'server_hostname': {},
-            'server_insecure': {},
+            'server_insecure': {'type': 'bool'},
             'rhsm_baseurl': {},
             'rhsm_repo_ca_cert': {},
             'auto_attach': {'aliases': ['autosubscribe'], 'type': 'bool'},


### PR DESCRIPTION
##### SUMMARY
the server_insecure option is always evaluated as true as it is not a bool

##### ISSUE TYPE
- Bugfix Pull Request

+label: docsite_pr

##### COMPONENT NAME
redhat_subscription.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
getting a warning during use in ansible about a bool variable that is being used as a string

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before

<10.2.51.10> (0, '\n{"msg": "System successfully registered to \'None\'.", "invocation": {"module_args": {"rhsm_repo_ca_cert": null, "server_hostname": null, "consumer_id": null, "activationkey": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "server_proxy_password": null, "consumer_name": null, "server_proxy_port": null, "environment": null, "force_register": true, "state": "present", "server_proxy_user": null, "username": null, "pool_ids": [], "auto_attach": false, **"server_insecure": "True"**, "password": null, "rhsm_baseurl": null, "pool": "^$", "consumer_type": null, "org_id": "CPB", "release": "7.7", "server_proxy_hostname": null}}, "changed": true, "subscribed_pool_ids": [], "warnings": ["The value True (type bool) in a string field was converted to u\'True\' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change."]}\n', '')
 [WARNING]: The value True (type bool) in a string field was converted to u'True' (type string). If this does not look like what you expect, quote the entire
value to ensure it does not change.

after

<10.2.51.11> (0, '\n{"msg": "System successfully registered to \'None\'.", "invocation": {"module_args": {"rhsm_repo_ca_cert": null, "server_hostname": null, "consumer_id": null, "activationkey": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "server_proxy_password": null, "consumer_name": null, "server_proxy_port": null, "environment": null, "force_register": true, "state": "present", "server_proxy_user": null, "username": null, "pool_ids": [], "auto_attach": false, "server_insecure": true, "password": null, "rhsm_baseurl": null, "pool": "^$", "consumer_type": null, "org_id": "CPB", "release": "7.7", "server_proxy_hostname": null}}, "changed": true, "subscribed_pool_ids": []}\n', '')

```
