### PR TITLE
change $partition variable name to $ansible_partition

### DIFF
--- a/changelogs/fragments/win_partition-var.yaml
+++ b/changelogs/fragments/win_partition-var.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_partition - Fix invalid variable name causing a failure on checks - https://github.com/ansible/ansible/issues/62401

--- a/lib/ansible/modules/windows/win_partition.ps1
+++ b/lib/ansible/modules/windows/win_partition.ps1
@@ -214,10 +214,10 @@ if ($ansible_partition) {
     }
     else {
 
-        if ($null -ne $gpt_type -and $gpt_styles.$gpt_type -ne $partition.GptType) {
+        if ($null -ne $gpt_type -and $gpt_styles.$gpt_type -ne $ansible_partition.GptType) {
             $module.FailJson("gpt_type is not a valid parameter for existing partitions")
         }
-        if ($null -ne $mbr_type -and $mbr_styles.$mbr_type -ne $partition.MbrType) {
+        if ($null -ne $mbr_type -and $mbr_styles.$mbr_type -ne $ansible_partition.MbrType) {
             $module.FailJson("mbr_type is not a valid parameter for existing partitions")
         }
 


### PR DESCRIPTION
##### SUMMARY
Corrects variable name `$partition` -> `$ansible_partition`

Fixes #62401

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`win_partition`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
