### PR TITLE
Remove deprecated kubernetes and oc module "indirection" in v2.9 changelog

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.9.rst
@@ -118,11 +118,11 @@ The following modules no longer exist:
 
 * Apstra's ``aos_*`` modules.  See the new modules at  `https://github.com/apstra <https://github.com/apstra>`_.
 * ec2_ami_find use :ref:`ec2_ami_facts <ec2_ami_facts_module>` instead.
-* kubernetes use :ref:`k8s_raw <k8s_raw_module>` instead.
+* kubernetes use :ref:`k8s <k8s_module>` instead.
 * nxos_ip_interface use :ref:`nxos_l3_interface <nxos_l3_interface_module>` instead.
 * nxos_portchannel use :ref:`nxos_linkagg <nxos_linkagg_module>` instead.
 * nxos_switchport use :ref:`nxos_l2_interface <nxos_l2_interface_module>` instead.
-* oc use :ref:`openshift_raw <openshift_raw_module>` instead.
+* oc use :ref:`k8s <k8s_module>` instead.
 * panos_nat_policy use :ref:`panos_nat_rule <panos_nat_rule_module>` instead.
 * panos_security_policy use :ref:`panos_security_rule <panos_security_rule_module>` instead.
 * vsphere_guest use :ref:`vmware_guest <vmware_guest_module>` instead.


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Both `_raw` modules listed as being removed are just aliases to the `k8s` module. While the module reference takes a reader to the right page through a redirect the doc should be clear in stating what is the real module behind it.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
