### PR TITLE
rabbitmq_policy support version 3.8.0

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py
@@ -125,7 +125,10 @@ class RabbitMqPolicy(object):
     def _rabbit_version(self):
         status = self._exec(['status'], True, False, False)
 
-        version_match = re.search('{rabbit,".*","(?P<version>.*)"}', status)
+        version_match = re.search(
+            r'({rabbit,".*","|RabbitMQ version:)\s?(?P<version>[0-9.]{3,})("})?',
+            status
+        )
         if version_match:
             return Version(version_match.group('version'))
 


### PR DESCRIPTION
### SUMMARY

In RabbitMQ version 3.8.0 rabbitmqctl output is not in json anymore.
So rabbitmqctl status returns plain text and current search return
None instead of rabbit version. This results in getting wrong
policies inside _list_policies as we need to omit first line from 3.7.9

While PR #62996 is not merged, this PR worth placing, and
is pretty backportable.

Signed-off-by: Dmitriy Rabotyagov <noonedeadpunk@ya.ru>

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rabbitmq_policy

##### ADDITIONAL INFORMATION

Current output of rabbitmqctl

```
# rabbitmqctl status
Status of node rabbit@aio1 ...
Runtime

OS PID: 2578
OS: Linux
Uptime (seconds): 49
RabbitMQ version: 3.8.0
Node name: rabbit@aio1
Erlang configuration: Erlang/OTP 22 [erts-10.5.3] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:128] [hipe]
Erlang processes: 435 used, 1048576 limit
Scheduler run queue: 1
Cluster heartbeat timeout (net_ticktime): 60

Plugins

Enabled plugin file: /etc/rabbitmq/enabled_plugins
Enabled plugins:

 * rabbitmq_management
 * rabbitmq_web_dispatch
 * rabbitmq_management_agent
 * amqp_client
 * cowboy
 * cowlib

Data directory

Node data directory: /var/lib/rabbitmq/mnesia/rabbit@aio1

Config files

 * /etc/rabbitmq/rabbitmq.config

Log file(s)

 * /var/log/rabbitmq/rabbit@aio1.log
 * /var/log/rabbitmq/rabbit@aio1_upgrade.log

Alarms

(none)

Memory

Calculation strategy: rss
Memory high watermark setting: 0.2 of available memory, computed to: 3.3639 gb
code: 0.0296 gb (32.47 %)
other_proc: 0.026 gb (28.54 %)
other_system: 0.0134 gb (14.65 %)
allocated_unused: 0.0103 gb (11.26 %)
reserved_unallocated: 0.0059 gb (6.46 %)
other_ets: 0.003 gb (3.29 %)
atom: 0.0015 gb (1.63 %)
plugins: 0.0009 gb (0.98 %)
metrics: 0.0002 gb (0.23 %)
mgmt_db: 0.0002 gb (0.17 %)
binary: 0.0001 gb (0.14 %)
mnesia: 0.0001 gb (0.09 %)
quorum_ets: 0.0 gb (0.05 %)
msg_index: 0.0 gb (0.03 %)
connection_other: 0.0 gb (0.0 %)
connection_channels: 0.0 gb (0.0 %)
connection_readers: 0.0 gb (0.0 %)
connection_writers: 0.0 gb (0.0 %)
queue_procs: 0.0 gb (0.0 %)
queue_slave_procs: 0.0 gb (0.0 %)
quorum_queue_procs: 0.0 gb (0.0 %)

File Descriptors

Total: 2, limit: 65436
Sockets: 0, limit: 58890

Free Disk Space

Low free disk space watermark: 0.05 gb
Free disk space: 97.472 gb

Totals

Connection count: 0
Queue count: 0
Virtual host count: 1

Listeners

Interface: [::], port: 25672, protocol: clustering, purpose: inter-node and CLI tool communication
Interface: 0.0.0.0, port: 5672, protocol: amqp, purpose: AMQP 0-9-1 and AMQP 1.0
Interface: 0.0.0.0, port: 5671, protocol: amqp/ssl, purpose: AMQP 0-9-1 and AMQP 1.0 over TLS
Interface: [::], port: 15672, protocol: http, purpose: HTTP API
```
