### PR TITLE
Add support for adding Openstack metadata to a host's hostvars

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -132,8 +132,16 @@ def append_hostvars(hostvars, groups, key, server, namegroup=False):
         openstack=server)
 
     metadata = server.get('metadata', {})
-    if 'ansible_user' in metadata:
-        hostvars[key]['ansible_user'] = metadata['ansible_user']
+    # iterate through metadata and append items that
+    # start with 'ansible_'
+    for dkey, dvalue in metadata.items():
+        if dkey.startswith('ansible_'):
+            hostvars[key][dkey] = metadata[dkey]
+
+    # special case: when ansible_ssh_host is found in metadata
+    # we also set ansible_host so that both are identical
+    if 'ansible_ssh_host' in metadata:
+        hostvars[key]['ansible_host'] = metadata['ansible_ssh_host']
 
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)


### PR DESCRIPTION
##### SUMMARY
The change is intended to enable the Openstack Inventory to be used with hosts
that do not have a public IP address and those that do in one project. This is
especially helpful when using bastion hosts.

This is achieved by adding any metadata that starts with 'ansible_' to
the host's hostvars.
##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
openstack_inventory.py

##### ADDITIONAL INFORMATION
I do have an Openstack project that consists of a bastion host with non RFC1918 IP addresses and multiple VMs that only have RFC1918 addresses configured on their interfaces. The openstack inventory is only properly reflecting the public IP address of the bastion host and the other VMs in the project are unreachable. By adding metadata to hostvars I am able to set the ansible_ssh_host in the VM's metadata and have it be reflected in the output of the Openstack dynamic inventory. The added benefit is that I am now able to also set hostvars as long as they begin with `ansible_`, i.e. `ansible_ssh_retries` or `ansible_ssh_port`.

