### PR TITLE
Fix image detection in os_image openstack module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -177,8 +177,10 @@ def main():
     try:
 
         changed = False
-        if module.params['checksum']:
-            image = cloud.get_image(name_or_id=None, filters={'checksum': module.params['checksum']})
+        if module.params['id']:
+            image = cloud.get_image(name_or_id=module.params['id'])
+        elif module.params['checksum']:
+            image = cloud.get_image(name_or_id=module.params['name'], filters={'checksum': module.params['checksum']})
         else:
             image = cloud.get_image(name_or_id=module.params['name'])
 


### PR DESCRIPTION
Currently first check to find an image was by checksum only, and if there are 2
images with the same checksum, but different names, this check
fails with error:
```diff
- fatal: [localhost]: FAILED! => {
-     "changed": false,
-     "extra_data": null
- }

- MSG:
- Multiple matches found for None
```
To prevent this let's add more exact check in the beginning:
1. Firstly try to find by unique ID if it's given, most safe way.
2. Try to find by combination of name and checksum, not only
checksum, it will drop duplicates with different name.
3. Try to find just by name, as most general approach.

By going from most narrow to more general checks we can drop
duplicates in more efficient manner.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_image

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
