### PR TITLE
flatpak: Build commands as lists instead of strings

### DIFF
--- a/lib/ansible/modules/packaging/os/flatpak_remote.py
+++ b/lib/ansible/modules/packaging/os/flatpak_remote.py
@@ -147,8 +147,7 @@ from ansible.module_utils._text import to_bytes, to_native
 def add_remote(module, binary, name, flatpakrepo_url, method):
     """Add a new remote."""
     global result
-    command = "{0} remote-add --{1} {2} {3}".format(
-        binary, method, name, flatpakrepo_url)
+    command = [binary, "remote-add", "--{0}".format(method), name, flatpakrepo_url]
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
@@ -156,15 +155,14 @@ def add_remote(module, binary, name, flatpakrepo_url, method):
 def remove_remote(module, binary, name, method):
     """Remove an existing remote."""
     global result
-    command = "{0} remote-delete --{1} --force {2} ".format(
-        binary, method, name)
+    command = [binary, "remote-delete", "--{0}".format(method), "--force", name]
     _flatpak_command(module, module.check_mode, command)
     result['changed'] = True
 
 
 def remote_exists(module, binary, name, method):
     """Check if the remote exists."""
-    command = "{0} remote-list -d --{1}".format(binary, method)
+    command = [binary, "remote-list", "-d", "--{0}".format(method)]
     # The query operation for the remote needs to be run even in check mode
     output = _flatpak_command(module, False, command)
     for line in output.splitlines():
@@ -178,16 +176,17 @@ def remote_exists(module, binary, name, method):
 
 def _flatpak_command(module, noop, command):
     global result
+    command_str = ' '.join(command)
     if noop:
         result['rc'] = 0
-        result['command'] = command
+        result['command'] = command_str
         return ""
 
     process = subprocess.Popen(
-        command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout_data, stderr_data = process.communicate()
     result['rc'] = process.returncode
-    result['command'] = command
+    result['command'] = command_str
     result['stdout'] = stdout_data
     result['stderr'] = stderr_data
     if result['rc'] != 0:


### PR DESCRIPTION
##### SUMMARY

Using a list ensures that all subprocess arguments are correctly escaped. By building strings and then calling `.split()`, potential arguments with a space will be incorrectly split over two arguments.
When a string is needed for presentation, join to the list to build the string.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

flatpak