### PR TITLE
Fixes various bugs and logic in OpenBSD syspatch module

### DIFF
--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -102,6 +102,9 @@ def syspatch_run(module):
     changed = False
     reboot_needed = False
     warnings = []
+    # Check mode by default
+    run_flag = ['-c']
+    check_flag = ['-c']
 
     # Setup command flags
     if module.params['revert']:
@@ -112,7 +115,6 @@ def syspatch_run(module):
         else:
             run_flag = ['-r']
     elif module.params['apply']:
-        check_flag = ['-c']
         run_flag = []
 
     # Run check command

--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -139,11 +139,11 @@ def syspatch_run(module):
         # http://openbsd-archive.7691.n7.nabble.com/Warning-applying-latest-syspatch-td354250.html
         if rc != 0 and err != 'ln: /usr/X11R6/bin/X: No such file or directory\n':
             module.fail_json(msg="Command %s failed rc=%d, out=%s, err=%s" % (cmd, rc, out, err))
-        elif out.lower().find('create unique kernel'):
+        elif out.lower().find('create unique kernel') != -1:
             # Kernel update applied
             reboot_needed = True
-        elif out.lower().find('syspatch updated itself'):
-            warnings.append['Syspatch was updated. Please run syspatch again.']
+        elif out.lower().find('syspatch updated itself') != -1:
+            warnings.append('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user
         if len(out) > 0:

--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -146,8 +146,8 @@ def syspatch_run(module):
             warnings.append('Syspatch was updated. Please run syspatch again.')
 
         # If no stdout, then warn user
-        if len(out) > 0:
-            warnings.append['syspatch had suggested changes, but stdout was empty.']
+        if len(out) <= 0:
+            warnings.append('syspatch had suggested changes, but stdout was empty.')
 
         changed = True
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes some oddities and logic flaws in the new syspatch module :

- Running with `apply: False` raise a python error
- Misuse of `str.find()` return code leading to bad handling of errors
- Fix typos

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
syspatch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

When running the playbook:
```
---
- hosts: "all"
  become: yes
  become_method: doas
  tasks:
    - name: Check available system patches
      syspatch: 
        apply: false
```

ansible fails with `[...]UnboundLocalError: local variable 'check_flag' referenced before assignment`

So this patch ensure `check_flag` and `run_flag` have proper default values. 

My understanding of the original developer logic is that `syspatch` is always ran two times (unless check mode is enabled):
- first with the `-c` flag to see if there is any patch pending
- second time in "real mode" to apply them. However if the `apply` parameter is set to `false`, syspatch should be run with `-c` again, or else changes will be commited to the host.


The other changes are more obvious and should not change the module's behaviour. 

Here is the playbook I use for testing, for reference:
```
---
- hosts:  all
  become: yes

  tasks:
    - name: Check available system patches
      syspatch: 
        apply: true
      register: result

    - name: Display output
      debug: 
        var: result

    # Print a big red line if reboot is needed
    - name: Display statement when reboot is needed
      debug: 
        msg: "Kernel patched, please reboot hosts to apply"
      when: result.reboot_needed
      failed_when: result.reboot_needed
      ignore_errors: true

    - name: Revert last patch
      syspatch:
        revert: one

    - name: List patches
      shell: syspatch -l
      register: list

    # We should have all patches but one applied
    - name: Display output of list
      debug:
        var: list

    - name: Revert all patches
      syspatch: 
        revert: all

    # Test if apply: false work as intended
    - name: Checkmode
      syspatch:
        apply: false
      register: checkres

    - name: Display check results
      debug:
        var: checkres

    - name: list no patches
      shell: syspatch -l
      register: listnone

    # We should have no patch applied
    - name: Display no patches
      debug:
        var: listnone

```


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
