### PR TITLE
postgresql_user: allow to pass user name with dots

### DIFF
--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -94,12 +94,8 @@ def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
         if module.params.get('session_role'):
             cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-            # If the session_role name contains dots:
-            if "." in module.params['session_role']:
-                module.params['session_role'] = '"%s"' % module.params['session_role']
-
             try:
-                cursor.execute('SET ROLE %s' % module.params['session_role'])
+                cursor.execute('SET ROLE "%s"' % module.params['session_role'])
             except Exception as e:
                 module.fail_json(msg="Could not switch role: %s" % to_native(e))
             finally:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -35,7 +35,6 @@ except ImportError:
     HAS_PSYCOPG2 = False
 
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.database import pg_quote_identifier
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
 from distutils.version import LooseVersion
@@ -94,6 +93,11 @@ def connect_to_db(module, conn_params, autocommit=False, fail_on_conn=True):
         # Switch role, if specified:
         if module.params.get('session_role'):
             cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+            # If the session_role name contains dots:
+            if "." in module.params['session_role']:
+                module.params['session_role'] = '"%s"' % module.params['session_role']
+
             try:
                 cursor.execute('SET ROLE %s' % module.params['session_role'])
             except Exception as e:
@@ -223,8 +227,7 @@ class PgMembership(object):
                 if self.__check_membership(group, role):
                     continue
 
-                query = "GRANT %s TO %s" % ((pg_quote_identifier(group, 'role'),
-                                            (pg_quote_identifier(role, 'role'))))
+                query = "GRANT %s TO %s" % (group, role)
                 self.changed = exec_sql(self, query, ddl=True)
 
                 if self.changed:
@@ -241,8 +244,7 @@ class PgMembership(object):
                 if not self.__check_membership(group, role):
                     continue
 
-                query = "REVOKE %s FROM %s" % ((pg_quote_identifier(group, 'role'),
-                                               (pg_quote_identifier(role, 'role'))))
+                query = "REVOKE %s FROM %s" % (group, role, 'role')
                 self.changed = exec_sql(self, query, ddl=True)
 
                 if self.changed:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -252,7 +252,7 @@ class PgMembership(object):
                 if "." in role:
                     role = '"%s"' % role
 
-                query = "REVOKE %s FROM %s" % (group, role, 'role')
+                query = "REVOKE %s FROM %s" % (group, role)
                 self.changed = exec_sql(self, query, ddl=True)
 
                 if self.changed:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -223,11 +223,7 @@ class PgMembership(object):
                 if self.__check_membership(group, role):
                     continue
 
-                # If role name has dots:
-                if "." in role:
-                    role = '"%s"' % role
-
-                query = "GRANT %s TO %s" % (group, role)
+                query = 'GRANT "%s" TO "%s"' % (group, role)
                 self.changed = exec_sql(self, query, ddl=True)
 
                 if self.changed:
@@ -244,11 +240,7 @@ class PgMembership(object):
                 if not self.__check_membership(group, role):
                     continue
 
-                # If role name has dots:
-                if "." in role:
-                    role = '"%s"' % role
-
-                query = "REVOKE %s FROM %s" % (group, role)
+                query = 'REVOKE "%s" FROM "%s"' % (group, role)
                 self.changed = exec_sql(self, query, ddl=True)
 
                 if self.changed:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -227,6 +227,10 @@ class PgMembership(object):
                 if self.__check_membership(group, role):
                     continue
 
+                # If role name has dots:
+                if "." in role:
+                    role = '"%s"' % role
+
                 query = "GRANT %s TO %s" % (group, role)
                 self.changed = exec_sql(self, query, ddl=True)
 
@@ -243,6 +247,10 @@ class PgMembership(object):
                 # If role is not in a group now, pass:
                 if not self.__check_membership(group, role):
                     continue
+
+                # If role name has dots:
+                if "." in role:
+                    role = '"%s"' % role
 
                 query = "REVOKE %s FROM %s" % (group, role, 'role')
                 self.changed = exec_sql(self, query, ddl=True)

--- a/test/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
+++ b/test/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
@@ -41,7 +41,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["GRANT \"group1\" TO \"user1\""]
+    - result.queries == ["GRANT group1 TO user1"]
     - result.granted.group1 == ["user1"]
     - result.state == "present"
     - result.target_roles == ["user1"]
@@ -88,7 +88,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["GRANT \"group1\" TO \"user1\""]
+    - result.queries == ["GRANT group1 TO user1"]
     - result.granted.group1 == ["user1"]
     - result.state == "present"
     - result.target_roles == ["user1"]
