### PR TITLE
ansible-test handle systems without /bin/python

### DIFF
--- a/test/lib/ansible_test/_internal/venv.py
+++ b/test/lib/ansible_test/_internal/venv.py
@@ -95,6 +95,12 @@ def run_venv(args,  # type: EnvironmentConfig
         # we must use the real python to create a virtual environment with venv
         # attempting to use python from a virtualenv created virtual environment results in a copy of that environment instead
         run_python = os.path.join(real_prefix, 'bin', 'python')
+        if not os.path.exists(run_python):
+            py2_run_python = run_python
+            run_python = os.path.join(real_prefix, 'bin', 'python3')
+            if not os.path.exists(run_python):
+                display.error("Unable to find local python interpreter: %s or %s" % (py2_run_python, run_python))
+
 
     cmd = [run_python, '-m', 'venv']
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On a RHEL8 system with only the python36 module installed, there is no `/usr/bin/python`, this causes `ansible-test` to fail with the following message `ERROR: Required program "/usr/bin/python" not found.`

This patch adds a check for `/usr/bin/python3` to the `run_venv()` function internal to `ansible-test` when `/usr/bin/python` is not found.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test

