### PR TITLE
Properly mask no_log values is sub parameters during failure

### DIFF
--- a/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
+++ b/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - properly hide parameters marked with no_log in suboptions when invalid parameters are passed to the module

--- a/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
+++ b/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - properly hide parameters marked with no_log in suboptions when invalid parameters are passed to the module
+  - '**security issue** - properly hide parameters marked with ``no_log`` in suboptions when invalid parameters are passed to the module (CVE-2019-14858)'

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1447,7 +1447,10 @@ class AnsibleModule(object):
         if param is None:
             param = self.params
 
-        self.no_log_values.update(list_no_log_values(spec, param))
+        try:
+            self.no_log_values.update(list_no_log_values(spec, param))
+        except TypeError as te:
+            self.fail_json(msg="Failure when processing no_log parameters. %s" % to_native(te), invocation={'module_args': 'HIDDEN DUE TO FAILURE'})
         self._deprecations.extend(list_deprecations(spec, param))
 
     def _check_arguments(self, check_invalid_arguments, spec=None, param=None, legal_inputs=None):
@@ -1722,7 +1725,6 @@ class AnsibleModule(object):
                     self._set_fallbacks(spec, param)
                     options_aliases = self._handle_aliases(spec, param, option_prefix=new_prefix)
 
-                    self._handle_no_log_values(spec, param)
                     options_legal_inputs = list(spec.keys()) + list(options_aliases.keys())
 
                     self._check_arguments(self.check_invalid_arguments, spec, param, options_legal_inputs)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1450,7 +1450,8 @@ class AnsibleModule(object):
         try:
             self.no_log_values.update(list_no_log_values(spec, param))
         except TypeError as te:
-            self.fail_json(msg="Failure when processing no_log parameters. %s" % to_native(te), invocation={'module_args': 'HIDDEN DUE TO FAILURE'})
+            self.fail_json(msg="Failure when processing no_log parameters. Module invocation will be hidden. "
+                               "%s" % to_native(te), invocation={'module_args': 'HIDDEN DUE TO FAILURE'})
         self._deprecations.extend(list_deprecations(spec, param))
 
     def _check_arguments(self, check_invalid_arguments, spec=None, param=None, legal_inputs=None):

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -86,6 +86,11 @@ def list_no_log_values(argument_spec, params):
             if no_log_object:
                 no_log_values.update(_return_datastructure_name(no_log_object))
 
+        # Get no_log values from suboptions
+        if arg_opts.get('options'):
+            sub_argument_spec = arg_opts.get('options')
+            sub_params = params.get(arg_name)
+            no_log_values.update(list_no_log_values(sub_argument_spec, sub_params))
     return no_log_values
 
 

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -8,11 +8,13 @@ __metaclass__ = type
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.common.collections import is_iterable
+from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.common.validation import check_type_dict, check_type_list
 
 from ansible.module_utils.six import (
     binary_type,
     integer_types,
+    string_types,
     text_type,
 )
 
@@ -90,11 +92,12 @@ def list_no_log_values(argument_spec, params):
         # Get no_log values from suboptions
         sub_argument_spec = arg_opts.get('options')
         if sub_argument_spec is not None:
-            # Sub parameters can be a dict or list of dicts. Ensure parameters are always a list.
             wanted_type = arg_opts.get('type')
             sub_parameters = params.get(arg_name)
             if sub_parameters is not None:
                 if wanted_type == 'dict' or (wanted_type == 'list' and arg_opts.get('elements', '') == 'dict'):
+
+                    # Sub parameters can be a dict or list of dicts. Ensure parameters are always a list.
                     if not isinstance(sub_parameters, list):
                         sub_parameters = [sub_parameters]
 
@@ -106,12 +109,13 @@ def list_no_log_values(argument_spec, params):
 
                         validator = validators[wanted_type]
                         # Validate list and dict fields in case they came in as strings and need to be parsed
-                        if isinstance(sub_param, text_type):
+                        if isinstance(sub_param, string_types):
                             sub_param = validator(sub_param)
 
-                        if not isinstance(sub_param, dict):
+                        if not isinstance(sub_param, Mapping):
                             raise TypeError("Value '{1}' in the sub parameter field '{0}' must by a {2}, "
                                             "not '{1.__class__.__name__}'".format(arg_name, sub_param, wanted_type))
+
                         no_log_values.update(list_no_log_values(sub_argument_spec, sub_param))
 
     return no_log_values

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -87,10 +87,19 @@ def list_no_log_values(argument_spec, params):
                 no_log_values.update(_return_datastructure_name(no_log_object))
 
         # Get no_log values from suboptions
-        if arg_opts.get('options'):
-            sub_argument_spec = arg_opts.get('options')
-            sub_params = params.get(arg_name)
-            no_log_values.update(list_no_log_values(sub_argument_spec, sub_params))
+        sub_argument_spec = arg_opts.get('options')
+        if sub_argument_spec:
+            # Sub parameters can be a dict or list of dicts. Ensure parameters are always a list.
+            sub_parameters = params.get(arg_name)
+            if sub_parameters is not None:
+                if not isinstance(sub_parameters, list):
+                    sub_parameters = [sub_parameters]
+
+                for sub_param in sub_parameters:
+                    if not isinstance(sub_param, dict):
+                        raise TypeError("Value '{1}' in the sub parameter field '{0}' must by a dict, not '{1.__class__.__name__}'".format(arg_name, sub_param))
+                    no_log_values.update(list_no_log_values(sub_argument_spec, sub_param))
+
     return no_log_values
 
 

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -8,8 +8,7 @@ __metaclass__ = type
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.common.collections import is_iterable
-from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils.common.validation import check_type_dict, check_type_list
+from ansible.module_utils.common.validation import check_type_dict
 
 from ansible.module_utils.six import (
     binary_type,
@@ -94,23 +93,18 @@ def list_no_log_values(argument_spec, params):
         if sub_argument_spec is not None:
             wanted_type = arg_opts.get('type')
             sub_parameters = params.get(arg_name)
+
             if sub_parameters is not None:
                 if wanted_type == 'dict' or (wanted_type == 'list' and arg_opts.get('elements', '') == 'dict'):
-
                     # Sub parameters can be a dict or list of dicts. Ensure parameters are always a list.
                     if not isinstance(sub_parameters, list):
                         sub_parameters = [sub_parameters]
 
-                    validators = {
-                        'dict': check_type_dict,
-                        'list': check_type_list,
-                    }
                     for sub_param in sub_parameters:
+                        # Validate dict fields in case they came in as strings
 
-                        validator = validators[wanted_type]
-                        # Validate list and dict fields in case they came in as strings and need to be parsed
                         if isinstance(sub_param, string_types):
-                            sub_param = validator(sub_param)
+                            sub_param = check_type_dict(sub_param)
 
                         if not isinstance(sub_param, Mapping):
                             raise TypeError("Value '{1}' in the sub parameter field '{0}' must by a {2}, "

--- a/test/integration/targets/no_log/library/module.py
+++ b/test/integration/targets/no_log/library/module.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'state': {},
+            'secret': {'no_log': True},
+            'subopt_dict': {
+                'type': 'dict',
+                'options': {
+                    'str_sub_opt1': {'no_log': True},
+                    'str_sub_opt2': {},
+                    'nested_subopt': {
+                        'type': 'dict',
+                        'options': {
+                            'n_subopt1': {'no_log': True},
+                        }
+                    }
+                }
+            },
+            'subopt_list': {
+                'type': 'list',
+                'elements': 'dict',
+                'options': {
+                    'subopt1': {'no_log': True},
+                    'subopt2': {},
+                }
+            }
+
+        }
+    )
+    module.exit_json(msg='done')
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/no_log/no_log_suboptions.yml
+++ b/test/integration/targets/no_log/no_log_suboptions.yml
@@ -1,0 +1,36 @@
+- name: test no log with suboptions
+  hosts: testhost
+  gather_facts: no
+  ignore_errors: yes
+
+  tasks:
+    - name: Task with suboptions
+      module:
+        secret: UNTURNED-SPILT
+        subopt_dict:
+          str_sub_opt1: ANTIRUST-VERIFY
+          str_sub_opt2: otherstring
+          nested_subopt:
+            n_subopt1: WHEAT-PROBATION
+
+        subopt_list:
+          - subopt1: GLAMOROUS-AFTERMATH
+            subopt2: thridstring
+
+          - subopt1: VERY-TWIDDLING
+
+    - name: Task with suboptions and invalid parameter
+      module:
+        secret: UNTURNED-SPILT
+        invalid: param
+        subopt_dict:
+          str_sub_opt1: ANTIRUST-VERIFY
+          str_sub_opt2: otherstring
+          nested_subopt:
+            n_subopt1: WHEAT-PROBATION
+
+        subopt_list:
+          - subopt1: GLAMOROUS-AFTERMATH
+            subopt2: thridstring
+
+          - subopt1: VERY-TWIDDLING

