### PR TITLE
paramiko_ssh - Improve authentication error message

### DIFF
--- a/changelogs/fragments/paramiko_ssh-improve-error-message.yaml
+++ b/changelogs/fragments/paramiko_ssh-improve-error-message.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko_ssh - improve authentication error message so it is less confusing

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -354,7 +354,7 @@ class Connection(ConnectionBase):
         except paramiko.ssh_exception.BadHostKeyException as e:
             raise AnsibleConnectionFailure('host key mismatch for %s' % e.hostname)
         except paramiko.ssh_exception.AuthenticationException as e:
-            msg = 'Invalid/incorrect username/password. {0}'.format(to_text(e))
+            msg = 'Failed to authenticate: {0}'.format(to_text(e))
             raise AnsibleAuthenticationFailure(msg)
         except Exception as e:
             msg = to_text(e)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The error is not always an invalid username/password. It could be a connection timeout or refusal which made the error message shown to the user a bit confusing.

```
fatal: [host]: UNREACHABLE! => {
    "changed": false, 
    "msg": "Invalid/incorrect username/password. Authentication timeout.", 
    "unreachable": true
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/connection/paramiko_ssh.py`
