### PR TITLE
[2.9] Fix typo in vmware_content_deploy_template docs

### DIFF
--- a/changelogs/fragments/vmware_content_deploy_typo_fix.yml
+++ b/changelogs/fragments/vmware_content_deploy_typo_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Fixing typo mistake in testbed with section. Deploy template from content library is supported from 67U3 (https://github.com/ansible/ansible/issues/62957).

--- a/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
@@ -25,7 +25,7 @@ version_added: '2.9'
 author:
 - Pavan Bidkar (@pgbidkar)
 notes:
-- Tested on vSphere 6.5, 6.7
+- Tested on vSphere 6.7 U3
 requirements:
 - python >= 2.6
 - PyVmomi


### PR DESCRIPTION
##### SUMMARY
Fixing typo mistake in testbed with section.
Deploy template from content library is supported from 67U3.

(cherry picked from commit c6c13b56260565dd0ae6cfdbfad3c4191e2a0a5d)

Backport of https://github.com/ansible/ansible/pull/62965

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_content_deploy_typo_fix.yml
lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py