### PR TITLE
Fix STS assume role error message when role does not exist

### DIFF
--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -290,14 +290,14 @@
       assert:
         that:
           - 'result.failed'
-          - "'Access denied' in result.msg"
+          - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume not existing sts role
       assert:
         that:
           - 'result.failed'
-          - "'Access denied' in result.module_stderr"
+          - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is defined
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
AWS appears to have changed this error message again.
Fixes https://app.shippable.com/github/ansible/ansible/runs/145643/115/tests

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
sts_assume_role

##### ADDITIONAL INFORMATION
We last changed this assertion in #46026 for the same reason.