### PR TITLE
parted: parse_unit() accepts negative numbers

### DIFF
--- a/changelogs/fragments/43369-parted_negative_numbers.yml
+++ b/changelogs/fragments/43369-parted_negative_numbers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - parted: accept negative numbers in part_start/part_end (issue #43369)

--- a/changelogs/fragments/43369-parted_negative_numbers.yml
+++ b/changelogs/fragments/43369-parted_negative_numbers.yml
@@ -1,2 +1,2 @@
 bugfixes:
- - parted: accept negative numbers in part_start/part_end (issue #43369)
+ - "parted: accept negative numbers in part_start/part_end (issue #43369)"

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -201,9 +201,9 @@ parted_units = units_si + units_iec + ['s', '%', 'cyl', 'chs', 'compact']
 
 def parse_unit(size_str, unit=''):
     """
-    Parses a string containing a size of information
+    Parses a string containing a size or boundary information
     """
-    matches = re.search(r'^([\d.]+)([\w%]+)?$', size_str)
+    matches = re.search(r'^(-?[\d.]+)([\w%]+)?$', size_str)
     if matches is None:
         # "<cylinder>,<head>,<sector>" format
         matches = re.search(r'^(\d+),(\d+),(\d+)$', size_str)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make parse_unit() understand negative numbers, allowing specifying part_start and part_end relative to disk end
Fixes: #43369
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parted
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Trivial change, I hope it will be backported to 2.7 soon, I need it.