### PR TITLE
integration tests - mongodb installation fix for xenial 

### DIFF
--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -1,14 +1,9 @@
 mongodb_version: "4.0"
 
-apt_xenial:
-  keyserver: "keyserver.ubuntu.com"
-  keyserver_id: "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
-  repo: "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu {{ansible_distribution_release}}/mongodb-org/{{mongodb_version}} multiverse"
-
-apt_bionic:
+apt:
   keyserver: "keyserver.ubuntu.com"
   keyserver_id: "9DA31620334BD75D9DCB49F368818C72E52529D4"
-  repo: "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu {{ansible_distribution_release}}/mongodb-org/{{mongodb_version}} multiverse"
+  repo: "deb [ arch=amd64 ] http://repo.mongodb.org/apt/ubuntu {{ansible_distribution_release}}/mongodb-org/{{mongodb_version}} multiverse"
 
 mongodb_packages:
   mongod: mongodb-org-server

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -28,42 +28,21 @@
     or (ansible_distribution == 'CentOS' and ansible_distribution_version == '7')
 
 # Ubuntu
-- name: Import MongoDB public GPG Key xenial
+- name: Import MongoDB public GPG Key
   apt_key:
-    keyserver: "{{ apt_xenial.keyserver }}"
-    id: "{{ apt_xenial.keyserver_id }}"
+    keyserver: "{{ apt.keyserver }}"
+    id: "{{ apt.keyserver_id }}"
   when:
-    - ansible_distribution_version == "16.04"
+    - ansible_distribution_version in ["16.04", "18.04"]
     - ansible_distribution == 'Ubuntu'
 
-- name: Add MongoDB repository into sources list xenial
+- name: Add MongoDB repository into sources list
   apt_repository:
-    repo: "{{ apt_xenial.repo }}"
+    repo: "{{ apt.repo }}"
     state: present
+    update_cache: yes
   when:
-    - ansible_distribution_version == "16.04"
-    - ansible_distribution == 'Ubuntu'
-
-- name: Import MongoDB public GPG Key bionic
-  apt_key:
-    keyserver: "{{ apt_bionic.keyserver }}"
-    id: "{{ apt_bionic.keyserver_id }}"
-  when:
-    - ansible_distribution_version == "18.04"
-    - ansible_distribution == 'Ubuntu'
-
-- name: Add MongoDB repository into sources list bionic
-  apt_repository:
-    repo: "{{ apt_bionic.repo }}"
-    state: present
-  when:
-    - ansible_distribution_version == "18.04"
-    - ansible_distribution == 'Ubuntu'
-
-- name: Update apt keys
-  shell: apt-key update && apt-get update
-  when:
-    - mongodb_version != "4.0"
+    - ansible_distribution_version in ["16.04", "18.04"]
     - ansible_distribution == 'Ubuntu'
 
 # Need to handle various platforms here. Package name will not always be the same


### PR DESCRIPTION
##### SUMMARY
setup_mongodb role has wrong APT key defined for repo.mongodb.org:
- 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 is for mongodb 3.6
- 9DA31620334BD75D9DCB49F368818C72E52529D4 is for mongodb 4.0, but was imported only on bionic

There is no need to import key for mongodb 3.6 if it is not going to be installed as `mongodb_version: "4.0"` is locked to specific version and there seems to be no other place where this gets overriden. This deprecates need to differentiate between apt repository and keys on xenial and bionic too so I've removed that logic. 

Also not updating apt-cache when `mongodb_version == 4.0` is not a very good idea. In this case I was the unlucky one that ran `apt update` in zabbix_host integration role and was presented with wrong repo key for mongo repo. Ref #64068. However, this could've had happened to any role that would run `apt update` after mongodb_* roles finished testing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_mongodb

##### ADDITIONAL INFORMATION
```paste below
devel
```
