### PR TITLE
Improve control node concept explanation

### DIFF
--- a/docs/docsite/rst/shared_snippets/basic_concepts.txt
+++ b/docs/docsite/rst/shared_snippets/basic_concepts.txt
@@ -1,7 +1,7 @@
 Control node
 ============
 
-Any machine with Ansible installed. You can run commands and playbooks, invoking ``/usr/bin/ansible`` or ``/usr/bin/ansible-playbook``, from any control node. You can use any computer that has Python installed on it as a control node - laptops, shared desktops, and servers can all run Ansible. However, you cannot use a Windows machine as a control node. You can have multiple control nodes.
+Any machine with Ansible installed. You can run Ansible commands and playbooks by invoking the ``ansible`` or ``ansible-playbook`` command from any control node. You can use any computer that has a Python installation as a control node - laptops, shared desktops, and servers can all run Ansible. However, you cannot use a Windows machine as a control node. You can have multiple control nodes.
 
 Managed nodes
 =============


### PR DESCRIPTION
##### SUMMARY
* Distinguish "Ansible commands" with generic commands
* Improve semantic overall
* Avoid using absolute paths for commands as they aren't always installed to `/usr`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
[Ansible concepts — Ansible Documentation](https://docs.ansible.com/ansible/latest/user_guide/basic_concepts.html#control-node)

##### ADDITIONAL INFORMATION
N/A