### PR TITLE
mysql_info: add support for global status

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -25,8 +25,8 @@ options:
   filter:
     description:
     - Limit the collected information by comma separated string or YAML list.
-    - Allowable values are C(version), C(databases), C(settings), C(users),
-      C(slave_status), C(slave_hosts), C(master_status), C(engines).
+    - Allowable values are C(version), C(databases), C(settings), C(global_status),
+      C(users), C(engines), C(master_status), C(slave_status), C(slave_hosts).
     - By default, collects all subsets.
     - You can use '!' before value (for example, C(!settings)) to exclude it from the information.
     - If you pass including and excluding values to the filter, for example, I(filter=!settings,version),
@@ -128,6 +128,12 @@ settings:
   type: dict
   sample:
   - { "innodb_open_files": 300, innodb_page_size": 16384 }
+global_status:
+  description: Global status information.
+  returned: if not excluded by filter
+  type: dict
+  sample:
+  - { "Innodb_buffer_pool_read_requests": 123, "Innodb_buffer_pool_reads": 32 }
 users:
   description: Users information.
   returned: if not excluded by filter
@@ -202,6 +208,7 @@ class MySQL_Info(object):
             'version': {},
             'databases': {},
             'settings': {},
+            'global_status': {},
             'engines': {},
             'users': {},
             'master_status': {},
@@ -254,6 +261,7 @@ class MySQL_Info(object):
         """Collect all possible subsets."""
         self.__get_databases()
         self.__get_global_variables()
+        self.__get_global_status()
         self.__get_engines()
         self.__get_users()
         self.__get_master_status()
@@ -305,6 +313,14 @@ class MySQL_Info(object):
                 minor=int(ver[1]),
                 release=int(release),
             )
+
+    def __get_global_status(self):
+        """Get global status."""
+        res = self.__exec_sql('SHOW GLOBAL STATUS')
+
+        if res:
+            for var in res:
+                self.info['global_status'][var['Variable_name']] = self.__convert(var['Value'])
 
     def __get_master_status(self):
         """Get master status if the instance is a master."""

--- a/test/integration/targets/mysql_info/tasks/main.yml
+++ b/test/integration/targets/mysql_info/tasks/main.yml
@@ -43,6 +43,7 @@
     - result.changed == false
     - result.version != {}
     - result.settings != {}
+    - result.global_status != {}
     - result.databases != {}
     - result.engines != {}
     - result.users != {}
@@ -92,6 +93,7 @@
     that:
     - result.changed == false
     - result.version != {}
+    - result.global_status != {}
     - result.databases != {}
     - result.engines != {}
     - result.settings is not defined
@@ -114,4 +116,5 @@
     - result.databases != {}
     - result.engines is not defined
     - result.settings is not defined
+    - result.global_status is not defined
     - result.users is not defined


### PR DESCRIPTION
##### SUMMARY
This allows the mysql_info module to also include the output of `SHOW GLOBAL STATUS`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mysql_info

##### ADDITIONAL INFORMATION
For my specific use case, we are checking whether the global status `wsrep_local_state_comment` is equal to `Synced`, after adding a node to galera replication.