### PR TITLE
digital_ocean_floating_ip: check if fip is already assigned

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py
@@ -115,6 +115,7 @@ from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.digital_ocean import DigitalOceanHelper
 
+
 class Response(object):
 
     def __init__(self, resp, info):
@@ -137,6 +138,7 @@ class Response(object):
     @property
     def status_code(self):
         return self.info["status"]
+
 
 def wait_action(module, rest, ip, action_id, timeout=10):
     end_time = time.time() + 10


### PR DESCRIPTION
##### SUMMARY
We need to ensure that there is no floating ip assigned to the droplet already before trying to create a new one. Fixes #63175. Moved from #63179

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
digital_ocean_floating_ip

