### PR TITLE
[backport/2.8/63280] acl: fix module failure if there're spaces in a path (#63280)

### DIFF
--- a/changelogs/fragments/63280-fix_acl_spaces_in_path.yml
+++ b/changelogs/fragments/63280-fix_acl_spaces_in_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acl - fixed module failure if there are spaces in a path"

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -190,10 +190,10 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
     '''Builds and returns a getfacl/setfacl command.'''
     if mode == 'set':
         cmd = [module.get_bin_path('setfacl', True)]
-        cmd.append('-m "%s"' % entry)
+        cmd.extend(['-m', entry])
     elif mode == 'rm':
         cmd = [module.get_bin_path('setfacl', True)]
-        cmd.append('-x "%s"' % entry)
+        cmd.extend(['-x', entry])
     else:  # mode == 'get'
         cmd = [module.get_bin_path('getfacl', True)]
         # prevents absolute path warnings and removes headers
@@ -241,7 +241,7 @@ def acl_changed(module, cmd):
 def run_acl(module, cmd, check_rc=True):
 
     try:
-        (rc, out, err) = module.run_command(' '.join(cmd), check_rc=check_rc)
+        (rc, out, err) = module.run_command(cmd, check_rc=check_rc)
     except Exception as e:
         module.fail_json(msg=to_native(e))
 

--- a/test/integration/targets/acl/tasks/acl.yml
+++ b/test/integration/targets/acl/tasks/acl.yml
@@ -43,7 +43,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -60,7 +60,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -88,7 +88,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file }}"
+  shell: "getfacl {{ test_file | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -110,7 +110,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -122,7 +122,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir }}"
+  shell: "setfacl -b {{ test_dir | quote }}"
 ##############################################################################
 - name: Same as previous but using entry shorthand
   acl:
@@ -133,7 +133,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -153,7 +153,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -165,7 +165,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir }}"
+  shell: "setfacl -b {{ test_dir | quote }}"
 ##############################################################################
 - name: Set default acls
   acl:
@@ -186,7 +186,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir }}"
+  shell: "getfacl {{ test_dir | quote }}"
   register: getfacl_output
 
 - name: verify output

--- a/test/integration/targets/acl/tasks/acl.yml
+++ b/test/integration/targets/acl/tasks/acl.yml
@@ -43,7 +43,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file | quote }}"
+  shell: "getfacl {{ test_file | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -60,7 +60,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file | quote }}"
+  shell: "getfacl {{ test_file | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -88,7 +88,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_file | quote }}"
+  shell: "getfacl {{ test_file | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -110,7 +110,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir | quote }}"
+  shell: "getfacl {{ test_dir | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -122,7 +122,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir | quote }}"
+  shell: "setfacl -b {{ test_dir | expanduser | quote }}"
 ##############################################################################
 - name: Same as previous but using entry shorthand
   acl:
@@ -133,7 +133,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir | quote }}"
+  shell: "getfacl {{ test_dir | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -153,7 +153,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir | quote }}"
+  shell: "getfacl {{ test_dir | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output
@@ -165,7 +165,7 @@
       - "'default:user:{{ test_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
 - name: Cleanup
-  shell: "setfacl -b {{ test_dir | quote }}"
+  shell: "setfacl -b {{ test_dir | expanduser | quote }}"
 ##############################################################################
 - name: Set default acls
   acl:
@@ -186,7 +186,7 @@
   register: output
 
 - name: get getfacl output
-  shell: "getfacl {{ test_dir | quote }}"
+  shell: "getfacl {{ test_dir | expanduser | quote }}"
   register: getfacl_output
 
 - name: verify output

--- a/test/integration/targets/acl/tasks/main.yml
+++ b/test/integration/targets/acl/tasks/main.yml
@@ -32,5 +32,5 @@
   vars:
     test_user: ansible_user
     test_group: ansible_group
-    test_file: /tmp/ansible_file
-    test_dir: /tmp/ansible_dir
+    test_file: '{{ output_dir }}/ansible file'
+    test_dir: "{{ output_dir }}/ansible_dir/with some space"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

ACL module will fail if there are spaces in a path.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of https://github.com/ansible/ansible/pull/63280

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/files/acl.py