### PR TITLE
na_ontap_command - new features

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_ontap_command.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_command.py
@@ -215,7 +215,7 @@ class NetAppONTAPCommand(object):
 
                     # Generate stdout_lines_filter_list
                     if self.exclude_lines:
-                        if len(stripped_line) > 1 and self.include_lines in stripped_line and not self.exclude_lines in stripped_line:
+                        if len(stripped_line) > 1 and self.include_lines in stripped_line and self.exclude_lines not in stripped_line:
                             self.result_dict['stdout_lines_filter'].append(stripped_line)
                     else:
                         if len(stripped_line) > 1 and self.include_lines in stripped_line:


### PR DESCRIPTION
##### SUMMARY

Adding _'stdout_lines_filter'_ list to dictionary output (`return_dict: true`) and two new module options:
- _exclude_lines_
- _include_lines_

stdout_lines_filter returns only lines that contains `<string>` defined in _include_lines_ and do not contain `<string>` defined in _exclude_lines_

This makes output parsing way easier:

```yaml
na_ontap_command:
        command: ["ldap", "client", "show", "-fields", "base-dn,ldap-servers"]
        exclude_lines: 'server '
```

```yaml
...
stdout_lines:
      - vserver    client-config    ldap-servers    base-dn
      - Vserver    Client Configuration Name    LDAP Server List    Base DN
      - svm1  client1    ldap.example.com    dc=example,dc=com
stdout_lines_filter:
      - svm1  client1    ldap.example.com    dc=example,dc=comm
...
```

```yaml
another_module:
      something: "{{ item }}"
loop: "{{ command_result.msg.stdout_lines_filter }}"

# rather than
another_module:
      something: "{{ item }}"
loop: "{{ command_result.msg.stdout_lines }}"
when:
      - not item is search("^Vserver")
      - not item is search("^vserver")
```

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
na_ontap_command 