### PR TITLE
Added a new parameter to modify DirectPath I/O

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -120,7 +120,7 @@ options:
      - ' - C(connected) (bool): Indicates that virtual network adapter connects to the associated virtual machine.'
      - ' - C(start_connected) (bool): Indicates that virtual network adapter starts with associated virtual machine powers on.'
      - ' - C(directpath_io) (bool): If set, Universal Pass-Through (UPT or DirectPath I/O) will be enabled on the network adapter.
-           UPT is only compatible for Vmxnet3 adapter. Clients can set this property enabled or disabled if ethernet virtual device is Vmxnet3.'
+           UPT is only compatible for Vmxnet3 adapter.'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -189,6 +189,7 @@ network_data:
             "label": "Network Adapter 1",
             "name": "VM Network",
             "device_type": "E1000E",
+            "directpath_io": "N/A",
             "mac_addr": "00:50:56:89:dc:05",
             "unit_number": 7,
             "wake_onlan": false,

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -173,10 +173,25 @@
       networks:
         - state: present
           mac: "00:50:56:58:59:61"
-          directpath_io: false
+          directpath_io: False
     register: disable_directpath_io
 
   - debug: var=disable_directpath_io
+
+  - name: enable DirectPath I/O on a Vmxnet3 adapter
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines[0].name }}"
+      networks:
+        - state: present
+          mac: "00:50:56:58:59:61"
+          directpath_io: True
+    register: enable_directpath_io
+
+  - debug: var=enable_directpath_io
 
   - name: disconnect one specified network adapter
     vmware_guest_network:

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -163,6 +163,21 @@
         - del_again_netadapter is changed
         - "{{ del_again_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
 
+  - name: disable DirectPath I/O on a Vmxnet3 adapter
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines[0].name }}"
+      networks:
+        - state: present
+          mac: "00:50:56:58:59:61"
+          directpath_io: false
+    register: disable_directpath_io
+
+  - debug: var=disable_directpath_io
+
   - name: disconnect one specified network adapter
     vmware_guest_network:
       validate_certs: False

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -169,10 +169,10 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines[0].name }}"
+      name: "test_vm1"
       networks:
         - state: present
-          mac: "00:50:56:58:59:61"
+          mac: "aa:50:56:58:59:61"
           directpath_io: False
     register: disable_directpath_io
 
@@ -184,10 +184,10 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines[0].name }}"
+      name: "test_vm1"
       networks:
         - state: present
-          mac: "00:50:56:58:59:61"
+          mac: "aa:50:56:58:59:61"
           directpath_io: True
     register: enable_directpath_io
 


### PR DESCRIPTION
Added a new parameter `directpath_io` to enable/disable DirectPath I/O in network adapters
Added a new task in integration tests

Signed-off-by: Anusha Hegde

##### SUMMARY
Fixes #63507 
After creating vm using the `vmware_guest` module, one can use `vmware_guest_network` module to modify network related parameters.
Adding DirectPath I/O param in this change

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest_network


