### PR TITLE
fix os_user_role for groups in multidomain context

### DIFF
--- a/changelogs/fragments/62858_fix_os_user_role_for_group.yaml
+++ b/changelogs/fragments/62858_fix_os_user_role_for_group.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "os_user_role: fix os_user_role for groups in multidomain context"

--- a/lib/ansible/modules/cloud/openstack/os_user_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_role.py
@@ -151,7 +151,10 @@ def main():
                 module.fail_json(msg="User %s is not valid" % user)
             filters['user'] = u['id']
         if group:
-            g = cloud.get_group(group)
+            if domain:
+                g = cloud.get_group(group, domain_id=filters['domain'])
+            else:
+                g = cloud.get_group(group)
             if g is None:
                 module.fail_json(msg="Group %s is not valid" % group)
             filters['group'] = g['id']


### PR DESCRIPTION
##### SUMMARY
In a multidomain context, if the same group name exists in multiple domains, the module fails with `"msg": "Multiple matches found for %s"`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_user_role

##### ADDITIONAL INFORMATION
Steps to reproduce:

Create a group & project in 2 separate domains and assign a role to the group on the project:

```
---
- hosts: localhost
  gather_facts: no

  tasks:
    - os_keystone_domain:
        cloud: test-cloud
        state: present
        name: "{{ item }}"
      with_items:
        - "domain_1"
        - "domain_2"
      register: domains

    - os_group:
        cloud: test-cloud
        name: group_1
        domain_id: "{{ item.id }}"
      with_items: "{{ domains.results }}"

    - os_project:
        cloud: test-cloud
        name: project_1
        domain_id: "{{ item.id }}"
      with_items: "{{ domains.results }}"

    - os_user_role:
        cloud: test-cloud
        role: admin
        group: group_1
        project: project_1
        domain: "{{ item.id }}"
      with_items: "{{ domains.results }}"
```

Before change:
```paste below
failed: [localhost] (item={'changed': False, <...>  "msg": "Multiple matches found for group_1"}
failed: [localhost] (item={'changed': False, <...>  "msg": "Multiple matches found for group_1"}                                
```
After change:
```paste below                                                           
changed: [localhost] => (item={<...> => {"ansible_loop_var": "item", "changed": true, <...> }
changed: [localhost] => (item={<...> => {"ansible_loop_var": "item", "changed": true, <...> }
```
