### PR TITLE
Fix SSL protocol references in mqtt module.

### DIFF
--- a/changelogs/fragments/mqtt-ssl-protocols.yml
+++ b/changelogs/fragments/mqtt-ssl-protocols.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fix SSL protcol references in the ``mqtt`` module to prevent failures on Python 2.6.

--- a/lib/ansible/modules/notification/mqtt.py
+++ b/lib/ansible/modules/notification/mqtt.py
@@ -142,10 +142,17 @@ from ansible.module_utils._text import to_native
 #
 
 def main():
-    tls_map = {
-        'tlsv1.2': ssl.PROTOCOL_TLSv1_2,
-        'tlsv1.1': ssl.PROTOCOL_TLSv1_1,
-    }
+    tls_map = {}
+
+    try:
+        tls_map['tlsv1.2'] = ssl.PROTOCOL_TLSv1_2
+    except AttributeError:
+        pass
+
+    try:
+        tls_map['tlsv1.1'] = ssl.PROTOCOL_TLSv1_1
+    except AttributeError:
+        pass
 
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### SUMMARY

Fix SSL protocol references in mqtt module.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

mqtt module

##### ADDITIONAL INFORMATION

This bug went undetected due to a bug in the import sanity test. I discovered it while working on a fix for the import sanity test.