### PR TITLE
[backport] win_hotfix: fix docs typo

### DIFF
--- a/lib/ansible/modules/windows/win_hotfix.py
+++ b/lib/ansible/modules/windows/win_hotfix.py
@@ -31,7 +31,7 @@ options:
   hotfix_kb:
     description:
     - The name of the KB the hotfix relates to, see examples for details.
-    - This of C(hotfix_identifier) MUST be set when C(state=absent).
+    - This or C(hotfix_identifier) MUST be set when C(state=absent).
     - If C(state=present) then the hotfix at C(source) will be validated
       against this value, if it does not match an error will occur.
     - Because DISM uses the identifier as a key and doesn't refer to a KB in


### PR DESCRIPTION
(cherry picked from commit b43a2b06078bbfff3f565cf8734342e85f6f4a32)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport of #59124 to stable-2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`win_hotfix`