### PR TITLE
Fix IOS_VLANS override operation for new VLANs

### DIFF
--- a/changelogs/fragments/63624-Fix-IOS_VLANS-override-operation-for-new-VLAN.yaml
+++ b/changelogs/fragments/63624-Fix-IOS_VLANS-override-operation-for-new-VLAN.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Fix IOS_VLANS override operation for new VLANs(https://github.com/ansible/ansible/pull/63624)"

--- a/lib/ansible/module_utils/network/ios/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/ios/config/vlans/vlans.py
@@ -146,16 +146,28 @@ class Vlans(ConfigBase):
         """
         commands = []
 
+        want_local = want
         for each in have:
-            for every in want:
+            count = 0
+            for every in want_local:
                 if each['vlan_id'] == every['vlan_id']:
                     break
+                count += 1
             else:
                 # We didn't find a matching desired state, which means we can
                 # pretend we recieved an empty desired state.
                 commands.extend(self._clear_config(every, each, state))
                 continue
             commands.extend(self._set_config(every, each))
+            # as the pre-existing VLAN are now configured by
+            # above set_config call, deleting the respective
+            # VLAN entry from the want_local list
+            del want_local[count]
+
+        # Iterating through want_local list which now only have new VLANs to be
+        # configured
+        for each in want_local:
+            commands.extend(self._set_config(each, dict()))
 
         return commands
 

--- a/test/integration/targets/ios_vlans/tests/cli/_remove_config.yaml
+++ b/test/integration/targets/ios_vlans/tests/cli/_remove_config.yaml
@@ -7,4 +7,5 @@
       no vlan 10
       no vlan 20
       no vlan 30
+      no vlan 40
   when: ansible_net_version != "15.6(2)T"

--- a/test/integration/targets/ios_vlans/tests/cli/merged.yaml
+++ b/test/integration/targets/ios_vlans/tests/cli/merged.yaml
@@ -12,7 +12,7 @@
             vlan_id: 10
             state: active
             shutdown: disabled
-            remote_span: 10
+            remote_span: True
           - name: Vlan_20
             vlan_id: 20
             mtu: 610

--- a/test/integration/targets/ios_vlans/tests/cli/overridden.yaml
+++ b/test/integration/targets/ios_vlans/tests/cli/overridden.yaml
@@ -13,6 +13,9 @@
           - name: VLAN_10
             vlan_id: 10
             mtu: 1000
+          - name: VLAN_40
+            vlan_id: 40
+            mtu: 850
         state: overridden
       register: result
 

--- a/test/integration/targets/ios_vlans/vars/main.yaml
+++ b/test/integration/targets/ios_vlans/vars/main.yaml
@@ -228,6 +228,9 @@ overridden:
     - "mtu 1000"
     - "no vlan 20"
     - "no vlan 30"
+    - "vlan 40"
+    - "name VLAN_40"
+    - "mtu 850"
 
   after:
     - mtu: 1500
@@ -240,6 +243,11 @@ overridden:
       shutdown: disabled
       state: active
       vlan_id: 10
+    - mtu: 850
+      name: VLAN_40
+      shutdown: disabled
+      state: active
+      vlan_id: 40
     - mtu: 1500
       name: fddi-default
       shutdown: enabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #63624, to Fix IOS_VLANS override operation for new VLANs.
Cherry-pick from: 4f2665810fd19ed625de83bb41bd2cb521052834
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
