### PR TITLE
Add option to specify ID of System/Manager/Chassis to modify

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -243,7 +243,8 @@ class RedfishUtils(object):
                         'ret': False,
                         'msg': "System resource %s not found" % self.resource_id}
             elif len(self.systems_uris) > 1:
-                self.module.deprecate(DEPRECATE_MSG % {'resource': 'System'})
+                self.module.deprecate(DEPRECATE_MSG % {'resource': 'System'},
+                                      version='2.13')
         return {'ret': True}
 
     def _find_updateservice_resource(self):
@@ -294,7 +295,8 @@ class RedfishUtils(object):
                         'ret': False,
                         'msg': "Chassis resource %s not found" % self.resource_id}
             elif len(self.chassis_uri_list) > 1:
-                self.module.deprecate(DEPRECATE_MSG % {'resource': 'Chassis'})
+                self.module.deprecate(DEPRECATE_MSG % {'resource': 'Chassis'},
+                                      version='2.13')
         return {'ret': True}
 
     def _find_managers_resource(self):
@@ -323,7 +325,8 @@ class RedfishUtils(object):
                         'ret': False,
                         'msg': "Manager resource %s not found" % self.resource_id}
             elif len(self.manager_uri_list) > 1:
-                self.module.deprecate(DEPRECATE_MSG % {'resource': 'Manager'})
+                self.module.deprecate(DEPRECATE_MSG % {'resource': 'Manager'},
+                                      version='2.13')
         return {'ret': True}
 
     def get_logs(self):

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1528,8 +1528,7 @@ class RedfishUtils(object):
             return {'ret': False,
                     'msg': "boot_order list required for SetBootOrder command"}
 
-        # TODO(billdodd): change to self.systems_uri after PR 62921 merged
-        systems_uri = self.systems_uris[0]
+        systems_uri = self.systems_uri
         response = self.get_request(self.root_uri + systems_uri)
         if response['ret'] is False:
             return response
@@ -1567,8 +1566,7 @@ class RedfishUtils(object):
         return {'ret': True, 'changed': True, 'msg': "BootOrder set"}
 
     def set_default_boot_order(self):
-        # TODO(billdodd): change to self.systems_uri after PR 62921 merged
-        systems_uri = self.systems_uris[0]
+        systems_uri = self.systems_uri
         response = self.get_request(self.root_uri + systems_uri)
         if response['ret'] is False:
             return response

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_command.py
@@ -52,6 +52,12 @@ options:
     default: 10
     type: int
     version_added: '2.8'
+  resource_id:
+    required: false
+    description:
+      - The ID of the System, Manager or Chassis to modify
+    type: str
+    version_added: '2.10'
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -61,6 +67,7 @@ EXAMPLES = '''
     idrac_redfish_command:
       category: Systems
       command: CreateBiosConfigJob
+      resource_id: System.Embedded.1
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -137,7 +144,8 @@ def main():
             baseuri=dict(required=True),
             username=dict(required=True),
             password=dict(required=True, no_log=True),
-            timeout=dict(type='int', default=10)
+            timeout=dict(type='int', default=10),
+            resource_id=dict()
         ),
         supports_check_mode=False
     )
@@ -152,9 +160,13 @@ def main():
     # timeout
     timeout = module.params['timeout']
 
+    # System, Manager or Chassis ID to modify
+    resource_id = module.params['resource_id']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module,
+                                 resource_id=resource_id, data_modification=True)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/idrac_redfish_config.py
@@ -63,6 +63,12 @@ options:
       - Timeout in seconds for URL requests to iDRAC controller
     default: 10
     type: int
+  resource_id:
+    required: false
+    description:
+      - The ID of the System, Manager or Chassis to modify
+    type: str
+    version_added: '2.10'
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -72,6 +78,7 @@ EXAMPLES = '''
     idrac_redfish_config:
       category: Manager
       command: SetManagerAttributes
+      resource_id: iDRAC.Embedded.1
       manager_attribute_name: NTPConfigGroup.1.NTPEnable
       manager_attribute_value: Enabled
       baseuri: "{{ baseuri }}"
