### PR TITLE
Backport PR to resolve CP domain login issue

### DIFF
--- a/changelogs/fragments/63976-enable-login-to-any-domain-check_point.yaml
+++ b/changelogs/fragments/63976-enable-login-to-any-domain-check_point.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - enable login to any domain in the check point management server.
+  - PR(https://github.com/ansible/ansible/pull/63976)

--- a/lib/ansible/plugins/httpapi/checkpoint.py
+++ b/lib/ansible/plugins/httpapi/checkpoint.py
@@ -14,6 +14,13 @@ description:
   - This HttpApi plugin provides methods to connect to Checkpoint
     devices over a HTTP(S)-based api.
 version_added: "2.8"
+options:
+  domain:
+    type: str
+    description:
+      - Specifies the domain of the Check Point device
+    vars:
+      - name: ansible_checkpoint_domain
 """
 
 import json
@@ -32,7 +39,11 @@ BASE_HEADERS = {
 class HttpApi(HttpApiBase):
     def login(self, username, password):
         if username and password:
-            payload = {'user': username, 'password': password}
+            cp_domain = self.get_option('domain')
+            if cp_domain:
+                payload = {'user': username, 'password': password, 'domain': cp_domain}
+            else:
+                payload = {'user': username, 'password': password}
             url = '/web_api/login'
             response, response_data = self.send_request(url, payload)
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cherry-pick from: 3a0c6454a96ff175d8b62dc49e91a3fc1972f64e
Backport PR to enable login to any domain in the check point management server.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of https://github.com/ansible/ansible/pull/63976

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
check_point

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
