### PR TITLE
[WIP] update links to galaxy docs

### DIFF
--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -236,12 +236,10 @@ Provide the ID of the integration to be disabled. You can find the ID by using t
 
 
 .. seealso::
-  `collections <collections>`_
+  :ref:`collections`
     Sharable collections of modules, playbooks and roles
-  `roles <playbooks_reuse_roles>`_
-    Reusable tasks, handlers, and other files in a known directory structure
   :ref:`playbooks_reuse_roles`
-    All about ansible roles
+    Reusable tasks, handlers, and other files in a known directory structure
   `Mailing List <https://groups.google.com/group/ansible-project>`_
     Questions? Help? Ideas?  Stop by the list on Google Groups
   `irc.freenode.net <http://irc.freenode.net>`_

--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -385,7 +385,7 @@ Use ``remove`` to delete a role from *roles_path*:
 
 
 .. seealso::
-  `collections <collections>`_
+  :ref:`collections`
     Sharable collections of modules, playbooks and roles
-  `roles <playbooks_reuse_roles>`_
+  :ref:`playbooks_reuse_roles`
     Reusable tasks, handlers, and other files in a known directory structure

--- a/docs/docsite/rst/network/getting_started/network_roles.rst
+++ b/docs/docsite/rst/network/getting_started/network_roles.rst
@@ -297,7 +297,7 @@ The Ansible Galaxy page for a role lists all available versions. To update a loc
 
 .. seealso::
 
-       `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_
+       `Ansible Galaxy documentation <https://docs.ansible.com/ansible-galaxy/latest/>`_
            Ansible Galaxy user guide
        `Ansible supported network roles <https://galaxy.ansible.com/ansible-network>`_
            List of Ansible-supported network and cloud roles on Ansible Galaxy

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -284,7 +284,7 @@ Role dependencies allow you to automatically pull in other roles when using a ro
 
 .. note::
     Role dependencies must use the classic role definition style.
-    
+
 Role dependencies are always executed before the role that includes them, and may be recursive. Dependencies also follow the duplication rules specified above. If another role also lists it as a dependency, it will not be run again based on the same rules given above. See :ref:`Galaxy role dependencies <galaxy_dependencies>` for more details.
 
 .. note::
@@ -397,9 +397,9 @@ Ansible Galaxy
 
 `Ansible Galaxy <https://galaxy.ansible.com>`_ is a free site for finding, downloading, rating, and reviewing all kinds of community developed Ansible roles and can be a great way to get a jumpstart on your automation projects.
 
-The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles. 
+The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles.
 
-Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information
+Read the `Ansible Galaxy documentation <https://docs.ansible.com/ansible-galaxy/latest/>`_ page for more information
 
 .. seealso::
 
@@ -425,4 +425,3 @@ Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page
        Complete playbook files from the GitHub project source
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Galaxy docs are moving to docs.ansible.com/ansible-galaxy url... update any links to go there.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
