### PR TITLE
acme_certificate: Fix ACME v1 support when modify_account is set to false

### DIFF
--- a/changelogs/fragments/64648-acme_certificate-acmev1.yml
+++ b/changelogs/fragments/64648-acme_certificate-acmev1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - fix misbehavior when ACME v1 is used with ``modify_account`` set to ``false``."

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -646,9 +646,6 @@ class ACMEClient(object):
         Return the authorization object of the new authorization
         https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4
         '''
-        if self.account.uri is None:
-            return
-
         new_authz = {
             "resource": "new-authz",
             "identifier": {"type": identifier_type, "value": identifier},


### PR DESCRIPTION
##### SUMMARY
When ACME v1 is used with `modify_account: false`, the module doesn't do anything. This is because no initial account setup is done (since this can not be done without accidentally creating a new account when the account key is unknown for ACME v1). This removes a check which isn't needed for ACME v1 (and not used for ACME v2) which causes this problem.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
