### PR TITLE
 vmware_guest: Enable setting mac address when cloning from VM or template

### DIFF
--- a/test/integration/targets/vmware_guest/defaults/main.yml
+++ b/test/integration/targets/vmware_guest/defaults/main.yml
@@ -4,6 +4,7 @@ vmware_guest_test_playbooks:
   - cdrom_d1_c1_f0.yml
   - check_mode.yml
   - clone_customize_guest_test.yml
+  - clone_set_manual_mac_address.yml
   - clone_d1_c1_f0.yml
   - clone_resize_disks.yml
   - clone_with_convert.yml

--- a/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_set_manual_mac_address.yml
@@ -1,0 +1,28 @@
+- name: clone VM from template and set manual mac address
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    name: test_vm1
+    template: "{{ virtual_machines[0].name }}"
+    datacenter: "{{ dc1 }}"
+    state: poweredoff
+    folder: "{{ virtual_machines[0].folder }}"
+    networks:
+      - name: VM Network
+        ip: 192.168.10.10
+        netmask: 255.255.255.0
+        gateway: 192.168.10.254
+        mac: aa:bb:cc:dd:aa:b0
+  register: clone_manual_mac_address
+
+- debug:
+    var: clone_manual_mac_address
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "clone_manual_mac_address.changed == true"
+      - "clone_manual_mac_address['instance']['hw_eth0']['addresstype'] == 'manual'"
+      - "clone_manual_mac_address['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:b0'"


### PR DESCRIPTION
##### SUMMARY
Rebased zeot/devel from https://github.com/ansible/ansible/pull/51368 on ansible/devel. Original summary:

The method previously used for device changes when cloning was deprecated in vCenter 6.0. Even though it still works on vCenter 6.5.0, the vcsim did not apply these changes (resolved in govmomi master now, but not released).

For future proofing and testability, the new method of implementing device changes on clone is used when applying device changes when vCenter version 6.0 or greater is detected.

Fixes #51123 and fixes #51124

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/cloud/vmware/vmware_guest.py`

##### ADDITIONAL INFORMATION
I wasn't able to use the suggested `prepare_vmware_roles`, but tested against a local vsphere instead