### PR TITLE
nxos_lag_interfaces: fix regression tests

### DIFF
--- a/test/integration/targets/nxos_lag_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lag_interfaces/tests/cli/deleted.yaml
@@ -10,14 +10,8 @@
     feature: lacp
 
 - name: Setup1
-  nxos_config:
-    lines:
-      - "no channel-group 10"
-    parents: "{{ item }}"
-  ignore_errors: yes
-  loop:
-    - "interface {{ test_int1 }}"
-    - "interface {{ test_int2 }}"
+  nxos_lag_interfaces: &remove_lags
+    state: deleted
 
 - block:
   - name: Setup2
@@ -63,14 +57,8 @@
 
   always:
   - name: Teardown
-    nxos_config:
-      lines:
-        - "no channel-group 10"
-      parents: "{{ item }}"
+    nxos_lag_interfaces: *remove_lags
     ignore_errors: yes
-    loop:
-      - "interface {{ test_int1 }}"
-      - "interface {{ test_int2 }}"
 
   - name: disable feature lacp
     nxos_feature:

--- a/test/integration/targets/nxos_lag_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lag_interfaces/tests/cli/merged.yaml
@@ -12,12 +12,12 @@
 - name: Setup
   nxos_config:
     lines:
-      - "no channel-group"
-    parents: "{{ item }}"
+      - no interface port-channel 10
   ignore_errors: yes
-  loop:
-    - "interface {{ test_int1 }}"
-    - "interface {{ test_int2 }}"
+
+- name: setup2
+  nxos_lag_interfaces: &remove_lags
+    state: deleted
 
 - block:
   - name: Merged
@@ -56,14 +56,8 @@
 
   always:
   - name: Teardown
-    nxos_config:
-      lines:
-        - "no channel-group"
-      parents: "{{ item }}"
+    nxos_lag_interfaces: *remove_lags
     ignore_errors: yes
-    loop:
-      - "interface {{ test_int1 }}"
-      - "interface {{ test_int2 }}"
 
   - name: Disable feature lacp
     nxos_feature:

--- a/test/integration/targets/nxos_lag_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_lag_interfaces/tests/cli/overridden.yaml
@@ -13,19 +13,13 @@
 - name: setup1
   nxos_config:
     lines:
-      - "no channel-group 10"
-    parents: "{{ item }}"
+      - no interface port-channel 10
+      - no interface port-channel 19
   ignore_errors: yes
-  loop:
-    - "interface {{ test_int1 }}"
-    - "interface {{ test_int2 }}"
 
 - name: setup2
-  nxos_config: &cleanup2
-    lines:
-      - "no channel-group 19"
-    parents: "interface {{ test_int3 }}"
-  ignore_errors: yes
+  nxos_lag_interfaces: &remove_lags
+    state: deleted
 
 - block:
   - name: setup3
@@ -74,18 +68,8 @@
       that:
         - "result.changed == false"
   always:
-  - name: teardown1
-    nxos_config:
-      lines:
-        - "no channel-group 10"
-      parents: "{{ item }}"
-    ignore_errors: yes
-    loop:
-      - "interface {{ test_int1 }}"
-      - "interface {{ test_int2 }}"
-
-  - name: teardown2
-    nxos_config: *cleanup2
+  - name: Teardown
+    nxos_lag_interfaces: *remove_lags
     ignore_errors: yes
 
   - name: disable feature lacp

--- a/test/integration/targets/nxos_lag_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lag_interfaces/tests/cli/replaced.yaml
@@ -10,18 +10,15 @@
     feature: lacp
 
 - name: setup1
-  nxos_config: &cleanup1
+  nxos_config:
     lines:
-      - "no channel-group 10"
-    parents: "interface {{ test_int1 }}"
+      - no interface port-channel 10
+      - no interface port-channel 11
   ignore_errors: yes
 
 - name: setup2
-  nxos_config: &cleanup2
-    lines:
-      - "no channel-group 11"
-    parents: "interface {{ test_int2 }}"
-  ignore_errors: yes
+  nxos_lag_interfaces: &remove_lags
+    state: deleted
 
 - block:
   - name: setup3
@@ -72,11 +69,7 @@
 
   always:
   - name: teardown1
-    nxos_config: *cleanup1
-    ignore_errors: yes
-
-  - name: teardown2
-    nxos_config: *cleanup2
+    nxos_lag_interfaces: *remove_lags
     ignore_errors: yes
 
   - name: disable feature lacp


### PR DESCRIPTION
##### SUMMARY
This is a change to the regression tests only. These tests were failing because of leftover device settings from previous tests:

- existing `channel-group` configurations on non-test interfaces were included in the before/after counts
  - fixed by using the `nxos_lag_interfaces` module with `state: deleted` to remove `channel-group` configurations from all interfaces

- existing `L2` `port-channel` interfaces with the same ID as the test `channel-group` ID may prevent configuring `channel-group` on the test ethernet interface
  - fixed by removing `port-channel` interfaces with the same ID; e.g.

```
  interface port-channel98
    switchport
    switchport mode trunk

nx-1(config-if)# interface Ethernet1/19
nx-1(config-if)# channel-group 98
command failed: port not compatible [switching port]
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_lag_interfaces`

##### ADDITIONAL INFORMATION
Fixes passed on `N6K,N7K,N9K,N3K` (internal TBs: `dt-n9k5-1,n6k-77,n7k-99,n7k-j,n3k-173,evergreen-nx-1,greensboro-nx-1,hamilton-nx-1,camden-nx-1`)
