### PR TITLE
Work around ssh-keygen issue in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-ssh-keygen-fix.yml
+++ b/changelogs/fragments/ansible-test-ssh-keygen-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now updates SSH keys it generates with newer versions of ssh-keygen to function with Paramiko

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -86,6 +86,8 @@ fi
 if [ ! -f "${HOME}/.ssh/id_rsa.pub" ]; then
     ssh-keygen -m PEM -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
     # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
+    touch "${HOME}/.ssh/id_rsa.new"
+    chmod 0600 "${HOME}/.ssh/id_rsa.new"
     sed 's/\(BEGIN\|END\) PRIVATE KEY/\1 RSA PRIVATE KEY/' "${HOME}/.ssh/id_rsa" > "${HOME}/.ssh/id_rsa.new"
     mv "${HOME}/.ssh/id_rsa.new" "${HOME}/.ssh/id_rsa"
     cp "${HOME}/.ssh/id_rsa.pub" "${HOME}/.ssh/authorized_keys"

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -86,7 +86,8 @@ fi
 if [ ! -f "${HOME}/.ssh/id_rsa.pub" ]; then
     ssh-keygen -m PEM -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
     # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
-    sed -i 's/\(BEGIN\|END\) PRIVATE KEY/\1 RSA PRIVATE KEY/' "${HOME}/.ssh/id_rsa"
+    sed 's/\(BEGIN\|END\) PRIVATE KEY/\1 RSA PRIVATE KEY/' "${HOME}/.ssh/id_rsa" > "${HOME}/.ssh/id_rsa.new"
+    mv "${HOME}/.ssh/id_rsa.new" "${HOME}/.ssh/id_rsa"
     cp "${HOME}/.ssh/id_rsa.pub" "${HOME}/.ssh/authorized_keys"
     for key in /etc/ssh/ssh_host_*_key.pub; do
         pk=$(cat "${key}")

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -85,6 +85,8 @@ fi
 
 if [ ! -f "${HOME}/.ssh/id_rsa.pub" ]; then
     ssh-keygen -m PEM -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
+    # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
+    sed -i 's/\(BEGIN\|END\) PRIVATE KEY/\1 RSA PRIVATE KEY/' "${HOME}/.ssh/id_rsa"
     cp "${HOME}/.ssh/id_rsa.pub" "${HOME}/.ssh/authorized_keys"
     for key in /etc/ssh/ssh_host_*_key.pub; do
         pk=$(cat "${key}")

--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 
 import json
 import os
+import re
 import traceback
 import uuid
 import errno
@@ -630,6 +631,13 @@ class SshKey:
 
         if not os.path.isfile(key) or not os.path.isfile(pub):
             run_command(args, ['ssh-keygen', '-m', 'PEM', '-q', '-t', 'rsa', '-N', '', '-f', key])
+
+            # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
+            with open(key, 'r+') as key_fd:
+                key_contents = key_fd.read()
+                key_contents = re.sub(r'(BEGIN|END) PRIVATE KEY', r'\1 RSA PRIVATE KEY', key_contents)
+                key_fd.seek(0)
+                key_fd.write(key_contents)
 
         return key, pub
 


### PR DESCRIPTION
##### SUMMARY

Work around ssh-keygen issue in ansible-test.

Newer versions of ssh-keygen create PEM keys that are not recognized by Paramiko.

Now ansible-test compensates for this by updating they keys it generates so Paramiko will recognize them.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
