### PR TITLE
postgresql_subscription:  new module

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -417,8 +417,8 @@ class PgSubscription():
                         params_to_update.append("%s = %s" % (param, value))
 
                 else:
-                    self.module.warn("Parameter '%s' not in params supported "
-                                     "for update '%s'" % SUBSPARAMS_KEYS_FOR_UPDATE)
+                    self.module.warn("Parameter '%s' is not in params supported "
+                                     "for update '%s', ignored..." % (param, SUBSPARAMS_KEYS_FOR_UPDATE))
 
             if params_to_update:
                 changed = self.__set_params(params_to_update, check_mode=check_mode)
@@ -435,7 +435,7 @@ class PgSubscription():
                 just make SQL, add it to ``self.executed_queries`` and return True.
 
         Returns:
-            changed (bool): True if publication has been updated, otherwise False.
+            changed (bool): True if the subscription has been removed, otherwise False.
         """
         if self.exists:
             query_fragments = ["DROP SUBSCRIPTION %s" % self.name]

--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -54,19 +54,23 @@ options:
     description:
     - Subscription owner.
     - If I(owner) is not defined, the owner will be set as I(login_user) or I(session_role).
+    - Ignored when I(state) is not C(present).
     type: str
   publications:
     description:
     - The publication names on the publisher to use for the subscription.
+    - Ignored when I(state) is not C(present).
     type: list
   connparams:
     description:
     - The connection dict param-value to connect to the publisher.
     - For more information see U(https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING).
+    - Ignored when I(state) is not C(present).
     type: dict
   cascade:
     description:
     - Drop subscription dependencies. Has effect with I(state=absent) only.
+    - Ignored when I(state) is not C(absent).
     type: bool
     default: false
   subsparams:
@@ -75,6 +79,7 @@ options:
     - For update the subscription allowed keys are C(enabled), C(slot_name), C(synchronous_commit), C(publication_name).
     - See available parameters to create a new subscription
       on U(https://www.postgresql.org/docs/current/sql-createsubscription.html).
+    - Ignored when I(state) is not C(present).
     type: dict
 
 notes:
@@ -196,7 +201,6 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-# from ansible.module_utils.database import pg_quote_identifier
 from ansible.module_utils.postgres import (
     connect_to_db,
     exec_sql,
@@ -600,6 +604,16 @@ def main():
 
     if state == 'present' and cascade:
         module.warm('parameter "cascade" is ignored when state is not absent')
+
+    if state != 'present':
+        if owner:
+            module.warm("parameter 'owner' is ignored when state is not 'present'")
+        if publications:
+            module.warm("parameter 'publications' is ignored when state is not 'present'")
+        if connparams:
+            module.warm("parameter 'connparams' is ignored when state is not 'present'")
+        if subsparams:
+            module.warm("parameter 'subsparams' is ignored when state is not 'present'")
 
     # Connect to DB and make cursor object:
     pg_conn_params = get_conn_params(module, module.params)

--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -91,6 +91,12 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+name:
+  description:
+  - Name of the subscription.
+  returned: always
+  type: str
+  sample: acme
 exists:
   description:
   - Flag indicates the subscription exists or not at the end of runtime.
@@ -106,12 +112,12 @@ initial_state:
   description: Subscription configuration at the beginning of runtime.
   returned: always
   type: dict
-  sample: {}
+  sample: {"conninfo": {}, "enabled": true, "owner": "postgres", "slotname": "test", "synccommit": true}
 final_state:
   description: Subscription configuration at the end of runtime.
   returned: always
   type: dict
-  sample: {}
+  sample: {"conninfo": {}, "enabled": true, "owner": "postgres", "slotname": "test", "synccommit": true}
 '''
 
 from copy import deepcopy
@@ -393,6 +399,7 @@ def main():
 
     # Return ret values and exit:
     module.exit_json(changed=changed,
+                     name=name,
                      exists=subscription.exists,
                      queries=subscription.executed_queries,
                      initial_state=initial_state,

--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -1,0 +1,323 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: postgresql_subscription
+short_description: Add, update, or remove PostgreSQL subscription
+description:
+- Add, update, or remove PostgreSQL subscription.
+version_added: '2.10'
+options:
+  name:
+    description:
+    - Name of the subscription to add, update, or remove.
+    required: true
+    type: str
+  db:
+    description:
+    - Name of the database to connect to and where
+      the subscription state will be changed.
+    aliases: [ login_db ]
+    type: str
+  state:
+    description:
+    - The subscription state.
+    default: present
+    choices: [ absent, present, stat ]
+    type: str
+notes:
+- PostgreSQL version must be 10 or greater.
+seealso:
+- module: postgresql_publication
+- name: CREATE SUBSCRIPTION reference
+  description: Complete reference of the CREATE SUBSCRIPTION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-createsubscription.html
+- name: ALTER SUBSCRIPTION reference
+  description: Complete reference of the ALTER SUBSCRIPTION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-altersubscription.html
+- name: DROP SUBSCRIPTION reference
+  description: Complete reference of the DROP SUBSCRIPTION command documentation.
+  link: https://www.postgresql.org/docs/current/sql-dropsubscription.html
+author:
+- Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+extends_documentation_fragment:
+- postgres
+'''
+
+EXAMPLES = r'''
+- name: Return the configuration of subscription acme if exists in mydb database
+  postgresql_subscription:
+    db: mydb
+    name: acme
+    state: stat
+'''
+
+RETURN = r'''
+exists:
+  description:
+  - Flag indicates the subscription exists or not at the end of runtime.
+  returned: always
+  type: bool
+  sample: true
+queries:
+  description: List of executed queries.
+  returned: always
+  type: str
+  sample: [ 'DROP SUBSCRIPTION "mysubscription"' ]
+initial_state:
+  description: Subscription configuration at the beginning of runtime.
+  returned: always
+  type: dict
+  sample: {}
+final_state:
+  description: Subscription configuration at the end of runtime.
+  returned: always
+  type: dict
+  sample: {}
+'''
+
+from copy import deepcopy
+
+try:
+    from psycopg2.extras import DictCursor
+except ImportError:
+    # psycopg2 is checked by connect_to_db()
+    # from ansible.module_utils.postgres
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+# from ansible.module_utils.database import pg_quote_identifier
+from ansible.module_utils.postgres import (
+    connect_to_db,
+    exec_sql,
+    get_conn_params,
+    postgres_common_argument_spec,
+)
+# from ansible.module_utils.six import iteritems
+
+SUPPORTED_PG_VERSION = 10000
+
+
+################################
+# Module functions and classes #
+################################
+
+class PgSubscription():
+    """Class to work with PostgreSQL subscription.
+
+    Args:
+        module (AnsibleModule): Object of AnsibleModule class.
+        cursor (cursor): Cursor object of psycopg2 library to work with PostgreSQL.
+        name (str): The name of the subscription.
+
+    Attributes:
+        module (AnsibleModule): Object of AnsibleModule class.
+        cursor (cursor): Cursor object of psycopg2 library to work with PostgreSQL.
+        name (str): Name of subscription.
+        executed_queries (list): List of executed queries.
+        attrs (dict): Dict with subscription attributes.
+        exists (bool): Flag indicates the subscription exists or not.
+    """
+
+    def __init__(self, module, cursor, name):
+        self.module = module
+        self.cursor = cursor
+        self.name = name
+        self.executed_queries = []
+        self.attrs = {
+            'owner': '',
+            'enabled': False,
+            'synccommit': '',
+            'conninfo': {},
+            'slotname': '',
+            'publications': [],
+        }
+        self.exists = self.check_subscr()
+
+    def get_info(self):
+        """Refresh the subscription information.
+
+        Returns:
+            ``self.attrs``.
+        """
+        self.exists = self.check_subscr()
+        return self.attrs
+
+    def check_subscr(self):
+        """Check the subscription and refresh ``self.attrs`` subscription attribute.
+
+        Returns:
+            True if the subscription with ``self.name`` exists, False otherwise.
+        """
+
+        subscr_info = self.__get_general_subscr_info()
+
+        if not subscr_info:
+            # The subcrtiption does not exist:
+            return False
+
+        return True
+
+    def create(self, check_mode=True):
+        """Create the subscription.
+
+        Args:
+
+        Kwargs:
+            check_mode (bool): If True, don't actually change anything,
+                just make SQL, add it to ``self.executed_queries`` and return True.
+
+        Returns:
+            changed (bool): True if the subscription has been created, otherwise False.
+        """
+        return False
+
+    def update(self, check_mode=True):
+        """Update the subscription.
+
+        Args:
+
+        Kwargs:
+            check_mode (bool): If True, don't actually change anything,
+                just make SQL, add it to ``self.executed_queries`` and return True.
+
+        Returns:
+            changed (bool): True if subscription has been updated, otherwise False.
+        """
+        return False
+
+    def drop(self, check_mode=True):
+        """Drop the subscription.
+
+        Kwargs:
+            check_mode (bool): If True, don't actually change anything,
+                just make SQL, add it to ``self.executed_queries`` and return True.
+
+        Returns:
+            changed (bool): True if publication has been updated, otherwise False.
+        """
+        return False
+
+    def __get_general_subscr_info(self):
+        """Get and return general subscription information.
+
+        Returns:
+            Dict with subscription information if successful, False otherwise.
+        """
+        return {}
+
+    def __exec_sql(self, query, check_mode=False):
+        """Execute SQL query.
+
+        Note: If we need just to get information from the database,
+            we use ``exec_sql`` function directly.
+
+        Args:
+            query (str): Query that needs to be executed.
+
+        Kwargs:
+            check_mode (bool): If True, don't actually change anything,
+                just add ``query`` to ``self.executed_queries`` and return True.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        if check_mode:
+            self.executed_queries.append(query)
+            return True
+        else:
+            return exec_sql(self, query, ddl=True)
+
+
+# ===========================================
+# Module execution.
+#
+
+
+def main():
+    argument_spec = postgres_common_argument_spec()
+    argument_spec.update(
+        name=dict(required=True),
+        db=dict(type='str', aliases=['login_db']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'stat']),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    # Parameters handling:
+    name = module.params['name']
+    state = module.params['state']
+
+    # Connect to DB and make cursor object:
+    conn_params = get_conn_params(module, module.params)
+    # We check subscription state without DML queries execution, so set autocommit:
+    db_connection = connect_to_db(module, conn_params, autocommit=True)
+    cursor = db_connection.cursor(cursor_factory=DictCursor)
+
+    # Check version:
+    if cursor.connection.server_version < SUPPORTED_PG_VERSION:
+        module.fail_json(msg="PostgreSQL server version should be 10.0 or greater")
+
+    # Set defaults:
+    changed = False
+    initial_state = {}
+    final_state = {}
+
+    ###################################
+    # Create object and do rock'n'roll:
+    subscription = PgSubscription(module, cursor, name)
+
+    if subscription.exists:
+        initial_state = subscription.attrs
+        final_state = deepcopy(initial_state)
+
+    # If module.check_mode=True, nothing will be changed:
+    if state == 'stat':
+        # Information has been collected already, so nothing is needed:
+        pass
+
+    if state == 'present':
+        if not subscription.exists:
+            changed = subscription.create(check_mode=module.check_mode)
+
+        else:
+            changed = subscription.update(check_mode=module.check_mode)
+
+    elif state == 'absent':
+        changed = subscription.drop(check_mode=module.check_mode)
+
+    # Get final subscription info if needed:
+    if state == 'present' or (state == 'absent' and module.check_mode):
+        final_state = subscription.get_info()
+    elif state == 'absent' and not module.check_mode:
+        subscription.exists = False
+
+    # Connection is not needed any more:
+    cursor.close()
+    db_connection.close()
+
+    # Return ret values and exit:
+    module.exit_json(changed=changed,
+                     exists=subscription.exists,
+                     queries=subscription.executed_queries,
+                     initial_state=initial_state,
+                     final_state=final_state)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/postgresql_subscription/aliases
+++ b/test/integration/targets/postgresql_subscription/aliases
@@ -1,0 +1,8 @@
+destructive
+shippable/posix/group1
+skip/osx
+skip/centos
+skip/freebsd
+skip/rhel
+skip/opensuse
+skip/fedora

