### PR TITLE
zabbix_host idempotency fix

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -445,13 +445,12 @@ class Host(object):
 
     # get group ids by group names
     def get_group_ids_by_group_names(self, group_names):
-        group_ids = []
         if self.check_host_group_exist(group_names):
-            group_list = self._zapi.hostgroup.get({'output': 'extend', 'filter': {'name': group_names}})
-            for group in group_list:
-                group_id = group['groupid']
-                group_ids.append({'groupid': group_id})
-        return group_ids
+            return self._zapi.hostgroup.get({'output': 'groupid', 'filter': {'name': group_names}})
+
+    # get host groups ids by host id
+    def get_group_ids_by_host_id(self, host_id):
+        return self._zapi.hostgroup.get({'output': 'groupid', 'hostids': host_id})
 
     # get host templates by host id
     def get_host_templates_by_host_id(self, host_id):
@@ -460,16 +459,6 @@ class Host(object):
         for template in template_list:
             template_ids.append(template['templateid'])
         return template_ids
-
-    # get host groups by host id
-    def get_host_groups_by_host_id(self, host_id):
-        exist_host_groups = []
-        host_groups_list = self._zapi.hostgroup.get({'output': 'extend', 'hostids': host_id})
-
-        if len(host_groups_list) >= 1:
-            for host_groups_name in host_groups_list:
-                exist_host_groups.append(host_groups_name['name'])
-        return exist_host_groups
 
     # check the exist_interfaces whether it equals the interfaces or not
     def check_interface_properties(self, exist_interface_list, interfaces):
@@ -504,14 +493,14 @@ class Host(object):
         return host['status']
 
     # check all the properties before link or clear template
-    def check_all_properties(self, host_id, host_groups, status, interfaces, template_ids,
+    def check_all_properties(self, host_id, group_ids, status, interfaces, template_ids,
                              exist_interfaces, host, proxy_id, visible_name, description, host_name,
                              inventory_mode, inventory_zabbix, tls_accept, tls_psk_identity, tls_psk,
                              tls_issuer, tls_subject, tls_connect, ipmi_authtype, ipmi_privilege,
                              ipmi_username, ipmi_password):
         # get the existing host's groups
-        exist_host_groups = self.get_host_groups_by_host_id(host_id)
-        if set(host_groups) != set(exist_host_groups):
+        exist_host_groups = sorted(self.get_group_ids_by_host_id(host_id), key=lambda k: k['groupid'])
+        if sorted(group_ids, key=lambda k: k['groupid']) != exist_host_groups:
             return True
 
         # get the existing status
@@ -818,8 +807,7 @@ def main():
             if not host_groups:
                 # if host_groups have not been specified when updating an existing host, just
                 # get the group_ids from the existing host without updating them.
-                host_groups = host.get_host_groups_by_host_id(host_id)
-                group_ids = host.get_group_ids_by_group_names(host_groups)
+                group_ids = host.get_group_ids_by_host_id(host_id)
 
             # get existing host's interfaces
             exist_interfaces = host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id})
@@ -849,12 +837,12 @@ def main():
                 template_ids = list(set(template_ids + host.get_host_templates_by_host_id(host_id)))
 
             if not force:
-                for group_id in host.get_group_ids_by_group_names(host.get_host_groups_by_host_id(host_id)):
+                for group_id in host.get_group_ids_by_host_id(host_id):
                     if group_id not in group_ids:
                         group_ids.append(group_id)
 
             # update host
-            if host.check_all_properties(host_id, host_groups, status, interfaces, template_ids,
+            if host.check_all_properties(host_id, group_ids, status, interfaces, template_ids,
                                          exist_interfaces, zabbix_host_obj, proxy_id, visible_name,
                                          description, host_name, inventory_mode, inventory_zabbix,
                                          tls_accept, tls_psk_identity, tls_psk, tls_issuer, tls_subject, tls_connect,


### PR DESCRIPTION
##### SUMMARY
Zabbix API retrieves host groups without being case sensitive. Providing that default group on Zabbix server is named `Linux servers` and that we spell it incorrectly in our task (e.g. `Linux SeRvERs`), the host group returned by API will still be `Linux servers` and the managed host will be assigned to it. However, subsequent runs of `zabbix_host` module will not yield idempotent results.

This PR changes how module compares wanted vs assigned host groups by simply checking their IDs instead of matching group names 1:1. By implementing it this way, we no longer need to retrieve full objects of host groups or work with their names, so we can speed & cleanup the module a little bit. Method `get_host_groups_by_host_id()` becomes unused then.

Fixes #58981

Tested against zabbix-server 3.0/4.0/4.2

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
```paste below
ansible 2.10.0.dev0
  python version = 2.7.15 (default, Feb 17 2019, 12:21:50) [GCC 7.4.0]
```
This works and is idempotent on subsequent runs (`Linux servers` is created by default after installation of zabbix-server package):
```yaml
- hosts: localhost
  tasks:
    - name: Test zabbix
      zabbix_host:
        server_url: '{{ zbx_server }}'
        login_user: '{{ zbx_user }}'
        login_password: '{{ zbx_pass }}'
        host_name: example-host
        host_groups:
          - "Linux servers"
        state: present
```
This works too, but always returns `changed=True`:
```yaml
- hosts: localhost
  tasks:
    - name: Test zabbix
      zabbix_host:
        server_url: '{{ zbx_server }}'
        login_user: '{{ zbx_user }}'
        login_password: '{{ zbx_pass }}'
        host_name: example-host
        host_groups:
          - "Linux sERVers"
        state: present
```
Function `sorted()` is used due to zabbix returning host groups in format:
```python
[{'groupid': u'1'}, {'groupid': u'2'}]
```

And finally this has another advantage, that if Zabbix become case sensitive for its `hostgroup.get` API call in the future, we wouldn't need to worry about it.