### PR TITLE
Fix pip module documentation

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -97,7 +97,7 @@ options:
     description:
       - The explicit executable or pathname for the pip executable,
         if different from the Ansible Python interpreter. For
-        example C(pip-3.3), if there are both Python 2.7 and 3.3 installations
+        example C(pip3.3), if there are both Python 2.7 and 3.3 installations
         in the system and you want to run pip for the Python 3.3 installation.
       - Mutually exclusive with I(virtualenv) (added in 2.1).
       - Does not affect the Ansible Python interpreter.
@@ -212,10 +212,10 @@ EXAMPLES = '''
     requirements: /my_app/requirements.txt
     extra_args: "--no-index --find-links=file:///my_downloaded_packages_dir"
 
-# Install (Bottle) for Python 3.3 specifically,using the 'pip-3.3' executable.
+# Install (Bottle) for Python 3.3 specifically,using the 'pip3.3' executable.
 - pip:
     name: bottle
-    executable: pip-3.3
+    executable: pip3.3
 
 # Install (Bottle), forcing reinstallation if it's already installed
 - pip:


### PR DESCRIPTION
##### SUMMARY
The documentation of the `executable` option for the `pip` module is wrong! The documentation told when there are multiple instances of python versions exists on the host, with the `executable` option it can set to run the task with the  specified version like `pip-3.3` but it's wrong.
I realized this when I tried to use this option with `pip-3.7` and it returns this error:
```
TASK [superset : Install requirements] ***********************************************************************************************************************************************
failed: [worker9] (item=requirements.txt) => {"ansible_loop_var": "item", "changed": false, "item": "requirements.txt", "msg": "Unable to find any of pip-3.7 to use.  pip needs to be
 installed."}
```
Then i changed it to `pip3.7` as the command that runs on the shell, For example `pip3.7 install setuptool` and it works!

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
pip module 
