### PR TITLE
fixes bug: visible_name was not updated when not set in existing host…

### DIFF
--- a/changelogs/fragments/fix_zabbix_host_visible_name.yml
+++ b/changelogs/fragments/fix_zabbix_host_visible_name.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - was not possible to update a host where visible_name was not set in zabbix
+    - zabbix_host - was not possible to update a host where visible_name was not set in zabbix

--- a/changelogs/fragments/fix_zabbix_host_visible_name.yml
+++ b/changelogs/fragments/fix_zabbix_host_visible_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - was not possible to update a host where visible_name was not set in zabbix

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -533,7 +533,7 @@ class Host(object):
 
         # Check whether the visible_name has changed; Zabbix defaults to the technical hostname if not set.
         if visible_name:
-            if host['name'] != visible_name and host['name'] != host_name:
+            if host['name'] != visible_name and host['host'] != visible_name:
                 return True
 
         # Only compare description if it is given as a module parameter

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -533,7 +533,7 @@ class Host(object):
 
         # Check whether the visible_name has changed; Zabbix defaults to the technical hostname if not set.
         if visible_name:
-            if host['name'] != visible_name and host['host'] != visible_name:
+            if host['name'] != visible_name:
                 return True
 
         # Only compare description if it is given as a module parameter


### PR DESCRIPTION
… in zabbix

##### SUMMARY
When updating visible_name for a host which has it unset, the update didn't  happen.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
The second condition was changed to validate that the new visible_name is not the same as the technical host name already set in zabbix
```
