### PR TITLE
Cloudformation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -451,7 +451,7 @@ def create_changeset(module, stack_params, cfn, events_limit):
                 # Lets not hog the cpu/spam the AWS API
                 time.sleep(1)
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET', events_limit)
-            result['change_set_name'] = cs['Id']
+            result['change_set_id'] = cs['Id']
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],
                                   'NOTE that dependencies on this stack might fail due to pending changes!']

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -451,6 +451,7 @@ def create_changeset(module, stack_params, cfn, events_limit):
                 # Lets not hog the cpu/spam the AWS API
                 time.sleep(1)
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET', events_limit)
+            result['change_set_name'] = cs['Id']
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],
                                   'NOTE that dependencies on this stack might fail due to pending changes!']


### PR DESCRIPTION
##### SUMMARY
A simple change to add the change set name to the output under the key change_set_name.  This change is to make it easier to check and retrieve the change set name instead of having to parse the warning message to get it.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
cloudformation.py

##### ADDITIONAL INFORMATION
The main purpose of this is so I can more easily conditionally check if a change set was created, and in combination with #63008 capture this information to create an approval pipeline.

BEFORE
```
TASK [debug] ***************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": true,
        "events": [
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_IN_PROGRESS"
        ],
        "failed": false,
        "log": [],
        "output": "Stack CREATE_CHANGESET complete",
        "stack_outputs": {
            "Role1": "KevinTest",
            "Role2": "KevinTest3"
        },
        "stack_resources": [
            {
                "last_updated_time": "2019-10-21T13:22:08.039000+00:00",
                "logical_resource_id": "IamRole1",
                "physical_resource_id": "KevinTest",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            },
            {
                "last_updated_time": "2019-10-21T13:22:06.175000+00:00",
                "logical_resource_id": "IamRole3",
                "physical_resource_id": "KevinTest3",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            }
        ],
        "warnings": [
            "Created changeset named Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c for stack KevinTestStack",
            "You can execute it using: aws cloudformation execute-change-set --change-set-name arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/3168307f-5084-4bb9-a035-b782fcd6b16c",
            "NOTE that dependencies on this stack might fail due to pending changes!"
        ]
    }
}
```

AFTER
```
TASK [debug] ***************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "change_set_id": "arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/c7109d1d-1973-498a-bbd8-3f41243f74ce",
        "changed": true,
        "events": [
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_IN_PROGRESS"
        ],
        "failed": false,
        "log": [],
        "output": "Stack CREATE_CHANGESET complete",
        "stack_outputs": {
            "Role1": "KevinTest",
            "Role2": "KevinTest3"
        },
        "stack_resources": [
            {
                "last_updated_time": "2019-10-21T13:22:08.039000+00:00",
                "logical_resource_id": "IamRole1",
                "physical_resource_id": "KevinTest",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            },
            {
                "last_updated_time": "2019-10-21T13:22:06.175000+00:00",
                "logical_resource_id": "IamRole3",
                "physical_resource_id": "KevinTest3",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            }
        ],
        "warnings": [
            "Created changeset named Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c for stack KevinTestStack",
            "You can execute it using: aws cloudformation execute-change-set --change-set-name arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/c7109d1d-1973-498a-bbd8-3f41243f74ce",
            "NOTE that dependencies on this stack might fail due to pending changes!"
        ]
    }
}
```