### PR TITLE
test/throttle: prepare env only once

### DIFF
--- a/test/integration/targets/throttle/test_throttle.yml
+++ b/test/integration/targets/throttle/test_throttle.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhosts
+- hosts: localhost
   gather_facts: false
   vars:
     throttledir: "{{ lookup('env', 'OUTPUT_DIR') }}/throttle.dir/"
@@ -9,12 +9,16 @@
         state: absent
         path: '{{ throttledir }}'
       ignore_errors: yes
-      run_once: yes
     - name: Create throttledir '{{ throttledir }}'
       file:
         state: directory
         path: '{{ throttledir }}'
-      run_once: yes
+
+- hosts: localhosts
+  gather_facts: false
+  vars:
+    throttledir: "{{ lookup('env', 'OUTPUT_DIR') }}/throttle.dir/"
+  tasks:
     - block:
       - name: "Test 1 (max throttle: 3)"
         script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 3"


### PR DESCRIPTION
##### SUMMARY

Prepare the throttle.dir only one time, this to avoid two times 8
lines of logs.


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

test/integration/targets/throttle/test_throttle.yml
<!--- Write the short name of the module, plugin, task or feature below -->