### PR TITLE
Add ansible cli options --ask-vault-password and --vault-pass-file

### DIFF
--- a/changelogs/fragments/63782-add-ansible-ask-vault-password-and-vault-password-file-options.yaml
+++ b/changelogs/fragments/63782-add-ansible-ask-vault-password-and-vault-password-file-options.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add --ask-vault-password and --vault-pass-file options to ansible cli commands

--- a/changelogs/fragments/63782-add-ansible-ask-vault-password-and-vault-password-file-options.yaml
+++ b/changelogs/fragments/63782-add-ansible-ask-vault-password-and-vault-password-file-options.yaml
@@ -1,2 +1,3 @@
 minor_changes:
 - Add --ask-vault-password and --vault-pass-file options to ansible cli commands
+- Change order of arguments in ansible cli to use --ask-vault-password and --vault-password-file by default

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -363,11 +363,7 @@ def add_vault_options(parser):
     parser.add_argument('--vault-id', default=[], dest='vault_ids', action='append', type=str,
                         help='the vault identity to use')
     base_group = parser.add_mutually_exclusive_group()
-    base_group.add_argument('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+    base_group.add_argument('--ask-vault-pass', '--ask-vault-password', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
-    base_group.add_argument('--ask-vault-password', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
-                            help='ask for vault password')
-    base_group.add_argument('--vault-password-file', default=[], dest='vault_password_files',
-                            help="vault password file", type=unfrack_path(), action='append')
-    base_group.add_argument('--vault-pass-file', default=[], dest='vault_password_files',
+    base_group.add_argument('--vault-password-file', '--vault-pass-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(), action='append')

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -365,5 +365,9 @@ def add_vault_options(parser):
     base_group = parser.add_mutually_exclusive_group()
     base_group.add_argument('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
+    base_group.add_argument('--ask-vault-password', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+                            help='ask for vault password')
     base_group.add_argument('--vault-password-file', default=[], dest='vault_password_files',
+                            help="vault password file", type=unfrack_path(), action='append')
+    base_group.add_argument('--vault-pass-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(), action='append')

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -363,7 +363,7 @@ def add_vault_options(parser):
     parser.add_argument('--vault-id', default=[], dest='vault_ids', action='append', type=str,
                         help='the vault identity to use')
     base_group = parser.add_mutually_exclusive_group()
-    base_group.add_argument('--ask-vault-pass', '--ask-vault-password', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+    base_group.add_argument('--ask-vault-password', '--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
     base_group.add_argument('--vault-password-file', '--vault-pass-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(), action='append')

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -106,6 +106,14 @@ if [ -x "$(command -v setsid)" ]; then
     setsid sh -c 'tty; echo test-vault-password|ansible-vault view --ask-vault-pass -vvvvv vaulted.inventory' < /dev/null > log 2>&1
     echo $?
     cat log
+
+    # test using --ask-vault-password option
+    CMD='ansible-playbook -i ../../inventory -vvvvv --ask-vault-password test_vault.yml'
+    setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1 && :
+    WRONG_RC=$?
+    cat log
+    echo "rc was $WRONG_RC (0 is expected)"
+    [ $WRONG_RC -eq 0 ]
 fi
 
 ansible-vault view "$@" --vault-password-file vault-password-wrong format_1_1_AES256.yml && :
@@ -410,6 +418,8 @@ ansible-playbook test_vault_embedded.yml -i ../../inventory -v "$@" --vault-pass
 ansible-playbook test_vaulted_inventory.yml -i vaulted.inventory -v "$@" --vault-password-file vault-password
 ansible-playbook test_vaulted_template.yml -i ../../inventory -v "$@" --vault-password-file vault-password
 
+# test using --vault-pass-file option
+ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-pass-file vault-password
 
 # install TOML for parse toml inventory
 # test playbooks using vaulted files(toml)


### PR DESCRIPTION
##### SUMMARY
The ansible-playbook command provides 2 options to specify a vault password:
--ask-vault-pass
--vault-password-file

One option use 'pass', the other uses 'password'. I propose to use either pass or password for both option. For now I added the following options:
-- ask-vault-password
--vault-pass-file

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible cli

##### ADDITIONAL INFORMATION

before:
```bash
ansible-playbook --ask-vault-pass ....
ansible-playbook --vault-password-file=<filename> ....
```

after:
```bash
ansible-playbook --ask-vault-password ....
ansible-playbook --vault-password-file=<filename> ....
```

or

```bash
ansible-playbook --ask-vault-pass ....
ansible-playbook --vault-pass-file=<filename> ....
```