### PR TITLE
mysql_replication: setup a later version of MariaDB to CI

### DIFF
--- a/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
@@ -70,3 +70,9 @@
     - slave_status.Last_IO_Errno == 0
     - slave_status.Last_IO_Error == ''
     - slave_status is not changed
+
+###############
+# Finish tests
+
+- name: Stop replication via shell
+  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'

--- a/test/integration/targets/setup_mariadb/defaults/main.yml
+++ b/test/integration/targets/setup_mariadb/defaults/main.yml
@@ -1,5 +1,7 @@
 master_port: 3306
 standby_port: 3307
-default_datadir: /var/lib/mysql
+master_datadir: /var/lib/mysql_master
 standby_datadir: /var/lib/mysql_standby
 standby_logdir: /var/log/mysql_standby
+default_logdir: /var/log/mariadb
+mysql_safe_err_log: /var/log/mariadb/mysql_safe-err.log

--- a/test/integration/targets/setup_mariadb/tasks/setup_mariadb.yml
+++ b/test/integration/targets/setup_mariadb/tasks/setup_mariadb.yml
@@ -1,13 +1,21 @@
 # We run two servers listening different ports
 # to be able to check replication (one server for master, another for standby).
 
+- name: Install MariaDB repo
+  yum_repository:
+    name: MariaDB
+    description: MariaDB official repo
+    baseurl: http://yum.mariadb.org/10.1/centos7-amd64
+    gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+    gpgcheck: yes
+
 - name: Install MariaDB packages on RedHat family OS
   yum:
     name: "{{ item }}"
     enablerepo: epel
   loop:
-  - mariadb-server
-  - mariadb
+  - MariaDB-server
+  - MariaDB-client
   when: ansible_os_family == 'RedHat'
 
 - name: Create directories for standby
@@ -17,8 +25,10 @@
     owner: mysql
     group: mysql
   loop:
+  - "{{ master_datadir }}"
   - "{{ standby_datadir }}"
   - "{{ standby_logdir }}"
+  - "{{ default_logdir }}"
 
 - name: Copy cnf template
   template:
@@ -28,14 +38,14 @@
     group: mysql
     force: yes
 
-- name: Initialize standby's DB
-  shell: 'mysql_install_db --user=mysql --datadir={{ standby_datadir }}'
-
-- name: Initialize master's DB
-  shell: 'mysql_install_db --user=mysql --datadir={{ default_datadir }}'
+- name: Initialize DBs
+  shell: 'mysql_install_db --user=mysql --datadir={{ item }}'
+  loop:
+  - '{{ master_datadir }}'
+  - '{{ standby_datadir }}'
 
 - name: Start services
-  shell: 'mysqld_multi start 1,2'
+  shell: 'mysqld_multi --log=/var/log/mariadb/mariadb.log start 1,2'
 
 - name: Pause
   pause: seconds=3
@@ -43,6 +53,9 @@
 ########### For painful debug uncomment the lines below ##
 #- name: DEBUG Check stratup log
 #  shell: cat /var/log/mariadb/mariadb.log
+
+#- name: DEBUG Check mysql_safe err log
+#  shell: cat '{{  mysql_safe_err_log }}'
 
 #- name: DEBUG Check processes
 #  shell: 'ps aux | grep mysqld | grep -v "grep\|root"'

--- a/test/integration/targets/setup_mariadb/templates/my.cnf.j2
+++ b/test/integration/targets/setup_mariadb/templates/my.cnf.j2
@@ -1,8 +1,9 @@
 [mysqld1]
 server_id           = 1
 port                = {{ master_port }}
-datadir             = {{ default_datadir }}
-socket              = {{ default_datadir }}/mysql.sock
+datadir             = {{ master_datadir }}
+socket              = {{ master_datadir }}/mysql.sock
+pid-file            = {{ master_datadir }}/mysql.pid
 mysqladmin          = /usr/bin/mysqladmin
 log_bin             = /var/log/mariadb/mysql-bin.log
 sync_binlog         = 1
@@ -29,5 +30,5 @@ user       = multi_admin
 password   = multipass
 
 [mysqld_safe]
-log-error=/var/log/mariadb/mariadb.log
+log-error={{  mysql_safe_err_log }}
 pid-file=/var/run/mariadb/mariadb.pid


### PR DESCRIPTION
##### SUMMARY
mysql_replication: setup a later version of MariaDB (5.6 -> 10.1) to CI

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request