### PR TITLE
[stable-2.9 backport] ansible-galaxy automation-hub authentication support (#63031)

### DIFF
--- a/changelogs/fragments/ansible-galaxy-support-for-automation-hub.yml
+++ b/changelogs/fragments/ansible-galaxy-support-for-automation-hub.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - Fix https://github.com/ansible/galaxy-dev/issues/96
+    Add support for automation-hub authentication to ansible-galaxy
+minor_changes:
+  - Add 'auth_url' field to galaxy server config stanzas in ansible.cfg
+    The url should point to the token_endpoint of a Keycloak server.

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -132,7 +132,12 @@ following entries like so:
 .. code-block:: ini
 
     [galaxy]
-    server_list = my_org_hub, release_galaxy, test_galaxy
+    server_list = automation_hub, my_org_hub, release_galaxy, test_galaxy
+
+    [galaxy_server.automation_hub]
+    url=https://ci.cloud.redhat.com/api/automation-hub/
+    auth_url=https://sso.qa.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+    token=my_token
 
     [galaxy_server.my_org_hub]
     url=https://automation.my_org/
@@ -165,6 +170,7 @@ define the following keys:
 * ``token``: A token key to use for authentication against the Galaxy instance, this is mutually exclusive with ``username``
 * ``username``: The username to use for basic authentication against the Galaxy instance, this is mutually exclusive with ``token``
 * ``password``: The password to use for basic authentication
+* ``auth_url``: The URL of a Keycloak server 'token_endpoint' if using SSO auth (Automation Hub for ex). This is mutually exclusive with ``username``. ``auth_url`` requires ``token``.
 
 As well as being defined in the ``ansible.cfg`` file, these server options can be defined as an environment variable.
 The environment variable is in the form ``ANSIBLE_GALAXY_SERVER_{{ id }}_{{ key }}`` where ``{{ id }}`` is the upper

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -26,7 +26,7 @@ from ansible.galaxy.collection import build_collection, install_collections, pub
     validate_collection_name
 from ansible.galaxy.login import GalaxyLogin
 from ansible.galaxy.role import GalaxyRole
-from ansible.galaxy.token import GalaxyToken, NoTokenSentinel
+from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.parsing.yaml.loader import AnsibleLoader
@@ -314,7 +314,8 @@ class GalaxyCLI(CLI):
                 ],
                 'required': required,
             }
-        server_def = [('url', True), ('username', False), ('password', False), ('token', False)]
+        server_def = [('url', True), ('username', False), ('password', False), ('token', False),
+                      ('auth_url', False)]
 
         config_servers = []
         for server_key in (C.GALAXY_SERVER_LIST or []):
@@ -325,8 +326,28 @@ class GalaxyCLI(CLI):
             C.config.initialize_plugin_configuration_definitions('galaxy_server', server_key, defs)
 
             server_options = C.config.get_plugin_options('galaxy_server', server_key)
+            # auth_url is used to create the token, but not directly by GalaxyAPI, so
+            # it doesn't need to be passed as kwarg to GalaxyApi
+            auth_url = server_options.pop('auth_url', None)
             token_val = server_options['token'] or NoTokenSentinel
-            server_options['token'] = GalaxyToken(token=token_val)
+            username = server_options['username']
+
+            # default case if no auth info is provided.
+            server_options['token'] = None
+
+            if username:
+                server_options['token'] = BasicAuthToken(username,
+                                                         server_options['password'])
+            else:
+                if token_val:
+                    if auth_url:
+                        server_options['token'] = KeycloakToken(access_token=token_val,
+                                                                auth_url=auth_url,
+                                                                validate_certs=not context.CLIARGS['ignore_certs'])
+                    else:
+                        # The galaxy v1 / github / django / 'Token'
+                        server_options['token'] = GalaxyToken(token=token_val)
+
             config_servers.append(GalaxyAPI(self.galaxy, server_key, **server_options))
 
         cmd_server = context.CLIARGS['api_server']

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import base64
 import json
 import os
 import tarfile
@@ -42,16 +41,7 @@ def g_connect(versions):
                 n_url = _urljoin(self.api_server, 'api')
                 error_context_msg = 'Error when finding available api versions from %s (%s)' % (self.name, n_url)
 
-                try:
-                    data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg)
-                except GalaxyError as e:
-                    if e.http_code != 401:
-                        raise
-
-                    # Assume this is v3 (Automation Hub) and auth is required
-                    headers = {}
-                    self._add_auth_token(headers, n_url, token_type='Bearer', required=True)
-                    data = self._call_galaxy(n_url, headers=headers, method='GET', error_context_msg=error_context_msg)
+                data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg)
 
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.
@@ -170,7 +160,7 @@ class GalaxyAPI:
         try:
             display.vvvv("Calling Galaxy at %s" % url)
             resp = open_url(to_native(url), data=args, validate_certs=self.validate_certs, headers=headers,
-                            method=method, timeout=20, unredirected_headers=['Authorization'])
+                            method=method, timeout=20)
         except HTTPError as e:
             raise GalaxyError(e, error_context_msg)
         except Exception as e:
@@ -190,22 +180,12 @@ class GalaxyAPI:
         if 'Authorization' in headers:
             return
 
