### PR TITLE
Remove empty overridden unittest.setUp and unittest.tearDown methods.

### DIFF
--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -35,9 +35,6 @@ class TestErrors(unittest.TestCase):
 
         self.obj = AnsibleBaseYAMLObject()
 
-    def tearDown(self):
-        pass
-
     def test_basic_error(self):
         e = AnsibleError(self.message)
         self.assertEqual(e.message, self.message)

--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -54,12 +54,6 @@ class NameStringIO(StringIO):
 
 class TestAnsibleLoaderBasic(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_parse_number(self):
         stream = StringIO(u"""
                 1

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -26,12 +26,6 @@ from ansible.playbook.task import Task
 
 class TestBlock(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_construct_empty_block(self):
         b = Block()
 

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -31,12 +31,6 @@ from units.mock.path import mock_unfrackpath_noop
 
 class TestPlay(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_empty_play(self):
         p = Play.load(dict())
         self.assertEqual(str(p), '')

--- a/test/units/template/test_safe_eval.py
+++ b/test/units/template/test_safe_eval.py
@@ -28,12 +28,6 @@ from ansible.template.safe_eval import safe_eval
 
 class TestSafeEval(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_safe_eval_usage(self):
         # test safe eval calls with different possible types for the
         # locals dictionary, to ensure we don't run into problems like

--- a/test/units/template/test_template_utilities.py
+++ b/test/units/template/test_template_utilities.py
@@ -74,9 +74,6 @@ class TestBackslashEscape(unittest.TestCase):
     def setUp(self):
         self.env = jinja2.Environment()
 
-    def tearDown(self):
-        pass
-
     def test_backslash_escaping(self):
 
         for test in self.test_data:
@@ -88,12 +85,6 @@ class TestBackslashEscape(unittest.TestCase):
 
 
 class TestCountNewlines(unittest.TestCase):
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
 
     def test_zero_length_string(self):
         self.assertEquals(_count_newlines_from_end(u''), 0)


### PR DESCRIPTION
##### SUMMARY
Removing overridden `setUp` and `tearDown` that do the same as the super-class: `unittest.TestCase`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
Those methods are already `pass` (empty hooks) in the `unittest` module. `unittest2` seems to build on top of `unittest` in Python 2.6 where this is also the case.