### PR TITLE
openssl_csr: fix tests

### DIFF
--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -39,6 +39,6 @@
 
   - import_tasks: ../tests/validate.yml
     vars:
-      select_crypto_backend: pyopenssl
+      select_crypto_backend: cryptography
 
   when: cryptography_version.stdout is version('1.3', '>=')

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -133,7 +133,7 @@
       - subject_key_identifier_3 is changed
       - subject_key_identifier_4 is changed
       - subject_key_identifier_5 is not changed
-      - subject_key_identifier_6 is not changed
+      - subject_key_identifier_6 is changed
   when: select_crypto_backend != 'pyopenssl'
 
 - name: Verify that authority key identifier handling works


### PR DESCRIPTION
##### SUMMARY
The tests for #60741 have a bug: the wrong backend is used for validating the cryptography tests. This causes a test to be validated wrongly without consequences.

No changelog fragment since this is tests-only.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
