### PR TITLE
route53_info  max_items should be a str

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_info.py
+++ b/lib/ansible/modules/cloud/amazon/route53_info.py
@@ -61,7 +61,7 @@ options:
         using the NextMarker entry from the first response to get the next page
         of results."
     required: false
-    type: int
+    type: str
   delegation_set_id:
     description:
       - The DNS Zone delegation set ID.
@@ -418,7 +418,7 @@ def main():
         change_id=dict(),
         hosted_zone_id=dict(),
         max_items=dict(),
-        next_marker=dict(type='int'),
+        next_marker=dict(),
         delegation_set_id=dict(),
         start_record_name=dict(),
         type=dict(choices=[

--- a/lib/ansible/modules/cloud/amazon/route53_info.py
+++ b/lib/ansible/modules/cloud/amazon/route53_info.py
@@ -52,7 +52,7 @@ options:
     description:
       - Maximum number of items to return for various get/list requests.
     required: false
-    type: int
+    type: str
   next_marker:
     description:
       - "Some requests such as list_command: hosted_zones will return a maximum
@@ -417,7 +417,7 @@ def main():
         ], required=True),
         change_id=dict(),
         hosted_zone_id=dict(),
-        max_items=dict(type='int'),
+        max_items=dict(),
         next_marker=dict(type='int'),
         delegation_set_id=dict(),
         start_record_name=dict(),

--- a/test/integration/targets/route53/aliases
+++ b/test/integration/targets/route53/aliases
@@ -1,2 +1,3 @@
+route53_info
 cloud/aws
 shippable/aws/group2

--- a/test/integration/targets/route53/tasks/main.yml
+++ b/test/integration/targets/route53/tasks/main.yml
@@ -21,8 +21,23 @@
       comment: Created in Ansible test {{ resource_prefix }}
     register: z1
 
-  - debug: msg='TODO write tests'
-  - debug: var=z1
+  - assert:
+      that:
+        - z1 is success
+        - z1 is changed
+        - "z1.comment == 'Created in Ansible test {{ resource_prefix }}'"
+
+  - name: List hosted zones
+    route53_info:
+      query: hosted_zone
+      hosted_zone_id: '{{ z1.zone_id }}'
+      max_items: 50
+    register: hosted_zones
+
+  - name: Assert hosted zones information
+    assert:
+      that:
+        - hosted_zones.HostedZones|length == 1
 
   - name: Create A record using zone fqdn
     route53:
@@ -93,6 +108,20 @@
         - mv_a_record is not failed
         - mv_a_record is not changed
 
+  - name: get Route53 A record information
+    route53_info:
+      type: A
+      query: record_sets
+      hosted_zone_id: '{{ z1.zone_id }}'
+      start_record_name: 'order_test.{{ zone_one }}'
+    register: records
+  - assert:
+      that:
+        - records.ResourceRecordSets|length == 3
+        - records.ResourceRecordSets[0].ResourceRecords|length == 2
+        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "4.5.6.7"
+        - records.ResourceRecordSets[0].ResourceRecords[1].Value == "1.2.3.4"
+
   - name: Remove a member from multi-value A record with values in different order
     route53:
       state: present
@@ -119,11 +148,24 @@
         - 4.5.6.7
     register: del_a_record
     ignore_errors: true
-  - name: This should fail, because `overwrite` is false
+  - name: This should not fail, because `overwrite` is true
     assert:
       that:
         - del_a_record is not failed
         - del_a_record is changed
+
+  - name: get Route53 zone A record information
+    route53_info:
+      type: A
+      query: record_sets
+      hosted_zone_id: '{{ z1.zone_id }}'
+      start_record_name: 'order_test.{{ zone_one }}'
+    register: records
+  - assert:
+      that:
+        - records.ResourceRecordSets|length == 3
+        - records.ResourceRecordSets[0].ResourceRecords|length == 1
+        - records.ResourceRecordSets[0].ResourceRecords[0].Value == "4.5.6.7"
 
   - name: Create a LetsEncrypt CAA record
     route53:
@@ -173,6 +215,8 @@
       that:
         - caa is not failed
         - caa is not changed
+
+
   always:
   - route53_info:
       query: record_sets

--- a/test/integration/targets/route53/tasks/main.yml
+++ b/test/integration/targets/route53/tasks/main.yml
@@ -27,17 +27,17 @@
         - z1 is changed
         - "z1.comment == 'Created in Ansible test {{ resource_prefix }}'"
 
-  - name: List hosted zones
+  - name: Get zone details
     route53_info:
       query: hosted_zone
       hosted_zone_id: '{{ z1.zone_id }}'
-      max_items: 50
+      hosted_zone_method: details
     register: hosted_zones
 
-  - name: Assert hosted zones information
+  - name: Assert newly created hosted zone only has NS and SOA records
     assert:
       that:
-        - hosted_zones.HostedZones|length == 1
+        - hosted_zones.HostedZone.ResourceRecordSetCount == 2
 
   - name: Create A record using zone fqdn
     route53:
@@ -114,6 +114,7 @@
       query: record_sets
       hosted_zone_id: '{{ z1.zone_id }}'
       start_record_name: 'order_test.{{ zone_one }}'
+      max_items: 50
     register: records
   - assert:
       that:
@@ -160,6 +161,7 @@
       query: record_sets
       hosted_zone_id: '{{ z1.zone_id }}'
       start_record_name: 'order_test.{{ zone_one }}'
+      max_items: 50
     register: records
   - assert:
       that:


### PR DESCRIPTION
##### SUMMARY
Type was changed to int in #64358, however boto3 takes a str for this option. The change is also backwards incompatible with existing playbooks.
Add some basic tests for route53_info.
Fixes: #64534

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
route53_info
