### PR TITLE
nsupdate: Don't try fixing non-existing TXT values

### DIFF
--- a/changelogs/fragments/63408-nsupdate-dont-fix-none-txt-value.yaml
+++ b/changelogs/fragments/63408-nsupdate-dont-fix-none-txt-value.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Do not try fixing non-existing TXT values (https://github.com/ansible/ansible/issues/63364)

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -232,7 +232,7 @@ class RecordManager(object):
         else:
             self.algorithm = module.params['key_algorithm']
 
-        if self.module.params['type'].lower() == 'txt':
+        if self.module.params['type'].lower() == 'txt' and self.module.params['value'] is not None:
             self.value = list(map(self.txt_helper, self.module.params['value']))
         else:
             self.value = self.module.params['value']


### PR DESCRIPTION
##### SUMMARY

The commit 4e895c1 aimed to ensure that TXT record values were sanely
quoted. Sadly it failed to take the scenario of non-existing values
into account. While record values are required for record creation
they are not required for record deletion.

This change rectifies that oversight, saving Ansible from
unsuccessfully trying to operate on NoneType objects.

Resolves #63364

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nsupdate