### PR TITLE
Disable iosxr_lag_interfaces testing

### DIFF
--- a/test/integration/targets/iosxr_lag_interfaces/defaults/main.yaml
+++ b/test/integration/targets/iosxr_lag_interfaces/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-testcase: "[^_].*"
+testcase: ""
 test_items: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Disable testing of iosxr_lag_interfaces, as there is a bug in:

  https://github.com/ansible/ansible/pull/62612

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_lag_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```