### PR TITLE
no more 'guess' code blocks

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
@@ -263,7 +263,7 @@ Example: ``aci.post_config()``
 
 Example code
 """"""""""""
-.. code-block:: guess
+.. code-block:: python
 
     if state == 'present':
         aci.payload(


### PR DESCRIPTION
##### SUMMARY
Fixes build error on dev_guide/developing_modules_general_aci.rst.

Warning message was:
`rst/dev_guide/developing_modules_general_aci.rst:322: WARNING: Could not lex literal_block as "guess". Highlighting skipped.`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
sphinx build
