### PR TITLE
Add spaces around {{ indicators.

### DIFF
--- a/lib/ansible/plugins/lookup/items.py
+++ b/lib/ansible/plugins/lookup/items.py
@@ -24,7 +24,7 @@ DOCUMENTATION = """
 EXAMPLES = """
 - name: "loop through list"
   debug:
-    msg: "An item: {{item}}"
+    msg: "An item: {{ item }}"
   with_items:
     - 1
     - 2
@@ -41,7 +41,7 @@ EXAMPLES = """
 
 - name: "loop through list from a variable"
   debug:
-    msg: "An item: {{item}}"
+    msg: "An item: {{ item }}"
   with_items: "{{ somelist }}"
 
 - name: more complex items to add several users


### PR DESCRIPTION
##### SUMMARY
The example looked a little less readable by not having spaces after `{{` and before `}}`. This commit should make the examples match [ansible-lint rule 206](https://github.com/ansible/ansible-lint/blob/master/lib/ansiblelint/rules/VariableHasSpacesRule.py)

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
