### PR TITLE
azure_rm_keyvaultkey_info: show_deleted_key error fix

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvaultkey_info.py
@@ -435,7 +435,7 @@ class AzureRMKeyVaultKeyInfo(AzureRMModuleBase):
 
         results = []
         try:
-            response = self._client.get_deleted_keys(vault_base_url=self.vault)
+            response = self._client.get_deleted_keys(vault_base_url=self.vault_uri)
             self.log("Response : {0}".format(response))
 
             if response:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #63156 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_keyvaultkey_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Traceback (most recent call last):
  File "azure_rm_keyvaultkey_info.py", line 456, in <module>
    main()
  File "azure_rm_keyvaultkey_info.py", line 452, in main
    AzureRMKeyVaultKeyInfo()
  File "azure_rm_keyvaultkey_info.py", line 281, in __init__
    supports_tags=False)
  File "/Users/imjoseangel/.pyenv/versions/3.7.4/Python.framework/Versions/3.7/lib/python3.7/site-packages/ansible/module_utils/azure_rm_common.py", line 325, in __init__
    res = self.exec_module(**self.module.params)
  File "azure_rm_keyvaultkey_info.py", line 302, in exec_module
    self.results['keys'] = self.list_deleted_keys()
  File "azure_rm_keyvaultkey_info.py", line 438, in list_deleted_keys
    response = self._client.get_deleted_keys(vault_base_url=self.vault)
AttributeError: 'AzureRMKeyVaultKeyInfo' object has no attribute 'vault'
```

```after
{"changed": false, "keys": [], "invocation": {"module_args": {"vault_uri": "https://daplatform0101lkv.vault.azure.net/", "show_deleted_key": true, "cloud_environment": "AzureCloud", "api_profile": "latest", "version": "current", "auth_source": null, "profile": null, "subscription_id": null, "client_id": null, "secret": null, "tenant": null, "ad_user": null, "password": null, "cert_validation_mode": null, "adfs_authority_url": null, "name": null, "tags": null}}}
```
