### PR TITLE
Fix ec2_instance module behavior when setting tenancy and placement_group params

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1128,7 +1128,10 @@ def build_top_level_options(params):
     if params.get('tenancy') is not None:
         spec['Placement'] = {'Tenancy': params.get('tenancy')}
     if params.get('placement_group'):
-        spec.setdefault('Placement', {'GroupName': str(params.get('placement_group'))})
+        if 'Placement' in spec:
+            spec['Placement']['GroupName'] = str(params.get('placement_group'))
+        else:
+            spec.setdefault('Placement', {'GroupName': str(params.get('placement_group'))})
     if params.get('ebs_optimized') is not None:
         spec['EbsOptimized'] = params.get('ebs_optimized')
     if params.get('instance_initiated_shutdown_behavior'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix logic bug in ec2_instance module where the placement_group param is ignored if tenanacy param is also set when calling the module. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce, call the ec2_instance module as follows:
```
- name: Create EC2 machine
   ec2_instance:
       key_name: "{{ keypair_name }}"
       security_group: "{{ valid_sg }}"
       image_id: "{{ ami_id}}"
       vpc_subnet_id: "{{ vpc }}"
       placement_group: "test"
       tenancy: "dedicated"
       state: running
```
When the EC2 instance is created currently through Ansible, when checking the console, the created machine will show that tenancy is set, but placement will remain empty.  If tenancy is removed, the placement is set properly.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
changed: [localhost] => (item={'ami_launch_index': 0, 'image_id': 'ami-111111111111', 'instance_id': 'i-111111111111', 'instance_type': 'm5.4xlarge', 'key_name': 'key_9a02cdfe-e437-5728-9038-364380299153', 'launch_time': '2019-10-10T14:33:09+00:00', 'monitoring': {'state': 'disabled'}, 'placement': {'availability_zone': 'us-east-1a', 'tenancy': 'dedicated'}, <rest of output>...)

After:
changed: [localhost] => (item={'ami_launch_index': 0, 'image_id': 'ami-111111111111', 'instance_id': 'i-111111111111', 'instance_type': 'm5.4xlarge', 'key_name': 'key_9a02cdfe-e437-5728-9038-364380299153', 'launch_time': '2019-10-10T14:33:09+00:00', 'monitoring': {'state': 'disabled'}, 'placement': {'availability_zone': 'us-east-1a', group_name: 'test', 'tenancy': 'dedicated'}, <rest of output>...)
```
