### PR TITLE
change mtu regex to match on digits only

### DIFF
--- a/lib/ansible/modules/network/vyos/_vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/_vyos_interface.py
@@ -260,8 +260,7 @@ def map_config_to_obj(module):
                         speed = match.group(1).strip("'")
                         interface['speed'] = speed
                     elif param == 'mtu':
-                        match = re.search(r'mtu (\S+)', line, re.M)
-                        mtu = match.group(1).strip("'")
+                        mtu = re.search(r'mtu \'(\d+)\'', line, re.M).group(1)
                         interface['mtu'] = int(mtu)
                     elif param == 'duplex':
                         match = re.search(r'duplex (\S+)', line, re.M)


### PR DESCRIPTION
##### SUMMARY
Change the regex for the MTU's value to match only digits.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vyos_interface

##### ADDITIONAL INFORMATION
I played around with the vyos network module and got this error message:
`ValueError: invalid literal for int() with base 10: "1400'\x1b[m"`
I dug a bit deeper. I could not find from where exactly that ANSI Escape sequence came from, my vyos-installation seems innocent (VyOS 1.2-rolling-201910080117)

I however found that the regex that grabs the mtus value could be improved upon so that it only matches on digits.

Play:
```
- hosts: router
    - name: Set up router interfaces to the internet
      vyos_interface:
        name: eth0
        enabled: yes
        description: internet
        state: up
```

Before:
```
TASK [Set up router interfaces to the internet] ***********************************************************************************************************************************************************************
task path: router.yml:13
<$hostname> ESTABLISH LOCAL CONNECTION FOR USER: raphael
<$hostname> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022 `" && echo ansible-tmp-1571041724.47-42562177141022="` echo /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022 `" ) && sleep 0'
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/network/vyos/vyos_interface.py
<$hostname> PUT /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/tmpQPojw1 TO /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py
<$hostname> EXEC /bin/sh -c 'chmod u+x /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/ /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py && sleep 0'
<$hostname> EXEC /bin/sh -c 'python3 /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py && sleep 0'
<$hostname> EXEC /bin/sh -c 'rm -f -r /home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py", line 114, in <module>
    _ansiballz_main()
  File "/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py", line 106, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py", line 49, in invoke_module
    imp.load_module('__main__', mod, module, MOD_DESC)
  File "/usr/lib/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 170, in load_source
    module = _exec(spec, sys.modules[name])
  File "<frozen importlib._bootstrap>", line 618, in _exec
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py", line 439, in <module>
  File "/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py", line 417, in main
  File "/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py", line 262, in map_config_to_obj
ValueError: invalid literal for int() with base 10: "1400'\x1b[m"

fatal: [$hostname]: FAILED! => {
    "changed": false, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/raphael/.ansible/tmp/ansible-local-10840bUJ0fH/ansible-tmp-1571041724.47-42562177141022/AnsiballZ_vyos_interface.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.6/imp.py\", line 235, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.6/imp.py\", line 170, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 618, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py\", line 439, in <module>\n  File \"/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py\", line 417, in main\n  File \"/tmp/ansible_vyos_interface_payload_6f5_q0mk/__main__.py\", line 262, in map_config_to_obj\nValueError: invalid literal for int() with base 10: \"1400'\\x1b[m\"\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", 
    "rc": 1
}
```

After changing the regex the play/module works as expected.