### PR TITLE
Refactor CLI prompt mode check for network plugins

### DIFF
--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -305,8 +305,9 @@ def main():
                 pc_data = to_text(init_data)
                 try:
                     conn.update_play_context(pc_data)
+                    conn.set_cli_prompt_context()
                 except Exception as exc:
-                    # Only network_cli has update_play context, so missing this is
+                    # Only network_cli has update_play context and set_cli_prompt_context, so missing this is
                     # not fatal e.g. netconf
                     if isinstance(exc, ConnectionError) and getattr(exc, 'code', None) == -32601:
                         pass

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -23,8 +23,6 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.aireos.aireos import aireos_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
@@ -68,14 +66,6 @@ class ActionModule(ActionNetworkModule):
             return {'failed': True,
                     'msg': 'unable to open shell. Please see: ' +
                            'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -23,8 +23,6 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.aruba.aruba import aruba_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
@@ -69,14 +67,6 @@ class ActionModule(ActionNetworkModule):
             return {'failed': True,
                     'msg': 'unable to open shell. Please see: ' +
                            'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -10,8 +10,6 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.cloudengine.ce import ce_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
@@ -84,23 +82,6 @@ class ActionModule(ActionNetworkModule):
                     (self._play_context.connection == 'netconf' and self._task.action in CLI_SUPPORTED_MODULES):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module."
                         % (self._play_context.connection, self._task.action)}
-
-        if (self._play_context.connection == 'local' and transport == 'cli' and self._task.action in CLI_SUPPORTED_MODULES) \
-                or self._play_context.connection == 'network_cli':
-            # make sure we are in the right cli context which should be
-            # enable mode and not config module
-            if socket_path is None:
-                socket_path = self._connection.socket_path
-            conn = Connection(socket_path)
-            out = conn.get_prompt()
-            prompt = to_text(out, errors='surrogate_then_replace').strip()
-            while prompt.endswith(']'):
-                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                if prompt.startswith('[*'):
-                    conn.exec_command('clear configuration candidate')
-                conn.exec_command('return')
-                out = conn.get_prompt()
-                prompt = to_text(out, errors='surrogate_then_replace').strip()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -24,8 +24,6 @@ from ansible import constants as C
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.cnos.cnos import cnos_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
-from ansible.module_utils.connection import Connection
-from ansible.module_utils._text import to_text
 from ansible.utils.display import Display
 
 display = Display()
@@ -37,7 +35,6 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         self._config_module = True if self._task.action == 'cnos_config' else False
-        socket_path = None
 
         if self._play_context.connection == 'local':
             provider = load_provider(cnos_provider_spec, self._task.args)
@@ -66,19 +63,6 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module or exec mode
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('In Config mode, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
-        else:
-            conn.send_command('enable')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -25,8 +25,6 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.dellos6.dellos6 import dellos6_provider_spec
 from ansible.module_utils.network.common.utils import load_provider
@@ -76,18 +74,6 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
-            out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -25,8 +25,6 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.dellos9.dellos9 import dellos9_provider_spec
@@ -76,18 +74,6 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
-            out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -19,12 +19,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
 import sys
 import copy
 
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.ios.ios import ios_provider_spec
@@ -40,7 +37,6 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'ios_config' else False
-        socket_path = None
 
         if self._play_context.connection == 'network_cli':
             provider = self._task.args.get('provider', {})
@@ -78,20 +74,6 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        try:
-            out = conn.get_prompt()
-            if re.search(r'config.*\)#', to_text(out, errors='surrogate_then_replace').strip()):
-                display.vvvv('wrong context, sending end to device', self._play_context.remote_addr)
-                conn.send_command('end')
-        except ConnectionError as exc:
-            return {'failed': True, 'msg': to_text(exc)}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -22,9 +22,6 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.iosxr.iosxr import iosxr_provider_spec
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.common.utils import load_provider
@@ -40,7 +37,6 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'iosxr_config' else False
-        socket_path = None
         force_cli = module_name in ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
 
         if self._play_context.connection == 'local':
@@ -85,19 +81,6 @@ class ActionModule(ActionNetworkModule):
                 del self._task.args['provider']
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
-            if socket_path is None:
-                socket_path = self._connection.socket_path
-
-            conn = Connection(socket_path)
-            out = conn.get_prompt()
-            while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                conn.send_command('abort')
-                out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -22,9 +22,6 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible import constants as C
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.ironware.ironware import ironware_provider_spec
@@ -39,7 +36,6 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         self._config_module = True if self._task.action == 'ironware_config' else False
-        socket_path = None
 
         if self._play_context.connection == 'network_cli':
             provider = self._task.args.get('provider', {})
@@ -77,21 +73,6 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        try:
-            out = conn.get_prompt()
-            while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                conn.send_command('exit')
-                out = conn.get_prompt()
-        except ConnectionError as exc:
-            return {'failed': True, 'msg': to_text(exc)}
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -22,8 +22,6 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.junos.junos import junos_provider_spec
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
@@ -41,7 +39,6 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'junos_config' else False
-        socket_path = None
 
         if self._play_context.connection == 'local':
             provider = load_provider(junos_provider_spec, self._task.args)
@@ -93,19 +90,6 @@ class ActionModule(ActionNetworkModule):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, module_name)}
-
-        if (self._play_context.connection == 'local' and pc.connection == 'network_cli') or self._play_context.connection == 'network_cli':
-            # make sure we are in the right cli context which should be
-            # enable mode and not config module
-            if socket_path is None:
-                socket_path = self._connection.socket_path
-
-            conn = Connection(socket_path)
-            out = conn.get_prompt()
-            while to_text(out, errors='surrogate_then_replace').strip().endswith('#'):
-                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                conn.send_command('exit')
-                out = conn.get_prompt()
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -22,10 +22,7 @@ __metaclass__ = type
 import sys
 import copy
 
