### PR TITLE
replaces deprecated ansible.module_utils.basic with platform.system().

### DIFF
--- a/changelogs/fragments/63990-replace-deprecated-basic-functions.yml
+++ b/changelogs/fragments/63990-replace-deprecated-basic-functions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - replace use of deprecated functions from ``ansible.module_utils.basic``.

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -135,9 +135,9 @@ def get_platform_subclass(cls):
 
         # New
         class User:
-            def __new__(cls, args, kwargs):
+            def __new__(cls, *args, **kwargs):
                 new_cls = get_platform_subclass(User)
-                return super(cls, new_cls).__new__(new_cls, args, kwargs)
+                return super(cls, new_cls).__new__(new_cls)
     '''
 
     this_platform = platform.system()

--- a/lib/ansible/module_utils/facts/packages.py
+++ b/lib/ansible/module_utils/facts/packages.py
@@ -7,8 +7,8 @@ __metaclass__ = type
 from abc import ABCMeta, abstractmethod
 
 from ansible.module_utils.six import with_metaclass
-from ansible.module_utils.basic import get_all_subclasses
 from ansible.module_utils.common.process import get_bin_path
+from ansible.module_utils.common._utils import get_all_subclasses
 
 
 def get_all_pkg_managers():

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -140,8 +140,9 @@ acl:
 '''
 
 import os
+import platform
 
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 
@@ -197,7 +198,7 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
     else:  # mode == 'get'
         cmd = [module.get_bin_path('getfacl', True)]
         # prevents absolute path warnings and removes headers
-        if get_platform().lower() == 'linux':
+        if platform.system().lower() == 'linux':
             cmd.append('--omit-header')
             cmd.append('--absolute-names')
 
@@ -210,9 +211,9 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
         cmd.append('--no-mask')
 
     if not follow:
-        if get_platform().lower() == 'linux':
+        if platform.system().lower() == 'linux':
             cmd.append('--physical')
-        elif get_platform().lower() == 'freebsd':
+        elif platform.system().lower() == 'freebsd':
             cmd.append('-h')
 
     if default:
@@ -225,7 +226,7 @@ def build_command(module, mode, path, follow, default, recursive, recalculate_ma
 def acl_changed(module, cmd):
     '''Returns true if the provided command affects the existing ACLs, false otherwise.'''
     # FreeBSD do not have a --test flag, so by default, it is safer to always say "true"
-    if get_platform().lower() == 'freebsd':
+    if platform.system().lower() == 'freebsd':
         return True
 
     cmd = cmd[:]  # lists are mutables so cmd would be overwritten without this
@@ -286,7 +287,7 @@ def main():
         supports_check_mode=True,
     )
 
-    if get_platform().lower() not in ['linux', 'freebsd']:
+    if platform.system().lower() not in ['linux', 'freebsd']:
         module.fail_json(msg="The acl module is not available on this system.")
 
     path = module.params.get('path')
@@ -338,7 +339,7 @@ def main():
         if default_flag is not None:
             default = default_flag
 
-    if get_platform().lower() == 'freebsd':
+    if platform.system().lower() == 'freebsd':
         if recursive:
             module.fail_json(msg="recursive is not supported on that platform.")
 

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -104,8 +104,9 @@ EXAMPLES = r'''
 '''
 
 import os
+import platform
 from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 
@@ -115,7 +116,7 @@ class PatchError(Exception):
 
 def add_dry_run_option(opts):
     # Older versions of FreeBSD, OpenBSD and NetBSD support the --check option only.
-    if get_platform().lower() in ['openbsd', 'netbsd', 'freebsd']:
+    if platform.system().lower() in ['openbsd', 'netbsd', 'freebsd']:
         opts.append('--check')
     else:
         opts.append('--dry-run')

--- a/lib/ansible/modules/notification/say.py
+++ b/lib/ansible/modules/notification/say.py
@@ -45,9 +45,9 @@ EXAMPLES = '''
     voice: Zarvox
   delegate_to: localhost
 '''
-import os
+import platform
 
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 
 
 def say(module, executable, msg, voice):
@@ -71,7 +71,7 @@ def main():
     voice = module.params['voice']
     possibles = ('say', 'espeak', 'espeak-ng')
 
-    if get_platform() != 'Darwin':
+    if platform.system() != 'Darwin':
         # 'say' binary available, it might be GNUstep tool which doesn't support 'voice' parameter
         voice = None
 

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -212,7 +212,7 @@ import re
 import sys
 import tempfile
 
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import shlex_quote
 
 
@@ -647,7 +647,7 @@ def main():
         module.fail_json(msg="You must specify time and date fields or special time.")
 
     # cannot support special_time on solaris
-    if (special_time or reboot) and get_platform() == 'SunOS':
+    if (special_time or reboot) and platform.system() == 'SunOS':
         module.fail_json(msg="Solaris does not support special_time=... or @reboot")
 
     if cron_file and do_install:

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -78,10 +78,11 @@ EXAMPLES = '''
 
 from distutils.version import LooseVersion
 import os
+import platform
 import re
 import stat
 
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 
 
 class Device(object):
@@ -281,7 +282,7 @@ class F2fs(Filesystem):
 
 
 class VFAT(Filesystem):
-    if get_platform() == 'FreeBSD':
+    if platform.system() == 'FreeBSD':
         MKFS = "newfs_msdos"
     else:
         MKFS = 'mkfs.vfat'

--- a/lib/ansible/modules/system/group.py
+++ b/lib/ansible/modules/system/group.py
@@ -77,7 +77,8 @@ EXAMPLES = '''
 import grp
 
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.sys_info import get_platform_subclass
 
 
 class Group(object):
@@ -98,7 +99,8 @@ class Group(object):
     GROUPFILE = '/etc/group'
 
     def __new__(cls, *args, **kwargs):
-        return load_platform_subclass(Group, args, kwargs)
+        new_cls = get_platform_subclass(Group)
+        return super(cls, new_cls).__new__(new_cls)
 
     def __init__(self, module):
         self.module = module

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -43,6 +43,7 @@ EXAMPLES = '''
 '''
 
 import os
+import platform
 import socket
 import traceback
 
@@ -50,9 +51,8 @@ from ansible.module_utils.basic import (
     AnsibleModule,
     get_distribution,
     get_distribution_version,
-    get_platform,
-    load_platform_subclass,
 )
+from ansible.module_utils.common.sys_info import get_platform_subclass
 from ansible.module_utils.facts.system.service_mgr import ServiceMgrFactCollector
 from ansible.module_utils._text import to_native
 
@@ -86,12 +86,12 @@ class UnimplementedStrategy(object):
         self.unimplemented_error()
 
     def unimplemented_error(self):
-        platform = get_platform()
+        system = platform.system()
         distribution = get_distribution()
         if distribution is not None:
-            msg_platform = '%s (%s)' % (platform, distribution)
+            msg_platform = '%s (%s)' % (system, distribution)
         else:
-            msg_platform = platform
+            msg_platform = system
         self.module.fail_json(
             msg='hostname module cannot be used on platform %s' % msg_platform)
 
@@ -111,7 +111,8 @@ class Hostname(object):
     strategy_class = UnimplementedStrategy
 
     def __new__(cls, *args, **kwargs):
