### PR TITLE
fixing issue where not comparing default_args dictionaries correctly …

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_glue_job.py
+++ b/lib/ansible/modules/cloud/amazon/aws_glue_job.py
@@ -231,9 +231,9 @@ def _compare_glue_job_params(user_params, current_params):
         return True
     if 'Command' in user_params and user_params['Command']['ScriptLocation'] != current_params['Command']['ScriptLocation']:
         return True
-    if 'Connections' in user_params and set(user_params['Connections']) != set(current_params['Connections']):
+    if 'Connections' in user_params and user_params['Connections'] != current_params['Connections']:
         return True
-    if 'DefaultArguments' in user_params and set(user_params['DefaultArguments']) != set(current_params['DefaultArguments']):
+    if 'DefaultArguments' in user_params and user_params['DefaultArguments'] != current_params['DefaultArguments']:
         return True
     if 'Description' in user_params and user_params['Description'] != current_params['Description']:
         return True


### PR DESCRIPTION
…thus resulting in NO updates to defaultArguments VALUES

##### SUMMARY
Attempting to fix issue where when updating existing glue DefaultArguments 'values' the script is NOT recognizing a change in the dictionary. The existing code uses set() on the dict which only takes the KEYS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_glue_job
##### ADDITIONAL INFORMATION

```paste below
Attempting to fix issue where when updating existing glue DefaultArguments 'values' the script is NOT recognizing a change in the dictionary. The existing code uses set() on the dict which only takes the KEYS.

```
