### PR TITLE
[BR28] ansible-vault: convert vault_password_files to list to prevent traceback

### DIFF
--- a/changelogs/fragments/vault-ensure-vault-password-files-are-list.yaml
+++ b/changelogs/fragments/vault-ensure-vault-password-files-are-list.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault - fix error when multiple vault password files are specified (https://github.com/ansible/ansible/issues/57172)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -176,7 +176,7 @@ class VaultCLI(CLI):
             vault_secrets = \
                 self.setup_vault_secrets(loader,
                                          vault_ids=vault_ids,
-                                         vault_password_files=context.CLIARGS['vault_password_files'],
+                                         vault_password_files=list(context.CLIARGS['vault_password_files']),
                                          ask_vault_pass=context.CLIARGS['ask_vault_pass'],
                                          create_new_password=True)
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -317,6 +317,10 @@ echo "rc was $WRONG_RC (1 is expected)"
 
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "a test string"
 
+# Test with multiple vault password files
+# https://github.com/ansible/ansible/issues/57172
+env ANSIBLE_VAULT_PASSWORD_FILE=vault-password ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --encrypt-vault-id default "a test string"
+
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy"
 
 ansible-vault encrypt_string "$@" --vault-id "${NEW_VAULT_PASSWORD}" "a test string"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes : #63512

* Convert vault_password_files to a list

* Add changelog and tests

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of https://github.com/ansible/ansible/pull/57186

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/vault-ensure-vault-password-files-are-list.yaml
lib/ansible/cli/vault.py
test/integration/targets/vault/runme.sh

