### PR TITLE
fix utils.color.stringc: enclosure non printable sequences in SOH,STX

### DIFF
--- a/changelogs/fragments/64751-fix-wrong-promt-len-calc-in-ansible-console.yaml
+++ b/changelogs/fragments/64751-fix-wrong-promt-len-calc-in-ansible-console.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix wrong command line length calculation in `ansible-console` when long command inputted

--- a/changelogs/fragments/64751-fix-wrong-promt-len-calc-in-ansible-console.yaml
+++ b/changelogs/fragments/64751-fix-wrong-promt-len-calc-in-ansible-console.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - fix wrong command line length calculation in `ansible-console` when long command inputted
+  - fix wrong command line length calculation in ``ansible-console`` when long command inputted

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -122,7 +122,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         else:
             prompt += "$ "
             color = self.NORMAL_PROMPT
-        self.prompt = stringc(prompt, color)
+        self.prompt = stringc(prompt, color, for_prompt=True)
 
     def list_modules(self):
         modules = set()

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -122,7 +122,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         else:
             prompt += "$ "
             color = self.NORMAL_PROMPT
-        self.prompt = stringc(prompt, color, for_prompt=True)
+        self.prompt = stringc(prompt, color, wrap_nonvisible_chars=True)
 
     def list_modules(self):
         modules = set()

--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -92,6 +92,16 @@ def stringc(text, color, wrap_nonvisible_chars=False):
         color_code = parsecolor(color)
         fmt = u"\033[%sm%s\033[0m"
         if wrap_nonvisible_chars:
+            # This option is provided for use in cases when the
+            # formatting of a command line prompt is needed, such as
+            # `ansible-console`. As said in `readline` sources:
+            # readline/display.c:321
+            # /* Current implementation:
+            #         \001 (^A) start non-visible characters
+            #         \002 (^B) end non-visible characters
+            #    all characters except \001 and \002 (following a \001) are copied to
+            #    the returned string; all characters except those between \001 and
+            #    \002 are assumed to be `visible'. */
             fmt = u"\001\033[%sm\002%s\001\033[0m\002"
         return u"\n".join([fmt % (color_code, t) for t in text.split(u'\n')])
     else:

--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -85,12 +85,15 @@ def parsecolor(color):
         return u'38;5;%d' % (232 + int(matches.group('gray')))
 
 
-def stringc(text, color):
+def stringc(text, color, for_prompt=False):
     """String in color."""
 
     if ANSIBLE_COLOR:
         color_code = parsecolor(color)
-        return u"\n".join([u"\001\033[%sm\002%s\001\033[0m\002" % (color_code, t) for t in text.split(u'\n')])
+        fmt = u"\033[%sm%s\033[0m"
+        if for_prompt:
+            fmt = u"\001\033[%sm\002%s\001\033[0m\002"
+        return u"\n".join([fmt % (color_code, t) for t in text.split(u'\n')])
     else:
         return text
 

--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -90,7 +90,7 @@ def stringc(text, color):
 
     if ANSIBLE_COLOR:
         color_code = parsecolor(color)
-        return u"\n".join([u"\033[%sm%s\033[0m" % (color_code, t) for t in text.split(u'\n')])
+        return u"\n".join([u"\001\033[%sm\002%s\001\033[0m\002" % (color_code, t) for t in text.split(u'\n')])
     else:
         return text
 

--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -85,13 +85,13 @@ def parsecolor(color):
         return u'38;5;%d' % (232 + int(matches.group('gray')))
 
 
-def stringc(text, color, for_prompt=False):
+def stringc(text, color, wrap_nonvisible_chars=False):
     """String in color."""
 
     if ANSIBLE_COLOR:
         color_code = parsecolor(color)
         fmt = u"\033[%sm%s\033[0m"
-        if for_prompt:
+        if wrap_nonvisible_chars:
             fmt = u"\001\033[%sm\002%s\001\033[0m\002"
         return u"\n".join([fmt % (color_code, t) for t in text.split(u'\n')])
     else:


### PR DESCRIPTION
##### SUMMARY
By default, readline calculates the number of both visible and invisible characters in prompt. It causes buggy behavior in ansible-console when colorized prompt used. For example, when an entered command is long enough, key sequence Ctrl-A places the cursor in the wrong position. To avoid it, nonprintable sequences should be enclosed between SOH and STX bytes. So it will allow readline to work properly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.utils.color.stringc

##### ADDITIONAL INFORMATION