### PR TITLE
contrib: foreman: Don't silently drop hosts

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -193,7 +193,13 @@ class ForemanInventory(object):
                 return json['results']
             # List of all hosts is returned paginaged
             results = results + json['results']
-            if len(results) >= json['subtotal']:
+            fetched = len(results)
+            self._debug("subtotal: {}, fetched {}".format(json['subtotal'], fetched))
+            # We're done if we get a page that isn't full when using a filter
+            if json['subtotal'] < params['per_page']:
+                break
+            # Without a filter subtotal == total, so check for number of hosts
+            if fetched >= json['total']:
                 break
             page += 1
             if len(json['results']) == 0:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -156,7 +156,12 @@ class ForemanInventory(object):
         parser.add_argument('--host', action='store', help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                             help='Force refresh of cache by making API requests to foreman (default: False - use cache files)')
+        parser.add_argument('--debug', action='store_true', default=False, help='Enable debug output (default: False)')
         self.args = parser.parse_args()
+
+    def _debug(self, msg):
+        if self.args.debug:
+            print(msg)
 
     def _get_session(self):
         if not self.session:


### PR DESCRIPTION
##### SUMMARY
contrib: foreman: Don't silently drop hosts
    
The 'subtotal' gives the number of hosts per page when a filter is in use while `subtotal` == `total` when no filter is in use.
    
So we can safely exit the loop if we get less results than we requested  (filter case) or if we got all 'total' results.
    
 For the unlikely case where we page, use a filter and have `(hosts % subtotal) == 0` we have to iterate the loop again to find out we're done.
   
Fixes: cd31f4a102d2f9acef480b92c32bc1ac2e21d2d2

Note: we can't use ./lib/ansible/plugins/inventory/foreman.py since it's at least lacking #63613 and #63611

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman

##### ADDITIONAL INFORMATION

`contrib/inventory/foreman.py --list --host`    

 * with host_filter 

    * *with* this MR applied:
```    
    $ foreman.py --debug --list
      subtotal: 250, fetched 250
      subtotal: 34, fetched 284
 ```   

* *without* this MR applied it misses 34 hosts since it stops when `subtotal` is reached`
```    
    $ foreman.py --debug --list
      subtotal: 250, fetched 250
 ```   

* without host_filter 

    * *with* and *without* this MR applied (since `subtotal == total`):

```  
    $ foreman.py --debug --list
      subtotal: 1032, fetched 250
      subtotal: 1032, fetched 500
      subtotal: 1032, fetched 750
      subtotal: 1032, fetched 1000
      subtotal: 1032, fetched 1032
```    
