### PR TITLE
Fix eos_facts over local eapi

### DIFF
--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -28,6 +28,7 @@
 import traceback
 import json
 
+from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
@@ -219,7 +220,7 @@ def get_resource_connection(module):
     elif network_api == "local":
         # This isn't supported, but we shouldn't fail here.
         # Set the connection to None to indicate failure and move on.
-        module._connection = None
+        module._connection = LocalResourceConnection(module)
     else:
         module.fail_json(msg='Invalid connection type {0!s}'.format(network_api))
 
@@ -239,3 +240,11 @@ def get_capabilities(module):
     module._capabilities = json.loads(capabilities)
 
     return module._capabilities
+
+
+class LocalResourceConnection:
+    def __init__(self, module):
+        self.module = module
+
+    def get(self, *args, **kwargs):
+        self.module.fail_json(msg="Network resource modules not supported over local connection.")

--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -218,7 +218,7 @@ def get_resource_connection(module):
         module._connection = NetconfConnection(module._socket_path)
     elif network_api == "local":
         # This isn't supported, but we shouldn't fail here.
-        # Set the connection to None to indicate failure and move on.
+        # Set the connection to a fake connection so it fails sensibly.
         module._connection = LocalResourceConnection(module)
     else:
         module.fail_json(msg='Invalid connection type {0!s}'.format(network_api))

--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -216,6 +216,10 @@ def get_resource_connection(module):
         module._connection = Connection(module._socket_path)
     elif network_api == 'netconf':
         module._connection = NetconfConnection(module._socket_path)
+    elif network_api == "local":
+        # This isn't supported, but we shouldn't fail here.
+        # Set the connection to None to indicate failure and move on.
+        module._connection = None
     else:
         module.fail_json(msg='Invalid connection type {0!s}'.format(network_api))
 
@@ -229,6 +233,9 @@ def get_capabilities(module):
         capabilities = Connection(module._socket_path).get_capabilities()
     except ConnectionError as exc:
         module.fail_json(msg=to_text(exc, errors='surrogate_then_replace'))
+    except AssertionError:
+        # No socket_path, connection most likely local.
+        return dict(network_api="local")
     module._capabilities = json.loads(capabilities)
 
     return module._capabilities

--- a/lib/ansible/module_utils/network/common/network.py
+++ b/lib/ansible/module_utils/network/common/network.py
@@ -28,7 +28,6 @@
 import traceback
 import json
 
-from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback

--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -388,6 +388,15 @@ class LocalEapi:
         diff['config_diff'] = configdiff if configdiffobjs else {}
         return diff
 
+    def get_capabilities(self):
+        # Implement the bare minimum to support eos_facts
+        return dict(
+            device_info=dict(
+                network_os="eos",
+            ),
+            network_api="eapi",
+        )
+
 
 class HttpApi:
     def __init__(self, module):

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -329,7 +329,7 @@ class LocalNxapi:
 
         headers = {'Content-Type': 'application/json'}
         result = list()
-        timeout = self._module.params['timeout']
+        timeout = self._module.params['provider']['timeout']
         use_proxy = self._module.params['provider']['use_proxy']
 
         for req in requests:

--- a/test/integration/targets/eos_facts/tasks/cli.yaml
+++ b/test/integration/targets/eos_facts/tasks/cli.yaml
@@ -14,3 +14,9 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/eos_facts/tasks/eapi.yaml
+++ b/test/integration/targets/eos_facts/tasks/eapi.yaml
@@ -3,14 +3,20 @@
   find:
     paths: "{{ role_path }}/tests/eapi"
     patterns: "{{ testcase }}.yaml"
