### PR TITLE
Don't return module error when mysql_connect fails (#64560)

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -78,11 +78,7 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
 
-    try:
-        db_connection = mysql_driver.connect(**config)
-
-    except Exception as e:
-        module.fail_json(msg="unable to connect to database: %s" % to_native(e))
+    db_connection = mysql_driver.connect(**config)
 
     if cursor_class == 'DictCursor':
         return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})

--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -452,9 +452,13 @@ def main():
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)
 
-    cursor = mysql_connect(module, login_user, login_password,
-                           config_file, ssl_cert, ssl_key, ssl_ca, db,
-                           connect_timeout=connect_timeout, cursor_class='DictCursor')
+    try:
+        cursor = mysql_connect(module, login_user, login_password,
+                               config_file, ssl_cert, ssl_key, ssl_ca, db,
+                               connect_timeout=connect_timeout, cursor_class='DictCursor')
+    except Exception as e:
+        module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
+                             "Exception message: %s" % (config_file, to_native(e)))
 
     ###############################
     # Create object and do main job

--- a/test/integration/targets/mysql_user/defaults/main.yml
+++ b/test/integration/targets/mysql_user/defaults/main.yml
@@ -7,6 +7,8 @@ user_name_2: 'db_user2'
 user_password_1: 'gadfFDSdtTU^Sdfuj'
 user_password_2: 'jkFKUdfhdso78yi&td'
 
+root_password: 'zevuR6oPh7'
+
 db_names:
     - clientdb
     - employeedb

--- a/test/integration/targets/mysql_user/tasks/issue-64560.yaml
+++ b/test/integration/targets/mysql_user/tasks/issue-64560.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: Set root password
+  mysql_user:
+    name: root
+    password: '{{ root_password }}'
+    login_user: root
+    login_password: '{{ root_password }}'
+    check_implicit_admin: yes
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: assert root password is changed
+  assert: { that: "result.changed == true" }
+
+- name: Set root password again
+  mysql_user:
+    name: root
+    password: '{{ root_password }}'
+    login_user: root
+    login_password: '{{ root_password }}'
+    check_implicit_admin: yes
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert root password is not changed
+  assert: { that: "result.changed == false" }

--- a/test/integration/targets/mysql_user/tasks/main.yml
+++ b/test/integration/targets/mysql_user/tasks/main.yml
@@ -211,3 +211,7 @@
 - import_tasks: issue-29511.yaml
   tags:
     - issue-29511
+
+- import_tasks: issue-64560.yaml
+  tags:
+    - issue-64560


### PR DESCRIPTION
mysql_user expects an Exception when using check_implicit_admin.

##### SUMMARY

Fixes ##64560

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

- mysql_user module
- mysql_utils

##### ADDITIONAL INFORMATION

Fixes regression bug #64560 introduced with #55434 (which raises `module.fail_json` in utility function `mysql_connect`)