### PR TITLE
pacman: remove package group handling in "name" option

### DIFF
--- a/changelogs/fragments/64022-pacman_change_group_handling.yaml
+++ b/changelogs/fragments/64022-pacman_change_group_handling.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - pacman - Remove handling of packages groups in ``name`` option, use the ``group`` option instead

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -35,6 +35,7 @@ options:
         description:
             - Name or list of names of groups to install, upgrade, or remove.
               Can't be used in combination with C(upgrade).
+        version_added: "2.10"
 
     state:
         description:
@@ -409,7 +410,7 @@ def expand_package_groups(module, pacman_path, groups):
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
-            module.fail_json(msg="could not find group '%s'"%group)
+            module.fail_json(msg="could not find group '%s'" % group)
 
         # A group was found matching the name, so expand it
         for name in stdout.strip().split('\n'):


### PR DESCRIPTION
##### SUMMARY

Remove handling of groups in "name", user should use "group" option instead.
It's a major breaking change… but I don't see any other way to fix issue #37334.

Fixes #37334

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

pacman