### PR TITLE
Fix doc errors in AWS modules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -151,9 +151,11 @@ EXAMPLES = '''
         tag1: value1
         tag2: value2
       service_role: arn:aws:iam::<account>:role/service-role/<role>
+    register: aws_batch_compute_environment_action
 
   - name: show results
-    debug: var=aws_batch_compute_environment_action
+    debug:
+      var: aws_batch_compute_environment_action
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
     state: present
   tasks:
   - name: My Batch Job Queue
-    batch_job_queue:
+    aws_batch_job_queue:
       job_queue_name: jobQueueName
       state: present
       region: us-east-1
@@ -78,9 +78,11 @@ EXAMPLES = '''
           compute_environment: my_compute_env1
         - order: 2
           compute_environment: my_compute_env2
+    register: batch_job_queue_action
 
   - name: show results
-    debug: var=batch_job_queue_action
+    debug:
+      var: batch_job_queue_action
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb_info.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb_info.py
@@ -57,7 +57,8 @@ EXAMPLES = '''
     names: "alb-name"
     region: "aws-region"
   register: alb_info
-- debug: var=alb_info
+- debug:
+    var: alb_info
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/amazon/lambda_policy.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_policy.py
@@ -111,9 +111,11 @@ EXAMPLES = '''
       principal: s3.amazonaws.com
       source_arn: arn:aws:s3:eu-central-1:123456789012:bucketName
       source_account: 123456789012
+    register: lambda_policy_action
 
   - name: show results
-    debug: var=lambda_policy_action
+    debug:
+      var: lambda_policy_action
 
 '''
 


### PR DESCRIPTION
##### SUMMARY

* Change docs for `aws_batch_job_queue` to use the right module name
* Add missing `register` parameters
* Use modern YAML syntax for `debug` tasks 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

Various AWS/EC2 modules.

##### ADDITIONAL INFORMATION

Just a few simple documentation improvements -- no code was changed.