### PR TITLE
vmware_host_kernel_manager: fix the test

### DIFF
--- a/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_host_kernel_manager/tasks/main.yml
@@ -33,8 +33,8 @@
     - name: Check that the provided kernel_module_name has kernel_module_option set
       assert:
         that:
-          - "'original_options' in my_results_01['ansible_module_results']['{{ esxi1 }}']"
-          - "my_results_01['ansible_module_results']['{{ esxi1 }}'].original_options == 'ipv6=0'"
+          - "'original_options' in my_results_01['host_kernel_status']['{{ esxi1 }}']"
+          - "my_results_01['host_kernel_status']['{{ esxi1 }}'].original_options == 'ipv6=0'"
 
     - name: host connected, module exists, same options for idempotence test
       vmware_host_kernel_manager:


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/ansible/pull/62161 changed the name of key
returned by the module from `ansible_module_results` to
`host_kernel_status`.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_kernel_manager