### PR TITLE
Add a user-agent header to ansible-galaxy requests

### DIFF
--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -31,6 +31,7 @@ import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible.galaxy import get_collections_galaxy_meta_info
 from ansible.galaxy.api import CollectionVersionMetadata, GalaxyError
+from ansible.galaxy import user_agent
 from ansible.module_utils import six
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils.collection_loader import AnsibleCollectionRef
@@ -843,6 +844,9 @@ def _get_collection_info(dep_map, existing_collections, collection, requirement,
 def _download_file(url, b_path, expected_hash, validate_certs, headers=None):
     bufsize = 65536
     digest = sha256()
+
+    headers = headers or {}
+    headers['User-Agent'] = user_agent.user_agent()
 
     urlsplit = os.path.splitext(to_text(url.rsplit('/', 1)[1]))
     b_file_name = to_bytes(urlsplit[0], errors='surrogate_or_strict')

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -29,6 +29,7 @@ from stat import S_IRUSR, S_IWUSR
 import yaml
 
 from ansible import constants as C
+from ansible.galaxy import user_agent
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
@@ -73,9 +74,11 @@ class KeycloakToken(object):
         #         or 'azp' (Authorized party - the party to which the ID Token was issued)
         payload = self._form_payload()
 
+        headers = {'User-Agent': user_agent.user_agent()}
         resp = open_url(to_native(self.auth_url),
                         data=payload,
                         validate_certs=self.validate_certs,
+                        headers=headers,
                         method='POST')
 
         # TODO: handle auth errors

--- a/lib/ansible/galaxy/user_agent.py
+++ b/lib/ansible/galaxy/user_agent.py
@@ -1,0 +1,18 @@
+
+import sys
+
+from ansible.release import __version__ as ansible_version
+
+# Based on suggestions at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+USER_AGENT_FORMAT = 'ansible-galaxy/{version} ({platform}; python:{py_major}.{py_minor}.{py_micro})'
+
+
+def user_agent():
+    '''Return a user-agent including mazer version, platform, and python version'''
+
+    user_agent_data = {'version': ansible_version,
+                       'platform': sys.platform,
+                       'py_major': sys.version_info.major,
+                       'py_minor': sys.version_info.minor,
+                       'py_micro': sys.version_info.micro}
+    return USER_AGENT_FORMAT.format(**user_agent_data)

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -199,7 +199,8 @@ def test_initialise_automation_hub(monkeypatch):
     assert api.available_api_versions['v3'] == u'v3/'
 
     assert mock_open.mock_calls[0][1][0] == 'https://galaxy.ansible.com/api/'
-    assert mock_open.mock_calls[0][2]['headers'] == {'Authorization': 'Bearer my_token'}
+    assert mock_open.mock_calls[0][2]['headers']['Authorization'] == 'Bearer my_token'
+    assert 'ansible-galaxy' in mock_open.mock_calls[0][2]['headers']['User-Agent']
 
 
 def test_initialise_unknown(monkeypatch):

--- a/test/units/galaxy/test_user_agent.py
+++ b/test/units/galaxy/test_user_agent.py
@@ -1,0 +1,12 @@
+import sys
+
+from ansible import release
+from ansible.galaxy import user_agent
+
+
+def test_user_agent():
+    res = user_agent.user_agent()
+    assert res.startswith('ansible-galaxy/%s' % release.__version__)
+    assert sys.platform in res
+    assert 'python:' in res
+    assert 'ansible-galaxy' in res


### PR DESCRIPTION

##### SUMMARY
Add a user-agent header to ansible-galaxy requests

Add lib/ansible/galaxy/user_agent.py with
user_agent() builder method.

user_agent() will create a user agent string like:

    ansible-galaxy/2.9.0 (linux; python:3.6.5)

Add user-agent header to:
- ansible.galaxy.api.GalaxyAPI() requests
- ansible.galaxy.token.KeycloakToken() sso requests
- ansible.galaxy.collection._download_file() method requests

Fixes: #63282

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bug Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy


