### PR TITLE
[stable-2.9] Add constraint for pathspec.

### DIFF
--- a/changelogs/fragments/ansible-test-pathspec-constraint.yml
+++ b/changelogs/fragments/ansible-test-pathspec-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now limits ``pathspec`` to versions prior to 0.6.0 on Python 2.6 to avoid installation errors

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -25,6 +25,7 @@ requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
 openshift >= 0.6.2, < 0.9.0 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
+pathspec < 0.6.0 ; python_version < '2.7' # pathspec 0.6.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pyyaml < 5.1 ; python_version < '2.7' # pyyaml 5.1 and later require python 2.7 or later


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Add constraint for pathspec.

This fixes installation of pathspec on Python 2.6.

Backport of https://github.com/ansible/ansible/pull/63519

(cherry picked from commit 32b57d57a046b500a412cfab5927c98f0e216b88)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
