### PR TITLE
Enable logging to any domain in the check point machine

### DIFF
--- a/lib/ansible/plugins/httpapi/checkpoint.py
+++ b/lib/ansible/plugins/httpapi/checkpoint.py
@@ -14,6 +14,18 @@ description:
   - This HttpApi plugin provides methods to connect to Checkpoint
     devices over a HTTP(S)-based api.
 version_added: "2.8"
+options:
+  domain:
+    type: str
+    description:
+      - Specifies the domain of the Check Point device
+    vars:
+      - name: ansible_checkpoint_domain
+    ini:
+      - section: checkpoint_httpapi
+        key: checkpoint_domain
+    env:
+      - name: ANSIBLE_CHECKPOINT_DOMAIN
 """
 
 import json
@@ -32,7 +44,11 @@ BASE_HEADERS = {
 class HttpApi(HttpApiBase):
     def login(self, username, password):
         if username and password:
-            payload = {'user': username, 'password': password}
+            cp_domain = self.get_option('domain')
+            if cp_domain:
+                payload = {'user': username, 'password': password, 'domain': cp_domain}
+            else:
+                payload = {'user': username, 'password': password}
             url = '/web_api/login'
             response, response_data = self.send_request(url, payload)
         else:

--- a/lib/ansible/plugins/httpapi/checkpoint.py
+++ b/lib/ansible/plugins/httpapi/checkpoint.py
@@ -21,11 +21,6 @@ options:
       - Specifies the domain of the Check Point device
     vars:
       - name: ansible_checkpoint_domain
-    ini:
-      - section: checkpoint_httpapi
-        key: checkpoint_domain
-    env:
-      - name: ANSIBLE_CHECKPOINT_DOMAIN
 """
 
 import json

--- a/test/units/plugins/httpapi/test_checkpoint.py
+++ b/test/units/plugins/httpapi/test_checkpoint.py
@@ -68,9 +68,9 @@ class TestCheckpointHttpApi(unittest.TestCase):
             {'sid': 'SID', 'uid': 'UID'}
         )
 
-        self.checkpoint_plugin.login('username', 'password')
+        self.checkpoint_plugin.login('USERNAME', 'PASSWORD')
 
-        self.connection_mock.send.assert_called_once_with('/test_domain', mock.ANY, headers=mock.ANY,
+        self.connection_mock.send.assert_called_once_with('/web_api/login', mock.ANY, headers=mock.ANY,
                                                           method=mock.ANY)
         self.checkpoint_plugin.hostvars['domain'] = temp_domain
 

--- a/test/units/plugins/httpapi/test_checkpoint.py
+++ b/test/units/plugins/httpapi/test_checkpoint.py
@@ -65,7 +65,7 @@ class TestCheckpointHttpApi(unittest.TestCase):
         temp_domain = self.checkpoint_plugin.hostvars['domain']
         self.checkpoint_plugin.hostvars['domain'] = 'test_domain'
         self.connection_mock.send.return_value = self._connection_response(
-            {'NOSIDKEY': 'NOSIDVALUE'}
+            {'sid': 'SID', 'uid': 'UID'}
         )
 
         self.checkpoint_plugin.login('username', 'password')

--- a/test/units/plugins/httpapi/test_checkpoint.py
+++ b/test/units/plugins/httpapi/test_checkpoint.py
@@ -63,7 +63,7 @@ class TestCheckpointHttpApi(unittest.TestCase):
 
     def test_login_to_global_domain(self):
         temp_domain = self.checkpoint_plugin.hostvars['domain']
-        self.ftd_plugin.hostvars['domain'] = 'test_domain'
+        self.checkpoint_plugin.hostvars['domain'] = 'test_domain'
         self.connection_mock.send.return_value = self._connection_response(
             200, {}
         )

--- a/test/units/plugins/httpapi/test_checkpoint.py
+++ b/test/units/plugins/httpapi/test_checkpoint.py
@@ -20,6 +20,15 @@ EXPECTED_BASE_HEADERS = {
 class FakeCheckpointHttpApiPlugin(HttpApi):
     def __init__(self, conn):
         super(FakeCheckpointHttpApiPlugin, self).__init__(conn)
+        self.hostvars = {
+            'domain': None
+        }
+
+    def get_option(self, var):
+        return self.hostvars[var]
+
+    def set_option(self, var, val):
+        self.hostvars[var] = val
 
 
 class TestCheckpointHttpApi(unittest.TestCase):
@@ -51,6 +60,19 @@ class TestCheckpointHttpApi(unittest.TestCase):
         resp = self.checkpoint_plugin.send_request('/test', None)
 
         assert resp == (500, {'errorMessage': 'ERROR'})
+
+    def test_login_to_global_domain(self):
+        temp_domain = self.checkpoint_plugin.hostvars['domain']
+        self.ftd_plugin.hostvars['domain'] = 'test_domain'
+        self.connection_mock.send.return_value = self._connection_response(
+            200, {}
+        )
+
+        self.checkpoint_plugin.login('username', 'password')
+
+        self.connection_mock.send.assert_called_once_with('/test_domain', mock.ANY, headers=mock.ANY,
+                                                          method=mock.ANY)
+        self.checkpoint_plugin.hostvars['domain'] = temp_domain
 
     @staticmethod
     def _connection_response(response, status=200):

--- a/test/units/plugins/httpapi/test_checkpoint.py
+++ b/test/units/plugins/httpapi/test_checkpoint.py
@@ -65,7 +65,7 @@ class TestCheckpointHttpApi(unittest.TestCase):
         temp_domain = self.checkpoint_plugin.hostvars['domain']
         self.checkpoint_plugin.hostvars['domain'] = 'test_domain'
         self.connection_mock.send.return_value = self._connection_response(
-            200, {}
+            {'NOSIDKEY': 'NOSIDVALUE'}
         )
 
         self.checkpoint_plugin.login('username', 'password')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable logging to any domain in the check point management machine
This solve issue #63890
And it's also a temporary solution for issue #63975
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
