### PR TITLE
[stable-2.9] Add missing var for format string in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-test-source-message.yml
+++ b/changelogs/fragments/ansible-test-test-source-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now shows the correct source path instead of ``%s`` for collection role based test targets when the ``-v`` option is used

--- a/test/lib/ansible_test/_internal/provider/layout/collection.py
+++ b/test/lib/ansible_test/_internal/provider/layout/collection.py
@@ -98,7 +98,7 @@ class CollectionLayout(LayoutProvider):
             messages.info.append('Falling back to tests in "%s" because "%s" was not found.' % (legacy_integration_path, modern_integration_path))
             integration_targets_path = legacy_integration_path
         elif modern_integration_path_found:
-            messages.info.append('Loading tests from "%s".')
+            messages.info.append('Loading tests from "%s".' % modern_integration_path)
             integration_targets_path = modern_integration_path
         else:
             messages.error.append('Cannot run integration tests without "%s" or "%s".' % (modern_integration_path, legacy_integration_path))


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Add missing var for format string in ansible-test.

Backport of https://github.com/ansible/ansible/pull/63202

(cherry picked from commit 32979430d06c1ec5c7b2a1d59447cfa66edce452)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
