### PR TITLE
Adding _prefix rule scopes to consul_acl

### DIFF
--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -187,7 +187,8 @@ from collections import defaultdict
 from ansible.module_utils.basic import to_text, AnsibleModule
 
 
-RULE_SCOPES = ["agent", "event", "key", "keyring", "node", "operator", "query", "service", "session", "agent_prefix", "event_prefix", "key_prefix", "node_prefix", "query_prefix", "service_prefix", "session_prefix"]
+RULE_SCOPES = ["agent", "event", "key", "keyring", "node", "operator", "query", "service", "session",
+               "agent_prefix", "event_prefix", "key_prefix", "node_prefix", "query_prefix", "service_prefix", "session_prefix"]
 
 MANAGEMENT_PARAMETER_NAME = "mgmt_token"
 HOST_PARAMETER_NAME = "host"

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -187,7 +187,7 @@ from collections import defaultdict
 from ansible.module_utils.basic import to_text, AnsibleModule
 
 
-RULE_SCOPES = ["agent", "event", "key", "keyring", "node", "operator", "query", "service", "session"]
+RULE_SCOPES = ["agent", "event", "key", "keyring", "node", "operator", "query", "service", "session", "agent_prefix", "event_prefix", "key_prefix", "node_prefix", "query_prefix", "service_prefix", "session_prefix"]
 
 MANAGEMENT_PARAMETER_NAME = "mgmt_token"
 HOST_PARAMETER_NAME = "host"


### PR DESCRIPTION
_prefix rule scopes for ACLs have been added with Consul 1.4

+label: docsite_pr

##### SUMMARY
With Consul 1.4 a new ACL system has been added, including _prefix rule scopes which allow simpler ACLs with regards to inheritance. I was writing a playbook to setup Consul and some base ACLs and noticed that the consul_acl modules whitelist does not yet support these. Adding valid _prefix rule scopes is fairly trivial and i hope others benefit from it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
consul_acl

##### ADDITIONAL INFORMATION
Current Consul ACLs are documented here: https://www.consul.io/docs/acl/acl-rules.html