### PR TITLE
Corrected Get-adcomputer

### DIFF
--- a/changelogs/fragments/win_domain_computer-credential.yaml
+++ b/changelogs/fragments/win_domain_computer-credential.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_domain_computer - Honour the explicit domain server and credentials when moving or removing a computer object - https://github.com/ansible/ansible/pull/63093

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -147,7 +147,7 @@ Function Add-ConstructedState($desired_state) {
 # ------------------------------------------------------------------------------
 Function Remove-ConstructedState($initial_state) {
   Try {
-    Get-ADComputer -identity $initial_state.name -credential $credential |
+Get-ADComputer -Identity $initial_state.name @extra_args |
      Remove-ADObject `
       -Recursive `
       -Confirm:$False `

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -119,7 +119,7 @@ Function Set-ConstructedState($initial_state, $desired_state) {
             -WhatIf:$check_mode `
             @extra_args
     } Catch {
-      Fail-Json -obj $result -message "Failed to move the AD object $($initial_state.distinguished_name) to $($desired_state.distinguished_name) .Exception message: $($_.Exception.Message)"
+      Fail-Json -obj $result -message "Failed to move the AD object $($initial_state.distinguished_name) to $($desired_state.distinguished_name): $($_.Exception.Message)"
     }
   }
   $result.changed = $true
@@ -147,12 +147,12 @@ Function Add-ConstructedState($desired_state) {
 # ------------------------------------------------------------------------------
 Function Remove-ConstructedState($initial_state) {
   Try {
-Get-ADComputer -Identity $initial_state.name @extra_args |
-     Remove-ADObject `
-      -Recursive `
-      -Confirm:$False `
-      -WhatIf:$check_mode `
-      @extra_args
+    Get-ADComputer -Identity $initial_state.name @extra_args |
+      Remove-ADObject `
+        -Recursive `
+        -Confirm:$False `
+        -WhatIf:$check_mode `
+        @extra_args
   } Catch {
     Fail-Json -obj $result -message "Failed to remove the AD object $($desired_state.name): $($_.Exception.Message)"
   }

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -112,14 +112,14 @@ Function Set-ConstructedState($initial_state, $desired_state) {
   If ($initial_state.distinguished_name -cne $desired_state.distinguished_name) {
     # Move computer to OU
     Try {
-      Get-ADComputer -Identity $desired_state.name -credential $credential |
+      Get-ADComputer -Identity $desired_state.name @extra_args |
           Move-ADObject `
             -TargetPath $desired_state.ou `
             -Confirm:$False `
             -WhatIf:$check_mode `
             @extra_args
     } Catch {
-      Fail-Json -obj $result -message "Failed to move the AD object $($initial_state.distinguished_name) to $($desired_state.distinguished_name) OU: $($_.Exception.Message)"
+      Fail-Json -obj $result -message "Failed to move the AD object $($initial_state.distinguished_name) to $($desired_state.distinguished_name) .Exception message: $($_.Exception.Message)"
     }
   }
   $result.changed = $true

--- a/lib/ansible/modules/windows/win_domain_computer.ps1
+++ b/lib/ansible/modules/windows/win_domain_computer.ps1
@@ -112,14 +112,14 @@ Function Set-ConstructedState($initial_state, $desired_state) {
   If ($initial_state.distinguished_name -cne $desired_state.distinguished_name) {
     # Move computer to OU
     Try {
-      Get-ADComputer -Identity $desired_state.name |
+      Get-ADComputer -Identity $desired_state.name -credential $credential |
           Move-ADObject `
             -TargetPath $desired_state.ou `
             -Confirm:$False `
             -WhatIf:$check_mode `
             @extra_args
     } Catch {
-      Fail-Json -obj $result -message "Failed to move the AD object $($desired_state.name) to $($desired_state.ou) OU: $($_.Exception.Message)"
+      Fail-Json -obj $result -message "Failed to move the AD object $($initial_state.distinguished_name) to $($desired_state.distinguished_name) OU: $($_.Exception.Message)"
     }
   }
   $result.changed = $true
@@ -147,8 +147,8 @@ Function Add-ConstructedState($desired_state) {
 # ------------------------------------------------------------------------------
 Function Remove-ConstructedState($initial_state) {
   Try {
-    Get-ADComputer $initial_state.name `
-    | Remove-ADObject `
+    Get-ADComputer -identity $initial_state.name -credential $credential |
+     Remove-ADObject `
       -Recursive `
       -Confirm:$False `
       -WhatIf:$check_mode `


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Corrected Get-adcomputer on "Remove-ConstructedState" and "Set-ConstructedState" functions.
resolved error: Unable to contact the server. This may be because this server does not exist, it is currently down, or it does not have the Active Directory Web Services running.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_computer.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
