### PR TITLE
nxos_lldp_global: fix regression tests

### DIFF
--- a/test/integration/targets/nxos_lldp_global/tests/cli/deleted.yml
+++ b/test/integration/targets/nxos_lldp_global/tests/cli/deleted.yml
@@ -1,22 +1,37 @@
 ---
   - debug:
       msg: "Start nxos_lldp_global deleted integration tests connection = {{ ansible_connection }}"
-  
-  - name: Enable LLDP feature
-    nxos_feature:
-      feature: lldp
-      state: enabled
 
+  # N35 skips all tests, image issues.
   - block:
+    - set_fact: cfg_port_id=True
+      when: platform is not search('N[567]K') and imagetag is not search("I[2345]")
+
+    - name: feature off to cleanup lldp
+      nxos_feature: &feature_off
+        feature: lldp
+        state: disabled
+
+    - name: Enable LLDP feature
+      nxos_feature:
+        feature: lldp
+        state: enabled
+
     - name: Setup
       cli_config:
         config: |
           lldp holdtime 125
           lldp timer 32
-          no lldp tlv-select dcbxp 
+          no lldp tlv-select dcbxp
           lldp tlv-select system-name
           no lldp tlv-select system-description
-          lldp tlv-select power-management
+
+    - name: Setup2
+      cli_config:
+        config: |
+          lldp portid-subtype 1
+          no lldp tlv-select power-management
+      when: cfg_port_id is defined
 
     - name: Gather lldp_global facts
       nxos_facts: &facts
@@ -40,6 +55,12 @@
           - "result.changed == true "
           - "result.after | length == 0"
 
+    - assert:
+        that:
+          - "'no lldp portid-subtype 1' in result.commands"
+          - "'lldp tlv-select power-management' in result.commands"
+      when: cfg_port_id is defined
+
     - name: Gather lldp_global post facts
       nxos_facts: *facts
 
@@ -55,9 +76,8 @@
         that:
           - "result.changed == false"
           - "result.commands|length == 0"
-
     always:
-    - name: teardown
-      nxos_feature:
-        feature: lldp
-        state: disabled
+      - name: teardown
+        nxos_feature: *feature_off
+
+    when: platform is not search('N35')

--- a/test/integration/targets/nxos_lldp_global/tests/cli/merged.yml
+++ b/test/integration/targets/nxos_lldp_global/tests/cli/merged.yml
@@ -2,19 +2,30 @@
   - debug:
       msg: "Start nxos_lldp_global merged integration tests connection={{ansible_connection}}"
 
-  - name: Enable lldp
-    nxos_feature:
-      feature: lldp
-
+  # N35 skips all tests, image issues.
   - block:
+    - set_fact:
+        port_id: 1
+        tlv_power_mgmt:
+          power_management: false
+      when: platform is not search('N5K|N6K|N7K') and imagetag is not search("I[2345]")
+
+    - name: feature off to cleanup lldp
+      nxos_feature: &feature_off
+        feature: lldp
+        state: disabled
+
+    - name: Enable lldp
+      nxos_feature:
+        feature: lldp
+
     - name: Merged
       nxos_lldp_global: &merged
         config:
           reinit: 5
           timer: 40
-          port_id: 1
-          tlv_select:
-            power_management: false
+          port_id: "{{port_id|default(omit)}}"
+          tlv_select: "{{tlv_power_mgmt|default(omit)}}"
         state: merged
       register: result
 
@@ -24,10 +35,17 @@
           - "result.changed == true"
           - "'lldp reinit 5' in result.commands"
           - "'lldp timer 40' in result.commands"
+
+    - assert:
+        that:
           - "'lldp portid-subtype 1' in result.commands"
+      when: port_id is defined
+
+    - assert:
+        that:
           - "'no lldp tlv-select power-management' in result.commands"
-          - "result.commands | length == 4"
-           
+      when: tlv_power_mgmt is defined
+
     - name: Gather lldp_global facts
       nxos_facts:
         gather_subset:
@@ -38,7 +56,7 @@
     - assert:
         that:
           - "ansible_facts.network_resources.lldp_global == result.after"
