### PR TITLE
edgeos_config: Fix check mode from reporting changes when there are none.

### DIFF
--- a/lib/ansible/plugins/cliconf/edgeos.py
+++ b/lib/ansible/plugins/cliconf/edgeos.py
@@ -66,7 +66,7 @@ class Cliconf(CliconfBase):
         self.send_command(command)
 
     def discard_changes(self, *args, **kwargs):
-        self.send_command('discard')
+        self.send_command('exit discard')
 
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()


### PR DESCRIPTION
##### SUMMARY
Mostly a cosmetic change - when in check mode, any task that generates a change causes subsequent tasks in the same play to be treated as if all lines are a change. (Specifically affecting edgeos_config)

The fix for this is to exit configuration mode when discarding changes ([either due to check mode, or from a commit error](https://github.com/ansible/ansible/blob/3c8abc0b824977d1941a307273e865aed49a2993/lib/ansible/module_utils/network/edgeos/edgeos.py#L119-L129) )

This is because subsequent tasks using `edgeos_config` are calling `get_config()`, which runs '`show configuration commands`' on the edgeos device (call tree: [call1](https://github.com/ansible/ansible/blob/stable-2.8/lib/ansible/modules/network/edgeos/edgeos_config.py#L249) -> [call2](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/network/edgeos/edgeos.py#L59-L66) -> [call3](https://github.com/ansible/ansible/blob/stable-2.8/lib/ansible/plugins/cliconf/edgeos.py#L51-L52)).

When still in configuration mode this returns no actual configuration lines due to a syntax error. This in turn indicates no running config, therefore all lines requested by the task are considered new, so the task returns as a change when it's potentially not.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
None