@@ -132,7 +132,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["REVOKE \"group1\" FROM \"user1\""]
+    - result.queries == ["REVOKE group1 FROM user1"]
     - result.revoked.group1 == ["user1"]
     - result.state == "absent"
     - result.target_roles == ["user1"]
@@ -180,7 +180,7 @@
     that:
     - result is changed
     - result.groups == ["group1", "group2"]
-    - result.queries == ["GRANT \"group1\" TO \"user1\"", "GRANT \"group1\" TO \"user2\"", "GRANT \"group2\" TO \"user1\"", "GRANT \"group2\" TO \"user2\""]
+    - result.queries == ["GRANT group1 TO user1", "GRANT group1 TO user2", "GRANT group2 TO user1", "GRANT group2 TO user2"]
     - result.granted.group1 == ["user1", "user2"]
     - result.granted.group2 == ["user1", "user2"]
     - result.state == "present"
@@ -230,7 +230,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["REVOKE \"group1\" FROM \"user1\""]
+    - result.queries == ["REVOKE group1 FROM user1"]
     - result.revoked.group1 == ["user1"]
     - result.state == "absent"
     - result.target_roles == ["user1"]
@@ -256,7 +256,7 @@
     that:
     - result is changed
     - result.groups == ["group1", "group2"]
-    - result.queries == ["GRANT \"group1\" TO \"user1\""]
+    - result.queries == ["GRANT group1 TO user1"]
     - result.granted.group1 == ["user1"]
     - result.granted.group2 == []
     - result.state == "present"

--- a/test/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
+++ b/test/integration/targets/postgresql_membership/tasks/postgresql_membership_initial.yml
@@ -41,7 +41,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["GRANT group1 TO user1"]
+    - result.queries == ["GRANT \"group1\" TO \"user1\""]
     - result.granted.group1 == ["user1"]
     - result.state == "present"
     - result.target_roles == ["user1"]
@@ -88,7 +88,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["GRANT group1 TO user1"]
+    - result.queries == ["GRANT \"group1\" TO \"user1\""]
     - result.granted.group1 == ["user1"]
     - result.state == "present"
     - result.target_roles == ["user1"]
@@ -132,7 +132,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["REVOKE group1 FROM user1"]
+    - result.queries == ["REVOKE \"group1\" FROM \"user1\""]
     - result.revoked.group1 == ["user1"]
     - result.state == "absent"
     - result.target_roles == ["user1"]
@@ -180,7 +180,7 @@
     that:
     - result is changed
     - result.groups == ["group1", "group2"]
-    - result.queries == ["GRANT group1 TO user1", "GRANT group1 TO user2", "GRANT group2 TO user1", "GRANT group2 TO user2"]
+    - result.queries == ["GRANT \"group1\" TO \"user1\"", "GRANT \"group1\" TO \"user2\"", "GRANT \"group2\" TO \"user1\"", "GRANT \"group2\" TO \"user2\""]
     - result.granted.group1 == ["user1", "user2"]
     - result.granted.group2 == ["user1", "user2"]
     - result.state == "present"
@@ -230,7 +230,7 @@
     that:
     - result is changed
     - result.groups == ["group1"]
-    - result.queries == ["REVOKE group1 FROM user1"]
+    - result.queries == ["REVOKE \"group1\" FROM \"user1\""]
     - result.revoked.group1 == ["user1"]
     - result.state == "absent"
     - result.target_roles == ["user1"]
@@ -256,7 +256,7 @@
     that:
     - result is changed
     - result.groups == ["group1", "group2"]
-    - result.queries == ["GRANT group1 TO user1"]
+    - result.queries == ["GRANT \"group1\" TO \"user1\""]
     - result.granted.group1 == ["user1"]
     - result.granted.group2 == []
     - result.state == "present"

--- a/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -551,7 +551,7 @@
       that:
       - result is changed
       - result.user == '{{ test_group1 }}'
-      - result.queries == ['CREATE USER {{ test_group1 }} NOLOGIN', 'GRANT {{ test_group2 }} TO {{ test_group1 }}']
+      - result.queries == ['CREATE USER "{{ test_group1 }}" NOLOGIN', 'GRANT "{{ test_group2 }}" TO "{{ test_group1 }}"']
 
   - name: check that the user doesn't exist
     <<: *task_parameters
@@ -585,7 +585,7 @@
       that:
       - result is changed
       - result.user == '{{ test_group1 }}'
