### PR TITLE
contrib: foreman: Don't fail on disappearing hosts

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -209,7 +209,10 @@ class ForemanInventory(object):
 
     def _get_host_data_by_id(self, hid):
         url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)
-        return self._get_json(url)
+        ret = self._get_json(url, [404])
+        if ret == []:
+            ret = {}
+        return ret
 
     def _get_facts_by_id(self, hid):
         url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)


### PR DESCRIPTION
##### SUMMARY

We don't want to fail the whole inventory generation when
a host disappears between fetching the list of available
hosts and getting the attributes for this host.

This is the same as

https://github.com/theforeman/foreman_ansible_inventory/blob/master/foreman_ansible_inventory.py#L226

Pugin is basically not usable in larger dynamic environments, this was notice when trying to switch over from https://github.com/theforeman/foreman_ansible_inventory

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
./contrib/inventory/foreman.py
