### PR TITLE
nxos_lacp: updated tests to handle platforms not supporting lacp system mac command

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -260,7 +260,10 @@ def dict_diff(base, comparable):
     if not isinstance(base, dict):
         raise AssertionError("`base` must be of type <dict>")
     if not isinstance(comparable, dict):
-        raise AssertionError("`comparable` must be of type <dict>")
+        if not comparable:
+            comparable = dict()
+        else:
+            raise AssertionError("`comparable` must be of type <dict>")
 
     updates = dict()
 

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -260,7 +260,7 @@ def dict_diff(base, comparable):
     if not isinstance(base, dict):
         raise AssertionError("`base` must be of type <dict>")
     if not isinstance(comparable, dict):
-        if not comparable:
+        if comparable is None:
             comparable = dict()
         else:
             raise AssertionError("`comparable` must be of type <dict>")

--- a/lib/ansible/module_utils/network/nxos/config/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/nxos/config/lacp/lacp.py
@@ -133,6 +133,9 @@ class Lacp(ConfigBase):
         if merged_commands:
             commands.extend(deleted_commands)
             commands.extend(merged_commands)
+        else:
+            commands.extend(deleted_commands)
+
         return commands
 
     def _state_merged(self, want, have):

--- a/lib/ansible/module_utils/network/nxos/config/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/nxos/config/lacp/lacp.py
@@ -130,11 +130,10 @@ class Lacp(ConfigBase):
                 del diff[k]
         deleted_commands = self.del_all(diff)
         merged_commands = self._state_merged(want, have)
+
+        commands.extend(deleted_commands)
         if merged_commands:
-            commands.extend(deleted_commands)
             commands.extend(merged_commands)
-        else:
-            commands.extend(deleted_commands)
 
         return commands
 

--- a/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
@@ -8,7 +8,7 @@
 
 - set_fact:
     mac: "lacp system-mac 00c1.4c00.bd15 role primary"
-  when: platform is search('N9K')
+  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
 - block:
   - name: Setup
@@ -31,9 +31,6 @@
       state: deleted
     register: result
 
-  - debug:
-      msg: "{{ result }}"
-
   - assert:
       that:
         - "ansible_facts.network_resources.lacp == result.before"
@@ -49,7 +46,7 @@
         - "'no lacp system-mac' in result.commands"
         - "result.changed == true"
         - "result.commands|length == 2"
-    when: platform is search('N9K')
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
   - name: Gather lacp post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
@@ -6,10 +6,18 @@
   nxos_feature:
     feature: lacp
 
+- set_fact:
+    mac: "lacp system-mac 00c1.4c00.bd15 role primary"
+  when: platform is search('N9K')
+
 - block:
   - name: Setup
     cli_config:
       config: lacp system-priority 11
+
+  - name: Setup
+    cli_config:
+      config: "{{ mac|default(omit) }}"
 
   - name: Gather lacp facts
     nxos_facts: &facts
@@ -23,12 +31,25 @@
       state: deleted
     register: result
 
+  - debug:
+      msg: "{{ result }}"
+
   - assert:
       that:
         - "ansible_facts.network_resources.lacp == result.before"
         - "'no lacp system-priority' in result.commands"
         - "result.changed == true"
         - "result.commands|length == 1"
+    when: platform is not search('N9K')
+
+  - assert:
+      that:
+        - "ansible_facts.network_resources.lacp == result.before"
+        - "'no lacp system-priority' in result.commands"
+        - "'no lacp system-mac' in result.commands"
+        - "result.changed == true"
+        - "result.commands|length == 2"
+    when: platform is search('N9K')
 
   - name: Gather lacp post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/deleted.yaml
@@ -8,7 +8,7 @@
 
 - set_fact:
     mac: "lacp system-mac 00c1.4c00.bd15 role primary"
-  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+  when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
 - block:
   - name: Setup
@@ -46,7 +46,7 @@
         - "'no lacp system-mac' in result.commands"
         - "result.changed == true"
         - "result.commands|length == 2"
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   - name: Gather lacp post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
@@ -6,12 +6,19 @@
   nxos_feature:
     feature: lacp
 
