### PR TITLE
Fix typo in deprecation warning message

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -134,7 +134,7 @@ class Conditional:
             conditional = templar.template(conditional, disable_lookups=disable_lookups)
             if bare_vars_warning and not isinstance(conditional, bool):
                 display.deprecated('evaluating %s as a bare variable, this behaviour will go away and you might need to add |bool'
-                                   ' to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.' % conditional, "2.12")
+                                   ' to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle' % conditional, "2.12")
             if not isinstance(conditional, text_type) or conditional == "":
                 return conditional
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I got this deprecation warning and noticed two dots at the end of the second sentence. Dot is coming from [display.deprecated](https://github.com/ansible/ansible/blob/ea6e96985a976f7bae703964e00028aef5fed218/lib/ansible/utils/display.py#L236).

>[DEPRECATION WARNING]: evaluating [] as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/playbook/conditional.py`
