### PR TITLE
making the lvol module check-run aware for thinpool creation

### DIFF
--- a/changelogs/fragments/64550-fix-check-run-lvol-thinpool.yml
+++ b/changelogs/fragments/64550-fix-check-run-lvol-thinpool.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lvol - Fix check run for lvol thinpool creation

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -444,9 +444,9 @@ def main():
                 if size_opt == 'l':
                     module.fail_json(changed=False, msg="Thin volume sizing with percentage not supported.")
                 size_opt = 'V'
-                cmd = "%s %s -n %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, thinpool)
+                cmd = "%s %s %s -n %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, test_opt, yesopt, lv, size_opt, size, size_unit, opts, vg, thinpool)
             elif thinpool and not lv:
-                cmd = "%s %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, opts, vg, thinpool)
+                cmd = "%s %s %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, test_opt, yesopt, size_opt, size, size_unit, opts, vg, thinpool)
             else:
                 cmd = "%s %s %s -n %s -%s %s%s %s %s %s" % (lvcreate_cmd, test_opt, yesopt, lv, size_opt, size, size_unit, opts, vg, pvs)
             rc, _, err = module.run_command(cmd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #64546 

The lvol module was ignoring the --check flag when using the thinpool parameter for both thin pool creation and creation of a logical volume inside a thin pool. 

Cause was a missing test_opt parameter in both of the commands in the lvol code.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lvol
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Ansible output both before and after is the same:
```
wdk-elastic3 | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "invocation": {
        "module_args": {
            "active": true,
            "force": false,
            "lv": null,
            "opts": null,
            "pvs": null,
            "resizefs": false,
            "shrink": true,
            "size": "1G",
            "snapshot": null,
            "state": "present",
            "thinpool": "tp_test",
            "vg": "vg_serv"
        }
    },
    "msg": ""
}
```
On the target host, before the fix:
```
[root@wdk-elastic3 ~]# lvs
  LV         VG         Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  lv_elastic vg_elastic -wi-ao---- 70.00g                                                    
  lv_root    vg_serv    -wi-ao---- 38.00g                                                    
  lv_var     vg_serv    -wi-ao----  6.00g                                                    
  tp_test    vg_serv    twi-a-tz--  1.00g             0.00   10.94                           
```

On the target host after the fix:
```
[root@wdk-elastic3 ~]# lvs
  LV         VG         Attr       LSize  Pool Origin Data%  Meta%  Move Log Cpy%Sync Convert
  lv_elastic vg_elastic -wi-ao---- 70.00g                                                    
  lv_root    vg_serv    -wi-ao---- 38.00g                                                    
  lv_var     vg_serv    -wi-ao----  6.00g   
```
