### PR TITLE
files modules: add elements to parameters of type list

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -30,6 +30,7 @@ options:
     description:
       - Remote absolute path, glob, or list of paths or globs for the file or files to compress or archive.
     type: list
+    elements: path
     required: true
   format:
     description:
@@ -47,6 +48,7 @@ options:
     description:
       - Remote absolute path, glob, or list of paths or globs for the file or files to exclude from the archive.
     type: list
+    elements: path
     version_added: '2.4'
   force_archive:
     version_added: '2.8'

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -45,6 +45,7 @@ options:
               patterns contain a comma, make sure to put them in a list to avoid splitting the patterns
               in undesirable ways.
         type: list
+        elements: str
         aliases: [ pattern ]
     excludes:
         description:
@@ -52,6 +53,7 @@ options:
             - Items whose basenames match an C(excludes) pattern are culled from C(patterns) matches.
               Multiple patterns can be specified using a list.
         type: list
+        elements: str
         aliases: [ exclude ]
         version_added: "2.5"
     contains:
@@ -62,6 +64,7 @@ options:
         description:
             - List of paths of directories to search. All paths must be fully qualified.
         type: list
+        elements: path
         required: true
         aliases: [ name, path ]
     file_type:

--- a/lib/ansible/modules/files/iso_extract.py
+++ b/lib/ansible/modules/files/iso_extract.py
@@ -51,6 +51,7 @@ options:
     - A list of files to extract from the image.
     - Extracting directories does not work.
     type: list
+    elements: path
     required: yes
   force:
     description:

--- a/lib/ansible/modules/files/read_csv.py
+++ b/lib/ansible/modules/files/read_csv.py
@@ -44,6 +44,7 @@ options:
     - A list of field names for every column.
     - This is needed if the CSV does not have a header.
     type: list
+    elements: str
   unique:
     description:
     - Whether the C(key) used is expected to be unique.

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -154,6 +154,7 @@ options:
       - Specify additional rsync options by passing in an array.
       - Note that an empty string in C(rsync_opts) will end up transfer the current working directory.
     type: list
+    elements: str
     default:
     version_added: "1.6"
   partial:
@@ -177,6 +178,7 @@ options:
     description:
       - Add a destination to hard link against during the rsync.
     type: list
+    elements: path
     default:
     version_added: "2.5"
 notes:

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -62,6 +62,7 @@ options:
     description:
       - List the directory and file entries that you would like to exclude from the unarchive action.
     type: list
+    elements: path
     version_added: "2.1"
   keep_newer:
     description:
@@ -75,6 +76,7 @@ options:
       - Each space-separated command-line option should be a new element of the array. See examples.
       - Command-line options with multiple elements must use multiple lines in the array, one for each element.
     type: list
+    elements: str
     default: ""
     version_added: "2.1"
   remote_src:


### PR DESCRIPTION
##### SUMMARY
files modules: add elements to parameters of type list

There are also two list parameters i'm not sure which type is proper
```
lib/ansible/modules/files/xml.py : 74
lib/ansible/modules/files/xml.py : 81
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```lib/ansible/modules/files/archive.py```
```lib/ansible/modules/files/find.py```
```lib/ansible/modules/files/iso_extract.py```
```lib/ansible/modules/files/read_csv.py```
```lib/ansible/modules/files/synchronize.py```
```lib/ansible/modules/files/unarchive.py```



