### PR TITLE
eos_lacp_interfaces : Fix to - lacp port-priority not set when…

### DIFF
--- a/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
@@ -126,6 +126,8 @@ class Lacp_interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
+            import q
+            q(desired,extant,add_config,del_config)
             commands.extend(generate_commands(key, add_config, del_config))
 
         return commands
@@ -199,14 +201,15 @@ class Lacp_interfaces(ConfigBase):
 
 def generate_commands(interface, to_set, to_remove):
     commands = []
+    for key in to_remove.keys():
+        commands.append("no lacp {0}".format(key.replace("_", "-")))
+
     for key, value in to_set.items():
         if value is None:
             continue
 
         commands.append("lacp {0} {1}".format(key.replace("_", "-"), value))
 
-    for key in to_remove.keys():
-        commands.append("no lacp {0}".format(key.replace("_", "-")))
 
     if commands:
         commands.insert(0, "interface {0}".format(interface))

--- a/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
@@ -208,7 +208,6 @@ def generate_commands(interface, to_set, to_remove):
 
         commands.append("lacp {0} {1}".format(key.replace("_", "-"), value))
 
-
     if commands:
         commands.insert(0, "interface {0}".format(interface))
 

--- a/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/eos/config/lacp_interfaces/lacp_interfaces.py
@@ -126,8 +126,6 @@ class Lacp_interfaces(ConfigBase):
             add_config = dict_diff(extant, desired)
             del_config = dict_diff(desired, extant)
 
-            import q
-            q(desired,extant,add_config,del_config)
             commands.extend(generate_commands(key, add_config, del_config))
 
         return commands

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/replaced.yaml
@@ -5,6 +5,7 @@
     config:
       - name: Ethernet1
         rate: fast
+        port_priority: 45
     other_config:
       - name: Ethernet2
         rate: fast


### PR DESCRIPTION
##### SUMMARY

Fix to #64453

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/network/eos/facts/lacp_interfaces/lacp_interfaces.py

