### PR TITLE
[2.9] Use templating in HostVarsVars __repr__ (#64282)

### DIFF
--- a/changelogs/fragments/64282-hostvarsvars-templating.yaml
+++ b/changelogs/fragments/64282-hostvarsvars-templating.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - HostVarsVars - Template the __repr__ value (https://github.com/ansible/ansible/issues/64128).

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -134,4 +134,5 @@ class HostVarsVars(Mapping):
         return len(self._vars.keys())
 
     def __repr__(self):
-        return repr(self._vars)
+        templar = Templar(variables=self._vars, loader=self._loader)
+        return repr(templar.template(self._vars, fail_on_undefined=False, static_vars=STATIC_VARS))

--- a/test/integration/targets/var_templating/group_vars/all.yml
+++ b/test/integration/targets/var_templating/group_vars/all.yml
@@ -1,0 +1,7 @@
+---
+x: 100
+y: "{{ x }}"
+nested_x:
+  value:
+    x: 100
+nested_y: "{{ nested_x }}"

--- a/test/integration/targets/var_templating/runme.sh
+++ b/test/integration/targets/var_templating/runme.sh
@@ -10,3 +10,6 @@ ansible-playbook undefined.yml -i inventory -v "$@"
 
 # this should work since we dont use the variable
 ansible-playbook undall.yml -i inventory -v "$@"
+
+# test hostvars templating
+ansible-playbook task_vars_templating.yml -v "$@"

--- a/test/integration/targets/var_templating/task_vars_templating.yml
+++ b/test/integration/targets/var_templating/task_vars_templating.yml
@@ -1,0 +1,58 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - add_host:
+      name: host1
+      ansible_connection: local
+      ansible_host: 127.0.0.1
+
+- hosts: all
+  gather_facts: no
+  tasks:
+    - debug:
+        msg: "{{ hostvars['host1']['x'] }}"
+      register: x_1
+    - debug:
+        msg: "{{ hostvars['host1']['y'] }}"
+      register: y_1
+    - debug:
+        msg: "{{ hostvars_['x'] }}"
+      vars:
+        hostvars_: "{{ hostvars['host1'] }}"
+      register: x_2
+    - debug:
+        msg: "{{ hostvars_['y'] }}"
+      vars:
+        hostvars_: "{{ hostvars['host1'] }}"
+      register: y_2
+
+    - assert:
+        that:
+          - x_1 == x_2
+          - y_1 == y_2
+          - x_1 == y_1
+
+    - debug:
+        msg: "{{ hostvars['host1']['nested_x']['value'] }}"
+      register: x_1
+    - debug:
+        msg: "{{ hostvars['host1']['nested_y']['value'] }}"
+      register: y_1
+    - debug:
+        msg: "{{ hostvars_['nested_x']['value'] }}"
+      vars:
+        hostvars_: "{{ hostvars['host1'] }}"
+      register: x_2
+    - debug:
+        msg: "{{ hostvars_['nested_y']['value'] }}"
+      vars:
+        hostvars_: "{{ hostvars['host1'] }}"
+      register: y_2
+
+    - assert:
+        that:
+          - x_1 == x_2
+          - y_1 == y_2
+          - x_1 == y_1


### PR DESCRIPTION
##### SUMMARY
* Fix HostVarsVars templating

* Add some tests for HostVars and HostVarsVars templating

* changelog

(cherry picked from commit 371d7aae316f5fdc756c9c7173c20c15f40305b5)

Backport of https://github.com/ansible/ansible/pull/64282

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
HostVarsVars
