### PR TITLE
path utils fix - don't cast None with to_bytes

### DIFF
--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -92,7 +92,7 @@ def makedirs_safe(path, mode=None):
 
 def basedir(source):
     """ returns directory for inventory or playbook """
-    source = to_bytes(source, errors='surrogate_or_strict')
+    source = to_bytes(source, errors='surrogate_or_strict', nonstring='passthru')
     dname = None
     if os.path.isdir(source):
         dname = source


### PR DESCRIPTION
##### SUMMARY
It looks like prior to 3f12fccd02c1a6481ff61740071e67c82562e469 source could be `None` as a representation of the current directory. Line 99 checks for `elif source in [None, '', '.']:`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/path.py

