### PR TITLE
Add SetBootOrder and SetDefaultBootOrder commands

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -74,7 +74,7 @@ options:
       - list of BootOptionReference strings specifying the BootOrder
     default: []
     type: list
-    version_added: "2.9"
+    version_added: "2.10"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added command `SetBootOrder` to set the boot order of a system and `SetDefaultBootOrder` to set the boot order back to the default order.

`SetBootOrder` will PATCH the `BootOrder` of the system using a new `boot_order` option in the `redfish_config.py` module.

`SetDefaultBootOrder` will issue a POST to the `#ComputerSystem.SetDefaultBootOrder` Action URI.

Fixes #63914

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_config.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Playbook snippets:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: Set boot order
    redfish_config:
      category: Systems
      command: SetBootOrder
      boot_order:
        - Boot0002
        - Boot0001
        - Boot0000
        - Boot0003
        - Boot0004
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```

```
  - name: Set boot order to the default
    redfish_config:
      category: Systems
      command: SetDefaultBootOrder
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
```