### PR TITLE
Update path to sanity test requirements.txt

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -29,7 +29,7 @@ To ensure that your module documentation matches your ``argument_spec``:
 
    .. code-block:: bash
 
-      pip install --user -r test/runner/requirements/sanity.txt
+      pip install --user -r test/sanity/requirements.txt
 
 #. run the ``validate-modules`` test::
 


### PR DESCRIPTION
##### SUMMARY

The path `test/runner/requirements/sanity.txt` does not exist.
Opening this PR based on the discussion from IRC #ansible-aws.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
sanity testing guide

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
<PrasadK_> Prasad Katti I am trying to run sanity tests but it seems my environment is missing some packages. I found a page that says `pip install --user -r test/runner/requirements/sanity.txt` should give me the required packages. But that looks like an old doc. I can't the file sanity.txt at that path. 3:12:00 PM 
<felixfontein> Felix Fontein PrasadK_: if you have docker, it's best to run the tests in a docker container by adding `--docker default` to the `ansible-test sanity` arguments 3:12:11 PM 
that container contains everything that is needed to run the sanity tests 3:13:15 PM 
also, I think the file is now test/sanity/requirements.txt 3:13:17 PM 
<PrasadK_> Prasad Katti thanks, that exactly what I was just trying out. :) 3:13:46 PM 
<felixfontein> Felix Fontein please create a docs PR to fix the path in the docs :) 3:14:06 PM 
<PrasadK_> Prasad Katti ah, okay. I will do that. 3:14:29 PM 
<felixfontein> Felix Fontein thanks a lot!
```
