### PR TITLE
Fix non-error with yum pkg mgr module

### DIFF
--- a/lib/ansible/plugins/action/yum.py
+++ b/lib/ansible/plugins/action/yum.py
@@ -22,6 +22,8 @@ from ansible.utils.display import Display
 
 display = Display()
 
+VALID_PKG_MGRS = frozenset(("yum", "yum4", "dnf"))
+
 
 class ActionModule(ActionBase):
 
@@ -56,7 +58,7 @@ class ActionModule(ActionBase):
             except Exception:
                 pass  # could not get it from template!
 
-        if module not in ["yum", "yum4", "dnf"]:
+        if module not in VALID_PKG_MGRS:
             facts = self._execute_module(module_name="setup", module_args=dict(filter="ansible_pkg_mgr", gather_subset="!all"), task_vars=task_vars)
             display.debug("Facts %s" % facts)
             module = facts.get("ansible_facts", {}).get("ansible_pkg_mgr", "auto")
@@ -68,7 +70,7 @@ class ActionModule(ActionBase):
             if module == "yum4":
                 module = "dnf"
 
-            if module not in self._shared_loader_obj.module_loader:
+            if module not in self._shared_loader_obj.module_loader or module not in VALID_PKG_MGRS:
                 result.update({'failed': True, 'msg': "Could not find a yum module backend for %s." % module})
             else:
                 # run either the yum (yum3) or dnf (yum4) backend module


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Based on the issue reported by @geerlingguy ([62362](https://github.com/ansible/ansible/issues/62362)) there is a non-error issue when we try to use yum on a non-Red Hat distro. The expected behavior is that appear an error but ansible finishes the task.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
More information about how to reproduce this issue is described in the issue [62362](https://github.com/ansible/ansible/issues/62362)

