### PR TITLE
use ~/.one/one_auth as default of ONE_AUTH file location

### DIFF
--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -1300,15 +1300,14 @@ def get_connection_info(module):
     if not username:
         if not password:
             authfile = os.environ.get('ONE_AUTH')
-            if authfile is not None:
-                try:
-                    authstring = open(authfile, "r").read().rstrip()
-                    username = authstring.split(":")[0]
-                    password = authstring.split(":")[1]
-                except BaseException:
-                    module.fail_json(msg="Could not read ONE_AUTH file")
-            else:
-                module.fail_json(msg="No Credentials are set")
+            if authfile is None:
+                authfile = os.environ.get('HOME') + '/.one/one_auth'
+            try:
+                authstring = open(authfile, "r").read().rstrip()
+                username = authstring.split(":")[0]
+                password = authstring.split(":")[1]
+            except BaseException:
+                module.fail_json(msg="Could not read ONE_AUTH file")
     if not url:
         module.fail_json(msg="Opennebula API url (api_url) is not specified")
     from collections import namedtuple

--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -1301,13 +1301,15 @@ def get_connection_info(module):
         if not password:
             authfile = os.environ.get('ONE_AUTH')
             if authfile is None:
-                authfile = os.environ.get('HOME') + '/.one/one_auth'
+                authfile = os.path.join(os.environ.get("HOME"), ".one", "one_auth")
             try:
                 authstring = open(authfile, "r").read().rstrip()
                 username = authstring.split(":")[0]
                 password = authstring.split(":")[1]
+            except (OSError, IOError) as e:
+                module.fail_json(msg=("Could not find or read ONE_AUTH file at '%s'" % authfile))
             except BaseException:
-                module.fail_json(msg="Could not read ONE_AUTH file")
+                module.fail_json(msg=("Error occurs when read ONE_AUTH file at '%s'" % authfile))
     if not url:
         module.fail_json(msg="Opennebula API url (api_url) is not specified")
     from collections import namedtuple

--- a/lib/ansible/modules/cloud/opennebula/one_vm.py
+++ b/lib/ansible/modules/cloud/opennebula/one_vm.py
@@ -1306,9 +1306,9 @@ def get_connection_info(module):
                 authstring = open(authfile, "r").read().rstrip()
                 username = authstring.split(":")[0]
                 password = authstring.split(":")[1]
-            except (OSError, IOError) as e:
+            except (OSError, IOError):
                 module.fail_json(msg=("Could not find or read ONE_AUTH file at '%s'" % authfile))
-            except BaseException:
+            except Exception:
                 module.fail_json(msg=("Error occurs when read ONE_AUTH file at '%s'" % authfile))
     if not url:
         module.fail_json(msg="Opennebula API url (api_url) is not specified")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
use ~/.one/one_auth as default of ONE_AUTH file location when there is no ONE_AUTH environment variables.
This feature was there so I think this is a bug fix.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
opennebula

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
