### PR TITLE
AWS module_utils: Clear out Sanity Test issues

### DIFF
--- a/hacking/aws_config/build_iam_policy_framework.py
+++ b/hacking/aws_config/build_iam_policy_framework.py
@@ -38,6 +38,9 @@
 #      ec2:DescribeSubnets, ec2:DescribeSecurityGroups, and ec2:DescribeInternetGateways, but AWS does not document this.
 #
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import json
 import requests
 import sys

--- a/lib/ansible/module_utils/aws/batch.py
+++ b/lib/ansible/module_utils/aws/batch.py
@@ -29,6 +29,9 @@
 This module adds shared support for Batch modules.
 """
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.module_utils.ec2 import get_aws_connection_info, boto3_conn, snake_dict_to_camel_dict
 
 try:

--- a/lib/ansible/module_utils/aws/cloudfront_facts.py
+++ b/lib/ansible/module_utils/aws/cloudfront_facts.py
@@ -22,11 +22,12 @@
 #   - cloudfront_distribution
 #   - cloudfront_invalidation
 #   - cloudfront_origin_access_identity
-
-
 """
 Common cloudfront facts shared between modules
 """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 from ansible.module_utils.ec2 import get_aws_connection_info, boto3_conn
 from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict

--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-
 """This module adds shared support for generic Amazon AWS modules
 
 **This code is not yet ready for use in user modules.  As of 2017**
@@ -57,8 +56,10 @@ using the `aws_retry` argument. By default, no retries are used.
 
 The call will be retried the specified number of times, so the calling functions
 don't need to be wrapped in the backoff decorator.
-
 """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 import re
 import logging

--- a/lib/ansible/module_utils/aws/direct_connect.py
+++ b/lib/ansible/module_utils/aws/direct_connect.py
@@ -29,6 +29,9 @@
 This module adds shared support for Direct Connect modules.
 """
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import traceback
 try:
     import botocore

--- a/lib/ansible/module_utils/aws/elb_utils.py
+++ b/lib/ansible/module_utils/aws/elb_utils.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.module_utils.ec2 import AWSRetry
 
 # Non-ansible imports

--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 # Ansible imports
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, get_ec2_security_group_ids_from_names, \
     ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict, compare_policies as compare_dicts, \

--- a/lib/ansible/module_utils/aws/iam.py
+++ b/lib/ansible/module_utils/aws/iam.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import traceback
 
 try:

--- a/lib/ansible/module_utils/aws/rds.py
+++ b/lib/ansible/module_utils/aws/rds.py
@@ -1,6 +1,9 @@
 # Copyright: (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.aws.waiters import get_waiter
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict

--- a/lib/ansible/module_utils/aws/s3.py
+++ b/lib/ansible/module_utils/aws/s3.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2018 Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:

--- a/lib/ansible/module_utils/aws/urls.py
+++ b/lib/ansible/module_utils/aws/urls.py
@@ -1,6 +1,9 @@
 # Copyright: (c) 2018, Aaron Haaf <aabonh@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import datetime
 import hashlib
 import hmac

