### PR TITLE
Improve module return values

### DIFF
--- a/lib/ansible/modules/cloud/alicloud/ali_instance.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance.py
@@ -468,7 +468,7 @@ instances:
         security_groups:
             description: One or more security groups for the instance.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 group_id:
                     description: The ID of the security group.

--- a/lib/ansible/modules/cloud/alicloud/ali_instance.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance.py
@@ -470,16 +470,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - group_id:
-                      description: The ID of the security group.
-                      returned: always
-                      type: str
-                      sample: sg-0123456
-                - group_name:
-                      description: The name of the security group.
-                      returned: always
-                      type: str
-                      sample: my-security-group
+                group_id:
+                    description: The ID of the security group.
+                    returned: always
+                    type: str
+                    sample: sg-0123456
+                group_name:
+                    description: The name of the security group.
+                    returned: always
+                    type: str
+                    sample: my-security-group
         status:
             description: The current status of the instance.
             returned: always

--- a/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
@@ -309,7 +309,7 @@ instances:
         security_groups:
             description: One or more security groups for the instance.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 group_id:
                     description: The ID of the security group.

--- a/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
+++ b/lib/ansible/modules/cloud/alicloud/ali_instance_info.py
@@ -311,16 +311,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - group_id:
-                      description: The ID of the security group.
-                      returned: always
-                      type: str
-                      sample: sg-0123456
-                - group_name:
-                      description: The name of the security group.
-                      returned: always
-                      type: str
-                      sample: my-security-group
+                group_id:
+                    description: The ID of the security group.
+                    returned: always
+                    type: str
+                    sample: sg-0123456
+                group_name:
+                    description: The name of the security group.
+                    returned: always
+                    type: str
+                    sample: my-security-group
         status:
             description: The current status of the instance.
             returned: always

--- a/lib/ansible/modules/cloud/amazon/aws_codebuild.py
+++ b/lib/ansible/modules/cloud/amazon/aws_codebuild.py
@@ -257,11 +257,11 @@ project:
     cache:
       description: Cache settings for the build project.
       returned: when configured
-      type: complex
+      type: dict
     environment:
       description: Environment settings for the build
       returned: always
-      type: complex
+      type: dict
     service_role:
       description: IAM role to be used during build to access other AWS services.
       returned: always

--- a/lib/ansible/modules/cloud/amazon/aws_codecommit.py
+++ b/lib/ansible/modules/cloud/amazon/aws_codecommit.py
@@ -73,7 +73,7 @@ repository_metadata:
     creation_date:
       description: "The date and time the repository was created, in timestamp format."
       returned: when state is present
-      type: datetime
+      type: str
       sample: "2018-10-16T13:21:41.261000+09:00"
     last_modified_date:
       description: "The date and time the repository was last modified, in timestamp format."
@@ -104,7 +104,7 @@ response_metadata:
     http_headers:
       description: "http headers of http response"
       returned: always
-      type: complex
+      type: dict
     http_status_code:
       description: "http status code of http response"
       returned: always

--- a/lib/ansible/modules/cloud/amazon/aws_secret.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret.py
@@ -119,7 +119,7 @@ secret:
     version_ids_to_stages:
       description: Provide the secret version ids and the associated secret stage.
       returned: always
