### PR TITLE
Adding new module win_auto_logon

### DIFF
--- a/lib/ansible/modules/windows/win_auto_logon.ps1
+++ b/lib/ansible/modules/windows/win_auto_logon.ps1
@@ -1,0 +1,83 @@
+#!powershell
+
+# Copyright: (c) 2019, Prasoon Karunan V (@prasoonkarunan) <kvprasoon@Live.in>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+# All helper methods are written in a binary module and has to be loaded for consuming them.
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+Set-StrictMode -Version 2.0
+
+$ErrorActionPreferrence = 'Stop'
+
+# argument spec hastable which has the input parameters and capabilities for this module
+$spec = @{
+    options = @{
+        domain = @{type = "str"; default = $env:userdomain}
+        user = @{type = "str"; required = $true}
+        password = @{type = "str"; required = $true}
+        state = @{type = "str"; choices = "absent","present"; default = "present"}
+    }
+    required_if = @(
+        @("state", "present", @("user","password")),
+        @("state","absent",@())
+    )
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args,$spec)
+$domain = $module.params.domain
+$user = $module.params.user
+$password = $module.params.password
+$state = $module.params.state
+
+try {
+    #Build ParamHash
+
+    $autoAdminLogon = 1
+    $stateMessage = 'added'
+    if($state -eq 'absent'){
+        $autoadminlogon = 0
+        $stateMessage = 'removed'
+    }
+    $module.Result.Msg     = "Auto logon registry keys are already $stateMessage"
+    $autoLogonKeyList   = @{
+        DefaultPassword = $password
+        DefaultUserName = $user
+        DefaultDomain   = $domain
+        AutoAdminLogon  = $autoAdminLogon
+    }
+    $actionTaken = $null
+    $autoLogonRegPath   = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\'
+    $autoLogonKeyRegList   = Get-ItemProperty -Path $autoLogonRegPath -Name $autoLogonKeyList.GetEnumerator().Name -ErrorAction SilentlyContinue
+
+    Foreach($key in $autoLogonKeyList.GetEnumerator().Name){
+        $currentKeyValue = $autoLogonKeyRegList | Select-Object -ExpandProperty $key -ErrorAction SilentlyContinue
+        if (-not [String]::IsNullOrEmpty($currentKeyValue)) {
+            $expectedValue = $autoLogonKeyList[$key]
+            if(($state -eq 'present') -and ($currentKeyValue -ne $expectedValue)) {
+                Set-ItemProperty -Path $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force
+                $actionTaken = $true
+            }
+            elseif($state -eq 'absent') {
+                $actionTaken = $true
+                Remove-ItemProperty -Path $autoLogonRegPath -Name $key -Force
+            }
+        }
+        else {
+            if ($state -eq 'present') {
+                $actionTaken = $true
+                New-ItemProperty -Path $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force | Out-Null
+            }
+        }
+    }
+    if($actionTaken){
+        $module.Result.Msg     = "Auto logon registry keys are $stateMessage"
+        $module.Result.changed = $true
+    }
+}
+catch {
+  $module.FailJson($_.Exception.Message)
+}
+
+$module.ExitJson()

--- a/lib/ansible/modules/windows/win_auto_logon.ps1
+++ b/lib/ansible/modules/windows/win_auto_logon.ps1
@@ -49,25 +49,25 @@ try {
     }
     $actionTaken = $null
     $autoLogonRegPath   = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\'
-    $autoLogonKeyRegList   = Get-ItemProperty -Path $autoLogonRegPath -Name $autoLogonKeyList.GetEnumerator().Name -ErrorAction SilentlyContinue
+    $autoLogonKeyRegList   = Get-ItemProperty -LiteralPath $autoLogonRegPath -Name $autoLogonKeyList.GetEnumerator().Name -ErrorAction SilentlyContinue
 
     Foreach($key in $autoLogonKeyList.GetEnumerator().Name){
         $currentKeyValue = $autoLogonKeyRegList | Select-Object -ExpandProperty $key -ErrorAction SilentlyContinue
         if (-not [String]::IsNullOrEmpty($currentKeyValue)) {
             $expectedValue = $autoLogonKeyList[$key]
             if(($state -eq 'present') -and ($currentKeyValue -ne $expectedValue)) {
-                Set-ItemProperty -Path $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force
+                Set-ItemProperty -LiteralPath $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force
                 $actionTaken = $true
             }
             elseif($state -eq 'absent') {
                 $actionTaken = $true
-                Remove-ItemProperty -Path $autoLogonRegPath -Name $key -Force
+                Remove-ItemProperty -LiteralPath  $autoLogonRegPath -Name $key -Force
             }
         }
         else {
             if ($state -eq 'present') {
                 $actionTaken = $true
-                New-ItemProperty -Path $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force | Out-Null
+                New-ItemProperty -LiteralPath $autoLogonRegPath -Name $key -Value $autoLogonKeyList[$key] -Force | Out-Null
             }
         }
     }

