### PR TITLE
Remove `timeout` parameter from `prepare_nxos_tests`

### DIFF
--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -31,7 +31,6 @@
 - name: "Collect interface list"
   nxos_command:
     commands: ['show interface brief | json']
-    timeout: 60
   connection: network_cli
   register: intout
 


### PR DESCRIPTION
##### SUMMARY
The error below occurs when attempting to run `ansible-playbook` with nxos regression tests.

```
fatal: [dt-n9k5-1.cisco.com]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "commands": [
                "show interface brief | json"
            ],
            "timeout": 60
        }
    },
    "msg": "Unsupported parameters for (nxos_command) module: timeout Supported parameters include: commands, interval, match, provider, retries, wait_for"
}
```

This error appears to be a result of https://github.com/ansible/ansible/pull/62625, but that has not been verified.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos`

