### PR TITLE
Exclude the ansible-test script from the main rpm package

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -284,6 +284,7 @@ ln -s /usr/bin/pytest-3 bin/pytest
 %files
 %defattr(-,root,root)
 %{_bindir}/ansible*
+%exclude %{_bindir}/ansible-test
 %config(noreplace) %{_sysconfdir}/ansible/
 %doc README.rst PKG-INFO COPYING changelogs/CHANGELOG*.rst
 %doc %{_mandir}/man1/ansible*


### PR DESCRIPTION
We want the script to live in the ansible-test rpm subpackage alongside
of its libraries

Fixes #64275


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
packaging/rpm/ansible.spec

