### PR TITLE
AWS sns topic support sub attributes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -23,7 +23,7 @@ author:
   - "Joel Thompson (@joelthompson)"
   - "Fernando Jose Pando (@nand0p)"
   - "Will Thames (@willthames)"
-  - "Brian Huang (@brianhhq)
+  - "Brian Huang (@brianhhq)"
 options:
   name:
     description:
@@ -525,14 +525,14 @@ def main():
         policy=dict(type='dict'),
         delivery_policy=dict(type='dict'),
         subscriptions=dict(
-          default=[],
-          type='list',
-          elements='dict',
-          options=dict(
-            protocol=dict(type='str', required=True),
-            endpoint=dict(type='str', required=True),
-            raw_message_delivery=dict(type='str', required=False),
-            filter_policy=dict(type='json', required=False)
+            default=[],
+            type='list',
+            elements='dict',
+            options=dict(
+                protocol=dict(type='str', required=True),
+                endpoint=dict(type='str', required=True),
+                raw_message_delivery=dict(type='str', required=False),
+                filter_policy=dict(type='json', required=False)
           )
         ),
         purge_subscriptions=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -63,15 +63,17 @@ options:
       raw_message_delivery:
         description: Raw messages are free of JSON formatting and can be sent to HTTP/S and Amazon SQS endpoints.
         required: no
-        default: "false"
-        choices: ["true", "false"]
         type: str
       filter_policy:
         description: The filter policy JSON assigned to the subscription
         required: no
+<<<<<<< HEAD
         type: str
     type: list
     elements: dict
+=======
+        type: json
+>>>>>>> Fix docs syntax
     default: []
   purge_subscriptions:
     description:
@@ -112,7 +114,7 @@ EXAMPLES = """
       - endpoint: "my_mobile_number"
         protocol: "sms"
         raw_message_delivery: "true"
-        filter_policy: "{ \"insurance_type\": [\"car\", \"boat\"] }"
+        filter_policy: "{{ lookup( 'template', 'filter_policy.json.j2') }}"
 
 """
 
@@ -533,7 +535,7 @@ def main():
                 endpoint=dict(type='str', required=True),
                 raw_message_delivery=dict(type='str', required=False),
                 filter_policy=dict(type='json', required=False)
-          )
+            )
         ),
         purge_subscriptions=dict(type='bool', default=True),
     )

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -57,9 +57,11 @@ options:
       endpoint:
         description: Endpoint of subscription.
         required: true
+        type: str
       protocol:
         description: Protocol of subscription
-        required: yes
+        required: true
+        type: str
       raw_message_delivery:
         description: Raw messages are free of JSON formatting and can be sent to HTTP/S and Amazon SQS endpoints.
         required: no
@@ -67,13 +69,9 @@ options:
       filter_policy:
         description: The filter policy JSON assigned to the subscription
         required: no
-<<<<<<< HEAD
-        type: str
+        type: json
     type: list
     elements: dict
-=======
-        type: json
->>>>>>> Fix docs syntax
     default: []
   purge_subscriptions:
     description:

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -413,7 +413,7 @@ class SnsTopicManager(object):
                                                                     AttributeValue=sub['raw_message_delivery'])
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         self.module.fail_json_aws(e, msg="Couldn't set subscription attribute - raw_message_delivery")
-            if sub['filter_policy'] is not None and compare_policies(
+            if sub['filter_policy'] is not None and 'FilterPolicy'in sub_attributes and compare_policies(
                     json.loads(sub['filter_policy']),
                     json.loads(sub_attributes['FilterPolicy'])):
                 self.changed = True

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -413,9 +413,9 @@ class SnsTopicManager(object):
                                                                     AttributeValue=sub['raw_message_delivery'])
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         self.module.fail_json_aws(e, msg="Couldn't set subscription attribute - raw_message_delivery")
-            if sub['filter_policy'] is not None and 'FilterPolicy'in sub_attributes and compare_policies(
+            if sub['filter_policy'] is not None and ('FilterPolicy' not in sub_attributes or compare_policies(
                     json.loads(sub['filter_policy']),
-                    json.loads(sub_attributes['FilterPolicy'])):
+                    json.loads(sub_attributes['FilterPolicy']))):
                 self.changed = True
                 if not self.check_mode:
                     try:

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -534,7 +534,7 @@ def main():
                 protocol=dict(type='str', required=True),
                 endpoint=dict(type='str', required=True),
                 raw_message_delivery=dict(type='str', required=False),
-                filter_policy=dict(type='json', required=False)
+                filter_policy=dict(type='str', required=False)
             )
         ),
         purge_subscriptions=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -447,22 +447,22 @@ class SnsTopicManager(object):
             return False
         for sub in subscriptions:
             if sub['SubscriptionArn'] not in ('PendingConfirmation', 'Deleted'):
+                self.changed = True
                 self.subscriptions_deleted.append(sub['SubscriptionArn'])
                 if not self.check_mode:
                     try:
                         self.connection.unsubscribe(SubscriptionArn=sub['SubscriptionArn'])
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         self.module.fail_json_aws(e, msg="Couldn't unsubscribe from topic")
-        return True
 
     def _delete_topic(self):
         self.topic_deleted = True
+        self.changed = True
         if not self.check_mode:
             try:
                 self.connection.delete_topic(TopicArn=self.topic_arn)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 self.module.fail_json_aws(e, msg="Couldn't delete topic %s" % self.topic_arn)
-        return True
 
     def _name_is_arn(self):
         return self.name.startswith('arn:')
@@ -531,8 +531,8 @@ def main():
           options=dict(
             protocol=dict(type='str', required=True),
             endpoint=dict(type='str', required=True),
-            raw_message_delivery=dict(type='str'),
-            filter_policy=dict(type='json')
+            raw_message_delivery=dict(type='str', required=False),
+            filter_policy=dict(type='json', required=False)
           )
         ),
         purge_subscriptions=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -534,7 +534,7 @@ def main():
                 protocol=dict(type='str', required=True),
                 endpoint=dict(type='str', required=True),
                 raw_message_delivery=dict(type='str', required=False),
-                filter_policy=dict(type='str', required=False)
+                filter_policy=dict(type='json', required=False)
             )
         ),
         purge_subscriptions=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY
Adding the ability to set subscription attributes when subscribing to sns topic.
Use object attribute to track the changed status

Fixes #51756

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/sns_topic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
