### PR TITLE
Improve code of Hiera lookup plugin.

### DIFF
--- a/lib/ansible/plugins/lookup/hiera.py
+++ b/lib/ansible/plugins/lookup/hiera.py
@@ -61,24 +61,23 @@ import json
 
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.cmd_functions import run_cmd
+from ansible.module_utils._text import to_text
 
 ANSIBLE_HIERA_CFG = os.getenv('ANSIBLE_HIERA_CFG', '/etc/hiera.yaml')
 ANSIBLE_HIERA_BIN = os.getenv('ANSIBLE_HIERA_BIN', '/usr/bin/hiera')
 
+
 class Hiera(object):
     def get(self, hiera_key):
         command = "{0} -f json -c {1} {2}".format(ANSIBLE_HIERA_BIN, ANSIBLE_HIERA_CFG, hiera_key[0])
-        _, output, _ = run_cmd(command)
+        returncode, output, stderr = run_cmd(command)
 
         return output.strip()
+
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=''):
         hiera = Hiera()
-        data = hiera.get(terms)
+        data = to_text(hiera.get(terms))
 
-        # Check for bytes literal and decode if necessary
-        if isinstance(data, bytes):
-            data = data.decode('utf-8')
-        
         return [json.loads(data)]

--- a/test/integration/targets/lookup_hiera/aliases
+++ b/test/integration/targets/lookup_hiera/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group3

--- a/test/integration/targets/lookup_hiera/hiera-data/defaults.yaml
+++ b/test/integration/targets/lookup_hiera/hiera-data/defaults.yaml
@@ -1,0 +1,12 @@
+---
+
+test_var: success
+
+test_list:
+  - gamertag: Art3mis
+    real_name: Samantha Evelyn Cook
+
+test_array:
+  - Ready
+  - Player
+  - One

--- a/test/integration/targets/lookup_hiera/hiera-data/production.yaml
+++ b/test/integration/targets/lookup_hiera/hiera-data/production.yaml
@@ -1,0 +1,4 @@
+---
+
+first:
+  to_the_key: First to the Egg

--- a/test/integration/targets/lookup_hiera/hiera.yaml
+++ b/test/integration/targets/lookup_hiera/hiera.yaml
@@ -1,0 +1,15 @@
+---
+
+:backends:
+  - yaml
+  
+:hierarchy:
+  - defaults
+  - "%{environment}"
+  - global
+
+:logger: console
+
+:yaml:
+  :datadir: "hiera-data"
+  

--- a/test/integration/targets/lookup_hiera/main.yml
+++ b/test/integration/targets/lookup_hiera/main.yml
@@ -1,0 +1,28 @@
+---
+- hosts: "localhost"
+  gather_facts: no
+
+  tasks:
+    - name: "Install Hiera"
+      gem:
+        name: "{{ item }}"
+        state: latest
+      with_items:
+          - "hiera"
+          - "hiera-eyaml"
+
+    - debug: msg="{{ lookup('hiera', 'test_var') }}"
+
+    - name: Fetch a value from Hiera
+      set_fact:
+        actual_value: "{{ lookup('hiera', 'test_var') }}"
+
+    - name: Perform assertions
+      assert:
+        that:
+          - actual_value == "success"
+          - "'{{ (lookup('hiera', 'test_list'))[0].gamertag }}' == 'Art3mis'"
+          - "{{ lookup('hiera', 'test_array') | length }} == 3"
+          - "'{{ lookup('hiera', 'test_array') | join(' ') }}' == 'Ready Player One'"
+          - "'{{ lookup('hiera', 'first.to_the_key environment=production') }}' == 'First to the Egg'"
+        

--- a/test/integration/targets/lookup_hiera/runme.sh
+++ b/test/integration/targets/lookup_hiera/runme.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# http://www.linuxcommand.org/lc3_man_pages/seth.html
+# set -eux
+
+if [[ -f /usr/local/bin/hiera ]]
+then
+    export ANSIBLE_HIERA_BIN=/usr/local/bin/hiera
+fi
+
+export ANSIBLE_HIERA_CFG="$(pwd)/hiera.yaml"
+export ANSIBLE_LOOKUP_PLUGINS="$(pwd)/../../../../lib/ansible/plugins/lookup"
+
+ansible-playbook main.yml -v "$@"

--- a/test/integration/targets/lookup_hiera/runme.sh
+++ b/test/integration/targets/lookup_hiera/runme.sh
@@ -8,7 +8,10 @@ then
     export ANSIBLE_HIERA_BIN=/usr/local/bin/hiera
 fi
 
-export ANSIBLE_HIERA_CFG="$(pwd)/hiera.yaml"
-export ANSIBLE_LOOKUP_PLUGINS="$(pwd)/../../../../lib/ansible/plugins/lookup"
+ANSIBLE_HIERA_CFG="$(pwd)/hiera.yaml"
+export ANSIBLE_HIERA_CFG
+
+ANSIBLE_LOOKUP_PLUGINS="$(pwd)/../../../../lib/ansible/plugins/lookup"
+export ANSIBLE_LOOKUP_PLUGINS
 
 ansible-playbook main.yml -v "$@"


### PR DESCRIPTION
##### SUMMARY
The current Hiera lookup did not work properly with (at least) Python 3.7.4
The output returned bytes literals which looked like 

    b'the_value_returned'

The call made to the Hiera binary also returned a Ruby format which made it difficult for the lookup to process complex data structures (which is now supported).

    -f, --format TYPE  Output the result in a specific format (ruby, yaml or json); default is 'ruby'

I fixed the bytes literals issue, made some code improvements and changed the output to json to deserialise. As a bonus I added some integration tests/assertions.

Tested with Python 3.7.4 on my own development environment and with Ruby 2.6.3 / Python 2.7.6 / Hiera 3.5.0 on TravisCI (https://github.com/orlissenberg/ansible-tests)

Hiera requires Ruby 2.x for the json format to work properly.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lookup/hiera

##### ADDITIONAL INFORMATION
Run the integration test added (runme.sh) with the current version of ansible-playbook (2.8.5)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Fetch a value from Hiera] ***************************************************************************************
ok: [localhost] => {"ansible_facts": {"actual_value": "b'success'"}, "changed": false}
```
