### PR TITLE
user: Handle exception when /etc/shadow file is missing

### DIFF
--- a/changelogs/fragments/user_missing_etc_shadow.yml
+++ b/changelogs/fragments/user_missing_etc_shadow.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle exception when /etc/shadow file is missing or not found, while operating user operation in user module (https://github.com/ansible/ansible/issues/63490).

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -911,7 +911,7 @@ class User(object):
                 # Python 3.6 raises PermissionError instead of KeyError
                 # Due to absence of PermissionError in python2.7 need to check
                 # errno
-                if e.errno in (errno.EACCES, errno.EPERM):
+                if e.errno in (errno.EACCES, errno.EPERM, errno.ENOENT):
                     return passwd, expires
                 raise
 


### PR DESCRIPTION
##### SUMMARY

Added exception handling when module tries to modify user details,
and /etc/shadow file is missing or not found.

Fixes: #63490

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/user_missing_etc_shadow.yml
lib/ansible/modules/system/user.py
