### PR TITLE
ManageIQ Ivanchuk fixes

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
@@ -411,11 +411,7 @@ class ManageIQgroup(object):
         filters_updated = False
         new_filters_resource = {}
 
-        # Process belongsto filters
-        if 'belongsto' in current_filters:
-            current_belongsto_set = set(current_filters['belongsto'])
-        else:
-            current_belongsto_set = set()
+        current_belongsto_set = current_filters.get('belongsto', set())
 
         if belongsto_filters:
             new_belongsto_set = set(belongsto_filters)
@@ -501,11 +497,12 @@ class ManageIQgroup(object):
 
     @staticmethod
     def manageiq_filters_to_sorted_dict(current_filters):
-        if 'managed' not in current_filters:
+        current_managed_filters = current_filters.get('managed')
+        if not current_managed_filters:
             return None
 
         res = {}
-        for tag_list in current_filters['managed']:
+        for tag_list in current_managed_filters:
             tag_list.sort()
             key = tag_list[0].split('/')[2]
             res[key] = tag_list
@@ -547,11 +544,11 @@ class ManageIQgroup(object):
         belongsto_filters = None
         if 'filters' in group['entitlement']:
             filters = group['entitlement']['filters']
-            if 'belongsto' in filters:
-                belongsto_filters = filters['belongsto']
-            if 'managed' in filters:
+            belongsto_filters = filters.get('belongsto')
+            group_managed_filters = filters.get('managed')
+            if group_managed_filters:
                 managed_filters = {}
-                for tag_list in filters['managed']:
+                for tag_list in group_managed_filters:
                     key = tag_list[0].split('/')[2]
                     tags = []
                     for t in tag_list:

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py
@@ -221,7 +221,7 @@ class ManageIQTenant(object):
                     self.module.fail_json(msg="Multiple parent tenants not found in manageiq with name '%s" % parent)
 
                 parent_tenant = parent_tenant_res[0]
-                parent_id = parent_tenant['id']
+                parent_id = int(parent_tenant['id'])
                 tenants = self.client.collections.tenants.find_by(name=name)
 
                 for tenant in tenants:
@@ -448,7 +448,7 @@ class ManageIQTenant(object):
 
         try:
             ancestry = tenant['ancestry']
-            tenant_parent_id = int(ancestry.split("/")[-1])
+            tenant_parent_id = ancestry.split("/")[-1]
         except AttributeError:
             # The root tenant does not return the ancestry attribute
             tenant_parent_id = None


### PR DESCRIPTION
##### SUMMARY
Testing the ansible module with the newes release of manageiq revealed some issues because the api responses did change somewhat. This caused the manageiq-tenant and manageiq-group to fail.
- manageiq-group: better handling if key not present
- manageiq-tenant: ivanchuk api now returns ids as strings

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- manageiq-group
- manageiq-tenant

##### ADDITIONAL INFORMATION
Errors include
manageiq-group
```
/ansible_manageiq_group_payload__nj7y90i/__main__.py\", line 554, in create_result_group\nTypeError: 'NoneType' object is not iterable\n",
```

manageiq-tenant
```
{
    "msg": "failed to create tenant TST: Api::BadRequestError: Failed to add a new tenant resource - Tenant: Name should be unique per parent",
    "exception": "  File \"/tmp/ansible_manageiq_tenant_payload_uwxaxtmh/__main__.py\", line 315, in create_tenant\n    result = self.client.post(url, action='create', resource=resource)\n  File \"/opt/custom-venvs/vipernext_team3/lib/python3.6/site-packages/manageiq_client/api.py\", line 135, in post\n    return self._result_processor(data)\n  File \"/opt/custom-venvs/vipernext_team3/lib/python3.6/site-packages/manageiq_client/api.py\", line 87, in _result_processor\n    \"{}: {}\".format(result_json[\"error\"][\"klass\"], result_json[\"error\"][\"message\"]))\n",
```
