### PR TITLE
Add integration tests for aws lightsail

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -245,6 +245,19 @@
             "Resource": [
               "arn:aws:states:*"
             ]
+        },
+        {
+            "Sid": "AllowLightsail",
+            "Effect": "Allow",
+            "Action": [
+                "lightsail:DeleteInstance",
+                "lightsail:StartInstance",
+                "lightsail:StopInstance",
+                "lightsail:RebootInstance",
+                "lightsail:CreateInstances",
+                "lightsail:GetInstance"
+            ],
+            "Resource": "arn:aws:lightsail:*:*:*"
         }
     ]
 }

--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -250,12 +250,14 @@
             "Sid": "AllowLightsail",
             "Effect": "Allow",
             "Action": [
-                "lightsail:DeleteInstance",
-                "lightsail:StartInstance",
-                "lightsail:StopInstance",
-                "lightsail:RebootInstance",
-                "lightsail:CreateInstances",
-                "lightsail:GetInstance"
+              "lightsail:CreateInstances",
+              "lightsail:CreateKeyPair",
+              "lightsail:DeleteInstance",
+              "lightsail:GetInstance",
+              "lightsail:GetInstances",
+              "lightsail:RebootInstance",
+              "lightsail:StartInstance",
+              "lightsail:StopInstance"
             ],
             "Resource": "arn:aws:lightsail:*:*:*"
         }

--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -253,8 +253,10 @@
               "lightsail:CreateInstances",
               "lightsail:CreateKeyPair",
               "lightsail:DeleteInstance",
+              "lightsail:DeleteKeyPair",
               "lightsail:GetInstance",
               "lightsail:GetInstances",
+              "lightsail:GetKeyPairs",
               "lightsail:RebootInstance",
               "lightsail:StartInstance",
               "lightsail:StopInstance"

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -487,6 +487,8 @@ groupings:
   - aws
   lightsail:
   - aws
+  lightsail_keypair:
+  - aws
   rds:
   - aws
   rds_instance:

--- a/test/integration/targets/lightsail/aliases
+++ b/test/integration/targets/lightsail/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/test/integration/targets/lightsail/defaults/main.yml
+++ b/test/integration/targets/lightsail/defaults/main.yml
@@ -1,3 +1,3 @@
 instance_name: "{{ resource_prefix }}_instance"
-keypair_name: "lightsail"
+keypair_name: "lightsail_ci"
 zone: "{{ aws_region }}a"

--- a/test/integration/targets/lightsail/defaults/main.yml
+++ b/test/integration/targets/lightsail/defaults/main.yml
@@ -1,3 +1,3 @@
 instance_name: "{{ resource_prefix }}_instance"
-keypair_name: "lightsail_ci"
+keypair_name: "{{ resource_prefix }}_keypair"
 zone: "{{ aws_region }}a"

--- a/test/integration/targets/lightsail/defaults/main.yml
+++ b/test/integration/targets/lightsail/defaults/main.yml
@@ -1,0 +1,3 @@
+instance_name: "{{ resource_prefix }}_instance"
+keypair_name: "lightsail"
+zone: "{{ aws_region }}a"

--- a/test/integration/targets/lightsail/library/lightsail_keypair.py
+++ b/test/integration/targets/lightsail/library/lightsail_keypair.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+try:
+    from botocore.exceptions import ClientError, BotoCoreError
+    import boto3
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import (get_aws_connection_info, boto3_conn)
+
+
+def create_keypair(module, client, keypair_name):
+    """
+    Create a keypair to use for your lightsail instance
+    """
+
+    try:
+        client.create_key_pair(keyPairName=keypair_name)
+    except ClientError as e:
+        if "Some names are already in use" in e.response['Error']['Message']:
+            module.exit_json(changed=False)
+        module.fail_json_aws(e)
+
+    module.exit_json(changed=True)
+
+
+def main():
+
+    argument_spec = dict(
+        name=dict(type='str', required=True),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    try:
+        client = boto3_conn(module, conn_type='client', resource='lightsail', region=region, endpoint=ec2_url,
+                            **aws_connect_params)
+    except ClientError as e:
+        module.fail_json_aws(e)
+
+    keypair_name = module.params.get('name')
+    create_keypair(module, client, keypair_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -7,7 +7,6 @@
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region | default(omit) }}'
 
