### PR TITLE
cloud/openstack: fix os_server_action error when wait is False

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_action.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_action.py
@@ -154,7 +154,7 @@ def main():
                 json={'os-stop': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
-                module.exit_json(changed=True)
+            module.exit_json(changed=True)
 
         if action == 'start':
             if not _system_state_change(action, status):
@@ -165,7 +165,7 @@ def main():
                 json={'os-start': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
-                module.exit_json(changed=True)
+            module.exit_json(changed=True)
 
         if action == 'pause':
             if not _system_state_change(action, status):
@@ -176,7 +176,7 @@ def main():
                 json={'pause': None})
             if wait:
                 _wait(timeout, cloud, server, action, module, sdk)
-                module.exit_json(changed=True)
+            module.exit_json(changed=True)
 
         elif action == 'unpause':
             if not _system_state_change(action, status):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Using os_server_action to perform `start`, `stop` and `pause` actions on a server in OpenStack results in an error when `wait=False`.

This is because `module.exit_json` was only being called when `wait=True`. The fix is trivial, move  `module.exit_json` outside of the `wait` check so that it's always called regardless. This brings `start`, `stop` and `pause` into line with other actions which behave this way.

Fixes #62958

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_server_action

##### ADDITIONAL INFORMATION

Toggling power state of server *without* patch:

```bash
$ ansible-playbook -i localhost, -c local ./playbook.yml -e wait=no

PLAY [Test os_server_action with wait disabled] *******************************************************************************************************************************************************************

TASK [Get server details] *****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Toggle state on servers] ************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "New-style module did not handle its own exit"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


```

Toggling power state of server *with* patch:

```bash
$ ansible-playbook -i localhost, -c local ./playbook.yml -e wait=no

PLAY [Test os_server_action with wait disabled] *******************************************************************************************************************************************************************

TASK [Get server details] *****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Toggle state on servers] ************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Setting the current state on the server *with* patch behaves as expected (not changed).

```bash
$ ansible-playbook -i localhost, -c local ./playbook.yml -e wait=no

PLAY [Test os_server_action with wait disabled] *******************************************************************************************************************************************************************

TASK [Get server details] *****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Set same state on servers] ************************************************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```