### PR TITLE
Backport 2.9: Fix traceback for empty config (#62520)

### DIFF
--- a/changelogs/fragments/62520-fix_traceback_for_empty_config_vyos.yaml
+++ b/changelogs/fragments/62520-fix_traceback_for_empty_config_vyos.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vyos - Make sure that empty configs don't throw a traceback for Resource Modules (https://github.com/ansible/ansible/pull/62520)

--- a/lib/ansible/module_utils/network/vyos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/vyos/config/interfaces/interfaces.py
@@ -108,6 +108,10 @@ class Interfaces(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+
+        if state in ('merged', 'replaced', 'overridden') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands.extend(self._state_overridden(want=want, have=have))
 

--- a/lib/ansible/module_utils/network/vyos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/vyos/config/l3_interfaces/l3_interfaces.py
@@ -110,6 +110,10 @@ class L3_interfaces(ConfigBase):
         """
         commands = []
         state = self._module.params['state']
+
+        if state in ('merged', 'replaced', 'overridden') and not want:
+            self._module.fail_json(msg='value of config parameter must not be empty for state {0}'.format(state))
+
         if state == 'overridden':
             commands.extend(self._state_overridden(want=want, have=have))
 

--- a/test/integration/targets/vyos_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START vyos_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  vyos_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  vyos_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  vyos_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'

--- a/test/integration/targets/vyos_l3_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/vyos_l3_interfaces/tests/cli/empty_config.yaml
@@ -1,0 +1,36 @@
+---
+- debug:
+      msg: "START vyos_l3_interfaces empty_config integration tests on connection={{ ansible_connection }}"
+
+- name: Merged with empty config should give appropriate error message
+  vyos_l3_interfaces:
+    config:
+    state: merged
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state merged'
+
+- name: Replaced with empty config should give appropriate error message
+  vyos_l3_interfaces:
+    config:
+    state: replaced
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state replaced'
+
+- name: Overridden with empty config should give appropriate error message
+  vyos_l3_interfaces:
+    config:
+    state: overridden
+  register: result
+  ignore_errors: True
+
+- assert:
+    that:
+      - result.msg == 'value of config parameter must not be empty for state overridden'


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 67213ccb4dfb2b476e658323885d117c3c582c88)

Backport of https://github.com/ansible/ansible/pull/62520

Add changelog for vyos traceback fix

##### SUMMARY
- No more traceback on empty config when state is 'merged', 'replaced' or 'overridden'.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vyos_interfaces.py
vyos_l3_interfaces.py

