### PR TITLE
Fix for plugins which used the boto libraries leaking the boto creden…

### DIFF
--- a/changelogs/fragments/boto-logging-credentials.yml
+++ b/changelogs/fragments/boto-logging-credentials.yml
@@ -1,0 +1,10 @@
+bugfixes:
+        - "**SECURITY** - CVE-2019-14846 - Several Ansible plugins could disclose aws credentials
+          in log files.  inventory/aws_ec2.py, inventory/aws_rds.py,
+          lookup/aws_account_attribute.py, and lookup/aws_secret.py, lookup/aws_ssm.py use the
+          boto3 library from the Ansible process. The boto3 library logs credentials at log level
+          DEBUG.  If Ansible's logging was enabled (by setting LOG_PATH to a value) Ansible would
+          set the global log level to DEBUG.  This was inherited by boto and would then log boto
+          credentials to the file specified by LOG_PATH.  This did not affect aws ansible modules
+          as those are executed in a separate process.  This has been fixed by switching to log
+          level INFO"

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -60,7 +60,7 @@ logger = None
 if getattr(C, 'DEFAULT_LOG_PATH'):
     path = C.DEFAULT_LOG_PATH
     if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
+        logging.basicConfig(filename=path, level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
         mypid = str(os.getpid())
         user = getpass.getuser()
         logger = logging.getLogger("p=%s u=%s | " % (mypid, user))


### PR DESCRIPTION
…tials to logs

(cherry picked from commit 3753304d209f2fdc28f0b2ebf1e139eb3d8c22b1)

https://github.com/ansible/ansible/pull/63366

##### SUMMARY
CVE-2019-14846 - Several Ansible plugins could disclose aws credentials
in log files. inventory/aws_ec2.py, inventory/aws_rds.py,
lookup/aws_account_attribute.py, and lookup/aws_secret.py, lookup/aws_ssm.py use the
boto3 library from the Ansible process. The boto3 library logs credentials at log level
DEBUG. If Ansible's logging was enabled (by setting LOG_PATH to a value) Ansible would
set the global log level to DEBUG. This was inherited by boto and would then log boto
credentials to the file specified by LOG_PATH. This did not affect aws ansible modules
as those are executed in a separate process. This has been fixed by switching to log
level INFO

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