--- a/test/integration/targets/no_log/no_log_suboptions.yml
+++ b/test/integration/targets/no_log/no_log_suboptions.yml
@@ -34,3 +34,15 @@
             subopt2: thridstring
 
           - subopt1: VERY-TWIDDLING
+
+    - name: Task with suboptions and invalid data
+      module:
+        secret: UNTURNED-SPILT
+        subopt_dict:
+          str_sub_opt1: ANTIRUST-VERIFY
+          str_sub_opt2: otherstring
+          nested_subopt:
+            n_subopt1: WHEAT-PROBATION
+
+        subopt_list:
+          foo: bar

--- a/test/integration/targets/no_log/no_log_suboptions.yml
+++ b/test/integration/targets/no_log/no_log_suboptions.yml
@@ -1,48 +1,24 @@
 - name: test no log with suboptions
   hosts: testhost
   gather_facts: no
-  ignore_errors: yes
 
   tasks:
     - name: Task with suboptions
       module:
-        secret: UNTURNED-SPILT
+        secret: GLAMOROUS
         subopt_dict:
-          str_sub_opt1: ANTIRUST-VERIFY
+          str_sub_opt1: AFTERMATH
           str_sub_opt2: otherstring
           nested_subopt:
-            n_subopt1: WHEAT-PROBATION
+            n_subopt1: MANPOWER
 
         subopt_list:
-          - subopt1: GLAMOROUS-AFTERMATH
+          - subopt1: UNTAPPED
             subopt2: thridstring
 
-          - subopt1: VERY-TWIDDLING
+          - subopt1: CONCERNED
 
-    - name: Task with suboptions and invalid parameter
+    - name: Task with suboptions as string
       module:
-        secret: UNTURNED-SPILT
-        invalid: param
-        subopt_dict:
-          str_sub_opt1: ANTIRUST-VERIFY
-          str_sub_opt2: otherstring
-          nested_subopt:
-            n_subopt1: WHEAT-PROBATION
-
-        subopt_list:
-          - subopt1: GLAMOROUS-AFTERMATH
-            subopt2: thridstring
-
-          - subopt1: VERY-TWIDDLING
-
-    - name: Task with suboptions and invalid data
-      module:
-        secret: UNTURNED-SPILT
-        subopt_dict:
-          str_sub_opt1: ANTIRUST-VERIFY
-          str_sub_opt2: otherstring
-          nested_subopt:
-            n_subopt1: WHEAT-PROBATION
-
-        subopt_list:
-          foo: bar
+        secret: MARLIN
+        subopt_dict: str_sub_opt1=FLICK

--- a/test/integration/targets/no_log/no_log_suboptions_invalid.yml
+++ b/test/integration/targets/no_log/no_log_suboptions_invalid.yml
@@ -1,0 +1,45 @@
+- name: test no log with suboptions
+  hosts: testhost
+  gather_facts: no
+  ignore_errors: yes
+
+  tasks:
+    - name: Task with suboptions and invalid parameter
+      module:
+        secret: SUPREME
+        invalid: param
+        subopt_dict:
+          str_sub_opt1: IDIOM
+          str_sub_opt2: otherstring
+          nested_subopt:
+            n_subopt1: MOCKUP
+
+        subopt_list:
+          - subopt1: EDUCATED
+            subopt2: thridstring
+          - subopt1: FOOTREST
+
+    - name: Task with suboptions as string with invalid parameter
+      module:
+        secret: FOOTREST
+        invalid: param
+        subopt_dict: str_sub_opt1=CRAFTY
+
+    - name: Task with suboptions with dict instead of list
+      module:
+        secret: FELINE
+        subopt_dict:
+          str_sub_opt1: CRYSTAL
+          str_sub_opt2: otherstring
+          nested_subopt:
+            n_subopt1: EXPECTANT
+        subopt_list:
+          foo: bar
+
+    - name: Task with suboptions with incorrect data type
+      module:
+        secret: AGROUND
+        subopt_dict: 9068.21361
+        subopt_list:
+          - subopt1: GOLIATH
+          - subopt1: FREEFALL

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -15,4 +15,7 @@ set -eux
 [ "$(ansible-playbook dynamic.yml -i ../../inventory -vvvvv "$@" -e unsafe_show_logs=yes|grep -c 'output has been hidden')" = "0" ]
 
 # test no log for sub options
