### PR TITLE
Fix modules code quote documentations 

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -325,7 +325,7 @@ options:
     restore_time:
         description:
           - If using I(creation_source=instance) this indicates the UTC date and time to restore from the source instance.
-            For example, "2009-09-07T23:45:00Z". May alternatively set c(use_latest_restore_time) to True.
+            For example, "2009-09-07T23:45:00Z". May alternatively set C(use_latest_restore_time) to True.
         type: str
     s3_bucket_name:
         description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_appgateway.py
@@ -327,7 +327,7 @@ options:
                     - Frontend port resource of an application gateway.
             protocol:
                 description:
-                    - Protocol of the c(http) listener.
+                    - Protocol of the C(http) listener.
                 choices:
                     - 'http'
                     - 'https'

--- a/lib/ansible/modules/cloud/google/gcp_appengine_firewall_rule.py
+++ b/lib/ansible/modules/cloud/google/gcp_appengine_firewall_rule.py
@@ -115,9 +115,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.firewall.ingressRules)'
 - 'Official Documentation: U(https://cloud.google.com/appengine/docs/standard/python/creating-firewalls#creating_firewall_rules)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_appengine_firewall_rule_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_appengine_firewall_rule_info.py
@@ -78,9 +78,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_bigquery_dataset_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_bigquery_dataset_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_bigquery_table_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_bigquery_table_info.py
@@ -85,9 +85,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudbuild_trigger.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudbuild_trigger.py
@@ -324,9 +324,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/cloud-build/docs/api/reference/rest/)'
 - 'Automating builds using build triggers: U(https://cloud.google.com/cloud-build/docs/running-builds/automate-builds)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudbuild_trigger_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudbuild_trigger_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudfunctions_cloud_function_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudfunctions_cloud_function_info.py
@@ -83,9 +83,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudscheduler_job.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudscheduler_job.py
@@ -319,9 +319,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/scheduler/docs/reference/rest/)'
 - 'Official Documentation: U(https://cloud.google.com/scheduler/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudscheduler_job_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudscheduler_job_info.py
@@ -83,9 +83,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_cloudtasks_queue_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_cloudtasks_queue_info.py
@@ -83,9 +83,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_address.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_address.py
@@ -167,9 +167,9 @@ notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/beta/addresses)'
 - 'Reserving a Static External IP Address: U(https://cloud.google.com/compute/docs/instances-and-network)'
 - 'Reserving a Static Internal IP Address: U(https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_address_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_address_info.py
@@ -92,9 +92,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_autoscaler.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_autoscaler.py
@@ -238,9 +238,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)'
 - 'Autoscaling Groups of Instances: U(https://cloud.google.com/compute/docs/autoscaler/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_autoscaler_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_autoscaler_info.py
@@ -89,9 +89,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_bucket.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_bucket.py
@@ -137,9 +137,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/backendBuckets)'
 - 'Using a Cloud Storage bucket as a load balancer backend: U(https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_bucket_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_bucket_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
@@ -378,9 +378,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/backendServices)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/load-balancing/http/backend-service)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_disk.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_disk.py
@@ -243,9 +243,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/disks)'
 - 'Adding a persistent disk: U(https://cloud.google.com/compute/docs/disks/add-persistent-disk)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_disk_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_disk_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_firewall.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_firewall.py
@@ -269,9 +269,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/firewalls)'
 - 'Official Documentation: U(https://cloud.google.com/vpc/docs/firewalls)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_firewall_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_firewall_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_forwarding_rule.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_forwarding_rule.py
@@ -265,9 +265,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/forwardingRule)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_forwarding_rule_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_forwarding_rule_info.py
@@ -92,9 +92,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_global_address.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_global_address.py
@@ -157,9 +157,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/globalAddresses)'
 - 'Reserving a Static External IP Address: U(https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_global_address_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_global_address_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_global_forwarding_rule_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_global_forwarding_rule_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_health_check.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_health_check.py
@@ -446,9 +446,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks)'
 - 'Official Documentation: U(https://cloud.google.com/load-balancing/docs/health-checks)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_health_check_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_health_check_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_http_health_check.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_http_health_check.py
@@ -153,9 +153,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/httpHealthChecks)'
 - 'Adding Health Checks: U(https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_http_health_check_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_http_health_check_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_https_health_check.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_https_health_check.py
@@ -150,9 +150,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/httpsHealthChecks)'
 - 'Adding Health Checks: U(https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_https_health_check_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_https_health_check_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_image.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_image.py
