### PR TITLE
[lightsail] make delete operation idempotent

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lightsail.py
+++ b/lib/ansible/modules/cloud/amazon/lightsail.py
@@ -249,6 +249,10 @@ def delete_instance(module, client, instance_name):
         if e.response['Error']['Code'] != 'NotFoundException':
             module.fail_json(msg='Error finding instance {0}, error: {1}'.format(instance_name, e))
 
+    # If instance doesn't exist, then return with 'changed:false'
+    if not inst:
+        return changed, {}
+
     # Wait for instance to exit transition state before deleting
     if wait:
         while wait_max > time.time() and inst is not None and inst['state']['name'] in ('pending', 'stopping'):


### PR DESCRIPTION
##### SUMMARY
When lightsail module is run with `state: absent`, return with `changed: false` if an instance by the given name doesn't exist.  This will make the delete operation on this module idempotent.
Currently, trying to delete an non-existent instance leads to a traceback.
Fixes #63315

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lightsail

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Fixes #63315
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
