### PR TITLE
Improve handling of "restarted" state for win_iis_website module

### DIFF
--- a/changelogs/fragments/win_iis_website-restarted.yaml
+++ b/changelogs/fragments/win_iis_website-restarted.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_iis_website - Actually restart the site when ``state=restarted`` - https://github.com/ansible/ansible/issues/63828

--- a/lib/ansible/modules/windows/win_iis_website.ps1
+++ b/lib/ansible/modules/windows/win_iis_website.ps1
@@ -143,7 +143,7 @@ Try {
     }
 
     # Set run state
-    if (($state -eq 'stopped') -and ($site.State -eq 'Started'))
+    if ((($state -eq 'stopped') -or ($state -eq 'restarted')) -and ($site.State -eq 'Started'))
     {
       Stop-Website -Name $name -ErrorAction Stop
       $result.changed = $true


### PR DESCRIPTION
##### SUMMARY
Improve "win_iis_website" so that the IIS website is restarted if state=restarted is passed as parameter.

Fixes #63828 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
win_iis_website module

##### ADDITIONAL INFORMATION
