### PR TITLE
fix aws_ssm_parameter_store description bug

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -192,8 +192,12 @@ def create_update_parameter(client, module):
                 except ClientError as e:
                     module.fail_json_aws(e, msg="getting description value")
 
-                if describe_existing_parameter['Parameters'][0]['Description'] != args['Description']:
+                existing_parameter = describe_existing_parameter['Parameters'][0]
+
+                # boto3 does not return a description if one is not set.
+                if 'Description' in existing_parameter.keys() and existing_parameter['Description'] != args['Description']:
                     (changed, response) = update_parameter(client, module, args)
+
     else:
         (changed, response) = update_parameter(client, module, args)
 

--- a/test/integration/targets/aws_ssm_parameters/tasks/description.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/description.yml
@@ -1,0 +1,30 @@
+- name: verify description based bug in ssm
+  module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+
+    # this bug presents when a parameter is created without a description then
+    # an update happens with a description.  
+    # This shows up as a Key error
+
+
+    - name: Create or update key/value pair in aws parameter store
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/description_bug"
+        value: "unimportant"
+
+    - name: update the parameter but make sure the description is different
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/description_bug"
+        description: "This description changes"
+        value: "unimportant"
+
+    - name: clean up
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/description_bug"
+        value: "unimportant"
+        state: absent

--- a/test/integration/targets/aws_ssm_parameters/tasks/description.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/description.yml
@@ -125,6 +125,9 @@
   always:
     - name: clean up
       aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/description_bug"
+        name: "/{{ssm_key_prefix}}/{{ item }}"
         value: "unimportant"
         state: absent
+      with_items:
+        - created_with_description
+        - created_without_description

--- a/test/integration/targets/aws_ssm_parameters/tasks/description.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/description.yml
@@ -10,19 +10,127 @@
     # this bug presents when a parameter is created without a description then
     # an update happens with a description.  
     # This shows up as a Key error
+    # when an ssm parameter is created
+
+    - name: install awscli
+      pip:
+        state: present
+        name: awscli
 
 
-    - name: Create or update key/value pair in aws parameter store
+    - name: Create param without description
       aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/description_bug"
+        name: "/{{ssm_key_prefix}}/created_without_description"
         value: "unimportant"
 
-    - name: update the parameter but make sure the description is different
+    - name: get info on parameter created without description before adding description
+      command: "aws ssm describe-parameters --filters Key=Name,Values=/{{ssm_key_prefix}}/created_without_description --query Parameters[0]"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: param_info_query
+
+    - name: convert it to an object for ease of assertion
+      set_fact:
+        without_param_info_pre: "{{ param_info_query.stdout |from_json }}"
+
+    - name: update param with description
       aws_ssm_parameter_store:
-        name: "/{{ssm_key_prefix}}/description_bug"
-        description: "This description changes"
+        name: "/{{ssm_key_prefix}}/created_without_description"
+        description: "this now has a description"
         value: "unimportant"
 
+    - name: wait for ssm to get consistent
+      pause: 
+        seconds: 5
+
+    - name: get info on parameter created without description after adding description
+      command: "aws ssm describe-parameters --filters Key=Name,Values=/{{ssm_key_prefix}}/created_without_description --query Parameters[0]"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: param_info_query
+
+    - name: convert it to an object for ease of assertion
+      set_fact:
+        without_param_info_post: "{{ param_info_query.stdout |from_json }}"
+
+    - name: dump variables
+      debug:
+        var: without_param_info_pre
+    - name: dump variables
+      debug:
+        var: without_param_info_post
+
+
+    - name: Verify param did not have description after first operation
+      assert:
+        that:
+          - "'Description' not in without_param_info_pre.keys()"
+
+    - name: Verify param has description after updated
+      assert:
+        that:
+          - "'Description' in without_param_info_post.keys()"
+          - "without_param_info_post['Description'] == 'this now has a description'"
+
+    # the opposite, created with and removing it later
+    - name: Create param with description
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/created_with_description"
+        description: "this has a description"
+        value: "unimportant"
+
+    - name: get info on parameter created with description
+      command: "aws ssm describe-parameters --filters Key=Name,Values=/{{ssm_key_prefix}}/created_with_description --query Parameters[0]"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: param_info_query
+
+    - name: convert it to an object for ease of assertion
+      set_fact:
+        with_param_info: "{{ param_info_query.stdout |from_json }}"
+
+    - name: Verify param has description after being created
+      assert:
+        that:
+          - "'Description' in with_param_info.keys()"
+          - "with_param_info['Description'] == 'this has a description'"
+
+    - name: update param created with description to remove description
+      aws_ssm_parameter_store:
+        name: "/{{ssm_key_prefix}}/created_with_description"
+        value: "unimportant"
+
+    - name: wait for ssm to get consistent
+      pause: 
+        seconds: 5
+
+    - name: get info on parameters
+      command: "aws ssm describe-parameters --filters Key=Name,Values=/{{ssm_key_prefix}}/created_with_description --query Parameters[0]"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: param_info_query
+
+    - name: convert it to an object
+      set_fact:
+        with_param_info_post: "{{ param_info_query.stdout |from_json }}"
+
+    - name: Verify param did not have description after update
+      assert:
+        that:
+          - "'Description' not in with_param_info_post.keys()"
+  always:
     - name: clean up
       aws_ssm_parameter_store:
         name: "/{{ssm_key_prefix}}/description_bug"

--- a/test/integration/targets/aws_ssm_parameters/tasks/description.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/description.yml
@@ -126,7 +126,6 @@
     - name: clean up
       aws_ssm_parameter_store:
         name: "/{{ssm_key_prefix}}/{{ item }}"
-        value: "unimportant"
         state: absent
       with_items:
         - created_with_description

--- a/test/integration/targets/aws_ssm_parameters/tasks/description.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/description.yml
@@ -59,14 +59,6 @@
       set_fact:
         without_param_info_post: "{{ param_info_query.stdout |from_json }}"
 
-    - name: dump variables
-      debug:
-        var: without_param_info_pre
-    - name: dump variables
-      debug:
-        var: without_param_info_post
-
-
     - name: Verify param did not have description after first operation
       assert:
         that:

--- a/test/integration/targets/aws_ssm_parameters/tasks/main.yml
+++ b/test/integration/targets/aws_ssm_parameters/tasks/main.yml
@@ -14,6 +14,11 @@
            region: "{{ aws_region }}"
       no_log: yes
     # ============================================================
+
+
+    - name: run description bug playbook
+      include_tasks: description.yml
+
     - name: Create or update key/value pair in aws parameter store
       aws_ssm_parameter_store:
         name: "/{{ssm_key_prefix}}/Hello"
@@ -116,6 +121,7 @@
       assert:
         that:
           - result.changed == False
+
   always:
     # ============================================================
     - name: Delete remaining key/value pairs in aws parameter store


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issues with descriptions on ssm parameters.  fixes #62516

Creating an ssm parameter with no description, then updating the parameter to include a description will cause the module to fail with `KeyError: 'Description'`.  This is because the module assumes that if module.params includes description, description will be returned by the describe parameter call.

This PR does change the behavior of the module slightly with regard to description.  Description will now be removed if module params does not include description.

Included tests need aws cli because the lookup module does not return description.  Also, I don't have a good way of demonstrating before/after behavior.  When tests are run with original aws_ssm_parameter_store module, they will fail.  After these updates, they will pass.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ssm_parameter_store.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
