### PR TITLE
adapt to firewalld 0.7.0 for RHEL 8.1 Beta, Fedora 31+

### DIFF
--- a/changelogs/fragments/firewalld-version-0_7_0.yml
+++ b/changelogs/fragments/firewalld-version-0_7_0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - firewalld - enable the firewalld module to function offline with firewalld version 0.7.0 and newer (https://github.com/ansible/ansible/issues/63254)

--- a/lib/ansible/module_utils/firewalld.py
+++ b/lib/ansible/module_utils/firewalld.py
@@ -8,7 +8,7 @@ from distutils.version import LooseVersion
 
 FW_VERSION = None
 fw = None
-fw_offline = None
+fw_offline = False
 import_failure = True
 try:
     import firewall.config
@@ -17,12 +17,12 @@ try:
     from firewall.client import FirewallClient
     from firewall.client import FirewallClientZoneSettings
     from firewall.errors import FirewallError
-    fw_offline = False
     import_failure = False
 
     try:
         fw = FirewallClient()
         fw.getDefaultZone()
+
     except (AttributeError, FirewallError):
         # Firewalld is not currently running, permanent-only operations
         fw_offline = True
@@ -31,10 +31,15 @@ try:
         #
         # NOTE:
         #  online and offline operations do not share a common firewalld API
-        from firewall.core.fw_test import Firewall_test
-        fw = Firewall_test()
-        fw.start()
+        try:
+            from firewall.core.fw_test import Firewall_test
+            fw = Firewall_test()
+        except (ModuleNotFoundError):
+            # In firewalld version 0.7.0 this behavior changed
+            from firewall.core.fw import Firewall
+            fw = Firewall(offline=True)
 
+        fw.start()
 except ImportError:
     pass
 

--- a/test/integration/targets/firewalld/aliases
+++ b/test/integration/targets/firewalld/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group3
 skip/freebsd
 skip/osx
-skip/rhel8.1b

--- a/test/integration/targets/firewalld/tasks/main.yml
+++ b/test/integration/targets/firewalld/tasks/main.yml
@@ -29,8 +29,26 @@
       register: check_output
       ignore_errors: true
 
-    - import_tasks: run_all_tests.yml
+    - name: Test Online Operations
+      block:
+        - name: start firewalld
+          service:
+            name: firewalld
+            state: started
+
+        - import_tasks: run_all_tests.yml
       when: check_output.rc == 0
+
+    - name: Test Offline Operations
+      block:
+        - name: stop firewalld
+          service:
+            name: firewalld
+            state: stopped
+
+        - import_tasks: run_all_tests.yml
+      when: check_output.rc == 0
+
   when:
   - not (ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7)
   - not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
In Firewalld 0.7.0, the object providing the API for offline operations has changed location. Need to handle that use case.

Fixes #63254

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld
