### PR TITLE
[2.9]Add note about large tarball sizes for collections (#64411)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -236,6 +236,7 @@ a tarball of the built collection in the current directory which can be uploaded
 .. note::
     Certain files and folders are excluded when building the collection artifact. This is not currently configurable
     and is a work in progress so the collection artifact may contain files you would not wish to distribute.
+    This includes any files built with ``mazer`` so delete those from :file:`releases/` before you build your collection with ``ansible-galaxy``.  The current Galaxy maximum tarball size is 2 MB.
 
 This tarball is mainly intended to upload to Galaxy
 as a distribution method, but you can use it directly to install the collection on target systems.


### PR DESCRIPTION
* add note on collection tarball size

(cherry picked from commit 797397558e436de925cbd89eae2a09099df0395c)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
