### PR TITLE
VMware: vmware_guest add CDROM attach to SATA controller support

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -153,7 +153,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm1
+    name: test_vm4
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: Resources
@@ -198,7 +198,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm1
+    name: test_vm4
     datacenter: "{{ dc1 }}"
     cdrom:
     - controller_type: ide
@@ -235,7 +235,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm2
+    name: test_vm5
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: Resources
@@ -282,7 +282,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm3
+    name: test_vm6
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     resource_pool: Resources
@@ -329,7 +329,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     folder: vm
-    name: test_vm3
+    name: test_vm6
     datacenter: "{{ dc1 }}"
     cdrom:
     - controller_type: ide

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -146,7 +146,7 @@
     that:
       - "cdrom_vm.changed == true"
 
-- name: Create VM with multiple CDROMs
+- name: Create VM with multiple CDROMs attached to IDE controller
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
@@ -215,6 +215,137 @@
       unit_number: 0
       state: absent
     - controller_type: ide
+      controller_number: 1
+      unit_number: 1
+      state: absent
+    state: present
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "cdrom_vm.changed == true"
+
+- name: Create VM with multiple CDROMs attached to SATA controller
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
+    name: test_vm2
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: "{{ ds2 }}"
+    cdrom:
+    - controller_type: sata
+      controller_number: 0
+      unit_number: 0
+      type: iso
+      iso_path: "[{{ ds1 }}] centos.iso"
+    - controller_type: sata
+      controller_number: 0
+      unit_number: 1
+      type: client
+    - controller_number: 1
+      unit_number: 0
+      type: none
+      controller_type: sata
+    - controller_number: 1
+      unit_number: 1
+      type: client
+      controller_type: sata
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "cdrom_vm.changed == true"
+
+- name: Create VM with multiple CDROMs attached to IDE and SATA controller
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
+    name: test_vm3
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: "{{ ds2 }}"
+    cdrom:
+    - controller_type: ide
+      controller_number: 0
+      unit_number: 0
+      type: iso
+      iso_path: "[{{ ds1 }}] centos.iso"
+    - controller_type: sata
+      controller_number: 0
+      unit_number: 1
+      type: client
+    - controller_number: 1
+      unit_number: 0
+      type: none
+      controller_type: ide
+    - controller_number: 1
+      unit_number: 1
+      type: client
+      controller_type: sata
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "cdrom_vm.changed == true"
+
+- name: Remove 3 CDROMs and reconfigure 1 CDROM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: vm
+    name: test_vm3
+    datacenter: "{{ dc1 }}"
+    cdrom:
+    - controller_type: ide
+      controller_number: 0
+      unit_number: 0
+      state: absent
+    - controller_type: sata
+      controller_number: 0
+      unit_number: 1
+      type: iso
+      iso_path: "[{{ ds1 }}] fedora.iso"
+    - controller_type: ide
+      controller_number: 1
+      unit_number: 0
+      state: absent
+    - controller_type: sata
       controller_number: 1
       unit_number: 1
       state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Support specify a list of cdroms added or reconfigure, before the controller is IDE, now support specify SATA controller.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #42995
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    cdrom:
    - controller_type: sata
      controller_number: 0
      unit_number: 0
      type: iso
      iso_path: "[{{ ds1 }}] centos.iso"
    - controller_type: sata
      controller_number: 0
      unit_number: 1
      type: client
```
