### PR TITLE
FortiAnalyzer Network Manager Hotfix

### DIFF
--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -87,7 +87,7 @@ class HttpApi(HttpApiBase):
         :param username: Username of FortiAnalyzer Admin
         :param password: Password of FortiAnalyzer Admin
 
-        :return: Dictionary of status, if it logged in or not.
+        :return: Dictionary of status if it logged in or not.
         """
 
         self._logged_in_user = username

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -29,7 +29,7 @@ httpapi : fortianalyzer
 short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM.
 description:
   - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
-version_added: "2.8"
+version_added: "2.9"
 
 """
 

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -446,6 +446,6 @@ class HttpApi(HttpApiBase):
             raise FAZBaseException(msg=("An error occurred while trying to get the locked adom list. Error: "
                                         + to_text(err)))
 
-    ################################
+    #################################
     # END DATABASE LOCK CONTEXT CODE
-    ################################
+    #################################

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -66,7 +66,7 @@ class HttpApi(HttpApiBase):
 
     def set_become(self, become_context):
         """
-        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED.
+        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED
         :param become_context: Unused input.
         :return: None
         """

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -145,7 +145,7 @@ class HttpApi(HttpApiBase):
         :param method: The preferred API Request method (GET, ADD, POST, etc....)
         :type method: basestring
 
-        :return: Dictionary of status, if it logged in or not.
+        :return: Dictionary of status if it logged in or not.
         """
 
         try:

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -150,9 +150,12 @@ class HttpApi(HttpApiBase):
 
         try:
             if self.sid is None and params[0]["url"] != "sys/login/user":
-                # If not connected, send connection request.
-                if not self.connection._connected:
+                try:
                     self.connection._connect()
+                except BaseException as err:
+                    raise FAZBaseException(
+                        msg="An problem happened with the httpapi plugin self-init connection process. "
+                            "Error: " + str(err))
         except IndexError:
             raise FAZBaseException("An attempt was made at communicating with a FAZ with "
                                    "no valid session and an incorrectly formatted request.")

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -155,7 +155,7 @@ class HttpApi(HttpApiBase):
                 except Exception as err:
                     raise FAZBaseException(
                         msg="An problem happened with the httpapi plugin self-init connection process. "
-                            "Error: " + str(err))
+                            "Error: " + to_text(err))
         except IndexError:
             raise FAZBaseException("An attempt was made at communicating with a FAZ with "
                                    "no valid session and an incorrectly formatted request.")

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -95,7 +95,7 @@ class HttpApi(HttpApiBase):
                                                                       passwd=password, user=username,))
 
         if "FortiAnalyzer object connected to FortiAnalyzer" in self.__str__():
-            # If Login worked, then inspect the FortiAnalyzer for Workspace Mode, and it's system information.
+            # If Login worked then inspect the FortiAnalyzer for Workspace Mode, and it's system information.
             self.inspect_faz()
             return
         else:

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -99,7 +99,7 @@ class HttpApi(HttpApiBase):
             self.inspect_faz()
             return
         else:
-            raise FAZBaseException(msg="Unknown error while logging in...connection was lost during login operation...."
+            raise FAZBaseException(msg="Unknown error while logging in...connection was lost during login operation..."
                                        " Exiting")
 
     def inspect_faz(self):

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -119,7 +119,7 @@ class HttpApi(HttpApiBase):
                     self.get_locked_adom_list()
                 self._connected_faz = status[1]
                 self._host = self._connected_faz["Hostname"]
-            except BaseException:
+            except Exception:
                 pass
         return
 
@@ -152,12 +152,7 @@ class HttpApi(HttpApiBase):
             if self.sid is None and params[0]["url"] != "sys/login/user":
                 # If not connected, send connection request.
                 if not self.connection._connected:
-                    try:
-                        self.connection._connect()
-                    except BaseException as err:
-                        raise FAZBaseException(
-                            msg="An problem happened with the httpapi plugin self-init connection process. "
-                                "Error: " + str(err))
+                    self.connection._connect()
         except IndexError:
             raise FAZBaseException("An attempt was made at communicating with a FAZ with "
                                    "no valid session and an incorrectly formatted request.")
@@ -221,7 +216,7 @@ class HttpApi(HttpApiBase):
         try:
             if self._connected_faz:
                 return self._connected_faz
-        except BaseException:
+        except Exception:
             raise FAZBaseException("Couldn't Retrieve Connected FAZ Stats")
 
     def get_system_status(self):
@@ -261,7 +256,7 @@ class HttpApi(HttpApiBase):
 
     def __str__(self):
         if self.sid is not None and self.connection._url is not None:
-            return "FortiAnalyzer object connected to FortiAnalyzer: " + str(self.connection._url)
+            return "FortiAnalyzer object connected to FortiAnalyzer: " + to_text(self.connection._url)
         return "FortiAnalyzer object with no valid connection to a FortiAnalyzer appliance."
 
     ##################################
@@ -308,7 +303,7 @@ class HttpApi(HttpApiBase):
                 self.uses_workspace = False
         except KeyError:
             self.uses_workspace = False
-        except BaseException:
+        except Exception:
             raise FAZBaseException(msg="Couldn't determine workspace-mode in the plugin")
         try:
             if resp_obj["adom-status"] in [1, "enable"]:
@@ -317,7 +312,7 @@ class HttpApi(HttpApiBase):
                 self.uses_adoms = False
         except KeyError:
             self.uses_adoms = False
-        except BaseException:
+        except Exception:
             raise FAZBaseException(msg="Couldn't determine adom-status in the plugin")
 
     def run_unlock(self):
@@ -393,12 +388,12 @@ class HttpApi(HttpApiBase):
         resp_obj = self.send_request(FAZMethods.GET, data)
         code = resp_obj[0]
         if code != 0:
-            self._module.fail_json(msg=("An error occurred trying to get the ADOM Lock Info. Error: " + str(resp_obj)))
+            self._module.fail_json(msg=("An error occurred trying to get the ADOM Lock Info. Error: " + to_text(resp_obj)))
         elif code == 0:
             try:
                 if resp_obj[1]["status"]["message"] == "OK":
                     self._lock_info = None
-            except BaseException:
+            except Exception:
                 self._lock_info = resp_obj[1]
         return resp_obj
 
@@ -413,13 +408,13 @@ class HttpApi(HttpApiBase):
             resp_obj = self.send_request(FAZMethods.GET, data)
             code = resp_obj[0]
             if code != 0:
-                self._module.fail_json(msg=("An error occurred trying to get the ADOM Info. Error: " + str(resp_obj)))
+                self._module.fail_json(msg=("An error occurred trying to get the ADOM Info. Error: " + to_text(resp_obj)))
             elif code == 0:
                 num_of_adoms = len(resp_obj[1])
                 append_list = ['root', ]
                 for adom in resp_obj[1]:
                     if adom["tab_status"] != "":
-                        append_list.append(str(adom["name"]))
+                        append_list.append(to_text(adom["name"]))
                 self._adom_list = append_list
             return resp_obj
 
@@ -435,21 +430,21 @@ class HttpApi(HttpApiBase):
                 try:
                     if adom_lock_info[1]["status"]["message"] == "OK":
                         continue
-                except BaseException:
+                except Exception:
                     pass
                 try:
                     if adom_lock_info[1][0]["lock_user"]:
-                        locked_list.append(str(adom))
+                        locked_list.append(to_text(adom))
                     if adom_lock_info[1][0]["lock_user"] == self._logged_in_user:
-                        locked_by_user_list.append({"adom": str(adom), "user": str(adom_lock_info[1][0]["lock_user"])})
-                except BaseException as err:
+                        locked_by_user_list.append({"adom": to_text(adom), "user": to_text(adom_lock_info[1][0]["lock_user"])})
+                except Exception as err:
                     raise FAZBaseException(err)
             self._locked_adom_list = locked_list
             self._locked_adoms_by_user = locked_by_user_list
 
-        except BaseException as err:
+        except Exception as err:
             raise FAZBaseException(msg=("An error occurred while trying to get the locked adom list. Error: "
-                                        + str(err)))
+                                        + to_text(err)))
 
     ################################
     # END DATABASE LOCK CONTEXT CODE

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -152,7 +152,7 @@ class HttpApi(HttpApiBase):
             if self.sid is None and params[0]["url"] != "sys/login/user":
                 try:
                     self.connection._connect()
-                except BaseException as err:
+                except Exception as err:
                     raise FAZBaseException(
                         msg="An problem happened with the httpapi plugin self-init connection process. "
                             "Error: " + str(err))

--- a/lib/ansible/plugins/httpapi/fortianalyzer.py
+++ b/lib/ansible/plugins/httpapi/fortianalyzer.py
@@ -26,10 +26,10 @@ author:
     - Andrew Welsh (@Ghilli3)
     - Jim Huber (@p4r4n0y1ng)
 httpapi : fortianalyzer
-short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM
+short_description: HttpApi Plugin for Fortinet FortiAnalyzer Appliance or VM.
 description:
-  - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API
-version_added: "2.9"
+  - This HttpApi plugin provides methods to connect to Fortinet FortiAnalyzer Appliance or VM via JSON RPC API.
+version_added: "2.8"
 
 """
 
