### PR TITLE
Find: Adding additional file_type options

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -363,7 +363,7 @@ def main():
             patterns=dict(type='list', default=['*'], aliases=['pattern']),
             excludes=dict(type='list', aliases=['exclude']),
             contains=dict(type='str'),
-            file_type=dict(type='str', default="file", choices=['any', 'directory', 'file', 'link']),
+            file_type=dict(type='str', default="file", choices=['any', 'block', 'char', 'directory', 'fifo', 'file', 'link', 'socket']),
             age=dict(type='str'),
             age_stamp=dict(type='str', default="mtime", choices=['atime', 'ctime', 'mtime']),
             size=dict(type='str'),

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -69,7 +69,7 @@ options:
             - Type of file to select.
             - The 'link' and 'any' choices were added in Ansible 2.3.
         type: str
-        choices: [ any, directory, file, link ]
+        choices: [ any, block, char, directory, fifo, file, link, socket ]
         default: file
     recurse:
         description:
@@ -440,7 +440,25 @@ def main():
                                 r['checksum'] = module.sha1(fsname)
                             filelist.append(r)
 
+                    elif stat.S_ISBLK(st.st_mode) and params['file_type'] == 'block':
+                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+
+                            r.update(statinfo(st))
+                            filelist.append(r)
+
+                    elif stat.S_ISCHR(st.st_mode) and params['file_type'] == 'char':
+                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+
+                            r.update(statinfo(st))
+                            filelist.append(r)
+
                     elif stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory':
+                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+
+                            r.update(statinfo(st))
+                            filelist.append(r)
+
+                    elif stat.S_ISFIFO(st.st_mode) and params['file_type'] == 'fifo':
                         if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))
@@ -457,6 +475,12 @@ def main():
                             filelist.append(r)
 
                     elif stat.S_ISLNK(st.st_mode) and params['file_type'] == 'link':
+                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+
+                            r.update(statinfo(st))
+                            filelist.append(r)
+
+                    elif stat.S_ISSOCK(st.st_mode) and params['file_type'] == 'socket':
                         if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -440,30 +440,6 @@ def main():
                                 r['checksum'] = module.sha1(fsname)
                             filelist.append(r)
 
-                    elif stat.S_ISBLK(st.st_mode) and params['file_type'] == 'block':
-                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
-
-                            r.update(statinfo(st))
-                            filelist.append(r)
-
-                    elif stat.S_ISCHR(st.st_mode) and params['file_type'] == 'char':
-                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
-
-                            r.update(statinfo(st))
-                            filelist.append(r)
-
-                    elif stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory':
-                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
-
-                            r.update(statinfo(st))
-                            filelist.append(r)
-
-                    elif stat.S_ISFIFO(st.st_mode) and params['file_type'] == 'fifo':
-                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
-
-                            r.update(statinfo(st))
-                            filelist.append(r)
-
                     elif stat.S_ISREG(st.st_mode) and params['file_type'] == 'file':
                         if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and \
                            agefilter(st, now, age, params['age_stamp']) and \
@@ -474,13 +450,7 @@ def main():
                                 r['checksum'] = module.sha1(fsname)
                             filelist.append(r)
 
-                    elif stat.S_ISLNK(st.st_mode) and params['file_type'] == 'link':
-                        if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
-
-                            r.update(statinfo(st))
-                            filelist.append(r)
-
-                    elif stat.S_ISSOCK(st.st_mode) and params['file_type'] == 'socket':
+                    elif params['file_type'] in ['block', 'char', 'directory', 'fifo', 'link', 'socket']:
                         if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -450,7 +450,12 @@ def main():
                                 r['checksum'] = module.sha1(fsname)
                             filelist.append(r)
 
-                    elif params['file_type'] in ['block', 'char', 'directory', 'fifo', 'link', 'socket']:
+                    elif ((stat.S_ISBLK(st.st_mode) and params['file_type'] == 'block') or
+                          (stat.S_ISCHR(st.st_mode) and params['file_type'] == 'char') or
+                          (stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory') or
+                          (stat.S_ISFIFO(st.st_mode) and params['file_type'] == 'fifo') or
+                          (stat.S_ISLNK(st.st_mode) and params['file_type'] == 'link') or
+                          (stat.S_ISSOCK(st.st_mode) and params['file_type'] == 'socket')):
                         if pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))


### PR DESCRIPTION
##### SUMMARY
For bare metal server deployments we need to validate certain block devices exist before continuing. Adding multiple file types from stat() for the find module to use.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
find

##### ADDITIONAL INFORMATION