Before change:
```
$ ./openstack_inventory.py --refresh --list
{
  "_meta": {
    "hostvars": {
      "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20": {
        "ansible_host": "<redacted>",
        "ansible_ssh_host": "<redacted>",
        "openstack": {
          "OS-DCF:diskConfig": "AUTO",
          "OS-EXT-AZ:availability_zone": "zone",
          "OS-EXT-SRV-ATTR:host": null,
          "OS-EXT-SRV-ATTR:hostname": null,
          "OS-EXT-SRV-ATTR:hypervisor_hostname": null,
          "OS-EXT-SRV-ATTR:instance_name": null,
          "OS-EXT-SRV-ATTR:kernel_id": null,
          "OS-EXT-SRV-ATTR:launch_index": null,
          "OS-EXT-SRV-ATTR:ramdisk_id": null,
          "OS-EXT-SRV-ATTR:reservation_id": null,
          "OS-EXT-SRV-ATTR:root_device_name": null,
          "OS-EXT-SRV-ATTR:user_data": null,
          "OS-EXT-STS:power_state": 1,
          "OS-EXT-STS:task_state": null,
          "OS-EXT-STS:vm_state": "active",
          "OS-SCH-HNT:scheduler_hints": null,
          "OS-SRV-USG:launched_at": "2019-10-02T20:48:07.000000",
          "OS-SRV-USG:terminated_at": null,
          "accessIPv4": "",
          "accessIPv6": "<redacted>",
          "addresses": {
            "devtest": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:69:36:12",
                "OS-EXT-IPS:type": "fixed",
                "addr": "<redacted>",
                "version": 4
              },
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:69:36:12",
                "OS-EXT-IPS:type": "fixed",
                "addr": "<redacted>",
                "version": 6
              }
            ]
          },
          "adminPass": null,
          "az": "zone",
          "block_device_mapping": null,
          "cloud": "os-cloud",
          "config_drive": "",
          "created": "2019-10-02T20:46:35Z",
          "created_at": "2019-10-02T20:46:35Z",
          "description": null,
          "disk_config": "AUTO",
          "flavor": {
            "id": "884d5b93-1467-4bc1-a445-ff7c74271cbd",
            "name": "m1.micro"
          },
          "has_config_drive": false,
          "host": null,
          "hostId": "<redacted>",
          "host_id": "<redacted>",
          "host_status": null,
          "hostname": null,
          "hypervisor_hostname": null,
          "id": "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20",
          "image": {
            "id": "863e3c20-3e89-47fc-bc3a-a01410d6e43b",
            "name": "Ubuntu 18.04"
          },
          "instance_name": null,
          "interface_ip": "<redacted>",
          "kernel_id": null,
          "key_name": "<redacted>",
          "launch_index": null,
          "launched_at": "2019-10-02T20:48:07.000000",
          "location": {
            "cloud": "os-cloud",
            "project": {
              "domain_id": null,
              "domain_name": null,
              "id": "id_is_here",
              "name": "os-project"
            },
            "region_name": "region",
            "zone": "zone"
          },
          "locked": null,
          "metadata": {
            "ansible_ssh_port": "2222",
            "ansible_ssh_retries": "4"
          },
          "name": "testbox",
          "networks": {},
          "os-extended-volumes:volumes_attached": [],
          "personality": null,
          "power_state": 1,
          "private_v4": "192.168.42.33",
          "progress": 0,
          "project_id": "id_is_here",
          "properties": {
            "OS-DCF:diskConfig": "AUTO",
            "OS-EXT-AZ:availability_zone": "zone",
            "OS-EXT-SRV-ATTR:host": null,
            "OS-EXT-SRV-ATTR:hostname": null,
            "OS-EXT-SRV-ATTR:hypervisor_hostname": null,
            "OS-EXT-SRV-ATTR:instance_name": null,
            "OS-EXT-SRV-ATTR:kernel_id": null,
            "OS-EXT-SRV-ATTR:launch_index": null,
            "OS-EXT-SRV-ATTR:ramdisk_id": null,
            "OS-EXT-SRV-ATTR:reservation_id": null,
            "OS-EXT-SRV-ATTR:root_device_name": null,
            "OS-EXT-SRV-ATTR:user_data": null,
            "OS-EXT-STS:power_state": 1,
            "OS-EXT-STS:task_state": null,
            "OS-EXT-STS:vm_state": "active",
            "OS-SCH-HNT:scheduler_hints": null,
            "OS-SRV-USG:launched_at": "2019-10-02T20:48:07.000000",
            "OS-SRV-USG:terminated_at": null,
            "host_status": null,
            "locked": null,
            "os-extended-volumes:volumes_attached": [],
            "trusted_image_certificates": null
          },
          "public_v4": "",
          "public_v6": "<redacted>",
          "ramdisk_id": null,
          "region": "region",
          "reservation_id": null,
          "root_device_name": null,
          "scheduler_hints": null,
          "security_groups": [
            {
              "description": "",
              "id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
              "location": {
                "cloud": "os-cloud",
                "project": {
                  "domain_id": null,
                  "domain_name": null,
                  "id": "id_is_here",
                  "name": "os-project"
                },
                "region_name": "region",
                "zone": null
              },
              "name": "devtest",
              "project_id": "id_is_here",
              "properties": {},
              "security_group_rules": [
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "0b1d0941-08e3-4983-9306-3c803a3faae7",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "0c8fee94-0fbe-42c4-a490-ccf3cb31a24c",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": null,
                  "port_range_min": null,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "icmp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "1d6eed42-3c2d-4492-8702-4c871f5e6eca",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 6565,
                  "port_range_min": 6565,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "2a76f930-10f1-414e-a5f3-6d12de9a25b6",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "udp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "2c21ee49-f47e-438e-82bb-db5130b24491",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "::/0",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "8779f3e5-c0da-4db6-a862-2b2f48f57cae",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": null,
                  "port_range_min": null,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "icmp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "9b50e673-f828-4d03-a984-c181b11b6104",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "udp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "a6dac7c4-8679-458f-b76e-5c8b035fdf5c",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "0.0.0.0/0",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "af469924-dddb-4d2c-bfb6-f6fd18073e15",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "ceb8b684-462d-4d7f-b039-0fd9ad8c7320",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "e07818e8-1c0a-43f0-99c9-cab2ae99896d",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                }
              ],
              "tenant_id": "id_is_here"
            }
          ],
          "server_groups": null,
          "status": "ACTIVE",
          "tags": [],
          "task_state": null,
          "tenant_id": "id_is_here",
          "terminated_at": null,
          "trusted_image_certificates": null,
          "updated": "2019-10-02T20:53:52Z",
          "user_data": null,
          "user_id": "55e8887ac4c140489d2de11e73349ce9",
          "vm_state": "active",
          "volumes": []
        }
      }
    }
  },
  "flavor-m1.micro": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "instance-8cd88c50-43a5-4aaf-ab51-f7c1fe156f20": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "meta-ansible_ssh_port_2222": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "meta-ansible_ssh_retries_4": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "testbox": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ]
}
```

After change:
```
$ ./openstack_inventory.py --refresh --list
{
  "_meta": {
    "hostvars": {
      "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20": {
        "ansible_host": "<redacted>",
        "ansible_ssh_host": "<redacted>",
        "ansible_ssh_port": "2222",
        "ansible_ssh_retries": "4",
        "openstack": {
          "OS-DCF:diskConfig": "AUTO",
          "OS-EXT-AZ:availability_zone": "zone",
          "OS-EXT-SRV-ATTR:host": null,
          "OS-EXT-SRV-ATTR:hostname": null,
          "OS-EXT-SRV-ATTR:hypervisor_hostname": null,
          "OS-EXT-SRV-ATTR:instance_name": null,
          "OS-EXT-SRV-ATTR:kernel_id": null,
          "OS-EXT-SRV-ATTR:launch_index": null,
          "OS-EXT-SRV-ATTR:ramdisk_id": null,
          "OS-EXT-SRV-ATTR:reservation_id": null,
          "OS-EXT-SRV-ATTR:root_device_name": null,
          "OS-EXT-SRV-ATTR:user_data": null,
          "OS-EXT-STS:power_state": 1,
          "OS-EXT-STS:task_state": null,
          "OS-EXT-STS:vm_state": "active",
          "OS-SCH-HNT:scheduler_hints": null,
          "OS-SRV-USG:launched_at": "2019-10-02T20:48:07.000000",
          "OS-SRV-USG:terminated_at": null,
          "accessIPv4": "",
          "accessIPv6": "<redacted>",
          "addresses": {
            "devtest": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:69:36:12",
                "OS-EXT-IPS:type": "fixed",
                "addr": "<redacted>",
                "version": 4
              },
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:69:36:12",
                "OS-EXT-IPS:type": "fixed",
                "addr": "<redacted>",
                "version": 6
              }
            ]
          },
          "adminPass": null,
          "az": "zone",
          "block_device_mapping": null,
          "cloud": "os-cloud",
          "config_drive": "",
          "created": "2019-10-02T20:46:35Z",
          "created_at": "2019-10-02T20:46:35Z",
          "description": null,
          "disk_config": "AUTO",
          "flavor": {
            "id": "884d5b93-1467-4bc1-a445-ff7c74271cbd",
            "name": "m1.micro"
          },
          "has_config_drive": false,
          "host": null,
          "hostId": "<redacted>",
          "host_id": "<redacted>",
          "host_status": null,
          "hostname": null,
          "hypervisor_hostname": null,
          "id": "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20",
          "image": {
            "id": "863e3c20-3e89-47fc-bc3a-a01410d6e43b",
            "name": "Ubuntu 18.04"
          },
          "instance_name": null,
          "interface_ip": "<redacted>",
          "kernel_id": null,
          "key_name": "<redacted>",
          "launch_index": null,
          "launched_at": "2019-10-02T20:48:07.000000",
          "location": {
            "cloud": "os-cloud",
            "project": {
              "domain_id": null,
              "domain_name": null,
              "id": "id_is_here",
              "name": "os-project"
            },
            "region_name": "region",
            "zone": "zone"
          },
          "locked": null,
          "metadata": {
            "ansible_ssh_port": "2222",
            "ansible_ssh_retries": "4"
          },
          "name": "testbox",
          "networks": {},
          "os-extended-volumes:volumes_attached": [],
          "personality": null,
          "power_state": 1,
          "private_v4": "192.168.42.33",
          "progress": 0,
          "project_id": "id_is_here",
          "properties": {
            "OS-DCF:diskConfig": "AUTO",
            "OS-EXT-AZ:availability_zone": "zone",
            "OS-EXT-SRV-ATTR:host": null,
            "OS-EXT-SRV-ATTR:hostname": null,
            "OS-EXT-SRV-ATTR:hypervisor_hostname": null,
            "OS-EXT-SRV-ATTR:instance_name": null,
            "OS-EXT-SRV-ATTR:kernel_id": null,
            "OS-EXT-SRV-ATTR:launch_index": null,
            "OS-EXT-SRV-ATTR:ramdisk_id": null,
            "OS-EXT-SRV-ATTR:reservation_id": null,
            "OS-EXT-SRV-ATTR:root_device_name": null,
            "OS-EXT-SRV-ATTR:user_data": null,
            "OS-EXT-STS:power_state": 1,
            "OS-EXT-STS:task_state": null,
            "OS-EXT-STS:vm_state": "active",
            "OS-SCH-HNT:scheduler_hints": null,
            "OS-SRV-USG:launched_at": "2019-10-02T20:48:07.000000",
            "OS-SRV-USG:terminated_at": null,
            "host_status": null,
            "locked": null,
            "os-extended-volumes:volumes_attached": [],
            "trusted_image_certificates": null
          },
          "public_v4": "",
          "public_v6": "<redacted>",
          "ramdisk_id": null,
          "region": "region",
          "reservation_id": null,
          "root_device_name": null,
          "scheduler_hints": null,
          "security_groups": [
            {
              "description": "",
              "id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
              "location": {
                "cloud": "os-cloud",
                "project": {
                  "domain_id": null,
                  "domain_name": null,
                  "id": "id_is_here",
                  "name": "os-project"
                },
                "region_name": "region",
                "zone": null
              },
              "name": "devtest",
              "project_id": "id_is_here",
              "properties": {},
              "security_group_rules": [
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "0b1d0941-08e3-4983-9306-3c803a3faae7",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "0c8fee94-0fbe-42c4-a490-ccf3cb31a24c",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": null,
                  "port_range_min": null,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "icmp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "1d6eed42-3c2d-4492-8702-4c871f5e6eca",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 6565,
                  "port_range_min": 6565,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "2a76f930-10f1-414e-a5f3-6d12de9a25b6",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "udp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "2c21ee49-f47e-438e-82bb-db5130b24491",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "::/0",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "8779f3e5-c0da-4db6-a862-2b2f48f57cae",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": null,
                  "port_range_min": null,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "icmp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "9b50e673-f828-4d03-a984-c181b11b6104",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "udp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "a6dac7c4-8679-458f-b76e-5c8b035fdf5c",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "0.0.0.0/0",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {},
                  "id": "af469924-dddb-4d2c-bfb6-f6fd18073e15",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 22,
                  "port_range_min": 22,
                  "project_id": "",
                  "properties": {
                    "group": {}
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": "<redacted>",
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "ceb8b684-462d-4d7f-b039-0fd9ad8c7320",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                },
                {
                  "direction": "ingress",
                  "ethertype": "IPv4",
                  "group": {
                    "name": "devtest",
                    "tenant_id": "id_is_here"
                  },
                  "id": "e07818e8-1c0a-43f0-99c9-cab2ae99896d",
                  "location": {
                    "cloud": "os-cloud",
                    "project": {
                      "domain_id": null,
                      "domain_name": null,
                      "id": "id_is_here",
                      "name": "os-project"
                    },
                    "region_name": "region",
                    "zone": null
                  },
                  "port_range_max": 65535,
                  "port_range_min": 1,
                  "project_id": "",
                  "properties": {
                    "group": {
                      "name": "devtest",
                      "tenant_id": "id_is_here"
                    }
                  },
                  "protocol": "tcp",
                  "remote_group_id": null,
                  "remote_ip_prefix": null,
                  "security_group_id": "8b360d9e-44cd-4fc8-891d-ec4528c9db0c",
                  "tenant_id": ""
                }
              ],
              "tenant_id": "id_is_here"
            }
          ],
          "server_groups": null,
          "status": "ACTIVE",
          "tags": [],
          "task_state": null,
          "tenant_id": "id_is_here",
          "terminated_at": null,
          "trusted_image_certificates": null,
          "updated": "2019-10-02T20:53:52Z",
          "user_data": null,
          "user_id": "55e8887ac4c140489d2de11e73349ce9",
          "vm_state": "active",
          "volumes": []
        }
      }
    }
  },
  "flavor-m1.micro": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "instance-8cd88c50-43a5-4aaf-ab51-f7c1fe156f20": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "meta-ansible_ssh_port_2222": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "meta-ansible_ssh_retries_4": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ],
  "testbox": [
    "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20"
  ]
}
```
Diff of the output:
```
--- no_patch.txt	2019-10-03 10:05:20.471199684 +0200
+++ with_patch.txt	2019-10-03 10:05:20.471199684 +0200
@@ -5,6 +5,8 @@
       "8cd88c50-43a5-4aaf-ab51-f7c1fe156f20": {
         "ansible_host": "<redacted>",
         "ansible_ssh_host": "<redacted>",
+        "ansible_ssh_port": "2222",
+        "ansible_ssh_retries": "4",
         "openstack": {
           "OS-DCF:diskConfig": "AUTO",
           "OS-EXT-AZ:availability_zone": "zone",
```