-- name: Integration test for lightsail module
   block:
 
     # ==== Tests ===================================================

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -123,4 +123,10 @@
       lightsail:
         name: "{{ instance_name }}"
         state: absent
-      ignore_errors: true
+      ignore_errors: yes
+
+    - name: Cleanup - delete keypair
+      lightsail_keypair:
+        name: "{{ keypair_name }}"
+        state: absent
+      ignore_errors: yes

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+
+- name: Integration test for lightsail module
+  block:
+
+    # ==== Setup ==================================================
+
+    - name: Set connection information for all tasks
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          aws_access_key: "{{ aws_access_key }}"
+          aws_secret_key: "{{ aws_secret_key }}"
+          security_token: "{{ security_token }}"
+          region: "{{ aws_region }}"
+      no_log: yes
+
+    # ==== Tests ===================================================
+
+    - name: Create a new instance
+      lightsail:
+        name: "{{ instance_name }}"
+        zone: "{{ zone }}"
+        blueprint_id: amazon_linux
+        bundle_id: nano_2_0
+        key_pair_name: "{{ keypair_name }}"
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == True
+          - "'instance' in result and result.instance.name == instance_name"
+
+    - name: Make sure create is idempotent
+      lightsail:
+        name: "{{ instance_name }}"
+        zone: "{{ zone }}"
+        blueprint_id: amazon_linux
+        bundle_id: nano_2_0
+        key_pair_name: "{{ keypair_name }}"
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == False
+
+    - name: Start the running instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: running
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == False
+
+    - name: Stop the instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: stopped
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == True
+          - "result.instance.state.name in ['stopping', 'stopped']"
+
+    - name: Stop the stopped instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: stopped
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == False
+
+    - name: Start the instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: running
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == True
+          - "result.instance.state.name in ['running', 'pending']"
+
+    - name: Restart the instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: restarted
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == True
+
+    - name: Delete the instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == True
+
+    - name: Make sure instance deletion is idempotent
+      lightsail:
+        name: "{{ instance_name }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed == False
+
+  # ==== Cleanup ====================================================
+
+  always:
+
+    - name: Cleanup - delete instance
+      lightsail:
+        name: "{{ instance_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: true

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -25,6 +25,7 @@
         that:
           - result.changed == True
           - "'instance' in result and result.instance.name == instance_name"
+          - "result.instance.state.name in ['pending', 'running']"
 
     - name: Make sure create is idempotent
       lightsail:

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -1,18 +1,14 @@
 ---
 
+- module_defaults:
+    group/aws:
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region | default(omit) }}'
+
 - name: Integration test for lightsail module
   block:
-
-    # ==== Setup ==================================================
-
-    - name: Set connection information for all tasks
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
 
     # ==== Tests ===================================================
 
@@ -23,7 +19,6 @@
         blueprint_id: amazon_linux
         bundle_id: nano_2_0
         key_pair_name: "{{ keypair_name }}"
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -38,7 +33,6 @@
         blueprint_id: amazon_linux
         bundle_id: nano_2_0
         key_pair_name: "{{ keypair_name }}"
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -49,7 +43,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: running
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -60,7 +53,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: stopped
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -72,7 +64,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: stopped
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -83,7 +74,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: running
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -95,7 +85,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: restarted
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -106,7 +95,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -117,7 +105,6 @@
       lightsail:
         name: "{{ instance_name }}"
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -132,5 +119,4 @@
       lightsail:
         name: "{{ instance_name }}"
         state: absent
-        <<: *aws_connection_info
       ignore_errors: true

--- a/test/integration/targets/lightsail/tasks/main.yml
+++ b/test/integration/targets/lightsail/tasks/main.yml
@@ -11,6 +11,10 @@
 
     # ==== Tests ===================================================
 
+    - name: Create a new keypair in lightsail
+      lightsail_keypair:
+        name: "{{ keypair_name }}"
+
     - name: Create a new instance
       lightsail:
         name: "{{ instance_name }}"


### PR DESCRIPTION
##### SUMMARY
Integration test suite for lightsail module

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lightsail

##### ADDITIONAL INFORMATION
This patch updates the aws IAM policy (compute-policy).

The lightsail module requires a keypair to create instances. I have created a keypair named `lightsail` in my account that I used while writing these tests. 
NOTE: A keypair will need to be created in the test account for the test suite to work.