--- a/test/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/test/integration/targets/postgresql_subscription/defaults/main.yml
@@ -9,3 +9,5 @@ replication_role: logical_replication
 replication_pass: alsdjfKJKDf1#
 test_db: acme_db
 test_subscription: test
+test_role1: alice
+test_role2: bob

--- a/test/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/test/integration/targets/postgresql_subscription/defaults/main.yml
@@ -4,10 +4,12 @@ master_port: 5433
 replica_port: 5434
 
 test_table1: acme1
-test_pub: acme_publication
+test_pub: first_publication
+test_pub2: second_publication
 replication_role: logical_replication
 replication_pass: alsdjfKJKDf1#
 test_db: acme_db
 test_subscription: test
 test_role1: alice
 test_role2: bob
+conn_timeout: 100

--- a/test/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/test/integration/targets/postgresql_subscription/defaults/main.yml
@@ -2,3 +2,9 @@ pg_user: postgres
 db_default: postgres
 master_port: 5433
 replica_port: 5434
+
+test_table1: acme1
+test_pub: acme_publication
+replication_role: logical_replication
+replication_pass: alsdjfKJKDf1#
+test_db: acme_db

--- a/test/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/test/integration/targets/postgresql_subscription/defaults/main.yml
@@ -1,0 +1,4 @@
+pg_user: postgres
+db_default: postgres
+master_port: 5433
+replica_port: 5434

