### PR TITLE
Change flatpak module to use the --noninteractive CLI argument

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak.py
+++ b/lib/ansible/modules/packaging/os/flatpak.py
@@ -122,7 +122,7 @@ command:
   description: The exact flatpak command that was executed
   returned: When a flatpak command has been executed
   type: str
-  sample: "/usr/bin/flatpak install --user -y flathub org.gnome.Calculator"
+  sample: "/usr/bin/flatpak install --user --noninteractive flathub org.gnome.Calculator"
 msg:
   description: Module error message
   returned: failure
@@ -157,9 +157,9 @@ def install_flat(module, binary, remote, name, method):
     """Add a new flatpak."""
     global result
     if name.startswith('http://') or name.startswith('https://'):
-        command = "{0} install --{1} -y {2}".format(binary, method, name)
+        command = "{0} install --{1} --noninteractive {2}".format(binary, method, name)
     else:
-        command = "{0} install --{1} -y {2} {3}".format(binary, method, remote, name)
+        command = "{0} install --{1} --noninteractive {2} {3}".format(binary, method, remote, name)
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
@@ -168,7 +168,7 @@ def uninstall_flat(module, binary, name, method):
     """Remove an existing flatpak."""
     global result
     installed_flat_name = _match_installed_flat_name(module, binary, name, method)
-    command = "{0} uninstall -y --{1} {2}".format(binary, method, installed_flat_name)
+    command = "{0} uninstall --noninteractive --{1} {2}".format(binary, method, installed_flat_name)
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY

The `--noninteractive` argument is documented as:

    $ flatpak install --help
      …
      --noninteractive        Produce minimal output and don't ask questions

This removes the poorly formatted output of the commands due to the use of non-serial output. For example, with the yaml output plugin, Ansible previously formatted the flatpak command output as (notice the repetitive "Installing" on one line):

    TASK [flatpak : Install flatpak applications]
    changed: [localhost] => (item=com.slack.Slack) => changed=true
      ansible_loop_var: item
      command: /usr/bin/flatpak install --user -y flathub com.slack.Slack
      item: com.slack.Slack
      rc: 0
      stderr: ''
      stderr_lines: <omitted>
      stdout: |-
        Looking for matches

        com.slack.Slack permissions:
            ipc network pulseaudio      x11
            devices     file access [1] dbus access [2]

            [1] xdg-documents:ro, xdg-download, xdg-music:ro, xdg-pictures:ro,
                xdg-run/dconf, xdg-videos:ro, ~/.config/dconf:ro
            [2] ca.desrt.dconf, org.freedesktop.Notifications,
                org.kde.StatusNotifierWatcher

         1.             com.slack.Slack x86_64  stable  flathub < 62.4MB

        Installing                                                                   Installing                       1%Installing                      9%Installing                      9%  880.8kB/sInstalling                      9%  1.1MB/sInstalling                    14%  2.2MB/sInstalling                  21%  3.0MB/sInstalling                 27%  3.3MB/s  00:10Installing                33%  3.4MB/s  00:10Installing               39%  3.6MB/s  00:09Installing             46%  3.7MB/s  00:08Installing            52%  3.8MB/s  00:07Installing           58%  3.8MB/s  00:06Installing          65%  3.9MB/s  00:05Installing        71%  3.9MB/s  00:04Installing       78%  4.0MB/s  00:03Installing      84%  4.0MB/s  00:02Installing    91%  4.0MB/s  00:01Installing   97%  4.0MB/s  00:00Installing  100%  4.2MB/s  00:00Installing  100%  3.7MB/s  00:00Installation complete.
      stdout_lines: <omitted>

Now, the output is formatted simply as as:

    Installing app/com.slack.Slack/x86_64/stable

The use of the `--noninteractive` argument obviates the need to use the `-y` argument.

The `--noninteractive` argument was added in flatpak 1.1.3.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

flatpak
