### PR TITLE
ipaddr('address'): Treat IPv6 /127 just like IPv4 /31

### DIFF
--- a/changelogs/fragments/62922-ipaddr-parse-ip6-127-addr.yaml
+++ b/changelogs/fragments/62922-ipaddr-parse-ip6-127-addr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipaddr filter - Fix IPv6 /127 address parsing (https://github.com/ansible/ansible/issues/62740)

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -90,11 +90,10 @@ def _6to4_query(v, vtype, value):
 
 
 def _ip_query(v):
-    if v.size == 1:
+    if v.size in [1, 2]:
         return str(v.ip)
-    if v.size > 1:
-        # /31 networks in netaddr have no broadcast address
-        if v.ip != v.network or not v.broadcast:
+    if v.size > 2:
+        if v.ip != v.network:
             return str(v.ip)
 
 


### PR DESCRIPTION
##### SUMMARY

Just like excluding the network address doesn't really make sense for
an IPv4 /31 range neither does it for an IPv6 /127 range. While the
indirect broadcast test only covers the IPv4 case the explicit size
test covers both the IPv4 case and the IPv6 case.

Fixes #62740

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipaddr