### PR TITLE
Add warning about winrm on MacoS

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -27,6 +27,14 @@ with the Ansible package, but can be installed by running the following:
 .. Note:: on distributions with multiple python versions, use pip2 or pip2.x,
     where x matches the python minor version Ansible is running under.
 
+.. Warning::
+     Using the ``winrm`` or ``psrp`` connection plugins in Ansible on MacOS in
+     the latest releases typically fail. This is a known problem that occurs
+     deep within the Python stack and cannot be changed by Ansible. The only
+     workaround today is to set the environment variable ``no_proxy=*`` and
+     avoid using Kerberos auth.
+
+
 Authentication Options
 ``````````````````````
 When connecting to a Windows host, there are several different options that can be used


### PR DESCRIPTION
##### SUMMARY
MacOS Catalina makes running winrm under Ansible even harder than before. The only way to workaround this issue is to set `no_proxy=*` in your environment vars and avoid using Kerberos in any way. This is to just document the issue as we in Ansible cannot really do anything about this.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
winrm