### PR TITLE
Fix access variable name programmatically faq docs

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -377,7 +377,7 @@ via a role parameter or other input.  Variable names can be built by adding stri
 
 .. code-block:: jinja
 
-    {{ hostvars[inventory_hostname]['ansible_' + which_interface]['ipv4']['address'] }}
+    {{ hostvars[inventory_hostname]['ansible_' + which_interface | replace('_', '-') ]['ipv4']['address'] }}
 
 The trick about going through hostvars is necessary because it's a dictionary of the entire namespace of variables.  'inventory_hostname'
 is a magic variable that indicates the current host you are looping over in the host loop.

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -377,6 +377,12 @@ via a role parameter or other input.  Variable names can be built by adding stri
 
 .. code-block:: jinja
 
+    {{ hostvars[inventory_hostname]['ansible_' + which_interface]['ipv4']['address'] }}
+
+If your interface names have dashes, replace them with underscores:
+
+.. code-block:: jinja
+
     {{ hostvars[inventory_hostname]['ansible_' + which_interface | replace('_', '-') ]['ipv4']['address'] }}
 
 The trick about going through hostvars is necessary because it's a dictionary of the entire namespace of variables.  'inventory_hostname'

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -382,7 +382,7 @@ via a role parameter or other input.  Variable names can be built by adding stri
 The trick about going through hostvars is necessary because it's a dictionary of the entire namespace of variables.  ``inventory_hostname``
 is a magic variable that indicates the current host you are looping over in the host loop.
 
-If your interface names have dashes, replace them with underscores:
+In the example above, if your interface names have dashes, you must replace them with underscores:
 
 .. code-block:: jinja
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -379,14 +379,14 @@ via a role parameter or other input.  Variable names can be built by adding stri
 
     {{ hostvars[inventory_hostname]['ansible_' + which_interface]['ipv4']['address'] }}
 
+The trick about going through hostvars is necessary because it's a dictionary of the entire namespace of variables.  ``inventory_hostname``
+is a magic variable that indicates the current host you are looping over in the host loop.
+
 If your interface names have dashes, replace them with underscores:
 
 .. code-block:: jinja
 
     {{ hostvars[inventory_hostname]['ansible_' + which_interface | replace('_', '-') ]['ipv4']['address'] }}
-
-The trick about going through hostvars is necessary because it's a dictionary of the entire namespace of variables.  'inventory_hostname'
-is a magic variable that indicates the current host you are looping over in the host loop.
 
 Also see dynamic_variables_.
 


### PR DESCRIPTION
The ansible ipv4 address is stored in 'ansible_' + which_interface | replace ('_','-')
not 'ansible_' + which_interface

Reference:
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/network/linux.py

```
interfaces[device].update(self.get_ethtool_data(device))

def get_ethtool_data(device):
~~
   features[key.strip().replace('-', '_')] = value.strip()
~~
```
Fixes #64043