### PR TITLE
fix aruba_config examples

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -184,7 +184,7 @@ EXAMPLES = """
 - name: diff the running-config against a provided config
   aruba_config:
     diff_against: intended
-    intended: "{{ lookup('file', 'master.cfg') }}"
+    intended_config: "{{ lookup('file', 'master.cfg') }}"
 
 - name: configure interface settings
   aruba_config:


### PR DESCRIPTION
##### SUMMARY
Fix option to use with 'diff_against: intended'.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The option ’diff_against: intended’ uses is 'intended_config' instead of 'intended', and is listed on lines 312 and 408.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aruba_config.py

##### ADDITIONAL INFORMATION
```paste below

```