-        return load_platform_subclass(Hostname, args, kwargs)
+        new_cls = get_platform_subclass(Hostname)
+        return super(cls, new_cls).__new__(new_cls)
 
     def __init__(self, module):
         self.module = module

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -149,8 +149,9 @@ EXAMPLES = r'''
 
 
 import os
+import platform
 
-from ansible.module_utils.basic import AnsibleModule, get_platform
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ismount import ismount
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native
@@ -196,7 +197,7 @@ def set_mount(module, args):
     escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args)])
     new_line = '%(src)s %(name)s %(fstype)s %(opts)s %(dump)s %(passno)s\n'
 
-    if get_platform() == 'SunOS':
+    if platform.system() == 'SunOS':
         new_line = (
             '%(src)s - %(name)s %(fstype)s %(passno)s %(boot)s %(opts)s\n')
 
@@ -216,16 +217,16 @@ def set_mount(module, args):
         # Check if we got a valid line for splitting
         # (on Linux the 5th and the 6th field is optional)
         if (
-                get_platform() == 'SunOS' and len(fields) != 7 or
-                get_platform() == 'Linux' and len(fields) not in [4, 5, 6] or
-                get_platform() not in ['SunOS', 'Linux'] and len(fields) != 6):
+                platform.system() == 'SunOS' and len(fields) != 7 or
+                platform.system() == 'Linux' and len(fields) not in [4, 5, 6] or
+                platform.system() not in ['SunOS', 'Linux'] and len(fields) != 6):
             to_write.append(line)
 
             continue
 
         ld = {}
 
-        if get_platform() == 'SunOS':
+        if platform.system() == 'SunOS':
             (
                 ld['src'],
                 dash,
@@ -263,7 +264,7 @@ def set_mount(module, args):
         exists = True
         args_to_check = ('src', 'fstype', 'opts', 'dump', 'passno')
 
-        if get_platform() == 'SunOS':
+        if platform.system() == 'SunOS':
             args_to_check = ('src', 'fstype', 'passno', 'boot', 'opts')
 
         for t in args_to_check:
@@ -306,15 +307,15 @@ def unset_mount(module, args):
 
         # Check if we got a valid line for splitting
         if (
-                get_platform() == 'SunOS' and len(line.split()) != 7 or
-                get_platform() != 'SunOS' and len(line.split()) != 6):
+                platform.system() == 'SunOS' and len(line.split()) != 7 or
+                platform.system() != 'SunOS' and len(line.split()) != 6):
             to_write.append(line)
 
             continue
 
         ld = {}
 
-        if get_platform() == 'SunOS':
+        if platform.system() == 'SunOS':
             (
                 ld['src'],
                 dash,
@@ -360,8 +361,8 @@ def _set_fstab_args(fstab_file):
     if (
             fstab_file and
             fstab_file != '/etc/fstab' and
-            get_platform().lower() != 'sunos'):
-        if get_platform().lower().endswith('bsd'):
+            platform.system().lower() != 'sunos'):
+        if platform.system().lower().endswith('bsd'):
             result.append('-F')
         else:
             result.append('-T')
@@ -378,7 +379,7 @@ def mount(module, args):
     name = args['name']
     cmd = [mount_bin]
 
-    if get_platform().lower() == 'openbsd':
+    if platform.system().lower() == 'openbsd':
         # Use module.params['fstab'] here as args['fstab'] has been set to the
         # default value.
         if module.params['fstab'] is not None:
@@ -419,12 +420,12 @@ def remount(module, args):
     cmd = [mount_bin]
 
     # Multiplatform remount opts
-    if get_platform().lower().endswith('bsd'):
+    if platform.system().lower().endswith('bsd'):
         cmd += ['-u']
     else:
         cmd += ['-o', 'remount']
 
-    if get_platform().lower() == 'openbsd':
+    if platform.system().lower() == 'openbsd':
         # Use module.params['fstab'] here as args['fstab'] has been set to the
         # default value.
         if module.params['fstab'] is not None:
@@ -439,7 +440,7 @@ def remount(module, args):
     out = err = ''
 
     try:
-        if get_platform().lower().endswith('bsd'):
+        if platform.system().lower().endswith('bsd'):
             # Note: Forcing BSDs to do umount/mount due to BSD remount not
             # working as expected (suspect bug in the BSD mount command)
             # Interested contributor could rework this to use mount options on
@@ -483,7 +484,7 @@ def is_bind_mounted(module, linux_mounts, dest, src=None, fstype=None):
 
     is_mounted = False
 
-    if get_platform() == 'Linux' and linux_mounts is not None:
+    if platform.system() == 'Linux' and linux_mounts is not None:
         if src is None:
             # That's for unmounted/absent
             if dest in linux_mounts:
@@ -615,7 +616,7 @@ def main():
     #   name, src, fstype, opts, dump, passno, state, fstab=/etc/fstab
     # Note: Do not modify module.params['fstab'] as we need to know if the user
     # explicitly specified it in mount() and remount()
-    if get_platform().lower() == 'sunos':
+    if platform.system().lower() == 'sunos':
         args = dict(
             name=module.params['path'],
             opts='-',
@@ -637,14 +638,14 @@ def main():
             args['fstab'] = '/etc/fstab'
 
         # FreeBSD doesn't have any 'default' so set 'rw' instead
-        if get_platform() == 'FreeBSD':
+        if platform.system() == 'FreeBSD':
             args['opts'] = 'rw'
 
     linux_mounts = []
 
     # Cache all mounts here in order we have consistent results if we need to
     # call is_bind_mounted() multiple times
-    if get_platform() == 'Linux':
+    if platform.system() == 'Linux':
         linux_mounts = get_linux_mounts(module)
 
         if linux_mounts is None:

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -144,10 +144,11 @@ import time
 if platform.system() != 'SunOS':
     from distutils.version import LooseVersion
 
-from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.sys_info import get_platform_subclass
 from ansible.module_utils.service import fail_if_missing
 from ansible.module_utils.six import PY2, b
-from ansible.module_utils._text import to_bytes, to_text
 
 
 class Service(object):
@@ -168,7 +169,8 @@ class Service(object):
     distribution = None
 
     def __new__(cls, *args, **kwargs):
-        return load_platform_subclass(Service, args, kwargs)
+        new_cls = get_platform_subclass(Service)
+        return super(cls, new_cls).__new__(new_cls)
 
     def __init__(self, module):
         self.module = module

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -99,10 +99,11 @@ EXAMPLES = '''
 # ==============================================================
 
 import os
