### PR TITLE
removing args from task_fields as it can contain sensitive data

### DIFF
--- a/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
+++ b/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - '**security issue** - Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs (CVE-2019-14864)'

--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -98,6 +98,9 @@ class SplunkHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -89,6 +89,9 @@ class SumologicHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Brute force way of addressing #63522. I considered other alternatives, such as only removing args if no_log was set to true on the task, but it's not guaranteed that no_log will be set on a task that consumes a module where a param has no_log set.

Fixes #63522
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
sumologic callback

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