--- a/test/integration/targets/postgresql_subscription/defaults/main.yml
+++ b/test/integration/targets/postgresql_subscription/defaults/main.yml
@@ -8,3 +8,4 @@ test_pub: acme_publication
 replication_role: logical_replication
 replication_pass: alsdjfKJKDf1#
 test_db: acme_db
+test_subscription: test

--- a/test/integration/targets/postgresql_subscription/meta/main.yml
+++ b/test/integration/targets/postgresql_subscription/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_postgresql_replication

--- a/test/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/main.yml
@@ -1,5 +1,7 @@
 # Initial tests of postgresql_subscription module:
+
+- import_tasks: setup_publication.yml
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'
+
 - import_tasks: postgresql_subscription_initial.yml
-  when:
-  - ansible_distribution == 'Ubuntu'
-  - ansible_distribution_major_version >= '18'
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'

--- a/test/integration/targets/postgresql_subscription/tasks/main.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/main.yml
@@ -1,0 +1,5 @@
+# Initial tests of postgresql_subscription module:
+- import_tasks: postgresql_subscription_initial.yml
+  when:
+  - ansible_distribution == 'Ubuntu'
+  - ansible_distribution_major_version >= '18'

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -33,6 +33,7 @@
   - assert:
       that:
       - result is changed
+      - result.name == '{{ test_subscription }}'
       - result.queries == ["CREATE SUBSCRIPTION test CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }}"]
       - result.exists == true
       - result.initial_state == {}
@@ -63,8 +64,9 @@
   - assert:
       that:
       - result is not changed
-      - result.final_state == result.initial_state
+      - result.name == '{{ test_subscription }}'
       - result.exists == true
+      - result.final_state == result.initial_state
       - result.final_state.owner == '{{ pg_user }}'
       - result.final_state.enabled == true
       - result.final_state.publications == ["{{ test_pub }}"]
@@ -87,8 +89,9 @@
   - assert:
       that:
       - result is not changed
-      - result.final_state == result.initial_state
+      - result.name == '{{ test_subscription }}'
       - result.exists == true
+      - result.final_state == result.initial_state
       - result.final_state.owner == '{{ pg_user }}'
       - result.final_state.enabled == true
       - result.final_state.publications == ["{{ test_pub }}"]

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -11,9 +11,6 @@
       login_db: '{{ test_db }}'
 
   block:
-#  - name: Create subscription via shell
-#    <<: *task_parameters
-#    shell: psql '{{ test_db }}' -p '{{ replica_port }}' -c "CREATE SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }};"
 
   ####################
   # Test mode: present
@@ -33,6 +30,23 @@
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
 
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["CREATE SUBSCRIPTION test CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }}"]
+      - result.exists == true
+      - result.initial_state == {}
+      - result.final_state.owner == '{{ pg_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo.dbname == '{{ test_db }}'
+      - result.final_state.conninfo.host == '127.0.0.1'
+      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.user == '{{ replication_role }}'
+      - result.final_state.conninfo.password == '{{ replication_pass }}'
+
   #################
   # Test mode: stat
   #################
@@ -49,8 +63,18 @@
   - assert:
       that:
       - result is not changed
-      - result.initial_state != {}
       - result.final_state == result.initial_state
+      - result.exists == true
+      - result.final_state.owner == '{{ pg_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo.dbname == '{{ test_db }}'
+      - result.final_state.conninfo.host == '127.0.0.1'
+      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.user == '{{ replication_role }}'
+      - result.final_state.conninfo.password == '{{ replication_pass }}'
 
   - name: Stat mode
     <<: *task_parameters
@@ -63,5 +87,15 @@
   - assert:
       that:
       - result is not changed
-      - result.initial_state != {}
       - result.final_state == result.initial_state
+      - result.exists == true
+      - result.final_state.owner == '{{ pg_user }}'
+      - result.final_state.enabled == true
+      - result.final_state.publications == ["{{ test_pub }}"]
+      - result.final_state.synccommit == true
+      - result.final_state.slotname == '{{ test_subscription }}'
+      - result.final_state.conninfo.dbname == '{{ test_db }}'
+      - result.final_state.conninfo.host == '127.0.0.1'
+      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.user == '{{ replication_role }}'
+      - result.final_state.conninfo.password == '{{ replication_pass }}'

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -1,4 +1,43 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- meta: end_play
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: yes
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ test_db }}'
+
+  block:
+  #################
+  # Test mode: stat
+  #################
+
+  - name: Stat mode in check mode
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      name: '{{ test_subscription }}'
+      state: stat
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is not changed
+      - result.initial_state == {}
+      - result.final_state == result.initial_state
+
+  - name: Stat mode
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.initial_state == {}
+      - result.final_state == result.initial_state

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -19,6 +19,7 @@
     <<: *task_parameters
     postgresql_subscription: 
       <<: *pg_parameters
+      login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: stat
     check_mode: yes
@@ -33,6 +34,7 @@
     <<: *task_parameters
     postgresql_subscription: 
       <<: *pg_parameters
+      login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: stat
 

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -644,7 +644,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: refresh
-    check_mode:
+    check_mode: yes
 
   - assert:
       that:
@@ -659,7 +659,6 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: refresh
-    check_mode:
 
   - assert:
       that:

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -31,7 +31,7 @@
   - assert:
       that:
       - result is not changed
