### PR TITLE
[stable-2.9] Switch from RHEL 8.0 & 8.1b to 8.1 in CI.

### DIFF
--- a/changelogs/fragments/ansible-test-rhel-8.1-testing.yml
+++ b/changelogs/fragments/ansible-test-rhel-8.1-testing.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - switch from testing RHEL 8.0 and RHEL 8.1 Beta to RHEL 8.1

--- a/shippable.yml
+++ b/shippable.yml
@@ -81,8 +81,7 @@ matrix:
 
     - env: T=osx/10.11/1
     - env: T=rhel/7.6/1
-    - env: T=rhel/8.0/1
-    - env: T=rhel/8.1b/1
+    - env: T=rhel/8.1/1
     - env: T=freebsd/11.1/1
     - env: T=freebsd/12.0/1
     - env: T=linux/centos6/1
@@ -96,8 +95,7 @@ matrix:
 
     - env: T=osx/10.11/2
     - env: T=rhel/7.6/2
-    - env: T=rhel/8.0/2
-    - env: T=rhel/8.1b/2
+    - env: T=rhel/8.1/2
     - env: T=freebsd/11.1/2
     - env: T=freebsd/12.0/2
     - env: T=linux/centos6/2
@@ -111,8 +109,7 @@ matrix:
 
     - env: T=osx/10.11/3
     - env: T=rhel/7.6/3
-    - env: T=rhel/8.0/3
-    - env: T=rhel/8.1b/3
+    - env: T=rhel/8.1/3
     - env: T=freebsd/11.1/3
     - env: T=freebsd/12.0/3
     - env: T=linux/centos6/3
@@ -126,8 +123,7 @@ matrix:
 
     - env: T=osx/10.11/4
     - env: T=rhel/7.6/4
-    - env: T=rhel/8.0/4
-    - env: T=rhel/8.1b/4
+    - env: T=rhel/8.1/4
     - env: T=freebsd/11.1/4
     - env: T=freebsd/12.0/4
     - env: T=linux/centos6/4

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,5 +2,4 @@ freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
 freebsd/12.0 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
-rhel/8.0 python=3.6
-rhel/8.1b python=3.6
+rhel/8.1 python=3.6


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Switch from RHEL 8.0 & 8.1b to 8.1 in CI.

Backport of https://github.com/ansible/ansible/pull/64521

(cherry picked from commit 75646037dc3b927a33912fd968a1864920115c6e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
