### PR TITLE
Backport PR to Fix ios_l2_interfaces skipping relevant L2 interfaces facts

### DIFF
--- a/changelogs/fragments/63779-ios_l2_interfaces-skipping-relevant-L2-interfaces-facts.yaml
+++ b/changelogs/fragments/63779-ios_l2_interfaces-skipping-relevant-L2-interfaces-facts.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "Fix ios_l2_interfaces skipping relevant L2 interfaces facts(https://github.com/ansible/ansible/pull/63779)"

--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -83,7 +83,7 @@ class L2_InterfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
 
-        if intf.lower().startswith('gi'):
+        if intf.upper()[:2] in ('HU', 'FO', 'TW', 'TE', 'GI', 'FA', 'ET', 'PO'):
             # populate the facts from the configuration
             config['name'] = normalize_interface(intf)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport PR to Fix ios_l2_interfaces skipping relevant L2 interfaces facts
cherry-pick from: d620a209a5935aff190e74057ad4e30fa9dcefb4

Backport of https://github.com/ansible/ansible/pull/63779

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
