### PR TITLE
clean_facts - use correct variable when evaluating the string

### DIFF
--- a/changelogs/fragments/clean_facts-use-correct-variable-for-startswith.yaml
+++ b/changelogs/fragments/clean_facts-use-correct-variable-for-startswith.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - clean_facts - use correct variable to avoid unnecessary handling of ``AttributeError``

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -133,15 +133,12 @@ def clean_facts(facts):
 
     # next we remove any connection plugin specific vars
     for conn_path in connection_loader.all(path_only=True):
-        try:
-            conn_name = os.path.splitext(os.path.basename(conn_path))[0]
-            re_key = re.compile('^ansible_%s_' % conn_name)
-            for fact_key in fact_keys:
-                # most lightweight VM or container tech creates devices with this pattern, this avoids filtering them out
-                if (re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge'))) or re_key.startswith('ansible_become_'):
-                    remove_keys.add(fact_key)
-        except AttributeError:
-            pass
+        conn_name = os.path.splitext(os.path.basename(conn_path))[0]
+        re_key = re.compile('^ansible_%s_' % conn_name)
+        for fact_key in fact_keys:
+            # most lightweight VM or container tech creates devices with this pattern, this avoids filtering them out
+            if (re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge'))) or fact_key.startswith('ansible_become_'):
+                remove_keys.add(fact_key)
 
     # remove some KNOWN keys
     for hard in C.RESTRICTED_RESULT_KEYS + C.INTERNAL_RESULT_KEYS:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A regexp object has no `.startswith()` method, which caused an unnecessary
try/except block to be added to handle this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/vars/clean.py`
##### ADDITIONAL INFORMATION

There is room for further optimization in this function since is call _a lot_ with large inventories. That will be done in a separate PR.