-      - result.initial_state == {}
+      - result.initial_state != {}
       - result.final_state == result.initial_state
 
   - name: Stat mode
@@ -45,5 +45,5 @@
   - assert:
       that:
       - result is not changed
-      - result.initial_state == {}
+      - result.initial_state != {}
       - result.final_state == result.initial_state

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -581,6 +581,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
+      relinfo: yes
       connparams:
         host: 127.0.0.1
         port: '{{ master_port }}'
@@ -665,3 +666,33 @@
       - result is changed
       - result.name == '{{ test_subscription }}'
       - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} REFRESH PUBLICATION"]
+
+  ####################
+  # Test relinfo param
+  ####################
+
+  - name: Get relinfo
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+      relinfo: yes
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.relinfo[0].relname == '{{ test_table1 }}'
+      - result.final_state == result.initial_state
+
+  ##########
+  # Clean up
+  ##########
+  - name: Drop subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -15,6 +15,10 @@
   # Test mode: stat
   #################
 
+  - name: Create subscription via shell
+    <<: *task_parameters
+    shell: psql '{{ test_db }}' -p '{{ replica_port }}' -c "CREATE SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }};"
+
   - name: Stat mode in check mode
     <<: *task_parameters
     postgresql_subscription: 

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -12,6 +12,17 @@
 
   block:
 
+  - name: Create roles to test owner parameter
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ item }}'
+      role_attr_flags: SUPERUSER,LOGIN
+    loop:
+    - '{{ test_role1 }}'
+    - '{{ test_role2 }}'
+
   ####################
   # Test mode: present
   ####################
@@ -164,11 +175,11 @@
       - result.name == '{{ test_subscription }}'
       - result.exists == false
 
-  ####################
-  # Test cascade param
-  ####################
+  ##################
+  # Test owner param
+  ##################
 
-  - name: Create subscription for further tests
+  - name: Create with owner
     <<: *task_parameters
     postgresql_subscription:
       <<: *pg_parameters
@@ -176,6 +187,7 @@
       name: '{{ test_subscription }}'
       state: present
       pubname: '{{ test_pub }}'
+      owner: '{{ test_role1 }}'
       connparams:
         host: 127.0.0.1
         port: '{{ master_port }}'
@@ -183,6 +195,110 @@
         password: '{{ replication_pass }}'
         dbname: '{{ test_db }}'
 
+  - assert:
+      that:
+      - result.final_state.owner == '{{ test_role1 }}'
+      - result.queries[1] == 'ALTER SUBSCRIPTION {{ test_subscription }} OWNER TO "{{ test_role1 }}"'
+
+  - name: Try to set this owner again
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      pubname: '{{ test_pub }}'
+      owner: '{{ test_role1 }}'
+
+  - assert:
+      that:
+      - result is not changed
+      - result.initial_state == result.final_state
+      - result.final_state.owner == '{{ test_role1 }}'
+
+  - name: Check owner
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+      - result.initial_state.owner == '{{ test_role1 }}'
+
+  - name: Set another owner in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      pubname: '{{ test_pub }}'
+      owner: '{{ test_role2 }}'
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.initial_state == result.final_state
+      - result.final_state.owner == '{{ test_role1 }}'
+      - result.queries == ['ALTER SUBSCRIPTION {{ test_subscription }} OWNER TO "{{ test_role2 }}"']
+
+  - name: Check owner
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+      - result.initial_state.owner == '{{ test_role1 }}'
+
+  - name: Set another owner
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      pubname: '{{ test_pub }}'
+      owner: '{{ test_role2 }}'
+
+  - assert:
+      that:
+      - result is changed
+      - result.initial_state != result.final_state
+      - result.final_state.owner == '{{ test_role2 }}'
+      - result.queries == ['ALTER SUBSCRIPTION {{ test_subscription }} OWNER TO "{{ test_role2 }}"']
+
+  - name: Check owner
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+      - result.initial_state.owner == '{{ test_role2 }}'
+
+  ##############################
+  # Test cascade and owner param
+  ##############################
 
   - name: Drop subscription cascade in check mode
     <<: *task_parameters

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -33,7 +33,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
-      pubname: '{{ test_pub }}'
+      publications: '{{ test_pub }}'
       connparams:
         host: 127.0.0.1
         port: '{{ master_port }}'
@@ -55,7 +55,7 @@
       - result.final_state.slotname == '{{ test_subscription }}'
       - result.final_state.conninfo.dbname == '{{ test_db }}'
       - result.final_state.conninfo.host == '127.0.0.1'
-      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.port == {{ master_port }}
       - result.final_state.conninfo.user == '{{ replication_role }}'
       - result.final_state.conninfo.password == '{{ replication_pass }}'
 
@@ -85,7 +85,7 @@
       - result.final_state.slotname == '{{ test_subscription }}'
       - result.final_state.conninfo.dbname == '{{ test_db }}'
       - result.final_state.conninfo.host == '127.0.0.1'
-      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.port == {{ master_port }}
       - result.final_state.conninfo.user == '{{ replication_role }}'
       - result.final_state.conninfo.password == '{{ replication_pass }}'
 
@@ -110,7 +110,7 @@
       - result.final_state.slotname == '{{ test_subscription }}'
       - result.final_state.conninfo.dbname == '{{ test_db }}'
       - result.final_state.conninfo.host == '127.0.0.1'
-      - result.final_state.conninfo.port == '{{ master_port }}'
+      - result.final_state.conninfo.port == {{ master_port }}
       - result.final_state.conninfo.user == '{{ replication_role }}'
       - result.final_state.conninfo.password == '{{ replication_pass }}'
 
@@ -186,7 +186,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
-      pubname: '{{ test_pub }}'
+      publications: '{{ test_pub }}'
       owner: '{{ test_role1 }}'
       connparams:
         host: 127.0.0.1
@@ -207,7 +207,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
-      pubname: '{{ test_pub }}'
+      publications: '{{ test_pub }}'
       owner: '{{ test_role1 }}'
 
   - assert:
@@ -238,7 +238,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
-      pubname: '{{ test_pub }}'
+      publications: '{{ test_pub }}'
       owner: '{{ test_role2 }}'
     check_mode: yes
 
@@ -271,7 +271,7 @@
       login_port: '{{ replica_port }}'
       name: '{{ test_subscription }}'
       state: present
