### PR TITLE
Fix cli context check for network_cli connection

### DIFF
--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -71,10 +71,11 @@ class ConnectionProcess(object):
     The connection process wraps around a Connection object that manages
     the connection to a remote device that persists over the playbook
     '''
-    def __init__(self, fd, play_context, socket_path, original_path, ansible_playbook_pid=None):
+    def __init__(self, fd, play_context, socket_path, original_path, task_uuid=None, ansible_playbook_pid=None):
         self.play_context = play_context
         self.socket_path = socket_path
         self.original_path = original_path
+        self._task_uuid = task_uuid
 
         self.fd = fd
         self.exception = None
@@ -98,7 +99,7 @@ class ConnectionProcess(object):
             if self.play_context.private_key_file and self.play_context.private_key_file[0] not in '~/':
                 self.play_context.private_key_file = os.path.join(self.original_path, self.play_context.private_key_file)
             self.connection = connection_loader.get(self.play_context.connection, self.play_context, '/dev/null',
-                                                    ansible_playbook_pid=self._ansible_playbook_pid)
+                                                    task_uuid=self._task_uuid, ansible_playbook_pid=self._ansible_playbook_pid)
             self.connection.set_options(var_options=variables)
 
             self.connection._socket_path = self.socket_path
@@ -257,8 +258,8 @@ def main():
     if rc == 0:
         ssh = connection_loader.get('ssh', class_only=True)
         ansible_playbook_pid = sys.argv[1]
+        task_uuid = sys.argv[2]
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user, play_context.connection, ansible_playbook_pid)
-
         # create the persistent connection dir if need be and create the paths
         # which we will be using later
         tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
@@ -266,7 +267,6 @@ def main():
 
         socket_path = unfrackpath(cp % dict(directory=tmp_path))
         lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
-        prev_ppid = os.getppid()
 
         with file_lock(lock_path):
             if not os.path.exists(socket_path):
@@ -279,7 +279,7 @@ def main():
                     try:
                         os.close(r)
                         wfd = os.fdopen(w, 'w')
-                        process = ConnectionProcess(wfd, play_context, socket_path, original_path, ansible_playbook_pid)
+                        process = ConnectionProcess(wfd, play_context, socket_path, original_path, task_uuid, ansible_playbook_pid)
                         process.start(variables)
                     except Exception:
                         messages.append(('error', traceback.format_exc()))
@@ -306,9 +306,7 @@ def main():
                 pc_data = to_text(init_data)
                 try:
                     conn.update_play_context(pc_data)
-                    if prev_ppid != os.getppid():
-                        # update cli context at start on new task run only
-                        conn.set_cli_prompt_context()
+                    conn.update_cli_prompt_context(task_uuid)
                 except Exception as exc:
                     # Only network_cli has update_play context and set_cli_prompt_context, so missing this is
                     # not fatal e.g. netconf

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -266,6 +266,7 @@ def main():
 
         socket_path = unfrackpath(cp % dict(directory=tmp_path))
         lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
+        prev_ppid = os.getppid()
 
         with file_lock(lock_path):
             if not os.path.exists(socket_path):
@@ -305,7 +306,9 @@ def main():
                 pc_data = to_text(init_data)
                 try:
                     conn.update_play_context(pc_data)
-                    conn.set_cli_prompt_context()
+                    if prev_ppid != os.getppid():
+                        # update cli context at start on new task run only
+                        conn.set_cli_prompt_context()
                 except Exception as exc:
                     # Only network_cli has update_play context and set_cli_prompt_context, so missing this is
                     # not fatal e.g. netconf

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -926,7 +926,7 @@ class TaskExecutor:
             display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
 
             options = self._get_persistent_connection_options(connection, variables, templar)
-            socket_path = start_connection(self._play_context, options)
+            socket_path = start_connection(self._play_context, options, self._task._uuid)
             display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
             setattr(connection, '_socket_path', socket_path)
 
@@ -1046,7 +1046,7 @@ class TaskExecutor:
         return handler
 
 
-def start_connection(play_context, variables):
+def start_connection(play_context, variables, task_uuid):
     '''
     Starts the persistent connection
     '''
@@ -1078,7 +1078,7 @@ def start_connection(play_context, variables):
     python = sys.executable
     master, slave = pty.openpty()
     p = subprocess.Popen(
-        [python, ansible_connection, to_text(os.getppid())],
+        [python, ansible_connection, to_text(os.getppid()), to_text(task_uuid)],
         stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
     )
     os.close(slave)

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -57,7 +57,7 @@ class ActionModule(ActionNetworkModule):
         command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
         display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
         connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
         socket_path = connection.run()

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -58,7 +58,7 @@ class ActionModule(ActionNetworkModule):
         command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
         display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
         connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
         socket_path = connection.run()

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -55,7 +55,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -69,7 +69,7 @@ class ActionModule(ActionNetworkModule):
                 command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
                 display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()

--- a/lib/ansible/plugins/action/bigiq.py
+++ b/lib/ansible/plugins/action/bigiq.py
@@ -66,7 +66,7 @@ class ActionModule(_ActionModule):
                 command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
                 display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -58,7 +58,7 @@ class ActionModule(ActionNetworkModule):
                 if self._task.action in ['ce_netconf'] or self._task.action not in CLI_SUPPORTED_MODULES:
                     pc.connection = 'netconf'
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
                 socket_path = connection.run()

--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -52,7 +52,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -62,7 +62,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_pass = provider['auth_pass']
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -63,7 +63,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_pass = provider['auth_pass']
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -63,7 +63,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_pass = provider['auth_pass']
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/enos.py
+++ b/lib/ansible/plugins/action/enos.py
@@ -52,7 +52,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_method = 'enable'
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -68,7 +68,7 @@ class ActionModule(ActionNetworkModule):
                 pc.become_pass = provider['auth_pass']
 
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
                 command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -59,7 +59,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_pass = provider['auth_pass']
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
             connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -58,7 +58,7 @@ class ActionModule(ActionNetworkModule):
             pc.password = provider['password'] or self._play_context.password
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
             connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -58,7 +58,7 @@ class ActionModule(ActionNetworkModule):
             pc.become_pass = provider['auth_pass']
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
             connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -63,7 +63,7 @@ class ActionModule(ActionNetworkModule):
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
             connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -133,7 +133,7 @@ class ActionModule(ActionBase):
 
         display.vvv('using connection plugin %s (was local)' % play_context.connection, play_context.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent',
-                                                                   play_context, sys.stdin)
+                                                                   play_context, sys.stdin, task_uuid=self._task._uuid)
 
         connection.set_options(direct={'persistent_command_timeout': play_context.timeout})
 

--- a/lib/ansible/plugins/action/netconf.py
+++ b/lib/ansible/plugins/action/netconf.py
@@ -54,7 +54,7 @@ class ActionModule(ActionNetworkModule):
             pc.private_key_file = args.get('ssh_keyfile') or self._play_context.private_key_file
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             timeout = args.get('timeout')
             command_timeout = int(timeout) if timeout else connection.get_option('persistent_command_timeout')

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -101,7 +101,7 @@ class ActionModule(ActionNetworkModule):
                 pc.become_pass = provider['auth_pass']
 
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+                connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
                 command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
                 connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -56,7 +56,7 @@ class ActionModule(ActionNetworkModule):
             command_timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
             connection.set_options(direct={'persistent_command_timeout': command_timeout})
 
             socket_path = connection.run()

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -55,7 +55,7 @@ class ActionModule(ActionNetworkModule):
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
 
             display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
-            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+            connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin, task_uuid=self._task._uuid)
 
             command_timeout = int(provider['timeout']) if provider['timeout'] else connection.get_option('persistent_command_timeout')
             connection.set_options(direct={'persistent_command_timeout': command_timeout})

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -319,6 +319,7 @@ class Connection(NetworkConnectionBase):
         self._terminal = None
         self.cliconf = None
         self._paramiko_conn = None
+        self._task_uuid = to_text(kwargs.get('task_uuid', ''))
 
         if self._play_context.verbosity > 3:
             logging.getLogger('paramiko').setLevel(logging.DEBUG)
@@ -407,6 +408,12 @@ class Connection(NetworkConnectionBase):
             self.reset_history()
         if hasattr(self, 'disable_response_logging'):
             self.disable_response_logging()
+
+    def update_cli_prompt_context(self, task_uuid):
+        # set cli prompt context at the start of new task run only
+        if self._task_uuid != task_uuid:
+            self.set_cli_prompt_context()
+            self._task_uuid = task_uuid
 
     def _connect(self):
         '''

--- a/test/integration/targets/junos_command/tests/cli/cli_commmand.yaml
+++ b/test/integration/targets/junos_command/tests/cli/cli_commmand.yaml
@@ -29,6 +29,36 @@
   - assert:
       that:
         - "result.changed == false"
+
+  - cli_command:
+      command: "{{item}}"
+      prompt:
+        - "New password"
+        - "Retype new password"
+      answer:
+        - "Test1234"
+        - "Test1234"
+      check_all: True
+    loop:
+      - "configure"
+      - "rollback"
+      - "set system login user ansible_test class operator authentication plain-text-password"
+      - "commit"
+    register: result
+    ignore_errors: True
+
+  - assert:
+      that:
+        - "'failed' not in result"
+
+  - junos_netconf:
+    register: result
+    ignore_errors: True
+
+  - assert:
+      that:
+        - "result.failed == false"
+
   when: ansible_connection == 'network_cli'
 
 - debug: msg="END cli/cli_command.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #64575

*  Check cli context for network_cli connection
   at the start of new task run only.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/cli/scripts/ansible_connection_cli_stub.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/232