### PR TITLE
Make docker_stack adhere to standard ansible return values

### DIFF
--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -1,2 +1,5 @@
 minor_changes:
   - docker_stack - Added ``stdout``, ``stderr``, and ``rc`` to return values.
+
+deprecated_features:
+  - docker_stack - Return values ``out`` and ``err`` have been deprecated and will be removed. Use ``stdout`` and ``stderr`` instead.

--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_stack - Added stdout, stderr, and rc to return values.

--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - docker_stack - Added stdout, stderr, and rc to return values.
+  - docker_stack - Added ``stdout``, ``stderr``, and ``rc`` to return values.

--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -2,4 +2,4 @@ minor_changes:
   - docker_stack - Added ``stdout``, ``stderr``, and ``rc`` to return values.
 
 deprecated_features:
-  - docker_stack - Return values ``out`` and ``err`` have been deprecated and will be removed. Use ``stdout`` and ``stderr`` instead.
+  - docker_stack - Return values ``out`` and ``err`` have been deprecated and will be removed in Ansible 2.14. Use ``stdout`` and ``stderr`` instead.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -62,6 +62,7 @@ The following functionality will change in Ansible 2.14. Please update update yo
 
 * The :ref:`docker_container <docker_container_module>` module has a new option, ``container_default_behavior``, whose default value will change from ``compatibility`` to ``no_defaults``. Set to an explicit value to avoid deprecation warnings.
 
+
 Noteworthy module changes
 -------------------------
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -56,12 +56,11 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`iam_managed_policy <iam_managed_policy_module>`: the ``fail_on_delete`` option wil be removed.  It has always been ignored by the module.
 * :ref:`s3_lifecycle <s3_lifecycle_module>`: the ``requester_pays`` option will be removed. It has always been ignored by the module.
 * :ref:`s3_sync <s3_sync_module>`: the ``retries`` option will be removed. It has always been ignored by the module.
-
+* :ref:`docker_stack <docker_stack_module>` has had return values `err` and `out` deprecated. Use new `stdout` and `stderr` instead.
 
 The following functionality will change in Ansible 2.14. Please update update your playbooks accordingly.
 
 * The :ref:`docker_container <docker_container_module>` module has a new option, ``container_default_behavior``, whose default value will change from ``compatibility`` to ``no_defaults``. Set to an explicit value to avoid deprecation warnings.
-
 
 Noteworthy module changes
 -------------------------

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -56,7 +56,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`iam_managed_policy <iam_managed_policy_module>`: the ``fail_on_delete`` option wil be removed.  It has always been ignored by the module.
 * :ref:`s3_lifecycle <s3_lifecycle_module>`: the ``requester_pays`` option will be removed. It has always been ignored by the module.
 * :ref:`s3_sync <s3_sync_module>`: the ``retries`` option will be removed. It has always been ignored by the module.
-* :ref:`docker_stack <docker_stack_module>` has had return values `err` and `out` deprecated. Use new `stdout` and `stderr` instead.
+* The return values ``err`` and ``out`` of :ref:`docker_stack <docker_stack_module>` have been deprecated. Use ``stdout`` and ``stderr`` from now on instead.
 
 The following functionality will change in Ansible 2.14. Please update update your playbooks accordingly.
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -275,10 +275,10 @@ def main():
 
         if not before_after_differences:
             module.exit_json(
-              changed=False,
-              rc=rc,
-              stdout=out,
-              stderr=err)
+                changed=False,
+                rc=rc,
+                stdout=out,
+                stderr=err)
         else:
             module.exit_json(
                 changed=True,

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -81,6 +81,9 @@ options:
 requirements:
   - jsondiff
   - pyyaml
+  
+notes:
+  - Return values C(out) and C(err) have been deprecated and will be removed. Use C(stdout) and C(stderr) instead.
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -262,7 +262,7 @@ def main():
         if rc != 0:
             module.fail_json(msg="docker stack up deploy command failed",
                              rc=rc,
-                             out=out, err=err
+                             out=out, err=err # Deprecated
                              stdout=out, stderr=err)
 
         before_after_differences = json_diff(before_stack_services,

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -261,8 +261,8 @@ def main():
 
         if rc != 0:
             module.fail_json(msg="docker stack up deploy command failed",
-                             out=out,
-                             rc=rc, err=err)
+                             stdout=out,
+                             rc=rc, stderr=err)
 
         before_after_differences = json_diff(before_stack_services,
                                              after_stack_services)
@@ -274,10 +274,17 @@ def main():
                     before_after_differences.pop(k)
 
         if not before_after_differences:
-            module.exit_json(changed=False)
+            module.exit_json(
+              changed=False
+              rc=rc,
+              stdout=out,
+              stderr=err)
         else:
             module.exit_json(
                 changed=True,
+                rc=rc,
+                stdout=out,
+                stderr=err,
                 stack_spec_diff=json_diff(before_stack_services,
                                           after_stack_services,
                                           dump=True))
@@ -287,11 +294,11 @@ def main():
             rc, out, err = docker_stack_rm(module, name, absent_retries, absent_retries_interval)
             if rc != 0:
                 module.fail_json(msg="'docker stack down' command failed",
-                                 out=out,
+                                 stdout=out,
                                  rc=rc,
-                                 err=err)
+                                 stderr=err)
             else:
