### PR TITLE
prepare_vmware_tests: datastore host is datastore.test

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -7,14 +7,12 @@ infra:
   datastores:
     LocalDS_0:
       type: nfs
-      server: gateway.test
+      server: datastore.test
       path: /srv/share/isos
-      # https://github.com/ansible/ansible/issues/58541 prevents us
-      # from using the "ro: true" mode
-      ro: false
+      ro: true
     LocalDS_1:
       type: nfs
-      server: gateway.test
+      server: datastore.test
       path: /srv/share/vms
       ro: false
 virtual_machines:

--- a/test/integration/targets/vmware_content_library_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_content_library_manager/tasks/main.yml
@@ -28,7 +28,7 @@
         validate_certs: False
         library_name: Sample_Library
         library_description: Sample Description
-        datastore_name: '{{ ds1 }}'
+        datastore_name: '{{ ds2 }}'
         state: present
       register: content_lib_create_result
 


### PR DESCRIPTION
##### SUMMARY

Use an alias to access the datastore host. This way, it's easier
to use an existing NFS server.
We can also disable the `write` access on the iso datastore.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

prepare_vmware_tests