### PR TITLE
mysql_replication: add master_delay parameter

### DIFF
--- a/changelogs/fragments/63130-mysql_replication_add_master_delay_parameter.yml
+++ b/changelogs/fragments/63130-mysql_replication_add_master_delay_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``master_delay`` parameter (https://github.com/ansible/ansible/issues/51326).

--- a/test/integration/targets/mysql_replication/defaults/main.yml
+++ b/test/integration/targets/mysql_replication/defaults/main.yml
@@ -2,6 +2,7 @@ master_port: 3306
 standby_port: 3307
 test_db: test_db
 test_table: test_table
+test_master_delay: 60
 replication_user: replication_user
 replication_pass: replication_pass
 dump_path: /tmp/dump.sql

--- a/test/integration/targets/mysql_replication/tasks/main.yml
+++ b/test/integration/targets/mysql_replication/tasks/main.yml
@@ -1,9 +1,10 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Initial CI tests of mysql_replication module
+# Initial CI tests of mysql_replication module:
 - import_tasks: mysql_replication_initial.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'
 
+# Tests of master_delay parameter:
 - import_tasks: mysql_replication_master_delay.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mysql_replication/tasks/main.yml
+++ b/test/integration/targets/mysql_replication/tasks/main.yml
@@ -4,3 +4,6 @@
 # Initial CI tests of mysql_replication module
 - import_tasks: mysql_replication_initial.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'
+
+- import_tasks: mysql_replication_master_delay.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_master_delay.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_master_delay.yml
@@ -1,0 +1,44 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Test master_delay mode:
+- name: Run replication
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_delay: '{{ test_master_delay }}'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["CHANGE MASTER TO MASTER_DELAY=60"]
+
+# Auxiliary step:
+- name: Start slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: startslave
+  register: result
+
+# Check master_delay:
+- name: Get standby status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.SQL_Delay == {{ test_master_delay }}
+    - slave_status is not changed
+
+# Stop standby for further tests:
+- name: Stop slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add master_delay parameter

instead of https://github.com/ansible/ansible/pull/56767

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```mysql_replication```