### PR TITLE
vmware_guest_sendkey/test: ensure the test VM is running

### DIFF
--- a/test/integration/targets/vmware_guest_sendkey/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_sendkey/tasks/main.yml
@@ -11,6 +11,16 @@
       setup_datastore: true
       setup_virtualmachines: true
 
+  - name: set state to poweron the first VM
+    vmware_guest_powerstate:
+      validate_certs: no
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines[0].name }}"
+      folder: '{{ f0 }}'
+      state: powered-on
+
   - name: send keys to virtual machine
     vmware_guest_sendkey:
       validate_certs: False


### PR DESCRIPTION
##### SUMMARY

The `vmware_guest_sendkey` module fails if the test VM is off. We this
commit, we ensures the VM is running.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_sendkey
<!--- Write the short name of the module, plugin, task or feature below -->