### PR TITLE
Update cache plugin documentation

### DIFF
--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -7,21 +7,18 @@ Cache Plugins
    :local:
    :depth: 2
 
-Cache plugin implement a backend caching mechanism that allows Ansible to store gathered facts or inventory source data
-without the performance hit of retrieving them from source.
+Cache plugins allow Ansible to store gathered facts or inventory source data without the performance hit of retrieving them from source.
 
-The default cache plugin is the :ref:`memory <memory_cache>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs.
+The default cache plugin is the :ref:`memory <memory_cache>` plugin, which only caches the data for the current execution of Ansible. Other plugins with persistent storage are available to allow caching the data across runs. Some of these cache plugins write to files, others write to databases.
 
-You can use a separate cache plugin for inventory and facts. If an inventory-specific cache plugin is not provided and inventory caching is enabled, the fact cache plugin is used for inventory.
+You can use different cache plugins for inventory and facts. If you enable inventory caching without setting an inventory-specific cache plugin, Ansible uses the fact cache plugin for both facts and inventory.
 
 .. _enabling_cache:
 
 Enabling Fact Cache Plugins
 ---------------------------
 
-Only one fact cache plugin can be active at a time.
-
-You can enable a cache plugin in the Ansible configuration, either via environment variable:
+Fact caching is always enabled. However, only one fact cache plugin can be active at a time. You can select the cache plugin to use for fact caching in the Ansible configuration, either with an environment variable:
 
 .. code-block:: shell
 
@@ -41,20 +38,15 @@ If the cache plugin is in a collection use the fully qualified name:
     [defaults]
     fact_caching = namespace.collection_name.cache_plugin_name
 
-You will also need to configure other settings specific to each plugin. Consult the individual plugin documentation
-or the Ansible :ref:`configuration <ansible_configuration_settings>` for more details.
+To enable a custom cache plugin, save it in a ``cache_plugins`` directory adjacent to your play, inside a role, or in one of the directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
 
-A custom cache plugin is enabled by dropping it into a ``cache_plugins`` directory adjacent to your play, inside a role, or by putting it in one of the directory sources configured in :ref:`ansible.cfg <ansible_configuration_settings>`.
+You also need to configure other settings specific to each plugin. Consult the individual plugin documentation or the Ansible :ref:`configuration <ansible_configuration_settings>` for more details.
 
 
 Enabling Inventory Cache Plugins
 --------------------------------
 
-Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the :ref:`developer guide on cache plugins<developing_cache_plugins>`. Cache plugins inside a collection are not supported for caching inventory.
-
-Also since Ansible 2.8, if inventory-specific cache plugin settings are not specified Ansible will fall back to caching inventory with the fact cache plugin options.
-
-The inventory cache is disabled by default. You may enable it via environment variable:
+Inventory caching is disabled by default. To cache inventory data, you must enable inventory caching and then select the specific cache plugin you want to use. Not all inventory plugins support caching, so check the documentation for the inventory plugin(s) you want to use. You can enable inventory caching with an environment variable:
 
 .. code-block:: shell
 
@@ -75,7 +67,7 @@ or if the inventory plugin accepts a YAML configuration source, in the configura
     plugin: aws_ec2
     cache: True
 
-Similarly with fact cache plugins, only one inventory cache plugin can be active at a time and may be set via environment variable:
+Only one inventory cache plugin can be active at a time. You can set it with an environment variable:
 
 .. code-block:: shell
 
@@ -96,7 +88,12 @@ or if the inventory plugin accepts a YAML configuration source, in the configura
     plugin: aws_ec2
     cache_plugin: jsonfile
 
-Consult the individual inventory plugin documentation or the Ansible :ref:`configuration <ansible_configuration_settings>` for more details.
+To cache inventory with a custom plugin in your plugin path, follow the :ref:`developer guide on cache plugins<developing_cache_plugins>`.
+
+You can use any cache plugin shipped with Ansible to cache inventory, but you cannot use a cache plugin inside a collection. If you enable caching for inventory plugins without selecting an inventory-specific cache plugin, Ansible falls back to caching inventory with the fact cache plugin you configured. Consult the individual inventory plugin documentation or the Ansible :ref:`configuration <ansible_configuration_settings>` for more details.
+
+.. Note: In Ansible 2.7 and earlier, inventory plugins can only use file-based cache plugins, such as jsonfile, pickle, and yaml.
+
 
 .. _using_cache:
 

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -50,7 +50,7 @@ A custom cache plugin is enabled by dropping it into a ``cache_plugins`` directo
 Enabling Inventory Cache Plugins
 --------------------------------
 
-Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the developer's guide for cache plugins. Cache plugins inside a collection are not supported for caching inventory.
+Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the `developer's guide for cache plugins <https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#cache-plugins>`_. Cache plugins inside a collection are not supported for caching inventory.
 
 Also since Ansible 2.8, if inventory-specific cache plugin settings are not specified Ansible will fall back to caching inventory with the fact cache plugin options.
 

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -50,7 +50,7 @@ A custom cache plugin is enabled by dropping it into a ``cache_plugins`` directo
 Enabling Inventory Cache Plugins
 --------------------------------
 
-Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the `developer's guide for cache plugins <https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#cache-plugins>`_. Cache plugins inside a collection are not supported for caching inventory.
+Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the :ref:`developer guide on cache plugins<developing_cache_plugins>`. Cache plugins inside a collection are not supported for caching inventory.
 
 Also since Ansible 2.8, if inventory-specific cache plugin settings are not specified Ansible will fall back to caching inventory with the fact cache plugin options.
 

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -50,8 +50,9 @@ A custom cache plugin is enabled by dropping it into a ``cache_plugins`` directo
 Enabling Inventory Cache Plugins
 --------------------------------
 
-Inventory may be cached using a file-based cache plugin (like jsonfile). Check the specific inventory plugin to see if it supports caching. Cache plugins inside a collection are not supported for caching inventory.
-If an inventory-specific cache plugin is not specified Ansible will fall back to caching inventory with the fact cache plugin options.
+Prior to Ansible 2.8, inventory plugins that support caching could use file-based cache plugins, such as jsonfile, pickle, and yaml. For Ansible 2.8 and later all cache plugins shipped with Ansible are supported. Check the specific inventory plugin to see if it supports caching. To cache inventory with a custom plugin in your plugin path, take a look at the developer's guide for cache plugins. Cache plugins inside a collection are not supported for caching inventory.
+
+Also since Ansible 2.8, if inventory-specific cache plugin settings are not specified Ansible will fall back to caching inventory with the fact cache plugin options.
 
 The inventory cache is disabled by default. You may enable it via environment variable:
 


### PR DESCRIPTION
##### SUMMARY
Fixes #63616

Since 2.8 cache plugins using BaseCacheModule and BaseFileCacheModule as the base class can be used for inventory.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/plugins/cache.rst
