### PR TITLE
Domain id added

### DIFF
--- a/lib/ansible/module_utils/network/aci/mso.py
+++ b/lib/ansible/module_utils/network/aci/mso.py
@@ -82,6 +82,7 @@ def mso_argument_spec():
         port=dict(type='int', required=False),
         username=dict(type='str', default='admin'),
         password=dict(type='str', required=True, no_log=True),
+        domain_id=dict(type='str', default='0000ffff0000000000000090'),
         output_level=dict(type='str', default='normal', choices=['debug', 'info', 'normal']),
         timeout=dict(type='int', default=30),
         use_proxy=dict(type='bool', default=True),
@@ -166,7 +167,9 @@ class MSOModule(object):
 
         # Perform login request
         self.url = urljoin(self.baseuri, 'auth/login')
-        payload = {'username': self.params['username'], 'password': self.params['password']}
+        payload = {'username': self.params['username'],
+                   'password': self.params['password'],
+                   'domainId': self.params['domain_id']}
         resp, auth = fetch_url(self.module,
                                self.url,
                                data=json.dumps(payload),

--- a/lib/ansible/plugins/doc_fragments/mso.py
+++ b/lib/ansible/plugins/doc_fragments/mso.py
@@ -35,7 +35,7 @@ options:
     required: yes
   domain_id:
     description:
-    - The domina id to use for authentication.
+    - The domain id to use for authentication.
     type: str
     default: 0000ffff0000000000000090
   output_level:

--- a/lib/ansible/plugins/doc_fragments/mso.py
+++ b/lib/ansible/plugins/doc_fragments/mso.py
@@ -33,6 +33,11 @@ options:
     - This option is mutual exclusive with C(private_key). If C(private_key) is provided too, it will be used instead.
     type: str
     required: yes
+  domain_id:
+    description:
+    - The domina id to use for authentication.
+    type: str
+    default: 0000ffff0000000000000090
   output_level:
     description:
     - Influence the output of this ACI module.


### PR DESCRIPTION
##### SUMMARY

Adding Domain ID for MSO login. Useful for example in the case the login is not made with a local user, i.e. Tacas User. By default, local user domain id is used.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
MSO
