### PR TITLE
azure_rm_virtualmachine: Fix VHD URI valid schemes in extract_names_from_blob_uri

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -790,7 +790,7 @@ AZURE_ENUM_MODULES = ['azure.mgmt.compute.models']
 
 def extract_names_from_blob_uri(blob_uri, storage_suffix):
     # HACK: ditch this once python SDK supports get by URI
-    m = re.match(r'^https://(?P<accountname>[^.]+)\.blob\.{0}/'
+    m = re.match(r'^https?://(?P<accountname>[^.]+)\.blob\.{0}/'
                  r'(?P<containername>[^/]+)/(?P<blobname>.+)$'.format(storage_suffix), blob_uri)
     if not m:
         raise Exception("unable to parse blob uri '%s'" % blob_uri)


### PR DESCRIPTION
##### SUMMARY
When a VM has been provisioned with unmanaged disks (VHD), the URI
schemes used for those disks are kept untouched. Unfortunately, the regexp that
parses the URI only accepts 'https' leading the module to fail if one
uses for instance 'http'.

Please note that the official Azure API documentation uses 'http' and
not 'https' as URI scheme.

Fixes #64506

Testing Done: Using an ARM template, provision a VM with one OS and one
data disk with 'http' as VHD URI scheme. Then use the
azure_rm_virtualmachine module to delete the VM. Finally check that the
module does not fail anymore and that the unmanaged disks are correctly
deleted from the storage account.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
* azure_rm_virtualmachines

##### ADDITIONAL INFORMATION

