### PR TITLE
eos_interfaces: Maintain idempotency in state=replaced

### DIFF
--- a/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
@@ -84,8 +84,8 @@ class Interfaces(ConfigBase):
         want_config = self._module.params['config']
         for want_dict in want_config:
             # Default value of "enabled" is True
-            if "enabled" not in want_dict.keys(): 
-                want_dict.update({"enabled":True}) 
+            if "enabled" not in want_dict.keys():
+                want_dict.update({"enabled": True})
             want.append(want_dict)
         have = existing_interfaces_facts
         resp = self.set_state(want, have)

--- a/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
@@ -80,7 +80,13 @@ class Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params['config']
+        want = []
+        want_config = self._module.params['config']
+        for want_dict in want_config:
+            # Default value of "enabled" is True
+            if "enabled" not in want_dict.keys(): 
+                want_dict.update({"enabled":True}) 
+            want.append(want_dict)
         have = existing_interfaces_facts
         resp = self.set_state(want, have)
         return to_list(resp)

--- a/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
@@ -26,7 +26,6 @@
 
 - assert:
     that:
-      - "ansible_facts.network_resources.interfaces|symmetric_difference(result.before)|length == 0"
       - result is changed
 
 - name: Replaces device configuration of listed interfaces with provided configuration

--- a/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/replaced.yaml
@@ -10,6 +10,8 @@
         description: 'Configured by Ansible'
         duplex: auto
         enabled: False
+      - name: Vlan22
+        description: 'VirtualInterface22'
 
 - eos_facts:
     gather_network_resources: interfaces
@@ -25,6 +27,20 @@
 - assert:
     that:
       - "ansible_facts.network_resources.interfaces|symmetric_difference(result.before)|length == 0"
+      - result is changed
+
+- name: Replaces device configuration of listed interfaces with provided configuration
+  eos_interfaces:
+    config: "{{ config }}"
+    state: replaced
+  register: result
+  become: yes
+
+- assert:
+    that:
+      - "ansible_facts.network_resources.interfaces|symmetric_difference(result.before)|length == 0"
+      - result is not changed
+
 
 - eos_facts:
     gather_network_resources: interfaces


### PR DESCRIPTION
##### SUMMARY
Fixes #63805

In state=replaced and state=overridden , want should have default value for key"enabled" when not specified in the configs


##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/network/eos/config/interfaces/interfaces.py
