### PR TITLE
VMWare: Fix issue #62810 Allow Dash in Windows Server DNS name

### DIFF
--- a/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
+++ b/changelogs/fragments/62810-Vmware-Guest-Allow-DashInWindowsServerDNSName.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - Allow '-' (Dash) special char in windows DNS name.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1813,7 +1813,8 @@ class PyVmomiHelper(PyVmomi):
             ident.userData.computerName = vim.vm.customization.FixedName()
             # computer name will be truncated to 15 characters if using VM name
             default_name = self.params['name'].replace(' ', '')
-            default_name = ''.join([c for c in default_name if c not in string.punctuation])
+            punctuation = string.punctuation.replace('-', '')
+            default_name = ''.join([c for c in default_name if c not in punctuation])
             ident.userData.computerName.name = str(self.params['customization'].get('hostname', default_name[0:15]))
             ident.userData.fullName = str(self.params['customization'].get('fullname', 'Administrator'))
             ident.userData.orgName = str(self.params['customization'].get('orgname', 'ACME'))


### PR DESCRIPTION
##### SUMMARY
Fix issue #62810 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION
Allow '-' Dash special char in Windows server DNS name

