### PR TITLE
Added production flag to npm ci install command

### DIFF
--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -173,7 +173,7 @@ class Npm(object):
 
             if self.glbl:
                 cmd.append('--global')
-            if self.production and ('install' in cmd or 'update' in cmd):
+            if self.production and ('install' in cmd or 'update' in cmd or 'ci' in cmd):
                 cmd.append('--production')
             if self.ignore_scripts:
                 cmd.append('--ignore-scripts')


### PR DESCRIPTION
##### SUMMARY

The `--production` flag can be used also for `npm ci` install command.
I've added the additional check.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
NPM Module

##### ADDITIONAL INFORMATION
