### PR TITLE
Pass a JSON file to the Lambda's payload

### DIFF
--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -106,8 +106,8 @@ EXAMPLES = '''
     wait: true
     tail_log: true
   register: response
-  # the response will have a `logs` key that will contain a log (up to 4KB) of the function execution in Lambda.
-  
+  # the response will have a `logs` key that will contain a log (up to 4KB) of the function execution in Lambda
+
 # Pass the Lambda event payload as a json file.
 - execute_lambda:
     name: test-function

--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -107,6 +107,12 @@ EXAMPLES = '''
     tail_log: true
   register: response
   # the response will have a `logs` key that will contain a log (up to 4KB) of the function execution in Lambda.
+  
+# Pass the Lambda event payload as a json file.
+- execute_lambda:
+    name: test-function
+    payload: "{{ lookup('file','lambda_event.json') }}"
+  register: response
 
 - execute_lambda:
     name: test-function


### PR DESCRIPTION
##### SUMMARY
The given examples doesn't show how to pass a JSON file as the Lambda's event/payload. Events passed to Lambda are commonly in JSON format, the change provides an example of using JSON file as an alternative to the inline YAML payload in the other examples.      


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
