### PR TITLE
ACMEAccount.get_request check status code value lower boundary

### DIFF
--- a/changelogs/fragments/63140-acme-fix-fetch-url-status-codes.yaml
+++ b/changelogs/fragments/63140-acme-fix-fetch-url-status-codes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ACME modules: make sure some connection errors are handled properly"

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -654,7 +654,7 @@ class ACMEAccount(object):
         else:
             result = content
 
-        if fail_on_error and info['status'] >= 400:
+        if fail_on_error and (info['status'] < 200 or info['status'] >= 400):
             raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], result))
         return result, info
 

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -587,6 +587,7 @@ class ACMEAccount(object):
                 'Content-Type': 'application/jose+json',
             }
             resp, info = fetch_url(self.module, url, data=data, headers=headers, method='POST')
+            _assert_fetch_url_success(resp, info)
             result = {}
             try:
                 content = resp.read()

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -431,8 +431,8 @@ def _assert_fetch_url_success(response, info, allow_redirect=False, allow_client
     if info['status'] < 0:
         raise ModuleFailException(msg="Failure downloading %s, %s" % (info['url'], info['msg']))
 
-    if (info['status'] >= 300 and info['status'] < 400 and not allow_redirect) or \
-       (info['status'] >= 400 and info['status'] < 500 and not allow_client_error) or \
+    if (300 <= info['status'] < 400 and not allow_redirect) or \
+       (400 <= info['status'] < 500 and not allow_client_error) or \
        (info['status'] >= 500 and not allow_server_error):
         raise ModuleFailException("ACME request failed: CODE: {0} MGS: {1} RESULT: {2}".format(info['status'], info['msg'], response))
 

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -426,6 +426,15 @@ def _sign_request_cryptography(module, payload64, protected64, key_data):
         "signature": nopad_b64(signature),
     }
 
+def _assert_fetch_url_success(response, info, allow_redirect=False, allow_client_error=True, allow_server_error=True):
+    if info['status'] < 0:
+        raise ModuleFailException(msg="Failure downloading %s, %s" % (url, to_native(e)))
+
+    if (info['status'] >= 300 and info['status'] < 400 and not allow_redirect) or \
+       (info['status'] >= 400 and info['status'] < 500 and not allow_client_error) or \
+       (info['status'] >= 500 and not allow_server_error):
+        raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], result))
+
 
 class ACMEDirectory(object):
     '''
@@ -660,16 +669,6 @@ class ACMEAccount(object):
         if fail_on_error and (info['status'] < 200 or info['status'] >= 400):
             raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], result))
         return result, info
-
-    def _assert_fetch_url_success(response, info, allow_redirect=False, allow_client_error=True, allow_server_error=True):
-        if info['status'] < 0:
-            raise ModuleFailException(msg="Failure downloading %s, %s" % (url, to_native(e)))
-
-        if (info['status'] >= 300 and info['status'] < 400 and not allow_redirect) or \
-		   (info['status'] >= 400 and info['status'] < 500 and not allow_client_error) or \
-		   (info['status'] >= 500 and not allow_server_error):
-            raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], result))
-
 
     def set_account_uri(self, uri):
         '''

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -426,14 +426,15 @@ def _sign_request_cryptography(module, payload64, protected64, key_data):
         "signature": nopad_b64(signature),
     }
 
+
 def _assert_fetch_url_success(response, info, allow_redirect=False, allow_client_error=True, allow_server_error=True):
     if info['status'] < 0:
-        raise ModuleFailException(msg="Failure downloading %s, %s" % (url, to_native(e)))
+        raise ModuleFailException(msg="Failure downloading %s, %s" % (info['url'], info['msg']))
 
     if (info['status'] >= 300 and info['status'] < 400 and not allow_redirect) or \
        (info['status'] >= 400 and info['status'] < 500 and not allow_client_error) or \
        (info['status'] >= 500 and not allow_server_error):
-        raise ModuleFailException("ACME request failed: CODE: {0} RESULT: {1}".format(info['status'], result))
+        raise ModuleFailException("ACME request failed: CODE: {0} MGS: {1} RESULT: {2}".format(info['status'], info['msg'], response))
 
 
 class ACMEDirectory(object):

--- a/lib/ansible/module_utils/acme.py
+++ b/lib/ansible/module_utils/acme.py
@@ -663,8 +663,7 @@ class ACMEAccount(object):
 
     def _assert_fetch_url_success(response, info, allow_redirect=False, allow_client_error=True, allow_server_error=True):
         if info['status'] < 0:
-            module.fail_json(msg="Failure downloading %s, %s" % (url, to_native(e)))
-            raise ModuleFailException
+            raise ModuleFailException(msg="Failure downloading %s, %s" % (url, to_native(e)))
 
         if (info['status'] >= 300 and info['status'] < 400 and not allow_redirect) or \
 		   (info['status'] >= 400 and info['status'] < 500 and not allow_client_error) or \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Any HTTP code below 200 cannot be considered a success, should be
handled like a failure instead.

This is particularly true for below zero status codes.

This change is required to avoid `ACMEAccount.get_request` to consider any HTTP status code below `400` to be a success. In #63139 status `-1` is returned due to a `.netrc` file permission error, but the function does not report it as an error.

Fixes #63139
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- module_utils/acme

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

