### PR TITLE
lineinfile - don't run os.makedirs on empty dir path 

### DIFF
--- a/changelogs/fragments/63919-lineinfile-create-no-dir-path.yml
+++ b/changelogs/fragments/63919-lineinfile-create-no-dir-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - "lineinfile - don't attempt mkdirs when path doesn't contain directory path"

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -260,7 +260,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
         if not create:
             module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
         b_destpath = os.path.dirname(b_dest)
-        if not os.path.exists(b_destpath) and not module.check_mode:
+        if b_destpath and not os.path.exists(b_destpath) and not module.check_mode:
             try:
                 os.makedirs(b_destpath)
             except Exception as e:

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -268,6 +268,24 @@
     that:
       - "result.stat.checksum == '038f10f9e31202451b093163e81e06fbac0c6f3a'"
 
+- name: Create a file without a path
+  lineinfile:
+    dest: file.txt
+    create: yes
+    line: Test line
+  register: create_no_path_test
+
+- name: Stat the file
+  stat:
+    path: file.txt
+  register: create_no_path_file
+
+- name: Ensure file was created
+  assert:
+    that:
+      - create_no_path_test is changed
+      - create_no_path_file.stat.exists
+
 # Test EOF in cases where file has no newline at EOF
 - name: testnoeof deploy the file for lineinfile
   copy:


### PR DESCRIPTION
* Fix #63919: don't run os.makedirs on empty dir path
* integration test for lineinfile create: yes without path (Sam Doran <sdoran@redhat.com>)

(cherry picked from commit 3c978a3225b1bb5118540dffd5006588f4228a8f)

Backport of https://github.com/ansible/ansible/pull/63921

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fixes #63919: don't run os.makedirs on empty dir path
* integration test for lineinfile create: yes without path (Sam Doran <sdoran@redhat.com>)

(cherry picked from commit 3c978a3225b1bb5118540dffd5006588f4228a8f)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lineinfile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
