### PR TITLE
Document match/search tests

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -37,7 +37,7 @@ Such as::
 Testing strings
 ```````````````
 
-To match strings against a substring or a regular expression, use the "match", "search" or "regex" filters::
+To match strings against a substring or a regular expression, use the ``match``, ``search`` or ``regex`` filters::
 
     vars:
       url: "http://example.com/users/foo/resources/bar"
@@ -59,7 +59,7 @@ To match strings against a substring or a regular expression, use the "match", "
             msg: "matched pattern 4"
           when: url is regex("example.com/\w+/foo")
 
-'match' succeeds if it finds the pattern at the beginning of the string, while 'search' succeeds if it finds the pattern anywhere within string. By default, 'regex' works like `search`, but `regex` can be configured to perform other tests as well.
+``match`` succeeds if it finds the pattern at the beginning of the string, while ``search`` succeeds if it finds the pattern anywhere within string. By default, ``regex`` works like ``search``, but ``regex`` can be configured to perform other tests as well.
 
 .. _testing_truthiness:
 

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -45,7 +45,7 @@ To match strings against a substring or a regular expression, use the "match", "
     tasks:
         - debug:
             msg: "matched pattern 1"
-          when: url is match("http://example.com/users/.*/resources/.*")
+          when: url is match("http://example.com/users/.*/resources/")
 
         - debug:
             msg: "matched pattern 2"
@@ -59,7 +59,7 @@ To match strings against a substring or a regular expression, use the "match", "
             msg: "matched pattern 4"
           when: url is regex("example.com/\w+/foo")
 
-'match' requires zero or more characters at the beginning of the string, while 'search' only requires matching a subset of the string. By default, 'regex' works like `search`, but `regex` can be configured to perform other tests as well.
+'match' succeeds if it finds the pattern at the beginning of the string, while 'search' succeeds if it finds the pattern anywhere within string. By default, 'regex' works like `search`, but `regex` can be configured to perform other tests as well.
 
 .. _testing_truthiness:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
The docs were so ambiguous that I had to open the source code, then look at the python docs for the difference between them.  Hopefully this clarifies them.  (also, minor formatting improvement)

Updated one example to demonstrate that `match` does not require a full string match, just that it be anchored to the beginning of the string.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
match test
search test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
