### PR TITLE
IOS-XR: Fix iosxr_lag_interfaces intermittent failures

### DIFF
--- a/lib/ansible/module_utils/network/iosxr/utils/utils.py
+++ b/lib/ansible/module_utils/network/iosxr/utils/utils.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.network.common.utils import is_masklen, to_netmask
+from ansible.module_utils.network.common.utils import dict_diff, is_masklen, to_netmask, search_obj_in_list
 
 
 def remove_command_from_config_list(interface, cmd, commands):
@@ -178,12 +178,15 @@ def diff_list_of_dicts(w, h):
         h = []
 
     diff = []
-    set_w = set(tuple(d.items()) for d in w)
-    set_h = set(tuple(d.items()) for d in h)
-    difference = set_w.difference(set_h)
-
-    for element in difference:
-        diff.append(dict((x, y) for x, y in element))
+    for w_item in w:
+        h_item = search_obj_in_list(w_item['member'], h, key='member')
+        if not h_item:
+            h_item = {}
+        d = dict_diff(h_item, w_item)
+        if d:
+            if 'member' not in d.keys():
+                d['member'] = w_item['member']
+            diff.append(d)
 
     return diff
 

--- a/lib/ansible/module_utils/network/iosxr/utils/utils.py
+++ b/lib/ansible/module_utils/network/iosxr/utils/utils.py
@@ -179,9 +179,7 @@ def diff_list_of_dicts(w, h):
 
     diff = []
     for w_item in w:
-        h_item = search_obj_in_list(w_item['member'], h, key='member')
-        if not h_item:
-            h_item = {}
+        h_item = search_obj_in_list(w_item['member'], h, key='member') or {}
         d = dict_diff(h_item, w_item)
         if d:
             if 'member' not in d.keys():


### PR DESCRIPTION
##### SUMMARY
- Using set to take diff between lag members doesn't work if reading order is wrong
- This fix used `dict_diff` to solve it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_lag_interfaces.py