### PR TITLE
IAM role can create Instance Profile with permissions boundary.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -30,7 +30,6 @@ options:
   boundary:
     description:
       - Add the ARN of an IAM managed policy to restrict the permissions this role can pass on to IAM roles/users that it creates.
-      - Boundaries cannot be set on Instance Profiles, so if this option is specified then C(create_instance_profile) must be false.
       - This is intended for roles/users that have permissions to create new IAM objects.
       - For more information on boundaries, see U(https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
     aliases: [boundary_policy_arn]
@@ -507,8 +506,6 @@ def main():
                               supports_check_mode=True)
 
     if module.params.get('boundary'):
-        if module.params.get('create_instance_profile'):
-            module.fail_json(msg="When using a boundary policy, `create_instance_profile` must be set to `false`.")
         if not module.params.get('boundary').startswith('arn:aws:iam'):
             module.fail_json(msg="Boundary policy must be an ARN")
     if module.params.get('boundary') is not None and not module.botocore_at_least('1.10.57'):


### PR DESCRIPTION
##### SUMMARY
This change will allow us to create Instance Profiles with permissions boundary. 
This functionality has been removed long time ago [](https://github.com/ansible/ansible/pull/43270). Nowadays (at least in our company) we need this functionality as we do have strong security restriction and thus all our entities including Instance Profiles should be created with Permissions Boundary 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iam_role

##### ADDITIONAL INFORMATION
Before
```
  msg: When using a boundary policy, `create_instance_profile` must be set to `false`.
  msg: 'Unable to create role: An error occurred (AccessDenied) when calling the CreateRole operation: User: arn:aws:sts::<USER> is not authorized to perform: iam:CreateRole on resource: arn:aws:iam::<ROLE_NAME> with an explicit deny'
```
After
```
resource has been created
```