### PR TITLE
- add nextToken support

### DIFF
--- a/changelogs/fragments/64598-add-next-token-support.yml
+++ b/changelogs/fragments/64598-add-next-token-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cloudwatchlogs_log_group_info - remove limitation of max 50 results

--- a/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_info.py
@@ -84,10 +84,12 @@ except ImportError:
     pass  # will be detected by imported HAS_BOTO3
 
 
-def describe_log_group(client, log_group_name, module):
+def describe_log_group(client, log_group_name, log_group_next_token, module):
     params = {}
     if log_group_name:
         params['logGroupNamePrefix'] = log_group_name
+    if log_group_next_token:
+        params['nextToken'] = log_group_next_token
     try:
         desc_log_group = client.describe_log_groups(**params)
         return desc_log_group
@@ -115,13 +117,22 @@ def main():
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     logs = boto3_conn(module, conn_type='client', resource='logs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
-    desc_log_group = describe_log_group(client=logs,
-                                        log_group_name=module.params['log_group_name'],
-                                        module=module)
     final_log_group_snake = []
+    group_next_token = None
 
-    for log_group in desc_log_group['logGroups']:
-        final_log_group_snake.append(camel_dict_to_snake_dict(log_group))
+    while True:
+        desc_log_group = describe_log_group(client=logs,
+                                            log_group_name=module.params['log_group_name'],
+                                            log_group_next_token=group_next_token,
+                                            module=module)
+
+        for log_group in desc_log_group['logGroups']:
+            final_log_group_snake.append(camel_dict_to_snake_dict(log_group))
+
+        if 'nextToken' in desc_log_group.keys():
+            group_next_token = desc_log_group['nextToken']
+        else:
+            break
 
     desc_log_group_result = dict(changed=False, log_groups=final_log_group_snake)
     module.exit_json(**desc_log_group_result)


### PR DESCRIPTION
##### SUMMARY
Add support for boto3 describe_log_groups#nextToken argument to fetch more than 50 results.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
cloudwatchlogs_log_group_info

##### ADDITIONAL INFORMATION
If you have more than 50 log groups to be queried.

playbook:
```
- name: loggroup test
  hosts:
    - localhost
  gather_facts: no
  tasks:
    - cloudwatchlogs_log_group_info:
        region: eu-west-1
      register: bla
      delegate_to: localhost
    - name: show length
      debug:
        var: bla.log_groups|length

```

before:
```
TASK [show length] ***********************************************************************************************************
ok: [localhost] => {
    "bla.log_groups|length": "50"
}
```

after:
```
TASK [show length] ***********************************************************************************************************
ok: [localhost] => {
    "bla.log_groups|length": "205"
}


```