### PR TITLE
Update RDS snapshot info to use DBClusterIdentifier

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_info.py
@@ -316,13 +316,13 @@ def common_snapshot_info(module, conn, method, prefix, params):
 def cluster_snapshot_info(module, conn):
     snapshot_name = module.params.get('db_cluster_snapshot_identifier')
     snapshot_type = module.params.get('snapshot_type')
-    instance_name = module.params.get('db_cluster_instance_identifier')
+    instance_name = module.params.get('db_cluster_identifier')
 
     params = dict()
     if snapshot_name:
         params['DBClusterSnapshotIdentifier'] = snapshot_name
     if instance_name:
-        params['DBClusterInstanceIdentifier'] = instance_name
+        params['DBClusterIdentifier'] = instance_name
     if snapshot_type:
         params['SnapshotType'] = snapshot_type
         if snapshot_type == 'public':


### PR DESCRIPTION
##### SUMMARY

The RDS module is not passing the db cluster identifier parameter to boto3, therefore sending all the snapshots available. This PR does the following:

- Fix `cluster_snapshot_info` instance_name parameter, since it was getting `db_cluster_instance_identifier` instead of `db_cluster_identifier`. 
- Update `DBClusterInstanceIdentifier` flag to `DBClusterIdentifier` as boto3 is using the latter. This issue surfaced as soon as the previous one was fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
amazon/rds_snapshot_info

##### ADDITIONAL INFORMATION
```
- name: List snapshots
  hosts: localhost
  tasks
    - rds_snapshot_facts:
        db_cluster_identifier: mydb-aurora-cluster
      register:  snapshot_ids
    - debug:
        msg: Snapshots are {{ snapshot_ids | json_query('cluster_snapshots[].{id: db_cluster_snapshot_identifier, cluster_id: db_cluster_identifier}' | to_nice_json) }}
```

This lists all the snapshots:
```
[
  {
    "id": "rds:anondb-2019-10-31-11-00-cluster-2019-10-31-22-49",
    "cluster_id": "anondb-2019-10-31-11-00-cluster"
  },
  {
    "id": "rds:backup-service-test-2019-11-01-04-53",
    "cluster_id": "backup-service-test"
  },
  {
    "id": "rds:mydb-aurora-cluster-2019-09-27-22-53",
    "cluster_id": "mydb-aurora-cluster"
  },
  ...
]
```

While the following is expected:
```
[
  {
    "id": "rds:mydb-aurora-cluster-2019-09-27-22-53",
    "cluster_id": "mydb-aurora-cluster"
  },
  {
    "id": "rds:mydb-aurora-cluster-2019-09-28-22-53",
    "cluster_id": "mydb-aurora-cluster"
  },
  {
    "id": "rds:mydb-aurora-cluster-2019-09-29-22-53",
    "cluster_id": "mydb-aurora-cluster"
  },
  ...
]
```