### PR TITLE
gitlab_user: Fix ssh key add and group membership add when there's other changes

### DIFF
--- a/changelogs/fragments/63621-gitlab_user-fix-sshkey-and-user.yml
+++ b/changelogs/fragments/63621-gitlab_user-fix-sshkey-and-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "gitlab_user - Fix adding ssh key to new/changed user and adding group membership for new/changed user"

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -233,13 +233,15 @@ class GitLabUser(object):
 
         # Assign ssh keys
         if options['sshkey_name'] and options['sshkey_file']:
-            changed = changed or self.addSshKeyToUser(user, {
-                'name': options['sshkey_name'],
-                'file': options['sshkey_file']})
+            key_changed = self.addSshKeyToUser(user, {
+              'name': options['sshkey_name'],
+              'file': options['sshkey_file']})
+            changed = changed or key_changed
 
         # Assign group
         if options['group_path']:
-            changed = changed or self.assignUserToGroup(user, options['group_path'], options['access_level'])
+            group_changed = self.assignUserToGroup(user, options['group_path'], options['access_level'])
+            changed = changed or group_changed
 
         self.userObject = user
         if changed:

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -234,8 +234,8 @@ class GitLabUser(object):
         # Assign ssh keys
         if options['sshkey_name'] and options['sshkey_file']:
             key_changed = self.addSshKeyToUser(user, {
-              'name': options['sshkey_name'],
-              'file': options['sshkey_file']})
+                'name': options['sshkey_name'],
+                'file': options['sshkey_file']})
             changed = changed or key_changed
 
         # Assign group


### PR DESCRIPTION
##### SUMMARY
SSH key and Group membership wouldn't be created if something else set `changed` to `True`.

Fixes #63447

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gitlab_user.py
