### PR TITLE
win_psmodule - remove reliance on PSGallery in the tests for stable-2.7

### DIFF
--- a/test/integration/targets/win_psmodule/defaults/main.yml
+++ b/test/integration/targets/win_psmodule/defaults/main.yml
@@ -1,7 +1,0 @@
----
-
-powershell_module: powershell-yaml
-wrong_module: powershell_yaml
-allow_clobber_module: PowerShellCookbook
-custom_repo_path: C:\_repo
-custom_repo_name: PSRegisterRepo

--- a/test/integration/targets/win_psmodule/files/module/template.nuspec
+++ b/test/integration/targets/win_psmodule/files/module/template.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>--- NAME ---</id>
+    <version>--- VERSION ---</version>
+    <authors>Ansible</authors>
+    <owners>Ansible</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Test for Ansible win_ps* modules</description>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright (c) 2019 Ansible, licensed under MIT.</copyright>
+    <tags>PSModule PSIncludes_Function PSFunction_--- FUNCTION --- PSCommand_--- FUNCTION ---</tags>
+  </metadata>
+</package>

--- a/test/integration/targets/win_psmodule/files/module/template.psd1
+++ b/test/integration/targets/win_psmodule/files/module/template.psd1
@@ -1,0 +1,17 @@
+@{
+    RootModule = '--- NAME ---.psm1'
+    ModuleVersion = '--- VERSION ---'
+    GUID = '--- GUID ---'
+    Author = 'Ansible'
+    Copyright = 'Copyright (c) 2019 Ansible, licensed under MIT.'
+    Description = "Test for Ansible win_ps* modules"
+    PowerShellVersion = '3.0'
+    FunctionsToExport = @(
+        "--- FUNCTION ---"
+    )
+    PrivateData = @{
+        PSData = @{
+--- PS_DATA ---
+        }
+    }
+}

--- a/test/integration/targets/win_psmodule/files/module/template.psm1
+++ b/test/integration/targets/win_psmodule/files/module/template.psm1
@@ -1,0 +1,9 @@
+Function --- FUNCTION --- {
+    return [PSCustomObject]@{
+        Name = "--- NAME ---"
+        Version = "--- VERSION ---"
+        Repo = "--- REPO ---"
+    }
+}
+
+Export-ModuleMember -Function --- FUNCTION ---

