### PR TITLE
Fix warnings for ufw examples

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -149,7 +149,7 @@ EXAMPLES = r'''
 
 - name: Set logging
   ufw:
-    logging: on
+    logging: 'on'
 
 # Sometimes it is desirable to let the sender know when traffic is
 # being denied, rather than simply ignoring it. In these cases, use
@@ -185,7 +185,7 @@ EXAMPLES = r'''
 - name: Deny all access to port 53
   ufw:
     rule: deny
-    port: 53
+    port: '53'
 
 - name: Allow port range 60000-61000
   ufw:
@@ -196,7 +196,7 @@ EXAMPLES = r'''
 - name: Allow all access to tcp port 80
   ufw:
     rule: allow
-    port: 80
+    port: '80'
     proto: tcp
 
 - name: Allow all access from RFC1918 networks to this host
@@ -213,7 +213,7 @@ EXAMPLES = r'''
     rule: deny
     proto: udp
     src: 1.2.3.4
-    port: 514
+    port: '514'
     comment: Block syslog
 
 - name: Allow incoming access to eth0 from 1.2.3.5 port 5469 to 1.2.3.4 port 5469
@@ -223,9 +223,9 @@ EXAMPLES = r'''
     direction: in
     proto: udp
     src: 1.2.3.5
-    from_port: 5469
+    from_port: '5469'
     dest: 1.2.3.4
-    to_port: 5469
+    to_port: '5469'
 
 # Note that IPv6 must be enabled in /etc/default/ufw for IPv6 firewalling to work.
 - name: Deny all traffic from the IPv6 2001:db8::/32 to tcp port 25 on this host
@@ -233,14 +233,14 @@ EXAMPLES = r'''
     rule: deny
     proto: tcp
     src: 2001:db8::/32
-    port: 25
+    port: '25'
 
 - name: Deny all IPv6 traffic to tcp port 20 on this host
   # this should be the first IPv6 rule
   ufw:
     rule: deny
     proto: tcp
-    port: 20
+    port: '20'
     to_ip: "::"
     insert: 0
     insert_relative_to: first-ipv6
@@ -254,7 +254,7 @@ EXAMPLES = r'''
   ufw:
     rule: deny
     proto: tcp
-    port: 20
+    port: '20'
     to_ip: "::"
     insert: -1
     insert_relative_to: last-ipv4


### PR DESCRIPTION
##### SUMMARY
Fixes #60335

This fix removes warning messages caused when running the example code.

**Note:**
sysctl part of #60335 appears to have been fixed in #57984

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
