### PR TITLE
new windows module: win_xml_document

### DIFF
--- a/lib/ansible/modules/windows/win_xml_document.ps1
+++ b/lib/ansible/modules/windows/win_xml_document.ps1
@@ -1,0 +1,952 @@
+#!powershell
+
+# Copyright: (c) 2019, Micah Hunsberger (@mhunsber)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#Requires -Module Ansible.ModuleUtils.Backup
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = 'Stop'
+
+function Get-IndexOfElement($XmlElement)
+{
+    $parentNode = $XmlElement.ParentNode
+    if ($parentNode -is [xml])
+    {
+        return 1 # document node is index 1
+    }
+    [System.Xml.XmlElement]$parent = [System.Xml.XmlElement]$parentNode
+    $index = 1
+    foreach($candidate in $parent.ChildNodes)
+    {
+        if(($candidate -is [System.Xml.XmlElement]) -and ($candidate.Name -eq $XmlElement.Name))
+        {
+            if ($candidate -eq $XmlElement)
+            {
+                return $index
+            }
+            $index++
+        }
+    }
+    throw "Element not found within parent!"
+}
+
+function Get-NodeXPath($XmlNode)
+{
+    # follow parent objects to the owner document
+    $sb = New-Object -TypeName System.Text.StringBuilder
+    while ($null -ne $XmlNode)
+    {
+        switch($XmlNode.NodeType)
+        {
+            'Attribute' {
+                $sb.Insert(0, "/@$($XmlNode.Name)") | Out-Null
+                $XmlNode = $XmlNode.OwnerElement
+                break
+            }
+            'Element' {
+                $index = Get-IndexOfElement -XmlElement $XmlNode
+                $sb.Insert(0, "/$($XmlNode.Name)[$index]") | Out-Null
+                $XmlNode = $XmlNode.ParentNode
+            }
+            'Document' {
+                return $sb.ToString()
+            }
+            default {
+                throw "Node Type <$($XmlNode.NodeType)> is unsupported!"
+            }
+        }
+    }
+    throw "Xml was not a member of a parent document!"
+}
+
+function Get-Namespace([string]$elementname, [string]$Default = '')
+{
+    if ($elementname.Contains(':'))
+    {
+        $prefix = $elementname.Split(':')[0]
+        if ($namespace_manager.HasNamespace($prefix))
+        {
+            return $namespace_manager.LookupNamespace($prefix)
+        }
+        else
+        {
+            $module.FailJson("Unknown namespace prefix $prefix for element $elementname!")
+        }
+    }
+    return $Default
+}
+
+function Get-XMLTextWriter($OutputStream)
+{
+    $encoding = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false # no BOM
+    $xmlTextWriter = New-Object -TypeName System.Xml.XmlTextWriter -ArgumentList $OutputStream, $encoding
+    if ($indent)
+    {
+        $xmlTextWriter.Formatting = [System.Xml.Formatting]::Indented
+        $xmlTextWriter.Indentation = $indent_spaces
+    }
+    else
+    {
+        $xmlTextWriter.Formatting = [System.Xml.Formatting]::None
+    }
+    return $xmlTextWriter
+}
+
+function Save-XMLDocument([bool]$Backup = $false, [switch]$AsString)
+{
+    if ($Backup)
+    {
+        $backup_file =  Backup-File -path $xml_file
+    }
+    if ($AsString)
+    {
+        $ms = New-Object -TypeName System.IO.MemoryStream
+        $writer = Get-XMLTextWriter -OutputStream $ms
+    }
+    else
+    {
+        $writer = Get-XMLTextWriter -OutputStream $xml_file
+    }
+    try
+    {
+        $xml_doc.Save($writer)
+        # Add carriage return/line feed at the end to keep git happy
+        $writer.WriteWhitespace("`r`n")
+    }
+    finally
+    {
+        $writer.Close()
+    }
+    if ($AsString)
+    {
+        return [System.Text.Encoding]::UTF8.GetString($ms.ToArray())
+    }
+    elseif ($Backup)
+    {
+        return $backup_file
+    }
+}
+
+function Get-XPathNodeType([string]$NodeSelector)
+{
+    if ($NodeSelector.EndsWith('text()'))
+    {
+        return [System.Xml.XmlNodeType]::Text
+    }
+    if ($NodeSelector.EndsWith('comment()'))
+    {
+        return [System.Xml.XmlNodeType]::Comment
+    }
+    if ($NodeSelector.Trim('/').StartsWith('@'))
+    {
+        return [System.Xml.XmlNodeType]::Attribute
+    }
+    else
+    {
+        return [System.Xml.XmlNodeType]::Element
+    }
+}
+
+function Get-XPathPredicateTokens([string]$Predicate)
+{
+    function Get-TokenType ([string]$Value)
+    {
+        if ($Value.StartsWith('@'))
+        {
+            return 'attribute'
+        }
+        elseif ($Value.StartsWith('"') -or $Value.StartsWith("'"))
+        {
+            return 'string'
+        }
+        elseif ($Value -eq 'text()')
+        {
+            return 'text'
+        }
+        elseif ($Value.EndsWith(')'))
+        {
+            return 'function'
+        }
+        elseif ('and', 'or' -contains $Value)
+        {
+            return 'control'
+        }
+        elseif ($value -eq '=')
+        {
+            return 'equality'
+        }
+        elseif ('<', '>', '<=', '>=' -contains $Value)
+        {
+            return 'inequality'
+        }
+        elseif ([double]::TryParse($Value, [ref]$null))
+        {
+            return 'number'
+        }
+        else
+        {
+            throw "cannot determine token type for token ($Value)!"
+            return $null
+        }
+    }
+    function Add-Token ($Token)
+    {
+        $Token.value = ([string]($Token.value)).Trim()
+        if ($Token.type -eq '')
+        {
+            $Token.type = Get-TokenType -Value $Token.value
+        }
+        if ($Token.type -eq 'string')
+        {
+            if ($Token.value.StartsWith('"'))
+            {
+                $token.value = $Token.value.Trim('"')
+            }
+            elseif ($Token.value.StartsWith("'"))
+            {
+                $token.value = $Token.value.Trim("'")
+            }
+        }
+        elseif ($Token.type -eq 'attribute')
+        {
+            $Token.value = $Token.Value.Trim('@')
+        }
+        $tokens.Add($Token) | Out-Null
+    }
+    function Get-NewToken
+    {
+        return @{
+            value = ''
+            type = ''
+        }
+    }
+    $tokens = New-Object -TypeName System.Collections.ArrayList
+    $lastQuote = ''
+    $token = Get-NewToken
+    for($i = 0; $i -lt $Predicate.Length; $i++)
+    {
+        $char = $Predicate[$i]
+        if ($char -eq $lastQuote) # end of string
+        {
+            $lastQuote = ''
+            $token.value += $char
+            $token.type = 'string'
+            Add-Token -Token $token
+            $token = Get-NewToken
+        }
+        elseif ($lastQuote -ne '') # in a quoted value
+        {
+            $token.value += $char
+        }
+        elseif ($char -eq "'" -or $char -eq '"') # start a quoted value
+        {
+            $lastQuote = $char
+            $token.value = $char
+            $token.type = 'string'
+        }
+        elseif ('=', '>', '<' -contains $char) # comparison
+        {
+            Add-Token -Token $token
+            $token = Get-NewToken
+            $comparer = $char
+            $type = 'equality'
+            if ('>', '<' -contains $char)
+            {
+                $type = 'inequality'
+                # need to check the next one (would be invalid predicate if no next character)
+                if ($Predicate[$i + 1] -eq '=')
+                {
+                    $comparer += '='
+                    $i++ # already tokenized it
+                }
+            }
+            Add-Token -Token @{type=$type; value=$comparer}
+            $token = Get-NewToken
+        }
+        elseif ($char -eq ' ' -and $token.value -ne '')
+        {
+            Add-Token -Token $token
+            $token = Get-NewToken
+        }
+        else
+        {
+            $token.value += $char
+        }
+    }
+    if ($token.value -ne '')
+    {
+        Add-Token -Token $token
+    }
+    return $tokens
+}
+
+function Get-XPathPredicateValues([string]$Predicate)
+{
+    $tokens = Get-XPathPredicateTokens -Predicate $Predicate
+    $attributes = @()
+    $text = @{
+        action = 'none'
+        value = ''
+    }
+
+    for($i = 0; $i -lt $tokens.Length; $i++)
+    {
+        if ($i -eq $tokens.Length - 1)
+        {
+            $nextToken = @{ type=''; value=''}
+        }
+        else
+        {
+            $nextToken = $tokens[$i + 1]
+        }
+        $token = $tokens[$i]
+        switch($token.type)
+        {
+            'text' {
+                if($nextToken.type -eq 'equality')
+                {
+                    $text.action = 'set'
+                    $text.value = $tokens[$i + 2].value # it better be there
+                    $i = $i + 2 # skip them because we've used them
+                }
+                else
+                {
+                    $text.action = 'present'
+                }
+                break;
+            }
+            'attribute' {
+                $attr = @{
+                    action = 'present'
+                    name = $token.value
+                    value = ''
+                }
+                if($nextToken.type -eq 'equality')
+                {
+                    $attr.action = 'set'
+                    $attr.value = $tokens[$i + 2].value # it better be there
+                    $i = $i + 2 # skip them because we've used them
+                }
+                $attributes += $attr
+                break;
+            }
+            'control' {
+                if ($token.value -eq 'or')
+                {
+                    $module.FailJson("Cannot create nonexistent node from predicate [$Predicate] because it contains an OR control value!")
+                }
+                break;
+            }
+            'inequality' {
+                $module.FailJson("Cannot create nonexistent node from predicate [$Predicate] because it contains an inequality!")
+                break;
+            }
+            'function' {
+                throw "dont know what to do with predicate function $($token.value)!"
+            }
+            'equality' {
+                throw "something is wrong, encountered equality operator when this should have been skipped."
+                break;
+            }
+            'number' {
+                # if we have gotten here and it is a number, it must be a positional argument
+                # so we can ingore it because it means the element doesn't exist at that position
+                # which either means there are no elements (create it) or none at that position (add it to the end)
+                break;
+            }
+            'string' {
+                # also don't know how we got here
+                throw "something is wrong, encounted string token when this shold have been skipped."
+                break;
+            }
+        }
+    }
+    return @{
+        attributes = $attributes
+        text = $text
+    }
+}
+
+function Split-XPath([string]$XPath)
+{
+    $info = @{
+        parentPath = ''
+        childPath = ''
+        childName = ''
+        namespace = ''
+        childType = ''
+        conditions = @{}
+    }
+    $pivot = $XPath.LastIndexOf('/')
+    if ($pivot -lt 0)
+    {
+        $info.childPath = $Xpath
+    }
+    elseif ($pivot -eq $Xpath.Length - 1)
+    {
+        $info.parentPath = $Xpath
+    }
+    else
+    {
+        $info.parentPath = $XPath.Substring(0, $pivot)
+        $info.childPath = $XPath.Substring($pivot + 1)
+    }
+    $info.childType = Get-XPathNodeType -NodeSelector $info.childPath
+    switch($info.childType)
+    {
+        'Text' {
+            break;
+        }
+        'Comment' {
+            break;
+        }
+        'Attribute' {
+            $info.childName = $info.childPath.Substring(1)
+            break;
+        }
+        'Element' {
+            $info.childName = $info.childPath
+            break;
+        }
+    }
+    # are there any conditions?
+    if($info.childPath.Contains('[') -and $info.childPath.Contains(']'))
+    {
+        $predicateStart = $info.childPath.IndexOf('[')
+        $predicateEnd = $info.childPath.LastIndexOf(']')
+        $predicateString = $info.childPath.Substring($predicateStart + 1, $predicateEnd - $predicateStart - 1)
+        $info.conditions = Get-XPathPredicateValues -Predicate $predicateString
+        $info.childName = $info.childName.Substring(0, $predicateStart)
+    }
+    $info.namespace = Get-Namespace -elementname $info.childName
+    return $info
+}
+
+function Exit-Module
+{
+    if ($module.DiffMode)
+    {
+        $module.Diff.after = Save-XMLDocument -AsString
+    }
+    if ($xml_string)
+    {
+        $module.Result.xmlstring = Save-XMLDocument -AsString
+    }
+    elseif (-not $module.CheckMode -and $module.Result.changed)
+    {
+        $backup_file = Save-XMLDocument -Backup $backup
+        if ($backup)
+        {
+            $module.Result.backup_file = $backup_file
+        }
+    }
+    $module.ExitJson()
+}
+function Set-NodeValues($NodeList, [string]$Value)
+{
+    foreach($node in $NodeList)
+    {
+        if ('Attribute', 'Text', 'Comment' -contains $node.NodeType)
+        {
+            if ($node.Value -ne $Value)
+            {
+                $module.Result.changed = $true
+                $node.Value = $Value
+            }
+        }
+        else
+        {
+            # assume we want to set value as a text node for the element
+            $current_text = Get-ElementText -XmlElement $node
+            if ($current_text -ne $Value)
+            {
+                # remove text nodes
+                $module.Result.changed = $true
+                $textNodes = $node.ChildNodes | Where-Object { $_.NodeType -eq 'Text' }
+                foreach ($textNode in $textNodes)
+                {
+                    $node.RemoveChild($textNode) | Out-Null
+                }
+                if ($Value -ne '')
+                {
+                    # add it back
+                    $node.AppendChild($xml_doc.CreateTextNode($Value)) | Out-Null
+                }
+            }
+        }
+    }
+}
+
+function Add-NodeAtXPath($Document, [string]$XPath)
+{
+    $matches = $Document.SelectNodes($XPath, $namespace_manager)
+    if ($matches.Count -gt 0)
+    {
+        return $matches
+    }
+    $xpath_parts = Split-XPath -XPath $XPath
+    if ($xpath_parts.parentPath.EndsWith('/'))
+    {
+        # there is a double-slash preceding the element we wish to create.
+        # This is unsupported because we cannot know at what depth to create the element.
+        $module.FailJson("cannot create element(s) at $XPath because a descendent path was used instead of a child.")
+    }
+    if ($xpath_parts.childPath.Contains('::'))
+    {
+        # cannot create elements based on Axes
+        $module.FailJson("cannot create element(s) at $XPath because an axis was used at a non-existent path.")
+    }
+
+    $parent_nodes = Add-NodeAtXPath -Document $Document -XPath $xpath_parts.parentPath
+    $nodes = @()
+    # since it didn't match before, we can blindly add now
+    foreach($node in $parent_nodes)
+    {
+        $module.Result.changed = $true
+        switch ($xpath_parts.childType)
+        {
+            'Text' {
+                $nodes += $node.AppendChild($Document.CreateTextNode(''))
+                break
+            }
+            'Comment' {
+                $nodes += $node.AppendChild($Document.CreateComment(''))
+                break
+            }
+            'Attribute' {
+                # attributes are not subject to the default namespace
+                $nodes += $node.Attributes.Append($Document.CreateAttribute($xpath_parts.childName, $xpath_parts.namespace))
+                break
+            }
+            'Element' {
+                if($xpath_parts.namespace -ne '')
+                {
+                    $element = $Document.CreateElement($xpath_parts.childName, $xpath_parts.namespace)
+                }
+                else
+                {
+                    $element = $Document.CreateElement($xpath_parts.childName, $node.NamespaceURI)
+                }
+                if ($xpath_parts.conditions.Count -gt 0)
+                {
+                    if ($xpath_parts.conditions.text.action -ne 'none')
+                    {
+                        $element.AppendChild($Document.CreateTextNode($xpath_parts.conditions.text.value)) | Out-Null
+                    }
+                    foreach($attribute in $xpath_parts.conditions.attributes)
+                    {
+                        $attributeNode = $Document.CreateAttribute($attribute.name, $xpath_parts.namespace)
+                        if($attribute.action -eq 'set')
+                        {
+                            $attributeNode.Value = $attribute.value
+                        }
+                        $element.Attributes.Append($attributeNode) | Out-Null
+                    }
+                }
+                $nodes += $node.AppendChild($element)
+                break
+            }
+            default {
+                throw "impossible error!"
+            }
+        }
+    }
+    return $nodes
+}
+
+function Get-ElementAttributes($XmlElement)
+{
+    $attrs = @{}
+    foreach($attr in $XmlElement.Attributes)
+    {
+        $key = $attr.Name
+        $attrs.$key = $attr.Value
+    }
+    return $attrs
+}
+
+function Get-ElementText($XmlElement)
+{
+    $text = ''
+    # cannot directly query '#text' directly in PowerShell strict mode
+    if ($XmlElement.PSObject.Properties.Name -contains '#text')
+    {
+        $text = $XmlElement.'#text'
+    }
+    return $text
+}
+
+function ConvertTo-Node($document, $child, $defaultNamespace)
+{
+    if ($child -is [string])
+    {
+        return $document.CreateElement($child, (Get-Namespace -elementname $child -Default $defaultNamespace))
+    }
+    elseif ($child -is [hashtable])
+    {
+        if ($child.Count -gt 1)
+        {
+            $module.FailJson("Cannot create children from hashes with more than one key")
+        }
+        foreach($prop in $child.GetEnumerator())
+        {
+            $element = $document.CreateElement($prop.Name, (Get-Namespace -elementname $prop.Name -Default $defaultNamespace))
+            if ($prop.Value -is [string])
+            {
+                $element.InnerText = $prop.Value
+            }
+            elseif ($prop.Value -is [hashtable])
+            {
+                foreach($item in $prop.Value.GetEnumerator())
+                {
+                    if ($item.Value -is [string])
+                    {
+                        # attributes are not subject to the default namespace
+                        $attributeNode = $document.CreateAttribute($item.Name, (Get-Namespace -elementname $item.Name))
+                        $attributeNode.Value = $item.Value
+                        $element.Attributes.Append($attributeNode) | Out-Null
+                    }
+                    elseif ($item.Value -is [array])
+                    {
+                        foreach($newChild in $item.Value)
+                        {
+                            $element.AppendChild((ConvertTo-Node -document $document -child $newChild -defaultNamespace $element.NamespaceURI)) | Out-Null
+                        }
+                    }
+                }
+            }
+            return $element
+        }
+    }
+    else
+    {
+        $module.FailJson("Invalid child type of $($child.GetType()). Children must be strings or hashes")
+    }
+}
+
+function ConvertTo-NodeList($document, $children, $defaultNamespace = '')
+{
+    if ($null -eq $children)
+    {
+        return @()
+    }
+
+    return @($children | Foreach-Object { ConvertTo-Node -document $document -child $_ -defaultNamespace $defaultNamespace})
+}
+
+function Test-NodeEqual($A, $B)
+{
+    if ($A.NodeType -ne $B.NodeType) { return $false }
+    if ($A.Name -ne $B.Name) { return $false }
+    if ($A.OuterXml -ne $B.OuterXML) { return $false }
+    return $true
+}
+
+function Add-NodeChildren($Node, $Children)
+{
+    foreach($child in $Children)
+    {
+        $Node.AppendChild($child) | out-null
+        $module.Result.changed = $true
+    }
+}
+function Set-NodeChildren($Node, $Children)
+{
+    $replace = $false
+    if ($Node.ChildNodes.Count -eq $Children.Count)
+    {
+        for($i = 0; $i -lt $Node.ChildNodes.Count; $i++)
+        {
+            $child_node = $Node.ChildNodes[$i]
+            $child_to_set = $Children[$i]
+            if (-not (Test-NodeEqual -A $child_node -B $child_to_set))
+            {
+                $replace = $true
+                break
+            }
+        }
+    }
+    else
+    {
+        $replace = $true
+    }
+    if ($replace)
+    {
+        $child = $node.FirstChild
+        while($null -ne $child)
+        {
+            $Node.RemoveChild($child) | Out-Null
+            $child = $node.FirstChild
+        }
+        foreach($child in $Children)
+        {
+            $Node.AppendChild($child) | Out-Null
+        }
+        $module.Result.changed = $true
+    }
+}
+
+$spec = @{
+    options = @{
+        path = @{ type='path'; aliases=@('dest','file') }
+        xmlstring = @{ type='str' }
+        xpath = @{ type='str' }
+        state = @{ type='str'; default='present'; choices=@('absent', 'present'); aliases=@('ensure') }
+        value = @{ type='str' }
+        add_children = @{ type='list' }
+        set_children = @{ type= 'list' }
+        count = @{ type='bool'; default = $false }
+        print_match = @{ type = 'bool'; default = $false }
+        indent = @{ type = 'bool'; default = $true }
+        indent_spaces = @{ type = 'int'; default = 2 }
+        content = @{ type= 'str'; choices=@('attribute','text') }
+        backup = @{ type='bool'; default = $false }
+        insertbefore = @{ type='bool'; default=$false }
+        insertafter = @{ type='bool'; default=$false }
+        namespaces = @{ type = 'dict'; default = @{} }
+    }
+    required_by = @{
+        add_children='xpath'
+        content='xpath'
+        set_children='xpath'
+        value='xpath'
+    }
+    required_if = @(
+        @('count', $true, @('xpath')),
+        @('print_match', $true, @('xpath')),
+        @('insertbefore', $true, @('xpath')),
+        @('insertafter', $true, @('xpath'))
+    )
+    required_one_of = @(
+        @('path', 'xmlstring'),
+        @('add_children','content','count','print_match','set_children','value')
+    )
+    mutually_exclusive = @(
+        @('add_children','content','count','print_match','set_children','value'),
+        @('path','xmlstring'),
+        @('insertbefore','insertafter')
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$xml_file = $module.Params.path
+$xml_string = $module.Params.xmlstring
+$xpath = $module.Params.xpath
+$state = $module.Params.state
+$value = $module.Params.value
+$set_children = $module.Params.set_children
+$add_children = $module.Params.add_children
+$indent = $module.Params.indent
+$indent_spaces = $module.Params.indent_spaces
+$content = $module.Params.content
+$print_match = $module.Params.print_match
+$count = $module.Params.count
+$backup = $module.Params.backup
+$insertbefore = $module.Params.insertbefore
+$insertafter = $module.Params.insertafter
+$namespaces = $module.Params.namespaces
+
+# check if the file exists
+if ($null -eq $xml_string -and -not (Test-Path -Path $xml_file -PathType Leaf))
+{
+    $module.FailJson("The target xml source $xml_file does not exist.")
+}
+
+# load the xml document
+$xml_doc = New-Object -TypeName System.Xml.XmlDocument
+$xml_doc.XmlResolver = $null
+if($xml_string)
+{
+    $xml_doc.LoadXml($xml_string)
+}
+elseif (Test-Path -LiteralPath $xml_file -PathType Leaf)
+{
+    $xml_doc.Load($xml_file)
+}
+
+$namespace_manager = New-Object -TypeName System.Xml.XmlNamespaceManager -ArgumentList $xml_doc.NameTable
+$namespace = $xml_doc.DocumentElement.NamespaceURI
+$local_name = $xml_doc.DocumentElement.LocalName
+$namespace_manager.AddNamespace($xml_doc.$local_name.SchemaInfo.Prefix, $namespace)
+foreach($ns in $namespaces.GetEnumerator())
+{
+    $namespace_manager.AddNamespace($ns.Key, $ns.Value)
+}
+
+# validate xpath expression and get matches
+if ($null -ne $xpath)
+{
+    try
+    {
+        $xpath_expression = [System.Xml.XPath.XPathExpression]::Compile($xpath)
+        if ($xpath_expression.ReturnType -ne 'NodeSet')
+        {
+            $module.FailJson("provided xpath expression must return a NodeSet, not $($xpath_expression.ReturnType)!")
+        }
+        $matched_nodes = $xml_doc.SelectNodes($xpath, $namespace_manager)
+    }
+    catch [System.Xml.XPath.XPathException]
+    {
+        $module.FailJson("Provided xpath expression failed to compile: $($_.Exception.Message)")
+    }
+}
+
+$module.Result.actions = @{
+    actions = @{
+        xpath = $xpath
+        namespaces = $namespace_manager -as [string[]]
+        $state = $state
+    }
+}
+$module.Result.changed = $false
+
+if ($module.DiffMode)
+{
+    $module.Diff.before = Save-XMLDocument -AsString
+}
+
+if ($print_match)
+{
+    $module.Result.matches = @($matched_nodes | ForEach-Object { Get-NodeXPath -XmlNode $_ })
+    Exit-Module
+}
+
+if ($count)
+{
+    $module.Result.count = $matched_nodes.Count
+    Exit-Module
+}
+
+if ($content -eq 'attribute')
+{
+    if ($matched_nodes.Count -eq 0)
+    {
+        $module.FailJson("xpath $xpath does not match any nodes!")
+    }
+    $module.Result.matches = @($matched_nodes | ForEach-Object { @{ $_.Name = (Get-ElementAttributes -Xml $_) } })
+    Exit-Module
+}
+elseif ($content -eq 'text')
+{
+    if ($matched_nodes.Count -eq 0)
+    {
+        $module.FailJson("xpath $xpath does not match any nodes!")
+    }
+    $module.Result.matches = @($matched_nodes | ForEach-Object { @{ $_.Name = (Get-ElementText -Xml $_) } })
+    Exit-Module
+}
+
+if ($state -eq 'absent')
+{
+    foreach($node in $matched_nodes)
+    {
+        if ($node.NodeType -eq 'Attribute')
+        {
+            $node.OwnerElement.RemoveAttributeNode($node) | Out-Null
+        }
+        else
+        {
+            $node.get_parentNode().RemoveChild($node) | Out-Null
+        }
+        $module.Result.changed = $true
+    }
+
+    Exit-Module
+}
+else # state -eq 'present'
+{
+    if ($set_children)
+    {
+        if ($matched_nodes.Count -eq 0)
+        {
+            $module.FailJson("xpath $xpath does not match any nodes!")
+        }
+        # if it is a namespaced search, all matched nodes should be of the same namespace
+        $parent_namespace = $matched_nodes[0].NamespaceURI
+        $children = ConvertTo-NodeList -document $xml_doc -children $set_children -defaultNamespace $parent_namespace
+
+        foreach($node in $matched_nodes)
+        {
+            Set-NodeChildren -Node $node -Children $children
+        }
+
+        Exit-Module
+    }
+
+    if ($add_children)
+    {
+        if ($matched_nodes.Count -eq 0)
+        {
+            $module.FailJson("xpath $xpath does not match any nodes!")
+        }
+        # if it is a namespaced search, all matched nodes should be of the same namespace
+        $parent_namespace = $matched_nodes[0].NamespaceURI
+        $children = ConvertTo-NodeList -document $xml_doc -children $add_children -defaultNamespace $parent_namespace
+
+        if ($insertBefore)
+        {
+            $node = $matched_nodes[0]
+            foreach($child in $children)
+            {
+                $module.Result.changed = $true
+                $node.ParentNode.InsertBefore($child, $node) | Out-Null
+            }
+        }
+        elseif ($insertafter)
+        {
+            $node = $matched_nodes[$matched_nodes.Count - 1]
+            foreach($child in $children)
+            {
+                $module.Result.changed = $true
+                $node = $node.ParentNode.InsertAfter($child, $node)
+            }
+        }
+        else
+        {
+            foreach($node in $matched_nodes)
+            {
+                Add-NodeChildren -Node $node -Children $children
+            }
+        }
+
+        Exit-Module
+    }
+
+    if ($null -ne $xpath)
+    {
+        $nodes_to_set = Add-NodeAtXPath -Document $xml_doc -XPath $xpath
+        # if value is None we are done because the nodes are present
+        if ($null -ne $value)
+        {
+            Set-NodeValues -NodeList $nodes_to_set -Value $value
+        }
+
+        Exit-Module
+    }
+
+    # must just want to reformat the document?
+    if ($xml_string)
+    {
+        $before = $xml_string
+    }
+    else
+    {
+        $before = [System.IO.File]::ReadAllText($xml_file)
+    }
+    if ($module.DiffMode)
+    {
+        # we should show the difference in formatting
+        $module.Diff.before = $before
+    }
+    $now = Save-XMLDocument -AsString
+    if ($before -ne $now)
+    {
+        $module.Result.changed = $true
+    }
+
+    Exit-Module
+}

--- a/lib/ansible/modules/windows/win_xml_document.ps1
+++ b/lib/ansible/modules/windows/win_xml_document.ps1
@@ -751,7 +751,7 @@ $insertafter = $module.Params.insertafter
 $namespaces = $module.Params.namespaces
 
 # check if the file exists
-if ($null -eq $xml_string -and -not (Test-Path -Path $xml_file -PathType Leaf))
+if ($null -eq $xml_string -and -not (Test-Path -LiteralPath $xml_file -PathType Leaf))
 {
     $module.FailJson("The target xml source $xml_file does not exist.")
 }

--- a/lib/ansible/modules/windows/win_xml_document.py
+++ b/lib/ansible/modules/windows/win_xml_document.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2019, Micah Hunsberger (@mhunsber)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_xml_document
+short_description: Manage an XML Document file or string.
+description:
+- A CRUD-like interface to managing XML documents.
+version_added: '2.10'
+options:
+  path:
+    description:
+    - Path to the file to operate on.
+    - This file must exist ahead of time.
+    - This parameter is required, unless C(xmlstring) is given.
+    type: path
+    required: yes
+    aliases: [ dest, file ]
+  xmlstring:
+    description:
+    - A string containing XML on which to operate.
+    - This parameter is required, unless C(path) is given.
+    type: str
+    required: yes
+  xpath:
+    description:
+    - A valid XPath expression describing the item(s) you want to manipulate.
+    - Differs slightly from the XPath expression in M(xml), see notes for details.
+    type: str
+  namespaces:
+    description:
+    - A dictionary maping of namespaces C(prefix:uri) XPath expression.
+    - Needs to be a C(dict), not a C(list) of items.
+    type: dict
+  state:
+    description:
+    - Set or remove an xpath selection (node(s), attribute(s)).
+    type: str
+    choices: [ absent, present ]
+    default: present
+    aliases: [ ensure ]
+  value:
+    description:
+    - Desired value of the selected node(s) from C(xpath).
+    - Must be a C(str), this is different from the M(xml) module.
+    - To unset an attribute or element text, set to an empty string.
+    - If not set, only element or attribute presence is checked.
+    type: str
+  add_children:
+    description:
+    - Add additional child-element(s) to a selected element for a given C(xpath).
+    - Child elements must be given in a list and each item may be either a string
+      (eg. C(children=ansible) to add an empty C(<ansible/>) child element),
+      or a hash where the key is an element name and the value is the element value.
+    - This parameter requires C(xpath) to be set.
+    - This parameter always adds the children, so it is never idempotent.
+    type: list
+  set_children:
+    description:
+    - Set the child-element(s) of a selected element for a given C(xpath).
+    - Removes any existing children.
+    - Child elements must be specified as in C(add_children).
+    - This parameter requires C(xpath) to be set.
+    type: list
+  count:
+    description:
+    - Search for a given C(xpath) and provide the count of any matches.
+    - This parameter requires C(xpath) to be set.
+    type: bool
+    default: no
+  print_match:
+    description:
+    - Search for a given C(xpath) and print out any matches.
+    - This parameter requires C(xpath) to be set.
+    type: bool
+    default: no
+  indent:
+    description:
+    - Whether or not to use the indent formatting for the XML document.
+    - If this is set to I(False), then the document will be printed on a single line.
+    type: bool
+    default: yes
+  indent_spaces:
+    description:
+    - When C(indent=true), this controls how many spaces to use for indentation when formatting the document.
+    type: int
+    default: 2
+  content:
+    description:
+    - Search for a given C(xpath) and get content.
+    - This parameter requires C(xpath) to be set.
+    type: str
+    choices: [ attribute, text ]
+  backup:
+    description:
+      - Create a backup file including the timestamp information so you can get
+        the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: no
+  insertbefore:
+    description:
+      - Add additional child-element(s) before the first selected element for a given C(xpath).
+      - Child elements must be given in a list and each item may be either a string
+        (eg. C(children=ansible) to add an empty C(<ansible/>) child element),
+        or a hash where the key is an element name and the value is the element value.
+      - This parameter requires C(xpath) to be set.
+    type: bool
+    default: no
+  insertafter:
+    description:
+      - Add additional child-element(s) after the last selected element for a given C(xpath).
+      - Child elements must be given in a list and each item may be either a string
+        (eg. C(children=ansible) to add an empty C(<ansible/>) child element),
+        or a hash where the key is an element name and the value is the element value.
+      - This parameter requires C(xpath) to be set.
+    type: bool
+    default: no
+notes:
+- Use the C(--check) and C(--diff) options when testing your expressions.
+- The diff output is automatically formatted based on the input parameters, so may not reflect the actual file content, only the file structure.
+- If you only set C(indent) and C(indent_spaces), the diff output will reflect the original file content, since formatting is the only thing changing.
+- This module does not handle complicated xpath expressions, so limit xpath selectors to simple expressions.
+- In M(xml), an xpath xpression of '/business/beers/beer/@alcohol = 0.3' will set the @alcohol attribute to 0.3.
+  In the .NET XPathExpression object, this resolves to a boolean expression, and can't be used to select attribute node(s).
+  Instead, use C(xpath='/business/beers/beer/@alcohol',state='present',value='0.3'), which will set all 'beer/@alcohol' attributes to 0.3.
+  To only set a specific beer alcohol attribute, limit your xpath expression to a single node, such as '//beer[text()="Old Rasputin"]/@alcohol'
+- Beware that in case your XML elements are namespaced, you need to use the C(namespaces) parameter, see the examples.
+- Namespaces prefix should be used for all children of an element where namespace is defined, unless another namespace is defined for them.
+seealso:
+- module: win_xml
+- module: xml
+- name: Introduction to XPath
+  description: A brief tutorial on XPath (w3schools.com).
+  link: https://www.w3schools.com/xml/xpath_intro.asp
+- name: XPath Reference document
+  description: The reference documentation on XSLT/XPath (developer.mozilla.org).
+  link: https://developer.mozilla.org/en-US/docs/Web/XPath
+author:
+- Micah Hunsberger (@mhunsber)
+'''
+
+EXAMPLES = r'''
+# Consider the following XML file:
+#
+# <business type="bar">
+#   <name>Tasty Beverage Co.</name>
+#     <beers>
+#       <beer>Rochefort 10</beer>
+#       <beer>St. Bernardus Abbot 12</beer>
+#       <beer>Schlitz</beer>
+#    </beers>
+#   <rating subjective="true">10</rating>
+#   <website>
+#     <mobilefriendly/>
+#     <address>http://tastybeverageco.com</address>
+#   </website>
+# </business>
+
+- name: Remove the 'subjective' attribute of the 'rating' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/rating/@subjective
+    state: absent
+
+- name: Set the rating to '11'
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/rating
+    value: 11
+
+# Retrieve and display the number of nodes
+- name: Get count of 'beers' nodes
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/beers/beer
+    count: yes
+  register: hits
+
+- debug:
+    var: hits.count
+
+# Example where parent XML nodes are created automatically
+- name: Add a 'phonenumber' element to the 'business' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/phonenumber
+    value: 555-555-1234
+
+- name: Add several more beers to the 'beers' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/beers
+    add_children:
+    - beer: Old Rasputin
+    - beer: Old Motor Oil
+    - beer: Old Curmudgeon
+
+- name: Add several more beers to the 'beers' element and add them before the 'Rochefort 10' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: '/business/beers/beer[text()="Rochefort 10"]'
+    insertbefore: yes
+    add_children:
+    - beer: Old Rasputin
+    - beer: Old Motor Oil
+    - beer: Old Curmudgeon
+
+# NOTE: The 'state' defaults to 'present' and 'value' defaults to 'null' for elements
+- name: Add a 'validxhtml' element to the 'website' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/website/validxhtml
+
+- name: Add an empty 'validatedon' attribute to the 'validxhtml' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/website/validxhtml/@validatedon
+
+- name: Add or modify an attribute, add element if needed
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/website/validxhtml/@validatedon
+    value: 1976-08-05
+
+# How to read an attribute value and access it in Ansible
+- name: Read an element's attribute values
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/website/validxhtml
+    content: attribute
+  register: xmlresp
+
+- name: Show an attribute value
+  debug:
+    var: xmlresp.matches[0].validxhtml.validatedon
+
+- name: Remove all children from the 'website' element
+  win_xml_document:
+    path: \foo\bar.xml
+    xpath: /business/website/*
+    state: absent
+
+# In case of namespaces, like in below XML, they have to be explicitly stated.
+#
+# <foo xmlns="http://x.test" xmlns:attr="http://z.test">
+#   <bar>
+#     <baz xmlns="http://y.test" attr:my_namespaced_attribute="true" />
+#   </bar>
+# </foo>
+
+# NOTE: There is the prefix 'x' in front of the 'bar' element, too.
+- name: Set namespaced '/x:foo/x:bar/y:baz/@z:my_namespaced_attribute' to 'false'
+  win_xml_document:
+    path: foo.xml
+    xpath: /x:foo/x:bar/y:baz
+    namespaces:
+      x: http://x.test
+      y: http://y.test
+      z: http://z.test
+    attribute: z:my_namespaced_attribute
+    value: 'false'
+'''
+
+RETURN = r'''
+actions:
+    description: A dictionary with the original xpath, namespaces and state.
+    type: dict
+    returned: success
+    sample: {xpath: xpath, namespaces: [namespace1, namespace2], state=present}
+backup_file:
+    description: The name of the backup file that was created
+    type: str
+    returned: when backup=yes
+    sample: /path/to/file.xml.1942.2017-08-24@14:16:01~
+count:
+    description: The count of xpath matches.
+    type: int
+    returned: when parameter 'count' is set
+    sample: 2
+matches:
+    description: The xpath matches found.
+    type: list
+    returned: when parameter 'print_match', or 'content' is set
+xmlstring:
+    description: An XML string of the resulting output.
+    type: str
+    returned: when parameter 'xmlstring' is set
+'''

--- a/test/integration/targets/win_xml_document/aliases
+++ b/test/integration/targets/win_xml_document/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/test/integration/targets/win_xml_document/fixtures/ansible-xml-beers-unicode.xml
+++ b/test/integration/targets/win_xml_document/fixtures/ansible-xml-beers-unicode.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Толстый бар</name>
+  <beers>
+    <beer>Окское</beer>
+    <beer>Невское</beer>
+  </beers>
+  <rating subjective="да">десять</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tolstyybar.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/fixtures/ansible-xml-beers.xml
+++ b/test/integration/targets/win_xml_document/fixtures/ansible-xml-beers.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/fixtures/ansible-xml-namespaced-beers.xml
+++ b/test/integration/targets/win_xml_document/fixtures/ansible-xml-namespaced-beers.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-elements-unicode.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-elements-unicode.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer>Окское</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-elements.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-elements.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer>Old Rasputin</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-from-groupvars.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-from-groupvars.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer>Natty Lite</beer>
+    <beer>Miller Lite</beer>
+    <beer>Coors Lite</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-insertafter.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-insertafter.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Old Rasputin</beer>
+    <beer>Old Motor Oil</beer>
+    <beer>Old Curmudgeon</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-insertbefore.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-insertbefore.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>Old Rasputin</beer>
+    <beer>Old Motor Oil</beer>
+    <beer>Old Curmudgeon</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-with-attributes-unicode.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-with-attributes-unicode.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer name="Окское" type="экстра" />
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-children-with-attributes.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-children-with-attributes.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer name="Ansible Brew" type="light" />
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-element-implicitly.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-element-implicitly.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer color="red">George Killian's Irish Red</beer>
+    <beer origin="CZ" color="blonde">Pilsner Urquell</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+    <validxhtml validateon="" />
+  </website>
+  <phonenumber>555-555-1234</phonenumber>
+  <owner dob="1976-04-12">
+    <name>
+      <last>Smith</last>
+      <first>John</first>
+      <middle>Q</middle>
+    </name>
+  </owner>
+  <website_bis>
+    <validxhtml validateon="" />
+  </website_bis>
+  <testnormalelement>xml tag with no special characters</testnormalelement>
+  <test-with-dash>xml tag with dashes</test-with-dash>
+  <test-with-dash.and.dot>xml tag with dashes and dots</test-with-dash.and.dot>
+  <test-with.dash_and.dot_and-underscores>xml tag with dashes, dots and underscores</test-with.dash_and.dot_and-underscores>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-add-namespaced-children-elements.xml
+++ b/test/integration/targets/win_xml_document/results/test-add-namespaced-children-elements.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer>Old Rasputin</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-formatting-indent-0.xml
+++ b/test/integration/targets/win_xml_document/results/test-formatting-indent-0.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+<name>Tasty Beverage Co.</name>
+<beers>
+<beer>Rochefort 10</beer>
+<beer>St. Bernardus Abbot 12</beer>
+<beer>Schlitz</beer>
+</beers>
+<rating subjective="true">10</rating>
+<website>
+<mobilefriendly />
+<address>http://tastybeverageco.com</address>
+</website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-formatting-indent-4.xml
+++ b/test/integration/targets/win_xml_document/results/test-formatting-indent-4.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+    <name>Tasty Beverage Co.</name>
+    <beers>
+        <beer>Rochefort 10</beer>
+        <beer>St. Bernardus Abbot 12</beer>
+        <beer>Schlitz</beer>
+    </beers>
+    <rating subjective="true">10</rating>
+    <website>
+        <mobilefriendly />
+        <address>http://tastybeverageco.com</address>
+    </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-formatting-no-indent.xml
+++ b/test/integration/targets/win_xml_document/results/test-formatting-no-indent.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><business type="bar"><name>Tasty Beverage Co.</name><beers><beer>Rochefort 10</beer><beer>St. Bernardus Abbot 12</beer><beer>Schlitz</beer></beers><rating subjective="true">10</rating><website><mobilefriendly /><address>http://tastybeverageco.com</address></website></business>

--- a/test/integration/targets/win_xml_document/results/test-remove-attribute.xml
+++ b/test/integration/targets/win_xml_document/results/test-remove-attribute.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating>10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-remove-element.xml
+++ b/test/integration/targets/win_xml_document/results/test-remove-element.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-remove-namespaced-attribute.xml
+++ b/test/integration/targets/win_xml_document/results/test-remove-namespaced-attribute.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-remove-namespaced-element.xml
+++ b/test/integration/targets/win_xml_document/results/test-remove-namespaced-element.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <website xmlns="http://test.website">
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-attribute-value-unicode.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-attribute-value-unicode.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="нет">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-attribute-value.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-attribute-value.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="false">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-children-elements-level.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-children-elements-level.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer name="90 Minute IPA" alcohol="0.5">
+      <Water liter="0.2" quantity="200g" />
+      <Starch quantity="10g" />
+      <Hops quantity="50g" />
+      <Yeast quantity="20g" />
+    </beer>
+    <beer name="Harvest Pumpkin Ale" alcohol="0.3">
+      <Water liter="0.2" quantity="200g" />
+      <Hops quantity="25g" />
+      <Yeast quantity="20g" />
+    </beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-children-elements-unicode.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-children-elements-unicode.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Окское</beer>
+    <beer>Невское</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-children-elements.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-children-elements.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>90 Minute IPA</beer>
+    <beer>Harvest Pumpkin Ale</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-element-value-empty.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-element-value-empty.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>
+    </address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-element-value-unicode.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-element-value-unicode.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">пять</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+  <rating>пять</rating>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-element-value.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-element-value.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">5</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+  <rating>5</rating>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-namespaced-attribute-value.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-namespaced-attribute-value.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="false">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-set-namespaced-element-value.xml
+++ b/test/integration/targets/win_xml_document/results/test-set-namespaced-element-value.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">11</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/results/test-xmlstring.xml
+++ b/test/integration/targets/win_xml_document/results/test-xmlstring.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly />
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/test/integration/targets/win_xml_document/tasks/main.yml
+++ b/test/integration/targets/win_xml_document/tasks/main.yml
@@ -5,6 +5,22 @@
     state: directory
     path: \tmp\
 
+# first make sure we don't add more \r by removing all of them
+- name: change our results files to windowsstyle line endings (1/2)
+  shell: sed -i 's/\r//' results/*
+  args:
+    chdir: '{{ role_path }}'
+    warn: no
+  delegate_to: localhost
+
+# now add \r before each line ending
+- name: 'change our results file to windows-style line endings (2/2)'
+  shell: sed -i 's/$/\r/' results/*
+  args:
+    chdir: '{{ role_path }}'
+    warn: no
+  delegate_to: localhost
+
 - name: run tests
   block:
 

--- a/test/integration/targets/win_xml_document/tasks/main.yml
+++ b/test/integration/targets/win_xml_document/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: set up test directory
+  win_file:
+    state: directory
+    path: \tmp\
+
+- name: run tests
+  block:
+
+  - include_tasks: test-add-children-elements.yml
+  - include_tasks: test-add-children-from-groupvars.yml
+  - include_tasks: test-add-children-insertafter.yml
+  - include_tasks: test-add-children-insertbefore.yml
+  - include_tasks: test-add-children-with-attributes.yml
+  - include_tasks: test-add-element-implicitly.yml
+  - include_tasks: test-count.yml
+  - include_tasks: test-mutually-exclusive-attributes.yml
+  - include_tasks: test-remove-attribute.yml
+  - include_tasks: test-remove-element.yml
+  - include_tasks: test-set-attribute-value.yml
+  - include_tasks: test-set-children-elements.yml
+  - include_tasks: test-set-children-elements-level.yml
+  - include_tasks: test-set-element-value.yml
+  - include_tasks: test-set-element-value-empty.yml
+  - include_tasks: test-formatting-indent.yml
+  - include_tasks: test-formatting-no-indent.yml
+  - include_tasks: test-add-namespaced-children-elements.yml
+  - include_tasks: test-remove-namespaced-attribute.yml
+  - include_tasks: test-set-namespaced-attribute-value.yml
+  - include_tasks: test-set-namespaced-element-value.yml
+  - include_tasks: test-set-namespaced-children-elements.yml
+  - include_tasks: test-get-element-content.yml
+  - include_tasks: test-xmlstring.yml
+#  - include_tasks: test-children-elements-xml.yml todo? input only allows for yml formatted list
+
+  # Unicode tests
+  - include_tasks: test-add-children-elements-unicode.yml
+  - include_tasks: test-add-children-with-attributes-unicode.yml
+  - include_tasks: test-set-attribute-value-unicode.yml
+  - include_tasks: test-count-unicode.yml
+  - include_tasks: test-get-element-content.yml
+  - include_tasks: test-set-children-elements-unicode.yml
+  - include_tasks: test-set-element-value-unicode.yml
+  always:
+    - name: cleanup test directory
+      win_file:
+        state: absent
+        path: \tmp\

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-elements-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-elements-unicode.yml
@@ -1,0 +1,29 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+      - beer: Окское
+    register: add_children_elements_unicode
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-elements-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_elements_unicode.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-add-children-elements-unicode.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-elements.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-elements.yml
@@ -1,0 +1,29 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+      - beer: Old Rasputin
+    register: add_children_elements
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-elements.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_elements.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-add-children-elements.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-from-groupvars.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-from-groupvars.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children: '{{ bad_beers }}'
+    register: add_children_from_groupvars
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-from-groupvars.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_from_groupvars.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-add-children-from-groupvars.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-insertafter.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-insertafter.yml
@@ -1,0 +1,31 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: '/business/beers/beer[text()="St. Bernardus Abbot 12"]'
+      insertafter: yes
+      add_children:
+      - beer: Old Rasputin
+      - beer: Old Motor Oil
+      - beer: Old Curmudgeon
+    register: add_children_insertafter
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-insertafter.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_insertafter.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-insertbefore.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-insertbefore.yml
@@ -1,0 +1,31 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: '/business/beers/beer[text()="St. Bernardus Abbot 12"]'
+      insertbefore: yes
+      add_children:
+      - beer: Old Rasputin
+      - beer: Old Motor Oil
+      - beer: Old Curmudgeon
+    register: add_children_insertbefore
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-insertbefore.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_insertbefore.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-with-attributes-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-with-attributes-unicode.yml
@@ -1,0 +1,31 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+      - beer:
+          name: Окское
+          type: экстра
+    register: add_children_with_attributes_unicode
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-with-attributes-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_with_attributes_unicode.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-add-children-with-attributes-unicode.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-add-children-with-attributes.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-children-with-attributes.yml
@@ -1,0 +1,30 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+      - beer:
+          name: Ansible Brew
+          type: light
+    register: add_children_with_attributes
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-children-with-attributes.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_children_with_attributes.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-add-element-implicitly.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-element-implicitly.yml
@@ -1,0 +1,225 @@
+---
+- name: Setup test fixture
+  win_copy:
+    src: fixtures/ansible-xml-beers.xml
+    dest: \tmp\ansible-xml-beers-implicit.xml
+
+- name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/phonenumber
+    value: 555-555-1234
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name/last
+    value: Smith
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name/first
+    value: John
+
+- name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website/validxhtml
+
+- name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website/validxhtml/@validateon
+
+- name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website_bis/validxhtml/@validateon
+
+- name: Add an attribute with a value
+  win_xml_document:
+     file: /tmp/ansible-xml-beers-implicit.xml
+     xpath: /business/owner/@dob
+     value: '1976-04-12'
+
+- name: Add an element with a value, alternate syntax
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/beers/beer[text()="George Killian's Irish Red"]  # note the quote within an XPath string thing
+
+- name: Add an element without special characters
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/testnormalelement
+    value: xml tag with no special characters
+
+- name: Add an element with dash
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash
+    value: xml tag with dashes
+
+- name: Add an element with dot
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash.and.dot
+    value: xml tag with dashes and dots
+
+- name: Add an element with underscore
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with.dash_and.dot_and-underscores
+    value: xml tag with dashes, dots and underscores
+
+- name: Add an attribute on a conditional element
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/beers/beer[text()="George Killian's Irish Red"]/@color
+    value: red
+
+- name: Add two attributes on a conditional element
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/beers/beer[text()="Pilsner Urquell" and @origin='CZ']/@color
+    value: blonde
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name[first/text()='John']/middle
+    value: Q
+
+- name: Compare to expected result
+  win_copy:
+    src: results/test-add-element-implicitly.xml
+    dest: \tmp\ansible-xml-beers-implicit.xml
+  check_mode: yes
+  diff: yes
+  register: comparison
+
+- name: Test expected result
+  assert:
+    that:
+    - comparison.changed == false  # identical
+  #command: diff -u {{ role_path }}/results/test-add-element-implicitly.xml /tmp/ansible-xml-beers-implicit.xml
+
+
+# Now we repeat the same, just to ensure proper use of namespaces
+- name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:phonenumber
+    value: 555-555-1234
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name/a:last
+    value: Smith
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name/a:first
+    value: John
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website/a:validxhtml
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website/a:validxhtml/@a:validateon
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website_bis/a:validxhtml/@a:validateon
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an attribute with a value
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/@a:dob
+    value: '1976-04-12'
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an element with a value, alternate syntax
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer/text()
+    value: "George Killian's Irish Red"  # note the quote within an XPath string thing
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an attribute on a conditional element
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer[text()="George Killian's Irish Red"]/@a:color
+    value: 'red'
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add two attributes on a conditional element
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer[text()="Pilsner Urquell" and @a:origin='CZ']/@a:color
+    value: 'blonde'
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name[a:first/text()='John']/a:middle
+    value: Q
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an element without special characters
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/testnormalelement
+    value: xml tag with no special characters
+    namespaces:
+      a:  http://example.com/some/namespace
+
+
+- name: Add an element with dash
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash
+    value: xml tag with dashes
+    namespaces:
+      a:  http://example.com/some/namespace
+
+- name: Add an element with dot
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash.and.dot
+    value: xml tag with dashes and dots
+    namespaces:
+      a:  http://example.com/some/namespace
+
+- name: Add an element with underscore
+  win_xml_document:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with.dash_and.dot_and-underscores
+    value: xml tag with dashes, dots and underscores
+    namespaces:
+      a:  http://example.com/some/namespace

--- a/test/integration/targets/win_xml_document/tasks/test-add-namespaced-children-elements.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-add-namespaced-children-elements.yml
@@ -1,0 +1,32 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+
+
+  - name: Add namespaced child element
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/ber:beers
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+      add_children:
+      - beer: Old Rasputin
+    register: add_namespaced_children_elements
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-add-namespaced-children-elements.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+    check_mode: yes
+    diff: yes 
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - add_namespaced_children_elements.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-add-namespaced-children-elements.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-count-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-count-unicode.yml
@@ -1,0 +1,19 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers-unicode.xml
+      dest: \tmp\ansible-xml-beers-unicode.xml
+
+
+  - name: Count child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers-unicode.xml
+      xpath: /business/beers/beer
+      count: yes
+    register: beers
+
+  - name: Test expected result
+    assert:
+      that:
+      - beers.changed == false
+      - beers.count == 2

--- a/test/integration/targets/win_xml_document/tasks/test-count.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-count.yml
@@ -1,0 +1,19 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add child element
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers/beer
+      count: yes
+    register: beers
+
+  - name: Test expected result
+    assert:
+      that:
+      - beers.changed == false
+      - beers.count == 3

--- a/test/integration/targets/win_xml_document/tasks/test-formatting-indent.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-formatting-indent.yml
@@ -1,0 +1,57 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+  - name: Set indentation to 4 spaces
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      indent_spaces: 4
+    register: indent_result
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-formatting-indent-4.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - indent_result.changed == true
+      - comparison.changed == false  # identical
+
+  - name: Set indentation to 4 spaces (again)
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      indent_spaces: 4
+    register: indent_result
+
+  - name: Test expected result
+    assert:
+      that:
+      - indent_result.changed == false
+      - comparison.changed == false  # identical
+
+  - name: Set indentation to 0 spaces
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      indent_spaces: 0
+    register: indent_result
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-formatting-indent-0.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - indent_result.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-formatting-no-indent.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-formatting-no-indent.yml
@@ -1,0 +1,26 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Save as all one line
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      indent: no
+    register: noindent_result
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-formatting-no-indent.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - noindent_result.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-get-element-content-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-get-element-content-unicode.yml
@@ -1,0 +1,32 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers-unicode.xml
+      dest: \tmp\ansible-xml-beers-unicode.xml
+
+
+  - name: Get element attributes
+    win_xml_document:
+      path: \tmp\ansible-xml-beers-unicode.xml
+      xpath: /business/rating
+      content: attribute
+    register: get_element_attribute
+
+  - name: Test expected result
+    assert:
+      that:
+      - get_element_attribute.changed == false
+      - get_element_attribute.matches[0]['rating'] is defined and get_element_attribute.matches[0]['rating']['subjective'] == 'да'
+
+  - name: Get element text
+    win_xml_document:
+      path: \tmp\ansible-xml-beers-unicode.xml
+      xpath: /business/rating
+      content: text
+    register: get_element_text
+
+  - name: Test expected result
+    assert:
+      that:
+      - get_element_text.changed == false
+      - get_element_text.matches[0]['rating'] == 'десять'

--- a/test/integration/targets/win_xml_document/tasks/test-get-element-content.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-get-element-content.yml
@@ -1,0 +1,33 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Get element attributes
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      content: attribute
+    register: get_element_attribute
+
+  - name: Test expected result
+    assert:
+      that:
+      - get_element_attribute.changed == false
+      - get_element_attribute.matches[0]['rating'] is defined
+      - get_element_attribute.matches[0]['rating']['subjective'] == 'true'
+
+  - name: Get element text
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      content: text
+    register: get_element_text
+
+  - name: Test expected result
+    assert:
+      that:
+      - get_element_text.changed == false
+      - get_element_text.matches[0]['rating'] == '10'

--- a/test/integration/targets/win_xml_document/tasks/test-mutually-exclusive-attributes.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-mutually-exclusive-attributes.yml
@@ -1,0 +1,22 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Specify both children to add and a value
+    win_xml_document:
+        path: \tmp\ansible-xml-beers.xml
+        add_children:
+        - child01
+        - child02
+        value: conflict!
+    register: module_output
+    ignore_errors: yes
+
+  - name: Test expected result
+    assert:
+      that:
+      - module_output.changed == false
+      - module_output.failed == true

--- a/test/integration/targets/win_xml_document/tasks/test-remove-attribute.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-remove-attribute.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Remove '/business/rating/@subjective'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating/@subjective
+      state: absent
+    register: remove_attribute
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-remove-attribute.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - remove_attribute.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-remove-attribute.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-remove-element.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-remove-element.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Remove '/business/rating'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      state: absent
+    register: remove_element
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-remove-element.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - remove_element.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-remove-element.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-remove-namespaced-attribute.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-remove-namespaced-attribute.yml
@@ -1,0 +1,33 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+
+
+  - name: Remove namespaced '/bus:business/rat:rating/@attr:subjective'
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating/@attr:subjective
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      state: absent
+    register: remove_namespaced_attribute
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-remove-namespaced-attribute.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - remove_namespaced_attribute.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-remove-namespaced-attribute.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-remove-namespaced-element.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-remove-namespaced-element.yml
@@ -1,0 +1,33 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+
+
+  - name: Remove namespaced '/bus:business/rat:rating'
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      state: absent
+    register: remove_namespaced_element
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-remove-element.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - remove_namespaced_element.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-remove-element.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-attribute-value-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-attribute-value-unicode.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set '/business/rating/@subjective' to 'нет'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating/@subjective
+      value: нет
+    register: set_attribute_value_unicode
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-attribute-value-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_attribute_value_unicode.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-attribute-value-unicode.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-attribute-value.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-attribute-value.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set '/business/rating/@subjective' to 'false'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating/@subjective
+      value: 'false'
+    register: set_attribute_value
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-attribute-value.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_attribute_value.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-attribute-value.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-children-elements-level.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-children-elements-level.yml
@@ -1,0 +1,74 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set child elements
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: &children
+        - beer:
+            name: 90 Minute IPA
+            alcohol: "0.5"
+            _:
+              - Water:
+                  liter: "0.2"
+                  quantity: 200g
+              - Starch:
+                  quantity: 10g
+              - Hops:
+                  quantity: 50g
+              - Yeast:
+                  quantity: 20g
+        - beer:
+            alcohol: "0.3"
+            name: Harvest Pumpkin Ale
+            _:
+              - Water:
+                  liter: "0.2"
+                  quantity: 200g
+              - Hops:
+                  quantity: 25g
+              - Yeast:
+                  quantity: 20g
+    register: set_children_elements_level
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements-level.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_elements_level.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-children-elements-level.xml /tmp/ansible-xml-beers.xml
+
+
+  - name: Set child elements (again)
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: *children
+    register: set_children_again
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements-level.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_again.changed == false
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-set-children-elements-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-children-elements-unicode.yml
@@ -1,0 +1,53 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set child elements
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: &children
+      - beer: Окское
+      - beer: Невское
+    register: set_children_elements_unicode
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_elements_unicode.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-children-elements-unicode.xml /tmp/ansible-xml-beers.xml
+
+
+  - name: Set child elements (again)
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: *children
+    register: set_children_elements_unicode_again
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_elements_unicode_again.changed == false
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-children-elements-unicode.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-children-elements.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-children-elements.yml
@@ -1,0 +1,53 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set child elements
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: &children
+        - beer: 90 Minute IPA
+        - beer: Harvest Pumpkin Ale
+    register: set_children_elements
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_elements.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-children-elements.xml /tmp/ansible-xml-beers.xml
+
+
+  - name: Set child elements (again)
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children: *children
+    register: set_children_again
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-children-elements.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_again.changed == false
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-children-elements.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-element-value-empty.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-element-value-empty.yml
@@ -1,0 +1,28 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Set '/business/website/address' to empty string.
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/website/address
+      value: ''
+    register: set_element_value_empty
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-element-value-empty.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_element_value_empty.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-element-value-empty.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-element-value-unicode.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-element-value-unicode.yml
@@ -1,0 +1,43 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add 2nd '/business/rating' with value 'пять'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business
+      add_children:
+      - rating: пять
+
+  - name: Set '/business/rating' to 'пять'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      value: пять
+    register: set_element_first_run
+
+  - name: Set '/business/rating' to 'false'... again
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      value: пять
+    register: set_element_second_run
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-element-value-unicode.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_element_first_run.changed == true
+      - set_element_second_run.changed == false
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-element-value-unicode.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-element-value.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-element-value.yml
@@ -1,0 +1,43 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-beers.xml
+      dest: \tmp\ansible-xml-beers.xml
+
+
+  - name: Add 2nd '/business/rating' with value '5'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business
+      add_children:
+      - rating: '5'
+
+  - name: Set '/business/rating' to '5'
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      value: '5'
+    register: set_element_first_run
+
+  - name: Set '/business/rating' to '5'... again
+    win_xml_document:
+      path: \tmp\ansible-xml-beers.xml
+      xpath: /business/rating
+      value: '5'
+    register: set_element_second_run
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-element-value.xml
+      dest: \tmp\ansible-xml-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_element_first_run.changed == true
+      - set_element_second_run.changed == false
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-element-value.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-namespaced-attribute-value.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-namespaced-attribute-value.yml
@@ -1,0 +1,33 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+
+
+  - name: Set namespaced '/bus:business/rat:rating/@attr:subjective' to 'false'
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating/@attr:subjective
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      value: 'false'
+    register: set_namespaced_attribute_value
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-namespaced-attribute-value.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_namespaced_attribute_value.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-set-namespaced-attribute-value.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-set-namespaced-children-elements.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-namespaced-children-elements.yml
@@ -1,0 +1,57 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers-xml.xml
+
+  - name: Set child elements
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers-xml.xml
+      xpath: /bus:business/ber:beers
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+      set_children:
+      - beer: 90 Minute IPA
+      - beer: Harvest Pumpkin Ale
+
+  - name: Copy state after first set_children
+    win_copy:
+      src: /tmp/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers-1.xml
+      remote_src: yes
+
+  - name: Set child elements again
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers-xml.xml
+      xpath: /bus:business/ber:beers
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+      set_children:
+      - beer: 90 Minute IPA
+      - beer: Harvest Pumpkin Ale
+    register: set_children_again
+
+  - name: Copy state after second set_children
+    win_copy:
+      src: /tmp/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers-2.xml
+      remote_src: yes
+
+  - name: Compare to expected result
+    win_copy:
+      src: /tmp/ansible-xml-namespaced-beers-1.xml
+      dest: \tmp\ansible-xml-namespaced-beers-2.xml
+      remote_src: yes
+    check_mode: yes
+    diff: yes
+    register: comparison
+    #command: diff /tmp/ansible-xml-namespaced-beers-1.xml /tmp/ansible-xml-namespaced-beers-2.xml
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_children_again.changed == false  # idempotency
+      - set_namespaced_attribute_value.changed == true
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-set-namespaced-element-value.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-set-namespaced-element-value.yml
@@ -1,0 +1,46 @@
+---
+  - name: Setup test fixture
+    win_copy:
+      src: fixtures/ansible-xml-namespaced-beers.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+
+
+  - name: Set namespaced '/bus:business/rat:rating' to '11'
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      xpath: /bus:business/rat:rating
+      value: '11'
+    register: set_element_first_run
+
+  - name: Set namespaced '/bus:business/rat:rating' to '11' again
+    win_xml_document:
+      path: \tmp\ansible-xml-namespaced-beers.xml
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      xpath: /bus:business/rat:rating
+      value: '11'
+    register: set_element_second_run
+
+  - name: Compare to expected result
+    win_copy:
+      src: results/test-set-namespaced-element-value.xml
+      dest: \tmp\ansible-xml-namespaced-beers.xml
+    check_mode: yes
+    diff: yes
+    register: comparison
+    #command: diff -u {{ role_path }}/results/test-set-namespaced-element-value.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Test expected result
+    assert:
+      that:
+      - set_element_first_run.changed == true
+      - set_element_second_run.changed == false
+      - comparison.changed == false  # identical

--- a/test/integration/targets/win_xml_document/tasks/test-xmlstring.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-xmlstring.yml
@@ -1,0 +1,57 @@
+---
+  - name: Copy expected result to remote
+    win_copy:
+      src: 'fixtures/ansible-xml-beers.xml'
+      dest: '\tmp\test-xmlstring.xml'
+
+  # NOTE: Jinja2 templating eats trailing newlines
+  - name: Read from xmlstring
+    win_xml_document:
+      xmlstring: "{{ lookup('file', '{{ role_path }}/fixtures/ansible-xml-beers.xml') }}"
+      xpath: .
+    register: xmlresponse
+
+  - name: Compare to expected result
+    win_copy:
+      content: "{{ xmlresponse.xmlstring }}\r\n"
+      dest: '\tmp\test-xmlstring.xml'
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  - name: Test expected result
+    assert:
+      that:
+      - xmlresponse.changed == false
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/fixtures/ansible-xml-beers.xml /tmp/ansible-xml-beers.xml
+
+  - name: Copy expected result to remote
+    win_copy:
+      src: 'results/test-add-children-elements.xml'
+      dest: '\tmp\test-xmlstring.xml'
+
+  # NOTE: Jinja2 templating eats trailing newlines
+  - name: Read from xmlstring
+    win_xml_document:
+      xmlstring: "{{ lookup('file', '{{ role_path }}/fixtures/ansible-xml-beers.xml') }}"
+      xpath: /business/beers
+      add_children:
+      - beer: Old Rasputin
+    register: xmlresponse_modification
+
+  - name: Compare to expected result
+    win_copy:
+      content: '{{ xmlresponse_modification.xmlstring }}'
+      dest: '/tmp/test-xmlstring.xml'
+    check_mode: yes
+    diff: yes
+    register: comparison
+
+  # FIXME: This change is related to the newline added by pretty_print
+  - name: Test expected result
+    assert:
+      that:
+      - xmlresponse_modification.changed == true
+      - comparison.changed == false  # identical
+    #command: diff -u {{ role_path }}/results/test-pretty-print.xml /tmp/ansible-xml-beers.xml

--- a/test/integration/targets/win_xml_document/tasks/test-xmlstring.yml
+++ b/test/integration/targets/win_xml_document/tasks/test-xmlstring.yml
@@ -1,13 +1,13 @@
 ---
   - name: Copy expected result to remote
     win_copy:
-      src: 'fixtures/ansible-xml-beers.xml'
+      src: 'results/test-xmlstring.xml'
       dest: '\tmp\test-xmlstring.xml'
 
   # NOTE: Jinja2 templating eats trailing newlines
   - name: Read from xmlstring
     win_xml_document:
-      xmlstring: "{{ lookup('file', '{{ role_path }}/fixtures/ansible-xml-beers.xml') }}"
+      xmlstring: "{{ lookup('file', '{{ role_path }}/results/test-xmlstring.xml') }}"
       xpath: .
     register: xmlresponse
 
@@ -34,7 +34,7 @@
   # NOTE: Jinja2 templating eats trailing newlines
   - name: Read from xmlstring
     win_xml_document:
-      xmlstring: "{{ lookup('file', '{{ role_path }}/fixtures/ansible-xml-beers.xml') }}"
+      xmlstring: "{{ lookup('file', '{{ role_path }}/results/test-xmlstring.xml') }}"
       xpath: /business/beers
       add_children:
       - beer: Old Rasputin

--- a/test/integration/targets/win_xml_document/vars/main.yml
+++ b/test/integration/targets/win_xml_document/vars/main.yml
@@ -1,0 +1,6 @@
+# -*- mode: yaml -*
+---
+bad_beers:
+- beer: "Natty Lite"
+- beer: "Miller Lite"
+- beer: "Coors Lite"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a new module for working with xml files on Windows that behaves closer to the standard `xml` module than the current `win_xml` module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_xml_document
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
`win_xml` is very useful for adding/ensuring static fragments of xml are in a file, but isn't a good way to update a specific tag or attribute value. `win_xml_document` is different by providing a way to both ensure a specific tag or attribute exists, and update the value if desired:

consider the following xml:
```xml
<business type="bar">
   <name>Tasty Beverage Co.</name>
     <beers>
       <beer>Rochefort 10</beer>
       <beer>St. Bernardus Abbot 12</beer>
       <beer>Schlitz</beer>
    </beers>
   <rating subjective="true">10</rating>
   <website>
     <mobilefriendly/>
     <address>http://tastybeverageco.com</address>
   </website>
 </business>
```

we can add a phone number element to the business element using `win_xml` like so:
```
win_xml:
  path: \foo\bar.xml
  xpath: /business
  fragment: '<phonenumber region="NA">555-555-1234</phonenumber>'
```
to get
```xml
...
       <beer>Schlitz</beer>
    </beers>
   <rating subjective="true">10</rating>
   <phonenumber region="NA">555-555-1234</phonenumber>
   <website>
...
```
but if we wanted to change the phone number using the same module, changing the fragment value will add another <phonenumber> element, not edit the one already there.

```
win_xml:
  path: \foo\bar.xml
  xpath: /business
  fragment: '<phonenumber region="NA">555-555-4321</phonenumber>'
```
yields
```xml
...
       <beer>Schlitz</beer>
    </beers>
   <rating subjective="true">10</rating>
   <phonenumber region="NA">555-555-1234</phonenumber>
   <phonenumber region="NA">555-555-4321</phonenumber>
   <website>
...
```
This module behaves closer to the standard `xml` module, where you can pass in an xpath and it will implicitly create missing elements. I tried to mimic the interface from the `xml` module as much as possible, with a few differences that are explained in the notes section of the documentation, such as removing the `attribute` option (just select the attribute with xpath instead).

It always "pretty prints" the document, so I used the `indent` and `indent_spaces` options to help control the formatting.

I named it `win_xml_document` because it expects the file to be a full and well-formed xml document, (and win_xml was already taken).
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
with the same xml file, we can do the following operations
```
# make sure the phone number tag is present and give it a value
win_xml_document:
  path: \foo\bar.xml
  xpath: /business/phonenumber[@region="NA"]
  value: 555-555-1234

# change the phone number
win_xml_document
  path: \foo\bar.xml
  xpath: /business/phonenumber[@region="NA"]
  value: 555-555-4321

# change the region attribute
win_xml_document
  path: \foo\bar.xml
  xpath: /business/phonenumber/@region
  value: EU
```

For tests, I just ported from the standard xml module to make sure the functionality was as similar as possible. I did have to change  the formatting of a few of the integration test results (but the structure of the documents are the same) because the XmlDocument/Writer in .NET will always make sure the attribute quotes are consistent, and the pretty print tests didn't make sense with the .net writer object since it always formats the xml when saving, there are just options for _how_ to format it.
