### PR TITLE
text-ify config warning message

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -393,7 +393,7 @@ class ConfigManager(object):
             try:
                 temp_value = container.get(name, None)
             except UnicodeEncodeError:
-                self.WARNINGS.add('value for config entry {0} contains invalid characters, ignoring...'.format(to_native(name)))
+                self.WARNINGS.add(u'value for config entry {0} contains invalid characters, ignoring...'.format(to_text(name)))
                 continue
             if temp_value is not None:  # only set if env var is defined
                 value = temp_value


### PR DESCRIPTION
##### SUMMARY
ensure that config warning messages are always wide strings

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
