### PR TITLE
[WIP] Fix casing for RDS parameter CACertificateIdentifier

### DIFF
--- a/changelogs/fragments/63324-fix_rds_instance-ca_certificate_identifier-option.yml
+++ b/changelogs/fragments/63324-fix_rds_instance-ca_certificate_identifier-option.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - rds_instance - Fix the casing of the ca_certificate_identifier option to be CACertificateIdentifier
+    instead of CaCertificateIdentifier. (https://github.com/ansible/ansible/issues/63324)

--- a/lib/ansible/module_utils/aws/rds.py
+++ b/lib/ansible/module_utils/aws/rds.py
@@ -202,7 +202,7 @@ def arg_spec_to_rds_params(options_dict):
         processor_features = options_dict.pop('processor_features')
     camel_options = snake_dict_to_camel_dict(options_dict, capitalize_first=True)
     for key in list(camel_options.keys()):
-        for old, new in (('Db', 'DB'), ('Iam', 'IAM'), ('Az', 'AZ')):
+        for old, new in (('Db', 'DB'), ('Iam', 'IAM'), ('Az', 'AZ'), ('Ca', 'CA')):
             if old in key:
                 camel_options[key.replace(old, new)] = camel_options.pop(key)
     camel_options['Tags'] = tags


### PR DESCRIPTION
##### SUMMARY
Add another exception when CamelCase is not quite right. The parameter is CACertificateIdentifier, not CaCertificateIdentifier.

Fixes #63324
Fixes #63934

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rds_instance

