### PR TITLE
Uptimerobot: add possibbility to add and remove monitors

### DIFF
--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -6,6 +6,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = '''
 module: uptimerobot
 short_description: Create, remove, pause and start monitors in Uptimerobot
@@ -67,11 +72,6 @@ EXAMPLES = '''
     check_type: http
     apikey: 12345-1234512345
 '''
-
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 import json
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -77,6 +77,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import Request
+from ansible.module_utils._text import to_text
 
 API_BASE = "https://api.uptimerobot.com/v2/"
 
@@ -119,7 +120,6 @@ class UptimeRobot:
         self.uri = API_BASE + "getMonitors"
         req = Request()
         state = req.post(url=self.uri, data=data, headers=self.headers)
-        state = state.read()
         state = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
         return state
 
@@ -127,8 +127,7 @@ class UptimeRobot:
         self.uri = API_BASE + self.api_method
         req = Request()
         state = req.post(url=self.uri, data=self.body, headers=self.headers)
-        state = state.read()
-        state = json.loads(state)
+        state = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
         return state, self.api_method
 
     def check_dict(self, dictionary):

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -25,7 +25,7 @@ options:
         choices: [ "started", "paused", "created", "absent" ]
     url:
         description:
-            - Url to be checked
+            - URL to be checked.
         required: true
         version_added: '2.10'
     name:

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -41,6 +41,7 @@ options:
     monitorid:
         description:
             - ID of the monitor to check.
+        required: false
     apikey:
         description:
             - Uptime Robot API key.

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -117,7 +117,7 @@ class UptimeRobot:
         req = Request()
         state = req.post(url=self.uri, data=data, headers=self.headers)
         state = state.read()
-        state = json.loads(state)
+        state = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
         return state
 
     def api_request(self):

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -42,6 +42,7 @@ options:
         description:
             - ID of the monitor to check.
         required: false
+        version_added: '2.10'
     apikey:
         description:
             - Uptime Robot API key.

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -22,8 +22,7 @@ options:
         description:
             - Define whether or not the monitor should be running or paused.
         required: true
-        choices: [ "started", "paused", "created", "absent" ]
-        version_added: '2.10'
+        choices: [ "started", "paused", "created", "absent", "present" ]
     url:
         description:
             - URL to be checked.
@@ -43,13 +42,13 @@ options:
         description:
             - ID of the monitor to check.
         required: false
-        version_added: '2.10'
     apikey:
         description:
             - Uptime Robot API key.
         required: true
 notes:
     - Support for further functionalities, which the api provides has not yet been implemented.
+    - created and absent are added in version 2.10
 '''
 
 EXAMPLES = '''
@@ -150,6 +149,7 @@ def main():
 
     api_methods = dict(
         started='editMonitor',
+        present='newMonitor',
         paused='editMonitor',
         absent='deleteMonitor',
         created='newMonitor'
@@ -160,7 +160,7 @@ def main():
             name=dict(required=True),
             url=dict(required=True),
             check_type=dict(required=False, choices=['http', 'dns']),
-            state=dict(required=True, choices=['started', 'paused', 'absent', 'created']),
+            state=dict(required=True, choices=['started', 'paused', 'absent', 'created', 'present']),
             apikey=dict(required=True, no_log=True),
             monitorid=dict(required=False)
         ),

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -113,20 +113,22 @@ class UptimeRobot:
                 return mid
 
     def get_monitors(self):
-        data = {}
-        data['api_key'] = self.params['api_key']
-        data = json.dumps(data)
+        self.body = {}
+        self.body['api_key'] = self.params['api_key']
+        self.body = json.dumps(self.body)
         self.uri = API_BASE + "getMonitors"
-        req = Request()
-        state = req.post(url=self.uri, data=data, headers=self.headers)
-        state = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
+        state = self.api_call()
         return state
+
+    def api_call(self):
+        req = Request()
+        state = req.post(url=self.uri, data=self.body, headers=self.headers)
+        json_response = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
+        return json_response
 
     def api_request(self):
         self.uri = API_BASE + self.api_method
-        req = Request()
-        state = req.post(url=self.uri, data=self.body, headers=self.headers)
-        state = json.loads(to_text(state.read(), errors='surrogate_or_strict'))
+        state = self.api_call()
         return state, self.api_method
 
     def check_dict(self, dictionary):

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -23,6 +23,7 @@ options:
             - Define whether or not the monitor should be running or paused.
         required: true
         choices: [ "started", "paused", "created", "absent" ]
+        version_added: '2.10'
     url:
         description:
             - URL to be checked.

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -30,7 +30,7 @@ options:
         version_added: '2.10'
     name:
         description:
-            - The friendly name of the monitor
+            - The friendly name of the monitor.
         required: true
         version_added: '2.10'
     check_type:

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -25,14 +25,17 @@ options:
         description:
             - Url to be checked
         required: true
+        version_added: '2.10'
     name:
         description:
             - The friendly name of the monitor
         required: true
+        version_added: '2.10'
     check_type:
         description:
             - The kind of check, that will be performed on the url.
         choices: [ "http", "dns" ]
+        version_added: '2.10'
     monitorid:
         description:
             - ID of the monitor to check.
@@ -113,7 +116,7 @@ class UptimeRobot:
         state = req.post(url=self.uri, data=data, headers=self.headers)
         state = state.read()
         state = json.loads(state)
-        return state #.decode('utf8')
+        return state
 
     def api_request(self):
         self.uri = API_BASE + self.api_method

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -11,7 +11,9 @@ module: uptimerobot
 short_description: Create, remove, pause and start monitors in Uptimerobot
 description:
     - This module lets you create, remove, pause and start monitors in Uptimerobot
-author: "Ninjiner (@Ninjiner)"
+author:
+- "Nate Kingsley (@nate-kingsley)"
+- "Ninjiner (@Ninjiner)"
 version_added: "1.9"
 requirements:
     - Valid Uptime Robot API Key

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -41,7 +41,7 @@ options:
     check_type:
         description:
             - The kind of check, that will be performed on the url.
-        choices: [ "http", "dns" ]
+        choices: [ "http", "ping" ]
         version_added: '2.10'
     monitorid:
         description:
@@ -131,7 +131,7 @@ class UptimeRobot:
             if v != '':
                 tmp[k] = v
             if k == 'type':
-                tmp[k] = 2 if v == 'dns' else 1
+                tmp[k] = 3 if v == 'ping' else 1
 
         if dictionary['status'] != 'created':
             tmp['id'] = self.get_monitor_id(dictionary['friendly_name'])
@@ -158,7 +158,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True),
             url=dict(required=True),
-            check_type=dict(required=False, choices=['http', 'dns']),
+            check_type=dict(required=False, choices=['http', 'ping']),
             state=dict(required=True, choices=['started', 'paused', 'absent', 'created', 'present']),
             apikey=dict(required=True, no_log=True),
             monitorid=dict(required=False)

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -93,11 +93,7 @@ class UptimeRobot:
         }
         self.uri = ''
         self.api_methods = api_methods
-        self.params = params
-        self.params = self.check_dict(self.params)
-        for k, v in self.params.items():
-            if k == 'type':
-                self.params[k] = 2 if v == 'dns' else 1
+        self.params = self.check_dict(params)
         self.body = json.dumps(self.params)
         for state, method in self.api_methods.items():
             if state == self.params['status']:
@@ -134,6 +130,9 @@ class UptimeRobot:
         for k, v in dictionary.items():
             if v != '':
                 tmp[k] = v
+            if k == 'type':
+                tmp[k] = 2 if v == 'dns' else 1
+
         if dictionary['status'] != 'created':
             tmp['id'] = self.get_monitor_id(dictionary['friendly_name'])
         dictionary.clear()

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -88,8 +88,9 @@ SUPPORTS_CHECK_MODE = False
 
 class UptimeRobot:
     def __init__(self, params, api_methods):
-        self.headers = {}
-        self.headers['Content-Type'] = "application/json"
+        self.headers = {
+            'Content-Type': "application/json"
+        }
         self.uri = ''
         self.api_methods = api_methods
         self.params = params

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -97,10 +97,7 @@ class UptimeRobot:
         self.params = self.check_dict(self.params)
         for k, v in self.params.items():
             if k == 'type':
-                if v == 'dns':
-                    self.params[k] = 2
-                else:
-                    self.params[k] = 1
+                self.params[k] = 2 if v == 'dns' else 1
         self.body = json.dumps(self.params)
         for state, method in self.api_methods.items():
             if state == self.params['status']:


### PR DESCRIPTION
##### SUMMARY
Although this code needs improvement, it makes it possible to add and remove monitors from uptimerobot. Also it interacts with the api v2 of uptimerobot. These three essential functionalities were missing before and I think they are the main reason you would use this module.

This would resolve this two issues:
- https://github.com/ansible/ansible/issues/36984
- https://github.com/ansible/ansible/issues/56994

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
uptimerobot

##### ADDITIONAL INFORMATION
I`m open for changes and improvements.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
