### PR TITLE
docker_node_info: improve error handling

### DIFF
--- a/changelogs/fragments/63418-docker_node_info-errors.yml
+++ b/changelogs/fragments/63418-docker_node_info-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_node_info - improve error handling when service inspection fails, for example because node name being ambiguous
+   (https://github.com/ansible/ansible/issues/63353, PR https://github.com/ansible/ansible/pull/63418)."

--- a/lib/ansible/module_utils/docker/swarm.py
+++ b/lib/ansible/module_utils/docker/swarm.py
@@ -164,10 +164,9 @@ class AnsibleDockerSwarmClient(AnsibleDockerClient):
             if exc.status_code == 503:
                 self.fail("Cannot inspect node: To inspect node execute module on Swarm Manager")
             if exc.status_code == 404:
-                if skip_missing is False:
-                    self.fail("Error while reading from Swarm manager: %s" % to_native(exc))
-                else:
+                if skip_missing:
                     return None
+            self.fail("Error while reading from Swarm manager: %s" % to_native(exc))
         except Exception as exc:
             self.fail("Error inspecting swarm node: %s" % exc)
 


### PR DESCRIPTION
##### SUMMARY
Improves error handling. Should fix #63353.

This generic function is only used in `docker_node_info`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_node_info
