### PR TITLE
checks if tags_dict exists and has data before using it. 

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -465,8 +465,9 @@ def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value
     """
 
     tags_list = []
-    for k, v in tags_dict.items():
-        tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
+    if bool(tags_dict):
+        for k, v in tags_dict.items():
+            tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
 
     return tags_list
 


### PR DESCRIPTION
##### SUMMARY
Checks if tags_dict was provided either as an empty dictionary or not provided at all (NoneType) before trying to access its items

Fixes #58821

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2 module_utils


