### PR TITLE
zabbix_action shouldn't require args other than name when state=absent

### DIFF
--- a/changelogs/fragments/63969-zabbix_action_argsfix.yml
+++ b/changelogs/fragments/63969-zabbix_action_argsfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_action - arguments ``event_source`` and ``esc_period`` no longer required when ``state=absent``

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -79,6 +79,7 @@ Noteworthy module changes
 * :ref:`vmware_tag <vmware_tag_module>` now returns ``tag_status`` instead of Ansible internal key ``results``.
 * The deprecated ``recurse`` option in :ref:`pacman <pacman_module>` module has been removed, you should use ``extra_args=--recursive`` instead.
 * :ref:`vmware_guest_custom_attributes <vmware_guest_custom_attributes_module>` module does not require VM name which was a required parameter for releases prior to Ansible 2.10.
+* :ref:`zabbix_action <zabbix_action_module>` no longer requires ``esc_period`` and ``event_source`` arguments when ``state=absent``.
 
 Plugins
 =======

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -40,7 +40,8 @@ options:
     event_source:
         description:
             - Type of events that the action will handle.
-        required: true
+            - Required when C(state=present).
+        required: false
         choices: ['trigger', 'discovery', 'auto_registration', 'internal']
     state:
         description:
@@ -63,7 +64,8 @@ options:
     esc_period:
         description:
             - Default operation step duration. Must be greater than 60 seconds. Accepts seconds, time unit with suffix and user macro.
-        required: true
+            - Required when C(state=present).
+        required: false
     conditions:
         type: list
         description:
@@ -1673,10 +1675,10 @@ def main():
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
-            esc_period=dict(type='int', required=True),
+            esc_period=dict(type='int', required=False),
             timeout=dict(type='int', default=10),
             name=dict(type='str', required=True),
-            event_source=dict(type='str', required=True, choices=['trigger', 'discovery', 'auto_registration', 'internal']),
+            event_source=dict(type='str', required=False, choices=['trigger', 'discovery', 'auto_registration', 'internal']),
             state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
             status=dict(type='str', required=False, default='enabled', choices=['enabled', 'disabled']),
             pause_in_maintenance=dict(type='bool', required=False, default=True),
@@ -1979,6 +1981,12 @@ def main():
                 ]
             )
         ),
+        required_if=[
+            ['state', 'present', [
+                'esc_period',
+                'event_source'
+            ]]
+        ],
         supports_check_mode=True
     )
 


### PR DESCRIPTION
##### SUMMARY
Only argument required during action.delete call is list of zabbix action IDs. Ref: [documentation](https://www.zabbix.com/documentation/4.4/manual/api/reference/action/delete)

Fixes #63455
Fixes #62641

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action

##### ADDITIONAL INFORMATION
```paste below
ansible 2.10.0.dev0
```