-from ansible import constants as C
 from ansible.plugins.action.network import ActionModule as ActionNetworkModule
-from ansible.module_utils._text import to_text
-from ansible.module_utils.connection import Connection
 from ansible.module_utils.network.common.utils import load_provider
 from ansible.module_utils.network.vyos.vyos import vyos_provider_spec
 from ansible.utils.display import Display
@@ -40,7 +37,6 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'vyos_config' else False
-        socket_path = None
 
         if self._play_context.connection == 'network_cli':
             provider = self._task.args.get('provider', {})
@@ -74,17 +70,6 @@ class ActionModule(ActionNetworkModule):
             task_vars['ansible_socket'] = socket_path
         else:
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        if socket_path is None:
-            socket_path = self._connection.socket_path
-
-        conn = Connection(socket_path)
-        out = conn.get_prompt()
-        if to_text(out, errors='surrogate_then_replace').strip().endswith('#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit discard')
 
         result = super(ActionModule, self).run(task_vars=task_vars)
         return result

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -19,8 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
-
 from abc import abstractmethod
 from functools import wraps
 

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import re
+
 from abc import abstractmethod
 from functools import wraps
 
@@ -447,3 +449,31 @@ class CliconfBase(AnsiblePlugin):
 
         if replace and not operations.get('supports_replace', False):
             raise ValueError("configuration replace is not supported")
+
+    def set_cli_prompt_context(self):
+        """
+        Ensure the command prompt on device is in right mode
+        :return: None
+        """
+        pass
+
+    def _update_cli_prompt_context(self, config_context=None, exit_command='exit'):
+        """
+        Update the cli prompt context to ensure it is in operational mode
+        :param config_context: It is string value to identify if the current cli prompt ends with config mode prompt
+        :param exit_command: Command to execute to exit the config mode
+        :return: None
+        """
+        out = self._connection.get_prompt()
+        if out is None:
+            raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                   u' response window: %s' % self._connection._last_recv_window)
+
+        while True:
+            out = to_text(out, errors='surrogate_then_replace').strip()
+            if config_context and out.endswith(config_context):
+                self._connection.queue_message('vvvv', 'wrong context, sending exit to device')
+                self.send_command(exit_command)
+                out = self._connection.get_prompt()
+            else:
+                break

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -87,7 +87,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/aireos.py
+++ b/lib/ansible/plugins/cliconf/aireos.py
@@ -34,6 +34,7 @@ import json
 
 from itertools import chain
 
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
@@ -85,3 +86,12 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -87,7 +87,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/aruba.py
+++ b/lib/ansible/plugins/cliconf/aruba.py
@@ -86,3 +86,12 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -100,7 +100,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode
@@ -115,7 +114,7 @@ class Cliconf(CliconfBase):
 
             prompt = to_text(out, errors='surrogate_then_replace').strip()
             while prompt.endswith(']'):
-                self._connection.queue_message('vvvv', 'wrong context, sending exit to device')
+                self._connection.queue_message('vvvv', 'wrong context, sending return to device')
                 if prompt.startswith('[*'):
                     self._connection.exec_command('clear configuration candidate')
                 self._connection.exec_command('return')

