### PR TITLE
Update maintenance notes on vmware_cfg_backup.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cfg_backup.py
@@ -24,7 +24,7 @@ author:
 notes:
     - Tested on ESXi 6.0
     - Works only for ESXi hosts
-    - For configuration save or reset, the host will be switched automatically to maintenance mode.
+    - For configuration load or reset, the host will be switched automatically to maintenance mode.
 requirements:
     - "python >= 2.6"
     - PyVmomi installed


### PR DESCRIPTION
##### SUMMARY
Maintenance mode seems only to be required for load or restet, not for save_configuration. 


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
