### PR TITLE
Add docs on hiding sensitive data in loops

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -317,6 +317,8 @@ When looping over complex data structures, the console output of your task can b
 
 The output of this task will display just the ``name`` field for each ``item`` instead of the entire contents of the multi-line ``{{ item }}`` variable.
 
+.. note:: This is for making console output more readable, not protecting sensitive data. If there is sensitive data in ``loop``, set ``no_log: yes`` on the task to prevent disclosure.
+
 Pausing within a loop
 ---------------------
 .. versionadded:: 2.2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Clarify that `loop_control['label']` is not meant for protecting sensitive data and recommend using `no_log` on the task when sensitive data is contained in the loop items.

I'm not sure if we should make this more prominent somewhere on the loops page. I put it in the section that seemed to make the most sense, but we may want to lead with a warning about using sensitive data is loop items.

Another thing that would be good to add somewhere in the docs is the relationship between loop items and `no_log` module parameters. If an item in a loop is passed to a module parameter that is marked as `no_log` in the module argument_spec, that value will be hidden in the module invocation but _not_ in the loop items. This is by design, which is why the only way to protect sensitive data in loop items is to set `no_log: yes` on the entire task.

Related issues: #62642, #33912, #38214

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`docs/docsite/rst/user_guide/playbooks_loops.rst`