### PR TITLE
Add a lookup plugin to retrieve latest tagged release version from a GitHub repository

### DIFF
--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -18,7 +18,6 @@ short_description: Get the latest tagged release version from a public Github re
 description:
   - This lookup returns the latest release tag of a public Github repository.
   - A future implementation will accept an optional Github token to allow lookup of private repositories.
-  - A future implementation will accept an optional version to look up a specific release, which defaults to the latest if not provided.
 options:
   repos:
     description: A list of Github repositories from which to retrieve versions.

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -34,7 +34,7 @@ seealso:
 EXAMPLES = r"""
 - name: Strip the 'v' out of the tag version, e.g. 'v1.0.0' -> '1.0.0'
   set_fact:
-    nvm_version: "{{ lookup('github_version', 'nvm-sh/nvm')[1:] }}"
+    nvm_version: "{{ lookup('github_version', 'ansible/ansible')[1:] }}"
 
 - name: Operate on multiple repositories
   git:

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -93,7 +93,7 @@ class LookupModule(LookupBase):
                 # ansible.module_utils.urls appears to handle the request errors for us
                 response = open_url('https://api.github.com/repos/%s/releases/latest' % repo,
                                     headers={'Accept': 'application/vnd.github.v3+json'}
-                           )
+                                   )
                 json_response = loads(response.read().decode('utf-8'))
 
                 version = json_response.get('tag_name')

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-#
 # (c) 2019, Ari Kalfus <dev@quantummadness.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -96,7 +93,7 @@ class LookupModule(LookupBase):
                 # ansible.module_utils.urls appears to handle the request errors for us
                 response = open_url('https://api.github.com/repos/%s/releases/latest' % repo,
                                     headers={'Accept': 'application/vnd.github.v3+json'}
-                )
+                           )
                 json_response = loads(response.read().decode('utf-8'))
 
                 version = json_response.get('tag_name')

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -64,7 +64,6 @@ from ansible.module_utils.urls import open_url
 
 from json import JSONDecodeError, loads
 from re import compile as regex_compile
-from urllib.error import URLError
 
 display = Display()
 

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -9,7 +9,7 @@ DOCUMENTATION = r"""
 lookup: github_version
 author:
   - Ari Kalfus (@artis3n) <dev@quantummadness.com>
-version_added: "2.8"
+version_added: "2.10"
 requirements:
   - json
   - re

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 lookup: github_version
 author:
-  - Ari Kalfus (@Artis3n) <dev@quantummadness.com>
+  - Ari Kalfus (@artis3n) <dev@quantummadness.com>
 version_added: "2.8"
 requirements:
   - json

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -1,6 +1,9 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
 # (c) 2019, Ari Kalfus <dev@quantummadness.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+# 
 # python 3 headers, required if submitting to Ansible
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -92,7 +95,7 @@ class LookupModule(LookupBase):
             try:
                 # ansible.module_utils.urls appears to handle the request errors for us
                 response = open_url('https://api.github.com/repos/%s/releases/latest' % repo,
-                    headers={'Accept': 'application/vnd.github.v3+json'}
+                                    headers={'Accept': 'application/vnd.github.v3+json'}
                 )
                 json_response = loads(response.read().decode('utf-8'))
 
@@ -100,7 +103,7 @@ class LookupModule(LookupBase):
                 if version is not None and len(version) != 0:
                     versions.append(version)
                 else:
