### PR TITLE
Fix #60633 - ec2.py cache inventory not working

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -157,6 +157,7 @@ These settings would produce a destination_format as the following:
 import sys
 import os
 import argparse
+import hashlib
 import re
 from time import time
 from copy import deepcopy
@@ -469,7 +470,7 @@ class Ec2Inventory(object):
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))
         if cache_id:
             cache_name = '%s-%s' % (cache_name, cache_id)
-        cache_name += '-' + str(abs(hash(__file__)))[1:7]
+        cache_name += '-' + hashlib.sha256(__file__.encode('ascii')).hexdigest()[1:7]
         self.cache_path_cache = os.path.join(cache_dir, "%s.cache" % cache_name)
         self.cache_path_index = os.path.join(cache_dir, "%s.index" % cache_name)
         self.cache_max_age = config.getint('ec2', 'cache_max_age')


### PR DESCRIPTION
##### SUMMARY

AWS Cache inventory was not working on python 3.7. When I take a look, I notice that the hash function was returning random integer. A friend of mine send me this link which is pretty interesting : https://stackoverflow.com/questions/27522626/hash-function-in-python-3-3-returns-different-results-between-sessions

Starting from 3.2.3, python hash default behaviour use randomization
Alternative is to set env variable PYTHONHASHSEED

More details here : https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHASHSEED

Thanks @cecileHBH for your participation

##### ISSUE TYPE

- Bugfix  #60633

##### COMPONENT NAME

Contrib
AWS ec2.py inventorr
