### PR TITLE
Fortinet FortiAnalyzer Network Connection Mgr Hotfix

### DIFF
--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -26,7 +26,7 @@ author:
     - Andrew Welsh (@Ghilli3)
     - Jim Huber (@p4r4n0y1ng)
 httpapi : fortianalyzer
-short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM
+short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM.
 description:
   - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
 version_added: "2.8"

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -28,8 +28,9 @@ author:
 httpapi : fortianalyzer
 short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM
 description:
-  - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API
-version_added: "2.9"
+  - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
+version_added: "2.8"
+v
 
 """
 
@@ -150,7 +151,14 @@ class HttpApi(HttpApiBase):
 
         try:
             if self.sid is None and params[0]["url"] != "sys/login/user":
-                raise FAZBaseException("An attempt was made to login with the SID None and URL != login url.")
+                # If not connected, send connection request.
+                if not self.connection._connected:
+                    try:
+                        self.connection._connect()
+                    except BaseException as err:
+                        raise FAZBaseException(
+                            msg="An problem happened with the httpapi plugin self-init connection process. "
+                                "Error: " + str(err))
         except IndexError:
             raise FAZBaseException("An attempt was made at communicating with a FAZ with "
                                    "no valid session and an incorrectly formatted request.")

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -66,7 +66,7 @@ class HttpApi(HttpApiBase):
 
     def set_become(self, become_context):
         """
-        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED
+        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED.
         :param become_context: Unused input.
         :return: None
         """

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -30,6 +30,7 @@ short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM
 description:
   - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
 version_added: "2.8"
+
 """
 
 import json

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -30,8 +30,6 @@ short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM
 description:
   - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
 version_added: "2.8"
-v
-
 """
 
 import json


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hotfix for connection manager persistent connection initialization. I

The issue is that the login() function is no longer being automatically called when playbooks start. So our module_utils would assume that connection had been made and try to send data and fail. We've added some code to the send_request() portion to double check if the network manager is connected, and if it isn't, we run the _connect() function from the connection object.

REMADE This pull request because rebasing resulted in over 100 other commits. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/httpapi/fortianalyzer.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
