### PR TITLE
add change_set_id to cloudformation output

### DIFF
--- a/changelogs/fragments/63752-cloudformation-return-changeset-id.yaml
+++ b/changelogs/fragments/63752-cloudformation-return-changeset-id.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cloudformation - Return change_set_id in the cloudformation output if a change set was created.

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -294,7 +294,7 @@ log:
 change_set_id:
   description: The ID of the stack change set if one was created
   returned:  I(state=present) and I(create_changeset=true)
-  type: string
+  type: str
   sample: "arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-StackName-f4496805bd1b2be824d1e315c6884247ede41eb0"
 stack_resources:
   description: AWS stack resources and their status. List of dictionaries, one dict per resource.

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -451,7 +451,7 @@ def create_changeset(module, stack_params, cfn, events_limit):
                 # Lets not hog the cpu/spam the AWS API
                 time.sleep(1)
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET', events_limit)
-            result['change_set_name'] = cs['Id']
+            result['change_set_id'] = cs['Id']
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],
                                   'NOTE that dependencies on this stack might fail due to pending changes!']

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -291,6 +291,11 @@ log:
   returned: always
   type: list
   sample: ["updating stack"]
+change_set_id:
+  description: The ID of the stack change set if one was created
+  returned:  I(state=present) and I(create_changeset=true)
+  type: string
+  sample: "arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-StackName-f4496805bd1b2be824d1e315c6884247ede41eb0"
 stack_resources:
   description: AWS stack resources and their status. List of dictionaries, one dict per resource.
   returned: state == present

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -451,6 +451,7 @@ def create_changeset(module, stack_params, cfn, events_limit):
                 # Lets not hog the cpu/spam the AWS API
                 time.sleep(1)
             result = stack_operation(cfn, stack_params['StackName'], 'CREATE_CHANGESET', events_limit)
+            result['change_set_name'] = cs['Id']
             result['warnings'] = ['Created changeset named %s for stack %s' % (changeset_name, stack_params['StackName']),
                                   'You can execute it using: aws cloudformation execute-change-set --change-set-name %s' % cs['Id'],
                                   'NOTE that dependencies on this stack might fail due to pending changes!']


### PR DESCRIPTION
##### SUMMARY
This change adds the stack change set id to the output of cloudformation, under the key change_set_id.  This is to make it easier to test and retrieve the change_set_id rather than having to parse the value from the warnings output.  This change, combined with PR  #63008 will allow for testing if a changeset was created, and aid in creating the necessary output for an change set approval pipeline.


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
cloudformation.pu

##### ADDITIONAL INFORMATION
OUTPUT BEFORE
```
TASK [debug] ***************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": true,
        "events": [
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_IN_PROGRESS"
        ],
        "failed": false,
        "log": [],
        "output": "Stack CREATE_CHANGESET complete",
        "stack_outputs": {
            "Role1": "KevinTest",
            "Role2": "KevinTest3"
        },
        "stack_resources": [
            {
                "last_updated_time": "2019-10-21T13:22:08.039000+00:00",
                "logical_resource_id": "IamRole1",
                "physical_resource_id": "KevinTest",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            },
            {
                "last_updated_time": "2019-10-21T13:22:06.175000+00:00",
                "logical_resource_id": "IamRole3",
                "physical_resource_id": "KevinTest3",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            }
        ],
        "warnings": [
            "Created changeset named Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c for stack KevinTestStack",
            "You can execute it using: aws cloudformation execute-change-set --change-set-name arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/3168307f-5084-4bb9-a035-b782fcd6b16c",
            "NOTE that dependencies on this stack might fail due to pending changes!"
        ]
    }
}
```

AFTER
```
TASK [debug] ***************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "change_set_id": "arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/c7109d1d-1973-498a-bbd8-3f41243f74ce",
        "changed": true,
        "events": [
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_COMPLETE",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole1 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::IAM::Role IamRole3 CREATE_IN_PROGRESS",
            "StackEvent AWS::CloudFormation::Stack KevinTestStack CREATE_IN_PROGRESS"
        ],
        "failed": false,
        "log": [],
        "output": "Stack CREATE_CHANGESET complete",
        "stack_outputs": {
            "Role1": "KevinTest",
            "Role2": "KevinTest3"
        },
        "stack_resources": [
            {
                "last_updated_time": "2019-10-21T13:22:08.039000+00:00",
                "logical_resource_id": "IamRole1",
                "physical_resource_id": "KevinTest",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            },
            {
                "last_updated_time": "2019-10-21T13:22:06.175000+00:00",
                "logical_resource_id": "IamRole3",
                "physical_resource_id": "KevinTest3",
                "resource_type": "AWS::IAM::Role",
                "status": "CREATE_COMPLETE",
                "status_reason": null
            }
        ],
        "warnings": [
            "Created changeset named Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c for stack KevinTestStack",
            "You can execute it using: aws cloudformation execute-change-set --change-set-name arn:aws:cloudformation:us-east-1:012345678901:changeSet/Ansible-KevinTestStack-4875d2c823f9589a459b9bc8ef7a6f5b00f2ac2c/c7109d1d-1973-498a-bbd8-3f41243f74ce",
            "NOTE that dependencies on this stack might fail due to pending changes!"
        ]
    }
}