--- a/test/integration/targets/win_psmodule/files/setup_modules.ps1
+++ b/test/integration/targets/win_psmodule/files/setup_modules.ps1
@@ -1,0 +1,57 @@
+$ErrorActionPreference = "Stop"
+
+$template_path = $args[0]
+$template_manifest = Join-Path -Path $template_path -ChildPath template.psd1
+$template_script = Join-Path -Path $template_path -ChildPath template.psm1
+$template_nuspec = Join-Path -Path $template_path -ChildPath template.nuspec
+$nuget_exe = Join-Path -Path $template_path -ChildPath nuget.exe
+
+$packages = @(
+    @{ name = "ansible-test1"; version = "1.0.0"; repo = "PSRepo 1"; function = "Get-AnsibleTest1" },
+    @{ name = "ansible-clobber"; version = "1.0.0"; repo = "PSRepo 1"; function = "Enable-PSTrace" }
+)
+
+foreach ($package in $packages) {
+    $tmp_dir = Join-Path -Path $template_path -ChildPath $package.name
+    if (Test-Path -Path $tmp_dir) {
+        Remove-Item -Path $tmp_dir -Force -Recurse
+    }
+    New-Item -Path $tmp_dir -ItemType Directory > $null
+
+    try {
+        $ps_data = ""
+        $nuget_version = $package.version
+
+        $manifest = [System.IO.File]::ReadAllText($template_manifest)
+        $manifest = $manifest.Replace('--- NAME ---', $package.name).Replace('--- VERSION ---', $package.version)
+        $manifest = $manifest.Replace('--- GUID ---', [Guid]::NewGuid()).Replace('--- FUNCTION ---', $package.function)
+
+        $manifest = $manifest.Replace('--- PS_DATA ---', $ps_data)
+        $manifest_path = Join-Path -Path $tmp_dir -ChildPath "$($package.name).psd1"
+        Set-Content -Path $manifest_path -Value $manifest
+
+        $script = [System.IO.File]::ReadAllText($template_script)
+        $script = $script.Replace('--- NAME ---', $package.name).Replace('--- VERSION ---', $package.version)
+        $script = $script.Replace('--- REPO ---', $package.repo).Replace('--- FUNCTION ---', $package.function)
+        $script_path = Join-Path -Path $tmp_dir -ChildPath "$($package.name).psm1"
+        Set-Content -Path $script_path -Value $script
+
+        # We should just be able to use Publish-Module but it fails when running over WinRM for older hosts and become
+        # does not fix this. It fails to respond to nuget.exe push errors when it canno find the .nupkg file. We will
+        # just manually do that ourselves. This also has the added benefit of being a lot quicker than Publish-Module
+        # which seems to take forever to publish the module.
+        $nuspec = [System.IO.File]::ReadAllText($template_nuspec)
+        $nuspec = $nuspec.Replace('--- NAME ---', $package.name).Replace('--- VERSION ---', $nuget_version)
+        $nuspec = $nuspec.Replace('--- FUNCTION ---', $package.function)
+        Set-Content -Path (Join-Path -Path $tmp_dir -ChildPath "$($package.name).nuspec") -Value $nuspec
+
+        &$nuget_exe pack "$tmp_dir\$($package.name).nuspec" -outputdirectory $tmp_dir
+
+        $repo_path = Join-Path -Path $template_path -ChildPath $package.repo
+        $nupkg_filename = "$($package.name).$($nuget_version).nupkg"
+        Copy-Item -Path (Join-Path -Path $tmp_dir -ChildPath $nupkg_filename) `
+            -Destination (Join-Path -Path $repo_path -ChildPath $nupkg_filename)
+    } finally {
+        Remove-Item -Path $tmp_dir -Force -Recurse
+    }
+}

--- a/test/integration/targets/win_psmodule/handlers/main.yml
+++ b/test/integration/targets/win_psmodule/handlers/main.yml
@@ -1,0 +1,22 @@
+- name: delete temporary directory
+  win_file:
+    path: "{{ remote_tmp_dir }}"
+    state: absent
+
+- name: re-add PSGallery repository
+  win_shell: Register-PSRepository -Default -InstallationPolicy Untrusted
+
+- name: remove registered repo
+  win_shell: |
+    $name = 'PSRepo 1'
+    if ((Get-PSRepository -Name $name -ErrorAction SilentlyContinue)) {
+        Unregister-PSRepository -Name $name
+    }
+
+- name: remove test packages
+  win_psmodule:
+    name: '{{ item }}'
+    state: absent
+  loop:
+  - ansible-test1
+  - ansible-clobber

--- a/test/integration/targets/win_psmodule/tasks/install.yml
+++ b/test/integration/targets/win_psmodule/tasks/install.yml
@@ -1,0 +1,60 @@
+# Updates PackageManagement to the required version so the module won't try and talk to PSGallery
+---
+- name: create the required folder for the nuget provider dll
+  win_file:
+    path: C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208
+    state: directory
+
+- name: download nuget provider dll
+  win_get_url:
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_psget/Microsoft.PackageManagement.NuGetProvider-2.8.5.208.dll
+    dest: C:\Program Files\PackageManagement\ProviderAssemblies\nuget\2.8.5.208\Microsoft.PackageManagement.NuGetProvider.dll
+
+- name: get version and install location of PackageManagement and PowerShellGet
+  win_shell: |
+    $info = @{}
+    $modules = Get-Module -ListAvailable | Where-Object {
+        ($_.Name -eq "PackageManagement" -and $_.Version -lt "1.1.7") -or `
+        ($_.Name -eq "PowerShellGet" -and $_.Version -lt "1.6.0")
+    } | ForEach-Object {
+        $module_version = switch($_.Name) {
+            PackageManagement { "1.1.7.0" }
+            PowerShellGet { "1.6.0" }
+        }
+        $module_info = @{
+            install_path = ([System.IO.Path]::Combine([System.IO.Path]::GetDirectoryName($_.ModuleBase), $module_version))
+        }
+        $info.($_.Name) = $module_info
+    }
+    ConvertTo-Json -InputObject $info -Compress
+  changed_when: False
+  register: installed_modules
+
+- name: register installed_modules info
+  set_fact:
+    installed_modules: '{{ installed_modules.stdout | trim | from_json }}'
+
+- name: update the PackageManagement and PowerShellGet versions
+  when: installed_modules.keys() | list | length > 0
+  block:
+  - name: download newer PackageManagement and PowerShellGet nupkg
+    win_get_url:
+      url: '{{ item.url }}'
+      dest: '{{ remote_tmp_dir }}\{{ item.name }}.zip'  # .zip is required for win_unzip
+    when: item.name in installed_modules
+    loop:
+    - name: PackageManagement
+      url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_psget/packagemanagement.1.1.7.nupkg
+    - name: PowerShellGet
+      url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_psget/powershellget.1.6.0.nupkg
+
+  - name: extract new modules to correct location
+    win_unzip:
+      src: '{{ remote_tmp_dir }}\{{ item.name }}.zip'
+      dest: '{{ item.path }}'
+    when: item.path != ""
+    loop:
+    - name: PackageManagement
+      path: '{{ installed_modules.PackageManagement.install_path | default("") }}'
+    - name: PowerShellGet
+      path: '{{ installed_modules.PowerShellGet.install_path | default("") }}'

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -1,28 +1,29 @@
-# test code for the win_psmodule module when using winrm connection
-# (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+---
+- name: get PowerShell version of the host
+  win_shell: $PSVersionTable.PSVersion.Major
+  changed_when: False
+  register: ps_version
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-
-- name: get facts
-  setup:
-
-- name: Perform integration tests for Powershell 5+
-  when: ansible_powershell_version >= 5
+- name: setup and run tests block
+  when: ps_version.stdout | trim | int >= 5
   block:
+  - name: create temporary directory
+    win_tempfile:
+      state: directory
+      suffix: .test
+    register: remote_tmp_dir
+    notify:
+    - delete temporary directory
 
-    - name: run all tasks
-      include: test.yml
+  - name: record temporary directory
+    set_fact:
+      remote_tmp_dir: '{{ remote_tmp_dir.path }}'
+
+  - name: update PSGet and PackageManagement for tests
+    include_tasks: install.yml
+
+  - name: setup local PSRepository with test modules
+    include_tasks: repo.yml
+
+  - name: test win_psmodule
+    include_tasks: test.yml

--- a/test/integration/targets/win_psmodule/tasks/repo.yml
+++ b/test/integration/targets/win_psmodule/tasks/repo.yml
@@ -1,0 +1,60 @@
+# Sets up a local repo that contains mock packages for testing.
+#
+# PSRepo 1 contains
+#     ansible-test1 - 1.0.0
+#     ansible-clobber - 1.0.0
+#
+# These modules will have the following cmdlets
+#     ansible-test1
+#         Get-AnsibleTest1
+#
+#     ansible-clobber
+#         Enable-PSTrace (clobbers the Enable-PSTrace cmdlet)
+#
+# All cmdlets return
+#     [PSCustomObject]@{
+#         Name = "the name of the module"
+#         Version = "the version of the module"
+#         Repo = "the repo where the module was sourced from"
+#     }
+---
+- name: create test repo folder
+  win_file:
+    path: '{{ remote_tmp_dir }}\PSRepo 1'
+    state: directory
+
+- name: register test repo
+  win_shell: |
+    $name = 'PSRepo 1'
+    $source_location = '{{ remote_tmp_dir }}\PSRepo 1'
+    if (-not (Get-PSRepository -Name $name -ErrorAction SilentlyContinue)) {
+        Register-PSRepository -Name $name -SourceLocation $source_location -InstallationPolicy Trusted
+    }
+  notify: remove registered repo
+
+- name: remove PSGallery repository
+  win_shell: |
+    if ((Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue)) {
+        Unregister-PSRepository -Name 'PSGallery'
+        $true
+    } else {
+        $false
+    }
+  register: remove_gallery
+  changed_when: remove_gallery.stdout | trim | bool
+  notify: re-add PSGallery repository
+
+- name: copy across module template files
+  win_copy:
+    src: module/
+    dest: '{{ remote_tmp_dir }}'
+
+# Used in the script below to create the .nupkg for each test module
+- name: download NuGet binary for module publishing
+  win_get_url:
+    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_psmodule/nuget.exe
+    dest: '{{ remote_tmp_dir }}'
+
+- name: create test PowerShell modules
+  script: setup_modules.ps1 "{{ remote_tmp_dir }}"
+  notify: remove test packages

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -1,20 +1,24 @@
 ---
-
-- name: install module from Powershell Gallery
+- name: install module
   win_psmodule:
-    name: "{{ powershell_module }}"
+    name: ansible-test1
     state: present
   register: module_setup
+
+- name: test that module is installed
+  win_shell: Import-Module -Name ansible-test1; Get-AnsibleTest1 | ConvertTo-Json
+  register: module_setup_actual
 
 - name: test Powershell Gallery module setup
   assert:
     that:
       - "module_setup is changed"
-      - "module_setup.output == 'Module {{ powershell_module }} installed'"
+      - "module_setup.output == 'Module ansible-test1 installed'"
+      - module_setup_actual.stdout | from_json == {"Name":"ansible-test1","Version":"1.0.0","Repo":"PSRepo 1"}
 
 - name: check idempotency reinstalling module
   win_psmodule:
-    name: "{{ powershell_module }}"
+    name: ansible-test1
     state: present
   register: module_reinstall
 
@@ -25,7 +29,7 @@
 
 - name: check module install with allow_clobber not active
   win_psmodule:
-    name: "{{ allow_clobber_module }}"
+    name: ansible-clobber
   register: fail_allow_clobber
   ignore_errors: yes
 
@@ -36,18 +40,23 @@
 
 - name: check module install with allow_clobber active
   win_psmodule:
-    name: "{{ allow_clobber_module }}"
+    name: ansible-clobber
     allow_clobber: yes
   register: ok_allow_clobber
+
+- name: get result of install with allow_clobber active
+  win_shell: Import-Module -Name ansible-clobber; Enable-PSTrace | ConvertTo-Json
+  register: ok_allow_clobber_actual
 
 - name: test module install with allow_clobber active
   assert:
     that:
       - "ok_allow_clobber is changed"
+      - ok_allow_clobber_actual.stdout | from_json == {"Name":"ansible-clobber","Version":"1.0.0","Repo":"PSRepo 1"}
 
 - name: check wrong module install attempt
-  win_psmodule: 
-    name: "{{ wrong_module }}"
+  win_psmodule:
+    name: fake_module
     state: present
   ignore_errors: yes
   register: module_fail
@@ -59,7 +68,7 @@
 
 - name: check fake custom ps repository registration attempt
   win_psmodule:
-    name: "{{ wrong_module }}"
+    name: fake_module
     repository: Fake repository
     url: http://my_fake_repo.com/repo/
   ignore_errors: yes
@@ -70,48 +79,26 @@
     that:
       - "repo_fail is failed"
 
-- name: check module is installed
-  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
-  register: module_check
-
-- name: test module is installed
-  assert:
-    that:
-      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
-
-- name: check allow_clobber module is installed
-  win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
-  register: allow_clobber_check
-
-- name: test allow_clobber module is installed
-  assert:
-    that:
-      - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
-
 - name: remove installed powershell module
   win_psmodule:
-    name: powershell-yaml
+    name: ansible-test1
     state: absent
   register: module_uninstall
+
+- name: get result of remove installed powershell module
+  win_shell: (Get-Module -ListAvailable -Name ansible-test1 | Measure-Object).Count
+  register: module_uninstall_actual
 
 - name: test powershell module removal
   assert:
     that:
       - "module_uninstall is changed"
-      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
-
-- name: check module is uninstalled
-  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
-  register: module_check
-
-- name: test module is no more present
-  assert:
-    that:
-      - "module_check.stdout == ''"
+      - "module_uninstall.output == 'Module ansible-test1 removed'"
+      - module_uninstall_actual.stdout | trim | int == 0
 
 - name: check idempotency re-removing module
   win_psmodule:
-    name: "{{ powershell_module }}"
+    name: ansible-test1
     state: absent
   register: module_uninstall_2
 
@@ -122,7 +109,7 @@
 
 - name: check removing allow_clobber module
   win_psmodule:
-    name: "{{ allow_clobber_module }}"
+    name: ansible-clobber
     state: absent
   register: module_uninstall_3
 
@@ -131,77 +118,3 @@
     that:
       - "module_uninstall_2 is not changed"
       - "module_uninstall_3 is changed"
-
-- name: Create repository path
-  win_file:
-    path: "{{custom_repo_path}}"
-    state: directory
-
-- name: Make sure sample module is uninstalled
-  win_psmodule:
-    name: "{{ powershell_module }}"
-    state: absent
-  register: module_uninstall_4
-
-- name: Copy some module to custom repo
-  win_shell: |
-
-    # Need PSGet 1.6.0 for publishing and named repo usage
-    $psg = [PSCustomObject]@{ n="PowerShellGet"; v="1.6.0"};
-    Remove-Module -Name $psg.n -Force -EA SilentlyContinue;
-    Import-PackageProvider -Name $psg.n -RequiredVersion $psg.v -EV missingProvider -Force | Out-Null;
-
-    if($missingProvider){
-      Install-PackageProvider -Name $psg.n -RequiredVersion $psg.v -Confirm:$false -Force | Out-Null;
-      
-      # Unload previous version
-      Remove-Module -Name $psg.n -Force -EA SilentlyContinue;
-      Import-PackageProvider -Name $psg.n -RequiredVersion $psg.v -Force | Out-Null;
-    }
-
-    $modName = "{{powershell_module}}";
-    $temp = $env:Temp;
-
-    Save-Module -Name $modName -Repository PSGallery -Path $temp | Out-Null;
-
-    $repoName = "{{custom_repo_name}}";
-    $repoPath = "{{custom_repo_path}}";
-
-    if(!(Test-Path $repoPath)){
-      New-Item -Type Directory $repoPath -Force | Out-Null;
-    }
-
-    Register-PSRepository -Name $repoName -SourceLocation $repoPath -InstallationPolicy Trusted | Out-Null;
-    
-    Publish-Module -Path "$temp\\$modName" -Repository $repoName -Force -Confirm:$false | Out-Null;
-    Get-ChildItem "$repoPath\\*" | ? Name -match "$modName.*.nupkg" | % Name;
-    
-  register: saved_package
-
-- name: Validate sample module in custom repo
-  assert:
-    that:
-      - "powershell_module in (saved_package.stdout_lines | last)"
-
-- name: Install module from custom Powershell repository
-  win_psmodule:
-    name: "{{ powershell_module }}"
-    state: present
-    repository: "{{custom_repo_name}}"
-    url: "{{custom_repo_path}}"
-  register: module_from_custom_repo
-
-- name: Test custom Powershell repository module install
-  assert:
-    that:
-      - "module_from_custom_repo is changed"
-      - "module_from_custom_repo.output == 'Module {{ powershell_module }} installed'"
-
-- name: Verify module was installed from custom repo
-  win_shell: (Get-InstalledModule -Name "{{powershell_module}}").Repository
-  register: is_package_customrepo
-
-- name: Validate sample module is installed from custom repo
-  assert:
-    that:
-      - "is_package_customrepo.stdout_lines[0] == custom_repo_name"

--- a/test/sanity/pslint/skip.txt
+++ b/test/sanity/pslint/skip.txt
@@ -1,1 +1,3 @@
 test/integration/targets/win_ping/library/win_ping_syntax_error.ps1
+test/integration/targets/win_psmodule/files/module/template.psd1
+test/integration/targets/win_psmodule/files/module/template.psm1


### PR DESCRIPTION
##### SUMMARY
This attempts to backport the testing changes for win_psmodule present in stable-2.8 and onwards to the stable-2.7 branch. It is designed to remove the reliance on the external PSGallery site which is prone to temporary communication issues.

The tests themselves have stayed largely the same but now we setup a local repo and install test packages from there.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule tests