### PR TITLE
postgresql_db: allow to pass users names with dots

### DIFF
--- a/changelogs/fragments/64007-postgresql_db_allow_user_name_with_dots.yml
+++ b/changelogs/fragments/64007-postgresql_db_allow_user_name_with_dots.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_db - allow to pass users names which contain dots (https://github.com/ansible/ansible/issues/63204).

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -207,9 +207,9 @@ class NotSupportedError(Exception):
 
 
 def set_owner(cursor, db, owner):
-    query = "ALTER DATABASE %s OWNER TO %s" % (
+    query = 'ALTER DATABASE %s OWNER TO "%s"' % (
             pg_quote_identifier(db, 'database'),
-            pg_quote_identifier(owner, 'role'))
+            owner)
     cursor.execute(query)
     return True
 
@@ -263,7 +263,7 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype, conn_
     if not db_exists(cursor, db):
         query_fragments = ['CREATE DATABASE %s' % pg_quote_identifier(db, 'database')]
         if owner:
-            query_fragments.append('OWNER %s' % pg_quote_identifier(owner, 'role'))
+            query_fragments.append('OWNER "%s"' % owner)
         if template:
             query_fragments.append('TEMPLATE %s' % pg_quote_identifier(template, 'database'))
         if encoding:
@@ -567,7 +567,7 @@ def main():
 
         if session_role:
             try:
-                cursor.execute('SET ROLE %s' % pg_quote_identifier(session_role, 'role'))
+                cursor.execute('SET ROLE "%s"' % session_role)
             except Exception as e:
                 module.fail_json(msg="Could not switch role: %s" % to_native(e), exception=traceback.format_exc())
 

--- a/test/integration/targets/postgresql_db/defaults/main.yml
+++ b/test/integration/targets/postgresql_db/defaults/main.yml
@@ -1,3 +1,4 @@
 db_name: 'ansible_db'
-db_user1: 'ansible_db_user1'
+db_user1: 'ansible.db.user1'
+db_user2: 'ansible.db.user2'
 tmp_dir: '/tmp'

--- a/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -245,6 +245,7 @@
   become: yes
   postgresql_query:
     db: postgres
+    login_user: "{{ pg_user }}"
     query: >
       SELECT 1 FROM pg_catalog.pg_database
       WHERE datname = '{{ db_name }}'
@@ -269,6 +270,7 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_query:
+    login_user: "{{ pg_user }}"
     db: postgres
     query: >
       SELECT 1 FROM pg_catalog.pg_database

--- a/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -222,11 +222,14 @@
   become_user: "{{ pg_user }}"
   become: yes
   postgresql_user:
-    name: "{{ db_user1 }}"
+    name: "{{ item }}"
     encrypted: 'yes'
     password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
     login_user: "{{ pg_user }}"
     db: postgres
+  loop:
+  - "{{ db_user1 }}"
+  - "{{ db_user2 }}"
 
 - name: Create db with user ownership
   become_user: "{{ pg_user }}"
@@ -240,13 +243,42 @@
 - name: Check that the user owns the newly created DB
   become_user: "{{ pg_user }}"
   become: yes
-  shell: echo "select pg_catalog.pg_get_userbyid(datdba) from pg_catalog.pg_database where datname = '{{ db_name }}';" | psql -d postgres
+  postgresql_query:
+    db: postgres
+    query: >
+      SELECT 1 FROM pg_catalog.pg_database
+      WHERE datname = '{{ db_name }}'
+      AND pg_catalog.pg_get_userbyid(datdba) = '{{ db_user1 }}'
   register: result
 
 - assert:
     that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-      - "'{{ db_user1 }}' == '{{ result.stdout_lines[-2] | trim }}'"
+    - result.rowcount == 1
+
+- name: Change the owner on an existing db, username with dots
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_db:
+    name: "{{ db_name }}"
+    state: "present"
+    owner: "{{ db_user2 }}"
+    login_user: "{{ pg_user }}"
+  register: result
+
+- name: Check the previous step
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_query:
+    db: postgres
+    query: >
+      SELECT 1 FROM pg_catalog.pg_database
+      WHERE datname = '{{ db_name }}'
+      AND pg_catalog.pg_get_userbyid(datdba) = '{{ db_user2 }}'
+  register: result
+
+- assert:
+    that:
+    - result.rowcount == 1
 
 - name: Change the owner on an existing db
   become_user: "{{ pg_user }}"


### PR DESCRIPTION
##### SUMMARY
postgresql_db: allow to pass users names with dots
Fixes: https://github.com/ansible/ansible/issues/63204

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_db.py```