### PR TITLE
Fix galaxy url use everywhere when url is set in config.

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -57,6 +57,10 @@ def g_connect(versions):
                         raise AnsibleError("Tried to find galaxy API root at %s but no 'available_versions' are available on %s"
                                            % (n_url, self.api_server))
 
+                    # Update api_server to point to the "real" API root, which in this case
+                    # was the configured url + '/api/' appended.
+                    self.api_server = n_url
+
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.
                 available_versions = data.get('available_versions', {u'v1': u'v1/'})


### PR DESCRIPTION
##### SUMMARY

Fix galaxy url use everywhere when url is set in config.

In addition to trying the configured url (for ex, a migrated
'https://galaxy.ansible.com/') there is an attempt at that
URL with '/api' postpended.

If the extended URL works, update GalaxyAPI.api_server to
use the extended URL. Previously it only used it for finding
the API root info ('available_versions', etc)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
If there is configuration (config file, env var, etc) that specify a galaxy server that
doesn't include the path to the galaxy API root, ansible-galaxy tries appending
a '/api/' to it. But it wasn't doing that for other calls.

Example config pointing at the imcomplete galaxy api URL, that is automatically
also tried with '/api/' appended to it.
``` ini
[galaxy]
# server_list = local_hub, local_galaxy, galaxy, automation_hub, automation_hub_ci
server_list = galaxy


[galaxy_server.galaxy]
url=https://galaxy-dev.ansible.com/
```


Before:

```
(ansible-py3) [newswoop:F29:ansible (devel % u=)]$ rm -rf /tmp/collections/* && ALOGGING_STACK_INFO=1 HTTP_PROXY=127.0.0.1:8080 HTTPS_PROXY=127.0.0.1:8080 ANSIBLE_GALAXY_IGNORE=true ANSIBLE_CONFIG=ansible-galaxy.cfg ansible-galaxy-alog collection install   -vvvvv alikins.collection_inspect -p /tmp/collections/
12:09:25,745 D root MainProcess:14088 <module>:93 - fffffffffffffff None
ansible-galaxy-alog 2.10.0.dev0
  config file = /home/adrian/src/ansible/ansible-galaxy.cfg
  configured module search path = ['/home/adrian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible-galaxy-alog
  python version = 3.6.9 (default, Jul  3 2019, 17:57:57) [GCC 8.3.1 20190223 (Red Hat 8.3.1-2)]
Using /home/adrian/src/ansible/ansible-galaxy.cfg as config file

Process install dependency map
Initial connection to galaxy_server: https://galaxy-dev.ansible.com/
Opened /home/adrian/.ansible/galaxy_token
Calling Galaxy at https://galaxy-dev.ansible.com/
Processing requirement collection 'alikins.collection_inspect'
Collection requirement 'alikins.collection_inspect' is the name of a collection
Calling Galaxy at https://galaxy-dev.ansible.com/api
Found API version 'v1, v2' with Galaxy server galaxy (https://galaxy-dev.ansible.com/)
Calling Galaxy at https://galaxy-dev.ansible.com/v2/collections/alikins/collection_inspect/versions
ERROR! Failed to parse Galaxy response from 'https://galaxy-dev.ansible.com/v2/collections/alikins/collection_inspect/versions' as JSON:
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Ansible Galaxy</title>
  <base href="/">

  <meta name="viewport" content="width=device-width, initial-scale=1">
  <link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico">
<link rel="stylesheet" href="styles.7bb982775d17919a33dd.css"></head>
<body>
  <galaxy-nav></galaxy-nav>
<script type="text/javascript" src="runtime.1ac76353d3406eb84d6a.js"></script><script type="text/javascript" src="polyfills.b630969cd11aa76bda54.js"></script><script type="text/javascript" src="main.95fdde42895545fd6626.js"></script></body>
</html>

ERROR! Failed to parse Galaxy response from 'https://galaxy-dev.ansible.com/v2/collections/alikins/collection_inspect/versions' as JSON:
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <title>Ansible Galaxy</title>
  <base href="/">

  <meta name="viewport" content="width=device-width, initial-scale=1">
  <link rel="shortcut icon" type="image/x-icon" href="/assets/favicon.ico">
<link rel="stylesheet" href="styles.7bb982775d17919a33dd.css"></head>
<body>
  <galaxy-nav></galaxy-nav>
<script type="text/javascript" src="runtime.1ac76353d3406eb84d6a.js"></script><script type="text/javascript" src="polyfills.b630969cd11aa76bda54.js"></script><script type="text/javascript" src="main.95fdde42895545fd6626.js"></script></body>
</html>

```

After:

```
(ansible-py3) [newswoop:F29:ansible (galaxy_api_path_migrate %)]$ rm -rf /tmp/collections/* && ALOGGING_STACK_INFO=1 HTTP_PROXY=127.0.0.1:8080 HTTPS_PROXY=127.0.0.1:8080 ANSIBLE_GALAXY_IGNORE=true ANSIBLE_CONFIG=ansible-galaxy.cfg ansible-galaxy-alog collection install   -vvvvv alikins.collection_inspect -p /tmp/collections/
12:10:44,633 D root MainProcess:14250 <module>:93 - fffffffffffffff None
ansible-galaxy-alog 2.10.0.dev0
  config file = /home/adrian/src/ansible/ansible-galaxy.cfg
  configured module search path = ['/home/adrian/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible-galaxy-alog
  python version = 3.6.9 (default, Jul  3 2019, 17:57:57) [GCC 8.3.1 20190223 (Red Hat 8.3.1-2)]
Using /home/adrian/src/ansible/ansible-galaxy.cfg as config file

Process install dependency map
Initial connection to galaxy_server: https://galaxy-dev.ansible.com/
Opened /home/adrian/.ansible/galaxy_token
Calling Galaxy at https://galaxy-dev.ansible.com/
Processing requirement collection 'alikins.collection_inspect'
Collection requirement 'alikins.collection_inspect' is the name of a collection
Calling Galaxy at https://galaxy-dev.ansible.com/api
Found API version 'v1, v2' with Galaxy server galaxy (https://galaxy-dev.ansible.com/api)
Calling Galaxy at https://galaxy-dev.ansible.com/api/v2/collections/alikins/collection_inspect/versions
Calling Galaxy at https://galaxy-dev.ansible.com/api/v2/collections/alikins/collection_inspect/versions/0.0.38
Collection 'alikins.collection_inspect' obtained from server galaxy https://galaxy-dev.ansible.com/api
Starting collection install process
Installing 'alikins.collection_inspect:0.0.38' to '/tmp/collections/ansible_collections/alikins/collection_inspect'
Downloading https://galaxy-dev.ansible.com/download/alikins-collection_inspect-0.0.38.tar.gz to /home/adrian/.ansible/tmp/ansible-local-14250nm0af0h3/tmps39i0sns
Validating downloaded file hash c6a69797cb04fa768acb74431ef7ea090e9c9d3e81044feeda65cdd020fbfffd with expected hash c6a69797cb04fa768acb74431ef7ea090e9c9d3e81044feeda65cdd020fbfffd
```