+import platform
 import re
 import tempfile
 
-from ansible.module_utils.basic import get_platform, AnsibleModule
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_FALSE, BOOLEANS_TRUE
 from ansible.module_utils._text import to_native
@@ -138,7 +139,7 @@ class SysctlModule(object):
 
     def process(self):
 
-        self.platform = get_platform().lower()
+        self.platform = platform.system().lower()
 
         # Whitespace is bad
         self.args['name'] = self.args['name'].strip()

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -83,7 +83,7 @@ import re
 import string
 import filecmp
 
-from ansible.module_utils.basic import AnsibleModule, get_platform, get_distribution
+from ansible.module_utils.basic import AnsibleModule, get_distribution
 from ansible.module_utils.six import iteritems
 
 
@@ -104,7 +104,7 @@ class Timezone(object):
         Args:
             module: The AnsibleModule.
         """
-        if get_platform() == 'Linux':
+        if platform.system() == 'Linux':
             timedatectl = module.get_bin_path('timedatectl')
             if timedatectl is not None:
                 rc, stdout, stderr = module.run_command(timedatectl)
@@ -116,7 +116,7 @@ class Timezone(object):
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
         elif re.match('^joyent_.*Z', platform.version()):
-            # get_platform() returns SunOS, which is too broad. So look at the
+            # platform.system() returns SunOS, which is too broad. So look at the
             # platform version instead. However we have to ensure that we're not
             # running in the global zone where changing the timezone has no effect.
             zonename_cmd = module.get_bin_path('zonename')

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -420,8 +420,9 @@ import subprocess
 import time
 
 from ansible.module_utils import distro
-from ansible.module_utils._text import to_native, to_bytes, to_text
-from ansible.module_utils.basic import load_platform_subclass, AnsibleModule
+from ansible.module_utils._text import to_native, to_bytes
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.sys_info import get_platform_subclass
 
 try:
     import spwd
@@ -458,7 +459,8 @@ class User(object):
     DATE_FORMAT = '%Y-%m-%d'
 
     def __new__(cls, *args, **kwargs):
-        return load_platform_subclass(User, args, kwargs)
+        new_cls = get_platform_subclass(User)
+        return super(cls, new_cls).__new__(new_cls)
 
     def __init__(self, module):
         self.module = module

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -229,7 +229,8 @@ import sys
 import time
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule, load_platform_subclass, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.common.sys_info import get_platform_subclass
 from ansible.module_utils._text import to_native
 
 
@@ -268,7 +269,8 @@ class TCPConnectionInfo(object):
     }
 
     def __new__(cls, *args, **kwargs):
-        return load_platform_subclass(TCPConnectionInfo, args, kwargs)
+        new_cls = get_platform_subclass(TCPConnectionInfo)
+        return super(cls, new_cls).__new__(new_cls)
 
     def __init__(self, module):
         self.module = module


### PR DESCRIPTION
##### SUMMARY

Cleaning up the code base. Don't use ansible.module_utils.basic.get_platform() defined as deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

