### PR TITLE
Fix doc errors on aws_batch_job_queue

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
     state: present
   tasks:
   - name: My Batch Job Queue
-    batch_job_queue:
+    aws_batch_job_queue:
       job_queue_name: jobQueueName
       state: present
       region: us-east-1
@@ -78,9 +78,11 @@ EXAMPLES = '''
           compute_environment: my_compute_env1
         - order: 2
           compute_environment: my_compute_env2
+    register: batch_job_queue_action
 
   - name: show results
-    debug: var=batch_job_queue_action
+    debug:
+      var: batch_job_queue_action
 '''
 
 RETURN = '''


### PR DESCRIPTION
* Correct `batch_job_queue` to `aws_batch_job_queue`
* Refactor `debug` task to use current YAML style
* Register the `batch_job_queue_action` variable to allow it
  to be checked in the `debug` task

Signed-off-by: Major Hayden <major@redhat.com>

##### SUMMARY

Fixes: ansible/ansible#63803

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

`aws_batch_job_queue`

##### ADDITIONAL INFORMATION

This is just a simple documentation fix. :)
