### PR TITLE
hcloud_floating_ip_info: add name to return values

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_floating_ip_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_floating_ip_info.py
@@ -66,6 +66,7 @@ hcloud_floating_ip_info:
             returned: Always
             type: str
             sample: my-floating-ip
+            version_added: "2.10"
         description:
             description: Description of the Floating IP
             returned: always

--- a/lib/ansible/modules/cloud/hcloud/hcloud_floating_ip_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_floating_ip_info.py
@@ -61,6 +61,11 @@ hcloud_floating_ip_info:
             returned: always
             type: int
             sample: 1937415
+        name:
+            description: Name of the Floating IP
+            returned: Always
+            type: str
+            sample: my-floating-ip
         description:
             description: Description of the Floating IP
             returned: always
@@ -117,6 +122,7 @@ class AnsibleHcloudFloatingIPInfo(Hcloud):
                     server_name = floating_ip.server.name
                 tmp.append({
                     "id": to_native(floating_ip.id),
+                    "name": to_native(floating_ip.name),
                     "description": to_native(floating_ip.description),
                     "ip": to_native(floating_ip.ip),
                     "type": to_native(floating_ip.type),

--- a/test/integration/targets/hcloud_floating_ip_info/defaults/main.yml
+++ b/test/integration/targets/hcloud_floating_ip_info/defaults/main.yml
@@ -1,6 +1,5 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-hcloud_test_floating_ip_name: "always-there-floating-ip"
-hcloud_test_floating_ip_label_selector: "key=value"
-hcloud_test_floating_ip_id: 62227
+hcloud_prefix: "tests"
+hcloud_floating_ip_name: "{{hcloud_prefix}}-integration"

--- a/test/integration/targets/hcloud_floating_ip_info/tasks/main.yml
+++ b/test/integration/targets/hcloud_floating_ip_info/tasks/main.yml
@@ -1,10 +1,29 @@
 # Copyright: (c) 2019, Hetzner Cloud GmbH <info@hetzner-cloud.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
+- name: setup ensure floating ip is absent
+  hcloud_floating_ip:
+    name: "{{ hcloud_floating_ip_name }}"
+    state: absent
+
+- name: setup floating ip
+  hcloud_floating_ip:
+    name: "{{ hcloud_floating_ip_name }}"
+    home_location: "fsn1"
+    type: ipv4
+    labels:
+      key: value
+  register: test_floating_ip
+
+- name: verify setup floating ip
+  assert:
+    that:
+      - test_floating_ip is changed
+
 - name: test gather hcloud floating ip infos
   hcloud_floating_ip_info:
   register: hcloud_floating_ips
-- name: verify test gather hcloud floating ip infos in check mode
+- name: verify test gather hcloud floating ip infos
   assert:
     that:
       - hcloud_floating_ips.hcloud_floating_ip_info| list | count >= 1
@@ -27,7 +46,7 @@
 - name: verify test gather hcloud floating ip with correct label selector
   assert:
     that:
-      - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('description','equalto','{{ hcloud_test_floating_ip_name }}') | list | count == 1
+      - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('name','equalto','{{ test_floating_ip.hcloud_floating_ip.name }}') | list | count == 1
 
 - name: test gather hcloud floating ip infos with wrong label selector
   hcloud_floating_ip_info:
@@ -40,19 +59,29 @@
 
 - name: test gather hcloud floating ip infos with correct id
   hcloud_floating_ip_info:
-    id: "{{hcloud_test_floating_ip_id}}"
+    id: "{{test_floating_ip.hcloud_floating_ip.id}}"
   register: hcloud_floating_ips
 - name: verify test gather hcloud floating ip with correct id
   assert:
     that:
-      - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('description','equalto','{{ hcloud_test_floating_ip_name }}') | list | count == 1
+      - hcloud_floating_ips.hcloud_floating_ip_info|selectattr('name','equalto','{{ test_floating_ip.hcloud_floating_ip.name }}') | list | count == 1
 
 - name: test gather hcloud floating ip infos with wrong id
   hcloud_floating_ip_info:
-      id: "{{hcloud_test_floating_ip_id}}1"
+      id: "{{test_floating_ip.hcloud_floating_ip.id}}1"
   register: result
   ignore_errors: yes
 - name: verify test gather hcloud floating ip with wrong id
   assert:
     that:
       - result is failed
+
+- name: cleanup
+  hcloud_floating_ip:
+    id: "{{ test_floating_ip.hcloud_floating_ip.id }}"
+    state: absent
+  register: result
+- name: verify cleanup
+  assert:
+    that:
+    - result is success


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Floating IPs in the [Hetzner cloud API](https://docs.hetzner.cloud/#floating-ips-get-a-specific-floating-ip) have a `name` attribute, which is not included in the return values of `hcloud_floating_ip_info`.

Since `name` is present in both input and output of `hcloud_floating_ip`, I think it would make sense to include the attribute in the `_info` variant as well.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* hcloud_floating_ip_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### Before

```
$ ansible -m hcloud_floating_ip_info localhost 
localhost | SUCCESS => {
    "changed": false,
    "hcloud_floating_ip_info": [
        {
            "description": "Testing 1 2 3",
            "home_location": "fsn1",
            "id": "123456",
            "ip": "192.0.2.123",
            "labels": {},
            "server": "None",
            "type": "ipv4"
        }
    ]
}
```

### After

```
$ ansible -m hcloud_floating_ip_info localhost 
localhost | SUCCESS => {
    "changed": false,
    "hcloud_floating_ip_info": [
        {
            "description": "Testing 1 2 3",
            "home_location": "fsn1",
            "id": "123456",
            "ip": "192.0.2.123",
            "labels": {},
            "name": "testing",
            "server": "None",
            "type": "ipv4"
        }
    ]
}
```

The integration tests seem to depend on some predefined floating IP and I wasn’t sure of its name so there are no changes to the tests here.