### PR TITLE
Bry properties

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -78,6 +78,7 @@ options:
             - Run ``systemctl set-property`` for each name/value pair provided.
             - The property name must already exist in the output of ``systemctl show``
         type: dict
+        version_added: "2.10"
     no_block:
         description:
             - Do not synchronously wait for the requested operation to finish.

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -78,7 +78,6 @@ options:
             - Run ``systemctl set-property`` for each name/value pair provided.
             - The property name must already exist in the output of ``systemctl show``
         type: dict
-        version_added: "2.9x"
     no_block:
         description:
             - Do not synchronously wait for the requested operation to finish.

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -540,14 +540,14 @@ def main():
 
                 # check if this is a valid property name
                 if prop not in result['status']:
-                    print("Property '%s' is invalid", prop)
+                    module.log("Property '%s' is invalid" % (prop))
 
                 # check if value already matches new value
                 elif prop_val != result['status'][prop]:
-                    print("Add '%s' to prop_mods list", prop)
+                    module.log("Add '%s' to prop_mods list" % (prop))
                     prop_action += (" %s=%s" % (prop, prop_val))
                 else:
-                    print("Property '%s' unchanged", prop)
+                    module.log("Property '%s' unchanged" % (prop))
 
             # Modify all items
             if prop_action:

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -535,20 +535,19 @@ def main():
             prop_list = module.params['properties']
             prop_action = ""
             for prop in prop_list.keys():
-                module.log("Evaluating property %s", prop)
                 # convert the output to a str as that is what result['status'][prop] will be when we compare later
                 prop_val = str(convert_property_suffix(prop_list[prop]))
 
                 # check if this is a valid property name
                 if prop not in result['status']:
-                    module.log("Property '%s' is invalid", prop)
+                    print("Property '%s' is invalid", prop)
 
                 # check if value already matches new value
                 elif prop_val != result['status'][prop]:
-                    module.log("Add '%s' to prop_mods list", prop)
+                    print("Add '%s' to prop_mods list", prop)
                     prop_action += (" %s=%s" % (prop, prop_val))
                 else:
-                    module.log("Property '%s' unchanged", prop)
+                    print("Property '%s' unchanged", prop)
 
             # Modify all items
             if prop_action:

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -335,6 +335,7 @@ def parse_systemctl_show(lines):
                 k = None
     return parsed
 
+
 def convert_property_suffix(raw_value):
     import math
 
@@ -343,11 +344,11 @@ def convert_property_suffix(raw_value):
         return raw_value
 
     last_char = raw_value[-1]
-    size_converter = {"K":1, "M":2, "G":3, "T":4}
+    size_converter = {"K": 1, "M": 2, "G": 3, "T": 4}
 
     if last_char.upper() in size_converter:
         p = int(math.pow(1024, size_converter[last_char.upper()]))
-        sz = int(raw_value[:-1])*p
+        sz = int(raw_value[:-1]) * p
         return sz
     else:
         return raw_value

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -136,6 +136,19 @@ EXAMPLES = '''
 - name: just force systemd to re-execute itself (2.8 and above)
   systemd:
     daemon_reexec: yes
+
+- name: set CPUShares and MemoryLimit on sshd.service
+  systemd:
+    name: sshd.service
+    properties:
+      CPUShares: 750
+      MemoryLimit: "750M"
+
+- name: set CPUShares to the default value on sshd.service
+  systemd:
+    name: sshd.service
+    properties:
+      CPUShares: ""
 '''
 
 RETURN = '''
@@ -326,7 +339,7 @@ def convert_property_suffix(raw_value):
     import math
 
     # check if we have an int, in which case there is nothing to convert
-    if isinstance(raw_value, int):
+    if isinstance(raw_value, int) or raw_value == "":
         return raw_value
 
     last_char = raw_value[-1]


### PR DESCRIPTION
##### SUMMARY
Add setting properties to the systemd module by executing the systemctl set-property command.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
systemd

##### ADDITIONAL INFORMATION
Specify systemd properties as dictionary items.  Output from module is updated after any changes to reflect the change in the results.

- name: set cpushare and memory on sshd.service
  systemd:
    name: sshd.service
    properties:
      CPUShares: 750
      MemoryLimit: 750M
