### PR TITLE
ios_bgp :  Fix for bug #59083

### DIFF
--- a/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/process.py
+++ b/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/process.py
@@ -89,7 +89,7 @@ class Provider(CliProvider):
         for entry in self.get_value('config.networks'):
             network = entry['prefix']
             cmd = 'network %s' % network
-            if entry['masklen']:
+            if entry['masklen'] and entry['masklen'] not in (24,16,8):
                 cmd += ' mask %s' % to_netmask(entry['masklen'])
                 network += ' mask %s' % to_netmask(entry['masklen'])
 

--- a/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/process.py
+++ b/lib/ansible/module_utils/network/ios/providers/cli/config/bgp/process.py
@@ -89,7 +89,7 @@ class Provider(CliProvider):
         for entry in self.get_value('config.networks'):
             network = entry['prefix']
             cmd = 'network %s' % network
-            if entry['masklen'] and entry['masklen'] not in (24,16,8):
+            if entry['masklen'] and entry['masklen'] not in (24, 16, 8):
                 cmd += ' mask %s' % to_netmask(entry['masklen'])
                 network += ' mask %s' % to_netmask(entry['masklen'])
 

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -380,6 +380,39 @@
         - "'router bgp 64497' in result.commands"
         - "'bgp router-id 192.0.2.10' in result.commands"
         - "'bgp log-neighbor-changes' in result.commands"
+  
+  - name: "Configure BGP neighbors with classful boundary"
+    ios_bgp: &classful
+      config:
+        bgp_as: 64497
+        log_neighbor_changes: true
+        networks:
+          - prefix: 198.51.100.0
+            masklen: 23
+
+          - prefix: 201.0.113.32
+            masklen: 24
+
+      operation: merge
+    register: result
+
+  - assert:
+      that:
+        - 'result.changed == true'
+        - "'router bgp 64497' in result.commands"
+        - "'network 198.51.100.0 mask 255.255.254.0' in result.commands"
+        - "'network 201.0.113.32' in result.commands"
+
+  - name: Configure BGP neighbors with classful boundary (idempotent)
+    ios_bgp: *classful
+    register: result
+
+  - assert:
+      that:
+        - 'result.changed == false'
+
+
+
 
   always:
   - name: Teardown

--- a/test/integration/targets/ios_bgp/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_bgp/tests/cli/basic.yaml
@@ -411,9 +411,6 @@
       that:
         - 'result.changed == false'
 
-
-
-
   always:
   - name: Teardown
     ios_bgp: &rm


### PR DESCRIPTION
SUMMARY
Added fix to handle idempotentency issue when using networks on classful boundaries

Fixes #59083

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/module_utils/network/ios/providers/cli/config/bgp/process.py