### PR TITLE
Backport #59614 to stable-2.8

### DIFF
--- a/changelogs/fragments/64011_vmware_deploy_ovf.yml
+++ b/changelogs/fragments/64011_vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_deploy_ovf - backport content fix from 2.9 (https://github.com/ansible/ansible/pull/59614)

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -339,7 +339,7 @@ class VMwareDeployOvf(PyVmomi):
             self.module.fail_json(msg='%(resource_pool)s could not be located' % self.params)
 
         for key, value in self.params['networks'].items():
-            network = find_network_by_name(self.si, value)
+            network = find_network_by_name(self.content, value)
             if not network:
                 self.module.fail_json(msg='%(network)s could not be located' % self.params)
             network_mapping = vim.OvfManager.NetworkMapping()
@@ -389,7 +389,7 @@ class VMwareDeployOvf(PyVmomi):
                 params['propertyMapping'].append(property_mapping)
 
         if self.params['folder']:
-            folder = self.si.searchIndex.FindByInventoryPath(self.params['folder'])
+            folder = self.content.searchIndex.FindByInventoryPath(self.params['folder'])
         else:
             folder = datacenter.vmFolder
 
@@ -397,7 +397,7 @@ class VMwareDeployOvf(PyVmomi):
 
         ovf_descriptor = self.get_ovf_descriptor()
 
-        self.import_spec = self.si.ovfManager.CreateImportSpec(
+        self.import_spec = self.content.ovfManager.CreateImportSpec(
             ovf_descriptor,
             resource_pool,
             datastore,
@@ -419,9 +419,9 @@ class VMwareDeployOvf(PyVmomi):
 
         if not self.params['allow_duplicates']:
             name = self.import_spec.importSpec.configSpec.name
-            match = find_vm_by_name(self.si, name, folder=folder)
+            match = find_vm_by_name(self.content, name, folder=folder)
             if match:
-                self.module.exit_json(instance=gather_vm_facts(self.si, match), changed=False)
+                self.module.exit_json(instance=gather_vm_facts(self.content, match), changed=False)
 
         if self.module.check_mode:
             self.module.exit_json(changed=True, instance={'hw_name': name})
@@ -548,9 +548,9 @@ class VMwareDeployOvf(PyVmomi):
         env = ET.Element('Environment', **attrib)
 
         platform = ET.SubElement(env, 'PlatformSection')
-        ET.SubElement(platform, 'Kind').text = self.si.about.name
-        ET.SubElement(platform, 'Version').text = self.si.about.version
-        ET.SubElement(platform, 'Vendor').text = self.si.about.vendor
+        ET.SubElement(platform, 'Kind').text = self.content.about.name
+        ET.SubElement(platform, 'Version').text = self.content.about.version
+        ET.SubElement(platform, 'Vendor').text = self.content.about.vendor
         ET.SubElement(platform, 'Locale').text = 'US'
 
         prop_section = ET.SubElement(env, 'PropertySection')
@@ -582,13 +582,13 @@ class VMwareDeployOvf(PyVmomi):
             if self.params['wait']:
                 wait_for_task(task)
                 if self.params['wait_for_ip_address']:
-                    _facts = wait_for_vm_ip(self.si, self.entity)
+                    _facts = wait_for_vm_ip(self.content, self.entity)
                     if not _facts:
                         self.module.fail_json(msg='Waiting for IP address timed out')
                     facts.update(_facts)
 
         if not facts:
-            facts.update(gather_vm_facts(self.si, self.entity))
+            facts.update(gather_vm_facts(self.content, self.entity))
 
         return facts
 


### PR DESCRIPTION
##### SUMMARY
#62513 introduced a regression, which was fixed by @Akasurde in #59614. Unfortunately, the fix was only included in the 2.9 branch.

As a result, the *vmware_deploy_ovf* module is broken in the current 2.8.6 release. Usage yields 

> AttributeError: 'NoneType' object has no attribute 'ovfManager'

This PR backports @Akasurde's fix to the 2.8 release branch.

@Akasurde PTAL

Backport of https://github.com/ansible/ansible/pull/59614

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_deploy_ovf

##### ADDITIONAL INFORMATION
The error occurs because `self.si` is no longer [initialized in the constructor](https://github.com/ansible/ansible/pull/62513/files#diff-72b54aa6d5b8129f70a84475868e149cL295-R304) but still being used.

The fix changes usage of `self.si` to `self.content`, which is initialized in the parent constructor.