### PR TITLE
adding ostype win10 support for proxmox_kvm to resolve issue #55045

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -223,7 +223,7 @@ options:
     description:
       - Specifies guest operating system. This is used to enable special optimization/features for specific operating systems.
       - The l26 is Linux 2.6/3.X Kernel.
-    choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'l24', 'l26', 'solaris']
+    choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'l24', 'l26', 'solaris']
     default: l26
   parallel:
     description:
@@ -828,7 +828,7 @@ def main():
             numa=dict(type='dict'),
             numa_enabled=dict(type='bool'),
             onboot=dict(type='bool', default='yes'),
-            ostype=dict(default='l26', choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'l24', 'l26', 'solaris']),
+            ostype=dict(default='l26', choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'win10', 'l24', 'l26', 'solaris']),
             parallel=dict(type='dict'),
             pool=dict(type='str'),
             protection=dict(type='bool'),


### PR DESCRIPTION
##### SUMMARY
Added 'win10' to the list of hardcoded supported values for the variable: ostype. 
Qemu officially supports this as a value as denoted here: https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines

Fixes #55045

https://github.com/ansible/ansible/issues/55045: proxmox_kvm cannot create a VM with ostype=win10
This patch is not currently present in any version of the proxmox_kvm module up through stable 2.9. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm

##### ADDITIONAL INFORMATION
Before
```
TASK [create/deploy vms] ***********************************************************************************************
failed: [proxmox] (item={'value': {u'ostype': u'win10', u'type': u'windows1903', u'ide': {'ide0': 'pd4_1T/iso:Windows10_1903.iso,media=cdrom'}, u'vmid': 997, u'name': u'win1903'}, 'key': u'windows'}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "windows", "value": {"ide": {"ide0": "pd4_1T/iso:Windows10_1903.iso,media=cdrom"}, "name": "win1903", "ostype": "win10", "type": "windows1903", "vmid": 997}}, "msg": "value of ostype must be one of: other, wxp, w2k, w2k3, w2k8, wvista, win7, win8, l24, l26, solaris, got: win10"}
```

After
```
TASK [create/deploy vms] ***********************************************************************************************
changed: [pvecenter710.breakfasthouse.xyz] => (item={'value': {u'ostype': u'win10', u'type': u'windows1903', u'ide': {'ide0': 'pd4_1T:iso/Windows10_1903.iso,media=cdrom'}, u'vmid': 997, u'name': u'win1903'}, 'key': u'windows'})
```