### PR TITLE
[2.8] Fixes #56832: Remove warning when falling back to apt-get if aptitude unavailable

### DIFF
--- a/changelogs/fragments/56832-remove-aptitude-warning.yml
+++ b/changelogs/fragments/56832-remove-aptitude-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove the unnecessary warning about aptitude not being installed (https://github.com/ansible/ansible/issues/56832).

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1057,7 +1057,6 @@ def main():
     use_apt_get = p['force_apt_get']
 
     if not use_apt_get and not APTITUDE_CMD:
-        module.warn("Could not find aptitude. Using apt-get instead")
         use_apt_get = True
 
     updated_cache = False

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -35,14 +35,6 @@
     when:
       - force_apt_get
 
-  - name: check that warning is given when aptitude not found and force_apt_get not set
-    assert:
-      that:
-        - "'Could not find aptitude. Using apt-get instead' in upgrade_result.warnings[0]"
-    when:
-      - not aptitude_present
-      - not force_apt_get
-
   - name: check that old version upgraded correctly
     assert:
       that:


### PR DESCRIPTION
##### SUMMARY
Backport of #61782 to stable-2.8. Removes unnecessary and annoying warning `Could not find aptitude. Using apt-get instead`.

CC @geerlingguy

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt
