### PR TITLE
Improve handling of "restarted" state for win_iis_website module (#63829) - 2.8

### DIFF
--- a/changelogs/fragments/win_iis_website-restarted.yaml
+++ b/changelogs/fragments/win_iis_website-restarted.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_iis_website - Actually restart the site when ``state=restarted`` - https://github.com/ansible/ansible/issues/63828

--- a/lib/ansible/modules/windows/win_iis_website.ps1
+++ b/lib/ansible/modules/windows/win_iis_website.ps1
@@ -138,7 +138,7 @@ Try {
     }
 
     # Set run state
-    if (($state -eq 'stopped') -and ($site.State -eq 'Started'))
+    if ((($state -eq 'stopped') -or ($state -eq 'restarted')) -and ($site.State -eq 'Started'))
     {
       Stop-Website -Name $name -ErrorAction Stop
       $result.changed = $true


### PR DESCRIPTION
(cherry picked from commit bd9a0b6700d2f54185d84a772a21605e67f7e077)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/63829

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_iis_website