### PR TITLE
Do not set ANSIBLE_LIBRARY in env-setup.fish

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -57,15 +57,13 @@ if not set -q PYTHON_BIN
     end
 end
 
-set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
-
 #
 # Generate egg_info so that pkg_resources works
 #
 
 # Do the work in a fuction
 function gen_egg_info
-    # Cannot use `test` on wildcards. 
+    # Cannot use `test` on wildcards.
     # @see https://github.com/fish-shell/fish-shell/issues/5960
     if count $PREFIX_PYTHONPATH/ansible*.egg-info > /dev/null
         rm -rf $PREFIX_PYTHONPATH/ansible*.egg-info


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Setting this env var was removed from env-setup back in 2014(7f6ab89b5b9ad4f84b19d1b14c2d03cb91e720bf). Not sure why it is in this setup script and it interferes with the default search path for modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hacking/env-setup.fish`