### PR TITLE
Zabbix: zabbix_host: fix #63449

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -478,20 +478,20 @@ class Host(object):
         if interfaces is not None:
             if len(interfaces) >= 1:
                 for interface in interfaces:
-                    interfaces_port_list.append(int(interface['port']))
+                    interfaces_port_list.append(str(interface['port']))
 
         exist_interface_ports = []
         if len(exist_interface_list) >= 1:
             for exist_interface in exist_interface_list:
-                exist_interface_ports.append(int(exist_interface['port']))
+                exist_interface_ports.append(str(exist_interface['port']))
 
         if set(interfaces_port_list) != set(exist_interface_ports):
             return True
 
         for exist_interface in exist_interface_list:
-            exit_interface_port = int(exist_interface['port'])
+            exit_interface_port = str(exist_interface['port'])
             for interface in interfaces:
-                interface_port = int(interface['port'])
+                interface_port = str(interface['port'])
                 if interface_port == exit_interface_port:
                     for key in interface.keys():
                         if str(exist_interface[key]) != str(interface[key]):


### PR DESCRIPTION
##### SUMMARY
Fix to be able to set usermacro to port of host using zabbix_host module.
Fixes https://github.com/ansible/ansible/issues/63449

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
tested with Zabbix 3.0/3.2/3.4/4.0/4.2/4.4