### PR TITLE
package_facts - use AnsibleModule.warn() directly for warnings

### DIFF
--- a/changelogs/fragments/package-facts-use-module-warnings.yaml
+++ b/changelogs/fragments/package-facts-use-module-warnings.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - package_facts - use module warnings rather than a custom implementation for reporting warnings

--- a/lib/ansible/module_utils/facts/packages.py
+++ b/lib/ansible/module_utils/facts/packages.py
@@ -18,8 +18,6 @@ def get_all_pkg_managers():
 
 class PkgMgr(with_metaclass(ABCMeta, object)):
 
-    warnings = []
-
     @abstractmethod
     def is_available(self):
         # This method is supposed to return True/False if the package manager is currently installed/usable

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -230,7 +230,7 @@ class RPM(LibMgr):
         ''' we expect the python bindings installed, but this gives warning if they are missing and we have rpm cli'''
         we_have_lib = super(RPM, self).is_available()
         if not we_have_lib and get_bin_path('rpm'):
-            self.warnings.append('Found "rpm" but %s' % (missing_required_lib('rpm')))
+            module.warn('Found "rpm" but %s' % (missing_required_lib('rpm')))
         return we_have_lib
 
 
@@ -256,7 +256,7 @@ class APT(LibMgr):
         if not we_have_lib:
             for exe in ('apt', 'apt-get', 'aptitude'):
                 if get_bin_path(exe):
-                    self.warnings.append('Found "%s" but %s' % (exe, missing_required_lib('apt')))
+                    module.warn('Found "%s" but %s' % (exe, missing_required_lib('apt')))
                     break
         return we_have_lib
 
@@ -381,9 +381,6 @@ def main():
                 if pkgmgr in module.params['manager']:
                     module.warn('Requested package manager %s was not usable by this module: %s' % (pkgmgr, to_text(e)))
                 continue
-
-            for warning in getattr(manager, 'warnings', []):
-                module.warn(warning)
 
         except Exception as e:
             if pkgmgr in module.params['manager']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simplify warning messages in `package_facts` by using the existing warning method directly rather than collecting them and later passing them to the `warn()` method.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/packages.py`
`lib/ansible/modules/packaging/os/package_facts.py`