### PR TITLE
Add default value to 0 for disk in nova_flavor module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -43,6 +43,7 @@ options:
      description:
         - Size of local disk, in GB.
      default: 0
+     type: int
    ephemeral:
      description:
         - Ephemeral space size, in GB.

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -42,6 +42,7 @@ options:
    disk:
      description:
         - Size of local disk, in GB.
+     default: 0
    ephemeral:
      description:
         - Ephemeral space size, in GB.
@@ -181,8 +182,8 @@ def main():
         # required when state is 'present'
         ram=dict(required=False, type='int'),
         vcpus=dict(required=False, type='int'),
-        disk=dict(required=False, type='int'),
 
+        disk=dict(required=False, default=0, type='int'),
         ephemeral=dict(required=False, default=0, type='int'),
         swap=dict(required=False, default=0, type='int'),
         rxtx_factor=dict(required=False, default=1.0, type='float'),


### PR DESCRIPTION
##### SUMMARY
Add default value 0 for disk if it's not specified like the openstack cli.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
os_nova_flavor
