### PR TITLE
[stable-2.9] Exclude tmp dir from ansible-test results copy.

### DIFF
--- a/changelogs/fragments/ansible-test-delegation-tmp-dir.yml
+++ b/changelogs/fragments/ansible-test-delegation-tmp-dir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now correctly excludes the test results temporary directory when copying files from the remote test system to the local system

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -425,7 +425,7 @@ def delegate_docker(args, exclude, require, integration_targets):
                 remote_temp_file = os.path.join('/root', remote_results_name + '.tgz')
 
                 with tempfile.NamedTemporaryFile(prefix='ansible-result-', suffix='.tgz') as local_result_fd:
-                    docker_exec(args, test_id, ['tar', 'czf', remote_temp_file, '-C', remote_test_root, remote_results_name])
+                    docker_exec(args, test_id, ['tar', 'czf', remote_temp_file, '--exclude', ResultType.TMP.name, '-C', remote_test_root, remote_results_name])
                     docker_get(args, test_id, remote_temp_file, local_result_fd.name)
                     run_command(args, ['tar', 'oxzf', local_result_fd.name, '-C', local_test_root])
         finally:
@@ -547,7 +547,7 @@ def delegate_remote(args, exclude, require, integration_targets):
                 remote_results_name = os.path.basename(remote_results_root)
                 remote_temp_path = os.path.join('/tmp', remote_results_name)
 
-                manage.ssh('rm -rf {0} && cp -a {1} {0} && chmod -R a+r {0}'.format(remote_temp_path, remote_results_root))
+                manage.ssh('rm -rf {0} && mkdir {0} && cp -a {1}/* {0}/ && chmod -R a+r {0}'.format(remote_temp_path, remote_results_root))
                 manage.download(remote_temp_path, local_test_root)
     finally:
         if args.remote_terminate == 'always' or (args.remote_terminate == 'success' and success):


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Exclude tmp dir from ansible-test results copy.

This fixes test errors related to failures copying temporary test results files from a remote system back to the local system.

It also speeds up processing of test results and reduces network utilization by avoiding the temporary files.

Backport of https://github.com/ansible/ansible/pull/62982

(cherry picked from commit 3f2380cccefe4c4352970324b57c7e3ee22558a1)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
