### PR TITLE
Fix MacOS Catalina SSL certificate requirements

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -136,7 +136,7 @@ options:
             - If this value is not specified, the certificate will stop being valid 10 years from now.
             - This is only used by the C(selfsigned) provider.
         type: str
-        default: +3650d
+        default: +825d
         aliases: [ selfsigned_notAfter ]
 
     selfsigned_create_subject_key_identifier:
@@ -217,7 +217,7 @@ options:
             - If this value is not specified, the certificate will stop being valid 10 years from now.
             - This is only used by the C(ownca) provider.
         type: str
-        default: +3650d
+        default: +825d
         version_added: "2.7"
 
     ownca_create_subject_key_identifier:
@@ -2442,7 +2442,7 @@ def main():
             selfsigned_version=dict(type='int', default=3),
             selfsigned_digest=dict(type='str', default='sha256'),
             selfsigned_not_before=dict(type='str', default='+0s', aliases=['selfsigned_notBefore']),
-            selfsigned_not_after=dict(type='str', default='+3650d', aliases=['selfsigned_notAfter']),
+            selfsigned_not_after=dict(type='str', default='+825d', aliases=['selfsigned_notAfter']),
             selfsigned_create_subject_key_identifier=dict(
                 type='str',
                 default='create_if_not_provided',
@@ -2456,7 +2456,7 @@ def main():
             ownca_digest=dict(type='str', default='sha256'),
             ownca_version=dict(type='int', default=3),
             ownca_not_before=dict(type='str', default='+0s'),
-            ownca_not_after=dict(type='str', default='+3650d'),
+            ownca_not_after=dict(type='str', default='+825d'),
             ownca_create_subject_key_identifier=dict(
                 type='str',
                 default='create_if_not_provided',


### PR DESCRIPTION
Since MacOS Catalina new certificates need to be not older that 825 days. For further information see [this stackexchange post](https://superuser.com/questions/1492207/neterr-cert-revoked-in-chrome-chromium-introduced-with-macos-catalina)

##### SUMMARY
Since MacOS Catalina changed their requirements for SSL certificates we should lower the default days till expiry to +825d. Otherwise a lot of people might get a lot of issues!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ADDITIONAL INFORMATION
[Stackexchange](https://superuser.com/questions/1492207/neterr-cert-revoked-in-chrome-chromium-introduced-with-macos-catalina)
[Apple Support Page](https://support.apple.com/en-us/HT210176)
