### PR TITLE
Fix plain format output functionality in validate-modules

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -171,12 +171,12 @@ class Reporter:
                 print('\n    '.join(('    %s' % trace).splitlines()))
             for error in report['errors']:
                 error['path'] = path
-                print('%(path)s:%(line)d:%(column)d: E%(code)d %(msg)s' % error)
+                print('%(path)s:%(line)d:%(column)d: E%(code)s %(msg)s' % error)
                 ret.append(1)
             if warnings:
                 for warning in report['warnings']:
                     warning['path'] = path
-                    print('%(path)s:%(line)d:%(column)d: W%(code)d %(msg)s' % warning)
+                    print('%(path)s:%(line)d:%(column)d: W%(code)s %(msg)s' % warning)
 
         return 3 if ret else 0
 


### PR DESCRIPTION
##### SUMMARY
When we switched from integer codes to string codes, the plain format output was not updated.

This is not used by ansible-test, only when calling directly, so I'm not sure we need to backport.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