@@ -66,7 +66,7 @@ class HttpApi(HttpApiBase):
 
     def set_become(self, become_context):
         """
-        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED
+        ELEVATION IS NOT REQUIRED ON FORTINET DEVICES - SKIPPED.
         :param become_context: Unused input.
         :return: None
         """
@@ -150,7 +150,14 @@ class HttpApi(HttpApiBase):
 
         try:
             if self.sid is None and params[0]["url"] != "sys/login/user":
-                raise FAZBaseException("An attempt was made to login with the SID None and URL != login url.")
+                # If not connected, send connection request.
+                if not self.connection._connected:
+                    try:
+                        self.connection._connect()
+                    except BaseException as err:
+                        raise FAZBaseException(
+                            msg="An problem happened with the httpapi plugin self-init connection process. "
+                                "Error: " + str(err))
         except IndexError:
             raise FAZBaseException("An attempt was made at communicating with a FAZ with "
                                    "no valid session and an incorrectly formatted request.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hotfix for connection manager persistent connection initialization. 

The issue is that the login() function is no longer being automatically called when playbooks start. So our module_utils would assume that connection had been made and try to send data and fail. We've added some code to the send_request() portion to double check if the network manager is connected, and if it isn't, we run the _connect() function from the connection object.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/httpapi/fortianalyzer.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
