### PR TITLE
Add support to delete vm from inventory. 

### DIFF
--- a/test/integration/targets/vmware_guest/defaults/main.yml
+++ b/test/integration/targets/vmware_guest/defaults/main.yml
@@ -30,3 +30,4 @@ vmware_guest_test_playbooks:
 #  - template_d1_c1_f0.yml
   - vapp_d1_c1_f0.yml
   - reconfig_vm_to_latest_version.yml
+  - remove_vm_from_inventory.yml

--- a/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
+++ b/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
@@ -1,0 +1,61 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Create VM to unregister
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    guest_id: centos64Guest
+    datacenter: "{{ dc1 }}"
+    folder: F0
+    hardware:
+      num_cpus: 4
+      num_cpu_cores_per_socket: 2
+      memory_mb: 512
+    disk:
+      - size: 1gb
+        type: thin
+        autoselect_datastore: True
+    state: present
+  register: create_vm_for_test
+
+- name: assert that changes were made
+  assert:
+    that:
+        - create_vm_for_test is changed
+   
+- name: Remove VM from Inventory
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    delete_from_inventory: True
+    state: absent
+  register: remove_vm_from_inventory
+
+- name: assert that changes were made
+  assert:
+    that:
+        - remove_vm_from_inventory is changed
+
+- name: Remove VM again from Inventory
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    delete_from_inventory: True
+    state: absent
+  register: remove_again_vm_from_inventory
+
+- name: assert that changes were made
+  assert:
+    that:
+        - not (remove_again_vm_from_inventory is changed)


### PR DESCRIPTION
##### SUMMARY
Fix issue https://github.com/ansible/ansible/issues/55572
Add support to delete VM from inventory.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
```
ansible 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/vmware/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vmware/Ansible/ansible/lib/ansible
  executable location = /home/vmware/Ansible/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]


```
