### PR TITLE
vmware guidlines: adjust the location of cloud-config-vcenter.ini.template

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -89,7 +89,7 @@ Configure your installation
 
 Prepare a configuration file that describes your set-up. The file
 should be called :file:`test/integration/cloud-config-vcenter.ini` and based on
-:file:`test/integration/cloud-config-vcenter.ini.template`. For instance, if you've deployed your lab with
+:file:`test/lib/ansible_test/config/cloud-config-vcenter.ini.template`. For instance, if you've deployed your lab with
 `vmware-on-libvirt <https://github.com/goneri/vmware-on-libvirt>`:
 
 .. code-block:: ini


### PR DESCRIPTION
##### SUMMARY

Update the location of the cloud-config-vcenter.ini.template template.
The file has been moved by: 2e7d36a3f969b31570d7ee34e3f1f971c5c586a9.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->