### PR TITLE
debian: install lib in dist-packages (#64412)

### DIFF
--- a/packaging/debian/ansible.dirs
+++ b/packaging/debian/ansible.dirs
@@ -1,4 +1,4 @@
 etc/ansible
 etc/ansible/roles
-usr/lib/python2.7/site-packages
+usr/lib/python2.7/dist-packages/ansible
 usr/share/ansible

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -2,14 +2,16 @@
 # -- makefile --
 
 DEB_PYTHON2_MODULE_PACKAGES=ansible ansible_test
+#DEB_PYTHON_INSTALL_ARGS_ALL="--install-purelib=/usr/lib/python2.7/site-packages/"
+DEB_PYTHON_DISTUTILS_INSTALLDIR_SKEL = /usr/lib/@PYTHONBINARY@/dist-packages/
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk
 
+# dist-packages for the modern distro, site-packages for the older (e.g: Ubuntu 14.04)
 ifeq ($(shell lsb_release -cs), precise)
   export ANSIBLE_CRYPTO_BACKEND = pycrypto
 endif
 ifeq ($(shell lsb_release -cs), trusty)
   export ANSIBLE_CRYPTO_BACKEND = pycrypto
 endif
-


### PR DESCRIPTION
##### SUMMARY

Backport of: https://github.com/ansible/ansible/pull/64412

On Ubuntu Precise and Trusty, the build was failing because the Ansible
libs were installed in /usr/lib/python2.7/site-packages.

According to the Debian Policy (2.5), they should actually be install in
/usr/lib/python2.7/dist-packages This is also CDBS default behaviour since
0.4.131.

See: https://www.debian.org/doc/packaging-manuals/python-policy/ch-python.html

Closes: #64160

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
packaging/debian