-      pubname: '{{ test_pub }}'
+      publications: '{{ test_pub }}'
       owner: '{{ test_role2 }}'
 
   - assert:
@@ -358,3 +358,276 @@
       - result is not changed
       - result.name == '{{ test_subscription }}'
       - result.exists == false
+
+  ###########################
+  # Test subsparams parameter
+  ###########################
+
+  - name: Create subscription with subsparams
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications: '{{ test_pub }}'
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+      subsparams:
+        enabled: no
+        synchronous_commit: no
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["CREATE SUBSCRIPTION test CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }} WITH (enabled = false, synchronous_commit = false)"]
+      - result.exists == true
+      - result.final_state.enabled == false
+      - result.final_state.synccommit == false
+
+  - name: Stat mode
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.enabled == false
+      - result.final_state.synccommit == false
+
+  - name: Enable changed params
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      publications: '{{ test_pub }}'
+      subsparams:
+        enabled: yes
+        synchronous_commit: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} ENABLE", "ALTER SUBSCRIPTION {{ test_subscription }} SET (synchronous_commit = true)"]
+      - result.exists == true
+      - result.final_state.enabled == true
+      - result.final_state.synccommit == true
+
+  - name: Stat mode
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.enabled == true
+      - result.final_state.synccommit == true
+
+  - name: Enable the same params again
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      publications: '{{ test_pub }}'
+      subsparams:
+        enabled: yes
+        synchronous_commit: yes
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == []
+      - result.exists == true
+      - result.final_state == result.initial_state
+      - result.final_state.enabled == true
+      - result.final_state.synccommit == true
+
+  ##########################
+  # Test change publications
+  ##########################
+
+  - name: Change publications in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications:
+      - '{{ test_pub }}'
+      - '{{ test_pub2 }}'
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.publications == result.initial_state.publications
+      - result.final_state.publications == ['{{ test_pub }}']
+      - result.queries == ['ALTER SUBSCRIPTION {{ test_subscription }} SET PUBLICATION {{ test_pub }}, {{ test_pub2 }}']
+
+  - name: Check publications
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.publications == ['{{ test_pub }}']
+
+  - name: Change publications
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications:
+      - '{{ test_pub }}'
+      - '{{ test_pub2 }}'
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.publications != result.initial_state.publications
+      - result.final_state.publications == ['{{ test_pub }}', '{{ test_pub2 }}']
+      - result.queries == ['ALTER SUBSCRIPTION {{ test_subscription }} SET PUBLICATION {{ test_pub }}, {{ test_pub2 }}']
+
+  - name: Check publications
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.publications == ['{{ test_pub }}', '{{ test_pub2 }}']
+
+  - name: Change publications with the same values again
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      publications:
+      - '{{ test_pub }}'
+      - '{{ test_pub2 }}'
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.publications == result.initial_state.publications
+      - result.final_state.publications == ['{{ test_pub }}', '{{ test_pub2 }}']
+      - result.queries == []
+
+  ######################
+  # Test update conninfo
+  ######################
+
+  - name: Change conninfo in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+        connect_timeout: '{{ conn_timeout }}'
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }} connect_timeout={{ conn_timeout }}'"]
+      - result.initial_state.conninfo == result.final_state.conninfo
+
+  - name: Change conninfo
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+        connect_timeout: '{{ conn_timeout }}'
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }} connect_timeout={{ conn_timeout }}'"]
+      - result.initial_state.conninfo != result.final_state.conninfo
+
+  - name: Check publications
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result.name == '{{ test_subscription }}'
+      - result.final_state.conninfo.connect_timeout == {{ conn_timeout }}
+
+  - name: Try to change conninfo again with the same values
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+        connect_timeout: '{{ conn_timeout }}'
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == []
+      - result.initial_state.conninfo == result.final_state.conninfo
+      - result.final_state.conninfo.connect_timeout == {{ conn_timeout }}

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -631,3 +631,37 @@
       - result.queries == []
       - result.initial_state.conninfo == result.final_state.conninfo
       - result.final_state.conninfo.connect_timeout == {{ conn_timeout }}
+
+  ####################
+  # Test state refresh
+  ####################
+
+  - name: Refresh in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: refresh
+    check_mode:
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} REFRESH PUBLICATION"]
+
+  - name: Refresh
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: refresh
+    check_mode:
+
+  - assert:
+      that:
+      - result is changed
+      - result.name == '{{ test_subscription }}'
+      - result.queries == ["ALTER SUBSCRIPTION {{ test_subscription }} REFRESH PUBLICATION"]

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -1,0 +1,4 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- meta: end_play

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -102,3 +102,143 @@
       - result.final_state.conninfo.port == '{{ master_port }}'
       - result.final_state.conninfo.user == '{{ replication_role }}'
       - result.final_state.conninfo.password == '{{ replication_pass }}'
+
+  ###################
+  # Test mode: absent
+  ###################
+
+  - name: Drop subscription in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["DROP SUBSCRIPTION {{ test_subscription }}"]
+      - result.final_state == result.initial_state
+
+  - name: Check the subscription exists
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+
+  - name: Drop subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["DROP SUBSCRIPTION {{ test_subscription }}"]
+      - result.final_state != result.initial_state
+
+  - name: Check the subscription doesn't exist
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == false
+
+  ####################
+  # Test cascade param
+  ####################
+
+  - name: Create subscription for further tests
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      pubname: '{{ test_pub }}'
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+
+
+  - name: Drop subscription cascade in check mode
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent
+      cascade: yes
+    check_mode: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["DROP SUBSCRIPTION {{ test_subscription }} CASCADE"]
+      - result.final_state == result.initial_state
+
+  - name: Check the subscription exists
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == true
+
+  - name: Drop subscription cascade
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: absent
+      cascade: yes
+
+  - assert:
+      that:
+      - result is changed
+      - result.queries == ["DROP SUBSCRIPTION {{ test_subscription }} CASCADE"]
+      - result.final_state != result.initial_state
+
+  - name: Check the subscription doesn't exist
+    <<: *task_parameters
+    postgresql_subscription: 
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: stat
+
+  - assert:
+      that:
+      - result is not changed
+      - result.name == '{{ test_subscription }}'
+      - result.exists == false

--- a/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
@@ -11,13 +11,31 @@
       login_db: '{{ test_db }}'
 
   block:
