### PR TITLE
Add example for port range to win_firewall_rule_module

### DIFF
--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -152,5 +152,5 @@ EXAMPLES = r'''
     direction: in
     protocol: tcp
     state: present
-    enabled: yes        
+    enabled: yes
 '''

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -144,4 +144,14 @@ EXAMPLES = r'''
     protocol: tcp
     state: present
     enabled: yes
+    
+- name: Firewall rule to allow port range
+  win_firewall_rule:
+    name: Sample port range
+    localport: 5000-5010
+    action: allow
+    direction: in
+    protocol: tcp
+    state: present
+    enabled: yes        
 '''

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -144,7 +144,6 @@ EXAMPLES = r'''
     protocol: tcp
     state: present
     enabled: yes
-    
 - name: Firewall rule to allow port range
   win_firewall_rule:
     name: Sample port range


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Sample for opening range of ports.

People often ask me if this is supported because it's not in the docs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- win_firewall_rule_module
