### PR TITLE
Ensure we preserve the /api appended URL

### DIFF
--- a/changelogs/fragments/ansile-galaxy-preserve-api-append.yml
+++ b/changelogs/fragments/ansile-galaxy-preserve-api-append.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Ensure we preserve the new URL when appending ``/api`` for the case where
+  the GET succeeds on galaxy.ansible.com

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -57,9 +57,9 @@ def g_connect(versions):
                         raise AnsibleError("Tried to find galaxy API root at %s but no 'available_versions' are available on %s"
                                            % (n_url, self.api_server))
 
-                    # Update api_server to point to the "real" API root, which in this case
-                    # was the configured url + '/api/' appended.
-                    self.api_server = n_url
+                # Update api_server to point to the "real" API root, which in this case
+                # was the configured url + '/api/' appended.
+                self.api_server = n_url
 
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.


### PR DESCRIPTION
##### SUMMARY
If the api url is `https://galaxy.ansible.com` we auto add `/api` but we never save that `n_url` to `self.api_server`, this PR resolves that issue.

Test:

```
ansible-galaxy collection install netapp.ontap -p .
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/api.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
