### PR TITLE
mysql_variables tests: change CI host group

### DIFF
--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group1
+shippable/posix/group3
 skip/osx
 skip/freebsd
 skip/ubuntu


### PR DESCRIPTION
##### SUMMARY
mysql_variables tests: change CI host group
fixes https://github.com/ansible/ansible/issues/63590
fixes https://github.com/ansible/ansible/pull/63592

it is related to attempt to install MySQL servers of different versions but it is needed for development.
The first installation installs libraries which conflict with the newest.

gradually i'll move all tests to MySQL 8.0

##### ISSUE TYPE
- Bugfix Pull Request