### PR TITLE
Remove temp directory created by wait_for_connection

### DIFF
--- a/changelogs/fragments/62407-wait_for_connection.yml
+++ b/changelogs/fragments/62407-wait_for_connection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Remove a temp directory created by wait_for_connection action plugin (https://github.com/ansible/ansible/issues/62407).

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -115,4 +115,7 @@ class ActionModule(ActionBase):
         elapsed = datetime.now() - start
         result['elapsed'] = elapsed.seconds
 
+        # remove a temporary path we created
+        self._remove_tmp_path(self._connection._shell.tmpdir)
+
         return result


### PR DESCRIPTION
##### SUMMARY

wait_for_connection creates AnsiballZ_ping.py in temp directory,
which remains on remote machine even after playbook run.

Fixes: #62407

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/62407-wait_for_connection.yml
lib/ansible/plugins/action/wait_for_connection.py
