### PR TITLE
Adjust conditional for disabling alert email

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_alert.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_alert.py
@@ -160,7 +160,7 @@ def main():
         create_alert(module, array)
     elif module.params['state'] == 'present' and exists and not enabled and module.params['enabled']:
         enable_alert(module, array)
-    elif module.params['state'] == 'present' and exists and not module.params['enabled']:
+    elif module.params['state'] == 'present' and exists and enabled and not module.params['enabled']:
         disable_alert(module, array)
     elif module.params['state'] == 'absent' and exists:
         delete_alert(module, array)

--- a/lib/ansible/modules/storage/purestorage/purefa_alert.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_alert.py
@@ -160,7 +160,7 @@ def main():
         create_alert(module, array)
     elif module.params['state'] == 'present' and exists and not enabled and module.params['enabled']:
         enable_alert(module, array)
-    elif module.params['state'] == 'present' and exists and enabled:
+    elif module.params['state'] == 'present' and exists and not module.params['enabled']:
         disable_alert(module, array)
     elif module.params['state'] == 'absent' and exists:
         delete_alert(module, array)


### PR DESCRIPTION
Conditional was improperly disabling existing alert email when it was found enabled.  The expectation is that it should only disable if module.param['enabled'] was set to false.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_alert.py

