### PR TITLE
Add output options for win_pester

### DIFF
--- a/lib/ansible/modules/windows/win_pester.ps1
+++ b/lib/ansible/modules/windows/win_pester.ps1
@@ -15,6 +15,8 @@ $diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -d
 
 $path = Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true
 $tags = Get-AnsibleParam -obj $params -name "tags" -type "list"
+$output_file = Get-AnsibleParam -obj $params -name "output_file" -type "str"
+$output_format = Get-AnsibleParam -obj $params -name "output_format" -type "str" -default "NunitXML"
 $test_parameters = Get-AnsibleParam -obj $params -name "test_parameters" -type "dict"
 $minimum_version = Get-AnsibleParam -obj $params -name "minimum_version" -type "str" -failifempty $false
 
@@ -76,6 +78,11 @@ If ($result.pester_version -ge "4.0.0") {
 
 if($tags.count){
     $Parameters.Tag = $tags
+}
+
+if($output_file){
+    $Parameters.OutputFile   = $output_file
+    $Parameters.OutputFormat = $output_format
 }
 # Run Pester tests
 If (Test-Path -LiteralPath $path -PathType Leaf) {

--- a/lib/ansible/modules/windows/win_pester.py
+++ b/lib/ansible/modules/windows/win_pester.py
@@ -32,6 +32,18 @@ options:
       - Accepts multiple comma separated tags.
     type: list
     version_added: '2.9'
+  output_file:
+    description:
+      - Generates an output test report.
+    type: str
+    version_added: '2.10'
+  output_format:
+    description:
+      - Format of the test report to be generated.
+      - This parameter is to be used with output_file option.
+    type: str
+    default: NunitXML
+    version_added: '2.10'
   test_parameters:
     description:
       - Allows to specify parameters to the test script.
@@ -42,6 +54,7 @@ options:
       - Minimum version of the pester module that has to be available on the remote host.
 author:
     - Erwan Quelin (@equelin)
+    - Prasoon Karunan V (@prasoonkarunan)
 '''
 
 EXAMPLES = r'''
@@ -76,6 +89,11 @@ EXAMPLES = r'''
     test_parameters:
       Process: lsass
       Service: bits
+
+- name: Run the pester test present in a folder and generate NunitXML test result..
+  win_pester:
+    path: C:\Pester\test04.test.ps1
+    output_file: c:\Pester\resullt\testresult.xml
 '''
 
 RETURN = r'''

--- a/test/integration/targets/win_pester/defaults/main.yml
+++ b/test/integration/targets/win_pester/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 test_win_pester_path: C:\ansible\win_pester
+test_report_file: c:\ansible\win_pester\test_report.xml

--- a/test/integration/targets/win_pester/tasks/test.yml
+++ b/test/integration/targets/win_pester/tasks/test.yml
@@ -121,7 +121,7 @@
 - name: Run Pester test(s) specifying a test file by generating test result xml
   win_pester:
     path: '{{test_win_pester_path}}\test03.test.ps1'
-    aoutput_file: '{{test_report_file}}'
+    output_file: '{{test_report_file}}'
 
 - name: Checks if the output result file exists
   win_stat:

--- a/test/integration/targets/win_pester/tasks/test.yml
+++ b/test/integration/targets/win_pester/tasks/test.yml
@@ -117,3 +117,18 @@
     - test_with_parameter.changed
     - test_with_parameter.output.PassedCount == 2
     - test_with_parameter.output.TotalCount == 2
+
+- name: Run Pester test(s) specifying a test file by generating test result xml
+  win_pester:
+    path: '{{test_win_pester_path}}\test03.test.ps1'
+    aoutput_file: '{{test_report_file}}'
+
+- name: Checks if the output result file exists
+  win_stat:
+    path: '{{test_with_output_file}}'
+  register: test_output_file
+
+- name: Checks if the output result file exists
+  assert:
+    that:
+    - test_output_file.stat.exists

--- a/test/integration/targets/win_pester/tasks/test.yml
+++ b/test/integration/targets/win_pester/tasks/test.yml
@@ -125,7 +125,7 @@
 
 - name: Checks if the output result file exists
   win_stat:
-    path: '{{test_with_output_file}}'
+    path: '{{test_report_file}}'
   register: test_output_file
 
 - name: Checks if the output result file exists


### PR DESCRIPTION
##### SUMMARY
This PR is to add two more options for win_pester module to output pester test result.
Fixes #63267

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
win_pester

##### ADDITIONAL INFORMATION
```paste below
- name: Run Pester test(s) specifying a test file by generating test result xml
  win_pester:
    path: c:\temp\test03.test.ps1
    output_file: c:\temp\testresult.xml
```
