### PR TITLE
Add note about spot instances for ec2_instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -15,7 +15,11 @@ DOCUMENTATION = '''
 module: ec2_instance
 short_description: Create & manage EC2 instances
 description:
-    - Create and manage AWS EC2 instance
+  - Create and manage AWS EC2 instances.
+  - >
+    Note: This module does not support creating
+    L(EC2 Spot instances,https://aws.amazon.com/ec2/spot/). The M(ec2) module
+    can create and manage spot instances.
 version_added: "2.5"
 author:
   - Ryan Scott Brown (@ryansb)


### PR DESCRIPTION
##### SUMMARY

The `ec2_instance` module cannot create spot instances, but the `ec2` module
can.

Add a small note to the `ec2_instance` documentation to redirect users to the
`ec2` module if spot instances are needed.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`ec2_instance`

##### ADDITIONAL INFORMATION

Just a small documentation update. :)