### PR TITLE
Integration tests: prevent loop squashing

### DIFF
--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -283,11 +283,12 @@
 
 - name: Clean up
   apt:
-    name: "{{ item }}"
+    name: "{{ pkgs }}"
     state: absent
-  with_items:
-    - libcaca-dev
-    - libslang2-dev
+  vars:
+    pkgs:
+      - libcaca-dev
+      - libslang2-dev
 
 # https://github.com/ansible/ansible/issues/38995
 - name: build-dep for a package

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -197,9 +197,7 @@
 
 - name: install non-existent rpm
   dnf:
-    name: "{{ item }}"
-  with_items:
-    - does-not-exist
+    name: does-not-exist
   register: non_existent_rpm
   ignore_errors: True
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -80,16 +80,8 @@
 
 - name: now put it back in case someone wanted it (like us!)
   pip:
-    name: "{{ item }}"
+    name: "{{ pip_test_packages  }}"
     state: present
-  with_items: "{{ pip_test_packages }}"
-  register: squash_param
-
-- name: check that list has been condensed
-  assert:
-    that:
-      - squash_param.results|length == 1
-      - squash_param.results[0].name|sort == pip_test_packages|sort
 
 # Test virtualenv installations
 

--- a/test/integration/targets/yum/tasks/repo.yml
+++ b/test/integration/targets/yum/tasks/repo.yml
@@ -385,11 +385,12 @@
 
       - name: install dinginessentail both archs
         yum:
-          name: "{{ item }}"
+          name: "{{ pkgs }}"
           state: present
-        with_items:
-          - "{{ repodir }}/dinginessentail-1.1-1.x86_64.rpm"
-          - "{{ repodir_i686 }}/dinginessentail-1.1-1.i686.rpm"
+        vars:
+          pkgs:
+            - "{{ repodir }}/dinginessentail-1.1-1.x86_64.rpm"
+            - "{{ repodir_i686 }}/dinginessentail-1.1-1.i686.rpm"
 
       - name: try to install lower version of dinginessentail from rpm file, without allow_downgrade, just one arch
         yum:
@@ -424,11 +425,12 @@
 
       - name: install dinginessentail both archs
         yum:
-          name: "{{ item }}"
+          name: "{{ pkgs }}"
           state: present
-        with_items:
-          - "{{ repodir }}/dinginessentail-1.0-1.x86_64.rpm"
-          - "{{ repodir_i686 }}/dinginessentail-1.0-1.i686.rpm"
+        vars:
+          pkgs:
+            - "{{ repodir }}/dinginessentail-1.0-1.x86_64.rpm"
+            - "{{ repodir_i686 }}/dinginessentail-1.0-1.i686.rpm"
 
       - name: Update both arch in one task using rpm files
         yum:

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -301,9 +301,8 @@
   yum: name=sos,bc state=removed
 
 - name: install non-existent rpm
-  yum: name="{{ item }}"
-  with_items:
-  - does-not-exist
+  yum:
+    name: does-not-exist
   register: non_existent_rpm
   ignore_errors: True
 

--- a/test/integration/targets/yum/tasks/yum_group_remove.yml
+++ b/test/integration/targets/yum/tasks/yum_group_remove.yml
@@ -1,19 +1,21 @@
 - name: install a group to test and yum-utils
   yum:
-    name: "{{ item }}"
+    name: "{{ pkgs }}"
     state: present
-  with_items:
-    - "@Custom Group"
-    - yum-utils
+  vars:
+    pkgs:
+      - "@Custom Group"
+      - yum-utils
   when: ansible_pkg_mgr == "yum"
 
 - name: install a group to test and dnf-utils
   yum:
-    name: "{{ item }}"
+    name: "{{ pkgs }}"
     state: present
-  with_items:
-    - "@Custom Group"
-    - dnf-utils
+  vars:
+    pkgs:
+      - "@Custom Group"
+      - dnf-utils
   when: ansible_pkg_mgr == "dnf"
 
 - name: check mode remove the group


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. the feature will be deprecated in 2.11
2. these modules support passing lists
3. loop squashing does not work with collections
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt, dnf, pip and yum integration tests
