### PR TITLE
mysql_replication: add resetmaster choice to mode param

### DIFF
--- a/changelogs/fragments/63321-mysql_replication_add_resetmaster_to_mode.yml
+++ b/changelogs/fragments/63321-mysql_replication_add_resetmaster_to_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_replication - add support of ``resetmaster`` choice to ``mode`` parameter (https://github.com/ansible/ansible/issues/42870).

--- a/test/integration/targets/mysql_replication/tasks/main.yml
+++ b/test/integration/targets/mysql_replication/tasks/main.yml
@@ -12,3 +12,7 @@
 # Tests of channel parameter:
 - import_tasks: mysql_replication_channel.yml
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'
+
+# Tests of resetmaster mode:
+- import_tasks: mysql_replication_resetmaster_mode.yml
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_resetmaster_mode.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_resetmaster_mode.yml
@@ -1,0 +1,48 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Needs for further tests:
+- name: Stop slave
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: stopslave
+
+- name: Reset slave all
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ standby_port }}"
+    mode: resetslaveall
+
+# Get master initial status:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_initial_status
+
+# Test resetmaster mode:
+- name: Reset master
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: resetmaster
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["RESET MASTER"]
+
+# Get master final status:
+- name: Get master status
+  mysql_replication:
+    login_host: 127.0.0.1
+    login_port: "{{ master_port }}"
+    mode: getmaster
+  register: master_final_status
+
+- assert:
+    that:
+    - master_initial_status.File != master_final_status.File


### PR DESCRIPTION
##### SUMMARY
mysql_replication: add resetmaster choice to mode param
fixes: https://github.com/ansible/ansible/issues/42870

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_replication.py```

##### EXAMPLE
```
- name: >
     Run RESET MASTER command which will delete all existing binary log files
     and reset the binary log index file on the master
   mysql_replication:
     mode: resetmaster
```

