### PR TITLE
win_package - Set raw for argument type

### DIFF
--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -32,7 +32,7 @@ options:
       module will escape the arguments as necessary, it is recommended to use a
       string when dealing with MSI packages due to the unique escaping issues
       with msiexec.
-    type: str
+    type: raw
   chdir:
     description:
     - Set the specified path as the current working directory before installing


### PR DESCRIPTION
##### SUMMARY
The `arguments` parameter for `win_package` accepts both a string and list. Set the arg type to `raw` to reflect this dual nature.

Supersedes https://github.com/ansible/ansible/pull/63929

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_package