### PR TITLE
Fix network plugin config option load from collection (#64046)

### DIFF
--- a/changelogs/fragments/network_plugin_collection_fix.yaml
+++ b/changelogs/fragments/network_plugin_collection_fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Can't use plugin options vars in playbook when using collections  (https://github.com/ansible/ansible/issues/63975)

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -201,8 +201,9 @@ class Connection(NetworkConnectionBase):
 
             self.httpapi = httpapi_loader.get(self._network_os, self)
             if self.httpapi:
-                self._sub_plugin = {'type': 'httpapi', 'name': self._network_os, 'obj': self.httpapi}
-                self.queue_message('vvvv', 'loaded API plugin for network_os %s' % self._network_os)
+                self._sub_plugin = {'type': 'httpapi', 'name': self.httpapi._load_name, 'obj': self.httpapi}
+                self.queue_message('vvvv', 'loaded API plugin %s from path %s for network_os %s' %
+                                   (self.httpapi._load_name, self.httpapi._original_path, self._network_os))
             else:
                 raise AnsibleConnectionFailure('unable to load API plugin for network_os %s' % self._network_os)
 

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -227,8 +227,9 @@ class Connection(NetworkConnectionBase):
 
         netconf = netconf_loader.get(self._network_os, self)
         if netconf:
-            self._sub_plugin = {'type': 'netconf', 'name': self._network_os, 'obj': netconf}
-            self.queue_message('log', 'loaded netconf plugin for network_os %s' % self._network_os)
+            self._sub_plugin = {'type': 'netconf', 'name': netconf._load_name, 'obj': netconf}
+            self.queue_message('vvvv', 'loaded netconf plugin %s from path %s for network_os %s' %
+                               (netconf._load_name, netconf._original_path, self._network_os))
         else:
             netconf = netconf_loader.get("default", self)
             self._sub_plugin = {'type': 'netconf', 'name': 'default', 'obj': netconf}

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -330,8 +330,9 @@ class Connection(NetworkConnectionBase):
 
             self.cliconf = cliconf_loader.get(self._network_os, self)
             if self.cliconf:
-                self.queue_message('vvvv', 'loaded cliconf plugin for network_os %s' % self._network_os)
-                self._sub_plugin = {'type': 'cliconf', 'name': self._network_os, 'obj': self.cliconf}
+                self._sub_plugin = {'type': 'cliconf', 'name': self.cliconf._load_name, 'obj': self.cliconf}
+                self.queue_message('vvvv', 'loaded cliconf plugin %s from path %s for network_os %s' %
+                                   (self.cliconf._load_name, self.cliconf._original_path, self._network_os))
             else:
                 self.queue_message('vvvv', 'unable to load cliconf for network_os %s' % self._network_os)
         else:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix network plugin config option load from collection

Fixes #63975

* Update the complete sub-plugin name within network
  connection plugins to handle sub-plugin in collection
  scenario.

* Fix review comments

(cherry picked from commit 60276d3d8da8496e45a5c320113b5a8d7deaeb3d)
Backport of https://github.com/ansible/ansible/pull/64046
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/httpapi.py
plugins/connection/netconf.py
plugins/connection/network_cli.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
