### PR TITLE
botmeta sanity: check migrated_to on non-existing file

### DIFF
--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -80,10 +80,11 @@ def main():
         path_macros.append(macro)
 
     # Ensure all `files` correspond to a file
-    for file in botmeta['files']:
+    for file, file_meta in botmeta['files'].items():
+        migrated = isinstance(file_meta, dict) and file_meta.get('migrated_to') is not None
         for macro in path_macros:
             file = file.replace('$' + macro, botmeta.get('macros', {}).get(macro, ''))
-        if not os.path.exists(file):
+        if not os.path.exists(file) and not migrated:
             # Not a file or directory, though maybe the prefix to one?
             # https://github.com/ansible/ansibullbot/pull/1023
             if not glob.glob('%s*' % file):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Do not fail sanity check on non-existing files when they are actually migrated into a collection.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/sanity/code-smell/botmeta.py`