### PR TITLE
Backport/2.8/62471 ce_link_status:update to fix a bug. (#62417)

### DIFF
--- a/changelogs/fragments/63422-ce_link_status_fix_bugs.yaml
+++ b/changelogs/fragments/63422-ce_link_status_fix_bugs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ce_link_status - fix some bugs, result of interface <get> operation involves a large amount of data,interact with the device through the <get-next>.(https://github.com/ansible/ansible/pull/62417).

--- a/lib/ansible/modules/network/cloudengine/ce_link_status.py
+++ b/lib/ansible/modules/network/cloudengine/ce_link_status.py
@@ -55,7 +55,7 @@ notes:
 options:
     interface:
         description:
-            - For the interface parameter, you can enter C(all) to display information about all interface,
+            - For the interface parameter, you can enter C(all) to display information about all interfaces,
               an interface type such as C(40GE) to display information about interfaces of the specified type,
               or full name of an interface such as C(40GE1/0/22) or C(vlanif10)
               to display information about the specific interface.
@@ -88,7 +88,7 @@ EXAMPLES = '''
       interface: 40GE
       provider: "{{ cli }}"
 
-  - name: Get all interface link status information
+  - name: Get all interfaces link status information
     ce_link_status:
       interface: all
       provider: "{{ cli }}"
@@ -128,7 +128,7 @@ result:
 
 from xml.etree import ElementTree
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, get_nc_config
+from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, get_nc_config, get_nc_next
 
 CE_NC_GET_PORT_SPEED = """
 <filter type="subtree">
@@ -393,10 +393,10 @@ class LinkStatus(object):
                             'Outbound rate(pkts/sec)'] = eles.text
 
     def get_all_interface_info(self, intf_type=None):
-        """Get interface information all or by interface type"""
+        """Get interface information by all or by interface type"""
 
         xml_str = CE_NC_GET_INT_STATISTICS % ''
-        con_obj = get_nc_config(self.module, xml_str)
+        con_obj = get_nc_next(self.module, xml_str)
         if "<data/>" in con_obj:
             return
 
@@ -406,7 +406,7 @@ class LinkStatus(object):
 
         # get link status information
         root = ElementTree.fromstring(xml_str)
-        intfs_info = root.find("ifm/interfaces")
+        intfs_info = root.findall("ifm/interfaces/interface")
         if not intfs_info:
             return
 


### PR DESCRIPTION
(cherry picked from commit 7541dab1ef64dd64266dd25f69bb826dd109507f)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/cloudengine/ce_link_status.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
For example, if the returned result of a <get> or <get-config> operation involves a large amount of data, the device must return the data using multiple <rpc-reply> elements. After the NETCONF client receives the first <rpc-reply> element, the NETCONF client interacts with the device through the <get-next> operation to request the next <rpc-reply> element or cancel the data query.

The following example shows how a NETCONF client sends an RPC request for interface information.

•RPC request
<rpc message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <get>
    <filter type="subtree">
      <ifm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
        <interfaces>
           <interface>
           </interface>
        </interfaces>
      </ifm>
    </filter>
  </get>
</rpc> 
•RPC reply
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" set-id="989">
  <data>
    <ifm xmlns="http://www.huawei.com/netconf/vrp" format-version="1.0" content-version="1.0">
      <interfaces>
        <interface>
          <ifIndex>2</ifIndex>
          <ifName>Virtual-Template0</ifName>
          <ifPhyType>Virtual-Template</ifPhyType>
     <!-- additional <user> elements appear here... --> 
        </interface>
      </interfaces>
    </ifm>
  </data>
</rpc-reply>
```
