### PR TITLE
Fix: 'file' lookup plugin to work with Windows utf-16 encoded files.

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -2,7 +2,6 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
-
 __metaclass__ = type
 
 DOCUMENTATION = """

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -29,10 +29,6 @@ DOCUMENTATION = """
         description: encoding types of files to be read
         default: ['utf-8', 'utf-16']
         type: list
-      warnings:
-        description: display warnings for failed decodes
-        default: False
-        type: bool
     notes:
       - if read in variable context, the file can be interpreted as YAML if the content is valid to the parser.
       - this lookup does not understand 'globing', use the fileglob lookup instead.
@@ -41,7 +37,7 @@ DOCUMENTATION = """
 EXAMPLES = """
 - debug: msg="the value of foo.txt is {{lookup('file', '/etc/foo.txt') }}"
 
-- debug: msg="the value of foo.txt is {{ lookup('file', '/tmp/test.sql', encodings=['utf-8', 'utf-16', 'utf-32'], warnings=True) }}"
+- debug: msg="the value of foo.txt is {{ lookup('file', '/tmp/test.sql', encodings=['utf-8', 'utf-16', 'utf-32'] }}"
 
 - name: display multiple file contents
   debug: var=item
@@ -64,7 +60,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
-def attempt_decode(b_contents, encodings, warnings=False):
+def attempt_decode(b_contents, encodings):
     """
     Attempts to decode content using passed encoding types.
 
@@ -79,8 +75,6 @@ def attempt_decode(b_contents, encodings, warnings=False):
                                encoding=encoding,
                                errors='surrogate_or_strict')
         except UnicodeDecodeError as e:
-            if warnings:
-                display.warning(e)
             decode_errors.append(e.encoding)
         else:
             return contents
@@ -106,8 +100,7 @@ class LookupModule(LookupBase):
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
                     encodings = kwargs.get('encodings', ['utf-8', 'utf-16'])
-                    warnings = kwargs.get('warnings', False)
-                    contents = attempt_decode(b_contents, encodings, warnings=warnings)
+                    contents = attempt_decode(b_contents, encodings)
                     if kwargs.get('lstrip', False):
                         contents = contents.lstrip()
                     if kwargs.get('rstrip', True):

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -37,6 +37,8 @@ DOCUMENTATION = """
 EXAMPLES = """
 - debug: msg="the value of foo.txt is {{lookup('file', '/etc/foo.txt') }}"
 
+- debug: msg="the value of foo.txt is {{ lookup('file', '/tmp/test.sql', encoding='utf-16') }}"
+
 - name: display multiple file contents
   debug: var=item
   with_file:

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -74,7 +74,7 @@ class LookupModule(LookupBase):
             try:
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
-                    encoding = kwargs.get('encoding')
+                    encoding = kwargs.get('encoding', 'utf-8')
                     contents = to_text(b_contents, encoding=encoding, errors='surrogate_or_strict')
                     if kwargs.get('lstrip', False):
                         contents = contents.lstrip()

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -81,8 +81,7 @@ def attempt_decode(b_contents, encodings):
             return contents
 
     raise AnsibleError(
-        'Failed to decode file using [{encoding_types}] encoding types.'
-            .format(encoding_types=', '.join(decode_errors))
+        'Failed to decode file using [{encoding_types}] encoding types.'.format(encoding_types=', '.join(decode_errors))
     )
 
 

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -25,6 +25,10 @@ DOCUMENTATION = """
         type: bool
         required: False
         default: False
+      encoding:
+        description: encoding of files to be read
+        default: 'utf-8'
+        type: str
     notes:
       - if read in variable context, the file can be interpreted as YAML if the content is valid to the parser.
       - this lookup does not understand 'globing', use the fileglob lookup instead.
@@ -70,11 +74,8 @@ class LookupModule(LookupBase):
             try:
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
-                    try:
-                        contents = to_text(b_contents, errors='surrogate_or_strict')
-                    except UnicodeDecodeError:
-                        # Attempts utf-16 decode for files coming from Windows.
-                        contents = to_text(b_contents, encoding='utf-16', errors='surrogate_or_strict')
+                    encoding = kwargs.get('encoding')
+                    contents = to_text(b_contents, encoding=encoding, errors='surrogate_or_strict')
                     if kwargs.get('lstrip', False):
                         contents = contents.lstrip()
                     if kwargs.get('rstrip', True):

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -80,9 +80,10 @@ def attempt_decode(b_contents, encodings):
             return contents
 
     raise AnsibleError(
-          'Failed to decode file using [{encoding_types}] encoding types.'\
+          'Failed to decode file using [{encoding_types}] encoding types.'
           .format(encoding_types=', '.join(decode_errors))
     )
+
 
 class LookupModule(LookupBase):
 

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -2,6 +2,7 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -60,6 +61,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
+
 def attempt_decode(b_contents, encodings):
     """
     Attempts to decode content using passed encoding types.
@@ -68,20 +70,19 @@ def attempt_decode(b_contents, encodings):
 
     Returns decoded contetn.
     """
+
     decode_errors = list()
     for encoding in encodings:
         try:
-            contents = to_text(b_contents,
-                               encoding=encoding,
-                               errors='surrogate_or_strict')
+            contents = to_text(b_contents, encoding=encoding, errors='surrogate_or_strict')
         except UnicodeDecodeError as e:
             decode_errors.append(e.encoding)
         else:
             return contents
 
     raise AnsibleError(
-          'Failed to decode file using [{encoding_types}] encoding types.'
-          .format(encoding_types=', '.join(decode_errors))
+        'Failed to decode file using [{encoding_types}] encoding types.'
+            .format(encoding_types=', '.join(decode_errors))
     )
 
 

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -70,7 +70,11 @@ class LookupModule(LookupBase):
             try:
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
-                    contents = to_text(b_contents, errors='surrogate_or_strict')
+                    try:
+                        contents = to_text(b_contents, errors='surrogate_or_strict')
+                    except UnicodeDecodeError:
+                        # Attempts utf-16 decode for files coming from Windows.
+                        contents = to_text(b_contents, encoding='utf-16', errors='surrogate_or_strict')
                     if kwargs.get('lstrip', False):
                         contents = contents.lstrip()
                     if kwargs.get('rstrip', True):


### PR DESCRIPTION
Added exception handling to attempt a 'utf-16' decode on file as we were encountering errors using lookup on files coming from Windows systems.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added try/except block to handle decode error of files that originate from Windows. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1.) Take a utf-16 encoded file from a Windows system which has non-utf8 decodable characters in it and place it on a linux control node.
2.) Use a lookup plugin file to attempt to read the file from above step.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# BEFORE

PLAY [localhost] ***********************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ***************************************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'file'. Error was a <type 'exceptions.UnicodeDecodeError'>, original message: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte"}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

# AFTER

PLAY [localhost] ***********************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] ***************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "This is a test."
}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
