### PR TITLE
[Doc-Release-2.9][2.9] fix spelling issues (#64103)

### DIFF
--- a/changelogs/fragments/mqtt-ssl-protocols.yml
+++ b/changelogs/fragments/mqtt-ssl-protocols.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - Fix SSL protcol references in the ``mqtt`` module to prevent failures on Python 2.6.
+    - Fix SSL protocol references in the ``mqtt`` module to prevent failures on Python 2.6.

--- a/lib/ansible/modules/cloud/vultr/vultr_account_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_account_info.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: vultr_account_info
-short_description: Get infos about the Vultr account.
+short_description: Get information about the Vultr account.
 description:
   - Get infos about account balance, charges and payments.
 version_added: "2.9"

--- a/lib/ansible/modules/cloud/vultr/vultr_block_storage_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_block_storage_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: vultr_block_storage_info
-short_description: Get infos about the Vultr block storage volumes available.
+short_description: Get information about the Vultr block storage volumes available.
 description:
   - Get infos about block storage volumes available in Vultr.
 version_added: "2.9"

--- a/lib/ansible/modules/cloud/vultr/vultr_os_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_os_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: vultr_os_info
-short_description: Get infos about the Vultr OSes available.
+short_description: Get information about the Vultr OSes available.
 description:
   - Get infos about OSes available to boot servers.
 version_added: "2.9"

--- a/lib/ansible/modules/cloud/vultr/vultr_ssh_key_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_ssh_key_info.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: vultr_ssh_key_info
-short_description: Get infos about the Vultr SSH keys available.
+short_description: Get information about the Vultr SSH keys available.
 description:
   - Get infos about SSH keys available.
 version_added: "2.9"

--- a/lib/ansible/modules/cloud/vultr/vultr_user_info.py
+++ b/lib/ansible/modules/cloud/vultr/vultr_user_info.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: vultr_user_info
-short_description: Get infos about the Vultr user available.
+short_description: Get information about the Vultr user available.
 description:
   - Get infos about users available in Vultr.
 version_added: "2.9"


### PR DESCRIPTION
(cherry picked from commit 26236f474ba8aa600d321c9cb7c5b11d123928ac)

##### SUMMARY
In preparation for the release of 2.9, backport fixed spelling errors in changelogs and porting guides.

Part of #64102
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
