### PR TITLE
Fix ios_l2_interfaces skipping relevant L2 interfaces facts

### DIFF
--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -83,7 +83,7 @@ class L2_InterfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
 
-        if intf.lower().startswith('gi'):
+        if intf.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE', 'TW', 'PO'):
             # populate the facts from the configuration
             config['name'] = normalize_interface(intf)
 

--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -83,7 +83,7 @@ class L2_InterfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
 
-        if intf.upper()[:2] in ('ET', 'GI', 'FA', 'TE', 'FO', 'HU', 'TWE', 'TW', 'PO'):
+        if intf.upper()[:2] in ('HU', 'FO', 'TW', 'TE', 'GI', 'FA', 'ET', 'PO'):
             # populate the facts from the configuration
             config['name'] = normalize_interface(intf)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix `ios_l2_interfaces` skipping relevant L2 interfaces facts, PR fixes the bug raised in issue #63777 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interfaces, ios_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
