### PR TITLE
clc_aa_policy: deprecate unused 'wait' parameter

### DIFF
--- a/changelogs/fragments/clc_aa_policy-remove-unused-wait-parameter.yaml
+++ b/changelogs/fragments/clc_aa_policy-remove-unused-wait-parameter.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "clc_aa_policy - The ``wait`` option had no effect and will be removed in Ansible 2.14"

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -70,6 +70,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`ec2_lc <ec2_lc_module>`: the ``associate_public_ip_address`` option will be removed. It has always been ignored by the module.
 * :ref:`iam_policy <iam_policy_module>`: the ``policy_document`` option will be removed. To maintain the existing behavior use the ``policy_json`` option and read the file with the ``lookup`` plugin.
 * :ref:`redfish_config <redfish_config_module>`: the ``bios_attribute_name`` and ``bios_attribute_value`` options will be removed. To maintain the existing behavior use the ``bios_attributes`` option instead.
+* :ref:`clc_aa_policy <clc_aa_policy_module>`: the ``wait`` parameter will be removed. It has always been ignored by the module.
 
 
 

--- a/lib/ansible/modules/cloud/centurylink/clc_aa_policy.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_aa_policy.py
@@ -35,9 +35,7 @@ options:
     choices: ['present','absent']
   wait:
     description:
-      - Whether to wait for the tasks to finish before returning.
-    default: True
-    required: False
+      - This option does nothing and will be removed in Ansible 2.14.
     type: bool
 requirements:
     - python = 2.7
@@ -191,7 +189,7 @@ class ClcAntiAffinityPolicy:
         argument_spec = dict(
             name=dict(required=True),
             location=dict(required=True),
-            wait=dict(default=True),
+            wait=dict(type='bool', removed_in_version='2.14'),
             state=dict(default='present', choices=['present', 'absent']),
         )
         return argument_spec

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -718,7 +718,6 @@ lib/ansible/modules/cloud/azure/azure_rm_webapp_info.py validate-modules:paramet
 lib/ansible/modules/cloud/azure/azure_rm_webappslot.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/azure/azure_rm_webappslot.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/centurylink/clc_aa_policy.py validate-modules:doc-missing-type
-lib/ansible/modules/cloud/centurylink/clc_aa_policy.py validate-modules:implied-parameter-type-mismatch
 lib/ansible/modules/cloud/centurylink/clc_aa_policy.py yamllint:unparsable-with-libyaml
 lib/ansible/modules/cloud/centurylink/clc_alert_policy.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/centurylink/clc_alert_policy.py validate-modules:no-default-for-required-parameter


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`clc_aa_policy`: deprecate unused `wait` parameter
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
clc_aa_policy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
