### PR TITLE
Remove empty setUp/tearDown/tearDownClass methods in test classes.

### DIFF
--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -32,12 +32,6 @@ from units.mock.path import mock_unfrackpath_noop
 
 class TestPlayIterator(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_host_state(self):
         hs = HostState(blocks=[x for x in range(0, 10)])
         hs.tasks_child_state = HostState(blocks=[0])

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -35,12 +35,6 @@ from units.mock.loader import DictDataLoader
 
 class TestTaskExecutor(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_task_executor_init(self):
         fake_loader = DictDataLoader({})
         mock_host = MagicMock()

--- a/test/units/modules/network/netscaler/test_netscaler_nitro_request.py
+++ b/test/units/modules/network/netscaler/test_netscaler_nitro_request.py
@@ -56,14 +56,8 @@ class TestNetscalerNitroRequestModule(TestModule):
 
         cls.MockException = MockException
 
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
+    # This has code in a parent class
     def setUp(self):
-        pass
-
-    def tearDown(self):
         pass
 
     def test_fail_on_conflicting_authentication_methods(self):

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -39,9 +39,6 @@ class TestDataLoader(unittest.TestCase):
     def setUp(self):
         self._loader = DataLoader()
 
-    def tearDown(self):
-        pass
-
     @patch('os.path.exists')
     def test__is_role(self, p_exists):
         p_exists.side_effect = lambda p: p == b'test_path/tasks/main.yml'

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -166,12 +166,6 @@ class TestHashParams(unittest.TestCase):
 
 class TestRole(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_load_role_with_tasks(self):
 

--- a/test/units/playbook/test_playbook.py
+++ b/test/units/playbook/test_playbook.py
@@ -29,12 +29,6 @@ from units.mock.loader import DictDataLoader
 
 class TestPlaybook(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_empty_playbook(self):
         fake_loader = DictDataLoader({})
         p = Playbook(loader=fake_loader)

--- a/test/units/plugins/lookup/test_ini.py
+++ b/test/units/plugins/lookup/test_ini.py
@@ -55,12 +55,6 @@ class TestINILookup(unittest.TestCase):
         ),
     )
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_parse_parameters(self):
         for testcase in self.old_style_params_data:
             # print(testcase)

--- a/test/units/plugins/lookup/test_lastpass.py
+++ b/test/units/plugins/lookup/test_lastpass.py
@@ -126,12 +126,6 @@ class LoggedOutMockLPass(MockLPass):
 
 class TestLPass(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_lastpass_cli_path(self):
         lp = MockLPass(path='/dev/null')
         self.assertEqual('/dev/null', lp.cli_path)

--- a/test/units/plugins/strategy/test_strategy_base.py
+++ b/test/units/plugins/strategy/test_strategy_base.py
@@ -36,12 +36,6 @@ from ansible.plugins.strategy import StrategyBase
 
 class TestStrategyBase(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_strategy_base_init(self):
         queue_items = []
 

--- a/test/units/plugins/strategy/test_strategy_linear.py
+++ b/test/units/plugins/strategy/test_strategy_linear.py
@@ -21,12 +21,6 @@ from units.mock.path import mock_unfrackpath_noop
 
 class TestStrategyLinear(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_noop(self):
         fake_loader = DictDataLoader({

--- a/test/units/plugins/terminal/test_slxos.py
+++ b/test/units/plugins/terminal/test_slxos.py
@@ -33,9 +33,6 @@ class TestPluginTerminalSLXOS(unittest.TestCase):
         self._mock_connection = MagicMock()
         self._terminal = slxos.TerminalModule(self._mock_connection)
 
-    def tearDown(self):
-        pass
-
     def test_on_open_shell(self):
         """ Test on_open_shell
         """

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -30,12 +30,6 @@ from ansible.plugins.loader import PluginLoader
 
 class TestErrors(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     @patch.object(PluginLoader, '_get_paths')
     def test_print_paths(self, mock_method):
         mock_method.return_value = ['/path/one', '/path/two', '/path/three']

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -64,12 +64,6 @@ class TestVariableUtils(unittest.TestCase):
         ),
     )
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_merge_hash(self):
         for test in self.test_merge_data:
             self.assertEqual(merge_hash(test['a'], test['b']), test['result'])

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -36,12 +36,6 @@ from ansible.vars.manager import VariableManager
 
 class TestVariableManager(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_basic_manager(self):
         fake_loader = DictDataLoader({})
 


### PR DESCRIPTION
##### SUMMARY
More clean-up. There's one of them that has `pass` although the super-class has code in `setUp`. I added a comment for that case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
This is a follow-up to #64360 The last chunk should be deleted now.