### PR TITLE
Correct usage of API call in aws_config_aggregator

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
@@ -128,7 +128,7 @@ def create_resource(client, module, params, result):
         module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
 
 
-def update_resource(client, module, resource_type, params, result):
+def update_resource(client, module, params, result):
     current_params = client.describe_configuration_aggregators(
         ConfigurationAggregatorNames=[params['name']]
     )
@@ -151,7 +151,7 @@ def update_resource(client, module, resource_type, params, result):
             module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
 
 
-def delete_resource(client, module, resource_type, params, result):
+def delete_resource(client, module, params, result):
     try:
         client.delete_configuration_aggregator(
             ConfigurationAggregatorName=params['ConfigurationAggregatorName']


### PR DESCRIPTION
##### SUMMARY

update_resource and delete_resource takes and requires four argument.
This PR fixes the requirement.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
