### PR TITLE
Wrap CLI passwords as AnsibleUnsafeText

### DIFF
--- a/changelogs/fragments/dont-template-cli-passwords.yml
+++ b/changelogs/fragments/dont-template-cli-passwords.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- >
+  **security issue** - Convert CLI provided passwords to text initially, to
+  prevent unsafe context being lost when converting from bytes->text during
+  post processing of PlayContext. This prevents CLI provided passwords from
+  being incorrectly templated.

--- a/changelogs/fragments/dont-template-cli-passwords.yml
+++ b/changelogs/fragments/dont-template-cli-passwords.yml
@@ -3,4 +3,4 @@ bugfixes:
   **security issue** - Convert CLI provided passwords to text initially, to
   prevent unsafe context being lost when converting from bytes->text during
   post processing of PlayContext. This prevents CLI provided passwords from
-  being incorrectly templated.
+  being incorrectly templated (CVE-2019-14856)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -29,7 +29,7 @@ from ansible.release import __version__
 from ansible.utils.collection_loader import set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
-from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText
 from ansible.vars.manager import VariableManager
 
 try:
@@ -240,8 +240,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             if op['ask_pass']:
                 sshpass = getpass.getpass(prompt="SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
-                if sshpass:
-                    sshpass = to_bytes(sshpass, errors='strict', nonstring='simplerepr')
             else:
                 become_prompt = "%s password: " % become_prompt_method
 
@@ -249,17 +247,15 @@ class CLI(with_metaclass(ABCMeta, object)):
                 becomepass = getpass.getpass(prompt=become_prompt)
                 if op['ask_pass'] and becomepass == '':
                     becomepass = sshpass
-                if becomepass:
-                    becomepass = to_bytes(becomepass)
         except EOFError:
             pass
 
         # we 'wrap' the passwords to prevent templating as
         # they can contain special chars and trigger it incorrectly
         if sshpass:
-            sshpass = AnsibleUnsafeBytes(sshpass)
+            sshpass = AnsibleUnsafeText(to_text(sshpass))
         if becomepass:
-            becomepass = AnsibleUnsafeBytes(becomepass)
+            becomepass = AnsibleUnsafeText(to_text(becomepass))
 
         return (sshpass, becomepass)
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -23,7 +23,6 @@ from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.parsing.dataloader import DataLoader
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel
-from ansible.utils.unsafe_proxy import AnsibleUnsafe, wrap_var
 from ansible.utils.vars import combine_vars, isidentifier, get_unique_id
 
 display = Display()

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -338,16 +338,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
 
     def get_validated_value(self, name, attribute, value, templar):
         if attribute.isa == 'string':
-            # This is a hack.  We should change the architecture so that playbook objects only
-            # deal with values that are coming from the playbook.  We can then combine those
-            # values with values from other sources (default values, values from the command line
-            # and environment, etc)  That's a big project, though, so use this special case instead
-            if not isinstance(value, AnsibleUnsafe):
-                value = to_text(value)
-            else:
-                # If this is unsafe and is not a string, then make it a string and re-mark it as
-                # unsafe
-                value = wrap_var(to_text(value))
+            value = to_text(value)
         elif attribute.isa == 'int':
             value = int(value)
         elif attribute.isa == 'float':

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -272,7 +272,7 @@ class AnsibleContext(Context):
             for item in val:
                 if self._is_unsafe(item):
                     return True
-        elif isinstance(val, string_types) and hasattr(val, '__UNSAFE__'):
+        elif hasattr(val, '__UNSAFE__'):
             return True
         return False
 

--- a/test/integration/targets/cli/aliases
+++ b/test/integration/targets/cli/aliases
@@ -1,0 +1,2 @@
+needs/target/setup_pexpect
+shippable/posix/group3

--- a/test/integration/targets/cli/runme.sh
+++ b/test/integration/targets/cli/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook setup.yml
+
+python test-cli.py

--- a/test/integration/targets/cli/setup.yml
+++ b/test/integration/targets/cli/setup.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: no
+  roles:
+    - setup_pexpect

--- a/test/integration/targets/cli/test-cli.py
+++ b/test/integration/targets/cli/test-cli.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# Copyright (c) 2019 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+import pexpect
+
+os.environ['ANSIBLE_NOCOLOR'] = '1'
+out = pexpect.run(
+    'ansible localhost -m debug -a msg="{{ ansible_password }}" -k',
+    events={
+        'SSH password:': '{{ 1 + 2 }}\n'
+    }
+)
+
+assert b'{{ 1 + 2 }}' in out

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -26,6 +26,7 @@ from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.template import Templar
 from ansible.playbook import base
+from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes, AnsibleUnsafeText
 
 from units.mock.loader import DictDataLoader
 
@@ -620,3 +621,12 @@ class TestBaseSubClass(TestBase):
         ds = {'test_attr_method_missing': a_string}
         bsc = self._base_validate(ds)
         self.assertEquals(bsc.test_attr_method_missing, a_string)
+
+    def test_get_validated_value_string_rewrap_unsafe(self):
+        attribute = FieldAttribute(isa='string')
+        value = AnsibleUnsafeBytes(b'bar')
+        templar = Templar(None)
+        bsc = self.ClassUnderTest()
+        result = bsc.get_validated_value('foo', attribute, value, templar)
+        self.assertIsInstance(result, AnsibleUnsafeText)
+        self.assertEquals(result, AnsibleUnsafeText(u'bar'))

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -624,7 +624,7 @@ class TestBaseSubClass(TestBase):
 
     def test_get_validated_value_string_rewrap_unsafe(self):
         attribute = FieldAttribute(isa='string')
-        value = AnsibleUnsafeBytes(b'bar')
+        value = AnsibleUnsafeText(u'bar')
         templar = Templar(None)
         bsc = self.ClassUnderTest()
         result = bsc.get_validated_value('foo', attribute, value, templar)


### PR DESCRIPTION
##### SUMMARY

Convert CLI provided passwords to text initially, to
prevent unsafe context being lost when converting from bytes->text during
post processing of PlayContext. This prevents CLI provided passwords from
being incorrectly templated (CVE-2019-14856)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/cli/__init__.py
```
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
