### PR TITLE
[2.9 backport] fix default collection resolution in adhoc (#63298)

### DIFF
--- a/changelogs/fragments/adhoc_default_collection.yml
+++ b/changelogs/fragments/adhoc_default_collection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - adhoc CLI - when playbook-dir is specified and inside a collection, use default collection logic to resolve modules/actions

--- a/changelogs/fragments/ansible-test-collections-ansible-adhoc.yml
+++ b/changelogs/fragments/ansible-test-collections-ansible-adhoc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly sets ``ANSIBLE_PLAYBOOK_DIR`` for integration tests so unqualified collection references work for adhoc ``ansible`` usage

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -26,7 +26,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import PromptVaultSecret, get_file_vault_secret
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.release import __version__
-from ansible.utils.collection_loader import set_collection_playbook_paths
+from ansible.utils.collection_loader import AnsibleCollectionLoader, get_collection_name_from_path, set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
 from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes
@@ -453,6 +453,10 @@ class CLI(with_metaclass(ABCMeta, object)):
             loader.set_basedir(basedir)
             add_all_plugin_dirs(basedir)
             set_collection_playbook_paths(basedir)
+            default_collection = get_collection_name_from_path(basedir)
+            if default_collection:
+                display.warning(u'running with default collection {0}'.format(default_collection))
+                AnsibleCollectionLoader().set_default_collection(default_collection)
 
         vault_ids = list(options['vault_ids'])
         default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -25,7 +25,7 @@ ANSIBLE_PLAYBOOK_DIR=/tmp ansible localhost -m debug -a var=playbook_dir | grep 
 ansible localhost -m debug -a var=playbook_dir --playbook-dir=/tmp | grep '"playbook_dir": "/tmp"'
 
 # test setting playbook dir via ansible.cfg
-ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
+env -u ANSIBLE_PLAYBOOK_DIR ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
 
 # Test that no tmp dirs are left behind when running ansible-config
 TMP_DIR=~/.ansible/tmptest

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -18,6 +18,10 @@ ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m pin
 # test documentation
 ansible-doc testns.testcoll.testmodule -vvv | grep -- "- normal_doc_frag"
 
+# test adhoc default collection resolution (use unqualified collection module with playbook dir under its collection)
+echo "testing adhoc default collection support with explicit playbook dir"
+ANSIBLE_PLAYBOOK_DIR=./collection_root_user/ansible_collections/testns/testcoll ansible localhost -m testmodule
+
 echo "testing bad doc_fragments (expected ERROR message follows)"
 # test documentation failure
 ansible-doc testns.testcoll.testmodule_bad_docfrags -vvv 2>&1 | grep -- "unknown doc_fragment"

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -1342,6 +1342,11 @@ def command_integration_script(args, target, test_dir, inventory_path, temp_path
         env = integration_environment(args, target, test_dir, test_env.inventory_path, test_env.ansible_config, env_config)
         cwd = os.path.join(test_env.targets_dir, target.relative_path)
 
+        env.update(dict(
+            # support use of adhoc ansible commands in collections without specifying the fully qualified collection name
+            ANSIBLE_PLAYBOOK_DIR=cwd,
+        ))
+
         if env_config and env_config.env_vars:
             env.update(env_config.env_vars)
 
@@ -1444,6 +1449,11 @@ def command_integration_role(args, target, start_at_task, test_dir, inventory_pa
 
             env = integration_environment(args, target, test_dir, test_env.inventory_path, test_env.ansible_config, env_config)
             cwd = test_env.integration_dir
+
+            env.update(dict(
+                # support use of adhoc ansible commands in collections without specifying the fully qualified collection name
+                ANSIBLE_PLAYBOOK_DIR=cwd,
+            ))
 
             env['ANSIBLE_ROLES_PATH'] = test_env.targets_dir
 


### PR DESCRIPTION
##### SUMMARY
* fix default collection resolution in adhoc

* if an adhoc command is run with a playbook-dir under a configured collection, default collection resolution is used to resolve unqualified module/action names

* Set ANSIBLE_PLAYBOOK_DIR in integration tests.

* Fix config conflict in ansible integration test.

* add adhoc default collection test

* text-ify warning string

(cherry picked from commit 6d52bdf4db39947327ff9584e879ed7baaa8b4b6)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
adhoc CLI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
