### PR TITLE
Bugfix of 23976: mysql_replication - allow to pass empty values to the module's parameters

### DIFF
--- a/changelogs/fragments/63546-mysql_replication_allow_to_pass_empty_values.yml
+++ b/changelogs/fragments/63546-mysql_replication_allow_to_pass_empty_values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_replication - allow to pass empty values to parameters (https://github.com/ansible/ansible/issues/23976).

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -148,7 +148,7 @@ options:
     version_added: '2.10'
 
 notes:
-- If an empty value for the parameter of string type is needed, use an underscore.
+- If an empty value for the parameter of string type is needed, use an empty string.
 
 extends_documentation_fragment:
 - mysql
@@ -336,11 +336,6 @@ def start_slave(cursor, connection_name='', channel=''):
 
 
 def changemaster(cursor, chm, connection_name='', channel=''):
-    # Params ransformation for issue #23976:
-    for num, param in enumerate(chm):
-        if param[-4:] == "='_'":
-            chm[num] = chm[num].replace("='_'", "=''")
-
     if connection_name:
         query = "CHANGE MASTER '%s' TO %s" % (connection_name, ','.join(chm))
     else:
@@ -462,37 +457,37 @@ def main():
     elif mode in "changemaster":
         chm = []
         result = {}
-        if master_host:
+        if master_host is not None:
             chm.append("MASTER_HOST='%s'" % master_host)
-        if master_user:
+        if master_user is not None:
             chm.append("MASTER_USER='%s'" % master_user)
-        if master_password:
+        if master_password is not None:
             chm.append("MASTER_PASSWORD='%s'" % master_password)
         if master_port is not None:
             chm.append("MASTER_PORT=%s" % master_port)
         if master_connect_retry is not None:
             chm.append("MASTER_CONNECT_RETRY=%s" % master_connect_retry)
-        if master_log_file:
+        if master_log_file is not None:
             chm.append("MASTER_LOG_FILE='%s'" % master_log_file)
         if master_log_pos is not None:
             chm.append("MASTER_LOG_POS=%s" % master_log_pos)
         if master_delay is not None:
             chm.append("MASTER_DELAY=%s" % master_delay)
-        if relay_log_file:
+        if relay_log_file is not None:
             chm.append("RELAY_LOG_FILE='%s'" % relay_log_file)
         if relay_log_pos is not None:
             chm.append("RELAY_LOG_POS=%s" % relay_log_pos)
         if master_ssl:
             chm.append("MASTER_SSL=1")
-        if master_ssl_ca:
+        if master_ssl_ca is not None:
             chm.append("MASTER_SSL_CA='%s'" % master_ssl_ca)
-        if master_ssl_capath:
+        if master_ssl_capath is not None:
             chm.append("MASTER_SSL_CAPATH='%s'" % master_ssl_capath)
-        if master_ssl_cert:
+        if master_ssl_cert is not None:
             chm.append("MASTER_SSL_CERT='%s'" % master_ssl_cert)
-        if master_ssl_key:
+        if master_ssl_key is not None:
             chm.append("MASTER_SSL_KEY='%s'" % master_ssl_key)
-        if master_ssl_cipher:
+        if master_ssl_cipher is not None:
             chm.append("MASTER_SSL_CIPHER='%s'" % master_ssl_cipher)
         if master_auto_position:
             chm.append("MASTER_AUTO_POSITION=1")

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -147,6 +147,10 @@ options:
     type: str
     version_added: '2.10'
 
+notes:
+- If an empty value for the parameter of string type is needed,
+  use string with a single space.
+
 extends_documentation_fragment:
 - mysql
 
@@ -333,6 +337,11 @@ def start_slave(cursor, connection_name='', channel=''):
 
 
 def changemaster(cursor, chm, connection_name='', channel=''):
+    # Params ransformation for issue #23976:
+    for num, param in enumerate(chm):
+        if "=' '" in param:
+            chm[num] = chm[num].replace("=' '","=''")
+
     if connection_name:
         query = "CHANGE MASTER '%s' TO %s" % (connection_name, ','.join(chm))
     else:

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -340,7 +340,7 @@ def changemaster(cursor, chm, connection_name='', channel=''):
     # Params ransformation for issue #23976:
     for num, param in enumerate(chm):
         if "=' '" in param:
-            chm[num] = chm[num].replace("=' '","=''")
+            chm[num] = chm[num].replace("=' '", "=''")
 
     if connection_name:
         query = "CHANGE MASTER '%s' TO %s" % (connection_name, ','.join(chm))

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -148,8 +148,7 @@ options:
     version_added: '2.10'
 
 notes:
-- If an empty value for the parameter of string type is needed,
-  use string with a single space.
+- If an empty value for the parameter of string type is needed, use an underscore.
 
 extends_documentation_fragment:
 - mysql
@@ -339,8 +338,8 @@ def start_slave(cursor, connection_name='', channel=''):
 def changemaster(cursor, chm, connection_name='', channel=''):
     # Params ransformation for issue #23976:
     for num, param in enumerate(chm):
-        if "=' '" in param:
-            chm[num] = chm[num].replace("=' '", "=''")
+        if param[-4:] == "='_'":
+            chm[num] = chm[num].replace("='_'", "=''")
 
     if connection_name:
         query = "CHANGE MASTER '%s' TO %s" % (connection_name, ','.join(chm))

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -33,7 +33,7 @@
     - master_status is not changed
 
 # Test changemaster mode:
-# master_ssl_ca will be set as '_' to check the module's behaviour for #23976,
+# master_ssl_ca will be set as '' to check the module's behaviour for #23976,
 # must be converted to an empty string
 - name: Run replication
   mysql_replication:
@@ -46,7 +46,7 @@
     master_password: "{{ replication_pass }}"
     master_log_file: "{{ master_status.File }}"
     master_log_pos: "{{ master_status.Position }}"
-    master_ssl_ca: _
+    master_ssl_ca: ''
   register: result
 
 - assert:

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -33,7 +33,7 @@
     - master_status is not changed
 
 # Test changemaster mode:
-# master_ssl_ca will be set as ' ' to check the module's behaviour for #23976,
+# master_ssl_ca will be set as '_' to check the module's behaviour for #23976,
 # must be converted to an empty string
 - name: Run replication
   mysql_replication:
@@ -46,7 +46,7 @@
     master_password: "{{ replication_pass }}"
     master_log_file: "{{ master_status.File }}"
     master_log_pos: "{{ master_status.Position }}"
-    master_ssl_ca: ' '
+    master_ssl_ca: _
   register: result
 
 - assert:

--- a/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
+++ b/test/integration/targets/mysql_replication/tasks/mysql_replication_initial.yml
@@ -33,6 +33,8 @@
     - master_status is not changed
 
 # Test changemaster mode:
+# master_ssl_ca will be set as ' ' to check the module's behaviour for #23976,
+# must be converted to an empty string
 - name: Run replication
   mysql_replication:
     login_host: 127.0.0.1
@@ -44,12 +46,13 @@
     master_password: "{{ replication_pass }}"
     master_log_file: "{{ master_status.File }}"
     master_log_pos: "{{ master_status.Position }}"
+    master_ssl_ca: ' '
   register: result
 
 - assert:
     that:
     - result is changed
-    - result.queries == ["CHANGE MASTER TO MASTER_HOST='127.0.0.1',MASTER_USER='replication_user',MASTER_PASSWORD='********',MASTER_PORT=3306,MASTER_LOG_FILE='{{ master_status.File }}',MASTER_LOG_POS={{ master_status.Position }}"]
+    - result.queries == ["CHANGE MASTER TO MASTER_HOST='127.0.0.1',MASTER_USER='replication_user',MASTER_PASSWORD='********',MASTER_PORT=3306,MASTER_LOG_FILE='{{ master_status.File }}',MASTER_LOG_POS={{ master_status.Position }},MASTER_SSL_CA=''"]
 
 # Test startslave mode:
 - name: Start slave


### PR DESCRIPTION
##### SUMMARY
Bugfix of #23976: mysql_replication - allow to pass empty values to the module's parameters
fixes #23976

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_replication.py```