-[ "$(ansible-playbook no_log_suboptions.yml -i ../../inventory -vvvvv "$@" | grep -Ec '(ANTIRUST-VERIFY)|(GLAMOROUS-AFTERMATH)|(UNTURNED-SPILT)|(VERY-TWIDDLING)|(WHEAT-PROBATION)')" = "0" ]
+[ "$(ansible-playbook no_log_suboptions.yml -i ../../inventory -vvvvv "$@" | grep -Ec '(MANPOWER|UNTAPPED|CONCERNED|MARLIN|FLICK)')" = "0" ]
+
+# test invalid data passed to a suboption
+[ "$(ansible-playbook no_log_suboptions_invalid.yml -i ../../inventory -vvvvv "$@" | grep -Ec '(SUPREME|IDIOM|MOCKUP|EDUCATED|FOOTREST|CRAFTY|FELINE|CRYSTAL|EXPECTANT|AGROUND|GOLIATH|FREEFALL)')" = "0" ]

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -13,3 +13,6 @@ set -eux
 
 # no log disabled, should produce 0 censored
 [ "$(ansible-playbook dynamic.yml -i ../../inventory -vvvvv "$@" -e unsafe_show_logs=yes|grep -c 'output has been hidden')" = "0" ]
+
+# test no log for sub options
+[ "$(ansible-playbook no_log_suboptions.yml -i ../../inventory -vvvvv "$@" | grep -Ec '(ANTIRUST-VERIFY)|(GLAMOROUS-AFTERMATH)|(UNTURNED-SPILT)|(VERY-TWIDDLING)|(WHEAT-PROBATION)')" = "0" ]

--- a/test/units/module_utils/common/parameters/test_list_no_log_values.py
+++ b/test/units/module_utils/common/parameters/test_list_no_log_values.py
@@ -79,7 +79,7 @@ def test_list_no_log_values_invalid_suboptions(argument_spec, module_parameters,
         }
     }
 
-    with pytest.raises(TypeError, match=r"Value '.*?' in the sub parameter field '.*?' must by a dict, not '.*?'"):
+    with pytest.raises(TypeError, match=r"(Value '.*?' in the sub parameter field '.*?' must by a dict, not '.*?')|(dictionary requested, could not parse JSON or key=value)"):
         list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))
 
 

--- a/test/units/module_utils/common/parameters/test_list_no_log_values.py
+++ b/test/units/module_utils/common/parameters/test_list_no_log_values.py
@@ -11,31 +11,107 @@ from ansible.module_utils.common.parameters import list_no_log_values
 
 
 @pytest.fixture
-def params():
-    return {
-        'secret': 'undercookwovennativity',
-        'other_secret': 'cautious-slate-makeshift',
-        'state': 'present',
-        'value': 5,
-    }
+def argument_spec():
+    # Allow extra specs to be passed to the fixture, which will be added to the output
+    def _argument_spec(extra_opts=None):
+        spec = {
+            'secret': {'type': 'str', 'no_log': True},
+            'other_secret': {'type': 'str', 'no_log': True},
+            'state': {'type': 'str'},
+            'value': {'type': 'int'},
+        }
+
+        if extra_opts:
+            spec.update(extra_opts)
+
+        return spec
+
+    return _argument_spec
 
 
-def test_list_no_log_values(params):
-    argument_spec = {
-        'secret': {'type': 'str', 'no_log': True},
-        'other_secret': {'type': 'str', 'no_log': True},
-        'state': {'type': 'str'},
-        'value': {'type': 'int'},
-    }
-    result = set(('undercookwovennativity', 'cautious-slate-makeshift'))
-    assert result == list_no_log_values(argument_spec, params)
+@pytest.fixture
+def module_parameters():
+    # Allow extra parameters to be passed to the fixture, which will be added to the output
+    def _module_parameters(extra_params=None):
+        params = {
+            'secret': 'undercookwovennativity',
+            'other_secret': 'cautious-slate-makeshift',
+            'state': 'present',
+            'value': 5,
+        }
+
+        if extra_params:
+            params.update(extra_params)
+
+        return params
+
+    return _module_parameters
 
 
-def test_list_no_log_values_no_secrets(params):
+def test_list_no_log_values_no_secrets(module_parameters):
     argument_spec = {
         'other_secret': {'type': 'str', 'no_log': False},
         'state': {'type': 'str'},
         'value': {'type': 'int'},
     }
     result = set()
