### PR TITLE
Add support for jumphost setting in junos_scp and junos_package

### DIFF
--- a/lib/ansible/module_utils/network/junos/junos.py
+++ b/lib/ansible/module_utils/network/junos/junos.py
@@ -113,6 +113,12 @@ def get_device(module):
     if 'ssh_keyfile' in provider:
         kwargs['ssh_private_key_file'] = provider.get('ssh_keyfile')
 
+    if module.params.get('ssh_config'):
+        kwargs['ssh_config'] = module.params['ssh_config']
+
+    if module.params.get('ssh_private_key_file'):
+        kwargs['ssh_private_key_file'] = module.params['ssh_private_key_file']
+
     kwargs['gather_facts'] = False
 
     try:

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -90,6 +90,20 @@ options:
     type: bool
     default: False
     version_added: 2.8
+  ssh_private_key_file:
+    description:
+      - The C(ssh_private_key_file) argument is path to the SSH private key file.
+        This can be used if you need to provide a private key rather than loading
+        the key into the ssh-key-ring/environment
+    type: path
+    version_added: 2.10
+  ssh_config:
+    description:
+      - The C(ssh_config) argument is path to the SSH configuration file.
+        This can be used to load SSH information from a configuration file.
+        If this option is not given by default ~/.ssh/config is queried.
+    type: path
+    version_added: 2.10
 requirements:
   - junos-eznc
   - ncclient (>=v0.5.2)
@@ -112,6 +126,11 @@ EXAMPLES = """
   junos_package:
     src: junos-vsrx-12.1X46-D10.2-domestic.tgz
     reboot: no
+
+- name: install local package on remote device with jumpost
+  junos_package:
+    src: junos-vsrx-12.1X46-D10.2-domestic.tgz
+    ssh_config: /home/user/customsshconfig
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.junos.junos import junos_argument_spec, get_device
@@ -158,7 +177,9 @@ def main():
         force=dict(type='bool', default=False),
         transport=dict(default='netconf', choices=['netconf']),
         force_host=dict(type='bool', default=False),
-        issu=dict(type='bool', default=False)
+        issu=dict(type='bool', default=False),
+        ssh_private_key_file=dict(type='path'),
+        ssh_config=dict(type='path')
     )
 
     argument_spec.update(junos_argument_spec)

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -96,14 +96,14 @@ options:
         This can be used if you need to provide a private key rather than loading
         the key into the ssh-key-ring/environment
     type: path
-    version_added: 2.10
+    version_added: '2.10'
   ssh_config:
     description:
       - The C(ssh_config) argument is path to the SSH configuration file.
         This can be used to load SSH information from a configuration file.
         If this option is not given by default ~/.ssh/config is queried.
     type: path
-    version_added: 2.10
+    version_added: '2.10'
 requirements:
   - junos-eznc
   - ncclient (>=v0.5.2)
@@ -112,6 +112,10 @@ notes:
     the remote device being managed.
   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
   - Works with C(local) connections only.
+  - Since this module uses junos-eznc to establish connection with junos
+    device the netconf configuration parameters needs to be passed
+    using module options for example C(ssh_config) unlike other junos
+    modules that uses C(netconf) connection type.
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/junos/junos_scp.py
+++ b/lib/ansible/modules/network/junos/junos_scp.py
@@ -53,14 +53,14 @@ options:
         This can be used if you need to provide a private key rather than loading
         the key into the ssh-key-ring/environment
     type: path
-    version_added: 2.10
+    version_added: '2.10'
   ssh_config:
     description:
       - The C(ssh_config) argument is path to the SSH configuration file.
         This can be used to load SSH information from a configuration file.
         If this option is not given by default ~/.ssh/config is queried.
     type: path
-    version_added: 2.10
+    version_added: '2.10'
 requirements:
   - junos-eznc
   - ncclient (>=v0.5.2)
@@ -69,6 +69,10 @@ notes:
     the remote device being managed.
   - Tested against vMX JUNOS version 17.3R1.10.
   - Works with C(local) connections only.
+  - Since this module uses junos-eznc to establish connection with junos
+    device the netconf configuration parameters needs to be passed
+    using module options for example C(ssh_config) unlike other junos
+    modules that uses C(netconf) connection type.
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/junos/junos_scp.py
+++ b/lib/ansible/modules/network/junos/junos_scp.py
@@ -47,6 +47,20 @@ options:
         to the remote device.
     type: bool
     default: 'no'
+  ssh_private_key_file:
+    description:
+      - The C(ssh_private_key_file) argument is path to the SSH private key file.
+        This can be used if you need to provide a private key rather than loading
+        the key into the ssh-key-ring/environment
+    type: path
+    version_added: 2.10
+  ssh_config:
+    description:
+      - The C(ssh_config) argument is path to the SSH configuration file.
+        This can be used to load SSH information from a configuration file.
+        If this option is not given by default ~/.ssh/config is queried.
+    type: path
+    version_added: 2.10
 requirements:
   - junos-eznc
   - ncclient (>=v0.5.2)
@@ -73,6 +87,12 @@ EXAMPLES = """
   junos_scp:
     src: test.tgz
     remote_src: true
+
+- name: ssh config file path for jumphost config
+  junos_scp:
+    src: test.tgz
+    remote_src: true
+    ssh_config: /home/user/customsshconfig
 """
 
 RETURN = """
@@ -112,6 +132,8 @@ def main():
         dest=dict(type='path', required=False, default="."),
         recursive=dict(type='bool', default=False),
         remote_src=dict(type='bool', default=False),
+        ssh_private_key_file=dict(type='path'),
+        ssh_config=dict(type='path'),
         transport=dict(default='netconf', choices=['netconf'])
     )
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -84,7 +84,7 @@ class ActionModule(ActionNetworkModule):
             if any(provider.values()):
                 # for legacy reasons provider value is required for junos_facts(optional) and junos_package
                 # modules as it uses junos_eznc library to connect to remote host
-                if not (module_name == 'junos_facts' or module_name == 'junos_package'):
+                if not (module_name == 'junos_facts' or module_name == 'junos_package' or module_name == 'junos_scp'):
                     display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                     del self._task.args['provider']
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Since junos_scp and junos_package module uses junos-eznc library
  to transfer file and load package respectively to a remote device
  it does not read the jumphost related configuration in netconf
  connection plugin unlike other junos modules which uses the
  Ansible persistent.
* Add `ssh_config` and `ssh_private_key_file` to add support to
  read custom ssh config file and mention ssh private key file
  for junos_scp and junos_package module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/network/junos/junos.py
modules/network/junos/junos_package.py
modules/network/junos/junos_scp.py
plugins/action/junos.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
