### PR TITLE
Clarify Python 2.x support in python_3_support.rst

### DIFF
--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -6,7 +6,7 @@ Ansible 2.5 and above work with Python 3. Previous to 2.5, using Python 3 was
 considered a tech preview.  This topic discusses how to set up your controller and managed machines
 to use Python 3.
 
-.. note:: Ansible works with Python version 3.5 and above only.
+.. note:: On the controller we support Python 3.5 or greater and Python 2.7 or greater. Module-side, we support Python 3.5 or greater and Python 2.6 or greater.
 
 On the controller side
 ----------------------


### PR DESCRIPTION
##### SUMMARY
Clarify Python 2.x support in python_3_support.rst as it currently reads that python 2.x is not supported


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
python3

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
