### PR TITLE
WIP: Fix #40879 - add quotes to column grants

### DIFF
--- a/changelogs/fragments/mysql_user-column-privs.yaml
+++ b/changelogs/fragments/mysql_user-column-privs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - column specific grants no longer report as changed

--- a/changelogs/fragments/mysql_user-reserved-keywords-columns.yml
+++ b/changelogs/fragments/mysql_user-reserved-keywords-columns.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mysql_user - column names are quoted when adding column specific grants

--- a/test/integration/targets/mysql_user/files/create-col-priv-db.sql
+++ b/test/integration/targets/mysql_user/files/create-col-priv-db.sql
@@ -1,0 +1,5 @@
+DROP DATABASE IF EXISTS `colprivdb`;
+CREATE DATABASE `colprivdb`;
+USE `colprivdb`;
+DROP TABLE IF EXISTS `t1`;
+CREATE TABLE `t1` (`c1` int(1), `c2` int(1), `c3` int(1));

--- a/test/integration/targets/mysql_user/files/create-col-priv-db.sql
+++ b/test/integration/targets/mysql_user/files/create-col-priv-db.sql
@@ -2,4 +2,4 @@ DROP DATABASE IF EXISTS `colprivdb`;
 CREATE DATABASE `colprivdb`;
 USE `colprivdb`;
 DROP TABLE IF EXISTS `t1`;
-CREATE TABLE `t1` (`c1` int(1), `c2` int(1), `c3` int(1));
+CREATE TABLE `t1` (`c1` int(1), `c2` int(1), `c3` int(1), `ssl` int(1));

--- a/test/integration/targets/mysql_user/files/drop-col-priv-db.sql
+++ b/test/integration/targets/mysql_user/files/drop-col-priv-db.sql
@@ -1,0 +1,1 @@
+DROP DATABASE IF EXISTS `colprivdb`;

--- a/test/integration/targets/mysql_user/tasks/main.yml
+++ b/test/integration/targets/mysql_user/tasks/main.yml
@@ -208,6 +208,8 @@
 #
 - include: test_privs.yml current_privilege='INSERT,DELETE' current_append_privs=yes
 
+- include: test_col_privs.yml
+
 - import_tasks: issue-29511.yaml
   tags:
     - issue-29511

--- a/test/integration/targets/mysql_user/tasks/test_col_privs.yml
+++ b/test/integration/targets/mysql_user/tasks/test_col_privs.yml
@@ -1,0 +1,51 @@
+# test code for column privileges for mysql_user module
+
+# ============================================================
+- name: Copy SQL script to remote
+  copy:
+    src: "{{ item }}"
+    dest: "{{ remote_tmp_dir }}/{{ item | basename }}"
+  with_items:
+    - create-col-priv-db.sql
+    - drop-col-priv-db.sql
+
+- name: Create col priv test db
+  shell: "mysql < {{ remote_tmp_dir }}/create-col-priv-db.sql"
+
+- name: Add privs to specific table columns (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1,c3)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed" }
+
+- name: Add privs to specific table columns (expect ok)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1,c3)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv did not change
+  assert: { that: "not result.changed" }
+
+- name: Drop privs for specific table columns (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(c1,c3)'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- include: assert_no_user.yml user_name="colprivuser1"
+
+- name: Drop col priv test db
+  shell: "mysql < {{ remote_tmp_dir }}/drop-col-priv-db.sql"

--- a/test/integration/targets/mysql_user/tasks/test_col_privs.yml
+++ b/test/integration/targets/mysql_user/tasks/test_col_privs.yml
@@ -45,6 +45,39 @@
     login_unix_socket: '{{ mysql_socket }}'
   register: result
 
+- name: Add privs to reserved keyword table column (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(ssl)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed" }
+
+- name: Add privs to reserved keyworld table column (expect ok)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(ssl)'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv did not change
+  assert: { that: "not result.changed" }
+
+- name: Drop privs for reserved keyword table column (expect changed)
+  mysql_user:
+    name: 'colprivuser1'
+    password: 'colprivpass1'
+    priv: 'colprivdb.t1:SELECT(ssl)'
+    state: absent
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
 - include: assert_no_user.yml user_name="colprivuser1"
 
 - name: Drop col priv test db


### PR DESCRIPTION
##### SUMMARY
> DO NOT MERGE - This PR depends on #63384

`mysql_user` plugin has some issues with handling column specific grants:

- If a column name matches a reserved keyword, ansible fails because of the lack of quotes. Add quotes where needed, depending on the mode (ANSI quoting or regular).

Fixes #40879

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ADDITIONAL INFORMATION
The code changes are obtained from a patch attached to #25158

A backport to 2.8 would be appreciated.