### PR TITLE
Prefer https:// links in the docs site

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -22,7 +22,7 @@ Ansible has several mailing lists.  Your first post to the mailing list will be 
 * `Ansible Container List <https://groups.google.com/forum/#!forum/ansible-container>`_ is for users and developers of the Ansible Container project.
 * `Ansible Development List <https://groups.google.com/forum/#!forum/ansible-devel>`_ is for learning how to develop on Ansible, asking about prospective feature design, or discussions about extending ansible or features in progress.
 * `Ansible Lockdown List <https://groups.google.com/forum/#!forum/ansible-lockdown>`_ is for all things related to Ansible Lockdown projects, including DISA STIG automation and CIS Benchmarks.
-* `Ansible Outreach List <https://groups.google.com/forum/#!forum/ansible-outreach>`_ help with promoting Ansible and `Ansible Meetups <http://ansible.meetup.com/>`_
+* `Ansible Outreach List <https://groups.google.com/forum/#!forum/ansible-outreach>`_ help with promoting Ansible and `Ansible Meetups <https://ansible.meetup.com/>`_
 * `Ansible Project List <https://groups.google.com/forum/#!forum/ansible-project>`_ is for sharing Ansible tips, answering questions, and general user discussion.
 * `Molecule List <https://groups.google.com/forum/#!forum/molecule-users>`_ is designed to aid with the development and testing of Ansible roles with Molecule.
 

--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -347,7 +347,7 @@ API throttling (rate limiting) and pagination
 =============================================
 
 For methods that return a lot of results, boto3 often provides
-`paginators <http://boto3.readthedocs.io/en/latest/guide/paginators.html>`_. If the method
+`paginators <https://boto3.readthedocs.io/en/latest/guide/paginators.html>`_. If the method
 you're calling has ``NextToken`` or ``Marker`` parameters, you should probably
 check whether a paginator exists (the top of each boto3 service reference page has a link
 to Paginators, if the service has any). To use paginators, obtain a paginator object,
@@ -640,7 +640,7 @@ to your test in the following variables:
 * `security_token`
 
 So all invocations of AWS modules in the test should set these parameters. To avoid duplication these
-for every call, it's preferable to use `YAML Anchors <http://blog.daemonl.com/2016/02/yaml.html>`_. For example:
+for every call, it's preferable to use `YAML Anchors <https://blog.daemonl.com/2016/02/yaml.html>`_. For example:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/dev_guide/platforms/openstack_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/openstack_guidelines.rst
@@ -46,7 +46,7 @@ Libraries
   standard input such as auth and ssl support.
 * All modules should include ``extends_documentation_fragment: openstack``.
 * All complex cloud interaction or interoperability code should be housed in
-  the `openstacksdk <http://git.openstack.org/cgit/openstack/openstacksdk>`_
+  the `openstacksdk <https://git.openstack.org/cgit/openstack/openstacksdk>`_
   library.
 * All OpenStack API interactions should happen via the openstacksdk and not via
   OpenStack Client libraries. The OpenStack Client libraries do no have end

--- a/docs/docsite/rst/dev_guide/platforms/ovirt_dev_guide.rst
+++ b/docs/docsite/rst/dev_guide/platforms/ovirt_dev_guide.rst
@@ -214,7 +214,7 @@ Testing
 -------
 
 -  Integration testing is currently done in oVirt's CI system
-   `on Jenkins <http://jenkins.ovirt.org/view/All/job/ovirt-system-tests_ansible-suite-master/>`__
+   `on Jenkins <https://jenkins.ovirt.org/view/All/job/ovirt-system-tests_ansible-suite-master/>`__
    and
    `on GitHub <https://github.com/oVirt/ovirt-system-tests/tree/master/ansible-suite-master/>`__.
 -  Please consider using these integration tests if you create a new module or add a new feature to an existing

--- a/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
@@ -61,7 +61,7 @@ For menu procedures, bold the menu names, button names, etc to help the user fin
 3. In the **Open** dialog box, click **Save**.
 4. On the toolbar, click the **Open File** icon.
 
