### PR TITLE
Don't search for VMDK if filename is defined

### DIFF
--- a/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
+++ b/changelogs/fragments/63741-do_not_search_for_vmdk_if_filename_defined.yaml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - vmware_guest - Don't search for VMDK if filename is defined.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -436,6 +436,8 @@ EXAMPLES = r'''
     - size_gb: 10
       type: thin
       datastore: g73_datastore
+    # Add another disk from an existing VMDK
+    - filename: "[datastore1] testvms/testvm_2_1/testvm_2_1.vmdk"
     hardware:
       memory_mb: 512
       num_cpus: 6
@@ -1940,34 +1942,15 @@ class PyVmomiHelper(PyVmomi):
         self.module.fail_json(
             msg="No size, size_kb, size_mb, size_gb or size_tb attribute found into disk configuration")
 
-    def find_vmdk(self, vmdk_path):
-        """
-        Takes a vsphere datastore path in the format
-
-            [datastore_name] path/to/file.vmdk
-
-        Returns vsphere file object or raises RuntimeError
-        """
-        datastore_name, vmdk_fullpath, vmdk_filename, vmdk_folder = self.vmdk_disk_path_split(vmdk_path)
-
-        datastore = self.cache.find_obj(self.content, [vim.Datastore], datastore_name)
-
-        if datastore is None:
-            self.module.fail_json(msg="Failed to find the datastore %s" % datastore_name)
-
-        return self.find_vmdk_file(datastore, vmdk_fullpath, vmdk_filename, vmdk_folder)
-
     def add_existing_vmdk(self, vm_obj, expected_disk_spec, diskspec, scsi_ctl):
         """
         Adds vmdk file described by expected_disk_spec['filename'], retrieves the file
         information and adds the correct spec to self.configspec.deviceChange.
         """
         filename = expected_disk_spec['filename']
-        # if this is a new disk, or the disk file names are different
+        # If this is a new disk, or the disk file names are different
         if (vm_obj and diskspec.device.backing.fileName != filename) or vm_obj is None:
-            vmdk_file = self.find_vmdk(expected_disk_spec['filename'])
-            diskspec.device.backing.fileName = expected_disk_spec['filename']
-            diskspec.device.capacityInKB = VmomiSupport.vmodlTypes['long'](vmdk_file.fileSize / 1024)
+            diskspec.device.backing.fileName = filename
             diskspec.device.key = -1
             self.change_detected = True
             self.configspec.deviceChange.append(diskspec)


### PR DESCRIPTION
##### SUMMARY
This PR is removing the need to search for VMDK file when `filename` option is defined. The search might take too long time if the datastore contains too many files. I'm affected by this because we have one massive datastore which contains many VMs and searching for the existing VMDK can take hours. Removing the search process allows to provision the VM much faster.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`vmware_guest`

##### ADDITIONAL INFORMATION
N/A