### PR TITLE
Add podman_volume_info module

### DIFF
--- a/lib/ansible/modules/cloud/podman/podman_volume_info.py
+++ b/lib/ansible/modules/cloud/podman/podman_volume_info.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = """
+module: podman_volume_info
+author:
+  - "Sagi Shnaidman (@sshnaidm)"
+version_added: '2.10'
+short_description: Gather info about podman volumes
+notes: []
+description:
+  - Gather info about podman volumes with podman inspect command.
+requirements:
+  - "Podman installed on host"
+options:
+  name:
+    description:
+      - Name of the volume
+    type: str
+  executable:
+    description:
+      - Path to C(podman) executable if it is not in the C($PATH) on the
+        machine running C(podman)
+    default: 'podman'
+    type: str
+"""
+EXAMPLES = """
+- name: Gather info about all present volumes
+  podman_volume_info:
+
+- name: Gather info about specific volume
+  podman_volume_info:
+    name: specific_volume
+"""
+RETURN = """
+volumes:
+    description: Facts from all or specified volumes
+    returned: always
+    type: list
+    sample: [
+                {
+                "name": "testvolume",
+                "labels": {},
+                "mountPoint": "/home/ansible/.local/share/testvolume/_data",
+                "driver": "local",
+                "options": {},
+                "scope": "local"
+                }
+        ]
+"""
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+
+
+def get_volume_info(module, executable, name):
+    command = [executable, 'volume', 'inspect']
+    if name:
+        command.append(name)
+    else:
+        command.append("--all")
+    rc, out, err = module.run_command(command)
+    if rc != 0 or 'no such volume' in err:
+        module.fail_json(msg="Unable to gather info for %s: %s" % (name or 'all volumes', err))
+    if not out or json.loads(out) is None:
+        return [], out, err
+    return json.loads(out), out, err
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            executable=dict(type='str', default='podman'),
+            name=dict(type='str')
+        ),
+        supports_check_mode=True,
+    )
+
+    name = module.params['name']
+    executable = module.get_bin_path(module.params['executable'], required=True)
+
+    inspect_results, out, err = get_volume_info(module, executable, name)
+
+    results = {
+        "changed": False,
+        "volumes": inspect_results,
+        "stderr": err
+    }
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/podman_volume_info/aliases
+++ b/test/integration/targets/podman_volume_info/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group2
+skip/osx
+skip/freebsd
+destructive

--- a/test/integration/targets/podman_volume_info/meta/main.yml
+++ b/test/integration/targets/podman_volume_info/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_podman

--- a/test/integration/targets/podman_volume_info/tasks/main.yml
+++ b/test/integration/targets/podman_volume_info/tasks/main.yml
@@ -1,0 +1,62 @@
+- name: Test podman_volume_info
+  when:
+    - ansible_facts.virtualization_type != 'docker'
+    - ansible_facts.distribution == 'RedHat'
+  block:
+
+    - name: Print podman version
+      command: podman version
+
+    - name: Generate random value for volume name
+      set_fact:
+        volume_name: "{{ 'ansible-test-podman-%0x' % ((2**32) | random) }}"
+
+    - name: Make sure volume doesn't exist
+      command: podman volume rm {{ volume_name }}
+      ignore_errors: true
+
+    - name: Get missing volume info
+      podman_volume_info:
+        name: "{{ volume_name }}"
+      register: nonexist
+      ignore_errors: true
+
+    - name: Check results
+      assert:
+        that:
+          - "'volumes' not in nonexist"
+          - nonexist is failed
+
+    - name: Make sure volume exists
+      command: podman volume create {{ volume_name }}
+
+    - name: Get existing volume info
+      podman_volume_info:
+        name: "{{ volume_name }}"
+      register: existing_volume
+
+    - name: Dump podman volume inspect result
+      debug: var=existing_volume
+
+    - name: Comparison with 'podman volume inspect'
+      command: podman volume inspect "{{ volume_name }}"
+      register: podman_inspect
+
+    - name: Convert podman inspect output to JSON
+      set_fact:
+        podman_inspect_result: "{{ podman_inspect.stdout | from_json }}"
+
+    - name: Cleanup
+      command: podman volume rm {{ volume_name }}
+
+    - name: Make checks
+      assert:
+        that:
+          - "'volumes' in existing_volume"
+          - existing_volume.volumes
+          - "existing_volume.volumes == podman_inspect_result"
+  always:
+
+    - name: Cleanup
+      command: podman volume rm {{ volume_name }}
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add module podman_volume_info that collects data about podman
volumes on the host. Acts as docker_volume_info module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

podman_volume_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
example of using podman_volume_info module
```yaml
- name: Get all volumes info
  podman_volume_info:

- name: Get specific volume info
  podman_volume_info:
    name: volume1

```