### PR TITLE
Zabbix integration tests

### DIFF
--- a/test/integration/targets/setup_zabbix/defaults/main.yml
+++ b/test/integration/targets/setup_zabbix/defaults/main.yml
@@ -3,7 +3,9 @@ db_name: 'zabbix'
 db_user: 'zabbix'
 db_password: 'fLhijUs3PgekNhwJ'
 
-zabbix_release_deb: 'http://repo.zabbix.com/zabbix/3.4/ubuntu/pool/main/z/zabbix-release/zabbix-release_3.4-1+trusty_all.deb'
+zabbix_version: 4.0
+zabbix_apt_repository: 'deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main'
+zabbix_apt_repository_key: 'http://repo.zabbix.com/zabbix-official-repo.key'
 
 zabbix_packages:
     - zabbix-server-mysql

--- a/test/integration/targets/setup_zabbix/tasks/main.yml
+++ b/test/integration/targets/setup_zabbix/tasks/main.yml
@@ -1,6 +1,3 @@
 ---
-
-# This integration test is only for Ubuntu 14.04 at the moment. This makes
-# installation of a Zabbix quite a bit easier.
 - include: setup.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+  when: ansible_os_family == 'Debian'

--- a/test/integration/targets/setup_zabbix/tasks/setup.yml
+++ b/test/integration/targets/setup_zabbix/tasks/setup.yml
@@ -1,5 +1,39 @@
-# sets up and starts Zabbix with default settings (works on Ubuntu 14.04,
-# possibly more) using a MySQL database.
+# sets up and starts Zabbix with default settings using a MySQL database.
+
+- name: install zabbix repository key
+  apt_key:
+    url: "{{ zabbix_apt_repository_key }}"
+    state: present
+
+- name: install zabbix repository
+  apt_repository:
+    repo: "{{ zabbix_apt_repository }}"
+    filename: zabbix
+    state: present
+
+- name: check if dpkg is set to exclude specific destinations
+  stat:
+    path: /etc/dpkg/dpkg.cfg.d/excludes
+  register: dpkg_excludes
+
+- name: ensure documentation installations are allowed for zabbix
+  lineinfile:
+    path: /etc/dpkg/dpkg.cfg.d/excludes
+    regexp: '^path-include=/usr/share/doc/zabbix*$'
+    line: 'path-include=/usr/share/doc/zabbix*'
+    state: present
+  when: dpkg_excludes.stat.exists
+
+- name: install zabbix apt dependencies
+  apt:
+    name: "{{ zabbix_packages }}"
+    state: latest
+    update_cache: yes
+
+- name: install zabbix-api python package
+  pip:
+    name: zabbix-api
+    state: latest
 
 - name: create mysql user {{ db_user }}
   mysql_user:
@@ -7,17 +41,7 @@
     password: "{{ db_password }}"
     state: present
     priv: "{{ db_name }}.*:ALL"
-
-- name: install zabbix repository
-  apt: deb={{ zabbix_release_deb }} state=present
-
-- name: install zabbix debian dependencies
-  apt: name={{ item }} state=latest update_cache=yes
-  with_items: "{{ zabbix_packages }}"
-
-- name: install zabbix-api python package
-  pip:
-    name: zabbix-api
+    login_unix_socket: '{{ mysql_socket }}'
 
 - name: import initial zabbix database
   mysql_db:
@@ -31,9 +55,9 @@
   template:
     src: zabbix_server.conf.j2
     dest: /etc/zabbix/zabbix_server.conf
-    owner: zabbix
+    owner: root
     group: zabbix
-    mode: 0644
+    mode: 0640
 
 - name: deploy zabbix web frontend configuration
   template:
@@ -41,8 +65,22 @@
     dest: /etc/zabbix/web/zabbix.conf.php
     mode: 0644
 
+- name: Create proper run directory for zabbix-server
+  file:
+    path: /var/run/zabbix
+    state: directory
+    owner: zabbix
+    group: zabbix
+    mode: 0775
+
 - name: restart zabbix-server
-  service: name=zabbix-server state=restarted enabled=yes
+  service:
+    name: zabbix-server
+    state: restarted
+    enabled: yes
 
 - name: restart apache2
-  service: name=apache2 state=restarted enabled=yes
+  service:
+    name: apache2
+    state: restarted
+    enabled: yes

--- a/test/integration/targets/setup_zabbix/templates/zabbix_server.conf.j2
+++ b/test/integration/targets/setup_zabbix/templates/zabbix_server.conf.j2
@@ -1,3 +1,4 @@
+PidFile=/var/run/zabbix/zabbix_server.pid
 LogFile=/tmp/zabbix_server.log
 DBName={{ db_name }}
 DBUser={{ db_user }}

--- a/test/integration/targets/zabbix_host/tasks/main.yml
+++ b/test/integration/targets/zabbix_host/tasks/main.yml
@@ -1,16 +1,17 @@
 ---
 # setup stuff not testing zabbix_host
-- include: zabbix_host_setup.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+- block:
+    - include: zabbix_host_setup.yml
 
-# zabbix_host module tests
-- include: zabbix_host_tests.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+    # zabbix_host module tests
+    - include: zabbix_host_tests.yml
 
-# documentation example tests
-- include: zabbix_host_doc.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+    # documentation example tests
+    - include: zabbix_host_doc.yml
 
-# tear down stuff set up earlier
-- include: zabbix_host_teardown.yml
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'trusty'
+    # tear down stuff set up earlier
+    - include: zabbix_host_teardown.yml
+
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_release == 'bionic'


### PR DESCRIPTION
##### SUMMARY
Updated zabbix_host and setup_zabbix integration tests roles to work with newer distributions.

Fixes #62286

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- test/integration/targets/setup_zabbix
- test/integration/targets/zabbix_host

##### ADDITIONAL INFORMATION
These roles can be now run against any distribution from Debian family. There is no need to test from RHEL distros as we are interested in interaction between modules and Zabbix server.

My previous questions from #62286 still stand and I would be very grateful if someone would be able to point me the right direction:
- is it possible to test against [official zabbix docker images](https://hub.docker.com/r/zabbix/zabbix-server-mysql)?
- is it possible to rerun these tests against multiple zabbix versions without duplicating integration roles? 

So far I haven't found anything useful in other integration roles or documentation