### PR TITLE
nclu: Add support for check_mode and --diff

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -203,7 +203,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
       command_helper(module, "abort")
 
     # Do the commit.
-    if do_commit:
+    if do_commit and not module.check_mode:
         result = command_helper(module, "commit description '%s'" % description)
         if "commit ignored" in result:
             _changed = False

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -200,7 +200,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
         diff = {"prepared": after}
 
     if module.check_mode:
-      command_helper(module, "abort")
+        command_helper(module, "abort")
 
     # Do the commit.
     if do_commit and not module.check_mode:
@@ -235,13 +235,13 @@ def main(testing=False):
     description = module.params.get('description')
 
     if module.check_mode:
-      commit = False
+        commit = False
 
     _changed, output, diff = run_nclu(module, command_list, command_string, commit, atomic, abort, description)
     result = {
-      "changed": _changed,
-      "msg": output,
-      "diff": diff
+        "changed": _changed,
+        "msg": output,
+        "diff": diff
     }
 
     _changed, output = run_nclu(module, command_list, command_string, commit, atomic, abort, description)

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -244,7 +244,6 @@ def main(testing=False):
         "diff": diff
     }
 
-    _changed, output = run_nclu(module, command_list, command_string, commit, atomic, abort, description)
     if not testing:
         module.exit_json(**result)
     elif testing:

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -144,7 +144,7 @@ class TestNclu(unittest.TestCase):
     def test_command_list(self):
         module = FakeModule()
         changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
-                                        None, False, False, False, "")
+                                              None, False, False, False, "")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net add int swp1',
@@ -157,8 +157,8 @@ class TestNclu(unittest.TestCase):
     def test_command_list_commit(self):
         module = FakeModule()
         changed, output, diff = nclu.run_nclu(module,
-                                        ['add int swp1', 'add int swp2'],
-                                        None, True, False, False, "committed")
+                                              ['add int swp1', 'add int swp2'],
+                                              None, True, False, False, "committed")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net add int swp1',
@@ -173,8 +173,8 @@ class TestNclu(unittest.TestCase):
     def test_command_atomic(self):
         module = FakeModule()
         changed, output, diff = nclu.run_nclu(module,
-                                        ['add int swp1', 'add int swp2'],
-                                        None, False, True, False, "atomically")
+                                              ['add int swp1', 'add int swp2'],
+                                              None, False, True, False, "atomically")
 
         self.assertEqual(module.command_history, ['/usr/bin/net abort',
                                                   '/usr/bin/net pending',
@@ -197,8 +197,8 @@ class TestNclu(unittest.TestCase):
     def test_command_template_commit(self):
         module = FakeModule()
         changed, output, diff = nclu.run_nclu(module, None,
-                                        "    add int swp1\n    add int swp2",
-                                        True, False, False, "committed")
+                                              "    add int swp1\n    add int swp2",
+                                              True, False, False, "committed")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net add int swp1',
@@ -226,7 +226,7 @@ class TestNclu(unittest.TestCase):
         module = FakeModule()
         module.check_mode = True
         changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
-                                        None, True, False, False, '')
+                                              None, True, False, False, '')
 
         self.assertEqual(module.command_history, ["/usr/bin/net pending",
                                                   "/usr/bin/net add int swp1",
@@ -240,7 +240,7 @@ class TestNclu(unittest.TestCase):
     def test_diff(self):
         module = FakeModule()
         changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
-                                        None, False, False, False, '')
+                                              None, False, False, False, '')
 
         print(module.command_history)
         self.assertEqual(diff, {'prepared': '/usr/bin/net add int swp1/usr/bin/net add int swp2'})

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -90,6 +90,7 @@ class FakeModule(object):
         self.mocks = {}
         self.pending = ""
         self.last_commit = ""
+        self.check_mode = False
 
 
 def skipUnlessNcluInstalled(original_function):
@@ -134,7 +135,7 @@ class TestNclu(unittest.TestCase):
 
     def test_empty_run(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module, None, None, False, False, False, "")
