### PR TITLE
docker_login: Use with statement for accessing files (#64382)

### DIFF
--- a/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
+++ b/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - Use ``with`` statement when accessing files, to prevent that invalid json output is produced"

--- a/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
+++ b/changelogs/fragments/64382-docker_login-fix-invalid-json.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_login - Use ``with`` statement when accessing files, to prevent that invalid json output is produced"
+- "docker_login - Use ``with`` statement when accessing files, to prevent that invalid JSON output is produced."

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -259,7 +259,8 @@ class LoginManager(DockerBaseClass):
 
     def write_config(self, path, config):
         try:
-            json.dump(config, open(path, "w"), indent=5, sort_keys=True)
+            with open(path, "w") as file:
+                json.dump(config, file, indent=5, sort_keys=True)
         except Exception as exc:
             self.fail("Error: failed to write config to %s - %s" % (path, str(exc)))
 
@@ -277,7 +278,8 @@ class LoginManager(DockerBaseClass):
 
         try:
             # read the existing config
-            config = json.load(open(path, "r"))
+            with open(path, "r") as file:
+                config = json.load(file)
         except ValueError:
             self.log("Error reading config from %s" % (path))
             config = dict()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use the with statement when writing and reading the config.json. This ensures that the file is properly closed and the content is written after usage.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #64382

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_login

##### ADDITIONAL INFORMATION
See issue #64382
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

