### PR TITLE
skip adding aliases to argument_spec #62315

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -630,11 +630,6 @@ class AnsibleModule(object):
         self._options_context = list()
         self._tmpdir = None
 
-        if add_file_common_args:
-            for k, v in FILE_COMMON_ARGUMENTS.items():
-                if k not in self.argument_spec:
-                    self.argument_spec[k] = v
-
         self._load_params()
         self._set_fallbacks()
 
@@ -645,6 +640,12 @@ class AnsibleModule(object):
             # Use exceptions here because it isn't safe to call fail_json until no_log is processed
             print('\n{"failed": true, "msg": "Module alias error: %s"}' % to_native(e))
             sys.exit(1)
+
+        if add_file_common_args:
+            print("add_file_common_args", add_file_common_args)
+            for k, v in FILE_COMMON_ARGUMENTS.items():
+                if k not in self.argument_spec and k not in self.aliases:
+                    self.argument_spec[k] = v
 
         # Save parameter values that should never be logged
         self.no_log_values = set()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Based on the issue reported by @sndv([62315](https://github.com/ansible/ansible/issues/62315)) 

Fix suggested by @sivel, thanks
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
More information about how to reproduce this issue is described in the issue [62315](https://github.com/ansible/ansible/issues/62315)
<!--- Paste verbatim command output below, e.g. before and after your change -->

RESULTS AFTER FIX 
```paste below
TASK [Gathering Facts] ***********************************************************************************************************[0/3864]
ok: [localhost]

TASK [blockinfile] ***********************************************************************************************************************
--- before: /tmp/blockinfile-test-block (content)
+++ after: /tmp/blockinfile-test-block (content)
@@ -0,0 +1,3 @@
+# BEGIN ANSIBLE MANAGED BLOCK
+some content
+# END ANSIBLE MANAGED BLOCK

changed: [localhost]

TASK [blockinfile] ***********************************************************************************************************************
--- before: /tmp/blockinfile-test-content (content)
+++ after: /tmp/blockinfile-test-content (content)
@@ -0,0 +1,3 @@
+# BEGIN ANSIBLE MANAGED BLOCK
+some content
+# END ANSIBLE MANAGED BLOCK

changed: [localhost]

PLAY RECAP *******************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
