### PR TITLE
Fix Bum Traffic Payload keyword (backport 2.8)

### DIFF
--- a/changelogs/fragments/mso_schema_template_bd-payload-fix.yaml
+++ b/changelogs/fragments/mso_schema_template_bd-payload-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- mso_schema_template_bd - Fix incorrect payload when setting intersiteBUMTrafficAllow.

--- a/lib/ansible/modules/network/aci/mso_schema_template_bd.py
+++ b/lib/ansible/modules/network/aci/mso_schema_template_bd.py
@@ -248,7 +248,7 @@ def main():
         payload = dict(
             name=bd,
             displayName=display_name,
-            intersiteBumTraffic=intersite_bum_traffic,
+            intersiteBumTrafficAllow=intersite_bum_traffic,
             optimizeWanBandwidth=optimize_wan_bandwidth,
             l2UnknownUnicast=layer2_unknown_unicast,
             l2Stretch=layer2_stretch,


### PR DESCRIPTION
##### SUMMARY
The payload was using the incorrect keyword to push the True or False
statement to the device and was getting dropped. This would also result
in erroring out if layer2_unknown_unicase was set to Flood instead of
Proxy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mso_schema_template_bd.py