### PR TITLE
Backport/2.9/63785 - zabbix_host logout missing

### DIFF
--- a/changelogs/fragments/63785-zabbix_host_missing_atexit.yml
+++ b/changelogs/fragments/63785-zabbix_host_missing_atexit.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - module will now properly logout from Zabbix server and won't leave open session behind (see https://github.com/ansible/ansible/issues/63774)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -742,6 +742,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #63774

Zabbix modules were leaving open sessions behind on Zabbix server. This was fixed in #58525, but `zabbix_host` module got accidentally skipped.

Backport of https://github.com/ansible/ansible/pull/63785

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host
