### PR TITLE
[stable-2.9] Fix ansible-test collections sanity import test. (#64467)

### DIFF
--- a/changelogs/fragments/ansible-test-collections-import-sanity-test.yml
+++ b/changelogs/fragments/ansible-test-collections-import-sanity-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly reports import errors for collections when running the import sanity test


### PR DESCRIPTION
##### SUMMARY
[stable-2.9] Fix ansible-test collections sanity import test. (#64467)

* Fix ansible-test collections sanity import test.

Resolves https://github.com/ansible/ansible/issues/64466

* Fix get_source implementation also.

* Fix is_package function.

Backport of https://github.com/ansible/ansible/pull/64467

(cherry picked from commit adcf9458f1732b02bd709d60fa294e66b0607b75)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
