### PR TITLE
Add timeout to jenkins_script CSFR requests

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -114,6 +114,7 @@ from ansible.module_utils._text import to_native
 def is_csrf_protection_enabled(module):
     resp, info = fetch_url(module,
                            module.params['url'] + '/api/json',
+                           timeout=module.params['timeout'],
                            method='GET')
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"], output='')
@@ -126,6 +127,7 @@ def get_crumb(module, cookies):
     resp, info = fetch_url(module,
                            module.params['url'] + '/crumbIssuer/api/json',
                            method='GET',
+                           timeout=module.params['timeout'],
                            cookies=cookies)
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"], output='')


### PR DESCRIPTION
##### SUMMARY

Fixes a timeout issue when making authenticated requests to the Jenkins API with CSFR enabled.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

jenkins_script

##### ADDITIONAL INFORMATION

Timeout was added previously to the main fetch_url call, but not to any of the calls that determine if CSFR (Cross-site Request Forgery) protection is enabled. CSFR protection is enabled by default in Jenkins. In my case, LDAP requests are taking longer than 10 seconds in our internal implementation so this module always fails.