### PR TITLE
jenkins_job: With ET.tostring we should specify a encoding

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -334,7 +334,7 @@ def test_dependencies(module):
 
 
 def job_config_to_string(xml_str):
-    return ET.tostring(ET.fromstring(xml_str))
+    return ET.tostring(ET.fromstring(xml_str), encoding='UTF-8')
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
With python3 this module fails as it can't figure out it's encoding

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

jenkins_job

##### ADDITIONAL INFORMATION

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_jenkins_job_payload_1u2qhjcy/__main__.py", line 277, in update_job
    if self.has_config_changed():
  File "/tmp/ansible_jenkins_job_payload_1u2qhjcy/__main__.py", line 238, in has_config_changed
    config_file = self.get_config()
  File "/tmp/ansible_jenkins_job_payload_1u2qhjcy/__main__.py", line 228, in get_config
    return job_config_to_string(self.config)
  File "/tmp/ansible_jenkins_job_payload_1u2qhjcy/__main__.py", line 337, in job_config_to_string
    return ET.tostring(ET.fromstring(xml_str))
  File "src/lxml/etree.pyx", line 3234, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1871, in lxml.etree._parseMemoryDocument
ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
```
