### PR TITLE
Add a banner which will display on the testing site.

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -1,6 +1,17 @@
 <!--- Based on sphinx versionwarning extension. Extension currently only works on READTHEDOCS -->
-{# Creates a banner at the top of the page for any version not latest. #}
   <script>
+    // Create a banner if we're not on the official docs site
+    if (location.host == "docs.testing.ansible.com") {
+      document.write('<div id="testing_banner_id" class="admonition danger">');
+      para = document.createElement('p');
+      banner_text=document.createTextNode("This is a testing site. For the official docs go to https://docs.ansible.com/");
+      para.appendChild(banner_text);
+      element = document.getElementById('testing_banner_id');
+      element.appendChild(para);
+      document.write('</div>');
+    }
+
+    // Create a banner if we're not the latest version
     current_url = window.location.href;
     if ((current_url.search("latest") > -1) || (current_url.search("/{{ latest_version }}/") > -1)) {
      // no banner for latest release

--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -2,7 +2,7 @@
   <script>
     // Create a banner if we're not on the official docs site
     if (location.host == "docs.testing.ansible.com") {
-      document.write('<div id="testing_banner_id" class="admonition danger">');
+      document.write('<div id="testing_banner_id" class="admonition important">');
       para = document.createElement('p');
       banner_text=document.createTextNode("This is a testing site. For the official docs go to https://docs.ansible.com/");
       para.appendChild(banner_text);


### PR DESCRIPTION
Thanks to shane for the javascript code

There were some people looking at our docs testing site who were confused about why it had old content.  Use a banner to tell people that this is not the place for official docs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
If we do it this way, we'll need to add this type of code to the top page and the tower docs as well.