### PR TITLE
[stable-2.9] Fix ansible-test integration temp dir location.

### DIFF
--- a/changelogs/fragments/ansible-test-integration-temp-dir.yml
+++ b/changelogs/fragments/ansible-test-integration-temp-dir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now creates its integration test temporary directory within the collection so ansible-playbook can properly detect the default collection

--- a/test/lib/ansible_test/_internal/cover.py
+++ b/test/lib/ansible_test/_internal/cover.py
@@ -256,6 +256,7 @@ def _sanitise_filename(filename, modules=None, collection_search_re=None, collec
     """
     ansible_path = os.path.abspath('lib/ansible/') + '/'
     root_path = data_context().content.root + '/'
+    integration_temp_path = os.path.sep + os.path.join(ResultType.TMP.relative_path, 'integration') + os.path.sep
 
     if modules is None:
         modules = {}
@@ -300,9 +301,9 @@ def _sanitise_filename(filename, modules=None, collection_search_re=None, collec
         new_name = re.sub('^(/.*?)?/root/ansible/', root_path, filename)
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
-    elif '/.ansible/test/tmp/' in filename:
+    elif integration_temp_path in filename:
         # Rewrite the path of code running from an integration test temporary directory.
-        new_name = re.sub(r'^.*/\.ansible/test/tmp/[^/]+/', root_path, filename)
+        new_name = re.sub(r'^.*' + re.escape(integration_temp_path) + '[^/]+/', root_path, filename)
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
 

--- a/test/lib/ansible_test/_internal/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/integration/__init__.py
@@ -209,7 +209,9 @@ def integration_test_environment(args, target, inventory_path_src):
         yield IntegrationEnvironment(integration_dir, targets_dir, inventory_path, ansible_config, vars_file)
         return
 
-    root_temp_dir = os.path.expanduser('~/.ansible/test/tmp')
+    # When testing a collection, the temporary directory must reside within the collection.
+    # This is necessary to enable support for the default collection for non-collection content (playbooks and roles).
+    root_temp_dir = os.path.join(ResultType.TMP.path, 'integration')
 
     prefix = '%s-' % target.name
     suffix = u'-\u00c5\u00d1\u015a\u00cc\u03b2\u0141\u00c8'


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test integration temp dir location.

Previously the temporary directory used to run integration tests resided under the user's home directory. This prevented ansible-playbook from detecting the default collection when running tests.

Now the temporary directory is created within the collection to facilitate default collection detection.

Backport of https://github.com/ansible/ansible/pull/63201

(cherry picked from commit 4c79f1ec4dc54357b431d078414566050f222a44)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
