### PR TITLE
action/ce.py:clear configuration candidate when return to user-view.

### DIFF
--- a/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
+++ b/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - action/ce - fix a bug, some new version os will not discard uncommited configure with a return direcly.(https://github.com/ansible/ansible/pull/63513).

--- a/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
+++ b/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - action/ce - fix a bug, some new version os will not discard uncommited configure with a return directly.(https://github.com/ansible/ansible/pull/63513).
+  - action/ce - fix a bug, some new version os will not discard uncommitted configure with a return directly.(https://github.com/ansible/ansible/pull/63513).

--- a/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
+++ b/changelogs/fragments/63513-ce_action_wait_prompt_trigger_time_out.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - action/ce - fix a bug, some new version os will not discard uncommited configure with a return direcly.(https://github.com/ansible/ansible/pull/63513).
+  - action/ce - fix a bug, some new version os will not discard uncommited configure with a return directly.(https://github.com/ansible/ansible/pull/63513).

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -93,10 +93,14 @@ class ActionModule(ActionNetworkModule):
                 socket_path = self._connection.socket_path
             conn = Connection(socket_path)
             out = conn.get_prompt()
-            while to_text(out, errors='surrogate_then_replace').strip().endswith(']'):
+            prompt = to_text(out, errors='surrogate_then_replace').strip()
+            while prompt.endswith(']'):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
+                if prompt.startswith('[*'):
+                    conn.exec_command('clear configuration candidate')
                 conn.exec_command('return')
                 out = conn.get_prompt()
+                prompt = to_text(out, errors='surrogate_then_replace').strip()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Clear configuration candidate when return to user-view.
For some new software-versions, return will not discard uncommited configure directly,but it will give a prompt to wait confirm.In this case, ansible connection will trigger a time out error until time is out.
So fix it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/action/ce.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
