### PR TITLE
ecs_task_definition - get and set tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -102,7 +102,7 @@ options:
         description:
             - A dictionary of key value pairs to assign to the task definition
         required: false
-        version_added: 2.10
+        version_added: "2.10"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -203,7 +203,7 @@ EXAMPLES = '''
     memory: 1GB
     state: present
     network_mode: awsvpc
-    
+
 - name: Create Task Definition with Tags
   ecs_taskdefinition:
     family: nginx

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -25,7 +25,7 @@ short_description: register a task definition in ecs
 description:
     - Registers or deregisters task definitions in the Amazon Web Services (AWS) EC2 Container Service (ECS)
 version_added: "2.0"
-author: 
+author:
     - Mark Chance (@Java1Guy)
     - Jason Kingsbury (@relvacode)
 requirements: [ json, botocore, boto3 ]
@@ -103,8 +103,6 @@ options:
             - A dictionary of key value pairs to assign to the task definition
         required: false
         version_added: 2.10
-        
-            
 extends_documentation_fragment:
     - aws
     - ec2
@@ -522,15 +520,15 @@ def main():
                 # Doesn't exist. create it.
                 volumes = module.params.get('volumes', []) or []
                 actual_tags, task_definition = task_mgr.register_task(module.params['family'],
-                                                               module.params['task_role_arn'],
-                                                               module.params['execution_role_arn'],
-                                                               module.params['network_mode'],
-                                                               module.params['containers'],
-                                                               volumes,
-                                                               module.params['launch_type'],
-                                                               module.params['cpu'],
-                                                               module.params['memory'],
-                                                               module.params.get('tags'))
+                                                                      module.params['task_role_arn'],
+                                                                      module.params['execution_role_arn'],
+                                                                      module.params['network_mode'],
+                                                                      module.params['containers'],
+                                                                      volumes,
+                                                                      module.params['launch_type'],
+                                                                      module.params['cpu'],
+                                                                      module.params['memory'],
+                                                                      module.params.get('tags'))
                 results['taskdefinition'] = task_definition
                 results['tags'] = actual_tags
             results['changed'] = True

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_info.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_info.py
@@ -330,11 +330,8 @@ def main():
                      region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     try:
-        task_definition = ecs.describe_task_definition(taskDefinition=module.params['task_definition'], include=['TAGS'])
-        ecs_td = {
-            **task_definition['taskDefinition'],
-            'tags': boto3_tag_list_to_ansible_dict(task_definition.get('tags', []), 'key', 'value')
-        }
+        ecs_td = ecs.describe_task_definition(taskDefinition=module.params['task_definition'], include=['TAGS'])
+        ecs_td['tags'] = boto3_tag_list_to_ansible_dict(ecs_td.get('tags', []), 'key', 'value')
     except botocore.exceptions.ClientError:
         ecs_td = {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds the ability to set and get tags on an Amazon ECS Task Definition resource

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

https://github.com/ansible/ansible/issues/51122 (partial)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ecs_taskdefinition
ecs_taskdefinition_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
