### PR TITLE
allow option docker_storage_driver=overlay2 in module os_coe_cluster_template

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_coe_cluster_template.py
+++ b/lib/ansible/modules/cloud/openstack/os_coe_cluster_template.py
@@ -37,7 +37,7 @@ options:
    docker_storage_driver:
       description:
          - Docker storage driver
-      choices: [devicemapper, overlay]
+      choices: [devicemapper, overlay, overlay2]
    docker_volume_size:
       description:
          - The size in GB of the docker volume
@@ -288,7 +288,7 @@ def main():
     argument_spec = openstack_full_argument_spec(
         coe=dict(required=True, choices=['kubernetes', 'swarm', 'mesos']),
         dns_nameserver=dict(default='8.8.8.8'),
-        docker_storage_driver=dict(choices=['devicemapper', 'overlay']),
+        docker_storage_driver=dict(choices=['devicemapper', 'overlay', 'overlay2']),
         docker_volume_size=dict(type='int'),
         external_network_id=dict(default=None),
         fixed_network=dict(default=None),


### PR DESCRIPTION
##### SUMMARY

Allow to define `docker_storage_driver=overlay2` in module `os_coe_cluster_template`

Currently only `devicemapper` and `overlay` are supported

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_coe_cluster_template

##### ADDITIONAL INFORMATION

Openstack magnum already supports `overlay2` and it's the recommended driver by docker

```
The overlay2 driver is supported on Docker Engine - Community, and Docker EE 17.06.02-ee5 and up, and is the recommended storage driver.
```

https://docs.docker.com/storage/storagedriver/overlayfs-driver/