### PR TITLE
jinja 2.10 compat: add missing built-in tests

### DIFF
--- a/changelogs/fragments/compat-jinja-2.10-test.yml
+++ b/changelogs/fragments/compat-jinja-2.10-test.yml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+minor_changes:
 - fixed ansible template failures on older jinja due to missing built-in tests

--- a/changelogs/fragments/compat-jinja-2.10-test.yml
+++ b/changelogs/fragments/compat-jinja-2.10-test.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- fixed ansible template failures on older jinja due to missing built-in tests

--- a/lib/ansible/plugins/test/compat_jinja_2_10.py
+++ b/lib/ansible/plugins/test/compat_jinja_2_10.py
@@ -9,7 +9,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import jinja2
 import operator
+from distutils.version import LooseVersion
 
 
 def test_in(value, seq):
@@ -27,6 +29,9 @@ class TestModule:
     """
 
     def tests(self):
+        if LooseVersion(str(jinja2.__version__)) >= LooseVersion('2.10'):
+            return {}
+
         return {
             'in': test_in,
             '==': operator.eq,

--- a/lib/ansible/plugins/test/compat_jinja_2_10.py
+++ b/lib/ansible/plugins/test/compat_jinja_2_10.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017, the Jinja Team
+# BSD 3-Clause "New" or "Revised" License (see https://opensource.org/licenses/BSD-3-Clause)
+
+# XXX: These tests exist for compatibility with Jinja < 2.10.  Once every
+# platform has at least 2.10 version of jinja, this file can go away.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import operator
+
+
+def test_in(value, seq):
+    """Check if value is in seq.
+    Copied from Jinja 2.10 https://github.com/pallets/jinja/pull/665
+
+    .. versionadded:: 2.10
+    """
+    return value in seq
+
+
+class TestModule:
+    """copied from jinja 2.10 for consistent test behavior independent of the
+    system jinja version
+    """
+
+    def tests(self):
+        return {
+            'in': test_in,
+            '==': operator.eq,
+            'eq': operator.eq,
+            'equalto': operator.eq,
+            '!=': operator.ne,
+            'ne': operator.ne,
+            '>': operator.gt,
+            'gt': operator.gt,
+            'greaterthan': operator.gt,
+            'ge': operator.ge,
+            '>=': operator.ge,
+            '<': operator.lt,
+            'lt': operator.lt,
+            'lessthan': operator.lt,
+            '<=': operator.le,
+            'le': operator.le,
+        }

--- a/lib/ansible/plugins/test/compat_jinja_2_11.py
+++ b/lib/ansible/plugins/test/compat_jinja_2_11.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017, the Jinja Team
+# BSD 3-Clause "New" or "Revised" License (see https://opensource.org/licenses/BSD-3-Clause)
+
+# XXX: These tests exist for compatibility with Jinja < 2.11.  Once every
+# platform has at least 2.11 version of jinja, this file can go away.
+# originally from https://github.com/pallets/jinja/pull/824
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import jinja2
+from distutils.version import LooseVersion
+from ansible.module_utils.six import integer_types
+
+
+def test_boolean(value):
+    """Return true if the object is a boolean value.
+    .. versionadded:: 2.11
+    """
+    return value is True or value is False
+
+
+def test_false(value):
+    """Return true if the object is False.
+    .. versionadded:: 2.11
+    """
+    return value is False
+
+
+def test_true(value):
+    """Return true if the object is True.
+    .. versionadded:: 2.11
+    """
+    return value is True
+
+
+# NOTE: The existing Jinja2 'number' test matches booleans and floats
+def test_integer(value):
+    """Return true if the object is an integer.
+    .. versionadded:: 2.11
+    """
+    return isinstance(value, integer_types) and value is not True and value is not False
+
+
+# NOTE: The existing Jinja2 'number' test matches booleans and integers
+def test_float(value):
+    """Return true if the object is a float.
+    .. versionadded:: 2.11
+    """
+    return isinstance(value, float)
+
+
+class TestModule:
+    """copied from jinja 2.11 for consistent test behavior independent of the
+    system jinja version
+    """
+
+    def tests(self):
+        if LooseVersion(str(jinja2.__version__)) >= LooseVersion('2.11'):
+            return {}
+
+        return {
+            'boolean': test_boolean,
+            'false': test_false,
+            'true': test_true,
+            'integer': test_integer,
+            'float': test_float,
+        }

--- a/test/integration/targets/test_core/tasks/main.yml
+++ b/test/integration/targets/test_core/tasks/main.yml
@@ -34,6 +34,25 @@
       - '{} is falsy'
       - '{"key": "value"} is not falsy'
 
+- name: jinja 2.10 tests
+  # tests from https://github.com/pallets/jinja/pull/665
+  assert:
+    that:
+      - 2 is eq 2
+      - 2 is not eq 3
+      - 2 is ne 3
+      - 2 is not ne 2
+      - 2 is lt 3
+      - 2 is not lt 2
+      - 2 is le 2
+      - 2 is not le 1
+      - 2 is gt 1
+      - 2 is not gt 2
+      - 2 is ge 2
+      - 2 is not ge 3
+      - 5 is in [5, 6, 7]
+      - 8 is not in [5, 6, 7]
+
 - name: jinja 2.11 tests
   # tests from https://github.com/pallets/jinja/pull/824
   assert:

--- a/test/integration/targets/test_core/tasks/main.yml
+++ b/test/integration/targets/test_core/tasks/main.yml
@@ -33,3 +33,41 @@
       - '"off" is falsy(convert_bool=True)'
       - '{} is falsy'
       - '{"key": "value"} is not falsy'
+
+- name: jinja 2.11 tests
+  # tests from https://github.com/pallets/jinja/pull/824
+  assert:
+    that:
+      - none is not true
+      - false is not true
+      - true is true
+      - 0 is not true
+      - 1 is not true
+      - 42 is not true
+      - none is not false
+      - false is false
+      - true is not false
+      - 0 is not false
+      - 1 is not false
+      - 42 is not false
+      - none is not boolean
+      - false is boolean
+      - true is boolean
+      - 0 is not boolean
+      - 1 is not boolean
+      - 42 is not boolean
+      - 0.0 is not boolean
+      - 1.0 is not boolean
+      - 3.14159 is not boolean
+      - none is not integer
+      - false is not integer
+      - true is not integer
+      - 42 is integer
+      - 3.14159 is not integer
+      - (10 ** 100) is integer
+      - none is not float
+      - false is not float
+      - true is not float
+      - 42 is not float
+      - 4.2 is float
+      - (10 ** 100) is not float


### PR DESCRIPTION
##### SUMMARY
fixed ansible template failures on older jinja due to missing built-in tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
jinja tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Playbooks and roles written on ansible 2.8 on a modern would fail if run with ansible 2.8 on RHEL 7 due to missing tests on that platform.

relevant jinja PR: https://github.com/pallets/jinja/pull/665

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
