### PR TITLE
[stable-2.9] Add RHEL 8.1b to the Shippable test matrix.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -82,6 +82,7 @@ matrix:
     - env: T=osx/10.11/1
     - env: T=rhel/7.6/1
     - env: T=rhel/8.0/1
+    - env: T=rhel/8.1b/1
     - env: T=freebsd/11.1/1
     - env: T=freebsd/12.0/1
     - env: T=linux/centos6/1
@@ -96,6 +97,7 @@ matrix:
     - env: T=osx/10.11/2
     - env: T=rhel/7.6/2
     - env: T=rhel/8.0/2
+    - env: T=rhel/8.1b/2
     - env: T=freebsd/11.1/2
     - env: T=freebsd/12.0/2
     - env: T=linux/centos6/2
@@ -110,6 +112,7 @@ matrix:
     - env: T=osx/10.11/3
     - env: T=rhel/7.6/3
     - env: T=rhel/8.0/3
+    - env: T=rhel/8.1b/3
     - env: T=freebsd/11.1/3
     - env: T=freebsd/12.0/3
     - env: T=linux/centos6/3
@@ -124,6 +127,7 @@ matrix:
     - env: T=osx/10.11/4
     - env: T=rhel/7.6/4
     - env: T=rhel/8.0/4
+    - env: T=rhel/8.1b/4
     - env: T=freebsd/11.1/4
     - env: T=freebsd/12.0/4
     - env: T=linux/centos6/4

--- a/test/integration/targets/firewalld/aliases
+++ b/test/integration/targets/firewalld/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group3
 skip/freebsd
 skip/osx
+skip/rhel8.1b

--- a/test/integration/targets/ufw/aliases
+++ b/test/integration/targets/ufw/aliases
@@ -3,6 +3,7 @@ skip/osx
 skip/freebsd
 skip/rhel8.0
 skip/rhel8.0b
+skip/rhel8.1b
 skip/docker
 needs/root
 destructive

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -3,3 +3,4 @@ freebsd/12.0 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
 rhel/8.0 python=3.6
+rhel/8.1b python=3.6


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Add RHEL 8.1b to the Shippable test matrix.

Backport of https://github.com/ansible/ansible/pull/63141

(cherry picked from commit 811127d64db689b28ab0de8ab11385e3722373f6)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml