### PR TITLE
gcp_storage_object - urlencode the object url

### DIFF
--- a/changelogs/fragments/63630-gcp_storage_object_urlencode.yml
+++ b/changelogs/fragments/63630-gcp_storage_object_urlencode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- gcp_storage_object - encode the url for objects (https://github.com/ansible/ansible/issues/58830).

--- a/lib/ansible/modules/cloud/google/gcp_storage_object.py
+++ b/lib/ansible/modules/cloud/google/gcp_storage_object.py
@@ -161,6 +161,7 @@ bucket:
 ################################################################################
 
 from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 import json
 import os
 import mimetypes
@@ -264,9 +265,9 @@ def fetch_resource(module, link, allow_not_found=True):
 
 def self_link(module):
     if module.params['action'] == 'download':
-        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}".format(**module.params)
+        return urlencode("https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}".format(**module.params))
     else:
-        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params)
+        return urlencode("https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params))
 
 
 def local_file_path(module):
@@ -278,13 +279,13 @@ def local_file_path(module):
 
 def media_link(module):
     if module.params['action'] == 'download':
-        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}?alt=media".format(**module.params)
+        return urlencode("https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}?alt=media".format(**module.params))
     else:
-        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}?alt=media".format(**module.params)
+        return urlencode("https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}?alt=media".format(**module.params))
 
 
 def upload_link(module):
-    return "https://www.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={dest}".format(**module.params)
+    return urlencode("https://www.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={dest}".format(**module.params))
 
 
 def return_if_object(module, response, allow_not_found=False):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
gcp_storage_object - encode the url for objects (https://github.com/ansible/ansible/issues/58830).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #58830

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/google/gcp_storage_object.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Looking for a easy clean way to update with minimal changes

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
