### PR TITLE
[stable-2.8] Work around ssh-keygen issue in ansible-test. (#63211)

### DIFF
--- a/changelogs/fragments/ansible-test-ssh-keygen-fix.yml
+++ b/changelogs/fragments/ansible-test-ssh-keygen-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now updates SSH keys it generates with newer versions of ssh-keygen to function with Paramiko

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import json
 import os
+import re
 import traceback
 import uuid
 import errno
@@ -551,6 +552,13 @@ class SshKey(object):
 
             if not os.path.isfile(key) or not os.path.isfile(pub):
                 run_command(args, ['ssh-keygen', '-m', 'PEM', '-q', '-t', 'rsa', '-N', '', '-f', key])
+
+                # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
+                with open(key, 'r+') as key_fd:
+                    key_contents = key_fd.read()
+                    key_contents = re.sub(r'(BEGIN|END) PRIVATE KEY', r'\1 RSA PRIVATE KEY', key_contents)
+                    key_fd.seek(0)
+                    key_fd.write(key_contents)
 
             if not args.explain:
                 shutil.copy2(key, self.key)

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -85,6 +85,11 @@ fi
 
 if [ ! -f "${HOME}/.ssh/id_rsa.pub" ]; then
     ssh-keygen -m PEM -q -t rsa -N '' -f "${HOME}/.ssh/id_rsa"
+    # newer ssh-keygen PEM output (such as on RHEL 8.1) is not recognized by paramiko
+    touch "${HOME}/.ssh/id_rsa.new"
+    chmod 0600 "${HOME}/.ssh/id_rsa.new"
+    sed 's/\(BEGIN\|END\) PRIVATE KEY/\1 RSA PRIVATE KEY/' "${HOME}/.ssh/id_rsa" > "${HOME}/.ssh/id_rsa.new"
+    mv "${HOME}/.ssh/id_rsa.new" "${HOME}/.ssh/id_rsa"
     cp "${HOME}/.ssh/id_rsa.pub" "${HOME}/.ssh/authorized_keys"
     for key in /etc/ssh/ssh_host_*_key.pub; do
         pk=$(cat "${key}")


### PR DESCRIPTION
##### SUMMARY

Newer versions of ssh-keygen create PEM keys that are not recognized by Paramiko.

Now ansible-test compensates for this by updating they keys it generates so Paramiko will recognize them.

Backport of https://github.com/ansible/ansible/pull/63211

(cherry picked from commit 022335669cc1732939cc609f8dcdc5ad75a42439)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
