### PR TITLE
[stable-2.9] Install zip for unarchive test when using dnf.

### DIFF
--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -22,9 +22,9 @@
   yum: name=zip,unzip state=latest
   when: ansible_pkg_mgr  ==  'yum'
 
-  #- name: Ensure zip is present to create test archive (dnf)
-  #  dnf: name=zip state=latest
-  #  when: ansible_pkg_mgr  ==  'dnf'
+- name: Ensure zip is present to create test archive (dnf)
+  dnf: name=zip state=latest
+  when: ansible_pkg_mgr  ==  'dnf'
 
 - name: Ensure zip & unzip is present to create test archive (apt)
   apt: name=zip,unzip state=latest


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Install zip for unarchive test when using dnf.

Backport of https://github.com/ansible/ansible/pull/63203

(cherry picked from commit 86ae3cfa12babee2762d180c75f4af8b810c664a)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unarchive integration test
