### PR TITLE
Ovirt add template timeout error

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -376,11 +376,11 @@ EXAMPLES = '''
 
 # Import template
 - ovirt_template:
-  state: imported
-  name: mytemplate
-  export_domain: myexport
-  storage_domain: mystorage
-  cluster: mycluster
+    state: imported
+    name: mytemplate
+    export_domain: myexport
+    storage_domain: mystorage
+    cluster: mycluster
 
 # Remove template
 - ovirt_template:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_template.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_template.py
@@ -1022,6 +1022,8 @@ def main():
                 template = templates_module.wait_for_import(
                     condition=lambda t: t.status == otypes.TemplateStatus.OK
                 )
+                if template is None:
+                    raise TimeoutError("Image/template '%s' could not be imported. Try again with larger timeout." % template_name)
                 ret = templates_module.create(result_state=otypes.TemplateStatus.OK)
                 ret = {
                     'changed': True,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ovirt add template timeout error while importing large image from glance.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
https://bugzilla.redhat.com/show_bug.cgi?id=1755487
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
