### PR TITLE
Galaxy publish fix

### DIFF
--- a/changelogs/fragments/ansible-galaxy-handle-import-task-url-changes.yml
+++ b/changelogs/fragments/ansible-galaxy-handle-import-task-url-changes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy - Handle the different task resource urls in API responses from publishing
+    collection artifacts to galaxy servers using v2 and v3 APIs.

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -450,7 +450,7 @@ class GalaxyAPI:
         state = 'waiting'
         data = None
 
-        # v3 returns relative task urls, v3 returns full urls
+        # v3 returns relative task urls, v2 returns full urls
         if 'v3' in self.available_api_versions:
             parsed = urlparse(self.api_server)
             n_url = parsed._replace(path=task_url).geturl()

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -450,16 +450,16 @@ class GalaxyAPI:
         state = 'waiting'
         data = None
 
-        display.display("Waiting until Galaxy import task %s has completed" % task_url)
-        start = time.time()
-        wait = 2
-
         # v3 returns relative task urls, v3 returns full urls
         if 'v3' in self.available_api_versions:
             parsed = urlparse(self.api_server)
             n_url = parsed._replace(path=task_url).geturl()
         else:
             n_url = task_url
+
+        display.display("Waiting until Galaxy import task %s has completed" % n_url)
+        start = time.time()
+        wait = 2
 
         while timeout == 0 or (time.time() - start) < timeout:
             data = self._call_galaxy(n_url, method='GET', auth_required=True,
@@ -478,7 +478,7 @@ class GalaxyAPI:
             wait = min(30, wait * 1.5)
         if state == 'waiting':
             raise AnsibleError("Timeout while waiting for the Galaxy import process to finish, check progress at '%s'"
-                               % to_native(task_url))
+                               % to_native(n_url))
 
         for message in data.get('messages', []):
             level = message['level']
@@ -492,7 +492,7 @@ class GalaxyAPI:
         if state == 'failed':
             code = to_native(data['error'].get('code', 'UNKNOWN'))
             description = to_native(
-                data['error'].get('description', "Unknown error, see %s for more details" % task_url))
+                data['error'].get('description', "Unknown error, see %s for more details" % n_url))
             raise AnsibleError("Galaxy import process failed: %s (Code: %s)" % (description, code))
 
     @g_connect(['v2', 'v3'])

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -453,17 +453,17 @@ class GalaxyAPI:
         # v3 returns relative task urls, v2 returns full urls
         if 'v3' in self.available_api_versions:
             parsed = urlparse(self.api_server)
-            n_url = parsed._replace(path=task_url).geturl()
+            full_url = parsed._replace(path=task_url).geturl()
         else:
-            n_url = task_url
+            full_url = task_url
 
-        display.display("Waiting until Galaxy import task %s has completed" % n_url)
+        display.display("Waiting until Galaxy import task %s has completed" % full_url)
         start = time.time()
         wait = 2
 
         while timeout == 0 or (time.time() - start) < timeout:
-            data = self._call_galaxy(n_url, method='GET', auth_required=True,
-                                     error_context_msg='Error when getting import task results at %s' % n_url)
+            data = self._call_galaxy(full_url, method='GET', auth_required=True,
+                                     error_context_msg='Error when getting import task results at %s' % full_url)
 
             state = data.get('state', 'waiting')
 
@@ -478,7 +478,7 @@ class GalaxyAPI:
             wait = min(30, wait * 1.5)
         if state == 'waiting':
             raise AnsibleError("Timeout while waiting for the Galaxy import process to finish, check progress at '%s'"
-                               % to_native(n_url))
+                               % to_native(full_url))
 
         for message in data.get('messages', []):
             level = message['level']