@@ -81,6 +88,7 @@ EXAMPLES = '''
     idrac_redfish_config:
       category: Manager
       command: SetManagerAttributes
+      resource_id: iDRAC.Embedded.1
       manager_attribute_name: NTPConfigGroup.1.NTP1
       manager_attribute_value: "{{ ntpserver1 }}"
       baseuri: "{{ baseuri }}"
@@ -90,6 +98,7 @@ EXAMPLES = '''
     idrac_redfish_config:
       category: Manager
       command: SetManagerAttributes
+      resource_id: iDRAC.Embedded.1
       manager_attribute_name: Time.1.Timezone
       manager_attribute_value: "{{ timezone }}"
       baseuri: "{{ baseuri }}"
@@ -168,7 +177,8 @@ def main():
             password=dict(required=True, no_log=True),
             manager_attribute_name=dict(default='null'),
             manager_attribute_value=dict(default='null'),
-            timeout=dict(type='int', default=10)
+            timeout=dict(type='int', default=10),
+            resource_id=dict()
         ),
         supports_check_mode=False
     )
@@ -187,9 +197,13 @@ def main():
     mgr_attributes = {'mgr_attr_name': module.params['manager_attribute_name'],
                       'mgr_attr_value': module.params['manager_attribute_value']}
 
+    # System, Manager or Chassis ID to modify
+    resource_id = module.params['resource_id']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module)
+    rf_utils = IdracRedfishUtils(creds, root_uri, timeout, module,
+                                 resource_id=resource_id, data_modification=True)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -113,6 +113,12 @@ options:
       - properties of account service to update
     type: dict
     version_added: "2.10"
+  resource_id:
+    required: false
+    description:
+      - The ID of the System, Manager or Chassis to modify
+    type: str
+    version_added: "2.10"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -122,6 +128,7 @@ EXAMPLES = '''
     redfish_command:
       category: Systems
       command: PowerGracefulRestart
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -130,6 +137,7 @@ EXAMPLES = '''
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: 437XR1138R2
       bootdevice: "{{ bootdevice }}"
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
@@ -139,6 +147,7 @@ EXAMPLES = '''
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: 437XR1138R2
       bootdevice: "UefiTarget"
       uefi_target: "/0x31/0x33/0x01/0x01"
       baseuri: "{{ baseuri }}"
@@ -149,6 +158,7 @@ EXAMPLES = '''
     redfish_command:
       category: Systems
       command: SetOneTimeBoot
+      resource_id: 437XR1138R2
       bootdevice: "UefiBootNext"
       boot_next: "Boot0001"
       baseuri: "{{ baseuri }}"
@@ -159,6 +169,7 @@ EXAMPLES = '''
     redfish_command:
       category: Chassis
       command: IndicatorLedBlink
+      resource_id: 1U
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -278,6 +289,7 @@ EXAMPLES = '''
     redfish_command:
       category: Manager
       command: ClearLogs
+      resource_id: BMC
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -327,7 +339,8 @@ def main():
             bootdevice=dict(),
             timeout=dict(type='int', default=10),
             uefi_target=dict(),
-            boot_next=dict()
+            boot_next=dict(),
+            resource_id=dict()
         ),
         supports_check_mode=False
     )
@@ -350,9 +363,13 @@ def main():
     # timeout
     timeout = module.params['timeout']
 
+    # System, Manager or Chassis ID to modify
+    resource_id = module.params['resource_id']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_utils = RedfishUtils(creds, root_uri, timeout, module)
+    rf_utils = RedfishUtils(creds, root_uri, timeout, module,
+                            resource_id=resource_id, data_modification=True)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -88,6 +88,12 @@ options:
       -  setting dict of manager services to update
     type: dict
     version_added: "2.10"
+  resource_id:
+    required: false
+    description:
+      - The ID of the System, Manager or Chassis to modify
+    type: str
+    version_added: "2.10"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -97,6 +103,7 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosAttributes
+      resource_id: 437XR1138R2
       bios_attributes:
         BootMode: "Uefi"
       baseuri: "{{ baseuri }}"
