### PR TITLE
Backport 2.9: IOS-XR - Fix iosxr_lag_interfaces intermittent failures (#62998)

### DIFF
--- a/changelogs/fragments/62998-fix_iosxr_lag_interfaces_random_failures.yaml
+++ b/changelogs/fragments/62998-fix_iosxr_lag_interfaces_random_failures.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iosxr - Fix random idempotence issues with iosxr_lag_interfaces Resource Module (https://github.com/ansible/ansible/pull/62998).

--- a/lib/ansible/module_utils/network/iosxr/utils/utils.py
+++ b/lib/ansible/module_utils/network/iosxr/utils/utils.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.network.common.utils import is_masklen, to_netmask
+from ansible.module_utils.network.common.utils import dict_diff, is_masklen, to_netmask, search_obj_in_list
 
 
 def remove_command_from_config_list(interface, cmd, commands):
@@ -178,12 +178,13 @@ def diff_list_of_dicts(w, h):
         h = []
 
     diff = []
-    set_w = set(tuple(d.items()) for d in w)
-    set_h = set(tuple(d.items()) for d in h)
-    difference = set_w.difference(set_h)
-
-    for element in difference:
-        diff.append(dict((x, y) for x, y in element))
+    for w_item in w:
+        h_item = search_obj_in_list(w_item['member'], h, key='member') or {}
+        d = dict_diff(h_item, w_item)
+        if d:
+            if 'member' not in d.keys():
+                d['member'] = w_item['member']
+            diff.append(d)
 
     return diff
 


### PR DESCRIPTION
* Fix iosxr_lag_interfaces intermittent failures

*  If the dictionary is read out of order from member
   the current logic in `diff_list_of_dicts` returns
   unwanted diff. Hence use `dict_diff` utils
   function instead of sets.

Remove zip() to make existing tests happy

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

* Address review comments

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 69317a9d3e7286ca5419114b52ebe307aafd702b)

Add changelog for iosxr_lag_interfaces fix

##### SUMMARY
- Fixes random idempotence issues with iosxr_lag_interfaces Resource Module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
iosxr_lag_interfaces.py