### PR TITLE
Backport of 63559 postgresql_user: remove unused import

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -252,7 +252,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier, SQLParseError
 from ansible.module_utils.postgres import (
     connect_to_db,
-    exec_sql,
     get_conn_params,
     postgres_common_argument_spec,
 )


### PR DESCRIPTION
(cherry picked from commit 3a733cb0a1f2a7e87f9caa2a6798869c253b24d8)

##### SUMMARY
Backport of 63559 postgresql_user: remove unused import

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request