### PR TITLE
Backport PR to fix ios_interfaces where non-existing virtual/loopback interfaces was not getting configured

### DIFF
--- a/changelogs/fragments/63901-fix-ios-interfaces-for-non-existing-virtual-interfaces.yaml
+++ b/changelogs/fragments/63901-fix-ios-interfaces-for-non-existing-virtual-interfaces.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- "To fix ios_interfaces where non-existing virtual/loopback interfaces was not getting configured"
+- "(https://github.com/ansible/ansible/pull/63901)"

--- a/lib/ansible/module_utils/network/ios/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/interfaces/interfaces.py
@@ -140,10 +140,11 @@ class Interfaces(ConfigBase):
                 elif interface['name'] in each['name']:
                     break
             else:
+                # configuring non-existing interface
+                commands.extend(self._set_config(interface, dict()))
                 continue
             have_dict = filter_dict_having_none_value(interface, each)
-            want = dict()
-            commands.extend(self._clear_config(want, have_dict))
+            commands.extend(self._clear_config(dict(), have_dict))
             commands.extend(self._set_config(interface, each))
         # Remove the duplicate interface call
         commands = remove_duplicate_interface(commands)
@@ -163,10 +164,12 @@ class Interfaces(ConfigBase):
 
         for each in have:
             for interface in want:
+                count = 0
                 if each['name'] == interface['name']:
                     break
                 elif interface['name'] in each['name']:
                     break
+                count += 1
             else:
                 # We didn't find a matching desired state, which means we can
                 # pretend we recieved an empty desired state.
@@ -174,9 +177,17 @@ class Interfaces(ConfigBase):
                 commands.extend(self._clear_config(interface, each))
                 continue
             have_dict = filter_dict_having_none_value(interface, each)
-            want = dict()
-            commands.extend(self._clear_config(want, have_dict))
+            commands.extend(self._clear_config(dict(), have_dict))
             commands.extend(self._set_config(interface, each))
+            # as the pre-existing interface are now configured by
+            # above set_config call, deleting the respective
+            # interface entry from the want list
+            del want[count]
+
+        # Iterating through want list which now only have new interfaces to be
+        # configured
+        for each in want:
+            commands.extend(self._set_config(each, dict()))
         # Remove the duplicate interface call
         commands = remove_duplicate_interface(commands)
 
@@ -198,6 +209,8 @@ class Interfaces(ConfigBase):
                 if each['name'] == interface['name']:
                     break
             else:
+                # configuring non-existing interface
+                commands.extend(self._set_config(interface, dict()))
                 continue
             commands.extend(self._set_config(interface, each))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cherry-pick from: be1bcc745019613c722c73c1562c11215b146dd3
Backport PR to fix ios_interfaces where non-existing virtual/loopback interfaces was not getting configured from base PR #63901
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of https://github.com/ansible/ansible/pull/63901

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