+#  - name: Create subscription via shell
+#    <<: *task_parameters
+#    shell: psql '{{ test_db }}' -p '{{ replica_port }}' -c "CREATE SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }};"
+
+  ####################
+  # Test mode: present
+  ####################
+  - name: Create subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      state: present
+      pubname: '{{ test_pub }}'
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+
   #################
   # Test mode: stat
   #################
-
-  - name: Create subscription via shell
-    <<: *task_parameters
-    shell: psql '{{ test_db }}' -p '{{ replica_port }}' -c "CREATE SUBSCRIPTION {{ test_subscription }} CONNECTION 'host=127.0.0.1 port={{ master_port }} user={{ replication_role }} password={{ replication_pass }} dbname={{ test_db }}' PUBLICATION {{ test_pub }};"
 
   - name: Stat mode in check mode
     <<: *task_parameters

--- a/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
@@ -63,6 +63,13 @@
       - result.tables == []
       - result.parameters.publish != {}
 
+  - name: postgresql_publication - create one more publication
+    <<: *task_parameters
+    postgresql_publication: 
+      <<: *pg_parameters
+      login_port: '{{ master_port }}'
+      name: '{{ test_pub2 }}'
+
   - name: postgresql_publication - check the publication was created
     <<: *task_parameters
     postgresql_query:

--- a/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
@@ -1,6 +1,6 @@
 # Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# The file for testing postgresql_copy module.
+# Preparation for further tests of postgresql_subscription module.
 
 - vars:
     task_parameters: &task_parameters
@@ -62,3 +62,7 @@
   - assert:
       that:
       - result.rowcount == 1
+
+#
+# COPY SCHEMA, ETC
+#

--- a/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
@@ -18,7 +18,6 @@
       login_user: '{{ pg_user }}'
       login_port: '{{ master_port }}'
       maintenance_db: '{{ db_default }}'
-      login_port: '{{ master_port }}'
       name: '{{ test_db }}'
 
   - name: postgresql_publication - create test role

--- a/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
@@ -16,13 +16,16 @@
     <<: *task_parameters
     postgresql_db:
       login_user: '{{ pg_user }}'
+      login_port: '{{ master_port }}'
       maintenance_db: '{{ db_default }}'
+      login_port: '{{ master_port }}'
       name: '{{ test_db }}'
 
   - name: postgresql_publication - create test role
     <<: *task_parameters
     postgresql_user:
       <<: *pg_parameters
+      login_port: '{{ master_port }}'
       name: '{{ replication_role }}'
       password: '{{ replication_pass }}'
       role_attr_flags: LOGIN,REPLICATION
@@ -31,14 +34,24 @@
     <<: *task_parameters
     postgresql_table:
       <<: *pg_parameters
+      login_port: '{{ master_port }}'
       name: '{{ test_table1 }}'
       columns:
       - id int
+
+  - name: Master - dump schema
+    <<: *task_parameters
+    shell: pg_dumpall -p '{{ master_port }}' -s > /tmp/schema.sql
+
+  - name: Replicat restore schema
+    <<: *task_parameters
+    shell: psql -p '{{ replica_port }}' -f /tmp/schema.sql
 
   - name: postgresql_publication - create publication
     <<: *task_parameters
     postgresql_publication: 
       <<: *pg_parameters
+      login_port: '{{ master_port }}'
       name: '{{ test_pub }}'
 
   - assert:
@@ -55,6 +68,7 @@
     <<: *task_parameters
     postgresql_query:
       <<: *pg_parameters
+      login_port: '{{ master_port }}'
       query: >
         SELECT * FROM pg_publication WHERE pubname = '{{ test_pub }}'
         AND pubowner = '10' AND puballtables = 't'
@@ -62,7 +76,3 @@
   - assert:
       that:
       - result.rowcount == 1
-
-#
-# COPY SCHEMA, ETC
-#

--- a/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_subscription/tasks/setup_publication.yml
@@ -1,0 +1,64 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# The file for testing postgresql_copy module.
+
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: yes
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ test_db }}'
+
+  block:
+  - name: postgresql_publication - create test db
+    <<: *task_parameters
+    postgresql_db:
+      login_user: '{{ pg_user }}'
+      maintenance_db: '{{ db_default }}'
+      name: '{{ test_db }}'
+
+  - name: postgresql_publication - create test role
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      name: '{{ replication_role }}'
+      password: '{{ replication_pass }}'
+      role_attr_flags: LOGIN,REPLICATION
+
+  - name: postgresql_publication - create test table
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      name: '{{ test_table1 }}'
+      columns:
+      - id int
+
+  - name: postgresql_publication - create publication
+    <<: *task_parameters
+    postgresql_publication: 
+      <<: *pg_parameters
+      name: '{{ test_pub }}'
+
+  - assert:
+      that:
+      - result is changed
+      - result.exists == true
+      - result.queries == ["CREATE PUBLICATION \"{{ test_pub }}\" FOR ALL TABLES"]
+      - result.owner == '{{ pg_user }}'
+      - result.alltables == true
+      - result.tables == []
+      - result.parameters.publish != {}
+
+  - name: postgresql_publication - check the publication was created
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: >
+        SELECT * FROM pg_publication WHERE pubname = '{{ test_pub }}'
+        AND pubowner = '10' AND puballtables = 't'
+
+  - assert:
+      that:
+      - result.rowcount == 1

--- a/test/integration/targets/setup_postgresql_replication/defaults/main.yml
+++ b/test/integration/targets/setup_postgresql_replication/defaults/main.yml
@@ -1,0 +1,30 @@
+# General:
+pg_user: postgres
+db_default: postgres
+
+pg_package_list:
+- apt-utils
+- postgresql
+- postgresql-contrib
+- python3-psycopg2
+
+packages_to_remove:
+- postgresql
+- postgresql-contrib
+- postgresql-server
+- postgresql-libs
+- python3-psycopg2
+
+# Master specific defaults:
+master_root_dir: '/var/lib/pgsql/master'
+master_data_dir: '{{ master_root_dir }}/data'
+master_postgresql_conf: '{{ master_data_dir }}/postgresql.conf'
+master_pg_hba_conf: '{{ master_data_dir }}/pg_hba.conf'
+master_port: 5433
+
+# Replica specific defaults:
+replica_root_dir: '/var/lib/pgsql/replica'
+replica_data_dir: '{{ replica_root_dir }}/data'
+replica_postgresql_conf: '{{ replica_data_dir }}/postgresql.conf'
+replica_pg_hba_conf: '{{ replica_data_dir }}/pg_hba.conf'
+replica_port: 5434

