### PR TITLE
[2.8] Callback: removing args from task_fields from Sumologic and Splunk plugin

### DIFF
--- a/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
+++ b/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - '**security issue** - Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs (CVE-2019-14864)'

--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -98,6 +98,9 @@ class SplunkHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -89,6 +89,9 @@ class SumologicHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session


### PR DESCRIPTION
##### SUMMARY

CVE-2019-14864 Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs

Fixes #63522

Signed-off-by: Patrick O’Brien <patrick.obrien@thetradedesk.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit c76e074e4c71c7621a1ca8159261c1959b5287af)

Backport of https://github.com/ansible/ansible/pull/63527

##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
lib/ansible/plugins/callback/splunk.py
lib/ansible/plugins/callback/sumologic.py
