### PR TITLE
distribution: ignore plesk-release file while parsing

### DIFF
--- a/changelogs/fragments/distribution_release.yml
+++ b/changelogs/fragments/distribution_release.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Ignore plesk-release file while parsing distribution release (https://github.com/ansible/ansible/issues/64101).

--- a/lib/ansible/module_utils/distro/_distro.py
+++ b/lib/ansible/module_utils/distro/_distro.py
@@ -94,7 +94,9 @@ _DISTRO_RELEASE_IGNORE_BASENAMES = (
     'lsb-release',
     'oem-release',
     _OS_RELEASE_BASENAME,
-    'system-release'
+    'system-release',
+    # Fixed in upstream via https://github.com/nir0s/distro/pull/246
+    'plesk-release'
 )
 
 


### PR DESCRIPTION
##### SUMMARY

/etc/plesk-release file is now ignored while parsing distribution
release.

Fixes: #64101

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/distribution_release.yml
lib/ansible/module_utils/distro/_distro.py
