### PR TITLE
Fix packet dynamic inventory "Slug" issue.

### DIFF
--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -353,7 +353,7 @@ class PacketInventory(object):
         if self.group_by_operating_system:
             self.push(self.inventory, device.operating_system['slug'], dest)
             if self.nested_groups:
-                self.push_group(self.inventory, 'operating_systems', device.operating_system.slug)
+                self.push_group(self.inventory, 'operating_systems', device.operating_system['slug'])
 
         # Inventory: Group by plan type
         if self.group_by_plan_type:

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -208,7 +208,6 @@ class PacketInventory(object):
 
         # Projects
         self.projects = []
-        # TODO: Allow override from ENV Var
         configProjects = config.get(ini_section, 'projects')
         configProjects_exclude = config.get(ini_section, 'projects_exclude')
         if (configProjects == 'all'):
@@ -352,7 +351,6 @@ class PacketInventory(object):
 
         # Inventory: Group by OS
         if self.group_by_operating_system:
-            #import pdb; pdb.set_trace()
             self.push(self.inventory, device.operating_system['slug'], dest)
             if self.nested_groups:
                 self.push_group(self.inventory, 'operating_systems', device.operating_system.slug)

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -208,6 +208,7 @@ class PacketInventory(object):
 
         # Projects
         self.projects = []
+        # TODO: Allow override from ENV Var
         configProjects = config.get(ini_section, 'projects')
         configProjects_exclude = config.get(ini_section, 'projects_exclude')
         if (configProjects == 'all'):
@@ -351,7 +352,8 @@ class PacketInventory(object):
 
         # Inventory: Group by OS
         if self.group_by_operating_system:
-            self.push(self.inventory, device.operating_system.slug, dest)
+            #import pdb; pdb.set_trace()
+            self.push(self.inventory, device.operating_system['slug'], dest)
             if self.nested_groups:
                 self.push_group(self.inventory, 'operating_systems', device.operating_system.slug)
 
@@ -400,7 +402,7 @@ class PacketInventory(object):
             elif key == 'packet_facility':
                 device_vars[key] = value['code']
             elif key == 'packet_operating_system':
-                device_vars[key] = value.slug
+                device_vars[key] = value['slug']
             elif key == 'packet_plan':
                 device_vars[key] = value['slug']
             elif key == 'packet_tags':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The Packet API introduced a breaking change in their `device.operating_system` object while referencing the `slug` property. This needed to be moved from a property notation `device.operating_system.slug` to a dict notation `device.operating_system['slug']`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Packet Dynamic Inventory Script
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
*Error 1*
```
# ./packet_net.py --list
Traceback (most recent call last):
  File "./packet_net.py", line 273, in get_devices_by_project
    self.add_device(device, project)
  File "./packet_net.py", line 354, in add_device
    self.push(self.inventory, device.operating_system.slug, dest)
AttributeError: 'dict' object has no attribute 'slug'
ERROR: "'dict' object has no attribute 'slug'", while: getting Packet devices
```

*Error 2:*
```
# ./packet_net.py --list
Traceback (most recent call last):
  File "./packet_net.py", line 273, in get_devices_by_project
    self.add_device(device, project)
  File "./packet_net.py", line 382, in add_device
    self.inventory["_meta"]["hostvars"][dest] = self.get_host_info_dict_from_device(device)
  File "./packet_net.py", line 404, in get_host_info_dict_from_device
    device_vars[key] = value.slug
AttributeError: 'dict' object has no attribute 'slug'
ERROR: "'dict' object has no attribute 'slug'", while: getting Packet devices
```
