### PR TITLE
Backport/2.8/58525 - Use atexit to logout after zabbix module run

### DIFF
--- a/changelogs/fragments/58525-zabbix-modules-logout.yml
+++ b/changelogs/fragments/58525-zabbix-modules-logout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_* modules - modules will now properly disconnect existing sessions from Zabbix server (see https://github.com/ansible/ansible/pull/58525)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -437,6 +437,9 @@ msg:
     sample: 'Action Deleted: Register webservers, ID: 0001'
 '''
 
+
+import atexit
+
 try:
     from zabbix_api import ZabbixAPI
     HAS_ZABBIX_API = True
@@ -1996,6 +1999,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user,
                         passwd=http_login_password, validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -75,6 +75,9 @@ EXAMPLES = '''
   when: inventory_hostname==groups['group_name'][0]
 '''
 
+
+import atexit
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import Already_Exists
@@ -165,6 +168,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_facts.py
@@ -55,6 +55,9 @@ EXAMPLES = '''
     timeout: 10
 '''
 
+
+import atexit
+
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -121,6 +124,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -223,6 +223,8 @@ EXAMPLES = '''
     tls_psk: 123456789abcdef123456789abcdef12
 '''
 
+
+import atexit
 import copy
 
 try:
@@ -698,6 +700,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_facts.py
@@ -94,6 +94,9 @@ EXAMPLES = '''
     remove_duplicate: yes
 '''
 
+
+import atexit
+
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -211,6 +214,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -71,6 +71,9 @@ EXAMPLES = '''
     state: present
 '''
 
+
+import atexit
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
@@ -196,6 +199,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -121,6 +121,8 @@ EXAMPLES = '''
     login_password: pAsSwOrD
 '''
 
+
+import atexit
 import datetime
 import time
 
@@ -314,6 +316,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     # zabbix_api can call sys.exit() so we need to catch SystemExit here
     except (Exception, SystemExit) as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -172,6 +172,8 @@ ANSIBLE_METADATA = {
     'status': ['preview']
 }
 
+
+import atexit
 import base64
 from io import BytesIO
 from operator import itemgetter
@@ -784,6 +786,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -125,6 +125,8 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 
+import atexit
+
 from ansible.module_utils.basic import AnsibleModule
 try:
     from zabbix_api import ZabbixAPI
@@ -308,6 +310,7 @@ def main():
                         passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -111,6 +111,9 @@ EXAMPLES = '''
   when: inventory_hostname==groups['group_name'][0]
 '''
 
+
+import atexit
+
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import ZabbixAPIException
@@ -336,6 +339,7 @@ def main():
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                                validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -196,6 +196,7 @@ template_json:
 from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+import atexit
 import json
 import traceback
 
@@ -493,6 +494,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout,
                         user=http_login_user, passwd=http_login_password, validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except ZabbixAPIException as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #63774 

Backport of https://github.com/ansible/ansible/pull/58525

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action
zabbix_group
zabbix_group_facts
zabbix_host
zabbix_host_facts
zabbix_hostmacro
zabbix_maintenance
zabbix_map
zabbix_proxy
zabbix_screen
zabbix_template