+- set_fact:
+    mac:
+      address: 00c1.4c00.bd15
+      role: primary
+  when: platform is search('N9K')
+
 - block:
   - name: Merged
     nxos_lacp: &merged
       config:
         system:
           priority: 11
+          mac: "{{ mac|default(omit) }}"
       state: merged
     register: result
 
@@ -20,7 +27,17 @@
         - "result.before|length == 0"
         - "result.changed == true"
         - "'lacp system-priority 11' in result.commands"
+        - "'lacp system-mac 00c1.4c00.bd15 role primary' in result.commands"
+        - "result.commands|length == 2"
+    when: platform is search('N9K')
+
+  - assert:
+      that:
+        - "result.before|length == 0"
+        - "result.changed == true"
+        - "'lacp system-priority 11' in result.commands"
         - "result.commands|length == 1"
+    when: platform is not search('N9K')
 
   - name: Gather lacp facts
     nxos_facts:

--- a/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
@@ -10,7 +10,7 @@
     mac:
       address: 00c1.4c00.bd15
       role: primary
-  when: platform is search('N9K')
+  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
 - block:
   - name: Merged
@@ -29,7 +29,7 @@
         - "'lacp system-priority 11' in result.commands"
         - "'lacp system-mac 00c1.4c00.bd15 role primary' in result.commands"
         - "result.commands|length == 2"
-    when: platform is search('N9K')
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
   - assert:
       that:

--- a/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/merged.yaml
@@ -10,7 +10,7 @@
     mac:
       address: 00c1.4c00.bd15
       role: primary
-  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+  when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
 - block:
   - name: Merged
@@ -29,7 +29,7 @@
         - "'lacp system-priority 11' in result.commands"
         - "'lacp system-mac 00c1.4c00.bd15 role primary' in result.commands"
         - "result.commands|length == 2"
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   - assert:
       that:

--- a/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
@@ -8,15 +8,23 @@
     feature: lacp
 
 - set_fact:
-    mac:
+    mac1: "lacp system-mac 00c1.4c00.bd20 role primary"
+  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+
+- set_fact:
+    mac2:
       address: 00c1.4c00.bd15
-      role: primary
-  when: platform is search('N9K')
+      role: secondary
+  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
 - block:
-  - name: Setup
+  - name: Setup1
     cli_config:
       config: lacp system-priority 11
+
+  - name: Setup2
+    cli_config:
+      config: "{{ mac1|default(omit) }}"
 
   - name: Gather lacp facts
     nxos_facts: &facts
@@ -29,7 +37,8 @@
     nxos_lacp: &replaced
       config:
         system:
-          mac: "{{ mac|default(omit) }}"
+          priority: 12
+          mac: "{{ mac2|default(omit) }}"
       state: replaced
     register: result
 
@@ -37,8 +46,9 @@
       that:
         - "ansible_facts.network_resources.lacp == result.before"
         - "result.changed == true"
-        - "result.commands|length == 1"
+        - "result.commands|length == 2"
         - "'no lacp system-priority' in result.commands"
+        - "'lacp system-priority 12' in result.commands"
     when: platform is not search('N9K')
 
   - assert:
@@ -46,9 +56,11 @@
         - "ansible_facts.network_resources.lacp == result.before"
         - "result.changed == true"
         - "'no lacp system-priority' in result.commands"
-        - "'lacp system-mac 00c1.4c00.bd15 role primary' in result.commands"
-        - "result.commands|length == 2"
-    when: platform is search('N9K')
+        - "'no lacp system-mac' in result.commands"
+        - "'lacp system-priority 12' in result.commands"
+        - "'lacp system-mac 00c1.4c00.bd15 role secondary' in result.commands"
+        - "result.commands|length == 4"
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
   - name: Gather lacp interfaces post facts
     nxos_facts: *facts
@@ -56,7 +68,7 @@
   - assert:
       that:
         - "ansible_facts.network_resources.lacp == result.after"
-    when: platform is match('N9K')
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
   - name: Idempotence - Replaced
     nxos_lacp: *replaced
@@ -66,6 +78,24 @@
       that:
         - "result.changed == false"
         - "result.commands|length == 0"
