### PR TITLE
[stable-2.9] Replace import of pycompat24.literal_eval with ast.literal_eval. (#64088)

### DIFF
--- a/changelogs/fragments/64088-ast-literal.yml
+++ b/changelogs/fragments/64088-ast-literal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - core - replace a compatibility import of pycompat24.literal_eval with ast.literal_eval.

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -8,13 +8,13 @@ __metaclass__ = type
 import os
 import re
 
+from ast import literal_eval
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._json_compat import json
 from ansible.module_utils.common.collections import is_iterable
 from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.common.text.formatters import human_to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
-from ansible.module_utils.pycompat24 import literal_eval
 from ansible.module_utils.six import (
     binary_type,
     integer_types,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64088 for Ansible 2.9
(cherry picked from commit 3126c38f8a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/common/validation.py`