### PR TITLE
user: compare Mac user properties using same type

### DIFF
--- a/changelogs/fragments/user-fix-value-comparison-on-macos.yaml
+++ b/changelogs/fragments/user-fix-value-comparison-on-macos.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix comprasion on macOS so module does not improperly report a change (https://github.com/ansible/ansible/issues/62969)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -420,7 +420,7 @@ import subprocess
 import time
 
 from ansible.module_utils import distro
-from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.sys_info import get_platform_subclass
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2305,7 +2305,7 @@ class DarwinUser(User):
         for field in self.fields:
             if field[0] in self.__dict__ and self.__dict__[field[0]]:
                 current = self._get_user_property(field[1])
-                if current is None or current != self.__dict__[field[0]]:
+                if current is None or current != str(self.__dict__[field[0]]):
                     cmd = self._get_dscl()
                     cmd += ['-create', '/Users/%s' % self.name, field[1], self.__dict__[field[0]]]
                     (rc, _err, _out) = self.execute_command(cmd)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2305,7 +2305,7 @@ class DarwinUser(User):
         for field in self.fields:
             if field[0] in self.__dict__ and self.__dict__[field[0]]:
                 current = self._get_user_property(field[1])
-                if current is None or current != str(self.__dict__[field[0]]):
+                if current is None or current != to_text(self.__dict__[field[0]]):
                     cmd = self._get_dscl()
                     cmd += ['-create', '/Users/%s' % self.name, field[1], self.__dict__[field[0]]]
                     (rc, _err, _out) = self.execute_command(cmd)

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -55,6 +55,33 @@
       - user_test0_1 is not changed
       - '"ansibulluser" in user_names.stdout_lines'
 
+# test adding user with uid
+# https://github.com/ansible/ansible/issues/62969
+- name: remove the test user
+  user:
+    name: ansibulluser
+    state: absent
+
+- name: try to create a user with uid
+  user:
+    name: ansibulluser
+    state: present
+    uid: 572
+  register: user_test01_0
+
+- name: create the user again
+  user:
+    name: ansibulluser
+    state: present
+    uid: 572
+  register: user_test01_1
+
+- name: validate results for testcase 0
+  assert:
+    that:
+      - user_test01_0 is changed
+      - user_test01_1 is not changed
+
 # test user add with password
 - name: add an encrypted password for user
   user:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`self._get_user_property` returns a string, so when doing a comparison
using this value, cast the second variable to a string so that the
comparison behaves correctly.

On Darwin systems, `_get_user_property` returns a string, however, `self.__dict__[field[0]]` sometimes returns an `int`, such as in the case when comparing the `uid`. In order for the comparison 
```
current != self.__dict__[field[0]]
```
to work correctly, both variables must be of the same type. This change casts `self.__dict__[field[0]]` to a string so that the comparison works properly.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #62969
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
failed: [127.0.0.1] (item={u'uid': u'500', u'name': u'test'}) => {"ansible_loop_var": "item", "changed": false, "err": "", "item": {"name": "test", "uid": "500"}, "msg": "Cannot update property \"uid\" for user \"test\".", "out": "", "rc": 40}

After:
ok: [127.0.0.1] => (item={u'uid': 500, u'name': u'test'})
```