--- a/lib/ansible/modules/windows/win_auto_logon.py
+++ b/lib/ansible/modules/windows/win_auto_logon.py
@@ -14,7 +14,7 @@ module: win_auto_logon
 short_description: Adds or Sets auto logon registry keys.
 description:
   - Used to apply auto logon registry setting.
-version_added: "2.9"
+version_added: "2.10"
 options:
   user:
     description:

--- a/lib/ansible/modules/windows/win_auto_logon.py
+++ b/lib/ansible/modules/windows/win_auto_logon.py
@@ -59,3 +59,11 @@ EXAMPLES = r'''
   win_auto_logon:
     state: absent
 '''
+
+RETURN = r'''
+changed:
+    description: Returns true if autologon keys successfully set.
+    returned: true/false
+    type: boolean
+    sample: true
+'''

--- a/lib/ansible/modules/windows/win_auto_logon.py
+++ b/lib/ansible/modules/windows/win_auto_logon.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Prasoon Karunan V (@prasoonkarunan)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_auto_logon
+short_description: Adds or Sets auto logon registry keys.
+description:
+  - Used to apply auto logon registry setting.
+version_added: "2.9"
+options:
+  user:
+    description:
+      - Username to login automatically.
+      - Value of this input will be set to DefaultUsername registry key..
+    type: str
+    required: yes
+  password:
+    description:
+      - Password to be used for automatic login.
+      - Value of this input will be used as password for Default user.
+    type: str
+    required: yes
+  domain:
+    description:
+      - Domain name to be used while automatic login.
+    type: str
+    default: default user domain.
+  state:
+    description:
+      - Whether the registry key should be C(present) or C(absent).
+    type: str
+    choices: [ absent, present ]
+    default: present
+author:
+  - Prasoon Karunan V (@prasoonkarunan)
+'''
+
+EXAMPLES = r'''
+- name: Set autologon for user1
+  win_auto_logon:
+    user: User1
+    password: str0ngp@ssword
+
+- name: Set autologon for abc.com\\user1
+  win_auto_logon:
+    user: User1
+    password: str0ngp@ssword
+    domain: abc.com
+
+- name: Remove autologon for user1
+  win_auto_logon:
+    state: absent
+'''

--- a/lib/ansible/modules/windows/win_auto_logon.py
+++ b/lib/ansible/modules/windows/win_auto_logon.py
@@ -64,6 +64,6 @@ RETURN = r'''
 changed:
     description: Returns true if autologon keys successfully set.
     returned: true/false
-    type: boolean
+    type: bool
     sample: true
 '''

--- a/lib/ansible/modules/windows/win_auto_logon.py
+++ b/lib/ansible/modules/windows/win_auto_logon.py
@@ -16,23 +16,20 @@ description:
   - Used to apply auto logon registry setting.
 version_added: "2.10"
 options:
-  user:
+  username:
     description:
       - Username to login automatically.
-      - Value of this input will be set to DefaultUsername registry key..
+      - Must be set when C(state=present).
+      - This can be the Netlogon or UPN of a domain account and is
+        automatically parsed to the C(DefaultUserName) and C(DefaultDomainName)
+        registry properties.
     type: str
-    required: yes
   password:
     description:
       - Password to be used for automatic login.
-      - Value of this input will be used as password for Default user.
+      - Must be set when C(state=present).
+      - Value of this input will be used as password for I(username).
     type: str
-    required: yes
-  domain:
-    description:
-      - Domain name to be used while automatic login.
-    type: str
-    default: default user domain.
   state:
     description:
       - Whether the registry key should be C(present) or C(absent).
@@ -46,14 +43,13 @@ author:
 EXAMPLES = r'''
 - name: Set autologon for user1
   win_auto_logon:
-    user: User1
+    username: User1
     password: str0ngp@ssword
 
-- name: Set autologon for abc.com\\user1
+- name: Set autologon for abc.com\user1
   win_auto_logon:
-    user: User1
+    username: abc.com\User1
     password: str0ngp@ssword
-    domain: abc.com
 
 - name: Remove autologon for user1
   win_auto_logon:
