### PR TITLE
VMware: New module vmware_host_sriov

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: vmware_host_sriov
+short_description: Manage SR-IOV settings on host
+description:
+- This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
+- module didn't reboot host after changes, but put in output "rebootRequired" key.
+- User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
+
+author:
+- Viktor Tsymbalyuk (@victron)
+notes:
+- Tested on vSphere 6.0
+requirements:
+- python >= 2.6
+- PyVmomi
+options:
+  esxi_hostname:
+    description:
+    - Name of the host system to work with.
+    - This parameter is required if C(cluster_name) is not specified.
+    type: str
+  cluster_name:
+    description:
+    - Name of the cluster from which all host systems will be used.
+    - This parameter is required if C(esxi_hostname) is not specified.
+    type: str
+  vmnic:
+    description:
+    - interface name, like vmnic0
+    type: str
+    required: True
+  sriovOn:
+    description:
+    - desired SR-IOV state on interface
+    type: bool
+    required: True
+  numVirtFunc:
+    description:
+    - number of functions to activate on interface
+    - if sriovOn false should be equal 0
+    - if sriovOn true should be more then 0
+    type: bool
+    required: True
+
+"""
+
+EXAMPLES = r"""
+- name: enable SR-IOV on vmnic0 with 8 functions
+  vmware_host_sriov:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi1 }}"
+    validate_certs: no
+    vmnic: vmnic0
+    sriovOn: true
+    numVirtFunc: 8
+
+- name: enable SR-IOV on already enabled interface vmnic0
+  vmware_host_sriov:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi1 }}"
+    validate_certs: no
+    vmnic: vmnic0
+    sriovOn: true
+    numVirtFunc: 8
+
+- name: enable SR-IOV on vmnic0 with big num. of functions
+  vmware_host_sriov:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi1 }}"
+    validate_certs: no
+    vmnic: vmnic0
+    sriovOn: true
+    numVirtFunc: 100
+  ignore_errors: yes
+
+- name: disable SR-IOV on vmnic0
+  vmware_host_sriov:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi1 }}"
+    validate_certs: no
+    vmnic: vmnic0
+    sriovOn: false
+    numVirtFunc: 0
+"""
+
+RETURN = r"""
+    description:
+    - contains info about SR-IOV staus on vmnic before, after and requested changes 
+    - sometimes vCenter slowly update info, as result "after" contains same info as "before"
+      need to run again in check_mode or reboot host, as ESXi requested 
+    returned: always
+    type: dict
+    "sample": {
+        "changed": true,
+        "diff": {
+            "after": {
+                "host_test": {
+                    "sriovActive": false,
+                    "sriovEnabled": true,
+                    "maxVirtualFunctionSupported": 63,
+                    "numVirtualFunction": 0,
+                    "numVirtualFunctionRequested": 8,
+                    "rebootRequired": true,
+                    "sriovCapable": true
+                }
+            },
+            "before": {
+                "host_test": {
+                    "sriovActive": false,
+                    "sriovEnabled": false,
+                    "maxVirtualFunctionSupported": 63,
+                    "numVirtualFunction": 0,
+                    "numVirtualFunctionRequested": 0,
+                    "rebootRequired": false,
+                    "sriovCapable": true
+                }
+            },
+            "changes": {
+                "host_test": {
+                    "numVirtualFunction": 8,
+                    "rebootRequired": true,
+                    "sriovEnabled": true
+                }
+            }
+        }
+"""
+
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
+from ansible.module_utils._text import to_native
+from time import sleep
+
+
+class VmwareAdapterConfigManager(PyVmomi):
+    """Class to manage configured NTP servers"""
+
+    def __init__(self, module):
+        super(VmwareAdapterConfigManager, self).__init__(module)
+        cluster_name = self.params.get("cluster_name", None)
+        esxi_host_name = self.params.get("esxi_hostname", None)
+
+        self.vmnic = self.params.get("vmnic", None)
+        self.sriovOn = self.params.get("sriovOn", None)
+        self.numVirtFunc = self.params.get("numVirtFunc", None)
+
+        self.hosts = self.get_all_host_objs(
+            cluster_name=cluster_name, esxi_host_name=esxi_host_name
+        )
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system.")
+        # self.change_list = []
+        self.results = {"before": {}, "after": {}, "changes": {}}
+
+    def set_host_state(self):
+        """Check ESXi host configuration"""
+        change_list = []
+        changed = False
+        for host in self.hosts:
+            self.results["before"][host.name] = {}
+            self.results["after"][host.name] = {}
+            self.results["changes"][host.name] = {}
+            self.results["before"][host.name] = self._check_sriov(host)
+            self.results["changes"][host.name]["rebootRequired"] = self.results[
+                "before"
+            ][host.name]["rebootRequired"]
+
+            # check compatability
+            if not self.results["before"][host.name]["sriovCapable"]:
+                change_list.append(False)
+                self.results["changes"][host.name][
+                    "msg"
+                ] = "sriov not supported on host= %s, nic= %s" % (host.name, self.vmnic)
+                self.results["after"][host.name] = self._check_sriov(host)
+                continue
+
+            if (
+                self.results["before"][host.name]["maxVirtualFunctionSupported"]
+                < self.numVirtFunc
+            ):
+                change_list.append(False)
+                maxVirtualFun = self.results["before"][host.name][
+                    "maxVirtualFunctionSupported"
+                ]
+                self.results["changes"][host.name]["msg"] = (
+                    "maxVirtualFunctionSupported= %d on %s"
+                    % (maxVirtualFun, self.vmnic)
+                )
+                self.results["after"][host.name] = self._check_sriov(host)
+                continue
+
+            # check current settings
+            params_to_change = {"sriovEnabled": None, "numVirtualFunction": None}
+            if self.results["before"][host.name]["sriovEnabled"] != self.sriovOn:
+                params_to_change["sriovEnabled"] = self.sriovOn
+
+            if (
+                self.results["before"][host.name]["numVirtualFunction"]
+                != self.numVirtFunc
+            ):
+                params_to_change["numVirtualFunction"] = self.numVirtFunc
+
+            success = self._update_sriov(host, **params_to_change)
+            if success:
+                change_list.append(True)
+            else:
+                change_list.append(False)
+
+            self.results["after"][host.name] = self._check_sriov(host)
+            self.results["changes"][host.name]["rebootRequired"] = self.results[
+                "after"
+            ][host.name]["rebootRequired"]
+
+        if any(change_list):
+            changed = True
+        self.module.exit_json(changed=changed, diff=self.results)
+
+    def _check_sriov(self, host):
+        pnic_info = {}
+        pnic_info["rebootRequired"] = host.summary.rebootRequired
+        for pci_device in host.configManager.pciPassthruSystem.pciPassthruInfo:
+            if pci_device.id == self._getPciId(host):
+                try:
+                    if pci_device.sriovCapable:
+                        pnic_info["sriovCapable"] = True
+                        pnic_info["sriovEnabled"] = pci_device.sriovEnabled
+                        pnic_info["sriovActive"] = pci_device.sriovActive
+                        pnic_info["numVirtualFunction"] = pci_device.numVirtualFunction
+                        pnic_info[
+                            "numVirtualFunctionRequested"
+                        ] = pci_device.numVirtualFunctionRequested
+                        pnic_info[
+                            "maxVirtualFunctionSupported"
+                        ] = pci_device.maxVirtualFunctionSupported
+                    else:
+                        pnic_info["sriovCapable"] = False
+                except AttributeError:
+                    pnic_info["sriovCapable"] = False
+                break
+        return pnic_info
+
+    def _getPciId(self, host):
+        for pnic in host.config.network.pnic:
+            if pnic.device == self.vmnic:
+                return pnic.pci
+        self.module.fail_json(msg="No nic= %s on host= %s" % (self.vmnic, host.name))
+
+    def _update_sriov(self, host, sriovEnabled=None, numVirtualFunction=None):
+        if sriovEnabled is None and numVirtualFunction is None:
+            self.results["changes"][host.name][
+                "msg"
+            ] = "No any changes, already configured"
+            return False
+        nic_sriov = vim.host.SriovConfig()
+        nic_sriov.id = self._getPciId(host)
+        if sriovEnabled is not None:
+            nic_sriov.sriovEnabled = sriovEnabled
+            self.results["changes"][host.name]["sriovEnabled"] = sriovEnabled
+        if numVirtualFunction is not None and numVirtualFunction >= 0:
+            nic_sriov.numVirtualFunction = numVirtualFunction
+            self.results["changes"][host.name][
+                "numVirtualFunction"
+            ] = numVirtualFunction
+
+        try:
+            if not self.module.check_mode:
+                host.configManager.pciPassthruSystem.UpdatePassthruConfig([nic_sriov])
+                # looks only for refresh info
+                host.configManager.pciPassthruSystem.Refresh()
+                sleep(2)  # TODO: needed method to know that host updated info
+                return True
+            return False
+        except vim.fault.HostConfigFault as config_fault:
+            self.module.fail_json(
+                msg="Failed to configure SR-IOV for host= %s due to : %s"
+                % (host.name, to_native(config_fault.msg))
+            )
+            return False
+
+
+def main():
+    """Main"""
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        cluster_name=dict(type="str", required=False),
+        esxi_hostname=dict(type="str", required=False),
+        vmnic=dict(type="str", required=True),
+        sriovOn=dict(type="bool", required=True),
+        numVirtFunc=dict(type="int", required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[["cluster_name", "esxi_hostname"], ["sriovOn", "numVirtFunc"]],
+        supports_check_mode=True,
+    )
+
+    vmware_host_adapter_config = VmwareAdapterConfigManager(module)
+    vmware_host_adapter_config.set_host_state()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -17,7 +17,7 @@ module: vmware_host_sriov
 short_description: Manage SR-IOV settings on host
 description:
 - This module can be used to configure, enable/disable SR-IOV functions on ESXi host.
-- module didn't reboot host after changes, but put in output "rebootRequired" key.
+- Module doesn't  reboot the host after changes, but puts it in output "rebootRequired" state.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
 version_added: "2.10"
 author:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -19,7 +19,7 @@ description:
 - This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
 - module didn't reboot host after changes, but put in output "rebootRequired" key.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
-version_added: 2.9
+version_added: 2.10
 author:
 - Viktor Tsymbalyuk (@victron)
 notes:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -178,7 +178,6 @@ class VmwareAdapterConfigManager(PyVmomi):
         )
         if not self.hosts:
             self.module.fail_json(msg="Failed to find host system.")
-        # self.change_list = []
         self.results = {"before": {}, "after": {}, "changes": {}}
 
     def set_host_state(self):

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -339,12 +339,11 @@ class VmwareAdapterConfigManager(PyVmomi):
                 return pnic.pci
         self.module.fail_json(msg="No nic= %s on host= %s" % (self.vmnic, host.name))
 
-    def _update_sriov(self, host, sriovEnabled=None, numVirtualFunction=None, **kwargs):
+    def _update_sriov(self, host, sriovEnabled, numVirtualFunction):
         nic_sriov = vim.host.SriovConfig()
         nic_sriov.id = self._getPciId(host)
         nic_sriov.sriovEnabled = sriovEnabled
         nic_sriov.numVirtualFunction = numVirtualFunction
-        self.results["changes"][host.name] = kwargs["changes"]
 
         try:
             if not self.module.check_mode:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -51,8 +51,8 @@ options:
   num_virt_func:
     description:
     - number of functions to activate on interface.
-    - if sriovOn false should be equal 0
-    - if sriovOn true should be more then 0
+    - if sriov_on false should be equal 0
+    - if sriov_on true should be more then 0
     type: int
     required: True
 extends_documentation_fragment: vmware.documentation
@@ -67,8 +67,8 @@ EXAMPLES = r"""
     esxi_hostname: "{{ esxi1 }}"
     validate_certs: no
     vmnic: vmnic0
-    sriovOn: true
-    numVirtFunc: 8
+    sriov_on: true
+    num_virt_func: 8
 
 - name: enable SR-IOV on already enabled interface vmnic0
   vmware_host_sriov:
@@ -78,8 +78,8 @@ EXAMPLES = r"""
     esxi_hostname: "{{ esxi1 }}"
     validate_certs: no
     vmnic: vmnic0
-    sriovOn: true
-    numVirtFunc: 8
+    sriov_on: true
+    num_virt_func: 8
 
 - name: enable SR-IOV on vmnic0 with big num. of functions
   vmware_host_sriov:
@@ -89,8 +89,8 @@ EXAMPLES = r"""
     esxi_hostname: "{{ esxi1 }}"
     validate_certs: no
     vmnic: vmnic0
-    sriovOn: true
-    numVirtFunc: 100
+    sriov_on: true
+    num_virt_func: 100
   ignore_errors: yes
 
 - name: disable SR-IOV on vmnic0
@@ -101,8 +101,8 @@ EXAMPLES = r"""
     esxi_hostname: "{{ esxi1 }}"
     validate_certs: no
     vmnic: vmnic0
-    sriovOn: false
-    numVirtFunc: 0
+    sriov_on: false
+    num_virt_func: 0
 """
 
 RETURN = r"""
@@ -170,8 +170,8 @@ class VmwareAdapterConfigManager(PyVmomi):
         esxi_host_name = self.params.get("esxi_hostname", None)
 
         self.vmnic = self.params.get("vmnic", None)
-        self.sriovOn = self.params.get("sriovOn", None)
-        self.numVirtFunc = self.params.get("numVirtFunc", None)
+        self.sriov_on = self.params.get("sriov_on", None)
+        self.num_virt_func = self.params.get("num_virt_func", None)
 
         self.hosts = self.get_all_host_objs(
             cluster_name=cluster_name, esxi_host_name=esxi_host_name
@@ -204,7 +204,7 @@ class VmwareAdapterConfigManager(PyVmomi):
 
             if (
                 self.results["before"][host.name]["maxVirtualFunctionSupported"]
-                < self.numVirtFunc
+                < self.num_virt_func
             ):
                 change_list.append(False)
                 maxVirtualFun = self.results["before"][host.name][
@@ -219,14 +219,14 @@ class VmwareAdapterConfigManager(PyVmomi):
 
             # check current settings
             params_to_change = {"sriovEnabled": None, "numVirtualFunction": None}
-            if self.results["before"][host.name]["sriovEnabled"] != self.sriovOn:
-                params_to_change["sriovEnabled"] = self.sriovOn
+            if self.results["before"][host.name]["sriovEnabled"] != self.sriov_on:
+                params_to_change["sriovEnabled"] = self.sriov_on
 
             if (
                 self.results["before"][host.name]["numVirtualFunction"]
-                != self.numVirtFunc
+                != self.num_virt_func
             ):
-                params_to_change["numVirtualFunction"] = self.numVirtFunc
+                params_to_change["numVirtualFunction"] = self.num_virt_func
 
             success = self._update_sriov(host, **params_to_change)
             if success:
@@ -313,13 +313,13 @@ def main():
         cluster_name=dict(type="str", required=False),
         esxi_hostname=dict(type="str", required=False),
         vmnic=dict(type="str", required=True),
-        sriovOn=dict(type="bool", required=True),
-        numVirtFunc=dict(type="int", required=True),
+        sriov_on=dict(type="bool", required=True),
+        num_virt_func=dict(type="int", required=True),
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_one_of=[["cluster_name", "esxi_hostname"], ["sriovOn", "numVirtFunc"]],
+        required_one_of=[["cluster_name", "esxi_hostname"], ["sriov_on", "num_virt_func"]],
         supports_check_mode=True,
     )
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -218,8 +218,7 @@ class VmwareAdapterConfigManager(PyVmomi):
 
             # check compatability
             if not before["sriovCapable"]:
-                self.module.fail_json(
-                    "sriov not supported on host= %s, nic= %s" % (hostname, vmnic)
+                self.module.fail_json(msg="sriov not supported on host= %s, nic= %s" % (hostname, vmnic)
                 )
 
             if (
@@ -238,14 +237,17 @@ class VmwareAdapterConfigManager(PyVmomi):
             ]
             params_to_change["change"] = True
         if before["numVirtualFunction"] != params_to_change["numVirtualFunction"]:
-            params_to_change["changes"]["numVirtualFunction"] = params_to_change[
-                "numVirtualFunction"
-            ]
-            params_to_change["change"] = True
+            if before["numVirtualFunctionRequested"] != params_to_change["numVirtualFunction"]:
+                params_to_change["changes"]["numVirtualFunction"] = params_to_change[
+                    "numVirtualFunction"
+                ]
+                params_to_change["change"] = True
+            else:
+                params_to_change["changes"]["msg"] = "Not active (looks not rebooted) "
 
         if not params_to_change["change"]:
-            params_to_change["changes"]["msg"] = "No any changes, already configured"
-
+            msg = params_to_change["changes"].get("msg", "") + "No any changes, already configured "
+            params_to_change["changes"]["msg"] = msg
         return params_to_change
 
     def set_host_state(self):

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -43,7 +43,7 @@ options:
     - interface name, like vmnic0
     type: str
     required: True
-  sriovOn:
+  sriov_on:
     description:
     - Desired SR-IOV state on interface.
     type: bool

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -19,7 +19,7 @@ description:
 - This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
 - module didn't reboot host after changes, but put in output "rebootRequired" key.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
-
+version_added: 2.9
 author:
 - Viktor Tsymbalyuk (@victron)
 notes:
@@ -28,14 +28,6 @@ requirements:
 - python >= 2.6
 - PyVmomi
 options:
-  hostname:
-    version_added: "2.9"
-    aliases: ['host']
-  port:
-    version_added: "2.9"
-  username:
-    version_added: "2.9"
-    aliases: ['login']
   esxi_hostname:
     description:
     - Name of the host system to work with.
@@ -45,19 +37,7 @@ options:
     description:
     - Name of the cluster from which all host systems will be used.
     - This parameter is required if C(esxi_hostname) is not specified.
-    type: str                                       
-  password:                                                 
-    description:                                            
-    - The password to authenticate on the vCenter server.  
-    aliases: ['pass', 'pwd'] 
-    type: str                                               
-    required: true  
-  validate_certs:
-    description:
-    - If C(no), SSL certificates will not be validated. This should only be
-      set to C(no) when no other option exists.
-    type: bool
-    default: yes                                        
+    type: str
   vmnic:
     description:
     - interface name, like vmnic0
@@ -73,9 +53,9 @@ options:
     - number of functions to activate on interface
     - if sriovOn false should be equal 0
     - if sriovOn true should be more then 0
-    type: bool
+    type: int
     required: True
-
+extends_documentation_fragment: vmware.documentation
 """
 
 EXAMPLES = r"""
@@ -128,9 +108,9 @@ EXAMPLES = r"""
 RETURN = r"""
 host_sriov_diff:
     description:
-    - contains info about SR-IOV staus on vmnic before, after and requested changes 
+    - contains info about SR-IOV staus on vmnic before, after and requested changes
     - sometimes vCenter slowly update info, as result "after" contains same info as "before"
-      need to run again in check_mode or reboot host, as ESXi requested 
+      need to run again in check_mode or reboot host, as ESXi requested
     returned: always
     type: dict
     "sample": {
@@ -166,6 +146,7 @@ host_sriov_diff:
                 }
             }
         }
+    }
 """
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -260,11 +260,11 @@ class VmwareAdapterConfigManager(PyVmomi):
         return params_to_change
 
     def set_host_state(self):
-        """Checking and applying ESXi host configuration one by one, 
+        """Checking and applying ESXi host configuration one by one,
         from prepared list of hosts in `self.hosts`.
         For every host applied:
-        - user input checking done via calling `sanitize_params` method 
-        - changes applied via calling `_update_sriov` method 
+        - user input checking done via calling `sanitize_params` method
+        - changes applied via calling `_update_sriov` method
         - host state before and after via calling `_check_sriov`
         """
         change_list = []

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -45,7 +45,7 @@ options:
     required: True
   sriovOn:
     description:
-    - desired SR-IOV state on interface
+    - Desired SR-IOV state on interface.
     type: bool
     required: True
   numVirtFunc:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -50,7 +50,7 @@ options:
     required: True
   numVirtFunc:
     description:
-    - number of functions to activate on interface
+    - number of functions to activate on interface.
     - if sriovOn false should be equal 0
     - if sriovOn true should be more then 0
     type: int

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -196,14 +196,14 @@ class VmwareAdapterConfigManager(PyVmomi):
                 self.module.fail_json(
                     msg="with sriov_on == true,  alowed value for num_virt_func > 0"
                 )
-            self.sriov_on = False  # fill value, if urser not provided
+            self.sriov_on = False  # fill value, if user not provided
 
         if self.num_virt_func > 0:
             if self.sriov_on is False:
                 self.module.fail_json(
                     msg="with sriov_on == false,  alowed value for num_virt_func is 0"
                 )
-            self.sriov_on = True  # fill value, if urser not provided
+            self.sriov_on = True  # fill value, if user not provided
 
     def check_compatibility(self, before, hostname):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -19,7 +19,7 @@ description:
 - This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
 - module didn't reboot host after changes, but put in output "rebootRequired" key.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
-version_added: 2.10
+version_added: "2.10"
 author:
 - Viktor Tsymbalyuk (@victron)
 notes:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -27,6 +28,14 @@ requirements:
 - python >= 2.6
 - PyVmomi
 options:
+  hostname:
+    version_added: "2.9"
+    aliases: ['host']
+  port:
+    version_added: "2.9"
+  username:
+    version_added: "2.9"
+    aliases: ['login']
   esxi_hostname:
     description:
     - Name of the host system to work with.
@@ -36,7 +45,19 @@ options:
     description:
     - Name of the cluster from which all host systems will be used.
     - This parameter is required if C(esxi_hostname) is not specified.
-    type: str
+    type: str                                       
+  password:                                                 
+    description:                                            
+    - The password to authenticate on the vCenter server.  
+    aliases: ['pass', 'pwd'] 
+    type: str                                               
+    required: true  
+  validate_certs:
+    description:
+    - If C(no), SSL certificates will not be validated. This should only be
+      set to C(no) when no other option exists.
+    type: bool
+    default: yes                                        
   vmnic:
     description:
     - interface name, like vmnic0
@@ -105,6 +126,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+host_sriov_diff:
     description:
     - contains info about SR-IOV staus on vmnic before, after and requested changes 
     - sometimes vCenter slowly update info, as result "after" contains same info as "before"
@@ -159,7 +181,7 @@ from time import sleep
 
 
 class VmwareAdapterConfigManager(PyVmomi):
-    """Class to manage configured NTP servers"""
+    """Class to configure SR-IOV settings"""
 
     def __init__(self, module):
         super(VmwareAdapterConfigManager, self).__init__(module)

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r"""
 module: vmware_host_sriov
 short_description: Manage SR-IOV settings on host
 description:
-- This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
+- This module can be used to configure, enable/disable SR-IOV functions on ESXi host.
 - module didn't reboot host after changes, but put in output "rebootRequired" key.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
 version_added: "2.10"

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -54,8 +54,8 @@ options:
     required: True
   sriov_on:
     description:
-    - optional parameter, related to num_virt_func.
-    - SR-IOV can be enabled only if num_virt_func > 0.
+    - optional parameter, related to C(num_virt_func).
+    - SR-IOV can be enabled only if C(num_virt_func) > 0.
     type: bool
     required: False
 extends_documentation_fragment: vmware.documentation
@@ -249,7 +249,7 @@ class VmwareAdapterConfigManager(PyVmomi):
                 ]
                 params_to_change["change"] = True
             else:
