### PR TITLE
vmware_httpapi: version_added==2.10

### DIFF
--- a/lib/ansible/modules/cloud/vmware_httpapi/vmware_appliance_access_info.py
+++ b/lib/ansible/modules/cloud/vmware_httpapi/vmware_appliance_access_info.py
@@ -20,7 +20,7 @@ description:
 - This module can be used to gather information about the four modes of accessing the VCSA.
 - This module is based on REST API and uses httpapi connection plugin for persistent connection.
 - The Appliance API works against the VCSA and uses the "administrator@vsphere.local" user.
-version_added: '2.9'
+version_added: '2.10'
 author:
 - Paul Knight (@n3pjk)
 notes:

--- a/lib/ansible/modules/cloud/vmware_httpapi/vmware_appliance_health_info.py
+++ b/lib/ansible/modules/cloud/vmware_httpapi/vmware_appliance_health_info.py
@@ -20,7 +20,7 @@ description:
 - This module can be used to gather information about VCSA health.
 - This module is based on REST API and uses httpapi connection plugin for persistent connection.
 - The Appliance API works against the VCSA and uses the "administrator@vsphere.local" user.
-version_added: '2.9'
+version_added: '2.10'
 author:
 - Paul Knight (@n3pjk)
 notes:

--- a/lib/ansible/modules/cloud/vmware_httpapi/vmware_cis_category_info.py
+++ b/lib/ansible/modules/cloud/vmware_httpapi/vmware_cis_category_info.py
@@ -20,7 +20,7 @@ description:
 - This module can be used to gather information about a specific category.
 - This module can also gather facts about all categories.
 - This module is based on REST API and uses httpapi connection plugin for persistent connection.
-version_added: '2.9'
+version_added: '2.10'
 author:
 - Paul Knight (@n3pjk)
 notes:

--- a/lib/ansible/modules/cloud/vmware_httpapi/vmware_core_info.py
+++ b/lib/ansible/modules/cloud/vmware_httpapi/vmware_core_info.py
@@ -20,7 +20,7 @@ short_description: Gathers info about various VMware inventory objects using RES
 description:
 - This module can be used to gather information about various VMware inventory objects.
 - This module is based on REST API and uses httpapi connection plugin for persistent connection.
-version_added: '2.9'
+version_added: '2.10'
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Paul Knight (@n3pjk)

--- a/lib/ansible/plugins/doc_fragments/VmwareRestModule.py
+++ b/lib/ansible/plugins/doc_fragments/VmwareRestModule.py
@@ -15,21 +15,21 @@ options:
       - Indicates whether get_id() can return multiple IDs for a given name.
       - Typically, this should be false when updating or deleting; otherwise, all named objects could be affected.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: bool
     log_level:
       description:
       - If ANSIBLE_DEBUG is set, this will be forced to 'debug', but can be user-defined otherwise.
       required: True
       choices: ['debug', 'info', 'normal']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'normal'
     status_code:
       description:
       - A list of integer status codes considered to be successful for the this module.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: list
       default: [200]
 '''

--- a/lib/ansible/plugins/doc_fragments/VmwareRestModule_filters.py
+++ b/lib/ansible/plugins/doc_fragments/VmwareRestModule_filters.py
@@ -15,27 +15,27 @@ options:
       - Indicates whether get_id() can return multiple IDs for a given name.
       - Typically, this should be false when updating or deleting; otherwise, all named objects could be affected.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: bool
     filters:
       description:
       - The key/value pairs describing filters to be applied to the request(s) made by this instance.
       required: false
-      version_added: "2.9"
+      version_added: "2.10"
       type: dict
     log_level:
       description:
       - If ANSIBLE_DEBUG is set, this will be forced to 'debug', but can be user-defined otherwise.
       required: True
       choices: ['debug', 'info', 'normal']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'normal'
     status_code:
       description:
       - A list of integer status codes considered to be successful for the this module.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: list
       default: [200]
 '''

--- a/lib/ansible/plugins/doc_fragments/VmwareRestModule_full.py
+++ b/lib/ansible/plugins/doc_fragments/VmwareRestModule_full.py
@@ -15,20 +15,20 @@ options:
       - Indicates whether get_id() can return multiple IDs for a given name.
       - Typically, this should be false when updating or deleting; otherwise, all named objects could be affected.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: bool
     filters:
       description:
       - The key/value pairs describing filters to be applied to the request(s) made by this instance.
       required: false
-      version_added: "2.9"
+      version_added: "2.10"
       type: dict
     log_level:
       description:
       - If ANSIBLE_DEBUG is set, this will be forced to 'debug', but can be user-defined otherwise.
       required: True
       choices: ['debug', 'info', 'normal']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'normal'
     state:
@@ -36,14 +36,14 @@ options:
       - Either 'absent' or 'present', depending on whether object should be removed or created.
       required: false
       choices: ['absent', 'present', 'query']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'present'
     status_code:
       description:
       - A list of integer status codes considered to be successful for the this module.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: list
       default: [200]
 '''

--- a/lib/ansible/plugins/doc_fragments/VmwareRestModule_state.py
+++ b/lib/ansible/plugins/doc_fragments/VmwareRestModule_state.py
@@ -15,14 +15,14 @@ options:
       - Indicates whether get_id() can return multiple IDs for a given name.
       - Typically, this should be false when updating or deleting; otherwise, all named objects could be affected.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: bool
     log_level:
       description:
       - If ANSIBLE_DEBUG is set, this will be forced to 'debug', but can be user-defined otherwise.
       required: True
       choices: ['debug', 'info', 'normal']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'normal'
     state:
@@ -30,14 +30,14 @@ options:
       - Either 'absent' or 'present', depending on whether object should be removed or created.
       required: false
       choices: ['absent', 'present', 'query']
-      version_added: "2.9"
+      version_added: "2.10"
       type: str
       default: 'present'
     status_code:
       description:
       - A list of integer status codes considered to be successful for the this module.
       required: true
-      version_added: "2.9"
+      version_added: "2.10"
       type: list
       default: [200]
 '''

--- a/lib/ansible/plugins/httpapi/vmware.py
+++ b/lib/ansible/plugins/httpapi/vmware.py
@@ -13,7 +13,7 @@ httpapi : vmware
 short_description: HttpApi Plugin for VMware REST API
 description:
   - This HttpApi plugin provides methods to connect to VMware vCenter over a HTTP(S)-based APIs.
-version_added: "2.9"
+version_added: "2.10"
 """
 
 import json


### PR DESCRIPTION
##### SUMMARY

`vmware_httpapi` hierachy will actually be released with Ansible 2.10, not
2.9. This commit fixes the `version_added` field.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_httpapi
<!--- Write the short name of the module, plugin, task or feature below -->