### PR TITLE
Added feature to use ansible.cfg and python3 compatibility.

### DIFF
--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -12,7 +12,8 @@ DOCUMENTATION = '''
     short_description: Sends events to Logstash
     description:
       - This callback will report facts and task events to Logstash https://www.elastic.co/products/logstash
-    version_added: "2.3"
+      - Before 2.8 only environment variables were available for configuring this plugin.
+    version_added: "2.8"
     requirements:
       - whitelisting in configuration
       - logstash (python library)

--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -57,6 +57,7 @@ try:
 except ImportError:
     HAS_LOGSTASH = False
 
+from ansible.module_utils.six import PY3
 from ansible.plugins.callback import CallbackBase
 
 
@@ -95,8 +96,9 @@ class CallbackModule(CallbackBase):
 
         if not HAS_LOGSTASH:
             self.disabled = True
-            self._display.warning("The required python-logstash is not installed. "
-                                  "pip install python3-logstash")
+            logstash_lib = 'python3-logstash' if PY3 else 'python-logstash'
+            self._display.warning("The required python logstash library is not installed. "
+                                  "pip install {}".format(logstash_lib))
         else:
             self.logger = logging.getLogger('python-logstash-logger')
             self.logger.setLevel(logging.DEBUG)

--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -12,8 +12,8 @@ DOCUMENTATION = '''
     short_description: Sends events to Logstash
     description:
       - This callback will report facts and task events to Logstash https://www.elastic.co/products/logstash
-      - Before 2.8 only environment variables were available for configuring this plugin.
-    version_added: "2.8"
+      - Before 2.10 only environment variables were available for configuring this plugin.
+    version_added: "2.10"
     requirements:
       - whitelisting in configuration
       - logstash (python library)

--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -98,7 +98,7 @@ class CallbackModule(CallbackBase):
             self.disabled = True
             logstash_lib = 'python3-logstash' if PY3 else 'python-logstash'
             self._display.warning("The required python logstash library is not installed. "
-                                  "pip install {}".format(logstash_lib))
+                                  "pip install {0}".format(logstash_lib))
         else:
             self.logger = logging.getLogger('python-logstash-logger')
             self.logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enabled feature to use ansible.cfg for callback plugin configuration and add support for python3.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
logstash.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
ansible.cfg was ignored by the callback plugin and only environment variables were used.
This chance enables the following configuration in ansible.cfg to be respected.

ini entries:
[callback_logstash]
server = localhost
port = 5000
type = ansible
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
