### PR TITLE
[2.9] Correct usage of API call in aws_config_aggregator

### DIFF
--- a/changelogs/fragments/64581-aws_config_aggregator_fix.yml
+++ b/changelogs/fragments/64581-aws_config_aggregator_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fixes update_resource and delete_resource API for correct number of arguments in aws_config_aggregator (https://github.com/ansible/ansible/pull/64581).

--- a/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
@@ -114,7 +114,7 @@ def create_resource(client, module, params, result):
         module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
 
 
-def update_resource(client, module, resource_type, params, result):
+def update_resource(client, module, params, result):
     current_params = client.describe_configuration_aggregators(
         ConfigurationAggregatorNames=[params['name']]
     )
@@ -137,7 +137,7 @@ def update_resource(client, module, resource_type, params, result):
             module.fail_json_aws(e, msg="Couldn't create AWS Config configuration aggregator")
 
 
-def delete_resource(client, module, resource_type, params, result):
+def delete_resource(client, module, params, result):
     try:
         client.delete_configuration_aggregator(
             ConfigurationAggregatorName=params['ConfigurationAggregatorName']


### PR DESCRIPTION
##### SUMMARY

update_resource and delete_resource takes and requires four argument.

Backport of https://github.com/ansible/ansible/pull/64581

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 21c8dae83b832a8abde59e7ba94c74d6c7f8a128)


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/64581-aws_config_aggregator_fix.yml
lib/ansible/modules/cloud/amazon/aws_config_aggregator.py
