### PR TITLE
mysql_replication: add basic CI tests with MySQL 5.6

### DIFF
--- a/test/integration/targets/mysql_replication/aliases
+++ b/test/integration/targets/mysql_replication/aliases
@@ -1,0 +1,10 @@
+destructive
+shippable/posix/group4
+mysql_replication
+skip/osx
+skip/freebsd
+skip/ubuntu
+skip/fedora
+skip/opensuse
+skip/rhel
+needs/root

--- a/test/integration/targets/mysql_replication/aliases
+++ b/test/integration/targets/mysql_replication/aliases
@@ -1,6 +1,5 @@
 destructive
 shippable/posix/group4
-mysql_replication
 skip/osx
 skip/freebsd
 skip/ubuntu

--- a/test/integration/targets/mysql_replication/defaults/main.yml
+++ b/test/integration/targets/mysql_replication/defaults/main.yml
@@ -1,0 +1,6 @@
+master_port: 3306
+standby_port: 3307
+test_db: test_db
+replication_user: replication_user
+replication_pass: replication_pass
+dump_path: /tmp/dump.sql

--- a/test/integration/targets/mysql_replication/defaults/main.yml
+++ b/test/integration/targets/mysql_replication/defaults/main.yml
@@ -1,6 +1,7 @@
 master_port: 3306
 standby_port: 3307
 test_db: test_db
+test_table: test_table
 replication_user: replication_user
 replication_pass: replication_pass
 dump_path: /tmp/dump.sql

--- a/test/integration/targets/mysql_replication/meta/main.yml
+++ b/test/integration/targets/mysql_replication/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- setup_mysql_replication

--- a/test/integration/targets/mysql_replication/tasks/main.yml
+++ b/test/integration/targets/mysql_replication/tasks/main.yml
@@ -1,0 +1,6 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Initial CI tests of mysql_replication module
+- import_tasks: mysql_replication_initial.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -91,6 +91,10 @@
     echo "INSERT INTO {{ test_table }} (id) VALUES (1), (2), (3); FLUSH LOGS;" |
     mysql -P {{ master_port }} -h 127.0.0.1 {{ test_db }}
 
+- name: Small pause to be sure the bin log, which was flushed previously, reached the slave
+  pause:
+    seconds: 2
+
 # Test master log pos has been changed:
 - name: Get standby status
   mysql_replication:

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -1,0 +1,96 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Preparation:
+- name: Create user for replication
+  shell: "echo \"GRANT REPLICATION SLAVE ON *.* TO '{{ replication_user }}'@'localhost' IDENTIFIED BY '{{ replication_pass }}'; FLUSH PRIVILEGES;\" | mysql -P {{ master_port }} -h 127.0.0.1"
+
+- name: Create test database
+  mysql_db:
+    login_host: 127.0.0.1
+    login_port: '{{ master_port }}'
+    state: present
+    name: '{{ test_db }}'
+
+- name: Dump all databases from the master
+  shell: 'mysqldump -P {{ master_port }} -h 127.0.01 --all-databases --master-data=2 > {{ dump_path }}'
+
+- name: Restore the dump to the standby
+  shell: 'mysql -P {{ standby_port }} -h 127.0.0.1 < {{ dump_path }}'
+
+# Test getmaster mode:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+- assert:
+    that:
+    - master_status.Is_Master == true
+    - master_status.Position != 0
+    - master_status is not changed
+
+# Test changemaster mode:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["CHANGE MASTER TO MASTER_HOST='127.0.0.1',MASTER_USER='replication_user',MASTER_PASSWORD='********',MASTER_PORT=3306,MASTER_LOG_FILE='mysql-bin.000001',MASTER_LOG_POS={{ master_status.Position }}"]
+
+# Test startslave mode:
+- name: Start slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: startslave
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["START SLAVE"]
+
+# Test getslave mode:
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Is_Slave == true
+    - slave_status.Master_Host == '127.0.0.1'
+    - slave_status.Exec_Master_Log_Pos == master_status.Position
+    - slave_status.Master_Port == {{ master_port }}
+    - slave_status.Last_IO_Errno == 0
+    - slave_status.Last_IO_Error == ''
+    - slave_status is not changed
+
+# Test stopslave mode:
+- name: Stop slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["STOP SLAVE"]

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -83,10 +83,10 @@
     - slave_status is not changed
 
 # Create test table and add data to it:
-- name: Create user for replication
+- name: Create test table
   shell: "echo \"CREATE TABLE {{ test_table }} (id int);\" | mysql -P {{ master_port }} -h 127.0.0.1 {{ test_db }}"
 
-- name: Create user for replication
+- name: Insert data
   shell: >
     echo "INSERT INTO {{ test_table }} (id) VALUES (1), (2), (3); FLUSH LOGS;" |
     mysql -P {{ master_port }} -h 127.0.0.1 {{ test_db }}

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -82,6 +82,29 @@
     - slave_status.Last_IO_Error == ''
     - slave_status is not changed
 
+# Create test table and add data to it:
+- name: Create user for replication
+  shell: "echo \"CREATE TABLE {{ test_table }} (id int);\" | mysql -P {{ master_port }} -h 127.0.0.1 {{ test_db }}"
+
+- name: Create user for replication
+  shell: >
+    echo "INSERT INTO {{ test_table }} (id) VALUES (1), (2), (3); FLUSH LOGS;" |
+    mysql -P {{ master_port }} -h 127.0.0.1 {{ test_db }}
+
+# Test master log pos has been changed:
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+# master_status.Position is not actual and it has been changed by the prev step,
+# so slave_status.Exec_Master_Log_Pos must be different:
+- assert:
+    that:
+    - slave_status.Exec_Master_Log_Pos != master_status.Position
+
 # Test stopslave mode:
 - name: Stop slave
   mysql_replication:

