### PR TITLE
add compatibility with Proxmox 6

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -347,8 +347,12 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
             kwargs.update(kwargs['mounts'])
             del kwargs['mounts']
         if 'pubkey' in kwargs:
-            if float(proxmox.version.get()['version']) >= 4.2:
-                kwargs['ssh-public-keys'] = kwargs['pubkey']
+            try:
+                if float(proxmox.version.get()['version']) >= 4.2:
+                    kwargs['ssh-public-keys'] = kwargs['pubkey']
+            except (ValueError):
+                if int(proxmox.version.get()['version'].split('.', 1)[0]):
+                    kwargs['ssh-public-keys'] = kwargs['pubkey']
             del kwargs['pubkey']
     else:
         kwargs['cpus'] = cpus
@@ -481,7 +485,10 @@ def main():
     try:
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
-        VZ_TYPE = 'openvz' if float(proxmox.version.get()['version']) < 4.0 else 'lxc'
+        try:
+            VZ_TYPE = 'openvz' if float(proxmox.version.get()['version']) < 4.0 else 'lxc'
+        except (ValueError):
+            VZ_TYPE = 'lxc'
 
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)


### PR DESCRIPTION
##### SUMMARY
Fix #59340
authorization on proxmox cluster failed with exception: invalid literal for float(): 6.0-4

Improves fix #59966
(which is missing colon, and does not address the second invocation of proxmox.version.get, which is equally incompatible with Proxmox 6)
Plus, this PR adds a try.. except... making sure it does not break compatibility with Proxmox 4 and less.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox module for Ansible

##### ADDITIONAL INFORMATION
