### PR TITLE
Expect upper case message 'levels' for galaxy publish results

### DIFF
--- a/changelogs/fragments/galaxy-import-level-fix.yml
+++ b/changelogs/fragments/galaxy-import-level-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy publish - Fix warning and error detection in import messages to properly display them in Ansible

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -715,9 +715,9 @@ class GalaxyAPI:
 
         for message in data.get('messages', []):
             level = message['level']
-            if level == 'ERROR':
+            if level.lower() == 'error':
                 display.error("Galaxy import error message: %s" % message['message'])
-            elif level == 'WARNING':
+            elif level.lower() == 'warning':
                 display.warning("Galaxy import warning message: %s" % message['message'])
             else:
                 display.vvv("Galaxy import message: %s - %s" % (level, message['message']))

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -715,9 +715,9 @@ class GalaxyAPI:
 
         for message in data.get('messages', []):
             level = message['level']
-            if level == 'error':
+            if level == 'ERROR':
                 display.error("Galaxy import error message: %s" % message['message'])
-            elif level == 'warning':
+            elif level == 'WARNING':
                 display.warning("Galaxy import warning message: %s" % message['message'])
             else:
                 display.vvv("Galaxy import message: %s - %s" % (level, message['message']))

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -509,11 +509,11 @@ def test_wait_import_task_with_failure(server_url, api_version, token_type, toke
             },
             'messages': [
                 {
-                    'level': 'ERROR',
+                    'level': 'ERrOR',
                     'message': u'Somé error',
                 },
                 {
-                    'level': 'WARNING',
+                    'level': 'WARNiNG',
                     'message': u'Some wärning',
                 },
                 {

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -509,15 +509,15 @@ def test_wait_import_task_with_failure(server_url, api_version, token_type, toke
             },
             'messages': [
                 {
-                    'level': 'error',
+                    'level': 'ERROR',
                     'message': u'Somé error',
                 },
                 {
-                    'level': 'warning',
+                    'level': 'WARNING',
                     'message': u'Some wärning',
                 },
                 {
-                    'level': 'info',
+                    'level': 'INFO',
                     'message': u'Somé info',
                 },
             ],
@@ -549,7 +549,7 @@ def test_wait_import_task_with_failure(server_url, api_version, token_type, toke
     assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     assert mock_vvv.call_count == 1
-    assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: info - Somé info'
+    assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: INFO - Somé info'
 
     assert mock_warn.call_count == 1
     assert mock_warn.mock_calls[0][1][0] == u'Galaxy import warning message: Some wärning'
@@ -582,15 +582,15 @@ def test_wait_import_task_with_failure_no_error(server_url, api_version, token_t
             'error': {},
             'messages': [
                 {
-                    'level': 'error',
+                    'level': 'ERROR',
                     'message': u'Somé error',
                 },
                 {
-                    'level': 'warning',
+                    'level': 'WARNING',
                     'message': u'Some wärning',
                 },
                 {
-                    'level': 'info',
+                    'level': 'INFO',
                     'message': u'Somé info',
                 },
             ],
@@ -622,7 +622,7 @@ def test_wait_import_task_with_failure_no_error(server_url, api_version, token_t
     assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     assert mock_vvv.call_count == 1
-    assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: info - Somé info'
+    assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: INFO - Somé info'
 
     assert mock_warn.call_count == 1
     assert mock_warn.mock_calls[0][1][0] == u'Galaxy import warning message: Some wärning'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Expect upper case message 'levels' for galaxy publish results

Before:

```
Publishing collection artifact '/home/adrian/src/testcollections/collection-releases/alikins-test_collection-0.0.102.tar.gz' to galaxy_dev https://galaxy-dev.ansible.com/api/
Collection has been published to the Galaxy server galaxy_dev https://galaxy-dev.ansible.com/api/
Waiting until Galaxy import task https://galaxy-dev.ansible.com/api/v2/collection-imports/35579/ has completed
Collection has been successfully published and imported to the Galaxy server galaxy_dev https://galaxy-dev.ansible.com/api/
```

After:

```
Publishing collection artifact '/home/adrian/src/testcollections/collection-releases/alikins-test_collection-0.0.101.tar.gz' to galaxy_dev https://galaxy-dev.ansible.com/api/
Collection has been published to the Galaxy server galaxy_dev https://galaxy-dev.ansible.com/api/
Waiting until Galaxy import task https://galaxy-dev.ansible.com/api/v2/collection-imports/35578/ has completed
[WARNING]: Galaxy import warning message: Exception running ansible-lint, could not complete linting

[WARNING]: Galaxy import warning message: plugins/modules/collection_inspect_no_module_utils.py:16:121: E501 line too long (127 > 120 characters)

[WARNING]: Galaxy import warning message: plugins/modules/get_collection_inspect.py:16:121: E501 line too long (127 > 120 characters)

[WARNING]: Galaxy import warning message: plugins/modules/get_collection_inspect.py:23:1: F401 'ansible.module_utils.basic.AnsibleModule' imported but unused

[WARNING]: Galaxy import warning message: plugins/modules/get_collection_inspect.py:35:121: E501 line too long (155 > 120 characters)

[WARNING]: Galaxy import warning message: plugins/callback/collection_inspect.py:53:121: E501 line too long (121 > 120 characters)

[WARNING]: Galaxy import warning message: plugins/callback/collection_inspect.py:55:121: E501 line too long (144 > 120 characters)

[WARNING]: Galaxy import warning message: plugins/vars/collection_inspect.py:34:121: E501 line too long (136 > 120 characters)

Collection has been successfully published and imported to the Galaxy server galaxy_dev https://galaxy-dev.ansible.com/api/
```

(WARNINGS are purplier in the 'after' as well)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