--- a/test/integration/targets/setup_postgresql_replication/handlers/main.yml
+++ b/test/integration/targets/setup_postgresql_replication/handlers/main.yml
@@ -9,9 +9,8 @@
 
 - name: Remove packages
   apt:
-    name: '{{ item }}'
+    name: '{{ packages_to_remove }}'
     state: absent
-  loop: '{{ packages_to_remove }}'
   listen: cleanup postgresql
 
 - name: Remove FS objects

--- a/test/integration/targets/setup_postgresql_replication/handlers/main.yml
+++ b/test/integration/targets/setup_postgresql_replication/handlers/main.yml
@@ -1,0 +1,24 @@
+- name: Stop services
+  become: yes
+  become_user: '{{ pg_user }}'
+  shell: '{{ pg_ctl }} -D {{ item.datadir }} -o "-p {{ item.port }}" -m immediate stop'
+  loop:
+  - { datadir: '{{ master_data_dir }}', port: '{{ master_port }}' }
+  - { datadir: '{{ replica_data_dir }}', port: '{{ replica_port }}' }
+  listen: stop postgresql
+
+- name: Remove packages
+  apt:
+    name: '{{ item }}'
+    state: absent
+  loop: '{{ packages_to_remove }}'
+  listen: cleanup postgresql
+
+- name: Remove FS objects
+  file:
+    state: absent
+    path: "{{ item }}"
+  loop:
+  - "{{ master_root_dir }}"
+  - "{{ replica_root_dir }}"
+  listen: cleanup postgresql

--- a/test/integration/targets/setup_postgresql_replication/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_replication/tasks/main.yml
@@ -1,0 +1,8 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Setup PostgreSQL master-standby replication into one container:
+- import_tasks: setup_postgresql_cluster.yml
+  when:
+  - ansible_distribution == 'Ubuntu'
+  - ansible_distribution_major_version >= '18'

--- a/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -3,8 +3,7 @@
 
 - name: Install packages
   apt:
-    name: '{{ item }}'
-  loop: '{{ pg_package_list }}'
+    name: '{{ pg_package_list }}'
   notify: cleanup postgresql
 
 - name: Create root dirs

--- a/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -1,0 +1,85 @@
+# We run two servers listening different ports
+# to be able to check replication (one server for master, another for standby).
+
+- name: Install packages
+  apt:
+    name: '{{ item }}'
+  loop: '{{ pg_package_list }}'
+  notify: cleanup postgresql
+
+- name: Create root dirs
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: postgres
+    group: postgres
+    mode: 0700
+  loop:
+  - "{{ master_root_dir }}"
+  - "{{ master_data_dir }}"
+  - "{{ replica_root_dir }}"
+  - "{{ replica_data_dir }}"
+  notify: cleanup postgresql
+
+- name: Find initdb
+  shell: find /usr/lib -type f -name "initdb"
+  register: result
+
+- name: Set path to initdb
+  set_fact:
+    initdb: '{{ result.stdout }}'
+
+- name: Initialize databases
+  become: yes
+  become_user: '{{ pg_user }}'
+  shell: '{{ initdb }} --pgdata {{ item }}'
+  loop:
+  - "{{ master_data_dir }}"
+  - "{{ replica_data_dir }}"
+
+- name: Copy config templates
+  template:
+    src: '{{ item.conf_templ }}'
+    dest: '{{ item.conf_dest }}'
+    owner: postgres
+    group: postgres
+    force: yes
+  loop:
+  - { conf_templ: master_postgresql.conf.j2, conf_dest: '{{ master_postgresql_conf }}' }
+  - { conf_templ: replica_postgresql.conf.j2, conf_dest: '{{ replica_postgresql_conf }}' }
+  - { conf_templ: pg_hba.conf.j2, conf_dest: '{{ master_pg_hba_conf }}' }
+  - { conf_templ: pg_hba.conf.j2, conf_dest: '{{ replica_pg_hba_conf }}' }
+
+- name: Find pg_ctl
+  shell: find /usr/lib -type f -name "pg_ctl"
+  register: result
+
+- name: Set path to initdb
+  set_fact:
+    pg_ctl: '{{ result.stdout }}'
+
+- name: Start servers
+  become: yes
+  become_user: '{{ pg_user }}'
+  shell: '{{ pg_ctl }} -D {{ item.datadir }} -o "-p {{ item.port }}" start'
+  loop:
+  - { datadir: '{{ master_data_dir }}', port: '{{ master_port }}' }
+  - { datadir: '{{ replica_data_dir }}', port: '{{ replica_port }}' }
+  notify: stop postgresql
+
+- name: Check connectivity and git PostgreSQL version
+  become: yes
+  become_user: '{{ pg_user }}'
+  postgresql_ping:
+    db: '{{ db_default }}'
+    login_user: '{{ pg_user }}'
+    login_port: '{{ item }}'
+  loop:
+  - '{{ master_port }}'
+  - '{{ replica_port }}'
+  register: result
+
+- name: Define server version
+  set_fact:
+    pg_major_version: '{{ result.server_version.major }}'
+    pg_minor_version: '{{ result.server_version.minor }}'

--- a/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
+++ b/test/integration/targets/setup_postgresql_replication/tasks/setup_postgresql_cluster.yml
@@ -67,19 +67,28 @@
   - { datadir: '{{ replica_data_dir }}', port: '{{ replica_port }}' }
   notify: stop postgresql
 
-- name: Check connectivity and git PostgreSQL version
+- name: Check connectivity to the master and get PostgreSQL version
   become: yes
   become_user: '{{ pg_user }}'
   postgresql_ping:
     db: '{{ db_default }}'
     login_user: '{{ pg_user }}'
-    login_port: '{{ item }}'
-  loop:
-  - '{{ master_port }}'
-  - '{{ replica_port }}'
+    login_port: '{{ master_port }}'
   register: result
+
+- name: Check connectivity to the replica and get PostgreSQL version
+  become: yes
+  become_user: '{{ pg_user }}'
+  postgresql_ping:
+    db: '{{ db_default }}'
+    login_user: '{{ pg_user }}'
+    login_port: '{{ replica_port }}'
 
 - name: Define server version
   set_fact:
     pg_major_version: '{{ result.server_version.major }}'
     pg_minor_version: '{{ result.server_version.minor }}'
