### PR TITLE
Fix #25158 - split column grants and apply sorting

### DIFF
--- a/changelogs/fragments/mysql_user-column-privs.yaml
+++ b/changelogs/fragments/mysql_user-column-privs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - column specific grants no longer report as changed (https://github.com/ansible/ansible/issues/25158).

--- a/test/integration/targets/mysql_user/files/create-col-priv-db.sql
+++ b/test/integration/targets/mysql_user/files/create-col-priv-db.sql
@@ -1,0 +1,5 @@
+DROP DATABASE IF EXISTS `colprivdb`;
+CREATE DATABASE `colprivdb`;
+USE `colprivdb`;
+DROP TABLE IF EXISTS `t1`;
+CREATE TABLE `t1` (`c1` int(1), `c2` int(1), `c3` int(1));

--- a/test/integration/targets/mysql_user/files/drop-col-priv-db.sql
+++ b/test/integration/targets/mysql_user/files/drop-col-priv-db.sql
@@ -1,0 +1,1 @@
+DROP DATABASE IF EXISTS `colprivdb`;

--- a/test/integration/targets/mysql_user/tasks/main.yml
+++ b/test/integration/targets/mysql_user/tasks/main.yml
@@ -208,6 +208,8 @@
 #
 - include: test_privs.yml current_privilege='INSERT,DELETE' current_append_privs=yes
 
+- include: test_col_privs.yml
+
 - import_tasks: issue-29511.yaml
   tags:
     - issue-29511

--- a/test/integration/targets/mysql_user/tasks/test_col_privs.yml
+++ b/test/integration/targets/mysql_user/tasks/test_col_privs.yml
@@ -1,0 +1,149 @@
+# test code for column privileges for mysql_user module
+
+# ============================================================
+- name: Copy SQL script to remote
+  copy:
+    src: "{{ item }}"
+    dest: "{{ remote_tmp_dir }}/{{ item | basename }}"
+  with_items:
+    - create-col-priv-db.sql
+    - drop-col-priv-db.sql
+
+- name: Create col priv test db
+  shell: "mysql < {{ remote_tmp_dir }}/create-col-priv-db.sql"
+
+- name: Add privs to specific table columns (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1,c3)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed" }
+
+- name: Get grants for test user
+  shell: >
+      mysql -S {{ mysql_socket }} -D mysql -NBe \
+        "SELECT Column_name,Column_priv
+          FROM columns_priv
+          WHERE Db='colprivdb'
+            AND User='colprivuser1'
+            AND Table_name='t1'"
+  check_mode: no
+  register: result
+
+- name: Assert column privs for C1, C3, but not C2
+  assert:
+    that: >
+      "C1\tSelect" in result.stdout_lines
+      and "C3\tSelect" in result.stdout_lines
+      and "C2\tSelect" not in result.stdout_lines
+
+- name: Add privs to specific table columns (expect ok)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c3,c1)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv did not change
+  assert: { that: "not result.changed" }
+
+- name: Get grants for test user
+  shell: >
+      mysql -S {{ mysql_socket }} -D mysql -NBe \
+        "SELECT Column_name,Column_priv
+          FROM columns_priv
+          WHERE Db='colprivdb'
+            AND User='colprivuser1'
+            AND Table_name='t1'"
+  check_mode: no
+  register: result
+
+- name: Assert column privs for C1, C3, but not C2
+  assert:
+    that: >
+      "C1\tSelect" in result.stdout_lines
+      and "C3\tSelect" in result.stdout_lines
+      and "C2\tSelect" not in result.stdout_lines
+
+- name: Check privs to specific table columns (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1,c2,c3)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  check_mode: yes
+  register: result
+
+- name: Assert that priv reports changed
+  assert: { that: "result.changed" }
+
+- name: Get grants for test user
+  shell: >
+      mysql -S {{ mysql_socket }} -D mysql -NBe \
+        "SELECT Column_name,Column_priv
+          FROM columns_priv
+          WHERE Db='colprivdb'
+            AND User='colprivuser1'
+            AND Table_name='t1'"
+  check_mode: no
+  register: result
+
+- name: Assert column privs for C1, C3, but not C2
+  assert:
+    that: >
+      "C1\tSelect" in result.stdout_lines
+      and "C3\tSelect" in result.stdout_lines
+      and "C2\tSelect" not in result.stdout_lines
+
+- name: Reduce privs to one table column (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed" }
+
+- name: Get grants for test user
+  shell: >
+      mysql -S {{ mysql_socket }} -D mysql -NBe \
+        "SELECT Column_name,Column_priv
+          FROM columns_priv
+          WHERE Db='colprivdb'
+            AND User='colprivuser1'
+            AND Table_name='t1'"
+  check_mode: no
+  register: result
+
+- name: Assert column privs
+  assert:
+    that: >
+      "C1\tSelect" in result.stdout_lines
+      and "C3\tSelect" not in result.stdout_lines
+      and "C2\tSelect" not in result.stdout_lines
+
+- name: Drop user privileges (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed" }
+
+- include: assert_no_user.yml user_name="colprivuser1"
+
+- name: Drop col priv test db
+  shell: "mysql < {{ remote_tmp_dir }}/drop-col-priv-db.sql"


### PR DESCRIPTION
##### SUMMARY
Re-implementation of #58928 as requested on IRC.

`mysql_user` plugin has some issues with handling column specific grants:

- MySQL doesn't keep track of the order of specified columns which results in ansible reporting the task as changed, even though the required grants are set. This change splits the columns and sorts them to work around this.

Fixes #25158

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ADDITIONAL INFORMATION
The code changes are obtained from a patch attached to #25158

A backport to 2.8 would be appreciated.


Example of how MariaDB/MySQL handle grants:

```
MariaDB [(none)]> create database a;
Query OK, 1 row affected (0.001 sec)

MariaDB [(none)]> use a;
Database changed
MariaDB [a]> create table t1 (c1 int(1), c2 int(1), c3 int(1));
Query OK, 0 rows affected (0.035 sec)

MariaDB [a]> GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY 'pwd';
Query OK, 0 rows affected (0.010 sec)

MariaDB [a]> GRANT SELECT (c2, c3) ON `a`.`t1` TO 'user'@'localhost';
Query OK, 0 rows affected (0.010 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
| GRANT SELECT (c3, c2) ON `a`.`t1` TO 'user'@'localhost'                                                     |
+-------------------------------------------------------------------------------------------------------------+
2 rows in set (0.000 sec)

MariaDB [a]> REVOKE SELECT (c3, c2) ON `a`.`t1` FROM 'user'@'localhost';
Query OK, 0 rows affected (0.010 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
+-------------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)

MariaDB [a]> GRANT SELECT (c3, c1) ON `a`.`t1` TO 'user'@'localhost';
Query OK, 0 rows affected (0.005 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
| GRANT SELECT (c1, c3) ON `a`.`t1` TO 'user'@'localhost'                                                     |
+-------------------------------------------------------------------------------------------------------------+
2 rows in set (0.000 sec)

MariaDB [a]> GRANT SELECT (c1, c3) ON `a`.`t1` TO 'user'@'localhost';
Query OK, 0 rows affected (0.013 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
| GRANT SELECT (c1, c3) ON `a`.`t1` TO 'user'@'localhost'                                                     |
+-------------------------------------------------------------------------------------------------------------+
2 rows in set (0.000 sec)

MariaDB [a]> REVOKE SELECT (c3, c1) ON `a`.`t1` FROM 'user'@'localhost';
Query OK, 0 rows affected (0.009 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
+-------------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)

MariaDB [a]> GRANT SELECT (c1, c3) ON `a`.`t1` TO 'user'@'localhost';
Query OK, 0 rows affected (0.010 sec)

MariaDB [a]> SHOW GRANTS FOR 'user'@'localhost';
+-------------------------------------------------------------------------------------------------------------+
| Grants for user@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'user'@'localhost' IDENTIFIED BY PASSWORD '*975B2CD4FF9AE554FE8AD33168FBFC326D2021DD' |
| GRANT SELECT (c3, c1) ON `a`.`t1` TO 'user'@'localhost'                                                     |
+-------------------------------------------------------------------------------------------------------------+
2 rows in set (0.000 sec)
```