### PR TITLE
restore case sensitivity to unique filter by default

### DIFF
--- a/changelogs/fragments/filter-unique-case-sensitive.yml
+++ b/changelogs/fragments/filter-unique-case-sensitive.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+- >-
+  ``unique` filter - unify case sensitivity between old and new jinja2 versions.
+  Prior to 2.8, the ``unique`` filter was always case sensitive.  Restore that
+  behavior as default.  (Ansible 2.8 case sensitivity previously dependeded on
+  which version of jinja2 was available.)

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -46,10 +46,10 @@ display = Display()
 
 
 @environmentfilter
-def unique(environment, a, case_sensitive=False, attribute=None):
+def unique(environment, a, case_sensitive=True, attribute=None):
 
     def _do_fail(e):
-        if case_sensitive or attribute:
+        if not case_sensitive or attribute:
             raise AnsibleFilterError("Jinja2's unique filter failed and we cannot fall back to Ansible's version "
                                      "as it does not support the parameters supplied", orig_exc=e)
 
@@ -72,7 +72,7 @@ def unique(environment, a, case_sensitive=False, attribute=None):
     if not HAS_UNIQUE or error:
 
         # handle Jinja2 specific attributes when using Ansible's version
-        if case_sensitive or attribute:
+        if not case_sensitive or attribute:
             raise AnsibleFilterError("Ansible's unique filter does not support case_sensitive nor attribute parameters, "
                                      "you need a newer version of Jinja2 that provides their version of the filter.")
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -46,16 +46,16 @@ display = Display()
 
 
 @environmentfilter
-def unique(environment, a, case_sensitive=True, attribute=None):
+def unique(environment, a, case_sensitive=None, attribute=None):
 
     def _do_fail(e):
-        if not case_sensitive or attribute:
+        if not case_sensitive and case_sensitive is not None or attribute:
             raise AnsibleFilterError("Jinja2's unique filter failed and we cannot fall back to Ansible's version "
                                      "as it does not support the parameters supplied", orig_exc=e)
 
     error = e = None
     try:
-        if HAS_UNIQUE:
+        if HAS_UNIQUE and (case_sensitive is not None or attribute is not None):
             c = do_unique(environment, a, case_sensitive=case_sensitive, attribute=attribute)
             if isinstance(a, Hashable):
                 c = set(c)
@@ -69,10 +69,10 @@ def unique(environment, a, case_sensitive=True, attribute=None):
         _do_fail(e)
         display.warning('Falling back to Ansible unique filter as Jinja2 one failed: %s' % to_text(e))
 
-    if not HAS_UNIQUE or error:
+    if not HAS_UNIQUE or (case_sensitive is None and attribute is None) or error:
 
         # handle Jinja2 specific attributes when using Ansible's version
-        if not case_sensitive or attribute:
+        if not case_sensitive and case_sensitive is not None or attribute:
             raise AnsibleFilterError("Ansible's unique filter does not support case_sensitive nor attribute parameters, "
                                      "you need a newer version of Jinja2 that provides their version of the filter.")
 

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -331,3 +331,13 @@
     - assert:
         that:
           - "combined.key2 == 'is_defined'"
+
+- name: ensure that unique is case sensitive by default
+  assert:
+    that:
+      - "{{ (mylist | unique) == mylist }}"
+  vars:
+    mylist:
+      - one
+      - two
+      - Two


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- https://github.com/ansible/ansible/pull/45637 made the case sensitivity of `unique` divergent depending on which jinja2 version was installed
- the `unique` filter is case-sensitive on RHEL 7, but case insensitive if you have jinja2-2.10+
- there is no associated release note, and we should have the default case-sensitivity not change without a deprecation period

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unique filter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

`unique` was added to jinja in 2017: https://github.com/pallets/jinja/pull/735
3.5 years earlier, `unique` was added to ansible in 2013: https://github.com/ansible/ansible/commit/efd87534eb05c231439750b236c53a1b2aecb10c

This was not a case of copying a filter from jinja into ansible.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