@@ -231,9 +231,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/images)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/images)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_image_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_image_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_group_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_group_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_group_manager_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_group_manager_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_instance_template_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance_template_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_interconnect_attachment_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_network.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_network.py
@@ -142,9 +142,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/networks)'
 - 'Official Documentation: U(https://cloud.google.com/vpc/docs/vpc)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_network_endpoint_group.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_network_endpoint_group.py
@@ -150,9 +150,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/beta/networkEndpointGroups)'
 - 'Official Documentation: U(https://cloud.google.com/load-balancing/docs/negs/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_network_endpoint_group_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_network_endpoint_group_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_network_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_network_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_node_group.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_node_group.py
@@ -118,9 +118,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/nodeGroups)'
 - 'Sole-Tenant Nodes: U(https://cloud.google.com/compute/docs/nodes/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_node_group_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_node_group_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_node_template.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_node_template.py
@@ -134,9 +134,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/nodeTemplates)'
 - 'Sole-Tenant Nodes: U(https://cloud.google.com/compute/docs/nodes/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_node_template_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_node_template_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_region_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_region_backend_service.py
@@ -181,9 +181,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/latest/regionBackendServices)'
 - 'Internal TCP/UDP Load Balancing: U(https://cloud.google.com/compute/docs/load-balancing/internal/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_region_backend_service_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_region_backend_service_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_region_disk.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_region_disk.py
@@ -202,9 +202,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks)'
 - 'Adding or Resizing Regional Persistent Disks: U(https://cloud.google.com/compute/docs/disks/regional-persistent-disk)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_region_disk_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_region_disk_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_route.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_route.py
@@ -187,9 +187,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/routes)'
 - 'Using Routes: U(https://cloud.google.com/vpc/docs/using-routes)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_route_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_route_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_router.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_router.py
@@ -168,9 +168,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/routers)'
 - 'Google Cloud Router: U(https://cloud.google.com/router/docs/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_router_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_router_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_snapshot.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_snapshot.py
@@ -167,9 +167,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/snapshots)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/disks/create-snapshots)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_snapshot_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_snapshot_info.py
@@ -84,9 +84,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_ssl_certificate.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_ssl_certificate.py
@@ -117,9 +117,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)'
 - 'Official Documentation: U(https://cloud.google.com/load-balancing/docs/ssl-certificates)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_ssl_certificate_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_ssl_certificate_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_ssl_policy.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_ssl_policy.py
@@ -128,9 +128,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies)'
 - 'Using SSL Policies: U(https://cloud.google.com/compute/docs/load-balancing/ssl-policies)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_ssl_policy_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_ssl_policy_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_subnetwork.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_subnetwork.py
@@ -181,9 +181,9 @@ notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks)'
 - 'Private Google Access: U(https://cloud.google.com/vpc/docs/configure-private-google-access)'
 - 'Cloud Networking: U(https://cloud.google.com/vpc/docs/using-vpc)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_subnetwork_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_subnetwork_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_http_proxy.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_http_proxy.py
@@ -115,9 +115,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/targetHttpProxies)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_http_proxy_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_http_proxy_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_https_proxy.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_https_proxy.py
@@ -146,9 +146,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/targetHttpsProxies)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/load-balancing/http/target-proxies)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_https_proxy_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_https_proxy_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_pool.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_pool.py
@@ -173,9 +173,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/targetPools)'
 - 'Official Documentation: U(https://cloud.google.com/compute/docs/load-balancing/network/target-pools)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_pool_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_pool_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_ssl_proxy.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_ssl_proxy.py
@@ -141,9 +141,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/targetSslProxies)'
 - 'Setting Up SSL proxy for Google Cloud Load Balancing: U(https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_ssl_proxy_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_ssl_proxy_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_tcp_proxy.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_tcp_proxy.py
@@ -121,9 +121,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/v1/targetTcpProxies)'
 - 'Setting Up TCP proxy for Google Cloud Load Balancing: U(https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_tcp_proxy_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_tcp_proxy_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_vpn_gateway.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_vpn_gateway.py
@@ -118,9 +118,9 @@ options:
     type: str
 notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_target_vpn_gateway_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_target_vpn_gateway_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_url_map_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_url_map_info.py
@@ -86,9 +86,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_vpn_tunnel.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_vpn_tunnel.py
@@ -162,9 +162,9 @@ notes:
 - 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels)'
 - 'Cloud VPN Overview: U(https://cloud.google.com/vpn/docs/concepts/overview)'
 - 'Networks and Tunnel Routing: U(https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_compute_vpn_tunnel_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_vpn_tunnel_info.py
@@ -91,9 +91,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_container_cluster_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_container_cluster_info.py
@@ -89,9 +89,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_container_node_pool_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_container_node_pool_info.py
@@ -99,9 +99,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_dns_managed_zone.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_managed_zone.py
@@ -212,9 +212,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/dns/api/v1/managedZones)'
 - 'Managing Zones: U(https://cloud.google.com/dns/zones/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_dns_managed_zone_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_managed_zone_info.py
@@ -84,9 +84,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_dns_resource_record_set_info.py
@@ -87,9 +87,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_filestore_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_filestore_instance.py
@@ -157,9 +157,9 @@ notes:
 - 'Official Documentation: U(https://cloud.google.com/filestore/docs/creating-instances)'
 - 'Use with Kubernetes: U(https://cloud.google.com/filestore/docs/accessing-fileshares)'
 - 'Copying Data In/Out: U(https://cloud.google.com/filestore/docs/copying-data)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_filestore_instance_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_filestore_instance_info.py
@@ -83,9 +83,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_iam_role_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_iam_role_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_iam_service_account_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_iam_service_account_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_kms_crypto_key.py
+++ b/lib/ansible/modules/cloud/google/gcp_kms_crypto_key.py
@@ -140,9 +140,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys)'
 - 'Creating a key: U(https://cloud.google.com/kms/docs/creating-keys#create_a_key)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_kms_crypto_key_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_kms_crypto_key_info.py
@@ -84,9 +84,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_kms_key_ring.py
+++ b/lib/ansible/modules/cloud/google/gcp_kms_key_ring.py
@@ -100,9 +100,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings)'
 - 'Creating a key ring: U(https://cloud.google.com/kms/docs/creating-keys#create_a_key_ring)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_kms_key_ring_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_kms_key_ring_info.py
@@ -85,9 +85,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_mlengine_model_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_mlengine_model_info.py
@@ -78,9 +78,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_mlengine_version_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_mlengine_version_info.py
@@ -88,9 +88,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_pubsub_subscription.py
+++ b/lib/ansible/modules/cloud/google/gcp_pubsub_subscription.py
@@ -205,9 +205,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions)'
 - 'Managing Subscriptions: U(https://cloud.google.com/pubsub/docs/admin#managing_subscriptions)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_pubsub_subscription_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_pubsub_subscription_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_pubsub_topic.py
+++ b/lib/ansible/modules/cloud/google/gcp_pubsub_topic.py
@@ -126,9 +126,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics)'
 - 'Managing Topics: U(https://cloud.google.com/pubsub/docs/admin#managing_topics)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_pubsub_topic_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_pubsub_topic_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_redis_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_redis_instance.py
@@ -165,9 +165,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/memorystore/docs/redis/reference/rest/)'
 - 'Official Documentation: U(https://cloud.google.com/memorystore/docs/redis/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_redis_instance_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_redis_instance_info.py
@@ -85,9 +85,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_resourcemanager_project_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_resourcemanager_project_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_sourcerepo_repository.py
+++ b/lib/ansible/modules/cloud/google/gcp_sourcerepo_repository.py
@@ -95,9 +95,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/source-repositories/docs/reference/rest/v1/projects.repos)'
 - 'Official Documentation: U(https://cloud.google.com/source-repositories/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_sourcerepo_repository_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_sourcerepo_repository_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_spanner_database.py
+++ b/lib/ansible/modules/cloud/google/gcp_spanner_database.py
@@ -112,9 +112,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases)'
 - 'Official Documentation: U(https://cloud.google.com/spanner/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_spanner_database_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_spanner_database_info.py
@@ -90,9 +90,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_spanner_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_spanner_instance.py
@@ -122,9 +122,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances)'
 - 'Official Documentation: U(https://cloud.google.com/spanner/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_spanner_instance_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_spanner_instance_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_sql_database_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_sql_database_info.py
@@ -85,9 +85,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_sql_instance_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_sql_instance_info.py
@@ -80,9 +80,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_sql_user_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_sql_user_info.py
@@ -90,9 +90,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_tpu_node.py
+++ b/lib/ansible/modules/cloud/google/gcp_tpu_node.py
@@ -149,9 +149,9 @@ options:
 notes:
 - 'API Reference: U(https://cloud.google.com/tpu/docs/reference/rest/)'
 - 'Official Documentation: U(https://cloud.google.com/tpu/docs/)'
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/google/gcp_tpu_node_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_tpu_node_info.py
@@ -83,9 +83,9 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- for authentication, you can set service_account_file using the c(gcp_service_account_file)
+- for authentication, you can set service_account_file using the C(gcp_service_account_file)
   env variable.
-- for authentication, you can set service_account_contents using the c(GCP_SERVICE_ACCOUNT_CONTENTS)
+- for authentication, you can set service_account_contents using the C(GCP_SERVICE_ACCOUNT_CONTENTS)
   env variable.
 - For authentication, you can set service_account_email using the C(GCP_SERVICE_ACCOUNT_EMAIL)
   env variable.

--- a/lib/ansible/modules/cloud/heroku/heroku_collaborator.py
+++ b/lib/ansible/modules/cloud/heroku/heroku_collaborator.py
@@ -47,7 +47,7 @@ options:
     choices: ["present", "absent"]
     default: "present"
 notes:
-  - C(HEROKU_API_KEY) and C(TF_VAR_HEROKU_API_KEY) env variable can be used instead setting c(api_key).
+  - C(HEROKU_API_KEY) and C(TF_VAR_HEROKU_API_KEY) env variable can be used instead setting C(api_key).
   - If you use I(--check), you can also pass the I(-v) flag to see affected apps in C(msg), e.g. ["heroku-example-app"].
 '''
 

--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -107,7 +107,7 @@ options:
       reason:
         description:
         - The value of the reason field in your desired condition
-        - For example, if a C(Deployment) is paused, The C(Progressing) c(type) will have the C(DeploymentPaused) reason.
+        - For example, if a C(Deployment) is paused, The C(Progressing) C(type) will have the C(DeploymentPaused) reason.
         - The possible reasons in a condition are specific to each resource type in Kubernetes. See the API documentation of the status field
           for a given resource to see possible choices.
     version_added: "2.8"

--- a/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
@@ -28,7 +28,7 @@ options:
   dest:
     description:
       - A directory to save the policy file into.
-      - This option is ignored when C(inline) is set to c(yes).
+      - This option is ignored when C(inline) is set to C(yes).
     type: path
   file:
     description:

--- a/lib/ansible/modules/network/f5/bigip_gtm_topology_record.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_topology_record.py
@@ -26,7 +26,7 @@ options:
     suboptions:
       negate:
         description:
-          - When set to c(yes) the system selects this topology record, when the request source does not match.
+          - When set to C(yes) the system selects this topology record, when the request source does not match.
         type: bool
         default: no
       subnet:
@@ -85,7 +85,7 @@ options:
     suboptions:
       negate:
         description:
-          - When set to c(yes) the system selects this topology record, when the request destination does not match.
+          - When set to C(yes) the system selects this topology record, when the request destination does not match.
         type: bool
         default: no
       subnet:

--- a/lib/ansible/modules/network/f5/bigip_gtm_topology_region.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_topology_region.py
@@ -35,7 +35,7 @@ options:
     suboptions:
       negate:
         description:
-          - When set to c(yes) the system selects this topology region, when the request source does not match.
+          - When set to C(yes) the system selects this topology region, when the request source does not match.
           - Only a single list entry can be specified together with negate.
         type: bool
         default: no

--- a/lib/ansible/modules/network/f5/bigip_provision.py
+++ b/lib/ansible/modules/network/f5/bigip_provision.py
@@ -54,7 +54,7 @@ options:
         For example, changing one module to C(dedicated) requires setting all
         others to C(none). Setting the level of a module to C(none) means that
         the module is not activated.
-      - Use C(state) absent to set c(level) to none and de-provision module.
+      - Use C(state) absent to set C(level) to none and de-provision module.
       - This parameter is not relevant to C(cgnat - pre tmos 15.0) or C(mgmt) and will not be
         applied to the C(cgnat - pre tmos 15.0) or C(mgmt) module.
     type: str

--- a/lib/ansible/modules/windows/win_dns_record.py
+++ b/lib/ansible/modules/windows/win_dns_record.py
@@ -51,7 +51,7 @@ options:
   value:
     description:
     - The value(s) to specify. Required when C(state=present).
-    - When c(type=PTR) only the partial part of the IP should be given.
+    - When C(type=PTR) only the partial part of the IP should be given.
     aliases: [ values ]
     type: list
   zone:

--- a/lib/ansible/modules/windows/win_iis_webbinding.py
+++ b/lib/ansible/modules/windows/win_iis_webbinding.py
@@ -62,8 +62,8 @@ options:
     description:
       - This parameter is only valid on Server 2012 and newer.
       - Primarily used for enabling and disabling server name indication (SNI).
-      - Set to c(0) to disable SNI.
-      - Set to c(1) to enable SNI.
+      - Set to C(0) to disable SNI.
+      - Set to C(1) to enable SNI.
     type: str
     version_added: "2.5"
 seealso:


### PR DESCRIPTION
##### SUMMARY
Replace erroneous lower case c in documentation string as module docs code quotes must use uppercase C. 
Fixes #63516

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

