### PR TITLE
[stable-2.9] wait_for - remove an obsolete fallback for Python 2.6 (#63988)

### DIFF
--- a/changelogs/fragments/63988-removes-python_compat_fallback.yml
+++ b/changelogs/fragments/63988-removes-python_compat_fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - code - removes some Python compatibility code for dealing with socket timeouts in ``wait_for``

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -225,7 +225,6 @@ import os
 import re
 import select
 import socket
-import sys
 import time
 import traceback
 
@@ -437,26 +436,6 @@ def _convert_host_to_hex(host):
     return ips
 
 
-def _create_connection(host, port, connect_timeout):
-    """
-    Connect to a 2-tuple (host, port) and return
-    the socket object.
-
-    Args:
-        2-tuple (host, port) and connection timeout
-    Returns:
-        Socket object
-    """
-    if sys.version_info < (2, 6):
-        (family, _) = (_convert_host_to_ip(host))[0]
-        connect_socket = socket.socket(family, socket.SOCK_STREAM)
-        connect_socket.settimeout(connect_timeout)
-        connect_socket.connect((host, port))
-    else:
-        connect_socket = socket.create_connection((host, port), connect_timeout)
-    return connect_socket
-
-
 def _timedelta_total_seconds(timedelta):
     return (
         timedelta.microseconds + 0.0 +
@@ -546,7 +525,7 @@ def main():
                     break
             elif port:
                 try:
-                    s = _create_connection(host, port, connect_timeout)
+                    s = socket.create_connection((host, port), connect_timeout)
                     s.shutdown(socket.SHUT_RDWR)
                     s.close()
                 except Exception:
@@ -596,7 +575,7 @@ def main():
             elif port:
                 alt_connect_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.utcnow()))
                 try:
-                    s = _create_connection(host, port, min(connect_timeout, alt_connect_timeout))
+                    s = socket.create_connection((host, port), min(connect_timeout, alt_connect_timeout))
                 except Exception:
                     # Failed to connect by connect_timeout. wait and try again
                     pass

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5555,7 +5555,6 @@ lib/ansible/modules/utilities/logic/async_status.py use-argspec-type-path
 lib/ansible/modules/utilities/logic/async_status.py validate-modules!skip
 lib/ansible/modules/utilities/logic/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/utilities/logic/async_wrapper.py use-argspec-type-path
-lib/ansible/modules/utilities/logic/wait_for.py pylint:blacklisted-name
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential_type.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #63988 for Ansible 2.9
(cherry picked from commit 39bf09517a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/utilities/logic/wait_for.py`
