### PR TITLE
Update 'delete' parameter description in synchronize module

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -83,6 +83,7 @@ options:
     description:
       - Delete files in C(dest) that don't exist (after transfer, not before) in the C(src) path.
       - This option requires C(recursive=yes).
+      - This option ignores exluded files and behaves like the rsync opt --delete-excluded
     type: bool
     default: no
   dirs:

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -83,7 +83,7 @@ options:
     description:
       - Delete files in C(dest) that don't exist (after transfer, not before) in the C(src) path.
       - This option requires C(recursive=yes).
-      - This option ignores exluded files and behaves like the rsync opt --delete-excluded
+      - This option ignores excluded files and behaves like the rsync opt --delete-excluded.
     type: bool
     default: no
   dirs:


### PR DESCRIPTION
##### SUMMARY
the synchronize module's parameter "delete" deletes excluded directories and files as well.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr