### PR TITLE
[stable-2.6] Fix STS assume role error message when role does not exist (#63249)

### DIFF
--- a/test/integration/targets/sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/sts_assume_role/tasks/main.yml
@@ -290,14 +290,14 @@
       assert:
         that:
           - 'result.failed'
-          - "'Access denied' in result.msg"
+          - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume not existing sts role
       assert:
         that:
           - 'result.failed'
-          - "'Access denied' in result.module_stderr"
+          - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is defined
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #63249 for Ansible 2.6
Co-authored-by: Jill R <4121322+jillr@users.noreply.github.com>
(cherry picked from commit ce402f003f)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/sts_assume_role/tasks/main.yml`