### PR TITLE
prepare_vmware_tests: use module_defaults

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -211,6 +211,41 @@ VM names should be predictable
 If you need to create a new VM during your test, you can use ``test_vm1``, ``test_vm2`` or ``test_vm3``. This
 way it will be automatically clean up for you.
 
+Avoid the common boiling plate code in your test
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since https://github.com/ansible/ansible/pull/63209, the test suite uses `modules_defaults`. This module
+allow us to preinitialize the following default keys of the VMware modules:
+
+- hostname
+- username
+- password
+- validate_certs
+
+For example, the following block:
+
+.. code-block:: yaml
+
+    - name: Add a VMware vSwitchs
+      vmware_vswitch:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        username: '{{ vcenter_username }}'
+        validate_certs: 'no'
+        esxi_hostname: 'esxi1'
+        switch_name: "boby"
+        state: present
+
+should be simplified to just:
+
+.. code-block:: yaml
+
+    - name: Add a VMware vSwitchs
+      vmware_vswitch:
+        esxi_hostname: 'esxi1'
+        switch_name: "boby"
+        state: present
+
 
 Typographic convention
 ======================

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -226,7 +226,7 @@ For example, the following block:
 
 .. code-block:: yaml
 
-    - name: Add a VMware vSwitchs
+    - name: Add a VMware vSwitch
       vmware_vswitch:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -240,7 +240,7 @@ should be simplified to just:
 
 .. code-block:: yaml
 
-    - name: Add a VMware vSwitchs
+    - name: Add a VMware vSwitch
       vmware_vswitch:
         esxi_hostname: 'esxi1'
         switch_name: "boby"

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -214,7 +214,7 @@ way it will be automatically clean up for you.
 Avoid the common boiling plate code in your test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since https://github.com/ansible/ansible/pull/63209, the test suite uses `modules_defaults`. This module
+From Ansible 2.10, the test suite uses `modules_defaults`. This module
 allow us to preinitialize the following default keys of the VMware modules:
 
 - hostname

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -211,7 +211,7 @@ VM names should be predictable
 If you need to create a new VM during your test, you can use ``test_vm1``, ``test_vm2`` or ``test_vm3``. This
 way it will be automatically clean up for you.
 
-Avoid the common boiling plate code in your test
+Avoid the common boiler plate code in your test playbook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 From Ansible 2.10, the test suite uses `modules_defaults`. This module

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -230,7 +230,7 @@ For example, the following block:
       vmware_vswitch:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
-        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
         validate_certs: 'no'
         esxi_hostname: 'esxi1'
         switch_name: "boby"

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -212,7 +212,7 @@ If you need to create a new VM during your test, you can use ``test_vm1``, ``tes
 way it will be automatically clean up for you.
 
 Avoid the common boiler plate code in your test playbook
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 From Ansible 2.10, the test suite uses `modules_defaults`. This module
 allow us to preinitialize the following default keys of the VMware modules:

--- a/test/integration/targets/prepare_vmware_tests/tasks/init_vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/init_vcsim.yml
@@ -38,10 +38,6 @@
 
 - name: set state to poweroff on all VMs
   vmware_guest:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     name: "{{ item.name }}"
     state: poweredoff
   with_items: "{{ virtual_machines + virtual_machines_in_cluster }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -1,23 +1,15 @@
 - name: Add ESXi Hosts to vCenter
   vmware_host:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
     esxi_hostname: '{{ item }}'
     esxi_username: '{{ esxi_user }}'
     esxi_password: '{{ esxi_password }}'
     state: present
-    validate_certs: no
   with_items: "{{ esxi_hosts }}"
 
 - name: Disable the Maintenance Mode
   vmware_maintenancemode:
-    validate_certs: no
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     esxi_hostname: '{{ item }}'
     state: absent
   with_items: "{{ esxi_hosts }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_category.yml
@@ -1,9 +1,5 @@
 - name: Create a category for cluster
   vmware_category:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: False
     category_name: '{{ cluster_category }}'
     category_description: '{{ cluster_category }} description'
     state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
@@ -1,18 +1,10 @@
 - name: Create Cluster
   vmware_cluster:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
-    validate_certs: no
 
 - name: Enable DRS on Cluster
   vmware_cluster_drs:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
     enable_drs: yes
-    validate_certs: no

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
@@ -1,11 +1,7 @@
 - name: Create Content Library
   vmware_content_library_manager:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     library_name: test-content-lib
     library_description: 'Library created by the prepare_vmware_tests role'
     library_type: local
     datastore_name: '{{ ds2 }}'
-    validate_certs: False
     state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
@@ -1,19 +1,11 @@
 - name: Create Datacenter
   vmware_datacenter:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     state: present
-    validate_certs: no
 
 - name: Create a VM folder on given Datacenter
   vcenter_folder:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
     folder_name: '{{ f0 }}'
     folder_type: vm
     state: present
-    validate_certs: no

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -30,9 +30,6 @@
 - name: The vcenter needs a bit of time to refresh the DS list
   vmware_datastore_info:
     validate_certs: false
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     cluster: '{{ ccr1 }}'
   register: setup_datastore_datatstore_info
   failed_when: setup_datastore_datatstore_info.datastores|selectattr('type', 'equalto', 'NFS')|list|length != 2

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
@@ -1,10 +1,6 @@
 ---
 - name: Create the DVSwitch
   vmware_dvswitch:
