### PR TITLE
Example incorrect: server_url is required argument

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -87,7 +87,7 @@ options:
 EXAMPLES = '''
 - name: "Delete GitLab Group"
   gitlab_group:
-    api_url: https://gitlab.example.com/
+    server_url: https://gitlab.example.com/
     api_token: "{{ access_token }}"
     validate_certs: False
     name: my_first_group
@@ -95,7 +95,7 @@ EXAMPLES = '''
 
 - name: "Create GitLab Group"
   gitlab_group:
-    api_url: https://gitlab.example.com/
+    server_url: https://gitlab.example.com/
     validate_certs: True
     api_usersername: dj-wasabi
     api_password: "MySecretPassword"
@@ -106,7 +106,7 @@ EXAMPLES = '''
 # The group will by created at https://gitlab.dj-wasabi.local/super_parent/parent/my_first_group
 - name: "Create GitLab SubGroup"
   gitlab_group:
-    api_url: https://gitlab.example.com/
+    server_url: https://gitlab.example.com/
     validate_certs: True
     api_usersername: dj-wasabi
     api_password: "MySecretPassword"


### PR DESCRIPTION
##### SUMMARY
The example "Delete GitLab Group" does not work.

- name: "Delete GitLab Group"
  gitlab_group:
    api_url: https://gitlab.example.com/
    api_token: "{{ access_token }}"
    validate_certs: False
    name: my_first_group
    state: absent

It errors with: 
fatal: [myhost.mydomain.com -> localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: server_url"}

If you provide server_url and api_url, it complains that they are mutually exclusive:
fatal: [myhost.mydomain.com -> localhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: api_url|server_url"}

This means there is no logical path in the use of the module where api_url can be specified without resulting in at least one of these fatal errors. I suggest adjusting the examples in the meantime, then changing the module to move away from the soon-to-be deprecated server_url parameter, removing it as a required argument.

This likely applies to all Examples, so this change proposes at least putting in the required parameter in the examples.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
