### PR TITLE
docs: Properly document to_uuid

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1279,9 +1279,11 @@ As of version 2.6, you can define the type of encoding to use, the default is ``
 
 .. versionadded:: 2.6
 
-To create a UUID from a string (new in version 1.9)::
+To create a UUIDv5 from a string using the Ansible namespace '361E6D51-FAEC-444A-9079-341386DA8E2E'::
 
     {{ hostname | to_uuid }}
+
+.. versionadded:: 1.9
 
 To cast values as certain types, such as when you input a string as "True" from a vars_prompt and the system
 doesn't know it is a boolean value::


### PR DESCRIPTION
Document that the `to_uuid` filter does not generate a common UUIDv4, but instead a [UUIDv5](https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions_3_and_5_(namespace_name-based) "UUID on Wikipedia") using an [arbitrary](https://github.com/ansible/ansible/commit/65e4f2b2bc917031df899fe09ada2916899db06b "commit 65e4f2b") namespace.

The reduction of the entropy from 128 to 122 bits is a tiny loss, but completely unjustifiable to my eyes: however, with this PR, the kind reader is at least aware what's going on.

##### SUMMARY
The Ansible filter `to_uuid` [generates](https://github.com/pierreprinetti/ansible/blob/16d4d2dba9d62103a198647894f7f82020dca27c/lib/ansible/plugins/filter/core.py#L279-L280) a UUIDv5 using an hardcoded namespace.

As a quick lookup on your favourite search engine will confirm, there is some confusion on the Internet over the use of this `to_uuid` filter. I think that the first urgent step is to properly document its behaviour.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`to_uuid`

##### ADDITIONAL INFORMATION

See issue #64054 for a `to_uuid4` proposal.