### PR TITLE
Add warning if ssh_opts is present and git<2.3.0

### DIFF
--- a/changelogs/fragments/git-add-ssh-opts-warning.yaml
+++ b/changelogs/fragments/git-add-ssh-opts-warning.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - git - add warning if ssh_opts argument is provided, but the version of git
+  does not support it (https://github.com/ansible/ansible/issues/64673)

--- a/changelogs/fragments/git-add-ssh-opts-warning.yaml
+++ b/changelogs/fragments/git-add-ssh-opts-warning.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - git - add warning if ssh_opts argument is provided, but the version of git
-  does not support it (https://github.com/ansible/ansible/issues/64673)
+- "git - add warning if ssh_opts argument is present, but the version of git
+does not support it (https://github.com/ansible/ansible/issues/64673)"

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -52,9 +52,9 @@ options:
         description:
             - Creates a wrapper script and exports the path as GIT_SSH
               which git then automatically uses to override ssh arguments.
-              An example value could be "-o StrictHostKeyChecking=no"
-              (although this particular option is better set via
-              C(accept_hostkey)).
+              Needs I(git>=2.3.0) to work correctly. An example value could
+              be "-o StrictHostKeyChecking=no" (although this particular
+              option is better set via C(accept_hostkey)).
         version_added: "1.5"
     key_file:
         description:
@@ -1151,6 +1151,9 @@ def main():
     if depth is not None and git_version_used < LooseVersion('1.9.1'):
         result['warnings'].append("Your git version is too old to fully support the depth argument. Falling back to full checkouts.")
         depth = None
+
+    if ssh_opts is not None and git_version_used < LooseVersion('2.3.0'):
+        result['warnings'].append("Your git version is too old to support the ssh_opts argument. Consider using an SSH config file.")
 
     recursive = module.params['recursive']
     track_submodules = module.params['track_submodules']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add warning if an argument is supplied to ssh_opts, but the version of Git does not support it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Addresses 64673: https://github.com/ansible/ansible/issues/64673

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
source control, git module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
