### PR TITLE
Backport of postgresql_publication: fix typo in module.warn (#64582)

### DIFF
--- a/changelogs/fragments/64582-postgresql_publication_fix_typo_in_module_warn.yml
+++ b/changelogs/fragments/64582-postgresql_publication_fix_typo_in_module_warn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_publication - fix typo in module.warn method name (https://github.com/ansible/ansible/issues/64582).

--- a/lib/ansible/modules/database/postgresql/postgresql_publication.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_publication.py
@@ -603,7 +603,7 @@ def main():
             module.warn('parameter "owner" is ignored when "state=absent"')
 
     if state == 'present' and cascade:
-        module.warm('parameter "cascade" is ignored when "state=present"')
+        module.warn('parameter "cascade" is ignored when "state=present"')
 
     # Connect to DB and make cursor object:
     conn_params = get_conn_params(module, module.params)


### PR DESCRIPTION
(cherry picked from commit 2039bf45fe60c9e748d54655afe5cecf72e9f3cc)

##### SUMMARY

Backport of #64582

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_publication.py```