### PR TITLE
nxos_lacp_interfaces: Updating the tests to handle platforms that don't support - lacp mode delay

### DIFF
--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
@@ -4,7 +4,8 @@
 
 - set_fact:
     mode: delay
-  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+  when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
+    image_version is not search ('9.2') and chassis_type is not search('C9508')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
@@ -5,7 +5,7 @@
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
-    image_version is not search ('9.2') and chassis_type is not search('C9508')
+    image_version is not search ('9.2') and chassis_type is not search('C95')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/deleted.yaml
@@ -2,6 +2,11 @@
 - debug:
     msg: "Start nxos_lacp_interfaces deleted integration tests connection={{ ansible_connection }}"
 
+#
+# "lacp mode delay" is not supported on Nexus 9500 series switches.
+# Three models of Nexus 9500 switches have chassis types C9504, C9508 and C9516.
+#
+
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
@@ -4,7 +4,8 @@
 
 - set_fact:
     mode: delay
-  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+  when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
+    image_version is not search ('9.2') and chassis_type is not search('C9508')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
@@ -5,7 +5,7 @@
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
-    image_version is not search ('9.2') and chassis_type is not search('C9508')
+    image_version is not search ('9.2') and chassis_type is not search('C95')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/merged.yaml
@@ -2,6 +2,11 @@
 - debug:
     msg: "Start nxos_lacp_interfaces merged integration tests connection={{ ansible_connection }}"
 
+#
+# "lacp mode delay" is not supported on Nexus 9500 series switches.
+# Three models of Nexus 9500 switches have chassis types C9504, C9508 and C9516.
+#
+
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
@@ -4,7 +4,8 @@
 
 - set_fact:
     mode: delay
-  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+  when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
+    image_version is not search ('9.2') and chassis_type is not search('C9508')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
@@ -5,7 +5,7 @@
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
-    image_version is not search ('9.2') and chassis_type is not search('C9508')
+    image_version is not search ('9.2') and chassis_type is not search('C95')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/overridden.yaml
@@ -2,6 +2,11 @@
 - debug:
     msg: "Start nxos_lacp_interfaces overridden integration tests connection={{ ansible_connection }}"
 
+#
+# "lacp mode delay" is not supported on Nexus 9500 series switches.
+# Three models of Nexus 9500 switches have chassis types C9504, C9508 and C9516.
+#
+
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
@@ -2,6 +2,11 @@
 - debug:
     msg: "Start nxos_lacp_interfaces replaced integration tests connection={{ ansible_connection }}"
 
+#
+# "lacp mode delay" is not supported on Nexus 9500 series switches.
+# Three models of Nexus 9500 switches have chassis types C9504, C9508 and C9516.
+#
+
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
@@ -4,7 +4,8 @@
 
 - set_fact:
     mode: delay
-  when: platform is not search('N5K|N6K|N7K') and ((imagetag != 'I2'))
+  when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
+    image_version is not search ('9.2') and chassis_type is not search('C9508')
 
 - name: setup1
   cli_config: &cleanup

--- a/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_lacp_interfaces/tests/cli/replaced.yaml
@@ -5,7 +5,7 @@
 - set_fact:
     mode: delay
   when: platform is not search('N3K|N5K|N6K|N7K') and imagetag is not search('A8|I2') and
-    image_version is not search ('9.2') and chassis_type is not search('C9508')
+    image_version is not search ('9.2') and chassis_type is not search('C95')
 
 - name: setup1
   cli_config: &cleanup


### PR DESCRIPTION
##### SUMMARY
The tests under nxos_lacp_interfaces were failing due to some image versions and some platforms not supporting the "lacp mode delay" command under port-channel interface configuration. Have updated the tests to handle such platforms.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
nxos_lacp_interfaces