### PR TITLE
win_acl no longer needs SeSecurityPrivilege (#57804) - 2.8

### DIFF
--- a/changelogs/fragments/57804-win_acl-no-longer-needs-SeSecurityPrivilege.yml
+++ b/changelogs/fragments/57804-win_acl-no-longer-needs-SeSecurityPrivilege.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_acl - Fixed error when setting rights on directory for which inheritance from parent directory has been disabled.

--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -188,7 +188,11 @@ Try {
     If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            Set-ACL -LiteralPath $path -AclObject $objACL
+            If ($path_item.PSProvider.Name -eq "Registry") {
+                Set-ACL -LiteralPath $path -AclObject $objACL
+            } else {
+                (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            }
             $result.changed = $true
         }
         Catch {
@@ -198,7 +202,11 @@ Try {
     ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            Set-ACL -LiteralPath $path -AclObject $objACL
+            If ($path_item.PSProvider.Name -eq "Registry") {
+                Set-ACL -LiteralPath $path -AclObject $objACL
+            } else {
+                (Get-Item -LiteralPath $path).SetAccessControl($objACL)
+            }
             $result.changed = $true
         }
         Catch {


### PR DESCRIPTION
(cherry picked from commit 95d613f3ab376af8c06399d256d931c6c00c21d6)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/57804

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl