### PR TITLE
Remove filtering from edgeos_config module

### DIFF
--- a/changelogs/fragments/63362-remove-edgeos-filtering.yaml
+++ b/changelogs/fragments/63362-remove-edgeos-filtering.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - edgeos_config - fix issue where module would silently filter out encrypted passwords


### PR DESCRIPTION
##### SUMMARY

The edgeos_config module had a list of commands to filter out to avoid
load failures. This list had a single regular expression which caught
commands that attempted to set pre-encrypted passwords. This behavior is
undesirable for a few reasons.

* It's poorly documented. The documentation makes cryptic mention of a
  return value that some commands might be filtered out, but offers no
  explanation as to what they are or why.

* It's hard-coded. There's no way for the user to change or disable this
  functionality, rendering the commands caught by that expression
  completely unusable with the edgeos_config module.

* The obvious workaround is unsafe. The filter catches passwords that
  are already encrypted, but is perfectly fine letting the user set
  plain-text passwords. EdgeOS will encrypt them upon commit, but this
  module encourages unsafe handling of secrets up to that point.

* It's a security vulnerability if the user doesn't know about this
  behavior. While the module will warn if commands are filtered, the
  user won't know what got filtered out until after the fact, and may
  easily miss that warning if they are not vigilant. For something as
  sensitive as setting a password, it's not hard to imagine naive use of
  this module resulting in incorrect credentials being deployed.

* It provides no discernible benefit. Using the module without filtering
  does not result in load failures. If those commands are indeed harmful
  for some reason on (old?) versions of EdgeOS, it should be incumbent
  upon the user to be scrupulous in what commands they issue, rather
  than the module maintaining a blacklist of possible ways the user
  might misuse their own system.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
This patch does not change output save for removing the `filtered` key from the return values, as it no longer has any use.
