### PR TITLE
Fixing typo in tested with section. Deploy template from content library is supported from 67U3

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
@@ -25,7 +25,7 @@ version_added: '2.9'
 author:
 - Pavan Bidkar (@pgbidkar)
 notes:
-- Tested on vSphere 6.5, 6.7
+- Tested on vSphere 6.7 U3
 requirements:
 - python >= 2.6
 - PyVmomi


### PR DESCRIPTION
##### SUMMARY
Deploy template from content library is supported after 67U3. Fixed typo in tested with section

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_content_deploy_template.py


