### PR TITLE
Confusing indication of no notable module changes

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -37,8 +37,6 @@ No notable changes
 Modules
 =======
 
-No notable changes
-
 
 Modules removed
 ---------------


### PR DESCRIPTION
##### SUMMARY
Removed indication of 'no notable changes' for modules in 2.10, since there are notable changes listed below.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
2.10 porting guide

