### PR TITLE
Add kwargs to podman command for passing parameters

### DIFF
--- a/lib/ansible/module_utils/podman/common.py
+++ b/lib/ansible/module_utils/podman/common.py
@@ -6,12 +6,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-def run_podman_command(module, executable='podman', args=None, expected_rc=0, ignore_errors=False):
+def run_podman_command(module, executable='podman', args=None, expected_rc=0, ignore_errors=False, **kwargs):
     if not isinstance(executable, list):
         command = [executable]
     if args is not None:
         command.extend(args)
-    rc, out, err = module.run_command(command)
+    rc, out, err = module.run_command(command, **kwargs)
     if not ignore_errors and rc != expected_rc:
         module.fail_json(
             msg='Failed to run {command} {args}: {err}'.format(


### PR DESCRIPTION
##### SUMMARY
When using run_podman_command we'll need to pass more parameters
to module.run_command, like use_unsafe_shell etc.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
podman