-                    raise AnsibleError("Error extracting version from Github API response:\n%s" % github_request.text)
+                    raise AnsibleError("Error extracting version from Github API response:\n%s" % response.text)
             except JSONDecodeError as e:
                 raise AnsibleError("Error parsing JSON from Github API response: %s" % to_native(e))
 

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -1,0 +1,112 @@
+# (c) 2019, Ari Kalfus <dev@quantummadness.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# python 3 headers, required if submitting to Ansible
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+lookup: github_version
+author:
+  - Ari Kalfus (@Artis3n) <dev@quantummadness.com>
+version_added: "2.8"
+requirements:
+  - json
+  - re
+  - urllib
+short_description: Get the latest tagged release version from a public Github repository.
+description:
+  - This lookup returns the latest release tag of a public Github repository.
+  - A future implementation will accept an optional Github token to allow lookup of private repositories.
+  - A future implementation will accept an optional version to look up a specific release, which defaults to the latest if not provided.
+options:
+  repos:
+    description: A list of Github repositories from which to retrieve versions.
+    required: True
+notes:
+  - The version tag is returned however it is defined by the Github repository. Most repositories used the convention 'vX.X.X' for a tag, while some use 'X.X.X'. Some may use release tagging structures other than semver. This plugin does not perform opinionated formatting of the release tag structure. Users should format the value via filters after calling this plugin, if needed.
+seealso:
+  - name: Github Releases API
+    description: API documentation for retrieving the latest version of a release.
+    link: https://developer.github.com/v3/repos/releases/#get-the-latest-release
+"""
+
+EXAMPLES = r"""
+- name: Strip the 'v' out of the tag version, e.g. 'v1.0.0' -> '1.0.0'
+  set_fact:
+    nvm_version: "{{ lookup('github_version', 'nvm-sh/nvm')[1:] }}"
+
+- name: Operate on multiple repositories
+  git:
+    repo: https://github.com/{{ item }}.git
+    version: "{{ lookup('github_version', item) }}"
+    dest: "{{ lookup('env', 'HOME') }}/projects"
+  with_items:
+    - ansible/ansible
+    - ansible/molecule
+    - ansible/awx
+"""
+
+RETURN = r"""
+  _list:
+    description:
+      - List of latest Github repository version(s)
+    type: list
+"""
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+from ansible.module_utils._text import to_native
+
+from json import JSONDecodeError, loads
+from re import compile as regex_compile
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+display = Display()
+
+
+class LookupModule(LookupBase):
+
+    def run(self, repos, variables=None, **kwargs):
+        # lookups in general are expected to both take a list as input and output a list
+        # this is done so they work with the looping construct 'with_'.
+        versions = []
+
+        if len(repos) == 0:
+          raise AnsibleParserError("You must specify at least one repo name")
+
+        for repo in repos:
+
+            # https://regex101.com/r/CHm7eZ/1
+            valid_github_username_and_repo_name = regex_compile(r'[a-z\d\-]+\/[a-z\d\S]+')
+            if not repo or not valid_github_username_and_repo_name.match(repo):
+                # The Parser error indicates invalid options passed
+                raise AnsibleParserError("repo name is incorrectly formatted: %s" % repo)
+
+            display.debug("Github version lookup term: '%s'" % repo)
+
+            # Retrieve the Github API Releases JSON
+            try:
+                github_request = Request('https://api.github.com/repos/%s/releases/latest' % repo,
+                headers={ 'Accept': 'application/vnd.github.v3+json' }
+                )
+                response = urlopen(github_request)
+                json_response = loads(response.read().decode('utf-8'))
+
+                version = json_response.get('tag_name')
+                if version != None and len(version) != 0:
+                    versions.append(version)
+                else:
+                    raise AnsibleError("Error extracting version from Github API response:\n%s" % github_request.text)
+            # Any errors raised by the urllib library inherit from URLError
+            except URLError as e:
+                raise AnsibleError("Error communicating with the Github API: %s" % to_native(e))
+            except JSONDecodeError as e:
+                raise AnsibleError("Error parsing JSON from Github API response: %s" % to_native(e))
+
+            display.vvvv(u"Github version lookup using %s as repo" % repo)
+
+
+        return versions

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -92,8 +92,7 @@ class LookupModule(LookupBase):
             try:
                 # ansible.module_utils.urls appears to handle the request errors for us
                 response = open_url('https://api.github.com/repos/%s/releases/latest' % repo,
-                                    headers={'Accept': 'application/vnd.github.v3+json'}
-                                   )
+                                    headers={'Accept': 'application/vnd.github.v3+json'})
                 json_response = loads(response.read().decode('utf-8'))
 
                 version = json_response.get('tag_name')

--- a/lib/ansible/plugins/lookup/github_version.py
+++ b/lib/ansible/plugins/lookup/github_version.py
@@ -3,7 +3,7 @@
 #
 # (c) 2019, Ari Kalfus <dev@quantummadness.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# 
+
 # python 3 headers, required if submitting to Ansible
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -306,3 +306,23 @@
     that:
       - 'var_host_info[0] == ansible_host'
       - 'var_host_info[1] == ansible_connection'
+
+# Github version lookups
+
+- name: Test that retrieving a url works
+  set_fact:
+    ansible_github_version: "{{ lookup('github_version', 'ansible/ansible') }}"
+
+- name: Collect the version in a task
+  shell: |
+    set -o pipefail
+    curl https://api.github.com/repos/ansible/ansible/releases/latest | jq .tag_name
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: ansible_task_version
+
+- name: Assert that the version was retrieved
+  assert:
+    that:
+      - 'ansible_github_version == ansible_task_version'

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -309,7 +309,7 @@
 
 # Github version lookups
 
-- name: Test that retrieving a url works
+- name: Test that getting a version works
   set_fact:
     ansible_github_version: "{{ lookup('github_version', 'ansible/ansible') }}"
 

--- a/test/units/plugins/lookup/github_version.py
+++ b/test/units/plugins/lookup/github_version.py
@@ -1,0 +1,27 @@
+# (c) 2019 Ari Kalfus <dev@quantummadness.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+# TODO: Add the freaking tests
+# Test 1: correct format (ansible/ansible)
+# Test 2: correct format with symbols (test-name/whatever&happened*to#this@repo+name)
+# Test 3: incorrect format: spaces in repo name (test-name/a repo)
+# Test 4: incorrect format: symbols in orgname/username (not&allowed/repo)
+# Test 5: incorrect format: empty string
+# Test 6: incorrect format: missing repo name (empty list)

--- a/test/units/plugins/lookup/test_github_version.py
+++ b/test/units/plugins/lookup/test_github_version.py
@@ -17,6 +17,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 # TODO: Add the freaking tests
 # Test 1: correct format (ansible/ansible)


### PR DESCRIPTION
##### SUMMARY
A convenience lookup plugin to get the latest tagged release version of a Github repo. If the reviewers agree on getting this into this repo I will add the ability to use a github token in an env var to look up private repo versions.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
github_version

##### ADDITIONAL INFORMATION

###### Tests
I was unable to get local unit tests running following the [unit test doc instructions](https://docs.ansible.com/ansible/devel/dev_guide/testing_units.html#running-tests). Due to this I did not write unit tests for this plugin, which I would like to do before this is accepted. I did manually tests all of the cases I have commented in the unit test file, and it's working great.

For example, running `ansible-test units --python 3.6 apt` returns an error that `pytest` is not available in my venv. I can add that easily enough, but that should probably be installed as part of some local dev setup step that I must be missing.

###### Usage
You can accomplish this lookup plugin's behavior through 2 different methods in tasks:

1-task option:

```yaml
- name: Get the latest version
  shell: |
    set -o pipefail
    curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/ansible/ansible/releases/latest | jq .tag_name
  args:
    executable: /bin/bash
  changed_when: false
  register: ansible_version
```

2-task option, not using `shell`:

```yaml
- name: Ansible | Get latest release
  uri:
    url: https://api.github.com/repos/ansible/ansible/releases/latest
    headers:
      Accept: application/vnd.github.v3+json
    body_format: json
    return_content: yes
  register: terraform_release

- name: Ansible | Set version
  set_fact:
    # This removes the 'v' from the tag: 'v1.1.0' -> '1.1.0'
    ansible_version: "{{ terraform_release.json.tag_name[1:] }}"
```

Now you can simply use:

```yaml

- name: Ansible | Get latest release
  set_fact:
    ansible_version: "{{ lookup('github_version', 'ansible/ansible')[1:] }}"
```