### PR TITLE
VMware: Added check for temp_version type

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1282,7 +1282,7 @@ class PyVmomiHelper(PyVmomi):
             if 'version' in self.params['hardware']:
                 hw_version_check_failed = False
                 temp_version = self.params['hardware'].get('version', 10)
-                if temp_version.lower() == 'latest':
+                if isinstance(temp_version, str) and temp_version.lower() == 'latest':
                     # Check is to make sure vm_obj is not of type template
                     if vm_obj and not vm_obj.config.template:
                         try:

--- a/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
+++ b/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
@@ -3,13 +3,59 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Skipping out idepotency test untill issue fixed in reconfigure_vm() become_method
 
+- name: Create VM with hardware version 12
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm_version12
+    guest_id: centos7_64Guest
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    datastore: '{{ ds2 }}'
+    hardware:
+        num_cpus: 4
+        memory_mb: 1028
+        version: 12
+    state: present
+  register: create_vm_with_version_12
+
+- name: assert that changes were made
+  assert:
+    that:
+        - create_vm_with_version_12 is changed
+
+- name: Deploy New VM with latest hardware version
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm_version_latest
+    guest_id: centos7_64Guest
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    datastore: '{{ ds2 }}'
+    hardware:
+        num_cpus: 4
+        memory_mb: 1028
+        version: latest
+    state: present
+  register: deploy_vm_to_latest
+
+- name: assert that changes were made
+  assert:
+    that:
+        - deploy_vm_to_latest is changed
+
 - name: Upgrade VM to latest version
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: test_vm1
+    name: test_vm_version12
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"


### PR DESCRIPTION
##### SUMMARY
Fix issue #64374 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION
Added check for version argument type. Change done as part of PR https://github.com/ansible/ansible/pull/62188 missed this check causing regression if version argument is of type string. 

