### PR TITLE
[stable-2.9] rpmfilename must be constructed using rpmmacros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ rpm: rpmcommon
 	--define "_srcrpmdir %{_topdir}" \
 	--define "_specdir $(RPMSPECDIR)" \
 	--define "_sourcedir %{_topdir}" \
-	--define "_rpmfilename $(RPMNVR).%%{ARCH}.rpm" \
+	--define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
 	--define "__python `which $(PYTHON)`" \
 	--define "upstream_version $(VERSION)" \
 	--define "rpmversion $(RPMVERSION)" \


### PR DESCRIPTION
Different subpackages have different names so, at the least, the %NAME
macros must be used when constructing the rpmfilename.  Otherwise each
subsequent subpackage will overwrite the previous one.

This reinstates dag's fix from d4b6aecd978736f034a6a2160475f04ec2451d36

Fixes #62673
(cherry picked from commit 30cc54d)

Backport of https://github.com/ansible/ansible/pull/63023

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This fix shouldn't affect the ansible release.  We use the ```mock-rpm``` target to make releases.  We can therefore hold off on merging the backport until after 2.9.0 is out.
