### PR TITLE
[2.9] Fixed tiny typo in interpreter_discovery.rst

### DIFF
--- a/changelogs/fragments/inventory_discovery_doc_typo.yml
+++ b/changelogs/fragments/inventory_discovery_doc_typo.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fixed typo in inventory_discovery.rst document.

--- a/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
+++ b/docs/docsite/rst/reference_appendices/interpreter_discovery.rst
@@ -23,7 +23,7 @@ auto_legacy : (default in 2.8)
   and issues a warning.
   This exception provides temporary compatibility with previous versions of
   Ansible that always defaulted to ``/usr/bin/python``, so if you have
-  installed Python and other dependencies at ``usr/bin/python`` on some hosts,
+  installed Python and other dependencies at ``/usr/bin/python`` on some hosts,
   Ansible will find and use them with this setting.
   If no entry is found, or the listed Python is not present on the
   target host, searches a list of common Python interpreter


### PR DESCRIPTION
##### SUMMARY

Added missing '/'

Backport of https://github.com/ansible/ansible/pull/64608

(cherry picked from commit 84bffff96a5e3b81a8caaaaca1da5d589cb80e82)


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/inventory_discovery_doc_typo.rst
docs/docsite/rst/reference_appendices/interpreter_discovery.rst
