### PR TITLE
[2.7] Callback: removing args from task_fields from Sumologic and Splunk pl…

### DIFF
--- a/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
+++ b/changelogs/fragments/63522-remove-args-from-sumologic-and-splunk-callbacks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - '**security issue** - Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs (CVE-2019-14864)'

--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -98,6 +98,9 @@ class SplunkHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session

--- a/lib/ansible/plugins/callback/sumologic.py
+++ b/lib/ansible/plugins/callback/sumologic.py
@@ -89,6 +89,9 @@ class SumologicHTTPCollectorSource(object):
         else:
             ansible_role = None
 
+        if 'args' in result._task_fields:
+            del result._task_fields['args']
+
         data = {}
         data['uuid'] = result._task._uuid
         data['session'] = self.session


### PR DESCRIPTION
…ugin(#63527)

CVE-2019-14864 Ansible: Splunk and Sumologic callback plugins leak sensitive data in logs

Fixes #63522

Backport of #63527

Signed-off-by: Patrick O’Brien <patrick.obrien@thetradedesk.com>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit c76e074e4c71c7621a1ca8159261c1959b5287af)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
