### PR TITLE
Make banner detection non-greedy in ios_banner

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -123,7 +123,7 @@ def map_config_to_obj(module):
                                     'show running-config | begin banner %s'
                                     % module.params['banner'])
         if out:
-            output = re.search(r'\^C(.*)\^C', out, re.S).group(1).strip()
+            output = re.search(r'\^C(.*?)\^C', out, re.S).group(1).strip()
         else:
             output = None
     obj = {'banner': module.params['banner'], 'state': 'absent'}

--- a/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
@@ -1,0 +1,55 @@
+---
+
+- name: Setup - set login and exec
+  ios_banner:
+    banner: "{{ item }}"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+  loop:
+    - login
+    - exec
+
+
+- name: Set login
+  ios_banner:
+    banner: "login"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "resut.commands | length == 0"
+
+- name: Set exec
+  ios_banner:
+    banner: "exec"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "resut.commands | length == 0"

--- a/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
@@ -32,7 +32,7 @@
 - assert:
     that:
       - "result.changed == false"
-      - "resut.commands | length == 0"
+      - "result.commands | length == 0"
 
 - name: Set exec
   ios_banner:
@@ -52,4 +52,4 @@
 - assert:
     that:
       - "result.changed == false"
-      - "resut.commands | length == 0"
+      - "result.commands | length == 0"

--- a/test/units/modules/network/ios/fixtures/ios_banner_show_running_config_ios12.txt
+++ b/test/units/modules/network/ios/fixtures/ios_banner_show_running_config_ios12.txt
@@ -1,0 +1,15 @@
+banner exec ^C
+this is a sample
+mulitline banner
+used for testing
+^C
+banner login ^C
+this is a sample
+mulitline banner
+used for testing
+^C
+!
+dummy
+end
+of
+config

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -60,3 +60,17 @@ class TestIosBannerModule(TestIosModule):
         banner_text = load_fixture('ios_banner_show_banner.txt').strip()
         set_module_args(dict(banner='login', text=banner_text))
         self.execute_module()
+
+class TestIosBannerIos12Module(TestIosBannerModule):
+
+    def load_fixtures(self, commands):
+        show_banner_return_value = (1, '', None)
+        show_running_config_return_value = \
+                (0, load_fixture('ios_banner_show_running_config_ios12.txt').strip(), None)
+        self.exec_command.side_effect = [show_banner_return_value, 
+                                         show_running_config_return_value]
+
+    def test_ios_banner_nochange(self):
+        banner_text = load_fixture('ios_banner_show_banner.txt').strip()
+        set_module_args(dict(banner='exec', text=banner_text))
+        self.execute_module()

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -61,13 +61,14 @@ class TestIosBannerModule(TestIosModule):
         set_module_args(dict(banner='login', text=banner_text))
         self.execute_module()
 
+
 class TestIosBannerIos12Module(TestIosBannerModule):
 
     def load_fixtures(self, commands):
         show_banner_return_value = (1, '', None)
         show_running_config_return_value = \
-                (0, load_fixture('ios_banner_show_running_config_ios12.txt').strip(), None)
-        self.exec_command.side_effect = [show_banner_return_value, 
+            (0, load_fixture('ios_banner_show_running_config_ios12.txt').strip(), None)
+        self.exec_command.side_effect = [show_banner_return_value,
                                          show_running_config_return_value]
 
     def test_ios_banner_nochange(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bug #63091 is caused because regex used in ios_banner is greedy.
If multiple banners are present in the configuration, a "show running-config | begin banner exec" will return the end of the configuration, including other configured banners.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #63091

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_banner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Only change is to make the regex that search for a banner non greedy (.*?)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See bug #63091 for reproducing the bug.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