--- a/test/integration/targets/setup_mysql_replication/defaults/main.yml
+++ b/test/integration/targets/setup_mysql_replication/defaults/main.yml
@@ -1,0 +1,10 @@
+repo_link: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
+repo_name: mysql-community
+
+master_port: 3306
+standby_port: 3307
+master_datadir: /var/lib/mysql_master
+standby_datadir: /var/lib/mysql_standby
+standby_logdir: /var/log/mysql_standby
+default_logdir: /var/log/mysql
+mysql_safe_err_log: /var/log/mysql/mysql_safe-err.log

--- a/test/integration/targets/setup_mysql_replication/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_replication/tasks/main.yml
@@ -1,0 +1,6 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Setup MySQL master-standby replication into one conteiner:
+- import_tasks: setup_mysql_cluster.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/setup_mysql_replication/tasks/setup_mysql_cluster.yml
+++ b/test/integration/targets/setup_mysql_replication/tasks/setup_mysql_cluster.yml
@@ -1,0 +1,69 @@
+# We run two servers listening different ports
+# to be able to check replication (one server for master, another for standby).
+
+- name: Install Repo
+  yum:
+    name: '{{ repo_link }}'
+
+- name: Install MySQL community server
+  yum:
+    name: mysql-community-server
+    #enablerepo: '{{ repo_name }}'
+
+- name: Create directories for standby
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: mysql
+    group: mysql
+  loop:
+  - "{{ master_datadir }}"
+  - "{{ standby_datadir }}"
+  - "{{ standby_logdir }}"
+  - "{{ default_logdir }}"
+
+- name: Copy cnf template
+  template:
+    src: my.cnf.j2
+    dest: /etc/my.cnf
+    owner: mysql
+    group: mysql
+    force: yes
+
+- name: Initialize DBs
+  shell: 'mysql_install_db --user=mysql --datadir={{ item }}'
+  loop:
+  - '{{ master_datadir }}'
+  - '{{ standby_datadir }}'
+
+- name: Start services
+  shell: 'mysqld_multi --log=/var/log/mysql/mysql.log start 1,2'
+
+- name: Pause
+  pause: seconds=3
+
+########### For painful debug uncomment the lines below ##
+#- name: DEBUG Check stratup log
+#  shell: cat /var/log/mysql/mysql.log
+
+#- name: DEBUG Check mysql_safe err log
+#  shell: cat '{{  mysql_safe_err_log }}'
+
+#- name: DEBUG Check processes
+#  shell: 'ps aux | grep mysqld | grep -v "grep\|root"'
+
+#- name: DEBUG
+#  yum: name=net-tools
+
+#- name: DEBUG
+#  shell: "netstat -ntpl"
+
+#- name: DEBUG
+#  shell: cat /etc/my.cnf
+##########################################################
+
+- name: Check connection to the master
+  shell: 'echo "SHOW DATABASES;" | mysql -P {{ master_port }} -h 127.0.0.1'
+
+- name: Check connection to the standby
+  shell: "echo \"SHOW VARIABLES LIKE '%version%';\" | mysql -P {{ standby_port }} -h 127.0.0.1"

--- a/test/integration/targets/setup_mysql_replication/templates/my.cnf.j2
+++ b/test/integration/targets/setup_mysql_replication/templates/my.cnf.j2
@@ -1,0 +1,34 @@
+[mysqld1]
+server_id           = 1
+port                = {{ master_port }}
+datadir             = {{ master_datadir }}
+socket              = {{ master_datadir }}/mysql.sock
+pid-file            = {{ master_datadir }}/mysql.pid
+mysqladmin          = /usr/bin/mysqladmin
+log_bin             = /var/log/mysql/mysql-bin.log
+sync_binlog         = 1
+binlog-format       = ROW
+innodb_flush_log_at_trx_commit  = 1
+
+[mysqld2]
+server_id           = 2
+port                = {{ standby_port }}
+socket              = /var/run/mysqld/mysqld_slave.sock
+pid-file            = /var/run/mysqld/mysqld_slave.pid
+datadir             = {{ standby_datadir }}
+log_bin             = {{ standby_logdir }}/mysql-bin.log
+relay-log           = {{ standby_logdir }}/relay-bin
+relay-log-index     = {{ standby_logdir }}/relay-bin.index
+master-info-file    = {{ standby_logdir }}/master.info
+relay-log-info-file = {{ standby_logdir }}/relay-log.info
+mysqladmin          = /usr/bin/mysqladmin
+
+[mysqld_multi]
+mysqld     = /usr/bin/mysqld_safe
+mysqladmin = /usr/bin/mysqladmin
+user       = multi_admin
+password   = multipass
+
+[mysqld_safe]
+log-error={{  mysql_safe_err_log }}
+pid-file=/var/run/mysql/mysql.pid


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add basic CI tests with MySQL 5.6, master-standby configuration in one container

it's needed for testing hanged PRs, e.g. https://github.com/ansible/ansible/pull/56767

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```mysql_replication```