### PR TITLE
get_url integration test: Fix missing conditional

### DIFF
--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -462,6 +462,7 @@
   slurp:
     src: "{{ remote_tmp_dir }}/ssl_client_verify"
   register: result
+  when: has_httptester
 
 - name: Assert that the ssl_client_verify file contains the correct content
   assert:


### PR DESCRIPTION
##### SUMMARY

If `has_httptester` is not set, the integration tests currently fail because a `when:` conditional is missing.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

get_url