### PR TITLE
mysql_replication: add return value, remove extra argument from function

### DIFF
--- a/changelogs/fragments/63036-mysql_replication_add_return_value.yml
+++ b/changelogs/fragments/63036-mysql_replication_add_return_value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``queries`` return value (https://github.com/ansible/ansible/pull/63036).

--- a/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_replication_initial.yml
@@ -49,9 +49,20 @@
 - assert:
     that:
     - result is changed
+    - result.queries == ["CHANGE MASTER TO MASTER_HOST='127.0.0.1',MASTER_USER='replication_user',MASTER_PASSWORD='********',MASTER_PORT=3306,MASTER_LOG_FILE='mysql-bin.000001',MASTER_LOG_POS=765"]
 
-- name: Run replication via shell
-  shell: 'echo "START SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+# Test startslave mode:
+- name: Start slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: startslave
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["START SLAVE"]
 
 # Test getslave mode:
 - name: Get standby status
@@ -71,8 +82,15 @@
     - slave_status.Last_IO_Error == ''
     - slave_status is not changed
 
-###############
-# Finish tests
+# Test stopslave mode:
+- name: Stop slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
+  register: result
 
-- name: Stop replication via shell
-  shell: 'echo "STOP SLAVE;" | mysql -P {{ standby_port }} -h 127.0.0.1'
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["STOP SLAVE"]


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add return value, remove extra argument from function

- it gives us and users useful information about what has actually been done on hosts
- it useful for CI tests and debug (used widely in postgresql modules, i added this feature earlier to them - really useful)
- it gives us opportunity to check even non supported features by checking executed queries (for example, there are a lot of forks including percone, mariadb, etc., so we could tests parameters supported in one and non supported in another rdbms)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```mysql_replication```
