### PR TITLE
Fixed example error in windows_winrm user guide

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -818,7 +818,7 @@ The below Ansible tasks can also be used to enable TLS v1.2:
         data: '{{ item.value }}'
         type: dword
         state: present
-        register: enable_tls12
+      register: enable_tls12
       loop:
       - type: Server
         property: Enabled


### PR DESCRIPTION
##### SUMMARY
The example code to configure TLS 1.2 Support using Ansible had an indention error. The register variable 'enable_tls12' was not indented. This caused the subsequent task to fail since the variable was not registered. 

##### ISSUE TYPE
- Docs Pull Request