### PR TITLE
Backport 2.9: Fix Gitlab module deprecation warning (#60425)

### DIFF
--- a/changelogs/fragments/60425-gitlab-fix-deprecation-warning.yml
+++ b/changelogs/fragments/60425-gitlab-fix-deprecation-warning.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix deprecation warning on GitLab modules
+  - Fix requirements on non required module parameters

--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -241,7 +241,9 @@ class GitLabDeployKey(object):
 def deprecation_warning(module):
     deprecated_aliases = ['private_token', 'access_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -32,7 +32,6 @@ options:
   server_url:
     description:
       - The URL of the GitLab server, with protocol (i.e. http or https).
-    required: true
     type: str
   login_user:
     description:
@@ -270,7 +269,9 @@ class GitLabGroup(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():
@@ -304,7 +305,8 @@ def main():
             ['login_user', 'login_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token']
+            ['api_username', 'api_token', 'login_user', 'login_token'],
+            ['server_url', 'api_url']
         ],
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -277,7 +277,7 @@ def deprecation_warning(module):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        server_url=dict(type='str', removed_in_version="2.10"),
         login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
         login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -297,9 +297,11 @@ class GitLabHook(object):
 
 
 def deprecation_warning(module):
-    deprecated_aliases = ['private_token', 'access_token']
+    deprecated_aliases = ['private_token', 'access_token', 'enable_ssl_verification']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -33,7 +33,6 @@ options:
   server_url:
     description:
       - The URL of the GitLab server, with protocol (i.e. http or https).
-    required: true
     type: str
   login_user:
     description:
@@ -289,7 +288,9 @@ class GitLabProject(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():
@@ -328,7 +329,8 @@ def main():
             ['login_user', 'login_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token']
+            ['api_username', 'api_token', 'login_user', 'login_token'],
+            ['server_url', 'api_url']
         ],
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -296,7 +296,7 @@ def deprecation_warning(module):
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        server_url=dict(type='str', removed_in_version="2.10"),
         login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
         login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -41,7 +41,6 @@ options:
   url:
     description:
       - The URL of the GitLab server, with protocol (i.e. http or https).
-    required: true
     type: str
   api_token:
     description:
@@ -286,15 +285,17 @@ class GitLabRunner(object):
 
 
 def deprecation_warning(module):
-    deprecated_aliases = ['login_token']
+    deprecated_aliases = ['private_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        url=dict(type='str', required=True, removed_in_version="2.10"),
+        url=dict(type='str', removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["private_token"]),
         description=dict(type='str', required=True, aliases=["name"]),
         active=dict(type='bool', default=True),
@@ -319,14 +320,16 @@ def main():
             ['login_user', 'login_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token']
+            ['api_username', 'api_token'],
+            ['api_url', 'url']
         ],
         supports_check_mode=True,
     )
 
     deprecation_warning(module)
 
-    url = re.sub('/api.*', '', module.params['url'])
+    if module.params['url'] is not None:
+        url = re.sub('/api.*', '', module.params['url'])
 
     api_url = module.params['api_url']
     validate_certs = module.params['validate_certs']

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -34,7 +34,6 @@ options:
   server_url:
     description:
       - The URL of the GitLab server, with protocol (i.e. http or https).
-    required: true
     type: str
   login_user:
     description:
@@ -411,13 +410,15 @@ class GitLabUser(object):
 def deprecation_warning(module):
     deprecated_aliases = ['login_token']
 
-    module.deprecate("Aliases \'{aliases}\' are deprecated".format(aliases='\', \''.join(deprecated_aliases)), "2.10")
+    for aliase in deprecated_aliases:
+        if aliase in module.params:
+            module.deprecate("Alias \'{aliase}\' is deprecated".format(aliase=aliase), "2.10")
 
 
 def main():
     argument_spec = basic_auth_argument_spec()
     argument_spec.update(dict(
-        server_url=dict(type='str', required=True, removed_in_version="2.10"),
+        server_url=dict(type='str', removed_in_version="2.10"),
         login_user=dict(type='str', no_log=True, removed_in_version="2.10"),
         login_password=dict(type='str', no_log=True, removed_in_version="2.10"),
         api_token=dict(type='str', no_log=True, aliases=["login_token"]),
@@ -451,7 +452,8 @@ def main():
             ['login_user', 'login_password'],
         ],
         required_one_of=[
-            ['api_username', 'api_token', 'login_user', 'login_token']
+            ['api_username', 'api_token', 'login_user', 'login_token'],
+            ['server_url', 'api_url']
         ],
         supports_check_mode=True,
     )


### PR DESCRIPTION
Issue #63690 complete the missing work of #60425

=====

Fix Gitlab module deprecation warning (#60425)

* gitlab modules : Fix deprecation warnings and parameters

Also preparing for 2.10 deprecation

* gitlab modules : Correct deprecation message

(cherry picked from commit 7bb90999d31951ebd41f612626e9f60e5965a564)

======

gitlab_modules :  remove misssing required parameter (#63690)
    
* gitlab_group: remove required=True on server_url param
    
* gitlab_project: remove required=True on server_url param
    
* Revert "Example incorrect: server_url is required argument (#63670)"
    
This reverts commit b02467961a5d9357d48ea2d955bc4de69308a16c.
This modification shouldn't have been made.
This parameter is deprecated and #60425 forget to remove the required
parameter
    
(cherry picked from commit 0af32a1093ca917aa5f8469c727d9b339572d171)

Backport of https://github.com/ansible/ansible/pull/60425