-                module.exit_json(changed=True, msg=out, err=err, rc=rc)
+                module.exit_json(changed=True, msg=out, stdout=out, stderr=err, rc=rc)
         module.exit_json(changed=False)
 
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -261,8 +261,9 @@ def main():
 
         if rc != 0:
             module.fail_json(msg="docker stack up deploy command failed",
-                             stdout=out,
-                             rc=rc, stderr=err)
+                             rc=rc,
+                             out=out, err=err
+                             stdout=out, stderr=err)
 
         before_after_differences = json_diff(before_stack_services,
                                              after_stack_services)
@@ -294,11 +295,15 @@ def main():
             rc, out, err = docker_stack_rm(module, name, absent_retries, absent_retries_interval)
             if rc != 0:
                 module.fail_json(msg="'docker stack down' command failed",
-                                 stdout=out,
                                  rc=rc,
-                                 stderr=err)
+                                 out=out, err=err, # Deprecated
+                                 stdout=out, stderr=stderr)
+                                 
             else:
-                module.exit_json(changed=True, msg=out, stdout=out, stderr=err, rc=rc)
+                module.exit_json(changed=True,
+                                 msg=out, rc=rc,
+                                 err=stderr # Deprecated
+                                 stdout=out, stderr=err)
         module.exit_json(changed=False)
 
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -275,7 +275,7 @@ def main():
 
         if not before_after_differences:
             module.exit_json(
-              changed=False
+              changed=False,
               rc=rc,
               stdout=out,
               stderr=err)

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -262,7 +262,7 @@ def main():
         if rc != 0:
             module.fail_json(msg="docker stack up deploy command failed",
                              rc=rc,
-                             out=out, err=err # Deprecated
+                             out=out, err=err,  # Deprecated
                              stdout=out, stderr=err)
 
         before_after_differences = json_diff(before_stack_services,
@@ -296,13 +296,13 @@ def main():
             if rc != 0:
                 module.fail_json(msg="'docker stack down' command failed",
                                  rc=rc,
-                                 out=out, err=err, # Deprecated
+                                 out=out, err=err,  # Deprecated
                                  stdout=out, stderr=stderr)
                                  
             else:
                 module.exit_json(changed=True,
                                  msg=out, rc=rc,
-                                 err=stderr # Deprecated
+                                 err=stderr,  # Deprecated
                                  stdout=out, stderr=err)
         module.exit_json(changed=False)
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -81,7 +81,7 @@ options:
 requirements:
   - jsondiff
   - pyyaml
-  
+
 notes:
   - Return values C(out) and C(err) have been deprecated and will be removed. Use C(stdout) and C(stderr) instead.
 '''

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -302,7 +302,7 @@ def main():
             else:
                 module.exit_json(changed=True,
                                  msg=out, rc=rc,
-                                 err=stderr,  # Deprecated
+                                 err=err,  # Deprecated
                                  stdout=out, stderr=err)
         module.exit_json(changed=False)
 

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -297,7 +297,7 @@ def main():
                 module.fail_json(msg="'docker stack down' command failed",
                                  rc=rc,
                                  out=out, err=err,  # Deprecated
-                                 stdout=out, stderr=stderr)
+                                 stdout=out, stderr=std)
                                  
             else:
                 module.exit_json(changed=True,

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -83,7 +83,7 @@ requirements:
   - pyyaml
 
 notes:
-  - Return values C(out) and C(err) have been deprecated and will be removed. Use C(stdout) and C(stderr) instead.
+  - Return values I(out) and I(err) have been deprecated and will be removed in Ansible 2.14. Use I(stdout) and I(stderr) instead.
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -297,8 +297,7 @@ def main():
                 module.fail_json(msg="'docker stack down' command failed",
                                  rc=rc,
                                  out=out, err=err,  # Deprecated
-                                 stdout=out, stderr=std)
-                                 
+                                 stdout=out, stderr=err)
             else:
                 module.exit_json(changed=True,
                                  msg=out, rc=rc,


### PR DESCRIPTION
The names of the various fields returned from ansible modules are e.g defined here https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#msg.

Adhering to this improves usability and makes use of functionality for e.g stdout_lines etc.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added missing instances of return values, and changed name of return values
where they did not adhere to ansible standard.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_stack

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
One example of why this is an improvement is that without access to std_err from the module,
there is no use for `--resolve-conf`, which only makes `docker stack deploy` print
a warning to `stderr`.
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the changes, this is an example of return values I received:
```
ok: [host1] => {
    "docker_stack": {
        "changed": false,
        "failed": false
    }
}
```
after the changes, this is another example, with a bunch of irrelevant/sensitive information removed:
```
ok: [host1] => {
    "docker_stack": {
        "changed": false,
        "failed": false,
        "rc": 0,
        "stderr": "image some-registry/some-image:3.0.1 could not be accessed on a registry to r....\n\n",
        "stderr_lines": [
            "image some-registry/some-image:3.0.1 could not be accessed on a registry to record",
            "its digest..." 
            ...
        ],
        "stdout": "Updating service service1(id: id1)\nUpdating service service2(id: id2)\n",
        "stdout_lines": [
            "Updating service service1(id: id1)",
            "Updating service service2(id: id2)"
        ]
    }
}
```

