### PR TITLE
VMware: name is not required parameter 

### DIFF
--- a/changelogs/fragments/vmware_guest_custom_attributes.yml
+++ b/changelogs/fragments/vmware_guest_custom_attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware_guest_custom_attributes does not require VM name (https://github.com/ansible/ansible/issues/63222).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -63,7 +63,7 @@ Noteworthy module changes
 * :ref:`vmware_host_service_manager <vmware_host_service_manager_module>` now returns ``host_service_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_tag <vmware_tag_module>` now returns ``tag_status`` instead of Ansible internal key ``results``.
 * The deprecated ``recurse`` option in :ref:`pacman <pacman_module>` module has been removed, you should use ``extra_args=--recursive`` instead.
-
+* :ref:`vmware_guest_custom_attributes <vmware_guest_custom_attributes_module>` module does not require VM name which was a required parameter for releases prior to Ansible 2.10.
 
 Plugins
 =======

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -37,7 +37,6 @@ options:
      description:
      - Name of the virtual machine to work with.
      - This is required parameter, if C(uuid) or C(moid) is not supplied.
-     required: True
      type: str
    state:
      description:
@@ -206,7 +205,7 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datacenter=dict(type='str'),
-        name=dict(required=True, type='str'),
+        name=dict(type='str'),
         folder=dict(type='str'),
         uuid=dict(type='str'),
         moid=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Name is not a required parameter for vmware_guest_custom_attributes

Fixes: #63222

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_guest_custom_attributes.yml
docs/docsite/rst/porting_guides/porting_guide_2.10.rst
lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py