-        token = self.token.get() if self.token else None
-
-        # 'Token' for v2 api, 'Bearer' for v3 but still allow someone to override the token if necessary.
-        is_v3 = 'v3' in url.split('/')
-        token_type = token_type or ('Bearer' if is_v3 else 'Token')
-
-        if token:
-            headers['Authorization'] = '%s %s' % (token_type, token)
-        elif self.username:
-            token = "%s:%s" % (to_text(self.username, errors='surrogate_or_strict'),
-                               to_text(self.password, errors='surrogate_or_strict', nonstring='passthru') or '')
-            b64_val = base64.b64encode(to_bytes(token, encoding='utf-8', errors='surrogate_or_strict'))
-            headers['Authorization'] = 'Basic %s' % to_text(b64_val)
-        elif required:
+        if not self.token and required:
             raise AnsibleError("No access token or username set. A token can be set with --api-key, with "
                                "'ansible-galaxy login', or set in ansible.cfg.")
+
+        if self.token:
+            headers.update(self.token.headers())
 
     @g_connect(['v1'])
     def authenticate(self, github_token):

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -152,7 +152,8 @@ class CollectionRequirement:
             download_url = self._metadata.download_url
             artifact_hash = self._metadata.artifact_sha256
             headers = {}
-            self.api._add_auth_token(headers, download_url)
+            self.api._add_auth_token(headers, download_url, required=False)
+
             self.b_path = _download_file(download_url, b_temp_path, artifact_hash, self.api.validate_certs,
                                          headers=headers)
 

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -21,13 +21,16 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import base64
 import os
+import json
 from stat import S_IRUSR, S_IWUSR
 
 import yaml
 
 from ansible import constants as C
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
 
 display = Display()
@@ -39,8 +42,61 @@ class NoTokenSentinel(object):
         return cls
 
 
+class KeycloakToken(object):
+    '''A token granted by a Keycloak server.
+
+    Like sso.redhat.com as used by cloud.redhat.com
+    ie Automation Hub'''
+
+    token_type = 'Bearer'
+
+    def __init__(self, access_token=None, auth_url=None, validate_certs=True):
+        self.access_token = access_token
+        self.auth_url = auth_url
+        self._token = None
+        self.validate_certs = validate_certs
+
+    def _form_payload(self):
+        return 'grant_type=refresh_token&client_id=cloud-services&refresh_token=%s' % self.access_token
+
+    def get(self):
+        if self._token:
+            return self._token
+
+        # - build a request to POST to auth_url
+        #  - body is form encoded
+        #    - 'request_token' is the offline token stored in ansible.cfg
+        #    - 'grant_type' is 'refresh_token'
+        #    - 'client_id' is 'cloud-services'
+        #       - should probably be based on the contents of the
+        #         offline_ticket's JWT payload 'aud' (audience)
+        #         or 'azp' (Authorized party - the party to which the ID Token was issued)
+        payload = self._form_payload()
+
+        resp = open_url(to_native(self.auth_url),
+                        data=payload,
+                        validate_certs=self.validate_certs,
+                        method='POST')
+
+        # TODO: handle auth errors
+
+        data = json.loads(to_text(resp.read(), errors='surrogate_or_strict'))
+
+        # - extract 'access_token'
+        self._token = data.get('access_token')
+
+        return self._token
+
+    def headers(self):
+        headers = {}
+        headers['Authorization'] = '%s %s' % (self.token_type, self.get())
+        return headers
+
+
 class GalaxyToken(object):
     ''' Class to storing and retrieving local galaxy token '''
+
+    token_type = 'Token'
 
     def __init__(self, token=None):
         self.b_file = to_bytes(C.GALAXY_TOKEN_PATH, errors='surrogate_or_strict')
@@ -84,3 +140,39 @@ class GalaxyToken(object):
     def save(self):
         with open(self.b_file, 'w') as f:
             yaml.safe_dump(self.config, f, default_flow_style=False)
+
+    def headers(self):
+        headers = {}
+        token = self.get()
+        if token:
+            headers['Authorization'] = '%s %s' % (self.token_type, self.get())
+        return headers
+
+
+class BasicAuthToken(object):
+    token_type = 'Basic'
+
+    def __init__(self, username, password=None):
+        self.username = username
+        self.password = password
+        self._token = None
+
+    @staticmethod
+    def _encode_token(username, password):
+        token = "%s:%s" % (to_text(username, errors='surrogate_or_strict'),
+                           to_text(password, errors='surrogate_or_strict', nonstring='passthru') or '')
+        b64_val = base64.b64encode(to_bytes(token, encoding='utf-8', errors='surrogate_or_strict'))
+        return to_text(b64_val)
+
+    def get(self):
+        if self._token:
+            return self._token
+
+        self._token = self._encode_token(self.username, self.password)
+
+        return self._token
+
+    def headers(self):
+        headers = {}
+        headers['Authorization'] = '%s %s' % (self.token_type, self.get())
+        return headers

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -609,6 +609,7 @@ def test_install_collection_with_download(galaxy_server, collection_artifact, mo
     mock_download.return_value = collection_tar
     monkeypatch.setattr(collection, '_download_file', mock_download)
 
+    monkeypatch.setattr(galaxy_server, '_available_api_versions', {'v2': 'v2/'})
     temp_path = os.path.join(os.path.split(collection_tar)[0], b'temp')
     os.makedirs(temp_path)
 


### PR DESCRIPTION
Adds support for token authentication in Automation Hub. Fixes: ansible/galaxy-dev#96

(cherry picked from commit 239d639feedb1a6881ebd1bb43e00d147442b833)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of https://github.com/ansible/ansible/pull/63031

Add support for automation-hub authentication to ansible-galaxy.

And pass it to GalaxyAPI() from cli.

Add a KeycloakToken for use with keycloak sso setups
ie, sso.redhat.com

Fixes: ansible/galaxy-dev#96

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy


