### PR TITLE
Note for virtual environment users

### DIFF
--- a/docs/docsite/rst/network/getting_started/first_playbook.rst
+++ b/docs/docsite/rst/network/getting_started/first_playbook.rst
@@ -65,6 +65,10 @@ The flags in this command set seven values:
 
 NOTE: If you use ``ssh-agent`` with ssh keys, Ansible loads them automatically. You can omit ``-k`` flag.
 
+.. note::
+
+   If you are running Ansible in a virtual environment, you will also need to add the variable ``ansible_python_interpreter=/path/to/venv/bin/python``
+
 
 Create and Run Your First Network Ansible Playbook
 ==================================================


### PR DESCRIPTION
##### SUMMARY
When I was trying to run Ansible from a virtual environment for an Aruba switch, I was getting an error. I found at https://clouddocs.f5.com/products/orchestration/ansible/devel/usage/virtualenv.html#configure-your-ansible-python-interpreter that I needed to set the ansible_python_interpreter variable. I thought this information would be useful here.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
