### PR TITLE
Documentation: Unlimited CPU credits apply to any T instance

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -222,7 +222,7 @@ options:
     type: bool
   cpu_credit_specification:
     description:
-      - For T2 series instances, choose whether to allow increased charges to buy CPU credits if the default pool is depleted.
+      - For T series instances, choose whether to allow increased charges to buy CPU credits if the default pool is depleted.
       - Choose I(unlimited) to enable buying additional CPU credits.
     choices: ['unlimited', 'standard']
     type: str


### PR DESCRIPTION
##### SUMMARY

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html

Unlimited CPU credits apply to any T instances, currently the options being T3, T3a, and T2.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### ISSUE TYPE
- Docs Pull Request

