### PR TITLE
Allow custom hash behavior for facts modules

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -642,6 +642,28 @@ systems, mainly, or if you are using Ansible on experimental platforms.   In any
     - hosts: whatever
       gather_facts: no
 
+.. _custom_facts:
+
+Custom facts modules
+--------------------
+
+.. versionadded:: 2.8
+
+You may also want to develop your own module to generate facts about a host.
+
+To do so, you will need to develop a :ref:`custom module <developing_modules>` (or :ref:`action plugin <developing_plugins>`), the only pre-requisite is to follow the various :ref:`Ansible conventions <module_conventions>` for facts modules and to customize ``FACTS_HASH_BEHAVIOUR`` configuration option to ``merge``.
+
+Your module's output must contains keys under ``ansible_facts`` key, example for the module ``custom_facts``::
+
+    {
+        "ansible_facts": {
+            "custom": {
+                "fact1": "foo",
+                "fact2": "bar"
+            }
+        }
+    }
+
 .. _local_facts:
 
 Local facts (facts.d)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1324,6 +1324,22 @@ CONNECTION_FACTS_MODULES:
   ini:
     - {key: connection_facts_modules, section: defaults}
   type: dict
+FACTS_HASH_BEHAVIOUR:
+  name: Facts hashes merge behaviour
+  default: default
+  type: string
+  choices: ["replace", "merge", "default"]
+  description:
+    - This setting controls how facts are merged in Ansible.
+      It allows to enrich the `ansible_facts` by custom values collected with custom modules defined by FACTS_MODULES.
+    - By "default", it uses the DEFAULT_HASH_BEHAVIOR value.
+      Using "merge" allows to enrich `ansible_facts` facts with the facts coming from a custom module.
+      Using "replace" will drop the facts of the previous module by the current one (always overriding previous ones).
+  env: [{name: ANSIBLE_FACTS_HASH_BEHAVIOUR}]
+  ini:
+    - {key: facts_hash_behaviour, section: defaults}
+  vars:
+    - name: ansible_facts_hash_behaviour
 FACTS_MODULES:
   name: Gather Facts Modules
   default:

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -12,6 +12,8 @@ from ansible.executor.module_common import get_action_args_with_defaults
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import combine_vars
 
+HASH_BEHAVIOUR = C.FACTS_HASH_BEHAVIOUR if C.FACTS_HASH_BEHAVIOUR != 'default' else C.DEFAULT_HASH_BEHAVIOUR
+
 
 class ActionModule(ActionBase):
 
@@ -73,7 +75,7 @@ class ActionModule(ActionBase):
                 elif res.get('skipped', False):
                     skipped[fact_module] = res
                 else:
-                    result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})})
+                    result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})}, behavior=HASH_BEHAVIOUR)
 
             self._remove_tmp_path(self._connection._shell.tmpdir)
         else:
@@ -95,7 +97,7 @@ class ActionModule(ActionBase):
                         elif res.get('skipped', False):
                             skipped[module] = res
                         else:
-                            result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})})
+                            result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})}, behavior=HASH_BEHAVIOUR)
                         del jobs[module]
                         break
                     else:

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -77,12 +77,15 @@ def _validate_mutable_mappings(a, b):
         )
 
 
-def combine_vars(a, b):
+def combine_vars(a, b, behavior=None):
     """
     Return a copy of dictionaries of variables based on configured hash behavior
     """
 
-    if C.DEFAULT_HASH_BEHAVIOUR == "merge":
+    if behavior is None:
+        behavior = C.DEFAULT_HASH_BEHAVIOUR
+
+    if behavior == "merge":
         return merge_hash(a, b)
     else:
         # HASH_BEHAVIOUR == 'replace'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

In order to allow usage of custom modules to generate facts that will be available in `ansible_facts` and collected via `gather_facts` (using `FACTS_MODULES` configuration option), the current PR allow to configure the hashes merging behaviour independently of the default one (to avoid side effect with `combine` filter).

Then we can obtain the following facts:

```javascript
{
  "ansible_facts": {
    // Default facts [...]
    "custom": {
      "fact1": "foo",
      "fact2": "bar"
    }
  }
}
```

Just by creating a custom facts module (eg: `custom_facts.py`), adding `facts_hash_behaviour = merge` and `facts_modules = smart, custom_facts` in the configuration file.

Then, the setup module will produce a fully enriched `ansible_facts`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`gather_facts`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Considering this `custom_facts.py` module:

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

"""custom_facts module"""

from ansible.module_utils.basic import AnsibleModule


def run_module():
    module = AnsibleModule(argument_spec=dict(), supports_check_mode=True)
    module.exit_json(ansible_facts=dict(
            custom=dict(
                fact1='foo', 
                fact2='bar'
            )
        )
    )

if __name__ == "__main__":
    run_module()
```

And the following dummy playbook dumping our custom facts (`demo.yml`):

```yaml
---
# Demo playbook only showing some custom facts

- hosts: localhost
  connection: local

  gather_facts: true

  tasks:
    - debug: 'var=ansible_facts.custom'
```

Assuming we want to collect those `custom_facts` automatically at play facts gathering step, we add the line `acts_modules = smart, custom_facts` to our configuration.

But, when running the command `ansible-playbook demo.yml` we obtain the following output:

```
PLAY [localhost] ********************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************

ok: [localhost]

TASK [debug] ************************************************************************************************************************************************
ok: [localhost] => {
    "ansible_facts.custom": "VARIABLE IS NOT DEFINED!"
}

PLAY RECAP **************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Now, adding the `facts_hash_behaviour = merge` line to our configuration, running the same command we obtain:

```
PLAY [localhost] ********************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************

ok: [localhost]

TASK [debug] ************************************************************************************************************************************************
ok: [localhost] => {
    "ansible_facts.custom": {
        "fact1": "foo",
        "fact2": "bar"
    }
}

PLAY RECAP **************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```
