### PR TITLE
[stable-2.9] generalized on_become prompt match for ios (#63528)

### DIFF
--- a/changelogs/fragments/63528_generalize_on_become_prompt_match_for_ios.yaml
+++ b/changelogs/fragments/63528_generalize_on_become_prompt_match_for_ios.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ios - generalized on_become prompt match for ios (https://github.com/ansible/ansible/pull/63528)

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -76,7 +76,7 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n](?:Local_)?[Pp]assword: ?$", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]?(?:.*)?[Pp]assword: ?$", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
             cmd[u'prompt_retry_check'] = True
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Backport of #63528 

Fixing a customer-related issue.

Modify regex to compare more generic which will help in situations where TACACS is returning an unexpected password prompt. (i.e. ADS_ID_password:)

(cherry picked from commit 88013e7)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

plugins/terminal/ios.py
