### PR TITLE
Enable changing the timeout of wait_for_ip_address

### DIFF
--- a/changelogs/fragments/vmware_guest.yaml
+++ b/changelogs/fragments/vmware_guest.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Added a timeout parameter `wait_for_ip_address_timeout` for `wait_for_ip_address` for longer-running tasks in vmware_guest.


### PR DESCRIPTION
##### SUMMARY

I was having an issue where the wait_for_ip_address parameter didn't appear to be working correctly. It turns out it was working as expected, but that my task was taking longer than the wait_for_vm_ip function was prepared to wait.

I've added a parameter (wait_for_ip_address_timeout) to allow a longer timeout than the default. I've also removed the wait_for_vm_ip function in this module as one in module_utils is already being used elsewhere.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

wait_for_ip_address_timeout

##### ADDITIONAL INFORMATION

I'm not a developer, so if there's anything I've omitted, please let me know!
