### PR TITLE
BOTMETA migrated_to should be namespace.collection

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -27,7 +27,7 @@
 #           ignored - these people should never be notified
 #           deprecated - this file is deprecated but probably not yet renamed
 #           keywords - used to identify this file based on the issue description
-#           migrated_to - Location on Galaxy,
+#           migrated_to - If this has been migrated to Galaxy, in the form collection.namespace
 #                         see https://docs.ansible.com/ansible/devel/dev_guide/developing_collections.html
 #           support - used for files without internal ANSIBLE_METADATA, see
 #                     https://github.com/ansible/ansible/labels?q=support for full list

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -40,7 +40,7 @@ def main():
             'maintainers': Any(list_string_types, *string_types),
             'migrated_to': All(
                 Any(*string_types),
-                Match(r'^https://galaxy.ansible.com/'),
+                Match(r'^\w+\.\w+$'),
             ),
             'notified': Any(list_string_types, *string_types),
             'supershipit': Any(list_string_types, *string_types),


### PR DESCRIPTION
##### SUMMARY

`migrated_to` should be in the form `namespace.collection` in *Galaxy*

This validation isn't as strict as it could be, that's covered by both building from ansible-galaxy and also importing into Galaxy.

Tests: https://regex101.com/r/8am55Q/1/

following on from https://github.com/ansible/ansible/pull/63952
##### ISSUE TYPE
- Bugfix Pull Request