-    validate_certs: no
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     datacenter_name: '{{ dc1 }}'
     switch_name: '{{ dvswitch1 }}'
     switch_version: 6.0.0
@@ -15,9 +11,6 @@
     state: present
 - name: Attach the hosts to the DVSwitch
   vmware_dvs_host:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     esxi_hostname: "{{ item }}"
     switch_name: '{{ dvswitch1 }}'
     vmnics:

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_resource_pool.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_resource_pool.yml
@@ -1,9 +1,6 @@
 ---
 - name: Add resource pool to vCenter
   vmware_resource_pool:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
     cluster: '{{ ccr1 }}'
     resource_pool: DC0_C0_RP1

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_switch.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_switch.yml
@@ -1,10 +1,6 @@
 ---
 - name: Add a VMware vSwitchs
   vmware_vswitch:
-    validate_certs: no
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     esxi_hostname: '{{ item }}'
     switch_name: "{{ switch1 }}"
     state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_tag.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_tag.yml
@@ -1,9 +1,5 @@
 - name: Get Category facts
   vmware_category_info:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: False
   register: cat_info
 
 - name: Get Category id for {{ cluster_category }}
@@ -16,10 +12,6 @@
 
 - name: Create a tag for cluster
   vmware_tag:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: False
     category_id: '{{ cluster_category_id }}'
     tag_name: '{{ cluster_tag }}'
     tag_description: '{{ cluster_tag }} Description'

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -1,11 +1,7 @@
 ---
 - name: Create VMs
   vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    validate_certs: no
     folder: '{{ item.folder }}'
     name: '{{ item.name }}'
     state: poweredoff
@@ -28,11 +24,7 @@
 
 - name: Create VMs in cluster
   vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    validate_certs: no
     folder: '{{ item.folder }}'
     cluster: '{{ item.cluster }}'
     name: '{{ item.name }}'

--- a/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -1,10 +1,6 @@
 ---
 - name: Remove the VM prepared by prepare_vmware_tests
   vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: no
     name: "{{ item.name }}"
     force: yes
     state: absent
@@ -12,10 +8,6 @@
 
 - name: Remove the test_vm* VMs
   vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: no
     name: "{{ item }}"
     force: yes
     state: absent
@@ -26,10 +18,6 @@
 
 - name: Remove the DVSwitch
   vmware_dvswitch:
-    validate_certs: no
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
     datacenter_name: '{{ dc1 }}'
     state: absent
     switch_name: '{{ item }}'
@@ -41,7 +29,6 @@
 
 - name: Remove the vSwitches
   vmware_vswitch:
-    validate_certs: no
     hostname: '{{ item }}'
     username: '{{ esxi_user }}'
     password: '{{ esxi_password }}'
@@ -52,16 +39,12 @@
 
 - name: Remove ESXi Hosts to vCenter
   vmware_host:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ dc1 }}'
     cluster_name: ccr1
     esxi_hostname: '{{ item }}'
     esxi_username: '{{ esxi_user }}'
     esxi_password: '{{ esxi_password }}'
     state: absent
-    validate_certs: no
   with_items: "{{ esxi_hosts }}"
   ignore_errors: yes
 
@@ -73,7 +56,6 @@
       esxi_hostname: '{{ item }}'  # Won't be necessary with  https://github.com/ansible/ansible/pull/56516
       datastore_name: '{{ ds1 }}'
       state: absent
-      validate_certs: no
   with_items: "{{ esxi_hosts }}"
 
 - name: Umount NFS datastores to ESXi (2/2)
@@ -84,15 +66,10 @@
       esxi_hostname: '{{ item }}'  # Won't be necessary with  https://github.com/ansible/ansible/pull/56516
       datastore_name: '{{ ds2 }}'
       state: absent
-      validate_certs: no
   with_items: "{{ esxi_hosts }}"
 
 - name: Delete a datastore cluster to datacenter
   vmware_datastore_cluster:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: no
     datacenter_name: "{{ dc1 }}"
     datastore_cluster_name: '{{ item }}'
     state: absent
@@ -103,10 +80,6 @@
 
 - name: Remove the datacenter
   vmware_datacenter:
-    validate_certs: no
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
     datacenter_name: '{{ item }}'
     state: absent
   when: vcsim is not defined

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -272,4 +272,12 @@ class VcenterEnvironment(CloudEnvironment):
         return CloudEnvironmentConfig(
             env_vars=env_vars,
             ansible_vars=ansible_vars,
+            module_defaults={
+                'group/vmware': {
+                    'hostname': env_vars['VCENTER_HOSTNAME'],
+                    'username': env_vars['VCENTER_USERNAME'],
+                    'password': env_vars['VCENTER_PASSWORD'],
+                    'validate_certs': env_vars.get('VMWARE_VALIDATE_CERTS', 'no'),
+                },
+            },
         )


### PR DESCRIPTION
##### SUMMARY

Use `module_defaults` to reduce the amount of duplicated parameters.

As a bonus point, we won't have to set `validate_certs: no` in the test-suite
roles.

See: https://github.com/ansible/ansible/pull/63197
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

vmware