### PR TITLE
[stable-2.9] Limit Shippable matrix check to ansible repo.

### DIFF
--- a/test/utils/shippable/check_matrix.py
+++ b/test/utils/shippable/check_matrix.py
@@ -25,6 +25,13 @@ except ImportError:
 
 def main():  # type: () -> None
     """Main entry point."""
+    repo_full_name = os.environ['REPO_FULL_NAME']
+    required_repo_full_name = 'ansible/ansible'
+
+    if repo_full_name != required_repo_full_name:
+        sys.stderr.write('Skipping matrix check on repo "%s" which is not "%s".\n' % (repo_full_name, required_repo_full_name))
+        return
+
     with open('shippable.yml', 'rb') as yaml_file:
         yaml = yaml_file.read().decode('utf-8').splitlines()
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Limit Shippable matrix check to ansible repo.

Backport of https://github.com/ansible/ansible/pull/63015

(cherry picked from commit ada02f1966efa1957587bd9d763a5c86fdb19602)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

check_matrix.py
