### PR TITLE
Return name of datadisk in azure_rm_virtualmachine_info

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_info.py
@@ -117,6 +117,12 @@ vms:
             returned: always
             type: complex
             contains:
+                name:
+                    description:
+                        - Name of data disk.
+                    returned: always
+                    type: str
+                    sample: My-Data-Disk
                 caching:
                     description:
                         - Type of data disk caching.
@@ -433,6 +439,7 @@ class AzureRMVirtualMachineInfo(AzureRMModuleBase):
         disks = result['properties']['storageProfile']['dataDisks']
         for disk_index in range(len(disks)):
             new_result['data_disks'].append({
+                'name': disks[disk_index].get('name'),
                 'lun': disks[disk_index].get('lun'),
                 'disk_size_gb': disks[disk_index].get('diskSizeGB'),
                 'managed_disk_type': disks[disk_index].get('managedDisk', {}).get('storageAccountType'),


### PR DESCRIPTION
List of attached data disks should return disks names too.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine_facts
