### PR TITLE
CentOS8/RHEL8 base don't have all the deps we were specifying

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -63,10 +63,11 @@ BuildRequires: python3-pytest
 BuildRequires: python3-pytest-xdist
 BuildRequires: python3-pytest-mock
 BuildRequires: python3-requests
-BuildRequires: python3-coverage
+BUildRequires: %{py3_dist coverage}
 BuildRequires: python3-mock
-BuildRequires: python3-boto3
-BuildRequires: python3-botocore
+# Not available in RHEL8, we'll just skip the tests where they apply
+#BuildRequires: python3-boto3
+#BuildRequires: python3-botocore
 BuildRequires: python3-systemd
 
 BuildRequires: git-core


### PR DESCRIPTION
We used a few packages for tests which don't exist in RHEL8 base.  Don't
dep on those so those tests will simply skip

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
packaging/rpm/ansible.spec
