### PR TITLE
Fixes --version in ansible-galaxy cli

### DIFF
--- a/changelogs/fragments/63628-ansible-galaxy-fix-version.yml
+++ b/changelogs/fragments/63628-ansible-galaxy-fix-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-galaxy cli - fixed ``--version`` argument"

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -44,7 +44,7 @@ class GalaxyCLI(CLI):
 
     def __init__(self, args):
         # Inject role into sys.argv[1] as a backwards compatibility step
-        if len(args) > 1 and args[1] not in ['-h', '--help'] and 'role' not in args and 'collection' not in args:
+        if len(args) > 1 and args[1] not in ['-h', '--help', '--version'] and 'role' not in args and 'collection' not in args:
             # TODO: Should we add a warning here and eventually deprecate the implicit role subcommand choice
             # Remove this in Ansible 2.13 when we also remove -v as an option on the root parser for ansible-galaxy.
             idx = 2 if args[1].startswith('-v') else 1

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -6,6 +6,9 @@ ansible-playbook setup.yml "$@"
 
 trap 'ansible-playbook cleanup.yml' EXIT
 
+# Very simple version test
+ansible-galaxy --version
+
 # Need a relative custom roles path for testing various scenarios of -p
 galaxy_relative_rolespath="my/custom/roles/path"
 


### PR DESCRIPTION
##### SUMMARY
`ansible-galaxy --version` got broken when [this line](https://github.com/ansible/ansible/commit/b6791e6ae3891951fc38518fdb52d53219987498#diff-0fb1ac8e85c5f8b604a2bcbbe16a50c8R44) was added. 
PR adds `--version` to the list so the version is correctly printed again. 
Also adds a minimal test, just in case something similar happens again.. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before**
```paste below
Documents/code/ansible ansible-galaxy --version                                                                                                                                                                                                                                                                                       ansible stable-2.9 :: 15h :: ● :: ⬢
usage: ansible-galaxy role [-h] ROLE_ACTION ...
ansible-galaxy role: error: the following arguments are required: ROLE_ACTION
```

**After**
```
Documents/code/ansible ansible-galaxy --version                                                                                                                                                                                                                                                                          ansible ⇡ fix_galaxy_cli_version :: 8m :: ● :: ⬢
ansible-galaxy 2.10.0.dev0
  config file = /home/shaps/.ansible.cfg
  configured module search path = ['/home/shaps/.virtualenvs/spansible/lib/python2.7/site-packages/ara/plugins/modules']
  ansible python module location = /home/shaps/Documents/code/ansible/lib/ansible
  executable location = /home/shaps/Documents/code/ansible/bin/ansible-galaxy
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]
```
