### PR TITLE
Fixed bug when asa_acl terminates when lines array is empty

### DIFF
--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -184,7 +184,6 @@ def main():
 
     lines = module.params['lines']
 
-
     result = {'changed': False}
     if len(lines) > 0:
         candidate = NetworkConfig(indent=1)

--- a/lib/ansible/modules/network/asa/asa_acl.py
+++ b/lib/ansible/modules/network/asa/asa_acl.py
@@ -184,36 +184,37 @@ def main():
 
     lines = module.params['lines']
 
+
     result = {'changed': False}
+    if len(lines) > 0:
+        candidate = NetworkConfig(indent=1)
+        candidate.add(lines)
 
-    candidate = NetworkConfig(indent=1)
-    candidate.add(lines)
+        acl_name = parse_acl_name(module)
 
-    acl_name = parse_acl_name(module)
+        if not module.params['force']:
+            contents = get_acl_config(module, acl_name)
+            config = NetworkConfig(indent=1, contents=contents)
 
-    if not module.params['force']:
-        contents = get_acl_config(module, acl_name)
-        config = NetworkConfig(indent=1, contents=contents)
+            commands = candidate.difference(config)
+            commands = dumps(commands, 'commands').split('\n')
+            commands = [str(c) for c in commands if c]
+        else:
+            commands = str(candidate).split('\n')
 
-        commands = candidate.difference(config)
-        commands = dumps(commands, 'commands').split('\n')
-        commands = [str(c) for c in commands if c]
-    else:
-        commands = str(candidate).split('\n')
+        if commands:
+            if module.params['before']:
+                commands[:0] = module.params['before']
 
-    if commands:
-        if module.params['before']:
-            commands[:0] = module.params['before']
+            if module.params['after']:
+                commands.extend(module.params['after'])
 
-        if module.params['after']:
-            commands.extend(module.params['after'])
+            if not module.check_mode:
+                load_config(module, commands)
 
-        if not module.check_mode:
-            load_config(module, commands)
+            result['changed'] = True
 
-        result['changed'] = True
-
-    result['updates'] = commands
+        result['updates'] = commands
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
Fix the bug in asa_acl module when lines array is empty 
Fixes #62441

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
asa_acl
##### ADDITIONAL INFORMATION
Just added a basic if clause which checks lines array length, if it is == 0 then the task terminates successfully with no change instead of throwing error which is harder to debug.

```
asa_acl:
  lines: []
  <more fields here>
  
before: task terminates with "local variable 'acl_name' referenced before assignment" error
after: task terminates successfully with no change.
```
