### PR TITLE
docker_swarm_service: Allow source to be omitted for tmpfs mounts

### DIFF
--- a/changelogs/fragments/64637-docker_swarm_service-tmpfs-source.yml
+++ b/changelogs/fragments/64637-docker_swarm_service-tmpfs-source.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - ``source`` must no longer be specified for ``tmpfs`` mounts."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -284,8 +284,8 @@ options:
       source:
         description:
           - Mount source (e.g. a volume name or a host path).
+          - Must be specified if I(type) is not C(tmpfs).
         type: str
-        required: yes
       target:
         description:
           - Container path.
@@ -1706,7 +1706,9 @@ class DockerService(DockerBaseClass):
                 service_m = {}
                 service_m['readonly'] = param_m['readonly']
                 service_m['type'] = param_m['type']
-                service_m['source'] = param_m['source']
+                if param_m['source'] is None and param_m['type'] != 'tmpfs':
+                    raise ValueError('Source must be specified for mounts which are not of type tmpfs')
+                service_m['source'] = param_m['source'] or ''
                 service_m['target'] = param_m['target']
                 service_m['labels'] = param_m['labels']
                 service_m['no_copy'] = param_m['no_copy']
@@ -2624,7 +2626,7 @@ def main():
         image=dict(type='str'),
         state=dict(type='str', default='present', choices=['present', 'absent']),
         mounts=dict(type='list', elements='dict', options=dict(
-            source=dict(type='str', required=True),
+            source=dict(type='str'),
             target=dict(type='str', required=True),
             type=dict(
                 type='str',

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -539,6 +539,18 @@
   register: mounts_tmpfs_source_2
   ignore_errors: yes
 
+- name: mounts.source (not specified for tmpfs idempotency)
+  docker_swarm_service:
+    name: "{{ service_name }}"
+    image: alpine:3.8
+    resolve_image: no
+    command: '/bin/sh -v -c "sleep 10m"'
+    mounts:
+      - target: "/tmp/{{ volume_name_1 }}"
+        type: "tmpfs"
+  register: mounts_tmpfs_source_3
+  ignore_errors: yes
+
 - name: cleanup
   docker_swarm_service:
     name: "{{ service_name }}"
@@ -549,6 +561,7 @@
     that:
       - mounts_tmpfs_source_1 is changed
       - mounts_tmpfs_source_2 is not changed
+      - mounts_tmpfs_source_3 is not changed
   when: docker_py_version is version('2.6.0', '>=')
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Fixes #62728. Allows `source` to be omitted when `type` is `tmpfs` for mounts. Currently, the user must use an empty string.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm_service
