### PR TITLE
DNF Handle Empty AppStream stream definition

### DIFF
--- a/changelogs/fragments/63683-dnf-handle-empty-appstream-stream.yml
+++ b/changelogs/fragments/63683-dnf-handle-empty-appstream-stream.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - dnf - Properly handle module AppStreams that don't define stream (https://github.com/ansible/ansible/issues/63683)

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -886,9 +886,16 @@ class DnfModule(YumDnf):
         if self.with_modules:
             module_spec = module_spec.strip()
             module_list, nsv = self.module_base._get_modules(module_spec)
+            enabled_streams = self.base._moduleContainer.getEnabledStream(nsv.name)
 
-            if nsv.stream in self.base._moduleContainer.getEnabledStream(nsv.name):
-                return True
+            if enabled_streams:
+                if nsv.stream:
+                    if nsv.stream in enabled_streams:
+                        return True     # The provided stream was found
+                    else:
+                        return False    # The provided stream was not found
+                else:
+                    return True         # No stream provided, but module found
 
         return False  # seems like a sane default
 

--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -49,3 +49,51 @@
     that:
         - "not dnf_result.failed"
         - "not dnf_result.changed"
+
+- name: install "{{ astream_name_no_stream }}" module without providing stream
+  dnf:
+    name: "{{ astream_name_no_stream }}"
+    state: present
+  register: dnf_result
+
+- name: verify installation of "{{ astream_name_no_stream }}" module without providing stream
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: install "{{ astream_name_no_stream }}" module again without providing stream
+  dnf:
+    name: "{{ astream_name_no_stream }}"
+    state: present
+  register: dnf_result
+
+- name: verify installation of "{{ astream_name_no_stream }}" module again without providing stream
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"
+
+- name: uninstall "{{ astream_name_no_stream }}" module without providing stream
+  dnf:
+    name: "{{ astream_name_no_stream }}"
+    state: absent
+  register: dnf_result
+
+- name: verify uninstallation of "{{ astream_name_no_stream }}" module without providing stream
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: uninstall "{{ astream_name_no_stream }}" module again without providing stream
+  dnf:
+    name: "{{ astream_name_no_stream }}"
+    state: absent
+  register: dnf_result
+
+- name: verify uninstallation of "{{ astream_name_no_stream }}" module again without providing stream
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"

--- a/test/integration/targets/dnf/vars/Fedora.yml
+++ b/test/integration/targets/dnf/vars/Fedora.yml
@@ -1,2 +1,2 @@
-astream_name: '@ripgrep:master/default'
-astream_name_no_stream: '@ripgrep/default'
+astream_name: '@stratis:1/default'
+astream_name_no_stream: '@stratis/default'

--- a/test/integration/targets/dnf/vars/Fedora.yml
+++ b/test/integration/targets/dnf/vars/Fedora.yml
@@ -1,1 +1,2 @@
 astream_name: '@ripgrep:master/default'
+astream_name_no_stream: '@ripgrep/default'

--- a/test/integration/targets/dnf/vars/RedHat.yml
+++ b/test/integration/targets/dnf/vars/RedHat.yml
@@ -1,1 +1,2 @@
 astream_name: '@php:7.2/minimal'
+astream_name_no_stream: '@php/minimal'


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously, the logic checking for a `stream` definition from a module/AppStream provided wasn't properly handling the scenario in which there was a missing/empty `stream`.

Fixes #63683

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf

