### PR TITLE
azure_rm: Fix missing ipConfiguration 'primary' attribute

### DIFF
--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -560,7 +560,7 @@ class AzureHost(object):
         # set nic-related values from the primary NIC first
         for nic in sorted(self.nics, key=lambda n: n.is_primary, reverse=True):
             # and from the primary IP config per NIC first
-            for ipc in sorted(nic._nic_model['properties']['ipConfigurations'], key=lambda i: i['properties']['primary'], reverse=True):
+            for ipc in sorted(nic._nic_model['properties']['ipConfigurations'], key=lambda i: i['properties'].get('primary', False), reverse=True):
                 private_ip = ipc['properties'].get('privateIPAddress')
                 if private_ip:
                     new_hostvars['private_ipv4_addresses'].append(private_ip)


### PR DESCRIPTION
If a NIC has no primary ipConfiguration, the 'primary' field returned
by Azure is set to 'null' thus removed from the 'nic_model'
ipConfigurations properties. Unfortunately the code generating the
hostvars dict. assumes the 'primary' key always exists, leading the
entire host parsing to fail.

This patch changes the way the 'primary' field is accessed by using the
dict. 'get' method with a default value set to 'False'.

Resolves #63721

Testing Done: Run ansible-inventory with an azure_rm plugin that points
to a resource group that contain a two VMs, on with a primary
ipConfiguration and another one without. Check that without the patch
the inventory output does not contain the VMs (or just the one with the
primary ipConfiguration set, depending on the VM names). Finally check
that with the patched azure_rm.py file, both VMs show up.