### PR TITLE
hashlib is preferred over md5 and sha1 from Python 2.5+.

### DIFF
--- a/lib/ansible/module_utils/aws/s3.py
+++ b/lib/ansible/module_utils/aws/s3.py
@@ -10,10 +10,7 @@ HAS_MD5 = True
 try:
     from hashlib import md5
 except ImportError:
-    try:
-        from md5 import md5
-    except ImportError:
-        HAS_MD5 = False
+    HAS_MD5 = False
 
 
 def calculate_etag(module, filename, etag, s3, bucket, obj, version=None):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -121,13 +121,7 @@ try:
     except ValueError:
         AVAILABLE_HASH_ALGORITHMS.pop('md5', None)
 except Exception:
-    import sha
-    AVAILABLE_HASH_ALGORITHMS = {'sha1': sha.sha}
-    try:
-        import md5
-        AVAILABLE_HASH_ALGORITHMS['md5'] = md5.md5
-    except Exception:
-        pass
+    pass
 
 from ansible.module_utils.common._collections_compat import (
     KeysView,

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -29,10 +29,7 @@ import time
 
 from numbers import Number
 
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from jinja2.loaders import FileSystemLoader

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -23,20 +23,14 @@ import os
 
 # Note, sha1 is the only hash algorithm compatible with python2.4 and with
 # FIPS-140 mode (as of 11-2014)
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 # Backwards compat only
 try:
     from hashlib import md5 as _md5
 except ImportError:
-    try:
-        from md5 import md5 as _md5
-    except ImportError:
-        # Assume we're running in FIPS mode here
-        _md5 = None
+    # Assume we're running in FIPS mode here
+    _md5 = None
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -24,10 +24,7 @@ import sys
 
 from collections import defaultdict
 
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 from jinja2.exceptions import UndefinedError
 


### PR DESCRIPTION
##### SUMMARY

Again, here's some code that hasn't been updated when removing support for older versions of Python.
https://docs.python.org/2/library/hashlib.html#module-hashlib 

There are cases where Python could have been compiled without support for `md5`; I'm not sure about `sha1`. That's why I kept some import fallbacks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

```
