### PR TITLE
Use more route information to improve default_ipvX facts on BSDs

### DIFF
--- a/lib/ansible/module_utils/facts/network/generic_bsd.py
+++ b/lib/ansible/module_utils/facts/network/generic_bsd.py
@@ -73,12 +73,12 @@ class GenericBsdIfconfigNetwork(Network):
     def get_default_interfaces(self, route_path):
 
         # Use the commands:
-        #     route -n get 8.8.8.8                            -> Google public DNS
-        #     route -n get -inet6 2404:6800:400a:800::1012    -> ipv6.google.com
+        #     route -n get default
+        #     route -n get -inet6 default
         # to find out the default outgoing interface, address, and gateway
 
-        command = dict(v4=[route_path, '-n', 'get', '8.8.8.8'],
-                       v6=[route_path, '-n', 'get', '-inet6', '2404:6800:400a:800::1012'])
+        command = dict(v4=[route_path, '-n', 'get', 'default'],
+                       v6=[route_path, '-n', 'get', '-inet6', 'default'])
 
         interface = dict(v4={}, v6={})
 


### PR DESCRIPTION
##### SUMMARY

Currently the generic BSD network facts module uses a route lookup to pick which interface has the default route on it, and then picks the first address on that interface to populate the default_ipv4 and default_ipv6 information. Unfortunately, on OpenBSD at least, the first IPv6 address on an interface is usually an interfaces link-local address, not the globally routable address that you probably want if you're using that information in a template.

This lets the route lookup provide extra information about the local address it's using, and then uses that to filter the addresses on the interface it merges from. This works on OpenBSD, and should work on NetBSD. route(8) in FreeBSD and probably DragonflyBSD don't appear to provide this information, so the existing behaviour is preserved.

While here, use "default" instead of some arbitrary google addresses as the thing to look up for default route information. This should produce fewer surprises in some situations, like if you're running a router and your upstream for google properties moves around a lot, but your default route is static.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
The generic BSD network information fact module.

##### ADDITIONAL INFORMATION

The default routes for both IPv4 and IPv6 are on the ix0 interface:

```
$ route -n get -inet default  
   route to: 0.0.0.0
destination: 0.0.0.0
       mask: 0.0.0.0
    gateway: 192.0.2.33
  interface: ix0
 if address: 192.0.2.46
   priority: 8 (static)
      flags: <UP,GATEWAY,DONE,STATIC>
     use       mtu    expire
   65788         0         0 
$ route -n get -inet6 default   
   route to: ::
destination: ::
       mask: ::
    gateway: 2001:db8:602:307::1
  interface: ix0
 if address: 2001:db8:602:307:28e4:f32c:7a4f:9b38
   priority: 8 (static)
      flags: <UP,GATEWAY,DONE,STATIC>
     use       mtu    expire
       0         0         0 
$ ifconfig ix0                                            
ix0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	lladdr b8:ca:3a:66:e2:70
	index 1 priority 0 llprio 3
	groups: egress
	media: Ethernet autoselect (10GSFP+Cu full-duplex,rxpause,txpause)
	status: active
	inet 192.0.2.46 netmask 0xffffffe0 broadcast 192.0.2.63
	inet6 fe80::baca:3aff:fe66:e270%ix0 prefixlen 64 scopeid 0x1
	inet6 2001:db8:602:307:28e4:f32c:7a4f:9b38 prefixlen 64
```

That facts about that interface look like this:

```
        "ansible_ix0": {
            "device": "ix0",
            "flags": [
                "UP",
                "BROADCAST",
                "RUNNING",
                "SIMPLEX",
                "MULTICAST"
            ],
            "ipv4": [
                {
                    "address": "192.0.2.46",
                    "broadcast": "192.0.2.63",
                    "netmask": "255.255.255.224",
                    "network": "192.0.2.32"
                }
            ],
            "ipv6": [
                {
                    "address": "fe80::baca:3aff:fe66:e270%ix0",
                    "prefix": "64",
                    "scope": "0x1"
                },
                {
                    "address": "2001:db8:602:307:28e4:f32c:7a4f:9b38",
                    "prefix": "64"
                }
            ],
            "macaddress": "b8:ca:3a:66:e2:70",
            "media": "Ethernet",
            "media_options": [],
            "media_select": "autoselect",
            "media_type": "10GSFP+Cu",
            "mtu": "1500",
            "status": "active",
            "type": "ether"
        },
```

Before these changes the `default_ipv6` facts look like this:

```
        "ansible_default_ipv6": {
            "address": "fe80::baca:3aff:fe66:e270%ix0",
            "device": "ix0",
            "flags": [
                "UP",
                "BROADCAST",
                "RUNNING",
                "SIMPLEX",
                "MULTICAST"
            ],
            "gateway": "2407:2e00:602:307::1",
            "interface": "ix0",
            "macaddress": "b8:ca:3a:66:e2:70",
            "media": "Ethernet",
            "media_options": [],
            "media_select": "autoselect",
            "media_type": "10GSFP+Cu",
            "mtu": "1500",
            "prefix": "64",
            "scope": "0x1",
            "status": "active",
            "type": "ether"
        },
```

After this change the facts look more like this:

```
        "ansible_default_ipv6": {
            "address": "2001:db8:602:307:28e4:f32c:7a4f:9b38",
            "device": "ix0",
            "flags": [
                "UP",
                "BROADCAST",
                "RUNNING",
                "SIMPLEX",
                "MULTICAST"
            ],
            "gateway": "2001:db8:602:307::1",
            "interface": "ix0",
            "macaddress": "b8:ca:3a:66:e2:70",
            "media": "Ethernet",
            "media_options": [],
            "media_select": "autoselect",
            "media_type": "10GSFP+Cu",
            "mtu": "1500",
            "prefix": "64",
            "status": "active",
            "type": "ether"
        },
```