### PR TITLE
facts: detect FreeBSD jails guest

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/freebsd.py
+++ b/lib/ansible/module_utils/facts/virtual/freebsd.py
@@ -41,7 +41,7 @@ class FreeBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
             virtual_facts['virtualization_role'] = 'guest'
 
         if virtual_facts['virtualization_type'] == '':
-            virtual_product_facts = self.detect_virt_product('kern.vm_guest') or self.detect_virt_product('hw.hv_vendor')
+            virtual_product_facts = self.detect_virt_product('kern.vm_guest') or self.detect_virt_product('hw.hv_vendor') or self.detect_virt_product('security.jail.jailed')
             virtual_facts.update(virtual_product_facts)
 
         if virtual_facts['virtualization_type'] == '':

--- a/lib/ansible/module_utils/facts/virtual/freebsd.py
+++ b/lib/ansible/module_utils/facts/virtual/freebsd.py
@@ -41,7 +41,8 @@ class FreeBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
             virtual_facts['virtualization_role'] = 'guest'
 
         if virtual_facts['virtualization_type'] == '':
-            virtual_product_facts = self.detect_virt_product('kern.vm_guest') or self.detect_virt_product('hw.hv_vendor') or self.detect_virt_product('security.jail.jailed')
+            virtual_product_facts = self.detect_virt_product('kern.vm_guest') or self.detect_virt_product(
+                'hw.hv_vendor') or self.detect_virt_product('security.jail.jailed')
             virtual_facts.update(virtual_product_facts)
 
         if virtual_facts['virtualization_type'] == '':

--- a/lib/ansible/module_utils/facts/virtual/sysctl.py
+++ b/lib/ansible/module_utils/facts/virtual/sysctl.py
@@ -48,6 +48,9 @@ class VirtualSysctlDetectionMixin(object):
                 elif out.rstrip() == 'RHEV Hypervisor':
                     virtual_product_facts['virtualization_type'] = 'RHEV'
                     virtual_product_facts['virtualization_role'] = 'guest'
+                elif (key == 'security.jail.jailed') and (out.rstrip() == '1'):
+                    virtual_product_facts['virtualization_type'] = 'jails'
+                    virtual_product_facts['virtualization_role'] = 'guest'
 
         return virtual_product_facts
 


### PR DESCRIPTION
##### SUMMARY

Fixes  #36350

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/facts/virtual/freebsd.py
lib/ansible/module_utils/facts/virtual/sysctl.py

##### ADDITIONAL INFORMATION

Before:

```
$ ansible -m setup -a 'filter=ansible_virtualization_*' freebsd
192.168.122.133 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "", 
        "ansible_virtualization_type": ""
    }, 
    "changed": false
}
```
After:

 ```
$ ansible -m setup -a 'filter=ansible_virtualization_*' freebsd
192.168.122.133 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "jails"
    }, 
    "changed": false
}
```