### PR TITLE
rpmfilename must be constructed using rpmmacros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ rpm: rpmcommon
 	--define "_srcrpmdir %{_topdir}" \
 	--define "_specdir $(RPMSPECDIR)" \
 	--define "_sourcedir %{_topdir}" \
-	--define "_rpmfilename $(RPMNVR).%%{ARCH}.rpm" \
+	--define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
 	--define "__python `which $(PYTHON)`" \
 	--define "upstream_version $(VERSION)" \
 	--define "rpmversion $(RPMVERSION)" \


### PR DESCRIPTION
Different subpackages have different names so, at the least, the %NAME
macros must be used when constructing the rpmfilename.  Otherwise each
subsequent subpackage will overwrite the previous one.

This reinstates dag's fix from d4b6aecd978736f034a6a2160475f04ec2451d36

Fixes #62673

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
Makefile --- building of the rpms

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
