### PR TITLE
Default collection install to first path in COLLECTIONS_PATHS

### DIFF
--- a/changelogs/fragments/62870-collection-install-default-path.yml
+++ b/changelogs/fragments/62870-collection-install-default-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Default collection install path to first path in COLLECTIONS_PATHS (https://github.com/ansible/ansible/pull/62870)

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -245,15 +245,19 @@ as a distribution method, but you can use it directly to install the collection 
 Trying collection locally
 -------------------------
 
-You can try your collection locally by installing it from the tarball.
+You can try your collection locally by installing it from the tarball. The following will enable an adjacent playbook to
+access the collection:
 
 .. code-block:: bash
 
-   ansible-galaxy collection install my_namespace-my_collection-1.0.0.tar.gz -p ./collections/ansible_collections
+   ansible-galaxy collection install my_namespace-my_collection-1.0.0.tar.gz -p ./collections
 
-You should use one of the values configured in :ref:`COLLECTIONS_PATHS` for your path. This is also where Ansible itself will expect to find collections when attempting to use them.
 
-Then try to use the local collection inside a playbook, for more details see :ref:`Using collections <using_collections>`
+You should use one of the values configured in :ref:`COLLECTIONS_PATHS` for your path. This is also where Ansible itself will
+expect to find collections when attempting to use them. If you don't specify a path value, ``ansible-galaxy collection install``
+installs the collection in the first path defined in :ref:`COLLECTIONS_PATHS`, which by default is ``~/.ansible/collections``.
+
+Next, try using the local collection inside a playbook. For examples and more details see :ref:`Using collections <using_collections>`
 
 .. _publishing_collections:
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -17,13 +17,13 @@ You can install and use collections through `Ansible Galaxy <https://galaxy.ansi
 Installing collections
 ======================
 
-You can use the ``ansible-galaxy collection install`` command to install a collection on your system. You must specify an installation location using the ``-p`` option.
+You can use the ``ansible-galaxy collection install`` command to install a collection on your system.
 
 To install a collection hosted in Galaxy:
 
 .. code-block:: bash
 
-   ansible-galaxy collection install my_namespace.my_collection -p /collections
+   ansible-galaxy collection install my_namespace.my_collection
 
 You can also directly use the tarball from your build:
 
@@ -36,7 +36,9 @@ You can also directly use the tarball from your build:
     parent directory is already in a folder called ``ansible_collections``.
 
 
-You should use one of the values configured in :ref:`COLLECTIONS_PATHS` for your path. This is also where Ansible itself will expect to find collections when attempting to use them.
+When using the ``-p`` option to specify the install path, use one of the values configured in :ref:`COLLECTIONS_PATHS`, as this is
+where Ansible itself will expect to find collections. If you don't specify a path, ``ansible-galaxy collection install`` installs
+the collection to the first path defined in :ref:`COLLECTIONS_PATHS`, which by default is ``~/.ansible/collections``
 
 You can also keep a collection adjacent to the current playbook, under a ``collections/ansible_collections/`` directory structure.
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -251,7 +251,8 @@ class GalaxyCLI(CLI):
                                             "dependencies.".format(galaxy_type))
 
         if galaxy_type == 'collection':
-            install_parser.add_argument('-p', '--collections-path', dest='collections_path', required=True,
+            install_parser.add_argument('-p', '--collections-path', dest='collections_path',
+                                        default=C.COLLECTIONS_PATHS[0],
                                         help='The path to the directory containing your collections.')
             install_parser.add_argument('-r', '--requirements-file', dest='requirements',
                                         help='A file containing a list of collections to be installed.')


### PR DESCRIPTION
##### SUMMARY
Provide a sane default install path value for `ansible-galaxy collection install`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`ansible-galaxy`

##### ADDITIONAL INFORMATION

Fixes #62869