### PR TITLE
AWS dev guide testing updates

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -639,14 +639,14 @@ to your test in the following variables:
 * `aws_secret_key`
 * `security_token`
 
-So all invocations of AWS modules in the test should set these parameters. To avoid duplication these
-for every call, it's preferable to use `YAML Anchors <https://blog.daemonl.com/2016/02/yaml.html>`_. For example:
+So all invocations of AWS modules in the test should set these parameters. To avoid duplicating these
+for every call, it's preferable to use :ref:`module_defaults <module_defaults>`. For example:
 
 .. code-block:: yaml
 
    - name: set connection information for all tasks
-     set_fact:
-       aws_connection_info: &aws_connection_info
+     module_defaults:
+       group/aws:
          aws_access_key: "{{ aws_access_key }}"
          aws_secret_key: "{{ aws_secret_key }}"
          security_token: "{{ security_token }}"
@@ -656,12 +656,10 @@ for every call, it's preferable to use `YAML Anchors <https://blog.daemonl.com/2
    - name: Do Something
      ec2_instance:
        ... params ...
-       <<: *aws_connection_info
 
    - name: Do Something Else
      ec2_instance:
        ... params ...
-       <<: *aws_connection_info
 
 AWS Permissions for Integration Tests
 -------------------------------------
@@ -694,7 +692,7 @@ To start with the most permissive IAM policy:
 3) Modify your policy to allow only the actions your tests use. Restrict account, region, and prefix where possible. Wait a few minutes for your policy to update.
 4) Run the tests again with a user or role that allows only the new policy.
 5) If the tests fail, troubleshoot (see tips below), modify the policy, run the tests again, and repeat the process until the tests pass with a restrictive policy.
-6) Share the minimum policy in a comment on your PR.
+6) Open a pull request proposing the minimum required policy to the `testing policies <https://github.com/mattclay/aws-terminator/tree/master/aws/policy>`_.
 
 To start from the least permissive IAM policy:
 
@@ -711,7 +709,7 @@ To start from the least permissive IAM policy:
 3) Add the action or resource that caused the failure to `an IAM policy <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html#access_policies_create-start>`_. Wait a few minutes for your policy to update.
 4) Run the tests again with this policy attached to your user or role.
 5) If the tests still fail at the same place with the same error you will need to troubleshoot (see tips below). If the first test passes, repeat steps 2 and 3 for the next error. Repeat the process until the tests pass with a restrictive policy.
-6) Share the minimum policy in a comment on your PR.
+6) Open a pull request proposing the minimum required policy to the `testing policies <https://github.com/mattclay/aws-terminator/tree/master/aws/policy>`_.
 
 Troubleshooting IAM policies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
##### SUMMARY
Update AWS dev guide to recommend using module_defaults and point to CI policy repo

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
