### PR TITLE
hcloud_volume: add linux_device to return values

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
@@ -130,6 +130,11 @@ hcloud_volume:
             type: int
             returned: Always
             sample: 1337
+        linux_device:
+            description: Path to the device that contains the volume.
+            returned: always
+            type: src
+            sample: /dev/disk/by-id/scsi-0HC_Volume_12345
         location:
             description: Location name where the volume is located at
             type: string
@@ -178,6 +183,7 @@ class AnsibleHcloudVolume(Hcloud):
             "location": to_native(self.hcloud_volume.location.name),
             "labels": self.hcloud_volume.labels,
             "server": to_native(server_name),
+            "linux_device": to_native(self.hcloud_volume.linux_device),
         }
 
     def _get_volume(self):

--- a/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_volume.py
@@ -135,6 +135,7 @@ hcloud_volume:
             returned: always
             type: src
             sample: /dev/disk/by-id/scsi-0HC_Volume_12345
+            version_added: "2.10"
         location:
             description: Location name where the volume is located at
             type: string

--- a/lib/ansible/modules/cloud/hcloud/hcloud_volume_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_volume_info.py
@@ -73,6 +73,11 @@ hcloud_volume_info:
             returned: always
             type: str
             sample: 10
+        linux_device:
+            description: Path to the device that contains the volume.
+            returned: always
+            type: src
+            sample: /dev/disk/by-id/scsi-0HC_Volume_12345
         location:
             description: Name of the location where the volume resides in
             returned: always
@@ -119,6 +124,7 @@ class AnsibleHcloudVolumeInfo(Hcloud):
                     "location": to_native(volume.location.name),
                     "labels": volume.labels,
                     "server": to_native(server_name),
+                    "linux_device": to_native(volume.linux_device),
                 })
 
         return tmp

--- a/lib/ansible/modules/cloud/hcloud/hcloud_volume_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_volume_info.py
@@ -78,6 +78,7 @@ hcloud_volume_info:
             returned: always
             type: src
             sample: /dev/disk/by-id/scsi-0HC_Volume_12345
+            version_added: "2.10"
         location:
             description: Name of the location where the volume resides in
             returned: always

--- a/test/integration/targets/hcloud_volume/tasks/main.yml
+++ b/test/integration/targets/hcloud_volume/tasks/main.yml
@@ -52,6 +52,7 @@
       - volume.hcloud_volume.location == "fsn1"
       - volume.hcloud_volume.size == 10
       - volume.hcloud_volume.server != "{{hcloud_server_name}}"
+      - volume.hcloud_volume.linux_device is defined
 
 - name: test create volume idempotence
   hcloud_volume:

--- a/test/integration/targets/hcloud_volume_info/tasks/main.yml
+++ b/test/integration/targets/hcloud_volume_info/tasks/main.yml
@@ -26,9 +26,15 @@
   check_mode: yes
 
 - name: verify test gather hcloud volume infos in check mode
+  vars:
+    volume: "{{ hcloud_volume.hcloud_volume_info|selectattr('name','equalto',hcloud_volume_name) | first }}"
   assert:
     that:
       - hcloud_volume.hcloud_volume_info|selectattr('name','equalto','{{ hcloud_volume_name }}') | list | count == 1
+      - volume.name == "{{hcloud_volume_name}}"
+      - volume.location == "fsn1"
+      - volume.size == 10
+      - volume.linux_device is defined
 
 - name: test gather hcloud volume infos with correct label selector
   hcloud_volume_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The [volume operations of Hetzner Cloud API](https://docs.hetzner.cloud/#volumes) return a `linux_device` parameter, but it is not included in the return values of `hcloud_volume` or `hcloud_volume_info` modules.

This change adds the `linux_device` parameter to the set of return values from those modules. It should be useful for configuring mounts on servers in Hetzner cloud.

The generated device names seem to be predictable (e.g. `scsi-0HC_Volume_<VOLUME-ID>`) and could, alternatively, be generated from the `id` parameter that is already returned by the modules. But in the interest of robustness against changes in the device naming, would be nicer to just get the device name directly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- hcloud_volume
- hcloud_volume_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### Example output from `hcloud_volume` before this change
```
TASK [hcloud_volume : before PR] ***************************************************************************************************************************
ok: [testhost] => {
    "hcloud_volume": {
        "changed": false, 
        "failed": false, 
        "hcloud_volume_info": [
            {
                "id": "1234567", 
                "labels": {}, 
                "location": "fsn1", 
                "name": "test", 
                "server": "None", 
                "size": 10
            }
        ]
    }
}
```

### Example output from `hcloud_volume` after this change

```
TASK [hcloud_volume : after PR] ***************************************************************************************************************************
ok: [testhost] => {
    "hcloud_volume": {
        "changed": false, 
        "failed": false, 
        "hcloud_volume_info": [
            {
                "id": "1234567", 
                "labels": {}, 
                "linux_device": "/dev/disk/by-id/scsi-0HC_Volume_1234567", 
                "location": "fsn1", 
                "name": "test", 
                "server": "None", 
                "size": 10
            }
        ]
    }
}
```
