### PR TITLE
force Openstack dynamic inventory to always return the tenant private ips

### DIFF
--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -126,7 +126,7 @@ def get_host_groups(inventory, refresh=False, cloud=None):
 
 
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
-    # quick&dirty hack to alway get private tenant ips
+    # quick&dirty hack to always get private tenant ips
     tenant_net = list(server['addresses'])[0]
     tenant_net_info = server['addresses'][tenant_net]
     for i in tenant_net_info:

--- a/contrib/inventory/openstack_inventory.py
+++ b/contrib/inventory/openstack_inventory.py
@@ -126,6 +126,12 @@ def get_host_groups(inventory, refresh=False, cloud=None):
 
 
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
+    # quick&dirty hack to alway get private tenant ips
+    tenant_net = list(server['addresses'])[0]
+    tenant_net_info = server['addresses'][tenant_net]
+    for i in tenant_net_info:
+        if i['OS-EXT-IPS:type'] == "fixed":
+            server['interface_ip'] = i['addr']
     hostvars[key] = dict(
         ansible_ssh_host=server['interface_ip'],
         ansible_host=server['interface_ip'],


### PR DESCRIPTION
##### SUMMARY

This is quick&dirty hack to force the openstack dynamic inventory to always return the tenant private ips . It's a workaround for [this issue](https://github.com/ansible/ansible/issues/63946)

It's not ready to merge because with this patch the dynamic inventory will always return the private ips and never the floating ips. It will  work for you if you need to run ansible from inside the openstack tenant or using a bastion host but it won't work if you need to run ansible from outside the cloud. The flag `--private` is ignored

Contributed as reference in case it helps the maintainers to apply a proper fix

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
openstack dynamic inventory