+        changed, output, diff = nclu.run_nclu(module, None, None, False, False, False, "")
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net pending'])
         self.assertEqual(module.fail_code, {})
@@ -142,7 +143,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_list(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
+        changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
                                         None, False, False, False, "")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
@@ -155,7 +156,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_list_commit(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module,
+        changed, output, diff = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],
                                         None, True, False, False, "committed")
 
@@ -171,7 +172,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_atomic(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module,
+        changed, output, diff = nclu.run_nclu(module,
                                         ['add int swp1', 'add int swp2'],
                                         None, False, True, False, "atomically")
 
@@ -195,7 +196,7 @@ class TestNclu(unittest.TestCase):
 
     def test_command_template_commit(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module, None,
+        changed, output, diff = nclu.run_nclu(module, None,
                                         "    add int swp1\n    add int swp2",
                                         True, False, False, "committed")
 
@@ -211,7 +212,7 @@ class TestNclu(unittest.TestCase):
 
     def test_commit_ignored(self):
         module = FakeModule()
-        changed, output = nclu.run_nclu(module, None, None, True, False, False, "ignore me")
+        changed, output, diff = nclu.run_nclu(module, None, None, True, False, False, "ignore me")
 
         self.assertEqual(module.command_history, ['/usr/bin/net pending',
                                                   '/usr/bin/net pending',
@@ -220,3 +221,33 @@ class TestNclu(unittest.TestCase):
         self.assertEqual(len(module.pending), 0)
         self.assertEqual(module.fail_code, {})
         self.assertEqual(changed, False)
+
+    def test_check_mode(self):
+        module = FakeModule()
+        module.check_mode = True
+        changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
+                                        None, True, False, False, '')
+
+        self.assertEqual(module.command_history, ["/usr/bin/net pending",
+                                                  "/usr/bin/net add int swp1",
+                                                  "/usr/bin/net add int swp2",
+                                                  "/usr/bin/net pending",
+                                                  "/usr/bin/net abort"])
+        self.assertEqual(len(module.pending), 0)
+        self.assertEqual(module.fail_code, {})
+        self.assertEqual(changed, True)
+
+    def test_diff(self):
+        module = FakeModule()
+        changed, output, diff = nclu.run_nclu(module, ['add int swp1', 'add int swp2'],
+                                        None, False, False, False, '')
+
+        print(module.command_history)
+        self.assertEqual(diff, {'prepared': '/usr/bin/net add int swp1/usr/bin/net add int swp2'})
+        self.assertEqual(module.command_history, ["/usr/bin/net pending",
+                                                  "/usr/bin/net add int swp1",
+                                                  "/usr/bin/net add int swp2",
+                                                  "/usr/bin/net pending"])
+        self.assertNotEqual(len(module.pending), 0)
+        self.assertEqual(module.fail_code, {})
+        self.assertEqual(changed, True)


### PR DESCRIPTION
##### SUMMARY
Adds support for `check_mode` and `--diff`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
nclu

##### ADDITIONAL INFORMATION
Example:
```
$ ansible-playbook --check --diff test.yml

PLAY [spine] *************************************************************************************************************************************************************************************************************************

TASK [nclu] **************************************************************************************************************************************************************************************************************************
--- /etc/network/interfaces	2019-11-11 11:03:27.483081304 -0800
+++ /run/nclu/ifupdown2/interfaces.tmp	2019-11-11 11:03:37.828080895 -0800
@@ -5,20 +5,23 @@
 ###############

 auto lo
 iface lo inet loopback
     address 10.10.10.101/32

 ###############
 # Mgmt interface
 ###############

+auto swp1
+iface swp1
+
 auto mgmt
 iface mgmt
     vrf-table auto
     address 127.0.0.1/8

 auto eth0
 iface eth0 inet dhcp
     vrf mgmt
 ###############
 # Fabric Links



net add/del commands since the last "net commit"
================================================

User     Timestamp                   Command
-------  --------------------------  ----------------------
cumulus  2019-11-11 11:03:37.764682  net add interface swp1

changed: [spine01]

PLAY RECAP ***************************************************************************************************************************************************************************************************************************
spine01                    : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
