### PR TITLE
2.9: template lookup: fix regression when templating hostvars (#64070)

### DIFF
--- a/changelogs/fragments/63940-template-lookup-hostvars-regression.yml
+++ b/changelogs/fragments/63940-template-lookup-hostvars-regression.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - template lookup - fix regression when templating hostvars (https://github.com/ansible/ansible/issues/63940)

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -111,6 +111,12 @@ class HostVars(Mapping):
             out[host] = self.get(host)
         return repr(out)
 
+    def __deepcopy__(self, memo):
+        # We do not need to deepcopy because HostVars is immutable,
+        # however we have to implement the method so we can deepcopy
+        # variables' dicts that contain HostVars.
+        return self
+
 
 class HostVarsVars(Mapping):
 

--- a/test/integration/targets/lookups/runme.sh
+++ b/test/integration/targets/lookups/runme.sh
@@ -11,3 +11,5 @@ pip install passlib
 ANSIBLE_ROLES_PATH=../ ansible-playbook lookups.yml "$@"
 
 ansible-playbook template_lookup_vaulted.yml --vault-password-file test_vault_pass "$@"
+
+ansible-playbook -i template_deepcopy/hosts template_deepcopy/playbook.yml "$@"

--- a/test/integration/targets/lookups/template_deepcopy/hosts
+++ b/test/integration/targets/lookups/template_deepcopy/hosts
@@ -1,0 +1,1 @@
+h1 ansible_connection=local host_var=foo

--- a/test/integration/targets/lookups/template_deepcopy/playbook.yml
+++ b/test/integration/targets/lookups/template_deepcopy/playbook.yml
@@ -1,0 +1,10 @@
+- hosts: h1
+  gather_facts: no
+  tasks:
+    - set_fact:
+        templated_foo: "{{ lookup('template', 'template.in') }}"
+
+    - name: Test that the hostvar was templated correctly
+      assert:
+        that:
+          - templated_foo == "foo\n"

--- a/test/integration/targets/lookups/template_deepcopy/template.in
+++ b/test/integration/targets/lookups/template_deepcopy/template.in
@@ -1,0 +1,1 @@
+{{hostvars['h1'].host_var}}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes a regression that was caused by switching from copy() to
deepcopy() when 'saving' variables before templating. Since HostVars
did not implement the `__deepcopy__()` method, deepcopy returned incorrect
results when host vars were present in the variables.

Fixes #63940

Backport of https://github.com/ansible/ansible/pull/64070

(cherry picked from commit cd8ce16d4830782063692d897e57bd0af33ab5db)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
template lookup