### PR TITLE
Update sros_config.py

### DIFF
--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -114,7 +114,7 @@ options:
       - This argument specifies whether or not to collect all defaults
         when getting the remote device running config.  When enabled,
         the module will get the current config by issuing the command
-        C(show running-config all).
+        C(admin display-config detail).
     type: bool
     default: 'no'
     aliases: ['detail']


### PR DESCRIPTION
##### SUMMARY
"show running-config all" doesn't exist is SROS. Equivalent is "admin display-config detail"


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
To be consistent with SROS CLI


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
"show running-config all" is not a valid command for SROS:
*B:7750SR12# show running-config all
                         ^
Error: Invalid parameter.


```