-      - result.queries == ['CREATE USER {{ test_group1 }} NOLOGIN', 'GRANT {{ test_group2 }} TO {{ test_group1 }}']
+      - result.queries == ['CREATE USER "{{ test_group1 }}" NOLOGIN', 'GRANT "{{ test_group2 }}" TO "{{ test_group1 }}"']
 
   - name: check that the user exists
     <<: *task_parameters
@@ -642,7 +642,7 @@
       that:
       - result is changed
       - result.user == '{{ test_user }}'
-      - result.queries == ['GRANT {{ test_group1 }} TO "{{ test_user }}"', 'GRANT {{ test_group2 }} TO "{{ test_user }}"']
+      - result.queries == ['GRANT "{{ test_group1 }}" TO "{{ test_user }}"', 'GRANT "{{ test_group2 }}" TO "{{ test_user }}"']
 
   - name: check membership
     <<: *task_parameters

--- a/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -3,7 +3,8 @@
 # Integration tests for postgresql_user module.
 
 - vars:
-    test_user: hello_user
+    test_user: hello.user.with.dots
+    test_user2: hello
     test_group1: group1
     test_group2: group2
     test_table: test
@@ -490,18 +491,24 @@
   #
   # fail_on_user
   #
+  - name: Create role for test
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ test_user2 }}'
+
   - name: Create test table, set owner as test_user
     <<: *task_parameters
     postgresql_table:
       <<: *pg_parameters
       name: '{{ test_table }}'
-      owner: '{{ test_user }}'
+      owner: '{{ test_user2 }}'
 
   - name: Test fail_on_user
     <<: *task_parameters
     postgresql_user:
       <<: *pg_parameters
-      name: '{{ test_user }}'
+      name: '{{ test_user2 }}'
       state: absent
     ignore_errors: yes
 
@@ -544,7 +551,7 @@
       that:
       - result is changed
       - result.user == '{{ test_group1 }}'
-      - result.queries == ['CREATE USER "{{ test_group1 }}" NOLOGIN', 'GRANT "{{ test_group2 }}" TO "{{ test_group1 }}"']
+      - result.queries == ['CREATE USER {{ test_group1 }} NOLOGIN', 'GRANT {{ test_group2 }} TO {{ test_group1 }}']
 
   - name: check that the user doesn't exist
     <<: *task_parameters
@@ -578,7 +585,7 @@
       that:
       - result is changed
       - result.user == '{{ test_group1 }}'
-      - result.queries == ['CREATE USER "{{ test_group1 }}" NOLOGIN', 'GRANT "{{ test_group2 }}" TO "{{ test_group1 }}"']
+      - result.queries == ['CREATE USER {{ test_group1 }} NOLOGIN', 'GRANT {{ test_group2 }} TO {{ test_group1 }}']
 
   - name: check that the user exists
     <<: *task_parameters
@@ -635,7 +642,7 @@
       that:
       - result is changed
       - result.user == '{{ test_user }}'
-      - result.queries == ['GRANT "{{ test_group1 }}" TO "{{ test_user }}"', 'GRANT "{{ test_group2 }}" TO "{{ test_user }}"']
+      - result.queries == ['GRANT {{ test_group1 }} TO {{ test_user }}', 'GRANT {{ test_group2 }} TO {{ test_user }}']
 
   - name: check membership
     <<: *task_parameters
@@ -666,5 +673,6 @@
       state: absent
     loop:
     - '{{ test_user }}'
+    - '{{ test_user2 }}'
     - '{{ test_group1 }}'
     - '{{ test_group2 }}'

--- a/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
+++ b/test/integration/targets/postgresql_user/tasks/postgresql_user_general.yml
@@ -642,7 +642,7 @@
       that:
       - result is changed
       - result.user == '{{ test_user }}'
-      - result.queries == ['GRANT {{ test_group1 }} TO {{ test_user }}', 'GRANT {{ test_group2 }} TO {{ test_user }}']
+      - result.queries == ['GRANT {{ test_group1 }} TO "{{ test_user }}"', 'GRANT {{ test_group2 }} TO "{{ test_user }}"']
 
   - name: check membership
     <<: *task_parameters


### PR DESCRIPTION
##### SUMMARY
postgresql_user: allow to pass user name with dots

fixes: https://github.com/ansible/ansible/issues/63204

it is obvious now - pg_quote_identifier doesn't work in this case

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/module_utils/postgres.py```
```lib/ansible/modules/database/postgresql/postgresql_user.py```