-For code or command snippets, use the RST `code-block directive <http://www.sphinx-doc.org/en/1.5/markup/code.html#directive-code-block>`_::
+For code or command snippets, use the RST `code-block directive <https://www.sphinx-doc.org/en/1.5/markup/code.html#directive-code-block>`_::
 
    .. code-block:: bash
 

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -81,7 +81,7 @@ We follow these technical or mechanical guidelines on all rST pages:
 Header notation
 ---------------
 
-`Section headers in reStructuredText <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_
+`Section headers in reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_
 can use a variety of notations.
 Sphinx will 'learn on the fly' when creating a hierarchy of headers.
 To make our documents easy to read and to edit, we follow a standard set of header notations.
@@ -135,7 +135,7 @@ We use:
 Internal navigation
 -------------------
 
-`Anchors (also called labels) and links <http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#ref-role>`_
+`Anchors (also called labels) and links <https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#ref-role>`_
 work together to help users find related content.
 Local tables of contents also help users navigate quickly to the information they need.
 All internal links should use the ``:ref:`` syntax.

--- a/docs/docsite/rst/network/getting_started/network_resources.rst
+++ b/docs/docsite/rst/network/getting_started/network_resources.rst
@@ -44,4 +44,4 @@ Join us on:
 
 * Freenode IRC - ``#ansible-network`` Freenode channel
 
-* Slack - `<http://ansiblenetwork.slack.com>`_
+* Slack - `<https://ansiblenetwork.slack.com>`_

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -233,9 +233,9 @@ value::
        Questions? Help? Ideas?  Stop by the list on Google Groups
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel and #yaml for YAML specific questions
-   `YAML 1.1 Specification <http://yaml.org/spec/1.1/>`_
+   `YAML 1.1 Specification <https://yaml.org/spec/1.1/>`_
        The Specification for YAML 1.1, which PyYAML and libyaml are currently
        implementing
-   `YAML 1.2 Specification <http://yaml.org/spec/1.2/spec.html>`_
+   `YAML 1.2 Specification <https://yaml.org/spec/1.2/spec.html>`_
        For completeness, YAML 1.2 is the successor of 1.1
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -246,7 +246,7 @@ There are a few common errors that one might run into when trying to execute Ans
 * When ``pipelining = False`` in `/etc/ansible/ansible.cfg` then Ansible modules are transferred in binary mode via sftp however execution of python fails with
 
   .. error::
-      SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
+      SyntaxError: Non-UTF-8 code starting with \'\\x83\' in file /a/user1/.ansible/tmp/ansible-tmp-1548232945.35-274513842609025/AnsiballZ_stat.py on line 1, but no encoding declared; see https://python.org/dev/peps/pep-0263/ for details
 
   To fix it set ``pipelining = True`` in `/etc/ansible/ansible.cfg`.
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -565,7 +565,7 @@ Or, alternatively print out the ports in a comma separated string::
 
 .. note:: Here, quoting literals using backticks avoids escaping quotes and maintains readability.
 
-Or, using YAML `single quote escaping <http://yaml.org/spec/current.html#id2534365>`_::
+Or, using YAML `single quote escaping <https://yaml.org/spec/current.html#id2534365>`_::
 
     - name: "Display all ports from cluster1"
       debug:

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -1229,7 +1229,7 @@ For information about advanced YAML syntax used to declare variables and have mo
        Best practices in playbooks
    :ref:`special_variables`
        List of special variables
-   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+   `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel

--- a/docs/docsite/rst/user_guide/windows_usage.rst
+++ b/docs/docsite/rst/user_guide/windows_usage.rst
@@ -388,7 +388,7 @@ standard:
 .. Note:: You should only quote strings when it is absolutely
     necessary or required by YAML, and then use single quotes.
 
-The YAML specification considers the following `escape sequences <http://yaml.org/spec/current.html#id2517668>`_:
+The YAML specification considers the following `escape sequences <https://yaml.org/spec/current.html#id2517668>`_:
 
 * ``\0``, ``\\``, ``\"``, ``\_``, ``\a``, ``\b``, ``\e``, ``\f``, ``\n``, ``\r``, ``\t``,
   ``\v``, ``\L``, ``\N`` and ``\P`` -- Single character escape


### PR DESCRIPTION
##### SUMMARY

This is a follow-up of last year's 1a11cec. It deals with links which
at that point either wasn't present or then didn't support https://.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
documentation