### PR TITLE
Refactor AWS ecs_ecr module to rely on AnsibleAWSModule

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -136,6 +136,7 @@ except ImportError:
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (boto3_conn, boto_exception, get_aws_connection_info, compare_policies)
 from ansible.module_utils.six import string_types
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
 def build_kwargs(registry_id):
@@ -367,9 +368,9 @@ def main():
     passed, result = run(EcsEcr(module), module.params, module._module._verbosity)
 
     if passed:
-        module.exit_json(**result)
+        module.exit_json(**camel_dict_to_snake_dict(result))
     else:
-        module.fail_json(**result)
+        module.fail_json(**camel_dict_to_snake_dict(result))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -134,7 +134,7 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO3
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (boto3_conn, boto_exception, get_aws_connection_info, compare_policies)
+from ansible.module_utils.ec2 import (boto_exception, compare_policies)
 from ansible.module_utils.six import string_types
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
@@ -154,15 +154,8 @@ def build_kwargs(registry_id):
 
 class EcsEcr:
     def __init__(self, module):
-        region, ec2_url, aws_connect_kwargs = \
-            get_aws_connection_info(module, boto3=True)
-
-        self.ecr = boto3_conn(module, conn_type='client',
-                              resource='ecr', region=region,
-                              endpoint=ec2_url, **aws_connect_kwargs)
-        self.sts = boto3_conn(module, conn_type='client',
-                              resource='sts', region=region,
-                              endpoint=ec2_url, **aws_connect_kwargs)
+        self.ecr = module.client('ecr')
+        self.sts = module.client('sts')
         self.check_mode = module.check_mode
         self.changed = False
         self.skipped = False

--- a/test/integration/targets/ecs_ecr/defaults/main.yml
+++ b/test/integration/targets/ecs_ecr/defaults/main.yml
@@ -1,10 +1,2 @@
-policy:
-  Version: '2008-10-17'
-  Statement:
-    - Sid: new statement
-      Effect: Allow
-      Principal: "*"
-      Action:
-        - ecr:GetDownloadUrlForLayer
-        - ecr:BatchGetImage
-        - ecr:BatchCheckLayerAvailability
+---
+# defaults file for ecs_ecr

--- a/test/integration/targets/ecs_ecr/meta/main.yml
+++ b/test/integration/targets/ecs_ecr/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - prepare_tests
-  - setup_ec2

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -51,6 +51,15 @@
           - result is changed
           - result.created
 
+    - name: it should expose repository information returned from api
+      assert:
+        that:
+          - result.repository['createdAt'] is defined
+          - result.repository['imageTagMutability'] is defined
+          - result.repository['registryId'] is defined
+          - result.repository['repositoryArn'] is defined
+          - result.repository['repositoryName'] is defined
+          - result.repository['repositoryUri'] is defined
 
     - name: When creating a repository that already exists in check mode
       ecs_ecr:

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -54,12 +54,12 @@
     - name: it should expose repository information returned from api
       assert:
         that:
-          - result.repository['createdAt'] is defined
-          - result.repository['imageTagMutability'] is defined
-          - result.repository['registryId'] is defined
-          - result.repository['repositoryArn'] is defined
-          - result.repository['repositoryName'] is defined
-          - result.repository['repositoryUri'] is defined
+          - result.repository['created_at'] is defined
+          - result.repository['image_tag_mutability'] is defined
+          - result.repository['registry_id'] is defined
+          - result.repository['repository_arn'] is defined
+          - result.repository['repository_name'] is defined
+          - result.repository['repository_uri'] is defined
 
     - name: When creating a repository that already exists in check mode
       ecs_ecr:

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -2,15 +2,19 @@
 - set_fact:
     ecr_name: '{{ resource_prefix }}-ecr'
 
-- block:
+- name: Run tests against ecs_ecr
+  module_defaults:
+    group/aws:
+      region: '{{ aws_region }}'
+      aws_access_key: '{{ aws_access_key }}'
+      aws_secret_key: '{{ aws_secret_key }}'
+      security_token: '{{ security_token | default(omit) }}'
+
+  block:
 
     - name: When creating with check mode
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -26,10 +30,6 @@
       ecs_ecr:
         registry_id: 999999999999
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -43,10 +43,6 @@
     - name: When creating a repository
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and create
@@ -59,10 +55,6 @@
     - name: When creating a repository that already exists in check mode
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -76,10 +68,6 @@
     - name: When creating a repository that already exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -90,11 +78,7 @@
 
     - name: When in check mode, and deleting a policy that does not exist
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
         delete_policy: yes
       register: result
       check_mode: yes
@@ -108,12 +92,8 @@
 
     - name: When in check mode, setting policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -127,12 +107,8 @@
 
     - name: When setting policy on a repository that has no policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -144,12 +120,8 @@
 
     - name: When in check mode, and deleting a policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         delete_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -163,12 +135,8 @@
 
     - name: When deleting a policy that exists
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         delete_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -180,12 +148,8 @@
 
     - name: When setting a policy as a string
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy | to_json }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -197,12 +161,8 @@
 
     - name: When setting a policy to its current value
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -213,11 +173,7 @@
 
     - name: When omitting policy on a repository that has a policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -228,13 +184,9 @@
 
     - name: When specifying both policy and delete_policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
         delete_policy: yes
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -246,12 +198,8 @@
 
     - name: When specifying invalid JSON for policy
       ecs_ecr:
-        region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy_text: "Ceci n'est pas une JSON"
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -264,11 +212,7 @@
     - name: When in check mode, deleting a policy that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -283,11 +227,7 @@
     - name: When deleting a policy that exists
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should change
@@ -299,11 +239,7 @@
     - name: When in check mode, deleting a policy that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -317,11 +253,7 @@
     - name: When deleting a policy that does not exist
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -334,8 +266,4 @@
     - name: Delete lingering ECR repository
       ecs_ecr:
         name: '{{ ecr_name }}'
-        region: '{{ ec2_region }}'
         state: absent
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'

--- a/test/integration/targets/ecs_ecr/vars/main.yml
+++ b/test/integration/targets/ecs_ecr/vars/main.yml
@@ -1,0 +1,10 @@
+policy:
+  Version: '2008-10-17'
+  Statement:
+    - Sid: new statement
+      Effect: Allow
+      Principal: "*"
+      Action:
+        - ecr:GetDownloadUrlForLayer
+        - ecr:BatchGetImage
+        - ecr:BatchCheckLayerAvailability


### PR DESCRIPTION
##### SUMMARY
This PR consists in refactoring AWS ecs_ecr module to rely on AnsibleAWSModule helper, following @tremble ask for improvement in #62892

This PR follow this guide in order to migrate this module accordingly.
https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html#porting-code-to-ansibleawsmodule

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ecs_ecr

##### ADDITIONAL INFORMATION
This PR include a BREAKING CHANGE in [https://github.com/ansible/ansible/commit/8207143fc00573f81efa0015d9ee16d834ae12f0](this commit) leveraging camel-dict-to-snake-dict helper which lead to a breaking change in the result format.

see: https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html#camel-dict-to-snake-dict