-  delegate_to: localhost
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=httpapi)
   include: "{{ test_case_to_run }} ansible_connection=httpapi"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test cases (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
@@ -1,6 +1,12 @@
 ---
 - debug: msg="START cli/all_facts.yaml on connection={{ ansible_connection }}"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    provider:
+      authorize: yes
+  become: yes
 
 - name: test getting all facts
   eos_facts:

--- a/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/all_facts.yaml
@@ -1,17 +1,11 @@
 ---
 - debug: msg="START cli/all_facts.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test getting all facts
   eos_facts:
     gather_subset:
       - all
+    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
@@ -1,6 +1,12 @@
 ---
 - debug: msg="START cli/default_facts.yaml on connection={{ ansible_connection }}"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    provider:
+      authorize: yes
+  become: yes
 
 - name: test getting default facts
   eos_facts:
@@ -28,4 +34,4 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config
 
-- debug: msg="END cli/default.yaml on connection={{ ansible_connection }}"
+- debug: msg="END cli/default_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/default_facts.yaml
@@ -1,15 +1,9 @@
 ---
 - debug: msg="START cli/default_facts.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test getting default facts
   eos_facts:
+    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_facts/tests/cli/invalid_subset.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/invalid_subset.yaml
@@ -1,11 +1,12 @@
 ---
 - debug: msg="START cli/invalid_subset.yaml on connection={{ ansible_connection }}"
 
-
 - name: test invalid subset (foobar)
   eos_facts:
     gather_subset:
       - "foobar"
+    provider: "{{ cli }}"
+  become: yes
   register: result
   ignore_errors: true
 
@@ -18,29 +19,5 @@
       - "result.failed == true"
       # Sensible Failure message
       - "'Subset must be one of' in result.msg"
-
-###############
-# FIXME Future
-# We may in the future want to add a test for
-
-- name: test subset specified multiple times
-  eos_facts:
-    gather_subset:
-      - "!hardware"
-      - "hardware"
-  register: result
-  ignore_errors: true
-
-- assert:
-    that:
-      # Failures shouldn't return changes
-      - "result.changed == false"
-      # It's a failure
-      - "result.failed == true"
-      # Sensible Failure message
-      - "'Subset must be one of' in result.msg"
-  ignore_errors: true
-
-
 
 - debug: msg="END cli/invalid_subset.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
@@ -1,17 +1,11 @@
 ---
 - debug: msg="START cli/not_hardware.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test not hardware
   eos_facts:
     gather_subset:
       - "!hardware"
+    provider: "{{ cli }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/cli/not_hardware.yaml
@@ -1,6 +1,12 @@
 ---
 - debug: msg="START cli/not_hardware.yaml on connection={{ ansible_connection }}"
 
+- name: Make sure LLDP is running (setup)
+  eos_config:
+    lines: lldp run
+    provider:
+      authorize: yes
+  become: yes
 
 - name: test not hardware
   eos_facts:

--- a/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
@@ -1,9 +1,11 @@
 ---
-- debug: msg="START eapi/all_facts.yaml"
+- debug: msg="START eapi/all_facts.yaml on connection={{ ansible_connection }}"
 
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
+    provider:
+      authorize: yes
   become: yes
 
 - name: test getting all facts
@@ -30,4 +32,4 @@
       - "result.ansible_facts.ansible_net_memfree_mb > 1"
       - "result.ansible_facts.ansible_net_memtotal_mb > 1"
 
-- debug: msg="END eapi/all_facts.yaml"
+- debug: msg="END eapi/all_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/all_facts.yaml
@@ -1,17 +1,11 @@
 ---
 - debug: msg="START eapi/all_facts.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test getting all facts
   eos_facts:
     gather_subset:
       - all
+    provider: "{{ eapi }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
@@ -1,15 +1,9 @@
 ---
 - debug: msg="START eapi/default_facts.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test getting default facts
   eos_facts:
+    provider: "{{ eapi }}"
   become: yes
   register: result
 

--- a/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/default_facts.yaml
@@ -1,9 +1,11 @@
 ---
-- debug: msg="START eapi/default_facts.yaml"
+- debug: msg="START eapi/default_facts.yaml on connection={{ ansible_connection }}"
 
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
+    provider:
+      authorize: yes
   become: yes
 
 - name: test getting default facts
@@ -32,4 +34,4 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_config is not defined" # config
 
-- debug: msg="END eapi/default.yaml"
+- debug: msg="END eapi/default_facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/eapi/invalid_subset.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/invalid_subset.yaml
@@ -1,11 +1,12 @@
 ---
-- debug: msg="START eapi/invalid_subset.yaml"
-
+- debug: msg="START eapi/invalid_subset.yaml on connection={{ ansible_connection }}"
 
 - name: test invalid subset (foobar)
   eos_facts:
     gather_subset:
       - "foobar"
+    provider: "{{ eapi }}"
+  become: yes
   register: result
   ignore_errors: true
 
@@ -19,28 +20,4 @@
       # Sensible Failure message
       - "'Subset must be one of' in result.msg"
 
-###############
-# FIXME Future
-# We may in the future want to add a test for
-
-- name: test subset specified multiple times
-  eos_facts:
-    gather_subset:
-      - "!hardware"
-      - "hardware"
-  register: result
-  ignore_errors: true
-
-- assert:
-    that:
-      # Failures shouldn't return changes
-      - "result.changed == false"
-      # It's a failure
-      - "result.failed == true"
-      # Sensible Failure message
-      #- "result.msg == 'Bad subset'"
-  ignore_errors: true
-
-
-
-- debug: msg="END eapi/invalid_subset.yaml"
+- debug: msg="END eapi/invalid_subset.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
@@ -1,9 +1,11 @@
 ---
-- debug: msg="START eapi/not_hardware.yaml"
+- debug: msg="START eapi/not_hardware.yaml on connection={{ ansible_connection }}"
 
 - name: Make sure LLDP is running (setup)
   eos_config:
     lines: lldp run
+    provider:
+      authorize: yes
   become: yes
 
 - name: test not hardware
@@ -31,4 +33,4 @@
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 
-- debug: msg="END eapi/not_hardware.yaml"
+- debug: msg="END eapi/not_hardware.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
+++ b/test/integration/targets/eos_facts/tests/eapi/not_hardware.yaml
@@ -1,17 +1,11 @@
 ---
 - debug: msg="START eapi/not_hardware.yaml on connection={{ ansible_connection }}"
 
-- name: Make sure LLDP is running (setup)
-  eos_config:
-    lines: lldp run
-    provider:
-      authorize: yes
-  become: yes
-
 - name: test not hardware
   eos_facts:
     gather_subset:
       - "!hardware"
+    provider: "{{ eapi }}"
   become: yes
   register: result
 

--- a/test/integration/targets/nxos_facts/tests/common/all_facts.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/all_facts.yaml
@@ -3,16 +3,12 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-
 - name: test getting all facts
   nxos_facts:
     gather_subset:
       - all
-    timeout: 60
     provider: "{{ connection }}"
   register: result
-
-
 
 - assert:
     that:

--- a/test/integration/targets/nxos_facts/tests/common/default_facts.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/default_facts.yaml
@@ -3,7 +3,6 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-
 - name: test getting default facts
   nxos_facts:
     provider: "{{ connection }}"
@@ -27,7 +26,7 @@
       - "result.ansible_facts.ansible_net_memtotal_mb > 10" #hw
       - "result.ansible_facts.ansible_net_model is defined" #default
       - "result.ansible_facts.ansible_net_interfaces is defined" #interfaces
-    # FIXME
+      # FIXME
 #      - "result.ansible_facts.ansible_net_interfaces.Ethernet1.ipv4.masklen > 1" # interfaces
 
       # ... and not present

--- a/test/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/invalid_subset.yaml
@@ -3,7 +3,6 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-
 - name: test invalid subset (foobar)
   nxos_facts:
     gather_subset:
@@ -11,7 +10,6 @@
     provider: "{{ connection }}"
   register: result
   ignore_errors: true
-
 
 - assert:
     that:
@@ -21,30 +19,5 @@
       - "result.failed == true"
       # Sensible Failure message
       - "'Subset must be one of' in result.msg"
-
-###############
-# FIXME Future
-# We may in the future want to add a test for
-
-- name: test subset specified multiple times
-  nxos_facts:
-    gather_subset:
-      - "!hardware"
-      - "hardware"
-    provider: "{{ connection }}"
-  register: result
-  ignore_errors: true
-
-- assert:
-    that:
-      # Failures shouldn't return changes
-      - "result.changed == false"
-      # It's a failure
-      - "result.failed == true"
-      # Sensible Failure message
-      - "result.msg == 'Bad subset'"
-  ignore_errors: true
-
-
 
 - debug: msg="END connection={{ ansible_connection }}/invalid_subset.yaml"

--- a/test/integration/targets/nxos_facts/tests/common/not_hardware.yaml
+++ b/test/integration/targets/nxos_facts/tests/common/not_hardware.yaml
@@ -3,12 +3,10 @@
 - debug: msg="Using provider={{ connection.transport }}"
   when: ansible_connection == "local"
 
-
 - name: test not hardware
   nxos_facts:
     gather_subset:
       - "!hardware"
-    timeout: 30
     provider: "{{ connection }}"
   register: result
 
@@ -21,13 +19,12 @@
       - "'config' in result.ansible_facts.ansible_net_gather_subset"
       - "'default' in result.ansible_facts.ansible_net_gather_subset"
       - "'interfaces' in result.ansible_facts.ansible_net_gather_subset"
-
       # ... and not present
       - "'hardware' not in result.ansible_facts.ansible_net_gather_subset"
 
       # Items from those subsets are present
       # FIXME
-      #      - "result.ansible_facts.ansible_net_interfaces.['Ethernet2/15'].mtu > 1" # interfaces
+#      - "result.ansible_facts.ansible_net_interfaces.['Ethernet2/15'].mtu > 1" # interfaces
       # ... and not present
       - "result.ansible_facts.ansible_net_filesystems is not defined"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Avoid failing {e,nx}os_facts when only legacy facts are asked for.

`gather_network_resources` are not supported over `connection: local`

Fixes #60592

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_facts
nxos_facts