### PR TITLE
nxos_igmp_interface: fix regression test failure

### DIFF
--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -25,7 +25,7 @@
   ignore_errors: yes
 
 - block:
-  
+
   - name: put interface in L3 and enable PIM
     nxos_config:
       commands:
@@ -188,5 +188,6 @@
       feature: pim
       provider: "{{ connection }}"
       state: disabled
+    ignore_errors: yes
 
   - debug: msg="END connection={{ ansible_connection }} nxos_igmp_interface sanity test"


### PR DESCRIPTION
##### SUMMARY
This is a minor change to the regression test only.

- The cleanup at the end of the test (does a `no feature pim`) will sometimes run long and timeout but the command is successful. This change allows the test to complete gracefully. This is primarily just an issue for the legacy n3k platform.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_igmp_interface`

##### ADDITIONAL INFORMATION
Fixes passed on `N6K,N7K,N9K,N3K` 
(internal TBs: `dt-n9k5-1,n6k-77,n7k-99,n7k-j,n3k-173,n3k-105,n9k-108,evergreen-nx-1,greensboro-nx-1,hamilton-nx-1,camden-nx-1`)