### PR TITLE
[2.9] acme_* modules: Buypass now has a ACME v2 production endpoint

### DIFF
--- a/lib/ansible/plugins/doc_fragments/acme.py
+++ b/lib/ansible/plugins/doc_fragments/acme.py
@@ -64,8 +64,8 @@ options:
   acme_version:
     description:
       - "The ACME version of the endpoint."
-      - "Must be 1 for the classic Let's Encrypt ACME endpoint and Buypass'
-         current production endpoint, or 2 for standardized ACME v2 endpoints."
+      - "Must be 1 for the classic Let's Encrypt and Buypass ACME endpoints,
+         or 2 for standardized ACME v2 endpoints."
     type: int
     default: 1
     choices: [ 1, 2 ]
@@ -84,7 +84,7 @@ options:
       - "For Let's Encrypt, the production directory URL for ACME v1 is
          U(https://acme-v01.api.letsencrypt.org/directory), and the production
          directory URL for ACME v2 is U(https://acme-v02.api.letsencrypt.org/directory)."
-      - "For Buypass, the production directory URL for ACME v1 is
+      - "For Buypass, the production directory URL for ACME v2 and v1 is
          U(https://api.buypass.com/acme/directory)."
       - "I(Warning): So far, the module has only been tested against Let's Encrypt
          (staging and production), Buypass (staging and production), and


### PR DESCRIPTION
##### SUMMARY
Backport of #64649 to stable-2.9.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_account
acme_account_info
acme_certificate
acme_certificate_revoke
acme_inspect
