### PR TITLE
[2.9] ansible-test: bumping ACME test container version

### DIFF
--- a/changelogs/fragments/64424-ansible-test-acme-container.yml
+++ b/changelogs/fragments/64424-ansible-test-acme-container.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - bump version of ACME test container. The new version includes updated dependencies."

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -45,7 +45,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.8.0'
+            self.image = 'quay.io/ansible/acme-test-container:1.9.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Backport of #64424 to stable-2.9.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/cloud/acme.py