-    assert result == list_no_log_values(argument_spec, params)
+    assert result == list_no_log_values(argument_spec, module_parameters)
+
+
+def test_list_no_log_values(argument_spec, module_parameters):
+    result = set(('undercookwovennativity', 'cautious-slate-makeshift'))
+    assert result == list_no_log_values(argument_spec(), module_parameters())
+
+
+def test_list_no_log_values_suboptions(argument_spec, module_parameters):
+    extra_opts = {
+        'subopt1': {
+            'type': 'dict',
+            'options': {
+                'sub_1_1': {'no_log': True},
+                'sub_1_2': {'type': 'list'},
+            },
+        },
+    }
+
+    extra_params = {
+        'subopt1': {
+            'sub_1_1': 'Precision-Bagel',
+            'sub_1_2': ['Pebble-Slogan'],
+        }
+    }
+
+    result = set(('undercookwovennativity', 'cautious-slate-makeshift', 'Precision-Bagel'))
+    assert result == list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))
+
+
+def test_list_no_log_values_recursive_suboptions(argument_spec, module_parameters):
+    extra_opts = {
+        'subopt1': {
+            'type': 'dict',
+            'options': {
+                'sub_1_1': {'no_log': True},
+                'subopt2': {
+                    'type': 'dict',
+                    'options': {
+                        'sub_2_1': {'no_log': True},
+                        'sub_2_2': {},
+                    },
+                },
+            },
+        },
+    }
+
+    extra_params = {
+        'subopt1': {
+            'sub_1_1': 'Precision-Bagel',
+            'subopt2': {
+                'sub_2_1': 'Sandstone-Unwrapped',
+                'sub_2_2': 'Hamstring-Aged',
+            },
+        }
+    }
+    result = set(('undercookwovennativity', 'cautious-slate-makeshift', 'Precision-Bagel', 'Sandstone-Unwrapped'))
+    assert result == list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))
+
+

--- a/test/units/module_utils/common/parameters/test_list_no_log_values.py
+++ b/test/units/module_utils/common/parameters/test_list_no_log_values.py
@@ -79,7 +79,8 @@ def test_list_no_log_values_invalid_suboptions(argument_spec, module_parameters,
         }
     }
 
-    with pytest.raises(TypeError, match=r"(Value '.*?' in the sub parameter field '.*?' must by a dict, not '.*?')|(dictionary requested, could not parse JSON or key=value)"):
+    with pytest.raises(TypeError, match=r"(Value '.*?' in the sub parameter field '.*?' must by a dict, not '.*?')"
+                                        r"|(dictionary requested, could not parse JSON or key=value)"):
         list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))
 
 
@@ -204,3 +205,24 @@ def test_list_no_log_values_sub_suboptions_list(argument_spec, module_parameters
 
     expected = set(('under', 'makeshift', 'playroom', 'luxury', 'basis', 'gave', 'composure', 'thumping'))
     assert expected == list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))
+
+
+@pytest.mark.parametrize('extra_params, expected', (
+    ({'subopt_dict': 'dict_subopt1=rekindle-scandal,dict_subopt2=subgroupavenge'}, ('rekindle-scandal',)),
+    ({'subopt_dict': 'dict_subopt1=aversion-mutable dict_subopt2=subgroupavenge'}, ('aversion-mutable',)),
+    ({'subopt_dict': ['dict_subopt1=blip-marine,dict_subopt2=subgroupavenge', 'dict_subopt1=tipping,dict_subopt2=hardening']}, ('blip-marine', 'tipping')),
+))
+def test_string_suboptions_as_string(argument_spec, module_parameters, extra_params, expected):
+    extra_opts = {
+        'subopt_dict': {
+            'type': 'dict',
+            'options': {
+                'dict_subopt1': {'no_log': True},
+                'dict_subopt2': {},
+            },
+        },
+    }
+
+    result = set(('under', 'makeshift'))
+    result.update(expected)
+    assert result == list_no_log_values(argument_spec(extra_opts), module_parameters(extra_params))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a module has an argument_spec with sub parameters marked as `no_log`, passing an invalid parameter name to the module will cause the task to fail before the no_log options in the sub parameters are processed.

Get all `no_log` parameters from sub options earlier so they will be properly masked during failure. Also hide all module invoration arguments if there is a failure when trying to determine `no_log` values. (CVE-2019-14858)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`
`lib/ansible/module_utils/common/parameters.py`