### PR TITLE
[stable-2.9] Fix use of deprecated function in xml module.

### DIFF
--- a/changelogs/fragments/xml-deprecated-functions.yml
+++ b/changelogs/fragments/xml-deprecated-functions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix the ``xml`` module to use ``list(elem)`` instead of ``elem.getchildren()`` since it is being removed in Python 3.9

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -441,7 +441,7 @@ def delete_xpath_target(module, tree, xpath, namespaces):
 
 
 def replace_children_of(children, match):
-    for element in match.getchildren():
+    for element in list(match):
         match.remove(element)
     match.extend(children)
 
@@ -458,8 +458,8 @@ def set_target_children_inner(module, tree, xpath, namespaces, children, in_type
     # xpaths always return matches as a list, so....
     for match in matches:
         # Check if elements differ
-        if len(match.getchildren()) == len(children):
-            for idx, element in enumerate(match.getchildren()):
+        if len(list(match)) == len(children):
+            for idx, element in enumerate(list(match)):
                 if etree.tostring(element) != children_as_string[idx]:
                     replace_children_of(children, match)
                     changed = True


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix use of deprecated function in xml module.

Backport of https://github.com/ansible/ansible/pull/63536

(cherry picked from commit d829a50a5b7030b82ec2d15a33540225209453d4)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

xml module