### PR TITLE
httpapi: Refine default 401 handling

### DIFF
--- a/lib/ansible/plugins/httpapi/__init__.py
+++ b/lib/ansible/plugins/httpapi/__init__.py
@@ -68,11 +68,15 @@ class HttpApiBase(AnsiblePlugin):
             server without making another request. In many cases, this can just
             be the original exception.
             """
-        if exc.code == 401 and self.connection._auth:
-            # Stored auth appears to be invalid, clear and retry
-            self.connection._auth = None
-            self.login(self.connection.get_option('remote_user'), self.connection.get_option('password'))
-            return True
+        if exc.code == 401:
+            if self.connection._auth:
+                # Stored auth appears to be invalid, clear and retry
+                self.connection._auth = None
+                self.login(self.connection.get_option('remote_user'), self.connection.get_option('password'))
+                return True
+            else:
+                # Unauthorized and there's no token. Return an error
+                return False
 
         return exc
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The worst case scenario of no auth and 401 returns the HTTPError object, when failure is probably more reasonable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi