### PR TITLE
Add warning about skipped vars

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -69,7 +69,7 @@ decide to do something conditionally based on success or failure::
 
 
 .. note:: both `success` and `succeeded` work (`fail`/`failed`, etc).
-.. warning:: You might expect a variable of a skipped task to be undefined and use `defined` or `default` to check that. **This is incorrect**! Even when a task is failed or skipped the variable is still registered with a failed or skipped status.
+.. warning:: You might expect a variable of a skipped task to be undefined and use `defined` or `default` to check that. **This is incorrect**! Even when a task is failed or skipped the variable is still registered with a failed or skipped status. See :ref:`registered_variables`.
 
 
 To see what facts are available on a particular system, you can do the following in a playbook::

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -69,6 +69,7 @@ decide to do something conditionally based on success or failure::
 
 
 .. note:: both `success` and `succeeded` work (`fail`/`failed`, etc).
+.. warning:: Do NOT use `defined` or `default` to check if a variable was skipped. A skipped variable is still defined - metadata is inserted into the variable to record whether it was skipped, among other things.
 
 
 To see what facts are available on a particular system, you can do the following in a playbook::

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -69,7 +69,7 @@ decide to do something conditionally based on success or failure::
 
 
 .. note:: both `success` and `succeeded` work (`fail`/`failed`, etc).
-.. warning:: Do NOT use `defined` or `default` to check if a variable was skipped. A skipped variable is still defined - metadata is inserted into the variable to record whether it was skipped, among other things.
+.. warning:: You might expect a variable of a skipped task to be undefined and use `defined` or `default` to check that. **This is incorrect**! Even when a task is failed or skipped the variable is still registered with a failed or skipped status.
 
 
 To see what facts are available on a particular system, you can do the following in a playbook::


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Many people are surprised to find out that a variable is still registered even when skipped. See https://github.com/ansible/ansible/issues/33827 and https://github.com/ansible/ansible/issues/17500 and https://github.com/ansible/ansible/issues/4297.  It is a persistent problem that has tripped dozens of people up. This commit adds a warning so people are aware of the unintuitive behavior.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

+label: docsite_pr


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Conditionals

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
