### PR TITLE
[ec2_launch_template] Update description of state param

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -44,10 +44,8 @@ options:
     default: latest
   state:
     description:
-    - Whether the launch template should exist or not. To delete only a
-      specific version of a launch template, combine I(state=absent) with
-      the I(version) option. By default, I(state=absent) will remove all
-      versions of the template.
+    - Whether the launch template should exist or not.
+    - Deleting specific versions of a launch template is not supported at this time.
     choices: [present, absent]
     default: present
   block_device_mappings:


### PR DESCRIPTION
##### SUMMARY
Currently, it is not possible to delete specific versions of an ec2 launch template. The module docs incorrectly suggest that there is a `version` param to the module that can be used to do that. This patch aims to correct that error.

Related to #59303

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
ec2_launch_template

