### PR TITLE
openssl_csr: deprecate version option

### DIFF
--- a/changelogs/fragments/63432-openssl_csr-version.yml
+++ b/changelogs/fragments/63432-openssl_csr-version.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+- "openssl_csr - the ``version`` option is deprecated."
+bugfixes:
+- "openssl_csr - a warning is issued if an unsupported value for ``version`` is used for the ``cryptography`` backend."

--- a/changelogs/fragments/63432-openssl_csr-version.yml
+++ b/changelogs/fragments/63432-openssl_csr-version.yml
@@ -1,4 +1,4 @@
 deprecated_features:
-- "openssl_csr - the ``version`` option is deprecated."
+- "openssl_csr - all values for the ``version`` option except ``1`` are deprecated."
 bugfixes:
 - "openssl_csr - a warning is issued if an unsupported value for ``version`` is used for the ``cryptography`` backend."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -53,7 +53,7 @@ Deprecation notices
 
 The following functionality will be removed in Ansible 2.14. Please update update your playbooks accordingly.
 
-* The :ref:`openssl_csr <openssl_csr_module>` module's option ``version`` will be removed.
+* The :ref:`openssl_csr <openssl_csr_module>` module's option ``version`` no longer supports values other than ``1`` (the current only standardized CSR version).
 
 
 Noteworthy module changes

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -51,7 +51,9 @@ The following modules no longer exist:
 Deprecation notices
 -------------------
 
-No notable changes
+The following functionality will be removed in Ansible 2.14. Please update update your playbooks accordingly.
+
+* The :ref:`openssl_csr <openssl_csr_module>` module's option ``version`` will be removed.
 
 
 Noteworthy module changes

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -58,8 +58,8 @@ options:
     version:
         description:
             - The version of the certificate signing request.
-            - The only allowed value according to L(RFC 2986,https://tools.ietf.org/html/rfc2986#section-4.1)
-              is 1.
+            - "The only allowed value according to L(RFC 2986,https://tools.ietf.org/html/rfc2986#section-4.1)
+               is 1."
             - This option will no longer accept unsupported values from Ansible 2.14 on.
         type: int
         default: 1

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -60,7 +60,7 @@ options:
             - The version of the certificate signing request.
             - The only allowed value according to L(RFC 2986,https://tools.ietf.org/html/rfc2986#section-4.1)
               is 1.
-            - This option is deprecated and will be removed in Ansible 2.14.
+            - This option will no longer accept unsupported values from Ansible 2.14 on.
         type: int
         default: 1
     force:
@@ -997,7 +997,7 @@ def main():
             digest=dict(type='str', default='sha256'),
             privatekey_path=dict(type='path', require=True),
             privatekey_passphrase=dict(type='str', no_log=True),
-            version=dict(type='int', default=1, removed_in_version='2.14'),
+            version=dict(type='int', default=1),
             force=dict(type='bool', default=False),
             path=dict(type='path', required=True),
             subject=dict(type='dict'),
@@ -1031,6 +1031,10 @@ def main():
         add_file_common_args=True,
         supports_check_mode=True,
     )
+
+    if module.params['version'] != 1:
+        module.deprecate('The version option will only support allowed values from Ansible 2.14 on. '
+                         'Currently, only the value 1 is allowed by RFC 2986', version='2.14')
 
     base_dir = os.path.dirname(module.params['path']) or '.'
     if not os.path.isdir(base_dir):

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -58,6 +58,9 @@ options:
     version:
         description:
             - The version of the certificate signing request.
+            - The only allowed value according to L(RFC 2986,https://tools.ietf.org/html/rfc2986#section-4.1)
+              is 1.
+            - This option is deprecated and will be removed in Ansible 2.14.
         type: int
         default: 1
     force:
@@ -755,6 +758,8 @@ class CertificateSigningRequestCryptography(CertificateSigningRequestBase):
     def __init__(self, module):
         super(CertificateSigningRequestCryptography, self).__init__(module)
         self.cryptography_backend = cryptography.hazmat.backends.default_backend()
+        if self.version != 1:
+            module.warn('The cryptography backend only supports version 1. (The only valid value according to RFC 2986.)')
 
     def _generate_csr(self):
         csr = cryptography.x509.CertificateSigningRequestBuilder()
@@ -992,7 +997,7 @@ def main():
             digest=dict(type='str', default='sha256'),
             privatekey_path=dict(type='path', require=True),
             privatekey_passphrase=dict(type='str', no_log=True),
-            version=dict(type='int', default=1),
+            version=dict(type='int', default=1, removed_in_version='2.14'),
             force=dict(type='bool', default=False),
             path=dict(type='path', required=True),
             subject=dict(type='dict'),


### PR DESCRIPTION
##### SUMMARY
Deprecates the `version` option of `openssl_csr`. Fixes #62227.

(WIP since I might change it significantly, see discussion in #62227.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
