### PR TITLE
Change to fix the update A record workflow.

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -436,10 +436,8 @@ class WapiModule(WapiBase):
                 name = obj_filter['name']
 
             if old_name and new_name:
-                if (ib_obj_type == NIOS_HOST_RECORD):
+                if (ib_obj_type in (NIOS_HOST_RECORD, NIOS_AAAA_RECORD, NIOS_A_RECORD)):
                     test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
-                elif (ib_obj_type in (NIOS_AAAA_RECORD, NIOS_A_RECORD)):
-                    test_obj_filter = obj_filter
                 else:
                     test_obj_filter = dict([('name', old_name)])
                 # get the object reference


### PR DESCRIPTION
##### SUMMARY
The request to update the IP address of an existing A record was wrongly sending create a request for a new A record with the same FQDN and new IP.

Fixes #64045

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
The change in the api.py file is to fix the update A record workflow.

The change fixes #64045 and supports the below update A record scenarios:
1) Update only the A record name
**Sample playbook snippet to change the A record name from test1.testzone.com to test2.testzone.com while keeping the same IP address:**

  tasks:
   - name: Update Nios A record
     nios_a_record:
       name: {new_name: test2.testzone.com, old_name: test1.testzone.com}
       view: testDnsView
       ipv4: 192.168.0.5
       comment: Created with Ansible
       state: present
       provider: "{{ nios_provider }}"

2) Update the IP address only
**Sample Playbook snippet to change the IP address of an A record while keeping the record name same:**

  tasks:
   - name: Update Nios A record
     nios_a_record:
       name: {new_name: test1.testzone.com, old_name: test1.testzone.com}
       view: testDnsView
       ipv4: 192.168.0.6
       comment: Created with Ansible
       state: present
       provider: "{{ nios_provider }}"


3) Update the IP address and the A record name
**Sample playbook snippet to change the A record name from test1.testzone.com to test2.testzone.com and add new the IP address:** 

  tasks:
   - name: Update Nios A record
     nios_a_record:
       name: {new_name: test2.testzone.com, old_name: test1.testzone.com}
       view: testDnsView
       ipv4: 192.168.0.7
       comment: Created with Ansible
       state: present
       provider: "{{ nios_provider }}"



