### PR TITLE
[2.9 backport] config encode errors should not be fatal (#63311)

### DIFF
--- a/changelogs/fragments/config_encoding_resilience.yml
+++ b/changelogs/fragments/config_encoding_resilience.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - config - encoding failures on config values should be non-fatal (https://github.com/ansible/ansible/issues/63310)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -390,7 +390,11 @@ class ConfigManager(object):
         origin = None
         for entry in entry_list:
             name = entry.get('name')
-            temp_value = container.get(name, None)
+            try:
+                temp_value = container.get(name, None)
+            except UnicodeEncodeError:
+                self.WARNINGS.add('value for config entry {0} contains invalid characters, ignoring...'.format(to_native(name)))
+                continue
             if temp_value is not None:  # only set if env var is defined
                 value = temp_value
                 origin = name

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -393,7 +393,7 @@ class ConfigManager(object):
             try:
                 temp_value = container.get(name, None)
             except UnicodeEncodeError:
-                self.WARNINGS.add('value for config entry {0} contains invalid characters, ignoring...'.format(to_native(name)))
+                self.WARNINGS.add(u'value for config entry {0} contains invalid characters, ignoring...'.format(to_text(name)))
                 continue
             if temp_value is not None:  # only set if env var is defined
                 value = temp_value

--- a/lib/ansible/utils/py3compat.py
+++ b/lib/ansible/utils/py3compat.py
@@ -27,14 +27,19 @@ class _TextEnviron(MutableMapping):
 
     Mimics the behaviour of os.environ on Python3
     """
-    def __init__(self, env=None):
+    def __init__(self, env=None, encoding=None):
         if env is None:
             env = os.environ
         self._raw_environ = env
         self._value_cache = {}
         # Since we're trying to mimic Python3's os.environ, use sys.getfilesystemencoding()
         # instead of utf-8
-        self.encoding = sys.getfilesystemencoding()
+        if encoding is None:
+            # Since we're trying to mimic Python3's os.environ, use sys.getfilesystemencoding()
+            # instead of utf-8
+            self.encoding = sys.getfilesystemencoding()
+        else:
+            self.encoding = encoding
 
     def __delitem__(self, key):
         del self._raw_environ[key]
@@ -61,4 +66,4 @@ class _TextEnviron(MutableMapping):
         return len(self._raw_environ)
 
 
-environ = _TextEnviron()
+environ = _TextEnviron(encoding='utf-8')


### PR DESCRIPTION
##### SUMMARY
* fixes #63310
* subset of fixes from #58638
* includes #63349
* added warning on error

(cherry picked from commit 77de663879bcf2f6ab82d5009b8a0b799814750b)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ConfigManager

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