--- a/lib/ansible/plugins/cliconf/ce.py
+++ b/lib/ansible/plugins/cliconf/ce.py
@@ -34,6 +34,7 @@ import json
 
 from itertools import chain
 
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
@@ -98,3 +99,25 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            out = self._connection.get_prompt()
+
+            if out is None:
+                raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                       u' response window: %s' % self._connection._last_recv_window)
+
+            prompt = to_text(out, errors='surrogate_then_replace').strip()
+            while prompt.endswith(']'):
+                self._connection.queue_message('vvvv', 'wrong context, sending exit to device')
+                if prompt.startswith('[*'):
+                    self._connection.exec_command('clear configuration candidate')
+                self._connection.exec_command('return')
+                out = self._connection.get_prompt()
+                prompt = to_text(out, errors='surrogate_then_replace').strip()

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -29,7 +29,7 @@ version_added: 2.6
 import re
 import json
 
-from itertools import chain
+from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.network.common.utils import to_list
@@ -116,3 +116,22 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            out = self._connection.get_prompt()
+
+            if out is None:
+                raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                       u' response window: %s' % self._connection._last_recv_window)
+
+            if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+                self._connection.queue_message('vvvv', 'In Config mode, sending exit to device')
+                self._connection.send_command('exit')
+            else:
+                self._connection.send_command('enable')

--- a/lib/ansible/plugins/cliconf/cnos.py
+++ b/lib/ansible/plugins/cliconf/cnos.py
@@ -117,7 +117,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -114,7 +114,6 @@ class Cliconf(CliconfBase):
 
         return responses
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/dellos10.py
+++ b/lib/ansible/plugins/cliconf/dellos10.py
@@ -113,3 +113,12 @@ class Cliconf(CliconfBase):
             responses.append(out)
 
         return responses
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -114,7 +114,6 @@ class Cliconf(CliconfBase):
 
         return responses
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/dellos6.py
+++ b/lib/ansible/plugins/cliconf/dellos6.py
@@ -113,3 +113,12 @@ class Cliconf(CliconfBase):
             responses.append(out)
 
         return responses
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -114,7 +114,6 @@ class Cliconf(CliconfBase):
 
         return responses
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/dellos9.py
+++ b/lib/ansible/plugins/cliconf/dellos9.py
@@ -113,3 +113,12 @@ class Cliconf(CliconfBase):
             responses.append(out)
 
         return responses
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -31,7 +31,8 @@ import json
 
 from itertools import chain
 
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text
 from ansible.module_utils.network.common.utils import to_list
 from ansible.plugins.cliconf import CliconfBase, enable_mode
 
@@ -83,3 +84,22 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            out = self._connection.get_prompt()
+
+            if out is None:
+                raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                       u' response window: %s' % self._connection._last_recv_window)
+
+            if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+                self._connection.queue_message('vvvv', 'In Config mode, sending exit to device')
+                self._connection.send_command('exit')
+            else:
+                self._connection.send_command('enable')

--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -85,7 +85,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -286,7 +286,6 @@ class Cliconf(CliconfBase):
 
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/eos.py
+++ b/lib/ansible/plugins/cliconf/eos.py
@@ -286,6 +286,15 @@ class Cliconf(CliconfBase):
 
         return json.dumps(result)
 
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context='(config', exit_command='abort')
+
     def _get_command_with_output(self, command, output):
         options_values = self.get_option_values()
         if output not in options_values['output']:

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -34,8 +34,6 @@ import re
 import time
 import json
 
-from itertools import chain
-
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
@@ -332,6 +330,23 @@ class Cliconf(CliconfBase):
             return 'all'
         else:
             return 'full'
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            out = self._connection.get_prompt()
+
+            if out is None:
+                raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                       u' response window: %s' % self._connection._last_recv_window)
+
+            if re.search(r'config.*\)#', to_text(out, errors='surrogate_then_replace').strip()):
+                self._connection.queue_message('vvvv', 'wrong context, sending end to device')
+                self._connection.send_command('end')
 
     def _extract_banners(self, config):
         banners = {}

--- a/lib/ansible/plugins/cliconf/ios.py
+++ b/lib/ansible/plugins/cliconf/ios.py
@@ -331,7 +331,6 @@ class Cliconf(CliconfBase):
         else:
             return 'full'
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -266,3 +266,12 @@ class Cliconf(CliconfBase):
         result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#', exit_command='abort')

