### PR TITLE
Find files/directories by owner or group

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -372,11 +372,11 @@ def statinfo(st):
 
 def filterbyownerandgroup(path, uid, gid):
     path_stat = os.stat(path)
-    if uid != -1 and path_stat.st_uid == uid:
+    if uid is not None and path_stat.st_uid == uid:
         return True
-    elif gid != -1 and path_stat.st_gid == gid:
+    elif gid is not None and path_stat.st_gid == gid:
         return True
-    elif uid == -1 and gid == -1:
+    elif uid is None and gid is None:
         return True
     else:
         return False
@@ -433,20 +433,16 @@ def main():
     now = time.time()
     msg = ''
     looked = 0
-    search_uid = -1
-    search_gid = -1
-    if params['owner']:
-        search_uid = pwd.getpwnam(params['owner'])[2]
-    if params['group']:
-        search_gid = grp.getgrnam(params['group'])[2]
+    uid = params['owner']
+    gid = params['group']
 
     for npath in params['paths']:
         npath = os.path.expanduser(os.path.expandvars(npath))
         if os.path.isdir(npath):
             ''' ignore followlinks for python version < 2.6 '''
             for root, dirs, files in (sys.version_info < (2, 6, 0) and os.walk(npath)) or os.walk(npath, followlinks=params['follow']):
-                dirs = list(filter(lambda dir: True if filterbyownerandgroup(os.path.join(root, dir), search_uid, search_gid) else False, dirs))
-                files = list(filter(lambda file: True if filterbyownerandgroup(os.path.join(root, file), search_uid, search_gid) else False, files))
+                dirs = list(filter(lambda dir: True if filterbyownerandgroup(os.path.join(root, dir), uid, gid) else False, dirs))
+                files = list(filter(lambda file: True if filterbyownerandgroup(os.path.join(root, file), uid, gid) else False, files))
                 if params['depth']:
                     depth = root.replace(npath.rstrip(os.path.sep), '').count(os.path.sep)
                     if files or dirs:

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -130,7 +130,7 @@ options:
             - Group must exist in the system otherwise the task will fail
             - Default is any group
         type: str
-        version_added: "2.10"   
+        version_added: "2.10"
 seealso:
 - module: win_find
 '''

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -119,19 +119,18 @@ options:
         version_added: "2.6"
     owner:
         description:
-            - Find the list of files whose owner matches the owner specified 
+            - Find the list of files whose owner matches the owner specified
             - Owner must exist in the system otherwise the task will fail
             - Default is any owner
         type: str
         version_added: "2.10"
     group:
         description:
-            - Find the list of files whose group matches the group specified 
+            - Find the list of files whose group matches the group specified
             - Group must exist in the system otherwise the task will fail
             - Default is any group
         type: str
-        version_added: "2.10"
-        
+        version_added: "2.10"   
 seealso:
 - module: win_find
 '''
@@ -370,6 +369,7 @@ def statinfo(st):
         'isgid': bool(st.st_mode & stat.S_ISGID),
     }
 
+
 def filterbyownerandgroup(path, uid, gid):
     path_stat = os.stat(path)
     if uid is not None and path_stat.st_uid == uid:
@@ -380,6 +380,7 @@ def filterbyownerandgroup(path, uid, gid):
         return True
     else:
         return False
+
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
added owner and group field in find module, which helps to find the files/directories by group or owner.
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Find
##### ADDITIONAL INFORMATION
```
find:
  path: "<path>"
  owner: "<name of owner>" (If absent then searching from owner is omitted)
  group: "<name of group>" (If absent then searching from group is omitted)


```
