### PR TITLE
Map Extreme Network OSes to their facts modules

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1311,6 +1311,10 @@ CONNECTION_FACTS_MODULES:
     junos: junos_facts
     nxos: nxos_facts
     vyos: vyos_facts
+    exos: exos_facts
+    slxos: slxos_facts
+    voss: voss_facts
+    ironware: ironware_facts
   description: "Which modules to run during a play's fact gathering stage based on connection"
   env: [{name: ANSIBLE_CONNECTION_FACTS_MODULES}]
   ini:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Map Extreme Network OSes to their facts modules for 'gather_facts' to work against those devices.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
slxos_facts
exos_facts
ironware_facts
voss_facts
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
