### PR TITLE
Zabbix: zabbix_template: fix #64030

### DIFF
--- a/changelogs/fragments/64032-zabbix_template_fix_return_XML_as_a_string_even_python3.yml
+++ b/changelogs/fragments/64032-zabbix_template_fix_return_XML_as_a_string_even_python3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix to return XML as a string even for python3 (https://github.com/ansible/ansible/pull/64032).

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -454,7 +454,7 @@ class Template(object):
         try:
             dump = self._zapi.configuration.export({'format': template_type, 'options': {'templates': template_ids}})
             if template_type == 'xml':
-                return str(ET.tostring(ET.fromstring(dump.encode('utf-8')), encoding='utf-8'))
+                return str(ET.tostring(ET.fromstring(dump.encode('utf-8')), encoding='utf-8').decode('utf-8'))
             else:
                 return self.load_json_template(dump)
 


### PR DESCRIPTION
##### SUMMARY
Fix to return XML as a string even for python3.
Fixes https://github.com/ansible/ansible/issues/64030

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ADDITIONAL INFORMATION
tested with Zabbix 3.0/3.2/3.4/4.0/4.2/4.4
