### PR TITLE
postgresql_sequence: allow to pass user name containing dots to owner parameter

### DIFF
--- a/changelogs/fragments/64084-postgresql_sequence_allow_user_name_with_dots.yml
+++ b/changelogs/fragments/64084-postgresql_sequence_allow_user_name_with_dots.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_sequence - allow to pass user name which contains dots (https://github.com/ansible/ansible/issues/63204).

--- a/lib/ansible/modules/database/postgresql/postgresql_sequence.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_sequence.py
@@ -441,7 +441,7 @@ class Sequence(object):
         """Implements ALTER SEQUENCE OWNER TO command behavior."""
         query = ['ALTER SEQUENCE']
         query.append(self.__add_schema())
-        query.append('OWNER TO %s' % pg_quote_identifier(self.module.params['owner'], 'role'))
+        query.append('OWNER TO "%s"' % self.module.params['owner'])
 
         return exec_sql(self, ' '.join(query), ddl=True)
 

--- a/test/integration/targets/postgresql_sequence/defaults/main.yml
+++ b/test/integration/targets/postgresql_sequence/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 db_name: 'ansible_db'
-db_user1: 'ansible_db_user1'
+db_user1: 'ansible.db.user1'
 db_user2: 'ansible_db_user2'
 db_default: 'postgres'


### PR DESCRIPTION
##### SUMMARY
Fixes #63204 
postgresql_sequence: allow to pass user name containing dots to owner parameter

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_sequence.py```
