### PR TITLE
[Backport][2.9] remove toshio as release manager (boohoo) (#64685)

### DIFF
--- a/docs/docsite/rst/community/committer_guidelines.rst
+++ b/docs/docsite/rst/community/committer_guidelines.rst
@@ -6,7 +6,7 @@ Committers Guidelines
 
 These are the guidelines for people with commit privileges on the Ansible GitHub repository. Committers are essentially acting as members of the Ansible Core team, although not necessarily as employees of Ansible and Red Hat. Please read the guidelines before you commit.
 
-These guidelines apply to everyone. At the same time, this ISN'T a process document. So just use good judgement. You've been given commit access because we trust your judgement.
+These guidelines apply to everyone. At the same time, this ISN'T a process document. So just use good judgment. You've been given commit access because we trust your judgment.
 
 That said, use the trust wisely.
 

--- a/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_9.rst
@@ -29,8 +29,9 @@ PRs must be raised well in advance of the dates below to have a chance of being 
 
 Release Manager
 ---------------
+TBD
 
-Toshio Kuratomi (IRC: abadger1999; GitHub: @abadger)
+Temporarily, Matt Davis (@nitzmahone) or Matt Clay (@mattclay) on IRC or github.
 
 Planned work
 ============


### PR DESCRIPTION
(cherry picked from commit 94e98d5369e33d7c447e4a890e9a105e097bb082)

Backport of https://github.com/ansible/ansible/pull/64685

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
