### PR TITLE
cronvar: Only read value when needed

### DIFF
--- a/lib/ansible/modules/system/cronvar.py
+++ b/lib/ansible/modules/system/cronvar.py
@@ -214,8 +214,8 @@ class CronVar(object):
         lexer.wordchars = self.wordchars
         varname = lexer.get_token()
         is_env_var = lexer.get_token() == '='
-        value = ''.join(lexer)
         if is_env_var:
+            value = ''.join(lexer)
             return (varname, value)
         raise CronVarError("Not a variable.")
 


### PR DESCRIPTION


##### SUMMARY
`''.join(lexer)` might fail for some “weird” cron commands but we only need to perform this action when we actually found a cron variable.

Fixes: #31309

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cronvar module
