### PR TITLE
Adjust documentation for yum clean to use best practices

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -225,8 +225,8 @@ notes:
     Use the "yum group list hidden ids" command to see which category of group the group
     you want to install falls into.'
   - 'The yum module does not support clearing yum cache in an idempotent way, so it
-    was decided not to implement it, the only method is to use shell and call the yum
-    command directly, namely "shell: yum clean all"
+    was decided not to implement it, the only method is to use command and call the yum
+    command directly, namely "command: yum clean all"
     https://github.com/ansible/ansible/pull/31450#issuecomment-352889579'
 # informational: requirements for nodes
 requirements:


### PR DESCRIPTION
##### SUMMARY

Currently a documentation note on 'yum clean all' usage says to use `shell: yum clean all`. But you should use the `command` module unless you need more advanced features than just passing in an arbitrary command. If you use the documentation's code verbatim, you get an `ansible-lint` error.

This PR fixes that problem by using the `command` module in the example instead.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
yum

##### ADDITIONAL INFORMATION
N/A