### PR TITLE
Correct a typo in documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -1044,7 +1044,7 @@ Basically, anything that goes into "role defaults" (the defaults folder inside t
           If you define a variable twice in a play's ``vars:`` section, the second one wins.
 .. note:: The previous describes the default config ``hash_behaviour=replace``, switch to ``merge`` to only partially overwrite.
 .. note:: Group loading follows parent/child relationships. Groups of the same 'parent/child' level are then merged following alphabetical order.
-          This last one can be superceeded by the user via ``ansible_group_priority``, which defaults to ``1`` for all groups.
+          This last one can be superseded by the user via ``ansible_group_priority``, which defaults to ``1`` for all groups.
           This variable, ``ansible_group_priority``, can only be set in the inventory source and not in group_vars/ as the variable is used in the loading of group_vars/.
 
 Another important thing to consider (for all versions) is that connection variables override config, command line and play/role/task specific options and keywords. See :ref:`general_precedence_rules` for more details. For example, if your inventory specifies ``ansible_user: ramon`` and you run::


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Correcting a typo in documentation.  

Additionally, I'd suggest rewriting the note (and the section requires some attention; it has 3 NOTEs in a row :) ).

What do you think of:

```
Group loading follows parent/child relationships. Groups of the same ‘parent/child’ level are merged
alphabetically. The user can overwrite the last group using the ansible_group_priority variable,
which defaults to 1 for all groups. You can set the ansible_group_priority variable in the inventory
source only.  Setting the ansible_group_priority variable in the group_vars directory is not possible
as the variable is used in the loading of variables from the group_vars/ directory.
```

Feel free to change it alone, or review and let me push the changes. Whichever works better for you. The main point of this PR is:

- Correct a typo
- Bring your attention towards a not very understandable note

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
