### PR TITLE
Update firewalld.py

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -163,13 +163,13 @@ EXAMPLES = r'''
 
 - firewalld:
     zone: drop
-    state: present
+    state: enabled
     permanent: yes
     icmp_block_inversion: yes
 
 - firewalld:
     zone: drop
-    state: present
+    state: enabled
     permanent: yes
     icmp_block: echo-request
 


### PR DESCRIPTION
##### SUMMARY
state should be "enabled" and not "present"
When running the example you get the following error:
  "msg: absent and present state can only be used in zone level operations"


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