--- a/lib/ansible/module_utils/aws/waf.py
+++ b/lib/ansible/module_utils/aws/waf.py
@@ -29,6 +29,9 @@
 This module adds shared support for Web Application Firewall modules
 """
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
 from ansible.module_utils.aws.waiters import get_waiter
 

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -1,5 +1,9 @@
 # Copyright: (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 try:
     import botocore.waiter as core_waiter
 except ImportError:

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -26,6 +26,9 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import os
 import re
 import traceback

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -115,8 +115,6 @@ examples/scripts/upgrade_to_ps3.ps1 pslint:PSCustomUseLiteralPath
 examples/scripts/upgrade_to_ps3.ps1 pslint:PSUseApprovedVerbs
 examples/scripts/uptime.py future-import-boilerplate
 examples/scripts/uptime.py metaclass-boilerplate
-hacking/aws_config/build_iam_policy_framework.py future-import-boilerplate
-hacking/aws_config/build_iam_policy_framework.py metaclass-boilerplate
 hacking/build-ansible.py shebang # only run by release engineers, Python 3.6+ required
 hacking/build_library/build_ansible/announce.py compile-2.6!skip # release process only, 3.6+ required
 hacking/build_library/build_ansible/announce.py compile-2.7!skip # release process only, 3.6+ required
@@ -164,30 +162,6 @@ lib/ansible/module_utils/ansible_tower.py future-import-boilerplate
 lib/ansible/module_utils/ansible_tower.py metaclass-boilerplate
 lib/ansible/module_utils/api.py future-import-boilerplate
 lib/ansible/module_utils/api.py metaclass-boilerplate
-lib/ansible/module_utils/aws/batch.py future-import-boilerplate
-lib/ansible/module_utils/aws/batch.py metaclass-boilerplate
-lib/ansible/module_utils/aws/cloudfront_facts.py future-import-boilerplate
-lib/ansible/module_utils/aws/cloudfront_facts.py metaclass-boilerplate
-lib/ansible/module_utils/aws/core.py future-import-boilerplate
-lib/ansible/module_utils/aws/core.py metaclass-boilerplate
-lib/ansible/module_utils/aws/direct_connect.py future-import-boilerplate
-lib/ansible/module_utils/aws/direct_connect.py metaclass-boilerplate
-lib/ansible/module_utils/aws/elb_utils.py future-import-boilerplate
-lib/ansible/module_utils/aws/elb_utils.py metaclass-boilerplate
-lib/ansible/module_utils/aws/elbv2.py future-import-boilerplate
-lib/ansible/module_utils/aws/elbv2.py metaclass-boilerplate
-lib/ansible/module_utils/aws/iam.py future-import-boilerplate
-lib/ansible/module_utils/aws/iam.py metaclass-boilerplate
-lib/ansible/module_utils/aws/rds.py future-import-boilerplate
-lib/ansible/module_utils/aws/rds.py metaclass-boilerplate
-lib/ansible/module_utils/aws/s3.py future-import-boilerplate
-lib/ansible/module_utils/aws/s3.py metaclass-boilerplate
-lib/ansible/module_utils/aws/urls.py future-import-boilerplate
-lib/ansible/module_utils/aws/urls.py metaclass-boilerplate
-lib/ansible/module_utils/aws/waf.py future-import-boilerplate
-lib/ansible/module_utils/aws/waf.py metaclass-boilerplate
-lib/ansible/module_utils/aws/waiters.py future-import-boilerplate
-lib/ansible/module_utils/aws/waiters.py metaclass-boilerplate
 lib/ansible/module_utils/azure_rm_common.py future-import-boilerplate
 lib/ansible/module_utils/azure_rm_common.py metaclass-boilerplate
 lib/ansible/module_utils/azure_rm_common_ext.py future-import-boilerplate
@@ -216,8 +190,6 @@ lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bu
 lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py no-assert
 lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
-lib/ansible/module_utils/ec2.py future-import-boilerplate
-lib/ansible/module_utils/ec2.py metaclass-boilerplate
 lib/ansible/module_utils/f5_utils.py future-import-boilerplate
 lib/ansible/module_utils/f5_utils.py metaclass-boilerplate
 lib/ansible/module_utils/facts/__init__.py empty-init # breaks namespacing, deprecate and eventually remove
@@ -6537,8 +6509,6 @@ test/units/plugins/inventory/test_group.py metaclass-boilerplate
 test/units/plugins/inventory/test_host.py future-import-boilerplate
 test/units/plugins/inventory/test_host.py metaclass-boilerplate
 test/units/plugins/loader_fixtures/import_fixture.py future-import-boilerplate
-test/units/plugins/lookup/test_aws_secret.py metaclass-boilerplate
-test/units/plugins/lookup/test_aws_ssm.py metaclass-boilerplate
 test/units/plugins/shell/test_cmd.py future-import-boilerplate
 test/units/plugins/shell/test_cmd.py metaclass-boilerplate
 test/units/plugins/shell/test_powershell.py future-import-boilerplate

--- a/test/units/plugins/lookup/test_aws_secret.py
+++ b/test/units/plugins/lookup/test_aws_secret.py
@@ -17,6 +17,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 import pytest
 import datetime

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -18,6 +18,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 import pytest
 from copy import copy


### PR DESCRIPTION
##### SUMMARY
AWS module_utils: Clear out Sanity Test issues

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
hacking/aws_config/build_iam_policy_framework.py
lib/ansible/module_utils/aws/batch.py
lib/ansible/module_utils/aws/cloudfront_facts.py
lib/ansible/module_utils/aws/core.py
lib/ansible/module_utils/aws/direct_connect.py
lib/ansible/module_utils/aws/elb_utils.py
lib/ansible/module_utils/aws/elbv2.py
lib/ansible/module_utils/aws/iam.py
lib/ansible/module_utils/aws/rds.py
lib/ansible/module_utils/aws/s3.py
lib/ansible/module_utils/aws/urls.py
lib/ansible/module_utils/aws/waf.py
lib/ansible/module_utils/aws/waiters.py
lib/ansible/module_utils/ec2.py

##### ADDITIONAL INFORMATION
These sanity failures are all just missing boilier-plate, but I may as well whack-em while I'm in the mood for clearing out AWS test/sanity/ignore.txt entries