### PR TITLE
Updated rhn_register module to use the provided transport in server_url

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -279,7 +279,11 @@ class Rhn(redhat.RegistrationBase):
         '''
         if self.server is None:
             if self.hostname != 'rhn.redhat.com':
-                url = "https://%s/rpc/api" % self.hostname
+                url = urllib.parse.urlparse(self.server_url)
+                if url[0] == 'http':
+                    url = "http://%s/rpc/api" % self.hostname
+                else:
+                    url = "https://%s/rpc/api" % self.hostname
             else:
                 url = "https://xmlrpc.%s/rpc/api" % self.hostname
             self.server = xmlrpc_client.ServerProxy(url)


### PR DESCRIPTION
##### SUMMARY
Currently the rhn_register module does not use the transport type (http / https) of the server_url (provided during registration of a system) in its api function (used e.g. for unregistering). Hardcoded is to use https which leads to confusion for users if they specify a plain http server_url in the module during registration and get back an unreachable or maybe even ssl certification failed when trying to unregister afterwards. Maybe "Fixes #22300"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rhn_register.py

##### ADDITIONAL INFORMATION
When registering a system using a plain http server_url and later trying to unregister the system ansible tries to reach the server_url using https no matter what transport type you provided during registration. 