+
+  - name: Setup3
+    cli_config:
+      config: "{{ mac1|default(omit) }}"
+
+  - name: Replaced
+    nxos_lacp:
+      state: replaced
+    register: result
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "result.commands|length == 2"
+        - "'no lacp system-mac' in result.commands"
+        - "'no lacp system-priority' in result.commands"
+    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
 
   always:
   - name: teardown

--- a/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
@@ -9,13 +9,13 @@
 
 - set_fact:
     mac1: "lacp system-mac 00c1.4c00.bd20 role primary"
-  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+  when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
 - set_fact:
     mac2:
       address: 00c1.4c00.bd15
       role: secondary
-  when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+  when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
 - block:
   - name: Setup1
@@ -60,7 +60,7 @@
         - "'lacp system-priority 12' in result.commands"
         - "'lacp system-mac 00c1.4c00.bd15 role secondary' in result.commands"
         - "result.commands|length == 4"
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   - name: Gather lacp interfaces post facts
     nxos_facts: *facts
@@ -68,7 +68,7 @@
   - assert:
       that:
         - "ansible_facts.network_resources.lacp == result.after"
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   - name: Idempotence - Replaced
     nxos_lacp: *replaced
@@ -87,7 +87,7 @@
     nxos_lacp:
       state: replaced
     register: result
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   - assert:
       that:
@@ -95,7 +95,7 @@
         - "result.commands|length == 2"
         - "'no lacp system-mac' in result.commands"
         - "'no lacp system-priority' in result.commands"
-    when: platform is search('N9K') and imagetag is not search('I2|I4|I5|I6')
+    when: platform is search('N9K') and imagetag is not search('I[2-6]')
 
   always:
   - name: teardown

--- a/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp/tests/cli/replaced.yaml
@@ -1,10 +1,17 @@
 ---
+
 - debug:
     msg: "Start nxos_lacp replaced integration tests connection={{ ansible_connection }}"
 
 - name: Enable lacp feature
   nxos_feature:
     feature: lacp
+
+- set_fact:
+    mac:
+      address: 00c1.4c00.bd15
+      role: primary
+  when: platform is search('N9K')
 
 - block:
   - name: Setup
@@ -22,11 +29,17 @@
     nxos_lacp: &replaced
       config:
         system:
-          mac:
-            address: 00c1.4c00.bd15
-            role: primary
+          mac: "{{ mac|default(omit) }}"
       state: replaced
     register: result
+
+  - assert:
+      that:
+        - "ansible_facts.network_resources.lacp == result.before"
+        - "result.changed == true"
+        - "result.commands|length == 1"
+        - "'no lacp system-priority' in result.commands"
+    when: platform is not search('N9K')
 
   - assert:
       that:
@@ -35,6 +48,7 @@
         - "'no lacp system-priority' in result.commands"
         - "'lacp system-mac 00c1.4c00.bd15 role primary' in result.commands"
         - "result.commands|length == 2"
+    when: platform is search('N9K')
 
   - name: Gather lacp interfaces post facts
     nxos_facts: *facts
@@ -42,6 +56,7 @@
   - assert:
       that:
         - "ansible_facts.network_resources.lacp == result.after"
+    when: platform is match('N9K')
 
   - name: Idempotence - Replaced
     nxos_lacp: *replaced

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -31,7 +31,6 @@
 - name: "Collect interface list"
   nxos_command:
     commands: ['show interface brief | json']
-    timeout: 60
   connection: network_cli
   register: intout
 


### PR DESCRIPTION
##### SUMMARY

Integration test for replace op for nxos_lacp module was failing on some platforms due to not handling the platforms which do not support "lacp system mac" command.
1. Fixed the replace test.
2. Fixed the merge and delete test to test the "lacp system mac" also on supported platforms, they were just checking the "lacp system-priority"
3. nxos_lacp module itself had a bug in the implementation of the replace operation. Was not replacing from a current state of single command to expected state of no command.
4. Idempotency task for nxos_lacp replace test started failing after fixing 3. Complained about incorrect data structure being passed to the diff function (when the data structure is blank). Have put a fix there as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_lacp
