### PR TITLE
[2.9] Make docker_stack adhere to standard ansible return values

### DIFF
--- a/changelogs/fragments/63467-docker-stack-return-fix.yml
+++ b/changelogs/fragments/63467-docker-stack-return-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker_stack - Added ``stdout``, ``stderr``, and ``rc`` to return values.

--- a/lib/ansible/modules/cloud/docker/docker_stack.py
+++ b/lib/ansible/modules/cloud/docker/docker_stack.py
@@ -261,8 +261,9 @@ def main():
 
         if rc != 0:
             module.fail_json(msg="docker stack up deploy command failed",
-                             out=out,
-                             rc=rc, err=err)
+                             rc=rc,
+                             out=out, err=err,
+                             stdout=out, stderr=err)
 
         before_after_differences = json_diff(before_stack_services,
                                              after_stack_services)
@@ -274,10 +275,17 @@ def main():
                     before_after_differences.pop(k)
 
         if not before_after_differences:
-            module.exit_json(changed=False)
+            module.exit_json(
+                changed=False,
+                rc=rc,
+                stdout=out,
+                stderr=err)
         else:
             module.exit_json(
                 changed=True,
+                rc=rc,
+                stdout=out,
+                stderr=err,
                 stack_spec_diff=json_diff(before_stack_services,
                                           after_stack_services,
                                           dump=True))
@@ -287,11 +295,14 @@ def main():
             rc, out, err = docker_stack_rm(module, name, absent_retries, absent_retries_interval)
             if rc != 0:
                 module.fail_json(msg="'docker stack down' command failed",
-                                 out=out,
                                  rc=rc,
-                                 err=err)
+                                 out=out, err=err,
+                                 stdout=out, stderr=err)
             else:
-                module.exit_json(changed=True, msg=out, err=err, rc=rc)
+                module.exit_json(changed=True,
+                                 msg=out, rc=rc,
+                                 err=err,
+                                 stdout=out, stderr=err)
         module.exit_json(changed=False)
 
 


### PR DESCRIPTION
##### SUMMARY
Backport of #63467 to stable-2.9.

This is the part of #63467 which doesn't deprecate something. It adds further return values, `stdout` and `stderr`, where `out` and `err` were used, and to other places so the module return values are more consistent.

This would normally be a New Feature, but since the "wrong" (i.e. non-standard) names were used, and there were only used sometimes, but not in all cases, I think this qualifies as a bugfix.

@dariko what do you think?

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_stack
