### PR TITLE
Retry is number of times we try after the first failure

### DIFF
--- a/lib/ansible/modules/network/exos/exos_command.py
+++ b/lib/ansible/modules/network/exos/exos_command.py
@@ -18,9 +18,9 @@ version_added: "2.6"
 author: "Rafael D. Vencioneck (@rdvencioneck)"
 short_description: Run commands on remote devices running Extreme EXOS
 description:
-  - Sends arbitrary commands to an Extreme EXOS device and returns the results
-    read from the device. This module includes an argument that will cause the
-    module to wait for a specific condition before returning or timing out if
+  - Sends arbitrary commands(except configuration commands) to an Extreme EXOS device and
+    returns the results read from the device. This module includes an argument that will
+    cause the module to wait for a specific condition before returning or timing out if
     the condition is not met.
   - This module does not support running configuration commands.
     Please use M(exos_config) to configure EXOS devices.
@@ -187,7 +187,7 @@ def main():
     interval = module.params['interval']
     match = module.params['match']
 
-    while retries > 0:
+    while True:
         responses = run_commands(module, commands)
 
         for item in list(conditionals):
@@ -202,6 +202,9 @@ def main():
 
         time.sleep(interval)
         retries -= 1
+
+        if retries < 0:
+            break
 
     if conditionals:
         failed_conditions = [item.raw for item in conditionals]

--- a/test/units/modules/network/exos/test_exos_command.py
+++ b/test/units/modules/network/exos/test_exos_command.py
@@ -80,13 +80,13 @@ class TestExosCommandModule(TestExosModule):
         wait_for = 'result[0] contains "test string"'
         set_module_args(dict(commands=['show version'], wait_for=wait_for))
         self.execute_module(failed=True)
-        self.assertEqual(self.run_commands.call_count, 10)
+        self.assertEqual(self.run_commands.call_count, 11)
 
     def test_exos_command_retries(self):
         wait_for = 'result[0] contains "test string"'
         set_module_args(dict(commands=['show version'], wait_for=wait_for, retries=2))
         self.execute_module(failed=True)
-        self.assertEqual(self.run_commands.call_count, 2)
+        self.assertEqual(self.run_commands.call_count, 3)
 
     def test_exos_command_match_any(self):
         wait_for = ['result[0] contains "Switch"',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #63872 - exos_command: Local variable 'responses' referenced before assignment and the way we use 'retries'.

'Retries' description: 
> Specifies the number of retries a command should by tried
        before it is considered failed. The command is run on the
        target device every retry and evaluated against the
        I(wait_for) conditions.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
exos_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
