### PR TITLE
mariadb_replication / mysql_replication integration tests: conflicts on centos7

### DIFF
--- a/test/integration/targets/mariadb_replication/aliases
+++ b/test/integration/targets/mariadb_replication/aliases
@@ -1,5 +1,6 @@
 destructive
 shippable/posix/group2
+# Make sure that this test runs in a different group than mysql_replication!
 mysql_replication
 skip/osx
 skip/freebsd

--- a/test/integration/targets/mariadb_replication/aliases
+++ b/test/integration/targets/mariadb_replication/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group4
+shippable/posix/group2
 mysql_replication
 skip/osx
 skip/freebsd

--- a/test/integration/targets/mysql_replication/aliases
+++ b/test/integration/targets/mysql_replication/aliases
@@ -1,5 +1,6 @@
 destructive
 shippable/posix/group4
+# Make sure that this test runs in a different group than mariadb_replication!
 skip/osx
 skip/freebsd
 skip/ubuntu


### PR DESCRIPTION
##### SUMMARY
When both the mariadb_replication and mysql_replication tests are run, they fail on CentOS 7 (see [here](https://app.shippable.com/github/ansible/ansible/runs/145560/106/tests)). This moves the mariadb_replication test to POSIX group 2 (the mysql_replication test runs in group 4) to avoid this problem.

Thanks to @Andersson007 for suggesting this.

CC @mattclay 

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
mariadb_replication
mysql_replication
