### PR TITLE
ini_file: remove incorrect documentation

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -59,10 +59,6 @@ options:
         the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: no
-  others:
-    description:
-      - All arguments accepted by the M(file) module also work here.
-    type: str
   state:
     description:
       - If set to C(absent) the option or section will be removed if present instead of created.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2241,7 +2241,6 @@ lib/ansible/modules/files/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/files/file.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/files/find.py use-argspec-type-path # fix needed
 lib/ansible/modules/files/find.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/files/ini_file.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/files/iso_extract.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/files/lineinfile.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/files/lineinfile.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* The module does not accept an option named `others`

* The common `file` arguments are already covered by the documentation
  fragment.

* There are other `file` arguments that are not implemented in this
  module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ini_file