### PR TITLE
Replace clear() method for backward compatibility.

### DIFF
--- a/changelogs/fragments/64501-fix-python2.x-backward-compatibility.yaml
+++ b/changelogs/fragments/64501-fix-python2.x-backward-compatibility.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - fix crash when module is used with Python 2.x."

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -859,7 +859,7 @@ class ACMEClient(object):
             if relation == 'up':
                 chain_result, chain_info = self.account.get_request(link, parse_json_result=False)
                 if chain_info['status'] in [200, 201]:
-                    chain.clear()
+                    del chain[:]
                     chain.append(self._der_to_pem(chain_result))
 
         process_links(info, f)


### PR DESCRIPTION
##### SUMMARY
The clear() method is only supported from python >= 3.3, but acme_certificate has python >=2.6 as requirement. Therefore we should replace the clear() method.

Fixes #64501 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
