### PR TITLE
Make prepending tags with tag_ optional

### DIFF
--- a/contrib/inventory/packet_net.ini
+++ b/contrib/inventory/packet_net.ini
@@ -4,10 +4,10 @@
 [packet]
 
 # Packet projects to get info for. Set this to 'all' to get info for all
-# projects in Packet and merge the results together. Alternatively, set 
+# projects in Packet and merge the results together. Alternatively, set
 # this to a comma separated list of projects. E.g. 'project-1,project-3,project-4'
 projects = all
-projects_exclude = 
+projects_exclude =
 
 # By default, packet devices in all state are returned. Specify
 # packet device states to return as a comma-separated list.
@@ -33,6 +33,9 @@ nested_groups = False
 
 # Replace - tags when creating groups to avoid issues with ansible
 replace_dash_in_groups = True
+
+# Prepend tags with tag_
+prepend_tags = True
 
 # The packet inventory output can become very large. To manage its size,
 # configure which groups should be created.

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -169,6 +169,12 @@ class PacketInventory(object):
         else:
             self.replace_dash_in_groups = True
 
+        # Prepend tags with 'tag_'
+        if config.has_option(ini_section, 'prepend_tags'):
+            self.prepend_tags = config.getboolean(ini_section, 'prepend_tags')
+        else:
+            self.prepend_tags = True
+
         # Configure which groups should be created.
         group_by_options = [
             'group_by_device_id',
@@ -364,10 +370,16 @@ class PacketInventory(object):
         # Inventory: Group by tag keys
         if self.group_by_tags:
             for k in device.tags:
-                key = self.to_safe("tag_" + k)
+                if self.prepend_tags:
+                    key = self.to_safe("tag_" + k)
+                else:
+                    key = self.to_safe(k)
                 self.push(self.inventory, key, dest)
                 if self.nested_groups:
-                    self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
+                    if self.prepend_tags:
+                        self.push_group(self.inventory, 'tags', self.to_safe("tag_" + k))
+                    else:
+                        self.push_group(self.inventory, 'tags', self.to_safe(k))
 
         # Global Tag: devices without tags
         if self.group_by_tag_none and len(device.tags) == 0:


### PR DESCRIPTION
##### SUMMARY
By default the packet.py dynamic inventory script will prepend `tag_` to the tags that are applied to packet devices. This will interfere with projects such as kubespray which expects specific tags. This means that if a `kube-master` tag is expected and it is modified to be `tag_kube_master` or `tag_kube-master` then it will not match what is expected.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Packet Dynamic Inventory Script

##### ADDITIONAL INFORMATION
By default the tags will continue to be prepended with tag_. If the ini file contains `prepend_tags = False` then it will disable it.
