### PR TITLE
added missing atexit logout for zabbix_host module

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -742,6 +742,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 


### PR DESCRIPTION
##### SUMMARY
Partially solves problems mentioned in #63774 (wanted to avoid closing that issue from this PR).

Fix where zabbix modules were leaving open sessions on Zabbix servers was introduced and merged in #58525 , but it accidentally skipped this change in `zabbix_host` module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
```
ansible 2.10.0.dev0
  python version = 2.7.15 (default, Feb 17 2019, 12:21:50) [GCC 7.4.0]
```
