### PR TITLE
[stable-2.9] Ensure we preserve the /api appended URL (#63472)

### DIFF
--- a/changelogs/fragments/ansile-galaxy-preserve-api-append.yml
+++ b/changelogs/fragments/ansile-galaxy-preserve-api-append.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Ensure we preserve the new URL when appending ``/api`` for the case where
+  the GET succeeds on galaxy.ansible.com

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -57,9 +57,9 @@ def g_connect(versions):
                         raise AnsibleError("Tried to find galaxy API root at %s but no 'available_versions' are available on %s"
                                            % (n_url, self.api_server))
 
-                    # Update api_server to point to the "real" API root, which in this case
-                    # was the configured url + '/api/' appended.
-                    self.api_server = n_url
+                # Update api_server to point to the "real" API root, which in this case
+                # was the configured url + '/api/' appended.
+                self.api_server = n_url
 
                 # Default to only supporting v1, if only v1 is returned we also assume that v2 is available even though
                 # it isn't returned in the available_versions dict.


### PR DESCRIPTION
(cherry picked from commit d8389d9)


Co-authored-by: Matt Martz <matt@sivel.net>