### PR TITLE
Support token_helpers in hashi_vault lookup plugin

### DIFF
--- a/changelogs/fragments/63793-hashi_vault_token_helper_support.yml
+++ b/changelogs/fragments/63793-hashi_vault_token_helper_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hashi_vault - support token helpers

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
+import subprocess
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -179,9 +180,20 @@ class HashiVault:
                     os.environ.get('HOME'),
                     '.vault-token'
                 )
+                vault_conf_file = os.path.join(
+                    os.environ.get('HOME'),
+                    '.vault'
+                )
                 if os.path.exists(token_filename):
                     with open(token_filename) as token_file:
                         self.token = token_file.read().strip()
+                elif os.path.exists(vault_conf_file):
+                    with open(vault_conf_file) as vault_conf:
+                        for line in vault_conf:
+                            if 'token-helper' in line:
+                                tokenhelper_path = line.split('=')[1].strip().strip('"')
+                    if os.path.exists(tokenhelper_path):
+                        self.token = subprocess.check_output([tokenhelper_path, "get"])
 
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This provides the ability to use token helpers when using the hashi_vault lookup plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If no token was set manually or per Env-Variable and the Auth-Process is not part of a playbook, there's a lookup for a token in `$HOME/.vault-token`. The Hashicorp Vault-Cli supports token-helpers, but they were not supported in this plugin yet.
So if no token was found, the plugin would fail even though the helper could provide a valid token.

This PR parses the `$HOME/.vault` (the Vault Config File) for the config-key "token-helper". The helper is then called via `subprocess.check_output["path/to/helper", "get"]` which is the same method that is used by the vault-cli.
