### PR TITLE
Spot instance code error

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -370,6 +370,7 @@ EXAMPLES = '''
     vpc_subnet_id: subnet-29e63245
     assign_public_ip: yes
     spot_launch_group: report_generators
+    instance_initiated_shutdown_behavior: terminate
 
 # Examples using pre-existing network interfaces
 - ec2:


### PR DESCRIPTION
##### SUMMARY
You need add following line to create spot instance
```
instance_initiated_shutdown_behavior: terminate
```
Otherwise, you will met error below:
```
instance_initiated_shutdown_behavior=stop is not supported for spot instances.
```


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
