### PR TITLE
Fix up role version pagination for Galaxy install

### DIFF
--- a/changelogs/fragments/galaxy-role-version.yaml
+++ b/changelogs/fragments/galaxy-role-version.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Fix pagination issue when retrieving role versions for install - https://github.com/ansible/ansible/issues/64355

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -21,6 +21,12 @@ from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash_s
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    # Python 2
+    from urlparse import urlparse
+
 display = Display()
 
 
@@ -289,14 +295,20 @@ class GalaxyAPI:
             data = self._call_galaxy(url)
             results = data['results']
             done = (data.get('next_link', None) is None)
+
+            # https://github.com/ansible/ansible/issues/64355
+            # api_server contains part of the API path but next_link includes the the /api part so strip it out.
+            url_info = urlparse(self.api_server)
+            base_url = "%s://%s/" % (url_info.scheme, url_info.netloc)
+
             while not done:
-                url = _urljoin(self.api_server, data['next_link'])
+                url = _urljoin(base_url, data['next_link'])
                 data = self._call_galaxy(url)
                 results += data['results']
                 done = (data.get('next_link', None) is None)
         except Exception as e:
-            display.vvvv("Unable to retrive role (id=%s) data (%s), but this is not fatal so we continue: %s"
-                         % (role_id, related, to_text(e)))
+            display.warning("Unable to retrieve role (id=%s) data (%s), but this is not fatal so we continue: %s"
+                            % (role_id, related, to_text(e)))
         return results
 
     @g_connect(['v1'])

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -876,7 +876,7 @@ def test_get_collection_versions_pagination(api_version, token_type, token_ins, 
     [
         {
             'count': 2,
-            'results': [{'name': '3.5.1',}],
+            'results': [{'name': '3.5.1'}],
             'next_link': '/api/v1/roles/432/versions/?page=2&page_size=50',
             'next': '/roles/432/versions/?page=2&page_size=50',
             'previous_link': None,


### PR DESCRIPTION
##### SUMMARY
A change in the 2.9 changes the value of `self.api_server` which broke the paginated collector for role versions as it would double on the api part (`https://galaxy.com/api/api/v1/....`). This fixes that issue by using the URL without any path when appending the `next_link` value which is `/api/v1/roles/...`.

This also makes a failure when collecting the role versions to be a warning and not hidden behind `-vvvv`.

Fixes https://github.com/ansible/ansible/issues/64355

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy