### PR TITLE
Ovirt host network dict correct

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -245,7 +245,9 @@ def get_bond_options(mode, usr_opts):
 class HostNetworksModule(BaseModule):
 
     def __compare_options(self, new_options, old_options):
-        return sorted(get_dict_of_struct(opt) for opt in new_options) != sorted(get_dict_of_struct(opt) for opt in old_options)
+        return sorted((get_dict_of_struct(opt) for opt in new_options),
+                      key=lambda x: x["name"]) != sorted((get_dict_of_struct(opt) for opt in old_options),
+                                                         key=lambda x: x["name"])
 
     def build_entity(self):
         return otypes.Host()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -214,7 +214,7 @@ def get_bond_options(mode, usr_opts):
             None,
             'Dynamic link aggregation (802.3ad)',
         ]
-        if (not 0 < mode_number <= len(modes) - 1):
+        if (not 0 < mode_number <= len(modes)):
             return None
         return modes[mode_number - 1]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ovirt_host_network: 
- correct comparing of two dicts
- correct when user uses 4th mode so it would not return status as changed 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #62909

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