- 
+
     - name: Idempotence - Merged
       nxos_lldp_global: *merged
       register: result
@@ -47,9 +65,8 @@
         that:
           - "result.changed == false"
           - "result.commands | length == 0"
-
     always:
     - name: teardown
-      nxos_feature: 
-        feature: lldp
-        state: disabled
+      nxos_feature: *feature_off
+
+    when: platform is not search('N35')

--- a/test/integration/targets/nxos_lldp_global/tests/cli/replaced.yml
+++ b/test/integration/targets/nxos_lldp_global/tests/cli/replaced.yml
@@ -2,20 +2,37 @@
   - debug:
       msg: "Start nxos_lldp_global replaced integration tests connection = {{ansible_connection}}"
 
-  - name: Enable lldp feature
-    nxos_feature:
-      feature: lldp
-      state: enabled
-
+  # N35 skips all tests, image issues.
   - block:
+    - set_fact:
+        port_id: 1
+        tlv_power_mgmt:
+          power_management: false
+      when: platform is not search('N[567]K') and imagetag is not search("I[2345]")
+
+    - name: feature off to cleanup lldp
+      nxos_feature: &feature_off
+        feature: lldp
+        state: disabled
+
+    - name: Enable lldp feature
+      nxos_feature:
+        feature: lldp
+        state: enabled
+
     - name: Setup
       cli_config:
         config: |
           lldp holdtime 125
+          lldp tlv-select system-name
+          no lldp tlv-select port-vlan
+
+    - name: Setup2
+      cli_config:
+        config: |
           lldp portid-subtype 1
-          lldp tlv-select system-name 
-          no lldp tlv-select port-vlan 
           no lldp tlv-select power-management
+      when: port_id is defined
 
     - name: Replaced
       nxos_lldp_global: &replaced
@@ -23,7 +40,7 @@
           holdtime: 125
           timer: 35
           tlv_select:
-            system: 
+            system:
                name: false
                description: false
             port:
@@ -36,35 +53,41 @@
         that:
           - "result.changed == true"
           - "'lldp timer 35' in result.commands"
-          - "'lldp tlv-select power-management' in result.commands"
-          - "'no lldp portid-subtype 1' in result.commands"
           - "'no lldp tlv-select system-name' in result.commands"
           - "'no lldp tlv-select system-description' in result.commands"
           - "'no lldp tlv-select dcbxp' in result.commands"
-          - "result.commands|length == 6"
+
+    - assert:
+        that:
+          - "'no lldp portid-subtype 1' in result.commands"
+      when: port_id is defined
+
+    - assert:
+        that:
+          - "'lldp tlv-select power-management' in result.commands"
+      when: tlv_power_mgmt is defined
 
     - name: Gather lldp_global post facts
-      nxos_facts: 
+      nxos_facts:
         gather_subset:
           - '!all'
           - '!min'
         gather_network_resources: lldp_global
 
-    - assert: 
+    - assert:
         that:
           - "ansible_facts.network_resources.lldp_global == result.after"
 
     - name: Idempotence - Replaced
       nxos_lldp_global: *replaced
       register: result
- 
+
     - assert:
         that:
           - "result.changed == false"
           - "result.commands|length == 0"
-
     always:
     - name: teardown
-      nxos_feature:
-        feature: lldp
-        state: disabled
+      nxos_feature: *feature_off
+
+    when: platform is not search('N35')


### PR DESCRIPTION
##### SUMMARY
This is a change to the regression tests only.

- Some `lldp` cli options are not supported on some platforms and some image versions:
  - `lldp portid-subtype 1`
  - `lldp tlv-select power-management`

I added conditionals to skip those commands on specific platforms/versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_lldp_global`

##### ADDITIONAL INFORMATION
Fixes passed on `N6K,N7K,N9K,N3K` 
(internal TBs: `dt-n9k5-1,n6k-77,n7k-99,n7k-j,n3k-173,n3k-105,n9k-108,evergreen-nx-1,greensboro-nx-1,hamilton-nx-1,camden-nx-1`)