### PR TITLE
Adding team_aruba as maintainer for aruba modules

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -286,7 +286,7 @@ files:
     maintainers: $team_aireos
     labels: [ aireos, cisco, networking ]
   $modules/network/aos/: dgarros jeremyschulman
-  $modules/network/aruba/: jmighion
+  $modules/network/aruba/: $team_aruba
   $modules/network/asa/: &asa
     maintainers: $team_asa
     labels: [ asa, cisco, networking ]
@@ -734,7 +734,7 @@ files:
   $module_utils/network/aos:
     maintainers: dgarros jeremyschulman
   $module_utils/network/aruba:
-    maintainers: jmighion
+    maintainers: $team_aruba
   $module_utils/network/asa: *asa
   $module_utils/network/avi:
     maintainers: $team_avi
@@ -949,7 +949,7 @@ files:
   $plugins/action/asa: *asa
   $plugins/action/aireos: *aireos
   $plugins/action/aruba:
-    maintainers: jmighion
+    maintainers: $team_aruba
     labels: networking
   $plugins/action/bigip:
     maintainers: caphrim007 wojtek0806
@@ -1052,6 +1052,8 @@ files:
 
   $plugins/cliconf/:
     labels: networking
+  $plugins/cliconf/aruba.py:
+    maintainers: $team_aruba
   $plugins/cliconf/ce.py:
     <<: *cloudengine
   $plugins/cliconf/edgeswitch.py:
@@ -1368,6 +1370,8 @@ files:
     labels: networking
   $plugins/terminal/__init__.py:
     support: network
+  $plugins/terminal/aruba.py:
+    maintainers: $team_aruba
   $plugins/terminal/asa.py: *asa
   $plugins/terminal/ce.py:
     <<: *cloudengine
@@ -1585,6 +1589,7 @@ macros:
   team_aci: brunocalogero dagwieers devarshishah3 fadallar jmcgill298 koladiya mtorelli rsmeyers schunduri smnmtzgr
   team_aireos: jmighion
   team_aix: bcoca dagwieers d-little flynn1973 gforster kairoaraujo marvin-sinister mator molekuul MorrisA ramooncamacho wtcross
+  team_aruba: karthikeyan-dhandapani
   team_asa: NilashishC ogenstad
   team_ansible: []
   team_avi: ericsysmin grastogi23 khaltore


### PR DESCRIPTION
##### SUMMARY
Adding team_aruba as maintainer for the aruba modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module and module_utils name: aruba
plugins, terminal and cliconf name: aruba.py

##### ADDITIONAL INFORMATION
Aruba would like to maintain the modules specific to Aruba Networks(HPE).
