### PR TITLE
Add option to get vault password from the environment

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -365,5 +365,7 @@ def add_vault_options(parser):
     base_group = parser.add_mutually_exclusive_group()
     base_group.add_argument('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
+    base_group.add_argument('--vault-password-env', default=[], dest='vault_password_env', action='append',
+                            help='vault password environment variable')
     base_group.add_argument('--vault-password-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(), action='append')


### PR DESCRIPTION
##### SUMMARY
This pull-request adds an option to get vault password from the environment, as requested in issue #45214

##### ISSUE  TYPE
- Feature Pull Request

##### COMPONENT NAME
vault

##### ADDITIONAL INFORMATION
Usage :
```
export ANSIBLE_VAULT_PASSWORD=****
ansible-playbook ... --vault-password-env "ANSIBLE_VAULT_PASSWORD"
ansible-playbook ... --vault-id "vault_id@env:ANSIBLE_VAULT_PASSWORD"
```
