### PR TITLE
docker modules: improve return value list documentation

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_compose.py
+++ b/lib/ansible/modules/cloud/docker/docker_compose.py
@@ -328,6 +328,7 @@ services:
                   description: One or more commands to be executed in the container.
                   returned: success
                   type: list
+                  elements: str
                   example: ["postgres"]
               image:
                   description: Name of the image from which the container was built.
@@ -337,12 +338,13 @@ services:
               labels:
                   description: Meta data assigned to the container.
                   returned: success
-                  type: complex
+                  type: dict
                   example: {...}
               networks:
                   description: Contains a dictionary for each network to which the container is a member.
                   returned: success
-                  type: complex
+                  type: list
+                  elements: dict
                   contains:
                       IPAddress:
                           description: The IP address assigned to the container.
@@ -358,6 +360,7 @@ services:
                           description: Aliases assigned to the container by the network.
                           returned: success
                           type: list
+                          elements: str
                           example: ['db']
                       globalIPv6:
                           description: IPv6 address assigned to the container.
@@ -373,6 +376,7 @@ services:
                           description: List of container names to which this container is linked.
                           returned: success
                           type: list
+                          elements: str
                           example: null
                       macAddress:
                           description: Mac Address assigned to the virtual NIC.
@@ -382,7 +386,7 @@ services:
               state:
                   description: Information regarding the current disposition of the container.
                   returned: success
-                  type: complex
+                  type: dict
                   contains:
                       running:
                           description: Whether or not the container is up with a running process.
@@ -436,6 +440,7 @@ actions:
                   description: A descriptive name of the action to be performed on the service's containers.
                   returned: always
                   type: list
+                  elements: str
                   contains:
                       id:
                           description: the container's long ID

--- a/lib/ansible/modules/cloud/docker/docker_host_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_info.py
@@ -155,6 +155,7 @@ volumes:
         See description for I(verbose_output).
     returned: When I(volumes) is C(yes)
     type: list
+    elements: dict
 networks:
     description:
       - List of dict objects containing the basic information about each network.
@@ -162,6 +163,7 @@ networks:
         See description for I(verbose_output).
     returned: When I(networks) is C(yes)
     type: list
+    elements: dict
 containers:
     description:
       - List of dict objects containing the basic information about each container.
@@ -169,6 +171,7 @@ containers:
         See description for I(verbose_output).
     returned: When I(containers) is C(yes)
     type: list
+    elements: dict
 images:
     description:
       - List of dict objects containing the basic information about each image.
@@ -176,6 +179,7 @@ images:
         See description for I(verbose_output).
     returned: When I(images) is C(yes)
     type: list
+    elements: dict
 disk_usage:
     description:
       - Information on summary disk usage by images, containers and volumes on docker host

--- a/lib/ansible/modules/cloud/docker/docker_image_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_info.py
@@ -79,6 +79,7 @@ images:
       - The list only contains inspection results of images existing locally.
     returned: always
     type: list
+    elements: dict
     sample: [
         {
             "Architecture": "amd64",

--- a/lib/ansible/modules/cloud/docker/docker_node_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_node_info.py
@@ -86,6 +86,7 @@ nodes:
         managers and nodes that are unreachable.
     returned: always
     type: list
+    elements: dict
 '''
 
 import traceback

--- a/lib/ansible/modules/cloud/docker/docker_prune.py
+++ b/lib/ansible/modules/cloud/docker/docker_prune.py
@@ -124,6 +124,7 @@ containers:
       - List of IDs of deleted containers.
     returned: I(containers) is C(true)
     type: list
+    elements: str
     sample: '[]'
 containers_space_reclaimed:
     description:
@@ -138,6 +139,7 @@ images:
       - List of IDs of deleted images.
     returned: I(images) is C(true)
     type: list
+    elements: str
     sample: '[]'
 images_space_reclaimed:
     description:
@@ -152,6 +154,7 @@ networks:
       - List of IDs of deleted networks.
     returned: I(networks) is C(true)
     type: list
+    elements: str
     sample: '[]'
 
 # volumes
@@ -160,6 +163,7 @@ volumes:
       - List of IDs of deleted volumes.
     returned: I(volumes) is C(true)
     type: list
+    elements: str
     sample: '[]'
 volumes_space_reclaimed:
     description:

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -236,12 +236,12 @@ RETURN = '''
 swarm_facts:
   description: Informations about swarm.
   returned: success
-  type: complex
+  type: dict
   contains:
       JoinTokens:
           description: Tokens to connect to the Swarm.
           returned: success
-          type: complex
+          type: dict
           contains:
               Worker:
                   description: Token to create a new *worker* node
@@ -264,6 +264,7 @@ actions:
   description: Provides the actions done on the swarm.
   returned: when action failed.
   type: list
+  elements: str
   example: "['This cluster is already a swarm cluster']"
 
 '''

--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -175,6 +175,7 @@ nodes:
         See description for I(verbose_output).
     returned: When I(nodes) is C(yes)
     type: list
+    elements: dict
 services:
     description:
       - List of dict objects containing the basic information about each volume.
@@ -182,6 +183,7 @@ services:
         See description for I(verbose_output).
     returned: When I(services) is C(yes)
     type: list
+    elements: dict
 tasks:
     description:
       - List of dict objects containing the basic information about each volume.
@@ -189,6 +191,7 @@ tasks:
         See description for I(verbose_output).
     returned: When I(tasks) is C(yes)
     type: list
+    elements: dict
 
 '''
 

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -901,6 +901,7 @@ changes:
   description:
     - List of changed service attributes if a service has been altered, [] otherwise.
   type: list
+  elements: str
   sample: ['container_labels', 'replicas']
 rebuilt:
   returned: always


### PR DESCRIPTION
##### SUMMARY
This is the part of #62179 which isn't possible with current module documentation mechanism. It adds elements: fields to type: list return value documentations.

Sibling to #62929.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_compose
docker_host_info
docker_image_info
docker_node_info
docker_prune
docker_swarm
docker_swarm_info
