### PR TITLE
mysql_user: make sure current_pass_hash is a string before using it in comparison

### DIFF
--- a/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
+++ b/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_user - make sure current_pass_hash is a string before using it in comparison.

--- a/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
+++ b/changelogs/fragments/64059-mysql_user_fix_password_comparison.yaml
@@ -1,2 +1,2 @@
-minor_changes:
-- mysql_user - make sure current_pass_hash is a string before using it in comparison.
+bugfixes:
+- mysql_user - make sure current_pass_hash is a string before using it in comparison (https://github.com/ansible/ansible/issues/60567).

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -357,6 +357,8 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                 FROM mysql.user WHERE user = %%s AND host = %%s
                 """ % (colA[0], colA[0], colB[0], colB[0]), (user, host))
             current_pass_hash = cursor.fetchone()[0]
+            if isinstance(current_pass_hash, bytes):
+                current_pass_hash = current_pass_hash.decode('ascii')
 
             if encrypted:
                 encrypted_password = password


### PR DESCRIPTION
##### SUMMARY
Fixes idempotency problem with mysql_user in python 3.7 that always reports changed even when nothing has actually changed.

Fixes #60567

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ADDITIONAL INFORMATION
Playbook used for testing:
```
---
- hosts:
    - db1test
  tasks:
    - name: install mysql user
      mysql_user:
        name: testi
        password: testi
        host: localhost
        state: present
        update_password: always
```


Current output:
```
TASK [install mysql user] ******************************************
changed: [db1test] => {
    "changed": true,
    "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
}

MSG:

Password updated (old style)
```

Output after the fix:
```
TASK [install mysql user] ***************************************
ok: [db1test] => {
    "changed": false,
    "user": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
}

MSG:

User unchanged
```
