### PR TITLE
ovirt_vm correct graphical port type

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -783,6 +783,7 @@ options:
             protocol:
                 description:
                     - Graphical protocol, a list of I(spice), I(vnc), or both.
+                type: list
             disconnect_action:
                 description:
                     - "Returns the action that will take place when the graphic console(SPICE only) is disconnected. The options are:"
@@ -1826,9 +1827,6 @@ class VmsModule(BaseModule):
 
         # If there are not gc add any gc to be added:
         protocol = graphical_console.get('protocol')
-        if isinstance(protocol, str):
-            protocol = [protocol]
-
         current_protocols = [str(gc.protocol) for gc in graphical_consoles]
         if not current_protocols:
             if not self._module.check_mode:
@@ -2437,7 +2435,7 @@ def main():
             type='dict',
             options=dict(
                 headless_mode=dict(type='bool'),
-                protocol=dict(),
+                protocol=dict(type='list'),
                 disconnect_action=dict(type='str'),
                 keyboard_layout=dict(type='str'),
                 monitors=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ovirt_vm correct graphical port type
issue was when type is not specified it's always string
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/pull/63230#issuecomment-540725831
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
