### PR TITLE
docker_container: change network_host default behavior for Ansible 2.14

### DIFF
--- a/changelogs/fragments/64635-docker_container-network_mode.yml
+++ b/changelogs/fragments/64635-docker_container-network_mode.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- "docker_container - the default value for ``network_mode`` will change in Ansible 2.14, provided at least one network is specified and ``networks_cli_compatible`` is ``true``. See porting guide, module documentation or deprecation warning for more details."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -75,6 +75,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 The following functionality will change in Ansible 2.14. Please update update your playbooks accordingly.
 
 * The :ref:`docker_container <docker_container_module>` module has a new option, ``container_default_behavior``, whose default value will change from ``compatibility`` to ``no_defaults``. Set to an explicit value to avoid deprecation warnings.
+* The :ref:`docker_container <docker_container_module>` module's ``network_mode`` option will be set by default to the name of the first network in ``networks`` if at least one network is given and ``networks_cli_compatible`` is ``true`` (will be default from Ansible 2.12 on). Set to an explicit value to avoid deprecation warnings if you specify networks and set ``networks_cli_compatible`` to ``true``. The current default (not specifying it) is equivalent to the value ``default``.
 * :ref:`iam_policy <iam_policy_module>`: the default value for the ``skip_duplicates`` option will change from ``true`` to ``false``.  To maintain the existing behavior explicitly set it to ``true``.
 
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -519,7 +519,7 @@ options:
     required: yes
   network_mode:
     description:
-      - Connect the container to a network. Choices are C(bridge), C(host), C(none) or C(container:<name|id>).
+      - Connect the container to a network. Choices are C(bridge), C(host), C(none), C(container:<name|id>), C(<network_name>) or C(default).
     type: str
   userns_mode:
     description:


### PR DESCRIPTION
##### SUMMARY
In case `networks_cli_compatible` is set to `true` (new default from 2.12 on) and `networks` has at least one entry, I want to change the default value of `network_mode` to the name of the first network in `networks`. This improves compatibility of `docker_container` to docker CLI and will prevent problems such as #64555 in the future.

Includes a deprecation warning for the situation `networks_cli_compatible is true`, `network_mode is none` and `networks | length > 0` (in which situation the default will actually change).

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docker_container
