### PR TITLE
Pull request for temp/backport-62998

### DIFF
--- a/changelogs/fragments/62998-iosxr_lag_interfaces-fixes.yaml
+++ b/changelogs/fragments/62998-iosxr_lag_interfaces-fixes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix iosxr_lag_interfaces idempotent issue under python35.

--- a/lib/ansible/module_utils/network/iosxr/utils/utils.py
+++ b/lib/ansible/module_utils/network/iosxr/utils/utils.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.network.common.utils import is_masklen, to_netmask
+from ansible.module_utils.network.common.utils import dict_diff, is_masklen, to_netmask, search_obj_in_list
 
 
 def remove_command_from_config_list(interface, cmd, commands):
@@ -178,12 +178,13 @@ def diff_list_of_dicts(w, h):
         h = []
 
     diff = []
-    set_w = set(tuple(d.items()) for d in w)
-    set_h = set(tuple(d.items()) for d in h)
-    difference = set_w.difference(set_h)
-
-    for element in difference:
-        diff.append(dict((x, y) for x, y in element))
+    for w_item in w:
+        h_item = search_obj_in_list(w_item['member'], h, key='member') or {}
+        d = dict_diff(h_item, w_item)
+        if d:
+            if 'member' not in d.keys():
+                d['member'] = w_item['member']
+            diff.append(d)
 
     return diff
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
stable-2.9: Backport python35 fix needed to help stablize testing. This fixes an idempotent issue with iosxr_lag_interfaces.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iosxr_lag_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```