### PR TITLE
nsupdate: Use provided TSIG key for all queries

### DIFF
--- a/changelogs/fragments/63174-nsupdate-tsig-all-the-queries.yaml
+++ b/changelogs/fragments/63174-nsupdate-tsig-all-the-queries.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - nsupdate - Use provided TSIG key to not only sign update queries but also lookup queries


### PR DESCRIPTION
##### SUMMARY

In addition to signing update queries also use the TSIG key to sign
lookup queries. By doing that we allow a hidden master to not only to
be looked down network wise, but also TSIG wise.

A bonus benefit of threating update queries and lookup queries more
the same is that will allow for all queries to be refactored into a
shared helper method. Currently we have a bit too much duplicated code
within the module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nsupdate