### PR TITLE
[2.9] openssl_csr: deprecate version option

### DIFF
--- a/changelogs/fragments/63432-openssl_csr-version.yml
+++ b/changelogs/fragments/63432-openssl_csr-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_csr - a warning is issued if an unsupported value for ``version`` is used for the ``cryptography`` backend."

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -58,6 +58,8 @@ options:
     version:
         description:
             - The version of the certificate signing request.
+            - "The only allowed value according to L(RFC 2986,https://tools.ietf.org/html/rfc2986#section-4.1)
+               is 1."
         type: int
         default: 1
     force:
@@ -750,6 +752,8 @@ class CertificateSigningRequestCryptography(CertificateSigningRequestBase):
     def __init__(self, module):
         super(CertificateSigningRequestCryptography, self).__init__(module)
         self.cryptography_backend = cryptography.hazmat.backends.default_backend()
+        if self.version != 1:
+            module.warn('The cryptography backend only supports version 1. (The only valid value according to RFC 2986.)')
 
     def _generate_csr(self):
         csr = cryptography.x509.CertificateSigningRequestBuilder()


### PR DESCRIPTION
##### SUMMARY
Backport of the backport-able parts of #63432 (i.e. the warning when a version != 1 is used with the `cryptography` version that the value will be ignored) to stable-2.9.

Backport of https://github.com/ansible/ansible/pull/63432

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
