### PR TITLE
Add extra args and executable name to podman connection plugin

### DIFF
--- a/changelogs/fragments/63166-add-extra-args-executalbe-podman-connection.yaml
+++ b/changelogs/fragments/63166-add-extra-args-executalbe-podman-connection.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - podman connection - add extra arguments to podman command and support configurable executable
+  - podman connection - allow to add extra arguments to podman command and to configure the executable.

--- a/changelogs/fragments/63166-add-extra-args-executalbe-podman-connection.yaml
+++ b/changelogs/fragments/63166-add-extra-args-executalbe-podman-connection.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - podman connection - add extra arguments to podman command and support configurable executable

--- a/lib/ansible/plugins/connection/podman.py
+++ b/lib/ansible/plugins/connection/podman.py
@@ -10,6 +10,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import distutils.spawn
 import shlex
 import shutil
 import subprocess
@@ -48,6 +49,25 @@ DOCUMENTATION = """
           - name: ANSIBLE_REMOTE_USER
         vars:
           - name: ansible_user
+      podman_extra_args:
+        description:
+          - Extra arguments to pass to the podman command line.
+        default: ''
+        ini:
+          - section: defaults
+            key: podman_extra_args
+        vars:
+          - name: ansible_podman_extra_args
+        env:
+          - name: ANSIBLE_PODMAN_EXTRA_ARGS
+      podman_executable:
+        description:
+          - Executable for podman command.
+        default: podman
+        vars:
+          - name: ansible_podman_executable
+        env:
+          - name: ANSIBLE_PODMAN_EXECUTABLE
 """
 
 
@@ -79,7 +99,17 @@ class Connection(ConnectionBase):
         :param in_data: data passed to podman's stdin
         :return: return code, stdout, stderr
         """
-        local_cmd = ['podman', cmd]
+        podman_exec = self.get_option('podman_executable')
+        podman_cmd = distutils.spawn.find_executable(podman_exec)
+        if not podman_cmd:
+            raise AnsibleError("%s command not found in PATH" % podman_exec)
+        local_cmd = [podman_cmd]
+        if self.get_option('podman_extra_args'):
+            local_cmd += shlex.split(
+                to_native(
+                    self.get_option('podman_extra_args'),
+                    errors='surrogate_or_strict'))
+        local_cmd.append(cmd)
         if use_container_id:
             local_cmd.append(self._container_id)
         if cmd_args:

--- a/test/integration/targets/connection_podman/runme.sh
+++ b/test/integration/targets/connection_podman/runme.sh
@@ -5,3 +5,10 @@ set -eux
 ./posix.sh "$@"
 
 ANSIBLE_REMOTE_TMP="/tmp" ANSIBLE_REMOTE_USER="1000" ./posix.sh "$@"
+ANSIBLE_PODMAN_EXECUTABLE=fakepodman ./posix.sh "$@" 2>&1 | grep "fakepodman command not found in PATH"
+
+ANSIBLE_PODMAN_EXECUTABLE=fakepodman ./posix.sh "$@" && {
+    echo "Playbook with fakepodman should fail!"
+    exit 1
+}
+ANSIBLE_VERBOSITY=4 ANSIBLE_PODMAN_EXTRA_ARGS=" --log-level debug " ./posix.sh "$@" | grep "level=debug msg="


### PR DESCRIPTION
##### SUMMARY
Like there is for docker plugin, add extra arguments for command
line of podman. Also add configurable executable and checking if
this executable exists on host. Fail module if executable is not
in PATH.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-podman connection plugin

##### ADDITIONAL INFORMATION
These settings allow to set podman command arguments like:
```yaml
hosts: container
connection: podman
vars:
    ansible_podman_extra_args: --log-level debug
tasks:
    - ...
```
Also when `podman-remote cp` will be implemented[1] for varlink interface, we can use it for remote containers execution like it's possible with docker plugin:

```yaml
hosts: container
connection: podman
vars:
    ansible_podman_executable: podman-remote
    ansible_podman_extra_args: --username user --remote-host 4.4.4.4
tasks:
    - ...
```
[1] https://github.com/containers/libpod/issues/4207