### PR TITLE
vmware_guest_network/test: fix name of test VM

### DIFF
--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -113,7 +113,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines[0].name }}"
+      name: test_vm1
       datacenter: '{{ dc1 }}'
     register: guest_info
 
@@ -125,14 +125,14 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      uuid: "{{ vm1_instance_uuid }}"
+      uuid: '{{ vm1_instance_uuid }}'
       use_instance_uuid: True
       networks:
         - name: "VM Network"
           state: new
           connected: True
           device_type: e1000e
-          manual_mac: "00:50:56:58:59:60"
+          manual_mac: "bb:50:56:58:59:60"
     register: add_netadapter_instanceuuid
 
   - debug: var=add_netadapter_instanceuuid
@@ -149,10 +149,10 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      name: "{{ virtual_machines[0].name }}"
+      name: test_vm1
       networks:
         - state: absent
-          mac: "00:50:56:58:59:60"
+          mac: "bb:50:56:58:59:60"
     register: del_again_netadapter
 
   - debug: var=del_again_netadapter


### PR DESCRIPTION
##### SUMMARY

The test VM is called `test_vm1` since
https://github.com/ansible/ansible/issues/63302.

Also, avoid the `00:50:56` prefix for the MAC address, since it's known
for being source of problem: https://github.com/ansible/ansible/issues/63302
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network
