### PR TITLE
[2.9 backport] add ANSIBLE_PLAYBOOK_DIR envvar support (#63220)

### DIFF
--- a/changelogs/fragments/59464-playbook-dir-envvar.yml
+++ b/changelogs/fragments/59464-playbook-dir-envvar.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- CLI - the `ANSIBLE_PLAYBOOK_DIR` envvar or `playbook_dir` config can now substitute for the --playbook-dir arg on CLIs that support it (https://github.com/ansible/ansible/issues/59464)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -223,7 +223,7 @@ def add_async_options(parser):
 
 def add_basedir_options(parser):
     """Add options for commands which can set a playbook basedir"""
-    parser.add_argument('--playbook-dir', default=None, dest='basedir', action='store',
+    parser.add_argument('--playbook-dir', default=C.config.get_config_value('PLAYBOOK_DIR'), dest='basedir', action='store',
                         help="Since this tool does not use playbooks, use this as a substitute playbook directory."
                              "This sets the relative path for many features including roles/ group_vars/ etc.")
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1668,6 +1668,14 @@ PERSISTENT_COMMAND_TIMEOUT:
   ini:
   - {key: command_timeout, section: persistent_connection}
   type: int
+PLAYBOOK_DIR:
+  name: playbook dir override for non-playbook CLIs (ala --playbook-dir)
+  version_added: "2.9"
+  description:
+    - A number of non-playbook CLIs have a ``--playbook-dir`` argument; this sets the default value for it.
+  env: [{name: ANSIBLE_PLAYBOOK_DIR}]
+  ini: [{key: playbook_dir, section: defaults}]
+  type: path
 PLAYBOOK_VARS_ROOT:
   name: playbook vars files root
   default: top

--- a/test/integration/targets/ansible/playbookdir_cfg.ini
+++ b/test/integration/targets/ansible/playbookdir_cfg.ini
@@ -1,0 +1,2 @@
+[defaults]
+playbook_dir = /tmp

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -18,6 +18,15 @@ ansible-config view -c ./ansible-non-existent.cfg 2> err1.txt || grep -Eq 'ERROR
 ansible-config view -c ./no-extension 2> err2.txt || grep -q 'Unsupported configuration file extension' err2.txt || (cat err2.txt; rm -f err*.txt; exit 1)
 rm -f err*.txt
 
+# test setting playbook_dir via envvar
+ANSIBLE_PLAYBOOK_DIR=/tmp ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
+
+# test setting playbook_dir via cmdline
+ansible localhost -m debug -a var=playbook_dir --playbook-dir=/tmp | grep '"playbook_dir": "/tmp"'
+
+# test setting playbook dir via ansible.cfg
+ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
+
 # Test that no tmp dirs are left behind when running ansible-config
 TMP_DIR=~/.ansible/tmptest
 if [[ -d "$TMP_DIR" ]]; then


### PR DESCRIPTION
##### SUMMARY
* add ANSIBLE_PLAYBOOK_DIR envvar support

* allows `ANSIBLE_PLAYBOOK_DIR` envvar as a fallback on CLI types that support `--playbook-dir`. This should have been implemented with #59464, but was missed due to an oversight.
* added basic integration test

* make first-class PLAYBOOK_DIR config entry

* update changelog

(cherry picked from commit fd229dcbb599f3b5de889f90112bba35d0da31f2)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CLIs (various)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
