### PR TITLE
Add a random component to state machine name in aws_step_functions_st…

### DIFF
--- a/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
+++ b/test/integration/targets/aws_step_functions_state_machine/defaults/main.yml
@@ -1,2 +1,3 @@
-state_machine_name: "{{ resource_prefix }}_step_functions_state_machine_ansible_test"
+# the random_num is generated in a set_fact task at the start of the testsuite
+state_machine_name: "{{ resource_prefix }}_step_functions_state_machine_ansible_test_{{ random_num }}"
 step_functions_role_name: "ansible-test-sts-{{ resource_prefix }}-step_functions-role"

--- a/test/integration/targets/aws_step_functions_state_machine/tasks/main.yml
+++ b/test/integration/targets/aws_step_functions_state_machine/tasks/main.yml
@@ -31,7 +31,7 @@
 
     - name: Create a random component for state machine name
       set_fact:
-        random_num: "{{ 100 | random }}"
+        random_num: "{{ 999999999 | random }}"
 
     - name: Create a new state machine -- check_mode
       aws_step_functions_state_machine:

--- a/test/integration/targets/aws_step_functions_state_machine/tasks/main.yml
+++ b/test/integration/targets/aws_step_functions_state_machine/tasks/main.yml
@@ -29,6 +29,10 @@
 
     # ==== Tests ===================================================
 
+    - name: Create a random component for state machine name
+      set_fact:
+        random_num: "{{ 100 | random }}"
+
     - name: Create a new state machine -- check_mode
       aws_step_functions_state_machine:
         name: "{{ state_machine_name }}"


### PR DESCRIPTION
…ate_machine testsuite

##### SUMMARY
Add a random component to the name of the state machine in aws_step_functions_state_machine testsuite.

This makes sure that when the testsuite is retried on a failure, the name of the state machine used in the second attempt is different from the one used in the first attempt.

Fixes the issue seen in this test run - https://app.shippable.com/github/ansible/ansible/runs/149434/120/tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_step_functions_state_machine

##### ADDITIONAL INFORMATION
Deleting a state machine is an asynchronous operation. When any test case in this test suite fails, the delete operation is called for the state machine. But the testsuite is retried and a create state machine is attempted with the same name. Since the old state machine is still in deleting state, an update is attempted instead of the create and the test fails. @mattclay suggested adding a random component to the name of the state machine on IRC.