@@ -107,6 +114,7 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosAttributes
+      resource_id: 437XR1138R2
       bios_attributes:
         BootMode: "Bios"
         OneTimeBootMode: "Enabled"
@@ -119,6 +127,7 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosAttributes
+      resource_id: 437XR1138R2
       bios_attribute_name: PxeDev1EnDis
       bios_attribute_value: Enabled
       baseuri: "{{ baseuri }}"
@@ -129,6 +138,7 @@ EXAMPLES = '''
     redfish_config:
       category: Systems
       command: SetBiosDefaultSettings
+      resource_id: 437XR1138R2
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
@@ -210,7 +220,8 @@ def main():
             network_protocols=dict(
                 type='dict',
                 default={}
-            )
+            ),
+            resource_id=dict()
         ),
         supports_check_mode=False
     )
@@ -237,9 +248,13 @@ def main():
     # boot order
     boot_order = module.params['boot_order']
 
+    # System, Manager or Chassis ID to modify
+    resource_id = module.params['resource_id']
+
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
-    rf_utils = RedfishUtils(creds, root_uri, timeout, module)
+    rf_utils = RedfishUtils(creds, root_uri, timeout, module,
+                            resource_id=resource_id, data_modification=True)
 
     # Check that Category is valid
     if category not in CATEGORY_COMMANDS_ALL:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added new option (`resource_id`) to the *_config.py and *_command.py modules to specify the ID of the particular System, Manager or Chassis to modify.

The data modification commands (SetBiosAttributes, IndicatorLedOn, etc.) act on a single System, Manager or Chassis. Previously, if there was more than one System/Manager/Chassis resource, the first one in the collection would be modified. This was a significant limitation as there was no way to perform those operations on any of the other resources.

With this PR, a particular resource ID can now be specified. To avoid breaking existing playbooks, the original behavior is still maintained (the first resource in the collection is used if there are more than one and the new `resource_id` option is not specified). But, in this case, a deprecation warning is displayed to let the operator know to use the new option.

For read-only commands (like GetSystemInventory, GetHealthReport, etc.), the behavior is unchanged; they will get the information from all the Systems, Managers and Chassis.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #58467


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_config.py
redfish_command.py
idrac_redfish_config.py
idrac_redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

**Before:**

Given a play like this:
```
  - name: Restart system power gracefully
    redfish_command:
      category: Systems
      command: PowerGracefulRestart
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

If there is more than one System on the target service, the command will run on the first System in the list of Systems.

No message is shown to indicate that the first System in the list was used:

```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/power_graceful_restart.yml 

PLAY [Manage System Power - Greaceful restart] *********************************

TASK [Restart system power gracefully] *****************************************

changed: [mockup-bladed]

PLAY RECAP *********************************************************************
mockup-bladed              : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

**After:**

Using the play specified above (with no `resource_id` specified), the command will still only apply to the first System in the list of Systems. But a deprecation warning will be issued:

```
$ ansible-playbook -i myinventory.yml playbooks/systems/power_graceful_restart.yml 

PLAY [Manage System Power - Greaceful restart] *********************************

TASK [Restart system power gracefully] *****************************************

[DEPRECATION WARNING]: Issuing a data modification command without specifying 
the ID of the target System resource when there is more than one System will 
use the first one in the collection. Use the `resource_id` option to specify 
the target System ID. This feature will be removed in version 2.13. Deprecation
 warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [mockup-bladed]

PLAY RECAP *********************************************************************
mockup-bladed              : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Now, update the play to specify the ID of the System to target:

```
  - name: Restart system power gracefully
    redfish_command:
      category: Systems
      command: PowerGracefulRestart
      resource_id: 529QB9452R6
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

With the resource ID specified the deprecation warning is no longer displayed:

```paste below
$ ansible-playbook -i myinventory.yml playbooks/systems/power_graceful_restart.yml 

PLAY [Manage System Power - Greaceful restart] *********************************

TASK [Restart system power gracefully] *****************************************

changed: [mockup-bladed]

PLAY RECAP *********************************************************************
mockup-bladed              : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
