### PR TITLE
VMWare: Added pool parameter to VM relocate Spec. 

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -69,9 +69,17 @@ options:
       type: str
     destination_datastore:
       description:
-      - "Name of the destination datastore the virtual machine's vmdk should be moved on."
+      - Name of the destination datastore the virtual machine's vmdk should be moved on.
       aliases: ['datastore']
       version_added: 2.7
+      type: str
+    destination_resourcepool:
+      description:
+      - Name of the destination resource pool where the virtual machine should be running.
+      - Resource pool is required if vmotion is done between hosts which are part of different clusters or datacenters.
+      - if not passed, resource_pool object will be retrived from host_obj parent.
+      aliases: ['resource_pool']
+      version_added: '2.10'
       type: str
 extends_documentation_fragment: vmware.documentation
 '''
@@ -95,6 +103,17 @@ EXAMPLES = '''
     validate_certs: no
     moid: vm-42
     destination_host: 'destination_host_as_per_vcenter'
+  delegate_to: localhost
+
+- name: Perform vMotion of virtual machine to resource_pool
+  vmware_vmotion:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    moid: vm-42
+    destination_host: 'destination_host_as_per_vcenter'
+    destination_resourcepool: 'destination_resourcepool_as_per_vcenter'
   delegate_to: localhost
 
 - name: Perform storage vMotion of of virtual machine
@@ -136,6 +155,7 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import (PyVmomi, find_hostsystem_by_name,
                                          find_vm_by_id, find_datastore_by_name,
+                                         find_resource_pool_by_name,
                                          vmware_argument_spec, wait_for_task, TaskError)
 
 
@@ -172,6 +192,18 @@ class VmotionManager(PyVmomi):
         if self.datastore_object is None and self.host_object is None:
             self.module.fail_json(msg="Unable to find destination datastore"
                                       " and destination host system.")
+
+        # Get Destination resourcepool
+        dest_resourcepool = self.params.get('destination_resourcepool', None)
+        self.resourcepool_object = None
+        if dest_resourcepool:
+            self.resourcepool_object = find_resource_pool_by_name(content=self.content,
+                                                                  resource_pool_name=dest_resourcepool)
+        elif not dest_resourcepool and dest_host_name:
+            self.resourcepool_object = self.host_object.parent.resourcePool
+        # Fail if resourcePool object is not found
+        if self.resourcepool_object is None:
+            self.module.fail_json(msg="Unable to destination resource pool object which is required")
 
         # Check if datastore is required, this check is required if destination
         # and source host system does not share same datastore.
@@ -271,7 +303,8 @@ class VmotionManager(PyVmomi):
         Migrate virtual machine and return the task.
         """
         relocate_spec = vim.vm.RelocateSpec(host=self.host_object,
-                                            datastore=self.datastore_object)
+                                            datastore=self.datastore_object,
+                                            pool=self.resourcepool_object)
         task_object = self.vm.Relocate(relocate_spec)
         return task_object
 
@@ -317,6 +350,7 @@ def main():
             moid=dict(type='str'),
             use_instance_uuid=dict(type='bool', default=False),
             destination_host=dict(aliases=['destination']),
+            destination_resourcepool=dict(aliases=['resource_pool']),
             destination_datastore=dict(aliases=['datastore'])
         )
     )

--- a/test/integration/targets/vmware_vmotion/aliases
+++ b/test/integration/targets/vmware_vmotion/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_vmotion/tasks/main.yml
+++ b/test/integration/targets/vmware_vmotion/tasks/main.yml
@@ -1,0 +1,79 @@
+# Test code for the vmware_vmotion module.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+
+- name: Create VMs
+  vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    name: test_vm1
+    folder: vm
+    esxi_hostname: "{{ esxi1 }}"
+    state: present
+    guest_id: centos7_64Guest
+    disk:
+    - size_gb: 1
+      type: thin
+      datastore: '{{ rw_datastore }}'
+    hardware:
+      version: latest
+      memory_mb: 1024
+      num_cpus: 1
+      scsi: paravirtual
+  register: vm_create
+
+- name: Perform vMotion of virtual machine
+  vmware_vmotion:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    vm_name: test_vm1
+    destination_host: '{{ esxi2 }}'
+  register: vm_vmotion
+
+- name: assert that changes were made
+  assert:
+    that:
+        - vm_vmotion is changed
+
+- name: Perform vMotion of virtual machine to resource_pool
+  vmware_vmotion:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    vm_name: DC0_C0_RP0_VM0
+    destination_host: '{{ esxi1 }}'
+    destination_resourcepool: Resources
+  register: vm_vmotion_to_rp
+
+- name: assert that changes were made
+  assert:
+    that:
+        - vm_vmotion_to_rp is changed
+
+- name: Perform storage vMotion of of virtual machine
+  vmware_vmotion:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    vm_name: DC0_C0_RP0_VM1
+    destination_host: '{{ esxi3 }}'
+    destination_datastore: '{{ ro_datastore }}'
+  register: vm_vmotion_to_datastore
+
+- name: assert that changes were made
+  assert:
+    that:
+        - vm_vmotion_to_datastore is changed


### PR DESCRIPTION
##### SUMMARY
Fix issue #64503 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vmotion.py

##### ADDITIONAL INFORMATION
VM relocate to destination host works without pool param when hosts are part of same cluster. but spec.pool is required when hosts are part different clusters.
here spec.pool is not actually resource_pool