@@ -492,7 +492,7 @@ class GalaxyAPI:
         if state == 'failed':
             code = to_native(data['error'].get('code', 'UNKNOWN'))
             description = to_native(
-                data['error'].get('description', "Unknown error, see %s for more details" % n_url))
+                data['error'].get('description', "Unknown error, see %s for more details" % full_url))
             raise AnsibleError("Galaxy import process failed: %s (Code: %s)" % (description, code))
 
     @g_connect(['v2', 'v3'])

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -382,10 +382,24 @@ def publish_collection(collection_path, api, wait, timeout):
     :param timeout: The time in seconds to wait for the import process to finish, 0 is indefinite.
     """
     import_uri = api.publish_collection(collection_path)
+
     if wait:
+        # Galaxy returns a url fragment which differs between v2 and v3.  The second to last entry is
+        # always the task_id, though.
+        # v2: {"task": "https://galaxy-dev.ansible.com/api/v2/collection-imports/35573/"}
+        # v3: {"task": "/api/automation-hub/v3/imports/collections/838d1308-a8f4-402c-95cb-7823f3806cd8/"}
+        task_id = None
+        for path_segment in reversed(import_uri.split('/')):
+            if path_segment:
+                task_id = path_segment
+                break
+
+        if not task_id:
+            raise AnsibleError("Publishing the collection did not return valid task info. Cannot wait for task status. Returned task info: '%s'" % import_uri)
+
         display.display("Collection has been published to the Galaxy server %s %s" % (api.name, api.api_server))
         with _display_progress():
-            api.wait_import_task(import_uri, timeout)
+            api.wait_import_task(task_id, timeout)
         display.display("Collection has been successfully published and imported to the Galaxy server %s %s"
                         % (api.name, api.api_server))
     else:

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -334,10 +334,10 @@ def test_publish_failure(api_version, collection_url, response, expected, collec
 
 @pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
     ('v2', 'Token', GalaxyToken('my token'),
-     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     '1234',
      'https://galaxy.server.com/api/v2/collection-imports/1234'),
     ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
-     '/api/automation-hub/v3/imports/collections/1234/',
+     '1234',
      'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
 def test_wait_import_task(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
@@ -367,10 +367,10 @@ def test_wait_import_task(api_version, token_type, token_ins, import_uri, full_i
 
 @pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
     ('v2', 'Token', GalaxyToken('my token'),
-     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     '1234',
      'https://galaxy.server.com/api/v2/collection-imports/1234'),
     ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
-     '/api/automation-hub/v3/imports/collections/1234/',
+     '1234',
      'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
 def test_wait_import_task_multiple_requests(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
@@ -414,10 +414,10 @@ def test_wait_import_task_multiple_requests(api_version, token_type, token_ins, 
 
 @pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri,', [
     ('v2', 'Token', GalaxyToken('my token'),
-     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     '1234',
      'https://galaxy.server.com/api/v2/collection-imports/1234'),
     ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
-     '/api/automation-hub/v3/imports/collections/1234/',
+     '1234',
      'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
 def test_wait_import_task_with_failure(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
@@ -491,10 +491,10 @@ def test_wait_import_task_with_failure(api_version, token_type, token_ins, impor
 
 @pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
     ('v2', 'Token', GalaxyToken('my_token'),
-     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     '1234',
      'https://galaxy.server.com/api/v2/collection-imports/1234'),
     ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
-     '/api/automation-hub/v3/imports/collections/1234/',
+     '1234',
      'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
 def test_wait_import_task_with_failure_no_error(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
@@ -541,8 +541,8 @@ def test_wait_import_task_with_failure_no_error(api_version, token_type, token_i
     mock_err = MagicMock()
     monkeypatch.setattr(Display, 'error', mock_err)
 
-    expected = 'Galaxy import process failed: Unknown error, see %s for more details (Code: UNKNOWN)' % full_import_uri
-    with pytest.raises(AnsibleError, match=re.escape(expected)):
+    expected = 'Galaxy import process failed: Unknown error, see %s for more details \\(Code: UNKNOWN\\)' % full_import_uri
+    with pytest.raises(AnsibleError, match=expected):
         api.wait_import_task(import_uri)
 
     assert mock_open.call_count == 1
@@ -564,10 +564,10 @@ def test_wait_import_task_with_failure_no_error(api_version, token_type, token_i
 
 @pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
     ('v2', 'Token', GalaxyToken('my token'),
-     'https://galaxy.server.com/api/v2/collection-imports/1234/',
-     'https://galaxy.server.com/api/v2/collection-imports/1234/'),
+     '1234',
+     'https://galaxy.server.com/api/v2/collection-imports/1234'),
     ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
-     '/api/automation-hub/v3/imports/collections/1234/',
+     '1234',
      'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
 def test_wait_import_task_timeout(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -332,13 +332,16 @@ def test_publish_failure(api_version, collection_url, response, expected, collec
         api.publish_collection(collection_artifact)
 
 
-@pytest.mark.parametrize('api_version, token_type, token_ins', [
-    ('v2', 'Token', GalaxyToken('my token')),
-    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/')),
+@pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
+    ('v2', 'Token', GalaxyToken('my token'),
+     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     'https://galaxy.server.com/api/v2/collection-imports/1234'),
+    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
+     '/api/automation-hub/v3/imports/collections/1234/',
+     'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
-def test_wait_import_task(api_version, token_type, token_ins, monkeypatch):
+def test_wait_import_task(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
     api = get_test_galaxy_api('https://galaxy.server.com/api/', api_version, token_ins=token_ins)
-    import_uri = 'https://galaxy.server.com/api/%s/task/1234' % api_version
 
     if token_ins:
         mock_token_get = MagicMock()
@@ -355,20 +358,23 @@ def test_wait_import_task(api_version, token_type, token_ins, monkeypatch):
     api.wait_import_task(import_uri)
 
     assert mock_open.call_count == 1
-    assert mock_open.mock_calls[0][1][0] == import_uri
+    assert mock_open.mock_calls[0][1][0] == full_import_uri
     assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
 
     assert mock_display.call_count == 1
-    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % import_uri
+    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
 
-@pytest.mark.parametrize('api_version, token_type, token_ins', [
-    ('v2', 'Token', GalaxyToken('my token')),
-    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/')),
+@pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
+    ('v2', 'Token', GalaxyToken('my token'),
+     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     'https://galaxy.server.com/api/v2/collection-imports/1234'),
+    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
+     '/api/automation-hub/v3/imports/collections/1234/',
+     'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
-def test_wait_import_task_multiple_requests(api_version, token_type, token_ins, monkeypatch):
+def test_wait_import_task_multiple_requests(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
     api = get_test_galaxy_api('https://galaxy.server.com/api/', api_version, token_ins=token_ins)
-    import_uri = 'https://galaxy.server.com/api/%s/task/1234' % api_version
 
     if token_ins:
         mock_token_get = MagicMock()
@@ -393,26 +399,29 @@ def test_wait_import_task_multiple_requests(api_version, token_type, token_ins, 
     api.wait_import_task(import_uri)
 
     assert mock_open.call_count == 2
-    assert mock_open.mock_calls[0][1][0] == import_uri
+    assert mock_open.mock_calls[0][1][0] == full_import_uri
     assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
-    assert mock_open.mock_calls[1][1][0] == import_uri
+    assert mock_open.mock_calls[1][1][0] == full_import_uri
     assert mock_open.mock_calls[1][2]['headers']['Authorization'] == '%s my token' % token_type
 
     assert mock_display.call_count == 1
-    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % import_uri
+    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     assert mock_vvv.call_count == 1
     assert mock_vvv.mock_calls[0][1][0] == \
         'Galaxy import process has a status of test, wait 2 seconds before trying again'
 
 
-@pytest.mark.parametrize('api_version, token_type, token_ins', [
-    ('v2', 'Token', GalaxyToken('my token')),
-    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/')),
+@pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri,', [
+    ('v2', 'Token', GalaxyToken('my token'),
+     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     'https://galaxy.server.com/api/v2/collection-imports/1234'),
+    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
+     '/api/automation-hub/v3/imports/collections/1234/',
+     'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
-def test_wait_import_task_with_failure(api_version, token_type, token_ins, monkeypatch):
+def test_wait_import_task_with_failure(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
     api = get_test_galaxy_api('https://galaxy.server.com/api/', api_version, token_ins=token_ins)
-    import_uri = 'https://galaxy.server.com/api/%s/task/1234' % api_version
 
     if token_ins:
         mock_token_get = MagicMock()
@@ -464,11 +473,11 @@ def test_wait_import_task_with_failure(api_version, token_type, token_ins, monke
         api.wait_import_task(import_uri)
 
     assert mock_open.call_count == 1
-    assert mock_open.mock_calls[0][1][0] == import_uri
+    assert mock_open.mock_calls[0][1][0] == full_import_uri
     assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
 
     assert mock_display.call_count == 1
-    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % import_uri
+    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     assert mock_vvv.call_count == 1
     assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: info - Somé info'
@@ -480,13 +489,16 @@ def test_wait_import_task_with_failure(api_version, token_type, token_ins, monke
     assert mock_err.mock_calls[0][1][0] == u'Galaxy import error message: Somé error'
 
 
-@pytest.mark.parametrize('api_version, token_type, token_ins', [
-    ('v2', 'Token', GalaxyToken('my_token')),
-    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/')),
+@pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
+    ('v2', 'Token', GalaxyToken('my_token'),
+     'https://galaxy.server.com/api/v2/collection-imports/1234',
+     'https://galaxy.server.com/api/v2/collection-imports/1234'),
+    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
+     '/api/automation-hub/v3/imports/collections/1234/',
+     'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
-def test_wait_import_task_with_failure_no_error(api_version, token_type, token_ins, monkeypatch):
+def test_wait_import_task_with_failure_no_error(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
     api = get_test_galaxy_api('https://galaxy.server.com/api/', api_version, token_ins=token_ins)
-    import_uri = 'https://galaxy.server.com/api/%s/task/1234' % api_version
 
     if token_ins:
         mock_token_get = MagicMock()
@@ -529,16 +541,16 @@ def test_wait_import_task_with_failure_no_error(api_version, token_type, token_i
     mock_err = MagicMock()
     monkeypatch.setattr(Display, 'error', mock_err)
 
-    expected = 'Galaxy import process failed: Unknown error, see %s for more details (Code: UNKNOWN)' % import_uri
+    expected = 'Galaxy import process failed: Unknown error, see %s for more details (Code: UNKNOWN)' % full_import_uri
     with pytest.raises(AnsibleError, match=re.escape(expected)):
         api.wait_import_task(import_uri)
 
     assert mock_open.call_count == 1
-    assert mock_open.mock_calls[0][1][0] == import_uri
+    assert mock_open.mock_calls[0][1][0] == full_import_uri
     assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
 
     assert mock_display.call_count == 1
-    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % import_uri
+    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     assert mock_vvv.call_count == 1
     assert mock_vvv.mock_calls[0][1][0] == u'Galaxy import message: info - Somé info'
@@ -550,13 +562,16 @@ def test_wait_import_task_with_failure_no_error(api_version, token_type, token_i
     assert mock_err.mock_calls[0][1][0] == u'Galaxy import error message: Somé error'
 
 
-@pytest.mark.parametrize('api_version, token_type, token_ins', [
-    ('v2', 'Token', GalaxyToken('my token')),
-    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/')),
+@pytest.mark.parametrize('api_version, token_type, token_ins, import_uri, full_import_uri', [
+    ('v2', 'Token', GalaxyToken('my token'),
+     'https://galaxy.server.com/api/v2/collection-imports/1234/',
+     'https://galaxy.server.com/api/v2/collection-imports/1234/'),
+    ('v3', 'Bearer', KeycloakToken(auth_url='https://api.test/'),
+     '/api/automation-hub/v3/imports/collections/1234/',
+     'https://galaxy.server.com/api/automation-hub/v3/imports/collections/1234/'),
 ])
-def test_wait_import_task_timeout(api_version, token_type, token_ins, monkeypatch):
+def test_wait_import_task_timeout(api_version, token_type, token_ins, import_uri, full_import_uri, monkeypatch):
     api = get_test_galaxy_api('https://galaxy.server.com/api/', api_version, token_ins=token_ins)
-    import_uri = 'https://galaxy.server.com/api/%s/task/1234' % api_version
 
     if token_ins:
         mock_token_get = MagicMock()
@@ -578,18 +593,18 @@ def test_wait_import_task_timeout(api_version, token_type, token_ins, monkeypatc
 
     monkeypatch.setattr(time, 'sleep', MagicMock())
 
-    expected = "Timeout while waiting for the Galaxy import process to finish, check progress at '%s'" % import_uri
+    expected = "Timeout while waiting for the Galaxy import process to finish, check progress at '%s'" % full_import_uri
     with pytest.raises(AnsibleError, match=expected):
         api.wait_import_task(import_uri, 1)
 
     assert mock_open.call_count > 1
-    assert mock_open.mock_calls[0][1][0] == import_uri
+    assert mock_open.mock_calls[0][1][0] == full_import_uri
     assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
-    assert mock_open.mock_calls[1][1][0] == import_uri
+    assert mock_open.mock_calls[1][1][0] == full_import_uri
     assert mock_open.mock_calls[1][2]['headers']['Authorization'] == '%s my token' % token_type
 
     assert mock_display.call_count == 1
-    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % import_uri
+    assert mock_display.mock_calls[0][1][0] == 'Waiting until Galaxy import task %s has completed' % full_import_uri
 
     # expected_wait_msg = 'Galaxy import process has a status of waiting, wait {0} seconds before trying again'
     assert mock_vvv.call_count > 9  # 1st is opening Galaxy token file.

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -439,7 +439,7 @@ def test_publish_with_wait(galaxy_server, collection_artifact, monkeypatch):
     assert mock_publish.mock_calls[0][1][0] == artifact_path
 
     assert mock_wait.call_count == 1
-    assert mock_wait.mock_calls[0][1][0] == fake_import_uri
+    assert mock_wait.mock_calls[0][1][0] == '1234'
 
     assert mock_display.mock_calls[0][1][0] == "Collection has been published to the Galaxy server test_server %s" \
         % galaxy_server.api_server


### PR DESCRIPTION
##### SUMMARY
Handle galaxy v2/v3 API diffs for artifact publish response

For publishing a collection artifact
(POST /v3/collections/artifacts/), the response
format is different between v2 and v3.
    
For v2 galaxy, the 'task' url returned is
a full url with scheme:
    
            {"task": "https://galaxy-dev.ansible.com/api/v2/collection-imports/35573/"}

For v3 galaxy, the task url is relative:
    
            {"task": "/api/automation-hub/v3/imports/collections/838d1308-a8f4-402c-95cb-7823f3806cd8/"}
    
So check which API we are using and update the task url approriately.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<strike>Note: unittests will likely fail until I update them for the new expected return values and parameters.</strike> Unittests have been updated