### PR TITLE
linux facts - return proper broadcast address

### DIFF
--- a/changelogs/fragments/linux-network-facts-broadcast-address.yaml
+++ b/changelogs/fragments/linux-network-facts-broadcast-address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linux network facts - get the correct value for broadcast address (https://github.com/ansible/ansible/issues/64384)

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -173,7 +173,8 @@ class LinuxNetwork(Network):
                         if '/' in words[1]:
                             address, netmask_length = words[1].split('/')
                             if len(words) > 3:
-                                broadcast = words[3]
+                                if words[2] == 'brd':
+                                    broadcast = words[3]
                         else:
                             # pointopoint interfaces do not have a prefix
                             address = words[1]

--- a/test/integration/targets/facts_linux_network/aliases
+++ b/test/integration/targets/facts_linux_network/aliases
@@ -1,0 +1,4 @@
+needs/privileged
+shippable/posix/group2
+skip/freebsd
+skip/osx

--- a/test/integration/targets/facts_linux_network/meta/main.yml
+++ b/test/integration/targets/facts_linux_network/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/facts_linux_network/tasks/main.yml
+++ b/test/integration/targets/facts_linux_network/tasks/main.yml
@@ -1,7 +1,3 @@
-- debug:
-    msg: "{{ ansible_facts.default_ipv4 }}"
-    verbosity: 2
-
 - block:
     - name: Add IP to interface
       command: ip address add 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
@@ -16,13 +12,7 @@
         that:
           - ansible_facts[ansible_facts['default_ipv4']['interface']]['ipv4_secondaries'][0]['broadcast'] == ''
 
-  rescue:
-    - debug:
-        msg: "{{ ansible_facts[ansible_facts['default_ipv4']['interface']]['ipv4_secondaries'] }}"
-        verbosity: 2
-
   always:
-
     - name: Remove IP from interface
       command: ip address delete 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
       ignore_errors: yes

--- a/test/integration/targets/facts_linux_network/tasks/main.yml
+++ b/test/integration/targets/facts_linux_network/tasks/main.yml
@@ -1,0 +1,28 @@
+- debug:
+    msg: "{{ ansible_facts.default_ipv4 }}"
+    verbosity: 2
+
+- block:
+    - name: Add IP to interface
+      command: ip address add 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
+      ignore_errors: yes
+
+    - name: Gather network facts
+      setup:
+        gather_subset: network
+
+    - name: Ensure broadcast is reported as empty
+      assert:
+        that:
+          - ansible_facts[ansible_facts['default_ipv4']['interface']]['ipv4_secondaries'][0]['broadcast'] == ''
+
+  rescue:
+    - debug:
+        msg: "{{ ansible_facts[ansible_facts['default_ipv4']['interface']]['ipv4_secondaries'] }}"
+        verbosity: 2
+
+  always:
+
+    - name: Remove IP from interface
+      command: ip address delete 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Check that the value being returned is actually a broadcast address instead of assuming that the value at the fourth position is a broadcast address.

Fixes #64384

We get the broadcast address by parsing the output of `ip addr show primary [interface]`. When the interface does not have a broadcast address, we incorrectly get the value of `scope` when we should return nothing.

Example output of an interface with no broadcast set.

```
$ ip addr show primary eth0
1019: eth0@if1020: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default
    link/ether 02:42:ac:11:00:08 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 172.17.0.8/16 scope global eth0
       valid_lft forever preferred_lft forever
```

Since we just grab the fourth item in the list, we get the value for `scope`, which is not the broadcast address.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/network/linux.py`

##### ADDITIONAL INFORMATION

I attempted to write unit tests for this, but given this is a private method doing a lot of things, it's nearly impossible to test. This code needs to be refactored to remove private functions and those functions should be broken up and simplified. The cyclomatic complexity score for this file is alarmingly high.

```
lib/ansible/module_utils/facts/network/linux.py:99:4: LinuxNetwork.get_interfaces_info (complexity 45)
```
