### PR TITLE
Fix for backup option dest key for network modules

### DIFF
--- a/changelogs/fragments/network_backup_option_fix.yaml
+++ b/changelogs/fragments/network_backup_option_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix for backup option dest key for network modules (https://github.com/ansible/ansible/issues/57131).

--- a/lib/ansible/plugins/action/network.py
+++ b/lib/ansible/plugins/action/network.py
@@ -103,7 +103,7 @@ class ActionModule(_ActionModule):
             result['msg'] = copy_result.get('msg')
             return
 
-        result['backup_path'] = copy_result['dest']
+        result['backup_path'] = dest
         if copy_result.get('changed', False):
             result['changed'] = copy_result['changed']
 


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/57131
(cherry picked from commit d4ad541eee90e951b47165120cd3edc932177c57)

Backport of https://github.com/ansible/ansible/pull/62444
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/action/network.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
