### PR TITLE
Pickle non-str objects to survive connection return

### DIFF
--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -155,7 +155,7 @@ class Connection(object):
         try:
             response = json.loads(out)
         except ValueError:
-            params = list(args) + ['{0}={1}'.format(k, v) for k, v in iteritems(kwargs)]
+            params = [repr(arg) for arg in args] + ['{0}={1!r}'.format(k, v) for k, v in iteritems(kwargs)]
             params = ', '.join(params)
             raise ConnectionError(
                 "Unable to decode JSON from response to {0}({1}). Received '{2}'.".format(name, params, out)

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -163,6 +163,8 @@ class Connection(object):
 
         if response['id'] != reqid:
             raise ConnectionError('invalid json-rpc id received')
+        if "result_type" in response:
+            response["result"] = cPickle.loads(to_bytes(response["result"]))
 
         return response
 

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -9,7 +9,8 @@ import traceback
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six import binary_type
+from ansible.module_utils.six import binary_type, text_type
+from ansible.module_utils.six.moves import cPickle
 from ansible.utils.display import Display
 
 display = Display()
@@ -67,7 +68,6 @@ class JsonRpcServer(object):
                     error = self.internal_error(data=to_text(exc, errors='surrogate_then_replace'))
                     response = json.dumps(error)
 
-
         delattr(self, '_identifier')
 
         return response
@@ -82,6 +82,9 @@ class JsonRpcServer(object):
         response = self.header()
         if isinstance(result, binary_type):
             result = to_text(result)
+        if not isinstance(result, text_type):
+            response["result_type"] = "pickle"
+            result = to_text(cPickle.dumps(result, protocol=0))
         response['result'] = result
         return response
 

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -60,7 +60,13 @@ class JsonRpcServer(object):
                 else:
                     response = self.response(result)
 
-                response = json.dumps(response)
+                try:
+                    response = json.dumps(response)
+                except Exception as exc:
+                    display.vvv(traceback.format_exc())
+                    error = self.internal_error(data=to_text(exc, errors='surrogate_then_replace'))
+                    response = json.dumps(error)
+
 
         delattr(self, '_identifier')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Objects which are not naively dumpable to JSON break ansible-connection RPC. This pickles any non-string to avoid this issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection