### PR TITLE
Update default-test-container to 1.10.1.

### DIFF
--- a/changelogs/fragments/ansible-test-default-test-container-1.10.1.yml
+++ b/changelogs/fragments/ansible-test-default-test-container-1.10.1.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - update ansible-test default-test-container from version 1.9.3 to 1.10.1

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,4 +1,4 @@
-default name=quay.io/ansible/default-test-container:1.9.3 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:1.10.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora29 name=quay.io/ansible/fedora29-test-container:1.9.4 python=3.7


### PR DESCRIPTION
##### SUMMARY

Update default-test-container to 1.10.1.

This brings in the final Python 3.8.0 release instead of a release candidate.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