-      type: complex
+      type: dict
       sample: { "dc1ed59b-6d8e-4450-8b41-536dfe4600a9": [ "AWSCURRENT" ] }
 '''
 

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -477,7 +477,7 @@ instances:
                 groups:
                     description: One or more security groups.
                     returned: always
-                    type: complex
+                    type: list of complex
                     contains:
                         group_id:
                             description: The ID of the security group.
@@ -522,7 +522,7 @@ instances:
                 private_ip_addresses:
                     description: The private IPv4 addresses associated with the network interface.
                     returned: always
-                    type: complex
+                    type: list of complex
                     contains:
                         association:
                             description: The association information for an Elastic IP address (IPv4) associated with the network interface.
@@ -607,7 +607,7 @@ instances:
         product_codes:
             description: One or more product codes.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 product_code_id:
                     description: The product code.
@@ -642,7 +642,7 @@ instances:
         security_groups:
             description: One or more security groups for the instance.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 group_id:
                     description: The ID of the security group.

--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -479,16 +479,16 @@ instances:
                     returned: always
                     type: complex
                     contains:
-                        - group_id:
-                              description: The ID of the security group.
-                              returned: always
-                              type: str
-                              sample: sg-abcdef12
-                          group_name:
-                              description: The name of the security group.
-                              returned: always
-                              type: str
-                              sample: mygroup
+                        group_id:
+                            description: The ID of the security group.
+                            returned: always
+                            type: str
+                            sample: sg-abcdef12
+                        group_name:
+                            description: The name of the security group.
+                            returned: always
+                            type: str
+                            sample: mygroup
                 ipv6_addresses:
                     description: One or more IPv6 addresses associated with the network interface.
                     returned: always
@@ -524,36 +524,36 @@ instances:
                     returned: always
                     type: complex
                     contains:
-                        - association:
-                              description: The association information for an Elastic IP address (IPv4) associated with the network interface.
-                              returned: always
-                              type: complex
-                              contains:
-                                  ip_owner_id:
-                                      description: The ID of the owner of the Elastic IP address.
-                                      returned: always
-                                      type: str
-                                      sample: amazon
-                                  public_dns_name:
-                                      description: The public DNS name.
-                                      returned: always
-                                      type: str
-                                      sample: ""
-                                  public_ip:
-                                      description: The public IP address or Elastic IP address bound to the network interface.
-                                      returned: always
-                                      type: str
-                                      sample: 1.2.3.4
-                          primary:
-                              description: Indicates whether this IPv4 address is the primary private IP address of the network interface.
-                              returned: always
-                              type: bool
-                              sample: true
-                          private_ip_address:
-                              description: The private IPv4 address of the network interface.
-                              returned: always
-                              type: str
-                              sample: 10.0.0.1
+                        association:
+                            description: The association information for an Elastic IP address (IPv4) associated with the network interface.
+                            returned: always
+                            type: complex
+                            contains:
+                                ip_owner_id:
+                                    description: The ID of the owner of the Elastic IP address.
+                                    returned: always
+                                    type: str
+                                    sample: amazon
+                                public_dns_name:
+                                    description: The public DNS name.
+                                    returned: always
+                                    type: str
+                                    sample: ""
+                                public_ip:
+                                    description: The public IP address or Elastic IP address bound to the network interface.
+                                    returned: always
+                                    type: str
+                                    sample: 1.2.3.4
+                        primary:
+                            description: Indicates whether this IPv4 address is the primary private IP address of the network interface.
+                            returned: always
+                            type: bool
+                            sample: true
+                        private_ip_address:
+                            description: The private IPv4 address of the network interface.
+                            returned: always
+                            type: str
+                            sample: 10.0.0.1
                 source_dest_check:
                     description: Indicates whether source/destination checking is enabled.
                     returned: always
@@ -609,16 +609,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - product_code_id:
-                      description: The product code.
-                      returned: always
-                      type: str
-                      sample: aw0evgkw8ef3n2498gndfgasdfsd5cce
-                  product_code_type:
-                      description: The type of product code.
-                      returned: always
-                      type: str
-                      sample: marketplace
+                product_code_id:
+                    description: The product code.
+                    returned: always
+                    type: str
+                    sample: aw0evgkw8ef3n2498gndfgasdfsd5cce
+                product_code_type:
+                    description: The type of product code.
+                    returned: always
+                    type: str
+                    sample: marketplace
         public_dns_name:
             description: The public DNS name assigned to the instance.
             returned: always
@@ -644,16 +644,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - group_id:
-                      description: The ID of the security group.
-                      returned: always
-                      type: str
-                      sample: sg-0123456
-                - group_name:
-                      description: The name of the security group.
-                      returned: always
-                      type: str
-                      sample: my-security-group
+                group_id:
+                    description: The ID of the security group.
+                    returned: always
+                    type: str
+                    sample: sg-0123456
+                group_name:
+                    description: The name of the security group.
+                    returned: always
+                    type: str
+                    sample: my-security-group
         network.source_dest_check:
             description: Indicates whether source/destination checking is enabled.
             returned: always

--- a/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
@@ -263,7 +263,7 @@ instances:
                 groups:
                     description: One or more security groups.
                     returned: always
-                    type: complex
+                    type: list of complex
                     contains:
                         group_id:
                             description: The ID of the security group.
@@ -308,7 +308,7 @@ instances:
                 private_ip_addresses:
                     description: The private IPv4 addresses associated with the network interface.
                     returned: always
-                    type: complex
+                    type: list of complex
                     contains:
                         association:
                             description: The association information for an Elastic IP address (IPv4) associated with the network interface.
@@ -393,7 +393,7 @@ instances:
         product_codes:
             description: One or more product codes.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 product_code_id:
                     description: The product code.
@@ -428,7 +428,7 @@ instances:
         security_groups:
             description: One or more security groups for the instance.
             returned: always
-            type: complex
+            type: list of complex
             contains:
                 group_id:
                     description: The ID of the security group.

--- a/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_info.py
@@ -265,16 +265,16 @@ instances:
                     returned: always
                     type: complex
                     contains:
-                        - group_id:
-                              description: The ID of the security group.
-                              returned: always
-                              type: str
-                              sample: sg-abcdef12
-                          group_name:
-                              description: The name of the security group.
-                              returned: always
-                              type: str
-                              sample: mygroup
+                        group_id:
+                            description: The ID of the security group.
+                            returned: always
+                            type: str
+                            sample: sg-abcdef12
+                        group_name:
+                            description: The name of the security group.
+                            returned: always
+                            type: str
+                            sample: mygroup
                 ipv6_addresses:
                     description: One or more IPv6 addresses associated with the network interface.
                     returned: always
@@ -310,36 +310,36 @@ instances:
                     returned: always
                     type: complex
                     contains:
-                        - association:
-                              description: The association information for an Elastic IP address (IPv4) associated with the network interface.
-                              returned: always
-                              type: complex
-                              contains:
-                                  ip_owner_id:
-                                      description: The ID of the owner of the Elastic IP address.
-                                      returned: always
-                                      type: str
-                                      sample: amazon
-                                  public_dns_name:
-                                      description: The public DNS name.
-                                      returned: always
-                                      type: str
-                                      sample: ""
-                                  public_ip:
-                                      description: The public IP address or Elastic IP address bound to the network interface.
-                                      returned: always
-                                      type: str
-                                      sample: 1.2.3.4
-                          primary:
-                              description: Indicates whether this IPv4 address is the primary private IP address of the network interface.
-                              returned: always
-                              type: bool
-                              sample: true
-                          private_ip_address:
-                              description: The private IPv4 address of the network interface.
-                              returned: always
-                              type: str
-                              sample: 10.0.0.1
+                        association:
+                            description: The association information for an Elastic IP address (IPv4) associated with the network interface.
+                            returned: always
+                            type: complex
+                            contains:
+                                ip_owner_id:
+                                    description: The ID of the owner of the Elastic IP address.
+                                    returned: always
+                                    type: str
+                                    sample: amazon
+                                public_dns_name:
+                                    description: The public DNS name.
+                                    returned: always
+                                    type: str
+                                    sample: ""
+                                public_ip:
+                                    description: The public IP address or Elastic IP address bound to the network interface.
+                                    returned: always
+                                    type: str
+                                    sample: 1.2.3.4
+                        primary:
+                            description: Indicates whether this IPv4 address is the primary private IP address of the network interface.
+                            returned: always
+                            type: bool
+                            sample: true
+                        private_ip_address:
+                            description: The private IPv4 address of the network interface.
+                            returned: always
+                            type: str
+                            sample: 10.0.0.1
                 source_dest_check:
                     description: Indicates whether source/destination checking is enabled.
                     returned: always
@@ -395,16 +395,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - product_code_id:
-                      description: The product code.
-                      returned: always
-                      type: str
-                      sample: aw0evgkw8ef3n2498gndfgasdfsd5cce
-                  product_code_type:
-                      description: The type of product code.
-                      returned: always
-                      type: str
-                      sample: marketplace
+                product_code_id:
+                    description: The product code.
+                    returned: always
+                    type: str
+                    sample: aw0evgkw8ef3n2498gndfgasdfsd5cce
+                product_code_type:
+                    description: The type of product code.
+                    returned: always
+                    type: str
+                    sample: marketplace
         public_dns_name:
             description: The public DNS name assigned to the instance.
             returned: always
@@ -430,16 +430,16 @@ instances:
             returned: always
             type: complex
             contains:
-                - group_id:
-                      description: The ID of the security group.
-                      returned: always
-                      type: str
-                      sample: sg-0123456
-                - group_name:
-                      description: The name of the security group.
-                      returned: always
-                      type: str
-                      sample: my-security-group
+                group_id:
+                    description: The ID of the security group.
+                    returned: always
+                    type: str
+                    sample: sg-0123456
+                group_name:
+                    description: The name of the security group.
+                    returned: always
+                    type: str
+                    sample: my-security-group
         source_dest_check:
             description: Indicates whether source/destination checking is enabled.
             returned: always

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_info.py
@@ -91,14 +91,14 @@ nacls:
         ingress:
             description:
               - A list of NACL ingress rules with the following format.
-              - [rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to]
+              - "C([rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to])"
             returned: always
             type: list of list
             sample: [[100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]]
         egress:
             description:
               - A list of NACL egress rules with the following format.
-              - [rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to]
+              - "C([rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to])"
             returned: always
             type: list of list
             sample: [[100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]]

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn_info.py
@@ -140,6 +140,11 @@ vpn_connections:
                returned: always
                type: str
                sample: IPSEC IS DOWN
+           certificate_arn:
+               description: The Amazon Resource Name of the virtual private gateway tunnel endpoint certificate.
+               returned: when a private certificate is used for authentication
+               type: str
+               sample: "arn:aws:acm:us-east-1:123456789101:certificate/c544d8ce-20b8-4fff-98b0-example"
       vpn_connection_id:
         description: The ID of the VPN connection.
         returned: always

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn_info.py
@@ -123,7 +123,7 @@ vpn_connections:
            last_status_change:
                description: The date and time of the last change in status.
                returned: always
-               type: datetime
+               type: str
                sample: "2018-02-09T14:35:27+00:00"
            outside_ip_address:
                description: The Internet-routable IP address of the virtual private gateway's outside interface.

--- a/lib/ansible/modules/cloud/openstack/os_coe_cluster.py
+++ b/lib/ansible/modules/cloud/openstack/os_coe_cluster.py
@@ -105,7 +105,7 @@ cluster:
       created_at:
           description:
             - The time in UTC at which the cluster is created
-          type: datetime
+          type: str
           sample: "2018-08-16T10:29:45+00:00"
       create_timeout:
           description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -169,7 +169,7 @@ ovirt_auth:
         ca_file:
             description: CA file, which is used to verify SSL/TLS connection.
             returned: success
-            type: path
+            type: str
             sample: "ca.pem"
         insecure:
             description: Flag indicating if insecure connection is used.

--- a/lib/ansible/modules/cloud/vmware/vcenter_folder.py
+++ b/lib/ansible/modules/cloud/vmware/vcenter_folder.py
@@ -132,8 +132,12 @@ result:
     returned: On success
     type: complex
     contains:
-        path: the full path of the new folder
-        msg: string stating about result
+        path:
+            description: the full path of the new folder
+            type: str
+        msg:
+            description: string stating about result
+            type: str
 '''
 
 try:

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -143,9 +143,9 @@ stat:
             type: str
             sample: '/path/to/file'
         mode:
