### PR TITLE
Set alter_sys=True instead of False to address backwards incompat

### DIFF
--- a/changelogs/fragments/64664-fix-sys-modules-file.yml
+++ b/changelogs/fragments/64664-fix-sys-modules-file.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- module executor - Address issue where changes to Ansiballz module code, change the behavior
+  of module execution as it pertains to ``__file__`` and ``sys.modules``
+  (https://github.com/ansible/ansible/issues/64664)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -192,7 +192,7 @@ def _ansiballz_main():
         basic._ANSIBLE_ARGS = json_params
 %(coverage)s
         # Run the module!  By importing it as '__main__', it thinks it is executing as a script
-        runpy.run_module(mod_name='%(module_fqn)s', init_globals=None, run_name='__main__', alter_sys=False)
+        runpy.run_module(mod_name='%(module_fqn)s', init_globals=None, run_name='__main__', alter_sys=True)
 
         # Ansible modules must exit themselves
         print('{"msg": "New-style module did not handle its own exit", "failed": true}')
@@ -286,7 +286,7 @@ def _ansiballz_main():
             basic._ANSIBLE_ARGS = json_params
 
             # Run the module!  By importing it as '__main__', it thinks it is executing as a script
-            runpy.run_module(mod_name='%(module_fqn)s', init_globals=None, run_name='__main__', alter_sys=False)
+            runpy.run_module(mod_name='%(module_fqn)s', init_globals=None, run_name='__main__', alter_sys=True)
 
             # Ansible modules must exit themselves
             print('{"msg": "New-style module did not handle its own exit", "failed": true}')

--- a/test/integration/targets/ansiballz_python/library/sys_check.py
+++ b/test/integration/targets/ansiballz_python/library/sys_check.py
@@ -2,6 +2,9 @@
 # https://github.com/ansible/ansible/issues/64664
 # https://github.com/ansible/ansible/issues/64479
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import sys
 
 from ansible.module_utils.basic import AnsibleModule

--- a/test/integration/targets/ansiballz_python/library/sys_check.py
+++ b/test/integration/targets/ansiballz_python/library/sys_check.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+# https://github.com/ansible/ansible/issues/64664
+# https://github.com/ansible/ansible/issues/64479
+
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule({})
+
+    this_module = sys.modules[__name__]
+    module.exit_json(
+        failed=not getattr(this_module, 'AnsibleModule', False)
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansiballz_python/tasks/main.yml
+++ b/test/integration/targets/ansiballz_python/tasks/main.yml
@@ -61,3 +61,8 @@
 
       # custom module returned the correct answer
       - custom_module_return.answer == 42
+
+# https://github.com/ansible/ansible/issues/64664
+# https://github.com/ansible/ansible/issues/64479
+- name: Run module that tries to access itself via sys.modules
+  sys_check:

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -223,7 +223,7 @@ def main():
                 with monitor_sys_modules(path, messages):
                     with blacklist_imports(path, name, messages):
                         with capture_output(capture_main):
-                            runpy.run_module(name, run_name='__main__')
+                            runpy.run_module(name, run_name='__main__', alter_sys=True)
         except ImporterAnsibleModuleException:
             # module instantiated AnsibleModule without raising an exception
             pass

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -114,7 +114,7 @@ def get_py_argument_spec(filename, collection):
     with setup_env(filename) as fake:
         try:
             with CaptureStd():
-                runpy.run_module(name, run_name='__main__')
+                runpy.run_module(name, run_name='__main__', alter_sys=True)
         except AnsibleModuleCallError:
             pass
         except BaseException as e:


### PR DESCRIPTION
##### SUMMARY
Set alter_sys=True instead of False to address backwards incompat

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