--- a/lib/ansible/plugins/cliconf/iosxr.py
+++ b/lib/ansible/plugins/cliconf/iosxr.py
@@ -267,7 +267,6 @@ class Cliconf(CliconfBase):
         result.update(self.get_option_values())
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -87,7 +87,6 @@ class Cliconf(CliconfBase):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -86,3 +86,12 @@ class Cliconf(CliconfBase):
     def get_capabilities(self):
         result = super(Cliconf, self).get_capabilities()
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context=')#')

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -246,7 +246,6 @@ class Cliconf(CliconfBase):
         result.update(self.get_option_values())
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -246,6 +246,15 @@ class Cliconf(CliconfBase):
         result.update(self.get_option_values())
         return json.dumps(result)
 
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context='#')
+
     def _get_command_with_output(self, command, output):
         options_values = self.get_option_values()
         if output not in options_values['output']:

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -258,6 +258,25 @@ class Cliconf(CliconfBase):
 
         return json.dumps(result)
 
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli context
+        :return: None
+        """
+        if self._connection.connected:
+            out = self._connection.get_prompt()
+            if out is None:
+                raise AnsibleConnectionFailure(message=u'cli prompt is not identified from the last received'
+                                                       u' response window: %s' % self._connection._last_recv_window)
+            # Match prompts ending in )# except those with (maint-mode)#
+            config_prompt = re.compile(r'^.*\((?!maint-mode).*\)#$')
+
+            while config_prompt.match(to_text(out, errors='surrogate_then_replace').strip()):
+                self._connection.queue_message('vvvv', 'wrong context, sending exit to device')
+                self._connection.send_command('exit')
+                out = self._connection.get_prompt()
+
     def _get_command_with_output(self, command, output):
         options_values = self.get_option_values()
         if output not in options_values['output']:

--- a/lib/ansible/plugins/cliconf/nxos.py
+++ b/lib/ansible/plugins/cliconf/nxos.py
@@ -258,7 +258,6 @@ class Cliconf(CliconfBase):
 
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli context

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -266,3 +266,12 @@ class Cliconf(CliconfBase):
         result['device_operations'] = self.get_device_operations()
         result.update(self.get_option_values())
         return json.dumps(result)
+
+    @property
+    def set_cli_prompt_context(self):
+        """
+        Make sure we are in the operational cli mode
+        :return: None
+        """
+        if self._connection.connected:
+            self._update_cli_prompt_context(config_context='#', exit_command='exit discard')

--- a/lib/ansible/plugins/cliconf/vyos.py
+++ b/lib/ansible/plugins/cliconf/vyos.py
@@ -267,7 +267,6 @@ class Cliconf(CliconfBase):
         result.update(self.get_option_values())
         return json.dumps(result)
 
-    @property
     def set_cli_prompt_context(self):
         """
         Make sure we are in the operational cli mode

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -314,6 +314,7 @@ class Connection(NetworkConnectionBase):
         self._last_response = None
         self._history = list()
         self._command_response = None
+        self._last_recv_window = None
 
         self._terminal = None
         self.cliconf = None
@@ -540,6 +541,7 @@ class Connection(NetworkConnectionBase):
             recv.seek(offset)
 
             window = self._strip(recv.read())
+            self._last_recv_window = window
             window_count += 1
 
             if prompts and not handled:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Move the CLI prompt mode check logic from action plugin
   to the controller side with the cliconf plugins.

*  This refactor also allows the network modules
   to initialize the persistent connection with the remote device
   only when it is required.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #55202

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cli/scripts/ansible_connection_cli_stub.py
module_utils/network/common/cfg/base.py
module_utils/network/junos/config/interfaces/interfaces.py
module_utils/network/nxos/argspec/interfaces/interfaces.py
module_utils/network/nxos/config/interfaces/interfaces.py
plugins/action/aireos.py
plugins/action/aruba.py
plugins/action/asa.py
plugins/action/ce.py
plugins/action/cnos.py
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/enos.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/ironware.py
plugins/action/junos.py
plugins/action/nxos.py
plugins/action/vyos.py
plugins/cliconf/__init__.py
plugins/cliconf/aireos.py
plugins/cliconf/aruba.py
plugins/cliconf/ce.py
plugins/cliconf/cnos.py
plugins/cliconf/dellos10.py
plugins/cliconf/dellos6.py
plugins/cliconf/dellos9.py
plugins/cliconf/enos.py
plugins/cliconf/eos.py
plugins/cliconf/ios.py
plugins/cliconf/iosxr.py
plugins/cliconf/ironware.py
plugins/cliconf/junos.py
plugins/cliconf/nxos.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