-            description: Unix permissions of the file in octal
+            description: Unix permissions of the file in octal representation as a string
             returned: success, path exists and user can read stats
-            type: octal
+            type: str
             sample: 1755
         isdir:
             description: Tells you if the path is a directory

--- a/lib/ansible/modules/network/meraki/meraki_mx_l7_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mx_l7_firewall.py
@@ -247,6 +247,16 @@ data:
                             returned: success
                             type: str
                             sample: meraki:layer7/application/4
+                id:
+                    description: URI of application category.
+                    returned: success
+                    type: string
+                    sample: Email
+                name:
+                    description: Descriptive name of application category.
+                    returned: success
+                    type: string
+                    sample: layer7/category/1
 '''
 
 import copy

--- a/lib/ansible/modules/network/meraki/meraki_mx_l7_firewall.py
+++ b/lib/ansible/modules/network/meraki/meraki_mx_l7_firewall.py
@@ -247,16 +247,6 @@ data:
                             returned: success
                             type: str
                             sample: meraki:layer7/application/4
-                    id:
-                        description: URI of application category.
-                        returned: success
-                        type: string
-                        sample: Email
-                    name:
-                        description: Descriptive name of application category.
-                        returned: success
-                        type: string
-                        sample: layer7/category/1
 '''
 
 import copy

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -221,7 +221,7 @@ updates:
         id:
             description: Internal Windows Update GUID.
             returned: always
-            type: str (guid)
+            type: str
             sample: "fb95c1c8-de23-4089-ae29-fd3351d55421"
         installed:
             description: Was the update successfully installed.


### PR DESCRIPTION
##### SUMMARY
Some more parts of #63411 resp. similar changes which can be backported back to 2.8.

The changes here contain less trivial changes than #63477 and #63478.

It also includes a new return value for `ec2_vpc_vpn_info` as suggested by @s-hertel in https://github.com/ansible/ansible/pull/63477#discussion_r334869663; according to @s-hertel, that return value can also be returned in Ansible 2.8 and 2.9.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ali_instance
ali_instance_info
ec2_instance
ec2_instance_info
ec2_vpc_vpn_info
aws_codebuild
aws_codecommit
aws_secret
ec2_instance
ec2_instance_info
ec2_vpc_nacl_info
ec2_vpc_vpn_info
os_coe_cluster
ovirt_auth
vcenter_folder
stat
meraki_mx_l7_firewall
win_updates
