### PR TITLE
hcloud inventory missing compose variables

### DIFF
--- a/changelogs/fragments/64559-hcloud-inventory-missing-compose-variables.yaml
+++ b/changelogs/fragments/64559-hcloud-inventory-missing-compose-variables.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hcloud - Added missing host variables in Compose section

--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -208,7 +208,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             strict = self.get_option('strict')
 
             # Composed variables
-            self._set_composite_vars(self.get_option('compose'), {}, server.name, strict=strict)
+            self._set_composite_vars(self.get_option('compose'), self.inventory.get_host(server.name).get_vars(), server.name, strict=strict)
 
             # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
             self._add_host_to_composed_groups(self.get_option('groups'), {}, server.name, strict=strict)


### PR DESCRIPTION
hcloud inventory plugin should pull in server attributes for use in `compose`.

##### SUMMARY
From what I'm concerned `compose` is pretty useless in the hcloud inventory plugin as it is not able to pull variables from the server attributes, i.e. label values.
With this fix you will be able to assign label values as vars
```yaml
plugin: hcloud
compose:
  role: labels['role']
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hcloud inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Given the following inventory and a server with a label `role=bar`
```yaml
plugin: hcloud
compose:
  role: labels['role']
```

one would expect the server to have a `role` server attribute, but this change will provide the server attribute,
```
ansible-inventory --host=web
{
    "ansible_host": "…",
    "datacenter": "fsn1-dc14",
    "id": "…",
    "image_id": "168855",
    "image_name": "ubuntu-18.04",
    "image_os_flavor": "ubuntu",
    "ipv4": "…",
    "ipv6_network": "…",
    "ipv6_network_mask": "…",
    "labels": {
        "role": "web"
    },
    "location": "fsn1",
    "name": "web",
    "server_type": "ubuntu-18.04",
    "status": "running",
    "type": "cx41"
}
```