### PR TITLE
Fix Bug

### DIFF
--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -75,7 +75,7 @@ class ActionModule(ActionBase):
                     for cmd in commands:
                         display.vvvvv('>>> %s' % cmd)
                         tn.write(to_bytes(cmd + "\n"))
-                        index, match, out = tn.expect(list(map(to_bytes, prompts)))
+                        index, match, out = tn.expect(list(map(to_bytes, prompts)), timeout=timeout)
                         display.vvvvv('<<< %s' % cmd)
                         output.append(out)
                         sleep(pause)


### PR DESCRIPTION
##### SUMMARY
I have add timeout  to the read return of the telnet command, 

On cisco switch, when you want to type the command : show cdp neighbors detail
The telnet return not contain EOF... 

This blocking entirely the telnet command wich waiting for return indefinitly.

#### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Telnet

