### PR TITLE
fix module_defaults example in AWS dev guide

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -644,22 +644,23 @@ for every call, it's preferable to use :ref:`module_defaults <module_defaults>`.
 
 .. code-block:: yaml
 
-   - name: set connection information for all tasks
+   - name: set connection information for aws modules and run tasks
      module_defaults:
        group/aws:
          aws_access_key: "{{ aws_access_key }}"
          aws_secret_key: "{{ aws_secret_key }}"
          security_token: "{{ security_token }}"
          region: "{{ aws_region }}"
-     no_log: yes
 
-   - name: Do Something
-     ec2_instance:
-       ... params ...
+     block:
 
-   - name: Do Something Else
-     ec2_instance:
-       ... params ...
+     - name: Do Something
+       ec2_instance:
+         ... params ...
+
+     - name: Do Something Else
+       ec2_instance:
+         ... params ...
 
 AWS Permissions for Integration Tests
 -------------------------------------


### PR DESCRIPTION
##### SUMMARY
I missed that the indentation wasn't right in #63589. module_defaults should be set on the play or block containing the tasks that should use those parameters. Fixing that in case people try to copy-paste the example. Removed no_log since the individual modules set no_log for secrets and the output of the tasks in the block should be displayed.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
