### PR TITLE
Make the DNS service optional when installing Active Directory

### DIFF
--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -34,6 +34,7 @@ $sysvol_path = Get-AnsibleParam -obj $params -name "sysvol_path" -type "path"
 $create_dns_delegation = Get-AnsibleParam -obj $params -name "create_dns_delegation" -type "bool"
 $domain_mode = Get-AnsibleParam -obj $params -name "domain_mode" -type "str"
 $forest_mode = Get-AnsibleParam -obj $params -name "forest_mode" -type "str"
+$install_dns = Get-AnsibleParam -obj $params -name "install_dns" -type "bool" -default $true
 
 # FUTURE: Support down to Server 2012?
 if ([System.Environment]::OSVersion.Version -lt [Version]"6.3.9600.0") {
@@ -89,7 +90,7 @@ if (-not $forest) {
         SafeModeAdministratorPassword=$sm_cred;
         Confirm=$false;
         SkipPreChecks=$true;
-        InstallDns=$true;
+        InstallDns=$install_dns;
         NoRebootOnCompletion=$true;
         WhatIf=$check_mode;
     }

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -76,7 +76,7 @@ options:
     - Whether to install the DNS service.
     type: bool
     default: yes
-    version_added: '2.8'
+    version_added: '2.10'
 seealso:
 - module: win_domain_controller
 - module: win_domain_computer

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -71,6 +71,12 @@ options:
     type: str
     choices: [ Win2003, Win2008, Win2008R2, Win2012, Win2012R2, WinThreshold ]
     version_added: '2.8'
+  install_dns:
+    description:
+    - Whether to install the DNS service.
+    type: bool
+    default: yes
+    version_added: '2.8'
 seealso:
 - module: win_domain_controller
 - module: win_domain_computer

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -73,7 +73,7 @@ options:
     version_added: '2.8'
   install_dns:
     description:
-    - Whether to install the DNS service.
+    - Whether to install the DNS service when creating the domain controller.
     type: bool
     default: yes
     version_added: '2.10'

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -213,7 +213,7 @@ Try {
                 if ($site_name) {
                     $install_params.SiteName = $site_name
                 }
-                if ($install_dns -ne $null) {
+                if ($null -ne $install_dns) {
                     $install_params.InstallDns = $install_dns
                 }
                 try

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -105,6 +105,7 @@ $database_path = Get-AnsibleParam -obj $params -name "database_path" -type "path
 $sysvol_path = Get-AnsibleParam -obj $params -name "sysvol_path" -type "path"
 $read_only = Get-AnsibleParam -obj $params -name "read_only" -type "bool" -default $false
 $site_name = Get-AnsibleParam -obj $params -name "site_name" -type "str" -failifempty $read_only
+$install_dns = Get-AnsibleParam -obj $params -name "install_dns" -type "bool"
 
 $state = Get-AnsibleParam -obj $params -name "state" -validateset ("domain_controller", "member_server") -failifempty $result
 
@@ -211,6 +212,9 @@ Try {
                 }
                 if ($site_name) {
                     $install_params.SiteName = $site_name
+                }
+                if ($install_dns -ne $null) {
+                    $install_params.InstallDns = $install_dns
                 }
                 try
                 {

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -72,9 +72,9 @@ options:
     version_added: '2.5'
   install_dns:
     description:
-    - Whether to install the DNS service.
-    - If not specified then the -InstallDns option is not supplied to Install-ADDSDomainController command,
-      see https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller.
+    - Whether to install the DNS service when creating the domain controller.
+    - If not specified then the C(-InstallDns) option is not supplied to C(Install-ADDSDomainController) command,
+      see U(https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller).
     type: bool
     version_added: '2.10'
 seealso:

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -75,7 +75,7 @@ options:
     - Whether to install the DNS service.
     - If not specified then the -InstallDns option is not supplied to Install-ADDSDomainController command, see https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller.
     type: bool
-    version_added: '2.8'
+    version_added: '2.10'
 seealso:
 - module: win_domain
 - module: win_domain_computer

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -73,7 +73,8 @@ options:
   install_dns:
     description:
     - Whether to install the DNS service.
-    - If not specified then the -InstallDns option is not supplied to Install-ADDSDomainController command, see https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller.
+    - If not specified then the -InstallDns option is not supplied to Install-ADDSDomainController command,
+      see https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller.
     type: bool
     version_added: '2.10'
 seealso:

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -70,6 +70,12 @@ options:
     - If not set then the default path is C(%SYSTEMROOT%\SYSVOL).
     type: path
     version_added: '2.5'
+  install_dns:
+    description:
+    - Whether to install the DNS service.
+    - If not specified then the -InstallDns option is not supplied to Install-ADDSDomainController command, see https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller.
+    type: bool
+    version_added: '2.8'
 seealso:
 - module: win_domain
 - module: win_domain_computer


### PR DESCRIPTION
##### SUMMARY
When installing Active Directory, this pull request provides the option to not install the DNS service.
This is required in environments where an external DNS service is being used.
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
win_domain
win_domain_controller
##### ADDITIONAL INFORMATION
This change is fully backward compatible, i.e. if the "install_dns" options are not specified, the modules behave as before.