### PR TITLE
[2.7] Fix import errors for docker_* modules for Python 2 when Ansible >= 2.8 is installed on the remote machine

### DIFF
--- a/changelogs/fragments/64639-docker-relative-import.yml
+++ b/changelogs/fragments/64639-docker-relative-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_* modules - fix Docker SDK for Python import problem when Python 2 is used and a newer Ansible version is installed on the target machine."

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
+
 import os
 import re
 import json


### PR DESCRIPTION
##### SUMMARY
Fixes a nasty import bug due to Python 2's implicit relative imports which happens when using Ansible 2.7 to run a docker_* module on a target machine with Python 2 and a newer version of Ansible installed (2.8 or newer).

Since `module_utils/docker_common.py` was renamed to `module_utils/docker/common.py` in 2.8, and `module_utils/docker_common.py` contains `import docker`, Python 2 will import `module_utils/docker/` instead of the Docker SKD for Python. This causes the strange `cannot import name __version__` errors. This does not happen for Python 3 (which has implicit relative imports removed) or when `from __future__ import absolute_import` is around.

Fixes #56576.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/docker_common.py
