### PR TITLE
[FIX] graceful is not an immutable attribute

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_service.py
@@ -444,6 +444,8 @@ def service_identical(client, module, service_proxy):
     # of the retrieved object
     if 'ip' in diff_dict:
         del diff_dict['ip']
+    if 'graceful' in diff_dict:
+        del diff_dict['graceful']
     if len(diff_dict) == 0:
         return True
     else:
@@ -828,7 +830,6 @@ def main():
         'td',
         'monitor_name_svc',
         'riseapbrstatsmsgcode',
-        'graceful',
         'all',
         'Internal',
         'newname',


### PR DESCRIPTION
##### SUMMARY
As described in the issue, currently the graceful attribute is unable to be utilized by the netscaler_service module, which is in contrast with the official API docs.

Fixes #64268 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/network/netscaler/netscaler_service.py`