### PR TITLE
azure_rm_storageaccount_info: Fix list_all method

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_info.py
@@ -435,7 +435,7 @@ class AzureRMStorageAccountInfo(AzureRMModuleBase):
     def list_all(self):
         self.log('List all items')
         try:
-            response = self.storage_client.storage_accounts.list_by_resource_group(self.resource_group)
+            response = self.storage_client.storage_accounts.list()
         except Exception as exc:
             self.fail("Error listing all items - {0}".format(str(exc)))
 


### PR DESCRIPTION
##### SUMMARY
The 'azure_rm_storageaccount_info' module was calling the storage client
'list_by_resource_group()' method rather than the 'list()' one, leading
to callers not being able to fetch all the storage accounts of their
subscription.
Fixes #64319

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
* azure_rm_storageaccount_info
* azure_rm_storageaccount_facts

##### ADDITIONAL INFORMATION

Test: manual by checking that I was successfully able to call the module and retrieve
all the storage accounts in the subscription without having to
specify a resource group.