+
+- name: Print PostgreSQL version
+  debug:
+    msg: 'PostgreSQL version is {{ pg_major_version }}.{{ pg_minor_version }}'

--- a/test/integration/targets/setup_postgresql_replication/templates/master_postgresql.conf.j2
+++ b/test/integration/targets/setup_postgresql_replication/templates/master_postgresql.conf.j2
@@ -1,0 +1,28 @@
+# Important parameters:
+listen_addresses='*'
+port = {{ master_port }}
+wal_level = logical
+max_wal_senders = 8
+track_commit_timestamp = on
+max_replication_slots = 10
+
+# Unimportant parameters:
+max_connections=10
+shared_buffers=8MB
+dynamic_shared_memory_type=posix
+log_destination='stderr'
+logging_collector=on
+log_directory='log'
+log_filename='postgresql-%a.log'
+log_truncate_on_rotation=on
+log_rotation_age=1d
+log_rotation_size=0 
+log_line_prefix='%m[%p]'
+log_timezone='W-SU'
+datestyle='iso,mdy'
+timezone='W-SU'
+lc_messages='en_US.UTF-8'           
+lc_monetary='en_US.UTF-8'           
+lc_numeric='en_US.UTF-8'            
+lc_time='en_US.UTF-8'               
+default_text_search_config='pg_catalog.english'

--- a/test/integration/targets/setup_postgresql_replication/templates/pg_hba.conf.j2
+++ b/test/integration/targets/setup_postgresql_replication/templates/pg_hba.conf.j2
@@ -1,0 +1,7 @@
+local  all          all                                trust
+local  replication  logical_replication                trust
+host   replication  logical_replication  127.0.0.1/32  trust
+host   replication  logical_replication  0.0.0.0/0     trust
+local  all          logical_replication                trust
+host   all          logical_replication  127.0.0.1/32  trust
+host   all          logical_replication  0.0.0.0/0     trust

--- a/test/integration/targets/setup_postgresql_replication/templates/replica_postgresql.conf.j2
+++ b/test/integration/targets/setup_postgresql_replication/templates/replica_postgresql.conf.j2
@@ -1,0 +1,28 @@
+# Important parameters:
+listen_addresses='*'
+port = {{ replica_port }}
+wal_level = logical
+max_wal_senders = 8
+track_commit_timestamp = on
+max_replication_slots = 10
+
+# Unimportant parameters:
+max_connections=10
+shared_buffers=8MB
+dynamic_shared_memory_type=posix
+log_destination='stderr'
+logging_collector=on
+log_directory='log'
+log_filename='postgresql-%a.log'
+log_truncate_on_rotation=on
+log_rotation_age=1d
+log_rotation_size=0 
+log_line_prefix='%m[%p]'
+log_timezone='W-SU'
+datestyle='iso,mdy'
+timezone='W-SU'
+lc_messages='en_US.UTF-8'           
+lc_monetary='en_US.UTF-8'           
+lc_numeric='en_US.UTF-8'            
+lc_time='en_US.UTF-8'               
+default_text_search_config='pg_catalog.english'


### PR DESCRIPTION
##### SUMMARY
New module postgresql_subscription
Regarding https://github.com/ansible/community/issues/435

Use case:
1. Create a publication with postgresql_publication module
2. Create a subscription with postgresql_subscription module

Has CI tests: the master and the replica both were configured and launched in one container

**IMPORTANT**, First of all, take a look at:
```
lib/ansible/modules/database/postgresql/postgresql_subscription.py
test/integration/targets/postgresql_subscription/tasks/postgresql_subscription_initial.yml
```
the other files configure a master-replica cluster and test publication in a test container

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
```test/integration/targets/postgresql_subscription```

##### EXAMPLES
```
- name: >
    Create acme subscription in mydb database using acme_publication and
    the following connection parameters to connect to the publisher.
    Set the subscription owner as alice.
  postgresql_subscription:
    db: mydb
    name: acme
    state: present
    publications: acme_publication
    owner: alice
    connparams:
      host: 127.0.0.1
      port: 5432
      user: repl
      password: replpass
      dbname: mydb

- name: Assuming that acme subscription exists, try to change conn parameters
  postgresql_subscription:
    db: mydb
    name: acme
    connparams:
      host: 127.0.0.1
      port: 5432
      user: repl
      password: replpass
      connect_timeout: 100

- name: Refresh acme publication
  postgresql_subscription:
    db: mydb
    name: acme
    state: refresh

- name: >
    Return the configuration of subscription acme if exists in mydb database.
    Also return state of replicated relations.
  postgresql_subscription:
    db: mydb
    name: acme
    state: stat
    relinfo: yes

- name: Drop acme subscription from mydb with dependencies (cascade=yes)
  postgresql_subscription:
    db: mydb
    name: acme
    state: absent
    cascade: yes

- name: Assuming that acme subscription exists and enabled, disable the subscription
  postgresql_subscription:
    db: mydb
    name: acme
    state: present
    subsparams:
      enabled: no
```

##### RETURNS
```
ok: [testhost] => {
    "changed": false,
    "exists": true,
    "final_state": {
        "conninfo": {
            "connect_timeout": 100,
            "dbname": "acme_db",
            "host": "127.0.0.1",
            "password": "alsdjfKJKDf1#",
            "port": 5433,
            "user": "logical_replication"
        },
        "enabled": true,
        "owner": "postgres",
        "publications": [
            "first_publication",
            "second_publication"
        ],
        "relinfo": [
            {
                "relname": "acme1",
                "srsublsn": null,
                "srsubstate": "d"
            }
        ],
        "slotname": "test",
        "synccommit": true
    },
    "initial_state": {
        "conninfo": {
            "connect_timeout": 100,
            "dbname": "acme_db",
            "host": "127.0.0.1",
            "password": "alsdjfKJKDf1#",
            "port": 5433,
            "user": "logical_replication"
        },
        "enabled": true,
        "owner": "postgres",
        "publications": [
            "first_publication",
            "second_publication"
        ],
        "relinfo": [
            {
                "relname": "acme1",
                "srsublsn": null,
                "srsubstate": "d"
            }
        ],
        "slotname": "test",
        "synccommit": true
    },
```