### PR TITLE
Update:alternative directory layout recommendation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_best_practices.rst
+++ b/docs/docsite/rst/user_guide/playbooks_best_practices.rst
@@ -104,10 +104,10 @@ Alternatively you can put each inventory file with its ``group_vars``/``host_var
     library/
     module_utils/
     filter_plugins/
-
-    site.yml
-    webservers.yml
-    dbservers.yml
+    plays/
+       site.yml
+       webservers.yml
+       dbservers.yml
 
     roles/
         common/


### PR DESCRIPTION
##### SUMMARY
Alternative directory layout is strongly recommended for more complex environments.
Due to this, it is highly recommended to store the playbooks itself not in the main folder. I recommend putting them in a subfolder called plays. This is already used in a lot of playbooks available in GitHub.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
