### PR TITLE
Fix kinesis_stream wait loop pause

### DIFF
--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -424,15 +424,15 @@ def wait_for_status(client, stream_name, status, wait_timeout=300,
                         status_achieved = True
                         break
 
-            elif status == 'DELETING' and not check_mode:
+            else:
                 if not find_success:
                     status_achieved = True
                     break
 
-            else:
-                time.sleep(polling_increment_secs)
         except botocore.exceptions.ClientError as e:
             err_msg = to_native(e)
+
+        time.sleep(polling_increment_secs)
 
     if not status_achieved:
         err_msg = "Wait time out reached, while waiting for results"


### PR DESCRIPTION
##### SUMMARY
Fixes #64267 

Moved the sleep command so it is called every time the loop repeats. The else block was never called because the second elif statement captured all statements that dropped through the if and first elif statements, so I also changed the second elif to an else statement and removed the old else statement.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
kinesis_stream

##### ADDITIONAL INFORMATION
The sleep statement was never called. This caused ansible to call describe_stream in a loop with no pause. To see the error, you would have to look at the CloudTrail log to see the large number of calls per second for DescribeStream.

```
---
- name: Create Kinesis Stream
  hosts: localhost
  tasks:
    - name: Create the Stream
      kinesis_stream:
        aws_access_key: xxxx
        aws_secret_key: xxxx
        region: xxxx
        name: test_stream
        shards: 1
        wait: yes
        wait_timeout: 600
```

```
[WARNING]: No inventory was parsed, only implicit localhost is available

[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [Create Kinesis Stream] ***********************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Create the Stream] ***************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```
