### PR TITLE
Fixes azure_rm_manageddisk data_disks not idempotent

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -460,6 +460,8 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             self.log('Did not find managed disk')
 
     def is_attach_caching_option_different(self, vm_name, disk):
+        if self.attach_caching is None:
+            return False
         resp = False
         if vm_name:
             vm = self._get_vm(vm_name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When `attach_caching` is not set, modules defaults to None. Then disk is created without caching (`caching.name == 'none'`) but `self.attach_caching == ''` is false causing module to detach and attach disks all the time.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
