### PR TITLE
mysql_replication: add connection_name param for MariaDB multi source replication support

### DIFF
--- a/changelogs/fragments/63229-mysql_replication_add_connection_name_parameter.yml
+++ b/changelogs/fragments/63229-mysql_replication_add_connection_name_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add ``connection_name`` parameter (https://github.com/ansible/ansible/issues/46243).

--- a/test/integration/targets/mariadb_replication/defaults/main.yml
+++ b/test/integration/targets/mariadb_replication/defaults/main.yml
@@ -4,3 +4,4 @@ test_db: test_db
 replication_user: replication_user
 replication_pass: replication_pass
 dump_path: /tmp/dump.sql
+conn_name: master-1

--- a/test/integration/targets/mariadb_replication/tasks/main.yml
+++ b/test/integration/targets/mariadb_replication/tasks/main.yml
@@ -9,3 +9,7 @@
 # https://github.com/ansible/ansible/pull/62648
 - import_tasks: mariadb_master_use_gtid.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'
+
+# Tests of connection_name parameter
+- import_tasks: mariadb_replication_connection_name.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mariadb_replication/tasks/mariadb_replication_connection_name.yml
+++ b/test/integration/targets/mariadb_replication/tasks/mariadb_replication_connection_name.yml
@@ -1,0 +1,118 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Needs for further tests:
+- name: Stop slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
+
+- name: Reset slave all
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: resetslaveall
+
+# Get master log pos:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_status
+
+# Test changemaster mode:
+- name: Run replication with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: changemaster
+    master_host: 127.0.0.1
+    master_port: "{{ master_port }}"
+    master_user: "{{ replication_user }}"
+    master_password: "{{ replication_pass }}"
+    master_log_file: mysql-bin.000001
+    master_log_pos: '{{ master_status.Position }}'
+    connection_name: '{{ conn_name }}'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["CHANGE MASTER '{{ conn_name }}' TO MASTER_HOST='127.0.0.1',MASTER_USER='replication_user',MASTER_PASSWORD='********',MASTER_PORT=3306,MASTER_LOG_FILE='mysql-bin.000001',MASTER_LOG_POS=765"]
+
+# Test startslave mode:
+- name: Start slave with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: startslave
+    connection_name: "{{ conn_name }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["START SLAVE \'{{ conn_name }}\'"]
+
+# Test getslave mode:
+- name: Get standby statu with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: getslave
+    connection_name: "{{ conn_name }}"
+  register: slave_status
+
+- assert:
+    that:
+    - slave_status.Is_Slave == true
+    - slave_status.Master_Host == '127.0.0.1'
+    - slave_status.Exec_Master_Log_Pos == master_status.Position
+    - slave_status.Master_Port == {{ master_port }}
+    - slave_status.Last_IO_Errno == 0
+    - slave_status.Last_IO_Error == ''
+    - slave_status is not changed
+
+# Test stopslave mode:
+- name: Stop slave with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
+    connection_name: "{{ conn_name }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["STOP SLAVE \'{{ conn_name }}\'"]
+
+# Test reset
+- name: Reset slave with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: resetslave
+    connection_name: "{{ conn_name }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["RESET SLAVE \'{{ conn_name }}\'"]
+
+# Test reset all
+- name: Reset slave all with connection_name
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: resetslaveall
+    connection_name: "{{ conn_name }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["RESET SLAVE \'{{ conn_name }}\' ALL"]


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add connection_name param for MariaDB multi source replication support

fixes https://github.com/ansible/ansible/pull/46243

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_replication.py```