### PR TITLE
[stable-2.9] Fix ansible-test env var mixing running commands.

### DIFF
--- a/changelogs/fragments/ansible-test-env-alteration.yml
+++ b/changelogs/fragments/ansible-test-env-alteration.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly uses a fresh copy of environment variables for each command invocation to avoid mixing vars between commands

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -335,6 +335,8 @@ def intercept_command(args, cmd, target_name, env, capture=False, data=None, cwd
     """
     if not env:
         env = common_environment()
+    else:
+        env = env.copy()
 
     cmd = list(cmd)
     version = python_version or args.python_version


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix ansible-test env var mixing running commands.

Backport of https://github.com/ansible/ansible/pull/63643

(cherry picked from commit 6be4741f722eb2d12c12bd35b16d57e3bc5410e4)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

