### PR TITLE
Typo usersername should be username

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -97,7 +97,7 @@ EXAMPLES = '''
   gitlab_group:
     api_url: https://gitlab.example.com/
     validate_certs: True
-    api_usersername: dj-wasabi
+    api_username: dj-wasabi
     api_password: "MySecretPassword"
     name: my_first_group
     path: my_first_group
@@ -108,7 +108,7 @@ EXAMPLES = '''
   gitlab_group:
     api_url: https://gitlab.example.com/
     validate_certs: True
-    api_usersername: dj-wasabi
+    api_username: dj-wasabi
     api_password: "MySecretPassword"
     name: my_first_group
     path: my_first_group


### PR DESCRIPTION
##### SUMMARY
Typo in examples using api_username. Example incorrectly has usersername.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Typo in examples using api_username. Example incorrectly has usersername.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
gitlab_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