-                params_to_change["changes"]["msg"] = "Not active (looks not rebooted) "
+                params_to_change["changes"]["msg"] = "Not active (looks like not rebooted) "
 
         if not params_to_change["change"]:
             msg = (

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -48,7 +48,7 @@ options:
     - Desired SR-IOV state on interface.
     type: bool
     required: True
-  numVirtFunc:
+  num_virt_func:
     description:
     - number of functions to activate on interface.
     - if sriovOn false should be equal 0

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -187,7 +187,7 @@ class VmwareAdapterConfigManager(PyVmomi):
         :before     : dict, of params on target interface before changing
         :hostname   : str, hosthame
         :vmnic      : srt, target nic
-        :return     : dict, of params forwarded to vCenter, or raise fail in case iconsistancy 
+        :return     : dict, of params forwarded to vCenter, or raise fail in case iconsistancy
         """
         params_to_change = {
             "sriovEnabled": None,
@@ -201,14 +201,14 @@ class VmwareAdapterConfigManager(PyVmomi):
             self.module.fail_json(msg="allowed value for num_virt_func >= 0")
 
         if self.num_virt_func == 0:
-            if self.sriov_on == True:
+            if self.sriov_on is True:
                 self.module.fail_json(
                     msg="with sriov_on == true,  alowed value for num_virt_func > 0"
                 )
             params_to_change.update({"sriovEnabled": False, "numVirtualFunction": 0})
 
         if self.num_virt_func > 0:
-            if self.sriov_on == False:
+            if self.sriov_on is False:
                 self.module.fail_json(
                     msg="with sriov_on == false,  alowed value for num_virt_func is 0"
                 )
@@ -218,7 +218,8 @@ class VmwareAdapterConfigManager(PyVmomi):
 
             # check compatability
             if not before["sriovCapable"]:
-                self.module.fail_json(msg="sriov not supported on host= %s, nic= %s" % (hostname, vmnic)
+                self.module.fail_json(
+                    msg="sriov not supported on host= %s, nic= %s" % (hostname, vmnic)
                 )
 
             if (
@@ -237,7 +238,10 @@ class VmwareAdapterConfigManager(PyVmomi):
             ]
             params_to_change["change"] = True
         if before["numVirtualFunction"] != params_to_change["numVirtualFunction"]:
-            if before["numVirtualFunctionRequested"] != params_to_change["numVirtualFunction"]:
+            if (
+                before["numVirtualFunctionRequested"]
+                != params_to_change["numVirtualFunction"]
+            ):
                 params_to_change["changes"]["numVirtualFunction"] = params_to_change[
                     "numVirtualFunction"
                 ]
@@ -246,7 +250,10 @@ class VmwareAdapterConfigManager(PyVmomi):
                 params_to_change["changes"]["msg"] = "Not active (looks not rebooted) "
 
         if not params_to_change["change"]:
-            msg = params_to_change["changes"].get("msg", "") + "No any changes, already configured "
+            msg = (
+                params_to_change["changes"].get("msg", "")
+                + "No any changes, already configured "
+            )
             params_to_change["changes"]["msg"] = msg
         return params_to_change
 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_sriov.py
@@ -25,7 +25,7 @@ author:
 notes:
 - Tested on vSphere 6.0
 requirements:
-- python >= 2.6
+- python >= 2.7
 - PyVmomi
 options:
   esxi_hostname:

--- a/test/integration/targets/vmware_host_sriov/aliases
+++ b/test/integration/targets/vmware_host_sriov/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_host_sriov/tasks/main.yml
+++ b/test/integration/targets/vmware_host_sriov/tasks/main.yml
@@ -15,8 +15,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: true
-        numVirtFunc: 8
+        sriov_on: true
+        num_virt_func: 8
       register: present
     - debug: var=present
 
@@ -28,8 +28,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: true
-        numVirtFunc: 8
+        sriov_on: true
+        num_virt_func: 8
       register: present
     - debug: var=present
 
@@ -41,8 +41,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: true
-        numVirtFunc: 100
+        sriov_on: true
+        num_virt_func: 100
       ignore_errors: yes
       register: present
     - debug: var=present
@@ -55,8 +55,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: true
-        numVirtFunc: 10
+        sriov_on: true
+        num_virt_func: 10
       register: present
     - debug: var=present
 
@@ -68,8 +68,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: false
-        numVirtFunc: 0
+        sriov_on: false
+        num_virt_func: 0
       register: present
     - debug: var=present
 
@@ -81,8 +81,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: true
-        numVirtFunc: 10
+        sriov_on: true
+        num_virt_func: 10
       check_mode: yes
       register: present
     - debug: var=present
@@ -95,8 +95,8 @@
         esxi_hostname: "{{ esxi1 }}"
         validate_certs: no
         vmnic: vmnic0
-        sriovOn: false
-        numVirtFunc: 1
+        sriov_on: false
+        num_virt_func: 1
       check_mode: yes
       register: present
     - debug: var=present

--- a/test/integration/targets/vmware_host_sriov/tasks/main.yml
+++ b/test/integration/targets/vmware_host_sriov/tasks/main.yml
@@ -100,5 +100,3 @@
       check_mode: yes
       register: present
     - debug: var=present
-
-

--- a/test/integration/targets/vmware_host_sriov/tasks/main.yml
+++ b/test/integration/targets/vmware_host_sriov/tasks/main.yml
@@ -87,7 +87,7 @@
       register: present
     - debug: var=present
 
-    - name: eanble SR-IOV on vmnic0, check mode
+    - name: disable SR-IOV with num_virt_func == 1, check mode 
       vmware_host_sriov:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"

--- a/test/integration/targets/vmware_host_sriov/tasks/main.yml
+++ b/test/integration/targets/vmware_host_sriov/tasks/main.yml
@@ -1,0 +1,104 @@
+# Test code for the  module vmware_host_sriov
+
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+
+    - name: enable SR-IOV on vmnic0 with 8 functions
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: true
+        numVirtFunc: 8
+      register: present
+    - debug: var=present
+
+    - name: enable SR-IOV on already enabled interface vmnic0
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: true
+        numVirtFunc: 8
+      register: present
+    - debug: var=present
+
+    - name: enable SR-IOV on vmnic0 with big num. of functions
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: true
+        numVirtFunc: 100
+      ignore_errors: yes
+      register: present
+    - debug: var=present
+
+    - name: change num of functions only
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: true
+        numVirtFunc: 10
+      register: present
+    - debug: var=present
+
+    - name: disable SR-IOV on vmnic0
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: false
+        numVirtFunc: 0
+      register: present
+    - debug: var=present
+
+    - name: change num of functions only, check mode
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: true
+        numVirtFunc: 10
+      check_mode: yes
+      register: present
+    - debug: var=present
+
+    - name: eanble SR-IOV on vmnic0, check mode
+      vmware_host_sriov:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi1 }}"
+        validate_certs: no
+        vmnic: vmnic0
+        sriovOn: false
+        numVirtFunc: 1
+      check_mode: yes
+      register: present
+    - debug: var=present
+
+

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -1,0 +1,194 @@
+import unittest
+from unittest import mock
+
+from ansible.modules.cloud.vmware import vmware_host_sriov
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
+from ansible.module_utils._text import to_native
+
+
+mock_host = mock.Mock()
+mock_host.name = "test_host"
+tests = [
+    # 1. normal activate
+    {
+        "pnic_info": {
+            "sriovCapable": True,
+            "sriovEnabled": False,
+            "sriovActive": False,
+            "numVirtualFunction": 0,
+            "numVirtualFunctionRequested": 0,
+            "maxVirtualFunctionSupported": 64,
+            "rebootRequired": True,
+        },
+        "mock_attrs": {
+            "hostname": "test_vCenter",
+            "esxi_host_name": "test_host",
+            "sriovOn": True,
+            "numVirtFunc": 8,
+            "vmnic": "vmnic7",
+            "results": {"before": {}, "after": {}, "changes": {}},
+            "hosts": [mock_host],
+        },
+        "changes": {
+            "test_host": {
+                "rebootRequired": True,
+                "sriovEnabled": True,
+                "numVirtualFunction": 8,
+            }
+        },
+    },
+    # 2. already eanabled
+    {
+        "pnic_info": {
+            "sriovCapable": True,
+            "sriovEnabled": True,
+            "sriovActive": False,
+            "numVirtualFunction": 8,
+            "numVirtualFunctionRequested": 8,
+            "maxVirtualFunctionSupported": 64,
+            "rebootRequired": True,
+        },
+        "mock_attrs": {
+            "hostname": "test_vCenter",
+            "esxi_host_name": "test_host",
+            "sriovOn": True,
+            "numVirtFunc": 8,
+            "vmnic": "vmnic7",
+            "results": {"before": {}, "after": {}, "changes": {}},
+            "hosts": [mock_host],
+        },
+        "changes": {
+            "test_host": {
+                "rebootRequired": True,
+                "msg": "No any changes, already configured",
+            }
+        },
+    },
+    # 3. already active
+    {
+        "pnic_info": {
+            "sriovCapable": True,
+            "sriovEnabled": True,
+            "sriovActive": True,
+            "numVirtualFunction": 8,
+            "numVirtualFunctionRequested": 8,
+            "maxVirtualFunctionSupported": 64,
+            "rebootRequired": False,
+        },
+        "mock_attrs": {
+            "hostname": "test_vCenter",
+            "esxi_host_name": "test_host",
+            "sriovOn": True,
+            "numVirtFunc": 8,
+            "vmnic": "vmnic7",
+            "results": {"before": {}, "after": {}, "changes": {}},
+            "hosts": [mock_host],
+        },
+        "changes": {
+            "test_host": {
+                "rebootRequired": False,
+                "msg": "No any changes, already configured",
+            }
+        },
+    },
+    # 4. not suported numVirtFunc
+    {
+        "pnic_info": {
+            "sriovCapable": True,
+            "sriovEnabled": True,
+            "sriovActive": True,
+            "numVirtualFunction": 8,
+            "numVirtualFunctionRequested": 8,
+            "maxVirtualFunctionSupported": 64,
+            "rebootRequired": False,
+        },
+        "mock_attrs": {
+            "hostname": "test_vCenter",
+            "esxi_host_name": "test_host",
+            "sriovOn": True,
+            "numVirtFunc": 100,
+            "vmnic": "vmnic7",
+            "results": {"before": {}, "after": {}, "changes": {}},
+            "hosts": [mock_host],
+        },
+        "changes": {
+            "test_host": {
+                "rebootRequired": False,
+                "msg": "maxVirtualFunctionSupported= 64 on vmnic7",
+            }
+        },
+    },
+    # 5. not supported sriov
+    {
+        "pnic_info": {
+            "sriovCapable": False,
+            "sriovEnabled": False,
+            "sriovActive": False,
+            "numVirtualFunction": 0,
+            "numVirtualFunctionRequested": 0,
+            "maxVirtualFunctionSupported": 0,
+            "rebootRequired": False,
+        },
+        "mock_attrs": {
+            "hostname": "test_vCenter",
+            "esxi_host_name": "test_host",
+            "sriovOn": True,
+            "numVirtFunc": 8,
+            "vmnic": "vmnic7",
+            "results": {"before": {}, "after": {}, "changes": {}},
+            "hosts": [mock_host],
+        },
+        "changes": {
+            "test_host": {
+                "rebootRequired": False,
+                "msg": "sriov not supported on host= test_host, nic= vmnic7",
+            }
+        },
+    },
+]
+
+
+class TestAdapterMethods(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @mock.patch.object(
+        vmware_host_sriov.VmwareAdapterConfigManager,
+        "_getPciId",
+        return_value="0000:87:00.1",
+    )
+    @mock.patch.object(
+        vmware_host_sriov.VmwareAdapterConfigManager,
+        "_check_sriov",
+        # there is 2 call _check_sriov in test, need duplicate
+        side_effect=[i["pnic_info"] for i in tests for _ in range(2)],
+    )
+    @mock.patch.object(
+        vmware_host_sriov.VmwareAdapterConfigManager, "__init__", return_value=None
+    )
+    def test_check_host_state(self, mock__init__, mock__check_sriov, mock__getPciId):
+        check_sriov_count = 0
+        for case in tests:
+            config = vmware_host_sriov.VmwareAdapterConfigManager()
+            config.module = mock.Mock()
+            config.module.check_mode = False
+            config.__dict__.update(case["mock_attrs"])
+            config.set_host_state()
+            self.assertEqual(
+                config.results["changes"],
+                case["changes"],
+                'wrong "changes" in "result"',
+            )
+            check_sriov_count += 2
+            self.assertEqual(
+                mock__check_sriov.call_count,
+                check_sriov_count,
+                "mock__check_sriov called mor or less 2 times",
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -3,8 +3,8 @@ __metaclass__ = type
 
 # do not execute test if mock is not available
 import sys
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    exit()
+if sys.version_info[0] < 3 and sys.version_info[1] < 7:
+    exit(0)
 
 import unittest
 from unittest import mock

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -25,10 +25,11 @@ def gen_mock_attrs(user_input):
     mock_attrs["hosts"] = [mock_host]
     return mock_attrs
 
+
 class AnsibleFailJson(Exception):
     """Exception class to be raised by module.fail_json and caught by the test case"""
     pass
- 
+
 
 def set_module_args(args):
     """prepare arguments so that they will be picked up during module creation"""

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -1,3 +1,11 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+# do not execute test if mock is not available
+import sys
+if sys.version_info[0] == 2 and sys.version.info[1] < 7:
+    exit()
+
 import unittest
 from unittest import mock
 
@@ -165,7 +173,7 @@ class TestAdapterMethods(unittest.TestCase):
         vmware_host_sriov.VmwareAdapterConfigManager,
         "_check_sriov",
         # there is 2 call _check_sriov in test, need duplicate
-        side_effect=[i["pnic_info"] for i in tests for _ in range(2)],
+        side_effect=[i["pnic_info"] for i in tests for ii in range(2)],
     )
     @mock.patch.object(
         vmware_host_sriov.VmwareAdapterConfigManager, "__init__", return_value=None

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 # do not execute test if mock is not available
 import sys
-if sys.version_info[0] == 2 and sys.version.info[1] < 7:
+if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     exit()
 
 import unittest
@@ -197,6 +197,7 @@ class TestAdapterMethods(unittest.TestCase):
                 check_sriov_count,
                 "mock__check_sriov called mor or less 2 times",
             )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -1,13 +1,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-# do not execute test if mock is not available
-import sys
-if sys.version_info[0] < 3 and sys.version_info[1] < 7:
-    exit(0)
-
-import unittest
-from unittest import mock
+from units.compat import mock
+from units.compat import unittest
 
 from ansible.modules.cloud.vmware import vmware_host_sriov
 from ansible.module_utils.basic import AnsibleModule

--- a/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
+++ b/test/units/modules/cloud/vmware/test_vmware_host_sriov.py
@@ -32,8 +32,8 @@ tests = [
         "mock_attrs": {
             "hostname": "test_vCenter",
             "esxi_host_name": "test_host",
-            "sriovOn": True,
-            "numVirtFunc": 8,
+            "sriov_on": True,
+            "num_virt_func": 8,
             "vmnic": "vmnic7",
             "results": {"before": {}, "after": {}, "changes": {}},
             "hosts": [mock_host],
@@ -60,8 +60,8 @@ tests = [
         "mock_attrs": {
             "hostname": "test_vCenter",
             "esxi_host_name": "test_host",
-            "sriovOn": True,
-            "numVirtFunc": 8,
+            "sriov_on": True,
+            "num_virt_func": 8,
             "vmnic": "vmnic7",
             "results": {"before": {}, "after": {}, "changes": {}},
             "hosts": [mock_host],
@@ -87,8 +87,8 @@ tests = [
         "mock_attrs": {
             "hostname": "test_vCenter",
             "esxi_host_name": "test_host",
-            "sriovOn": True,
-            "numVirtFunc": 8,
+            "sriov_on": True,
+            "num_virt_func": 8,
             "vmnic": "vmnic7",
             "results": {"before": {}, "after": {}, "changes": {}},
             "hosts": [mock_host],
@@ -100,7 +100,7 @@ tests = [
             }
         },
     },
-    # 4. not suported numVirtFunc
+    # 4. not suported num_virt_func
     {
         "pnic_info": {
             "sriovCapable": True,
@@ -114,8 +114,8 @@ tests = [
         "mock_attrs": {
             "hostname": "test_vCenter",
             "esxi_host_name": "test_host",
-            "sriovOn": True,
-            "numVirtFunc": 100,
+            "sriov_on": True,
+            "num_virt_func": 100,
             "vmnic": "vmnic7",
             "results": {"before": {}, "after": {}, "changes": {}},
             "hosts": [mock_host],
@@ -141,8 +141,8 @@ tests = [
         "mock_attrs": {
             "hostname": "test_vCenter",
             "esxi_host_name": "test_host",
-            "sriovOn": True,
-            "numVirtFunc": 8,
+            "sriov_on": True,
+            "num_virt_func": 8,
             "vmnic": "vmnic7",
             "results": {"before": {}, "after": {}, "changes": {}},
             "hosts": [mock_host],


### PR DESCRIPTION
##### SUMMARY
Add a new module for changing SR-IOV settings on host interface

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_host_sriov

##### ADDITIONAL INFORMATION
- This module can be used to configure, enable/disable SR-IOV functions an ESXi host.
- module didn't reboot host after changes, but put in output "rebootRequired" key from vCenter status
- tested on VMware 6.0