@@ -61,9 +57,5 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-changed:
-    description: Returns true if autologon keys successfully set.
-    returned: true/false
-    type: bool
-    sample: true
+#
 '''

--- a/test/integration/targets/win_auto_logon/aliases
+++ b/test/integration/targets/win_auto_logon/aliases
@@ -1,0 +1,2 @@
+shippable/windows/group1
+shippable/windows/smoketest

--- a/test/integration/targets/win_auto_logon/aliases
+++ b/test/integration/targets/win_auto_logon/aliases
@@ -1,2 +1,1 @@
 shippable/windows/group1
-shippable/windows/smoketest

--- a/test/integration/targets/win_auto_logon/defaults/main.yml
+++ b/test/integration/targets/win_auto_logon/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+test_win_user_name: ansibleuser
+test_win_user_password: userP@$$w0rd

--- a/test/integration/targets/win_auto_logon/defaults/main.yml
+++ b/test/integration/targets/win_auto_logon/defaults/main.yml
@@ -1,4 +1,0 @@
----
-
-test_win_user_name: ansibleuser
-test_win_user_password: userP@$$w0rd

--- a/test/integration/targets/win_auto_logon/tasks/main.yml
+++ b/test/integration/targets/win_auto_logon/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: Set autologon registry keys
   win_auto_logon:
     user: "{{test_win_user_name}}"
-    password: "{{test_win_user_password$hell1}}"
+    password: "{{test_win_user_password}}"
     state: present
   register: win_auto_logon_create_registry_key_set
 

--- a/test/integration/targets/win_auto_logon/tasks/main.yml
+++ b/test/integration/targets/win_auto_logon/tasks/main.yml
@@ -1,0 +1,51 @@
+# test code for the slurp module when using winrm connection
+# (c) 2015, Chris Church <cchurch@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: Set autologon registry keys
+  win_auto_logon:
+    user: "{{test_win_user_name}}"
+    password: "{{test_win_user_password$hell1}}"
+    state: present
+  register: win_auto_logon_create_registry_key_set
+
+- name: check win_auto_logon_create_registry_key_set is changed
+  assert:
+    that:
+      - "win_auto_logon_create_registry_key_set is changed"
+
+- name: Set autologon registry keys with missing input
+  win_auto_logon:
+    user: "{{test_win_user_name}}"
+    state: present
+  register: win_auto_logon_create_registry_key_missing_input
+  ignore_errors: true
+
+- name: check win_auto_logon_create_registry_key_missing_input is failed
+  assert:
+    that:
+      - "win_group_create_invalid_state is failed"
+
+- name: Remove autologon registry keys
+  win_auto_logon:
+    state: absent
+  register: win_auto_logon_create_registry_key_remove
+
+- name: check win_auto_logon_create_registry_key_remove is changed
+  assert:
+    that:
+      - "win_auto_logon_create_registry_key_remove is changed"

--- a/test/integration/targets/win_auto_logon/tasks/main.yml
+++ b/test/integration/targets/win_auto_logon/tasks/main.yml
@@ -1,36 +1,21 @@
-# test code for the slurp module when using winrm connection
-# (c) 2015, Chris Church <cchurch@ansible.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
+# Copyright: (c) 2019, Prasoon Karunan V (@prasoonkarunan) <kvprasoon@Live.in>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
 - name: Set autologon registry keys
   win_auto_logon:
-    user: "{{test_win_user_name}}"
-    password: "{{test_win_user_password}}"
+    username: "{{ ansible_user }}"
+    password: "{{ ansible_password }}"
     state: present
   register: win_auto_logon_create_registry_key_set
 
 - name: check win_auto_logon_create_registry_key_set is changed
   assert:
     that:
-      - "win_auto_logon_create_registry_key_set is changed"
+    - win_auto_logon_create_registry_key_set is changed
 
 - name: Set autologon registry keys with missing input
   win_auto_logon:
-    user: "{{test_win_user_name}}"
+    username: "{{ ansible_user }}"
     state: present
   register: win_auto_logon_create_registry_key_missing_input
   ignore_errors: true
@@ -38,7 +23,7 @@
 - name: check win_auto_logon_create_registry_key_missing_input is failed
   assert:
     that:
-      - "win_group_create_invalid_state is failed"
+    - win_auto_logon_create_registry_key_missing_input is failed
 
 - name: Remove autologon registry keys
   win_auto_logon:
@@ -48,4 +33,4 @@
 - name: check win_auto_logon_create_registry_key_remove is changed
   assert:
     that:
-      - "win_auto_logon_create_registry_key_remove is changed"
+    - win_auto_logon_create_registry_key_remove is changed


### PR DESCRIPTION
##### SUMMARY
This is a new module which can be used to set/remove autologon registry keys in windows.
This allows use of multiple `win_regedit` calls to set the auto logon registry keys.
more about windows autologon [here](https://support.microsoft.com/en-in/help/324737/how-to-turn-on-automatic-logon-in-windows)

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_auto_logon

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Usages:

```paste below
- name: Set autologon registry keys
  win_auto_logon:
    user: usera
    password: userap@$$w0rd
    state: present
```

```paste below
- name: Set autologon registry keys
  win_auto_logon:
    user: usera
    password: userap@$$w0rd
    domain: user.com
    state: present
```

```paste below
- name: Remove autologon
  win_auto_logon:
    state: absent
```
