### PR TITLE
Don't sort lists of routes again in os_subnet

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -202,7 +202,7 @@ def _needs_update(subnet, module, cloud, filters=None):
     if host_routes:
         curr_hr = sorted(subnet['host_routes'], key=lambda t: t.keys())
         new_hr = sorted(host_routes, key=lambda t: t.keys())
-        if sorted(curr_hr) != sorted(new_hr):
+        if curr_hr != new_hr:
             return True
     if no_gateway_ip and subnet['gateway_ip']:
         return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
When trying to run playbook with existing subnet it fails to compare host_routes for idempotency. The task fails with:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: '<' not supported between instances of 'dict' and 'dict'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "rc": 1
}

MSG:

MODULE FAILURE
See stdout/stderr for the exact error


MODULE_STDERR:

Traceback (most recent call last):
  File "/home/sshnaidm/.ansible/tmp/ansible-tmp-1571178416.1309097-159114948456565/AnsiballZ_os_subnet.py", line 102, in <module>
    _ansiballz_main()
  File "/home/sshnaidm/.ansible/tmp/ansible-tmp-1571178416.1309097-159114948456565/AnsiballZ_os_subnet.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/sshnaidm/.ansible/tmp/ansible-tmp-1571178416.1309097-159114948456565/AnsiballZ_os_subnet.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.cloud.openstack.os_subnet', init_globals=None, run_name='__main__', alter_sys=False)
  File "/usr/lib64/python3.7/runpy.py", line 208, in run_module
    return _run_code(code, {}, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_os_subnet_payload_uugb1hal/ansible_os_subnet_payload.zip/ansible/modules/cloud/openstack/os_subnet.py", line 360, in <module>
  File "/tmp/ansible_os_subnet_payload_uugb1hal/ansible_os_subnet_payload.zip/ansible/modules/cloud/openstack/os_subnet.py", line 331, in main
  File "/tmp/ansible_os_subnet_payload_uugb1hal/ansible_os_subnet_payload.zip/ansible/modules/cloud/openstack/os_subnet.py", line 205, in _needs_update
TypeError: '<' not supported between instances of 'dict' and 'dict'

```
No need to sort lists of dictionaries again, just compare already sorted.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_subnet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Tested with such subnet:

```paste below
ok: [localhost] => {
    "changed": false,
    "id": "3fce20f3-7880-448f-b53a-b90ffd210397",
    "subnet": {
        "allocation_pools": [
            {
                "end": "192.168.4.43",
                "start": "192.168.4.11"
            },
            {
                "end": "192.168.4.143",
                "start": "192.168.4.111"
            }
        ],
        "cidr": "192.168.4.0/24",
        "created_at": "2019-10-15T21:20:16Z",
        "description": "",
        "dns_nameservers": [
            "1.1.1.1",
            "2.2.2.2",
            "3.3.3.3"
        ],
        "enable_dhcp": true,
        "gateway_ip": "192.168.4.1",
        "host_routes": [
            {
                "destination": "10.0.0.0/24",
                "nexthop": "192.168.4.143"
            },
            {
                "destination": "10.0.0.1/24",
                "nexthop": "192.168.4.144"
            }
        ],
        "id": "3fce20f3-7880-448f-b53a-b90ffd210397",
        "ip_version": 4,
        "ipv6_address_mode": null,
        "ipv6_ra_mode": null,
        "name": "new_net4_sub",
        "network_id": "95cb3d4e-e7ca-4a97-ac55-46f087e701e4",
        "project_id": ""...................................................",",
        "revision_number": 2,
        "service_types": [],
        "subnetpool_id": null,
        "tags": [],
        "tenant_id": "...................................................",
        "updated_at": "2019-10-15T21:20:16Z"
    }
}

```
and task:
```yaml
- os_subnet:
    cidr: 192.168.4.0/24
    dns_nameservers:
    - 1.1.1.1
    - 2.2.2.2
    - 3.3.3.3
    gateway_ip: 192.168.4.1
    host_routes:
    - destination: 10.0.0.0/24
      nexthop: 192.168.4.143
    - destination: 10.0.0.1/24
      nexthop: 192.168.4.144
    name: new_net4_sub
    network_name: some_network
    state: present
```

```
python -V
Python 3.7.4```
```
```
$ ansible-playbook --version
ansible-playbook 2.10.0.dev0
  config file = /home/sshnaidm/.ansible.cfg
  configured module search path = ['/home/sshnaidm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sshnaidm/venvs/ansible-dev/src/ansible/lib/ansible
  executable location = /home/sshnaidm/venvs/ansible-dev/bin/ansible-playbook
  python version = 3.7.4 (default, Jul  9 2019, 16:32:37) [GCC 9.1.1 20190503 (Red Hat 9.1.1-1)]
```