### PR TITLE
mysql_replication: add basic CI tests for MariaDB from scratch

### DIFF
--- a/test/integration/targets/mariadb_replication/aliases
+++ b/test/integration/targets/mariadb_replication/aliases
@@ -1,0 +1,10 @@
+destructive
+shippable/posix/group4
+mysql_replication
+skip/osx
+skip/freebsd
+skip/ubuntu
+skip/fedora
+skip/opensuse
+skip/rhel
+needs/root

--- a/test/integration/targets/mariadb_replication/defaults/main.yml
+++ b/test/integration/targets/mariadb_replication/defaults/main.yml
@@ -1,0 +1,6 @@
+master_port: 3306
+standby_port: 3307
+test_db: test_db
+replication_user: replication_user
+replication_pass: replication_pass
+dump_path: /tmp/dump.sql

--- a/test/integration/targets/mariadb_replication/meta/main.yml
+++ b/test/integration/targets/mariadb_replication/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- setup_mariadb

--- a/test/integration/targets/mariadb_replication/tasks/main.yml
+++ b/test/integration/targets/mariadb_replication/tasks/main.yml
@@ -1,0 +1,6 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Initial CI tests of mysql_replication module
+- import_tasks: mariadb_replication_initial.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
@@ -1,0 +1,72 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Preparation:
+- name: Create user for replication
+  shell: "echo \"GRANT REPLICATION SLAVE ON *.* TO '{{ replication_user }}'@'localhost' IDENTIFIED BY '{{ replication_pass }}'; FLUSH PRIVILEGES;\" | mysql -P {{ master_port }} -h 127.0.0.1"
+
+- name: Create test database
+  mysql_db:
+    login_host: 127.0.0.1
+    login_port: '{{ master_port }}'
+    state: present
+    name: '{{ test_db }}'
+
+- name: Dump all databases from the master
+  shell: 'mysqldump -P {{ master_port }} -h 127.0.01 --all-databases --master-data=2 > {{ dump_path }}'
+
+- name: Restore the dump to the standby
+  shell: 'mysql -P {{ standby_port }} -h 127.0.0.1 < {{ dump_path }}'
+
+# Test getmaster mode:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+- assert:
+    that:
+    - master_status.Is_Master == true
+    - master_status.Position != 0
+    - master_status is not changed
+
+# Test changemaster mode:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+
+- name: Run replication via shell
+  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+
+# Test getslave mode:
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Is_Slave == true
+    - slave_status.Master_Host == '127.0.0.1'
+    - slave_status.Exec_Master_Log_Pos == master_status.Position
+    - slave_status.Master_Port == {{ master_port }}
+    - slave_status.Last_IO_Errno == 0
+    - slave_status.Last_IO_Error == ''
+    - slave_status is not changed

--- a/test/integration/targets/setup_mariadb/defaults/main.yml
+++ b/test/integration/targets/setup_mariadb/defaults/main.yml
@@ -1,0 +1,5 @@
+master_port: 3306
+standby_port: 3307
+default_datadir: /var/lib/mysql
+standby_datadir: /var/lib/mysql_standby
+standby_logdir: /var/log/mysql_standby

--- a/test/integration/targets/setup_mariadb/tasks/main.yml
+++ b/test/integration/targets/setup_mariadb/tasks/main.yml
@@ -1,0 +1,5 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_tasks: setup_mariadb.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/setup_mariadb/tasks/setup_mariadb.yml
+++ b/test/integration/targets/setup_mariadb/tasks/setup_mariadb.yml
@@ -1,0 +1,64 @@
+# We run two servers listening different ports
+# to be able to check replication (one server for master, another for standby).
+
+- name: Install MariaDB packages on RedHat family OS
+  yum:
+    name: "{{ item }}"
+    enablerepo: epel
+  loop:
+  - mariadb-server
+  - mariadb
+  when: ansible_os_family == 'RedHat'
+
+- name: Create directories for standby
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: mysql
+    group: mysql
+  loop:
+  - "{{ standby_datadir }}"
+  - "{{ standby_logdir }}"
+
+- name: Copy cnf template
+  template:
+    src: my.cnf.j2
+    dest: /etc/my.cnf
+    owner: mysql
+    group: mysql
+    force: yes
+
+- name: Initialize standby's DB
+  shell: 'mysql_install_db --user=mysql --datadir={{ standby_datadir }}'
+
+- name: Initialize master's DB
+  shell: 'mysql_install_db --user=mysql --datadir={{ default_datadir }}'
+
+- name: Start services
+  shell: 'mysqld_multi start 1,2'
+
+- name: Pause
+  pause: seconds=3
+
+########### For painful debug uncomment the lines below ##
+#- name: DEBUG Check stratup log
+#  shell: cat /var/log/mariadb/mariadb.log
+
+#- name: DEBUG Check processes
+#  shell: 'ps aux | grep mysqld | grep -v "grep\|root"'
+
+#- name: DEBUG
+#  yum: name=net-tools
+
+#- name: DEBUG
+#  shell: "netstat -ntpl"
+
+#- name: DEBUG
+#  shell: cat /etc/my.cnf
+##########################################################
+
+- name: Check connection to the master
+  shell: 'echo "SHOW DATABASES;" | mysql -P {{ master_port }} -h 127.0.0.1'
+
+- name: Check connection to the standby
+  shell: "echo \"SHOW VARIABLES LIKE 'datadir';\" | mysql -P {{ standby_port }} -h 127.0.0.1"

--- a/test/integration/targets/setup_mariadb/templates/my.cnf.j2
+++ b/test/integration/targets/setup_mariadb/templates/my.cnf.j2
@@ -1,0 +1,33 @@
+[mysqld1]
+server_id           = 1
+port                = {{ master_port }}
+datadir             = {{ default_datadir }}
+socket              = {{ default_datadir }}/mysql.sock
+mysqladmin          = /usr/bin/mysqladmin
+log_bin             = /var/log/mariadb/mysql-bin.log
+sync_binlog         = 1
+binlog-format       = ROW
+innodb_flush_log_at_trx_commit  = 1
+
+[mysqld2]
+server_id           = 2
+port                = {{ standby_port }}
+socket              = /var/run/mysqld/mysqld_slave.sock
+pid-file            = /var/run/mysqld/mysqld_slave.pid
+datadir             = {{ standby_datadir }}
+log_bin             = {{ standby_logdir }}/mysql-bin.log
+relay-log           = {{ standby_logdir }}/relay-bin
+relay-log-index     = {{ standby_logdir }}/relay-bin.index
+master-info-file    = {{ standby_logdir }}/master.info
+relay-log-info-file = {{ standby_logdir }}/relay-log.info
+mysqladmin          = /usr/bin/mysqladmin
+
+[mysqld_multi]
+mysqld     = /usr/bin/mysqld_safe
+mysqladmin = /usr/bin/mysqladmin
+user       = multi_admin
+password   = multipass
+
+[mysqld_safe]
+log-error=/var/log/mariadb/mariadb.log
+pid-file=/var/run/mariadb/mariadb.pid


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add basic CI tests for MariaDB from scratch

It needs to complete related PR, for example, https://github.com/ansible/ansible/pull/62648

This tests are **basic** now.
All mysql_replication's features will be covered later.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```mysql_replication```
