### PR TITLE
Add realpath_safe to support special files

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -76,7 +76,7 @@ from ansible.module_utils.six import PY3, binary_type
 from ansible.module_utils.six.moves import zip
 from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.utils.display import Display
-from ansible.utils.path import makedirs_safe
+from ansible.utils.path import makedirs_safe, realpath_safe
 
 display = Display()
 
@@ -371,7 +371,7 @@ def script_is_client(filename):
 
 
 def get_file_vault_secret(filename=None, vault_id=None, encoding=None, loader=None):
-    this_path = os.path.realpath(os.path.expanduser(filename))
+    this_path = realpath_safe(os.path.expanduser(filename))
 
     if not os.path.exists(this_path):
         raise AnsibleError("The vault password file %s was not found" % this_path)

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -41,24 +41,24 @@ def realpath_safe(path):
         would change the existence of the file.
     '''
 
-    path = to_text(path, errors='surrogate_or_strict')
-    path = os.path.abspath(path)
+    b_path = to_bytes(path, errors='surrogate_or_strict', nonstring='passthru')
+    b_path = os.path.abspath(b_path)
 
-    real = os.path.realpath(path)
-    if os.path.exists(real) or not os.path.exists(path):
-        return real
+    b_real = os.path.realpath(b_path)
+    if os.path.exists(b_real) or not os.path.exists(b_path):
+        return to_text(b_real, errors='surrogate_or_strict')
 
-    root = os.path.abspath(os.sep)
-    head, tail = os.path.split(path)
-    while head != root:
-        realhead = os.path.realpath(head)
-        if os.path.isdir(realhead):
-            return os.path.join(realhead, tail)
-        head, name = os.path.split(head)
-        tail = os.path.join(name, tail)
+    b_root = to_bytes(os.path.abspath(os.sep), errors='surrogate_or_strict')
+    b_head, b_tail = os.path.split(b_path)
+    while b_head != b_root:
+        b_realhead = os.path.realpath(b_head)
+        if os.path.isdir(b_realhead):
+            return to_text(os.path.join(b_realhead, b_tail), errors='surrogate_or_strict')
+        b_head, b_name = os.path.split(b_head)
+        b_tail = os.path.join(b_name, b_tail)
 
     # no parent realpath exists, just return real and let it die downstream
-    return real
+    return to_text(b_real, errors='surrogate_or_strict')
 
 
 def unfrackpath(path, follow=True, basedir=None):


### PR DESCRIPTION
##### SUMMARY
There are cases such as pipes where realpath may not exist but abspath does.  This change adds a fallback to perform best-effort realpath on parents while preserving the existence of the file.

The concrete use case in this PR is `--vault-password-file` but I put the logic in a utility function since it may be useful elsewhere.

Fixes #28058 (at least the `--vault-password-file` part of it)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `ansible.parsing.vault`
- `ansible.utils.path`

##### ADDITIONAL INFORMATION
To reproduce the old behavior:
```
$ ansible '*' --vault-password-file <(echo himom)
ERROR! The vault password file /proc/129798/fd/pipe:[207000610] was not found
```