### PR TITLE
re-enable zabbix_host integration tests and add cleanup handlers

### DIFF
--- a/test/integration/targets/setup_zabbix/handlers/main.yml
+++ b/test/integration/targets/setup_zabbix/handlers/main.yml
@@ -1,0 +1,15 @@
+- name: remove zabbix repository
+  apt_repository:
+    repo: "{{ zabbix_apt_repository }}"
+    filename: zabbix
+    state: absent
+
+- name: remove zabbix packages
+  apt:
+    name: "{{ zabbix_packages }}"
+    state: absent
+
+- name: remove zabbix pip packages
+  pip:
+    name: zabbix-api
+    state: absent

--- a/test/integration/targets/setup_zabbix/tasks/setup.yml
+++ b/test/integration/targets/setup_zabbix/tasks/setup.yml
@@ -10,6 +10,7 @@
     repo: "{{ zabbix_apt_repository }}"
     filename: zabbix
     state: present
+  notify: remove zabbix repository
 
 - name: check if dpkg is set to exclude specific destinations
   stat:
@@ -29,11 +30,13 @@
     name: "{{ zabbix_packages }}"
     state: latest
     update_cache: yes
+  notify: remove zabbix packages
 
 - name: install zabbix-api python package
   pip:
     name: zabbix-api
     state: latest
+  notify: remove zabbix pip packages
 
 - name: create mysql user {{ db_user }}
   mysql_user:

--- a/test/integration/targets/zabbix_host/aliases
+++ b/test/integration/targets/zabbix_host/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-disabled

--- a/test/integration/targets/zabbix_host/tasks/main.yml
+++ b/test/integration/targets/zabbix_host/tasks/main.yml
@@ -14,4 +14,3 @@
 
   when:
     - ansible_distribution == 'Ubuntu'
-    - ansible_distribution_release == 'bionic'


### PR DESCRIPTION
##### SUMMARY
Re-enable zabbix_host integration tests disabled in #64067

Fixes #64068

Original issue that lead to disabling this test role, not related to zabbix_host, was fixed in #64108

plus:

- some handlers were added that will cleanup packages and apt repositories once zabbix_host is finished testing
- zabbix_host role was unlocked for xenial, because setup_zabbix was still being executed, but the actual tests were only performed on bionic

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_zabbix
test/integration/targets/zabbix_host

##### ADDITIONAL INFORMATION
```paste below
devel
```
