### PR TITLE
backport of galaxy trailing api fix (63238) to stable-2.9

### DIFF
--- a/changelogs/fragments/galaxy_api_config.yaml
+++ b/changelogs/fragments/galaxy_api_config.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy -  Stop appendding '/api' to configured galaxy urls. Special case migrated configs.

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -57,6 +57,10 @@ def g_connect(versions):
                         raise AnsibleError("Tried to find galaxy API root at %s but no 'available_versions' are available on %s"
                                            % (n_url, self.api_server))
 
+                    # Update api_server to point to the "real" API root, which in this case
+                    # was the configured url + '/api/' appended.
+                    self.api_server = n_url
+
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.
                 available_versions = data.get('available_versions', {u'v1': u'v1/'})

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -38,16 +38,30 @@ def g_connect(versions):
 
                 # Determine the type of Galaxy server we are talking to. First try it unauthenticated then with Bearer
                 # auth for Automation Hub.
-                n_url = _urljoin(self.api_server, 'api')
+                n_url = self.api_server
                 error_context_msg = 'Error when finding available api versions from %s (%s)' % (self.name, n_url)
 
-                data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg)
+                if self.api_server == 'https://galaxy.ansible.com' or self.api_server == 'https://galaxy.ansible.com/':
+                    n_url = 'https://galaxy.ansible.com/api/'
+
+                try:
+                    data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg)
+                except (AnsibleError, GalaxyError, ValueError, KeyError):
+                    # Either the URL doesnt exist, or other error. Or the URL exists, but isn't a galaxy API
+                    # root (not JSON, no 'available_versions') so try appending '/api/'
+                    n_url = _urljoin(n_url, '/api/')
+
+                    # let exceptions here bubble up
+                    data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg)
+                    if 'available_versions' not in data:
+                        raise AnsibleError("Tried to find galaxy API root at %s but no 'available_versions' are available on %s"
+                                           % (n_url, self.api_server))
 
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.
-                available_versions = data.get('available_versions', {u'v1': u'/api/v1'})
+                available_versions = data.get('available_versions', {u'v1': u'v1/'})
                 if list(available_versions.keys()) == [u'v1']:
-                    available_versions[u'v2'] = u'/api/v2'
+                    available_versions[u'v2'] = u'v2/'
 
                 self._available_api_versions = available_versions
                 display.vvvv("Found API version '%s' with Galaxy server %s (%s)"


### PR DESCRIPTION
##### SUMMARY
    Stop appending '/api' to galaxy server url (#63238)
    
    * Stop appending '/api' to configured galaxy server url
    
    Since not all galaxy REST api server URLs live
    at '/api', stop always appending it to the
    'url' value loaded from config.
    
    * Add note about manually migrated galaxy configs and /api
    
    * Add '/api/' to galaxy url and guessing if galaxy API
    
    * Fix most unit tests (update to expect /api/)
    
    * Fix test_initialise_unknown unit test
    
    Since we retry now with an added /api/, mock it as well.
    
    * Update fallback default avail_ver to new format
    
    (cherry picked from commit bad72693e49bbeac2d80f56cdafe281e3d846471)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy
