### PR TITLE
[apt] Use -o Dpkg::Use-Pty=0

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -684,6 +684,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if allow_unauthenticated:
             cmd += " --allow-unauthenticated"
 
+        # Make this optionsl ?
+        cmd += " -o Dpkg::Use-Pty=0"
+
         with PolicyRcD(m):
             rc, out, err = m.run_command(cmd)
 

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -684,7 +684,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if allow_unauthenticated:
             cmd += " --allow-unauthenticated"
 
-        # Make this optionsl ?
+        # Make this optional ?
         cmd += " -o Dpkg::Use-Pty=0"
 
         with PolicyRcD(m):


### PR DESCRIPTION
I don't think it makes sense for ansible-playbook to consider
its output a TTY. If anyone disagrees on the matter I'm happy
to add a configuration (`use_pty`?) for that.

What I'm after is avoiding the console-oriented output
progress from ansible run...