### PR TITLE
[stable-2.9] Exclude the ansible-test script from the main rpm package (#64277)

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -283,6 +283,7 @@ ln -s /usr/bin/pytest-3 bin/pytest
 %files
 %defattr(-,root,root)
 %{_bindir}/ansible*
+%exclude %{_bindir}/ansible-test
 %config(noreplace) %{_sysconfdir}/ansible/
 %doc README.rst PKG-INFO COPYING changelogs/CHANGELOG*.rst
 %doc %{_mandir}/man1/ansible*


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64277 for Ansible 
(cherry picked from commit 87de146038)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`packaging/rpm/ansible.spec`