### PR TITLE
Prevents generating roles that do not pass linting

### DIFF
--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -50,6 +50,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
-  {% for dependency in dependencies %}
+{% for dependency in dependencies %}
   #- {{ dependency }}
-  {%- endfor %}
+{%- endfor %}

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -47,6 +47,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
-  {%- for dependency in dependencies %}
+{%- for dependency in dependencies %}
   #- {{ dependency }}
-  {%- endfor %}
+{%- endfor %}

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -57,6 +57,6 @@ dependencies: []
   # List your role dependencies here, one per line.
   # Be sure to remove the '[]' above if you add dependencies
   # to this list.
-  {%- for dependency in dependencies %}
+{%- for dependency in dependencies %}
   #- {{ dependency }}
-  {%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
##### SUMMARY
Fixes bug where newly created role fails linting due to extra space
at end of line: [201] Trailing whitespace

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ADDITIONAL INFORMATION
This was found while trying to switch molecule from using internal templates to use of galaxy templates for creating new roles. This uncovered that newly created roles did not pass ansible-lint tests due to this bug.

Related: #63734