### PR TITLE
Add support for adapters removal in standard vswitch

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
@@ -312,7 +312,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
         # Remove nics not specfied by user
         for notdesired_pnic in all_nics:
-            if notdesired_pnic not in self.nics:
+            if notdesired_pnic not in self.nics[:]:
                 all_nics.remove(notdesired_pnic)
                 diff = True
 

--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
@@ -310,6 +310,12 @@ class VMwareHostVirtualSwitch(PyVmomi):
             all_nics += remain_pnic
             diff = True
 
+        # Remove nics not specfied by user
+        for notdesired_pnic in all_nics:
+            if notdesired_pnic not in self.nics:
+                all_nics.remove(notdesired_pnic)
+                diff = True
+
         if vswitch_pnic_info['mtu'] != self.mtu or \
                 vswitch_pnic_info['num_ports'] != self.number_of_ports:
             diff = True

--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
@@ -311,8 +311,8 @@ class VMwareHostVirtualSwitch(PyVmomi):
             diff = True
 
         # Remove nics not specfied by user
-        for notdesired_pnic in all_nics:
-            if notdesired_pnic not in self.nics[:]:
+        for notdesired_pnic in all_nics[:]:
+            if notdesired_pnic not in self.nics:
                 all_nics.remove(notdesired_pnic)
                 diff = True
 


### PR DESCRIPTION
##### SUMMARY
A simple way to support adapters removal in standard vswitch. Adapter(s) not specified in nics parameter will be removed.

Issue #44589
Fixes #47015 is certainly more appropriate but require more validation

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vswitch

##### ADDITIONAL INFORMATION

```
---
- name: Test Vswitch creation / adapter removal
  hosts: localhost
  gather_facts: no
  vars:
    switch_name: VSWITCH_TEST
    all_adapters: [vmnic2, vmnic3, vmnic4, vmnic5]
    keep_adapters: [vmnic3, vmnic2]
    esxi_hostname: esxihost
    esxi_username: esxiroot
    esxi_password: esxipassword

  tasks:
    - name: VMware - Create standard vswitch {{ switch_name }} using adapters {{ all_adapters }}
      vmware_vswitch:
        hostname: "{{ esxi_hostname }}"
        username: "{{ esxi_username }}"
        password: "{{ esxi_password }}"
        validate_certs: no
        switch: "{{ switch_name }}"
        nics: "{{ all_adapters }}"
      delegate_to: localhost

    - name: VMware - Retreive standard vswitch information
      vmware_vswitch_info:
        hostname: "{{ esxi_hostname }}"
        username: "{{ esxi_username }}"
        password: "{{ esxi_password }}"
        esxi_hostname: "{{ esxi_hostname }}"
        validate_certs: no
      delegate_to: localhost
      register: vswitch_info
    - debug:
        msg: "{{ vswitch_info }}"

    - name: VMware - Delete all standard vswitch adapters on {{ switch_name }} except specfied adapters {{ keep_adapters }}
      vmware_vswitch:
        hostname: "{{ esxi_hostname }}"
        username: "{{ esxi_username }}"
        password: "{{ esxi_password }}"
        validate_certs: no
        switch: "{{ switch_name }}"
        nics: "{{ keep_adapters }}"
      delegate_to: localhost
      register: result

    - debug:
        msg: "{{ result }}"

    - name: VMware - Retreive standard vswitch information
      vmware_vswitch_info:
        hostname: "{{ esxi_hostname }}"
        username: "{{ esxi_username }}"
        password: "{{ esxi_password }}"
        esxi_hostname: "{{ esxi_hostname }}"
        validate_certs: no
      delegate_to: localhost
      register: vswitch_info

    - debug:
        msg: "{{ vswitch_info }}"

```