### PR TITLE
vmware/test: use better name for datastores

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
@@ -3,5 +3,5 @@
     library_name: test-content-lib
     library_description: 'Library created by the prepare_vmware_tests role'
     library_type: local
-    datastore_name: '{{ ds2 }}'
+    datastore_name: '{{ rw_datastore }}'
     state: present

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -1,28 +1,28 @@
 ---
-- name: Mount NFS (ds1) datastores to ESXi
+- name: Mount NFS (ro_datastore) datastores to ESXi
   vmware_host_datastore:
     hostname: '{{ item }}'
     username: '{{ esxi_user }}'
     password: '{{ esxi_password }}'
-    datastore_name: '{{ ds1 }}'
-    datastore_type: '{{ infra.datastores[ds1].type }}'
-    nfs_server: '{{ infra.datastores[ds1].server }}'
-    nfs_path: '{{ infra.datastores[ds1].path }}'
-    nfs_ro: '{{ infra.datastores[ds1].ro }}'
+    datastore_name: '{{ ro_datastore }}'
+    datastore_type: '{{ infra.datastores[ro_datastore].type }}'
+    nfs_server: '{{ infra.datastores[ro_datastore].server }}'
+    nfs_path: '{{ infra.datastores[ro_datastore].path }}'
+    nfs_ro: '{{ infra.datastores[ro_datastore].ro }}'
     state: present
     validate_certs: no
   with_items: "{{ esxi_hosts }}"
 
-- name: Mount NFS (ds2) datastores on the ESXi
+- name: Mount NFS (rw_datastore) datastores on the ESXi
   vmware_host_datastore:
     hostname: '{{ item }}'
     username: '{{ esxi_user }}'
     password: '{{ esxi_password }}'
-    datastore_name: '{{ ds2 }}'
-    datastore_type: '{{ infra.datastores[ds2].type }}'
-    nfs_server: '{{ infra.datastores[ds2].server }}'
-    nfs_path: '{{ infra.datastores[ds2].path }}'
-    nfs_ro: '{{ infra.datastores[ds2].ro }}'
+    datastore_name: '{{ rw_datastore }}'
+    datastore_type: '{{ infra.datastores[rw_datastore].type }}'
+    nfs_server: '{{ infra.datastores[rw_datastore].server }}'
+    nfs_path: '{{ infra.datastores[rw_datastore].path }}'
+    nfs_ro: '{{ infra.datastores[rw_datastore].ro }}'
     state: present
     validate_certs: no
   with_items: "{{ esxi_hosts }}"

--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -9,14 +9,14 @@
     disk:
     - size_gb: 1
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     hardware:
       memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines }}'
@@ -33,14 +33,14 @@
     disk:
     - size_gb: 1
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     hardware:
       memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines_in_cluster }}'

--- a/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -83,8 +83,7 @@
       hostname: '{{ item }}'
       username: '{{ esxi_user }}'
       password: '{{ esxi_password }}'
-      esxi_hostname: '{{ item }}'  # Won't be necessary with  https://github.com/ansible/ansible/pull/56516
-      datastore_name: '{{ ds1 }}'
+      datastore_name: '{{ ro_datastore }}'
       state: absent
   with_items: "{{ esxi_hosts }}"
 
@@ -93,8 +92,7 @@
       hostname: '{{ item }}'
       username: '{{ esxi_user }}'
       password: '{{ esxi_password }}'
-      esxi_hostname: '{{ item }}'  # Won't be necessary with  https://github.com/ansible/ansible/pull/56516
-      datastore_name: '{{ ds2 }}'
+      datastore_name: '{{ rw_datastore }}'
       state: absent
   with_items: "{{ esxi_hosts }}"
 

--- a/test/integration/targets/prepare_vmware_tests/vars/common.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/common.yml
@@ -1,8 +1,8 @@
 ---
 dc1: DC0
 ccr1: DC0_C0
-ds1: LocalDS_0
-ds2: LocalDS_1
+rw_datastore: LocalDS_0
+ro_datastore: LocalDS_1
 f0: F0
 switch1: switch1
 esxi1: '{{ esxi_hosts[0] }}'

--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -9,12 +9,12 @@ infra:
       type: nfs
       server: datastore.test
       path: /srv/share/isos
-      ro: true
+      ro: false
     LocalDS_1:
       type: nfs
       server: datastore.test
       path: /srv/share/vms
-      ro: false
+      ro: true
 virtual_machines:
   - name: DC0_H0_VM0
     folder: '{{ f0 }}'

--- a/test/integration/targets/vmware_content_deploy_template/tasks/main.yml
+++ b/test/integration/targets/vmware_content_deploy_template/tasks/main.yml
@@ -7,14 +7,14 @@
     setup_datacenter: true
 
 - when: vcsim is not defined
-  block: 
+  block:
     - &deploy_vm_from_content_library_template
       vmware_content_deploy_template:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
         template: '{{ test_vm_temp }}'
-        datastore: '{{ ds1 }}'
+        datastore: '{{ rw_datastore }}'
         datacenter: '{{ dc1 }}'
         folder: '{{ f0 }}'
         host: '{{ esx1 }}'

--- a/test/integration/targets/vmware_content_library_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_content_library_manager/tasks/main.yml
@@ -28,7 +28,7 @@
         validate_certs: False
         library_name: Sample_Library
         library_description: Sample Description
-        datastore_name: '{{ ds2 }}'
+        datastore_name: '{{ rw_datastore }}'
         state: present
       register: content_lib_create_result
 
@@ -80,7 +80,7 @@
       assert:
         that:
           - content_lib_delete_result.changed
-          
+
     - <<: *content_lib_delete
       name: Delete content library again
       register: content_lib_delete_result

--- a/test/integration/targets/vmware_datastore_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_facts/tasks/main.yml
@@ -76,7 +76,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 }}"
+    name: "{{ ro_datastore }}"
   register: datastore_facts_0003
 
 - debug:
@@ -84,7 +84,7 @@
 
 - assert:
     that:
-      - "datastore_facts_0003['datastores'][0]['name'] == ds1"
+      - "datastore_facts_0003['datastores'][0]['name'] == ro_datastore"
       - "datastore_facts_0003['datastores'][0]['capacity'] is defined"
 
 - name: get list of extended facts about one datastore
@@ -94,7 +94,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 | basename }}"
+    name: "{{ ro_datastore }}"
     gather_nfs_mount_info: True
     gather_vmfs_mount_info: True
   register: datastore_facts_0004
@@ -104,7 +104,7 @@
 
 - assert:
     that:
-      - "datastore_facts_0004['datastores'][0]['name'] == ds1"
+      - "datastore_facts_0004['datastores'][0]['name'] == ro_datastore"
       - "datastore_facts_0004['datastores'][0]['capacity'] is defined"
 
 - name: get list of facts about one datastore in check mode
@@ -114,7 +114,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 | basename }}"
+    name: "{{ ro_datastore }}"
   register: datastore_facts_0005
 
 - debug:
@@ -122,5 +122,5 @@
 
 - assert:
     that:
-      - "datastore_facts_0005['datastores'][0]['name'] == ds1"
+      - "datastore_facts_0005['datastores'][0]['name'] == ro_datastore"
       - "datastore_facts_0005['datastores'][0]['capacity'] is defined"

--- a/test/integration/targets/vmware_datastore_info/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_info/tasks/main.yml
@@ -76,7 +76,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 }}"
+    name: "{{ ro_datastore }}"
   register: datastore_info_0003
 
 - debug:
@@ -84,7 +84,7 @@
 
 - assert:
     that:
-      - "datastore_info_0003['datastores'][0]['name'] == ds1"
+      - "datastore_info_0003['datastores'][0]['name'] == ro_datastore"
       - "datastore_info_0003['datastores'][0]['capacity'] is defined"
 
 - name: get list of extended info about one datastore
@@ -94,7 +94,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 | basename }}"
+    name: "{{ ro_datastore }}"
     gather_nfs_mount_info: True
     gather_vmfs_mount_info: True
   register: datastore_info_0004
@@ -104,7 +104,7 @@
 
 - assert:
     that:
-      - "datastore_info_0004['datastores'][0]['name'] == ds1"
+      - "datastore_info_0004['datastores'][0]['name'] == ro_datastore"
       - "datastore_info_0004['datastores'][0]['capacity'] is defined"
 
 - name: get list of info about one datastore in check mode
@@ -114,7 +114,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ dc1 }}"
-    name: "{{ ds1 | basename }}"
+    name: "{{ ro_datastore }}"
   register: datastore_info_0005
 
 - debug:
@@ -122,5 +122,5 @@
 
 - assert:
     that:
-      - "datastore_info_0005['datastores'][0]['name'] == ds1"
+      - "datastore_info_0005['datastores'][0]['name'] == ro_datastore"
       - "datastore_info_0005['datastores'][0]['capacity'] is defined"

--- a/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_datastore_maintenancemode/tasks/main.yml
@@ -17,7 +17,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       state: present
-      datastore: "{{ ds1 }}"
+      datastore: "{{ ro_datastore }}"
       validate_certs: no
     register: test_result_0001
 
@@ -35,7 +35,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       state: present
-      datastore: "{{ ds1 }}"
+      datastore: "{{ ro_datastore }}"
       validate_certs: no
     register: test_result_0002
 
@@ -53,7 +53,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       state: absent
-      datastore: "{{ ds1 }}"
+      datastore: "{{ ro_datastore }}"
       validate_certs: no
     register: test_result_0003
 
@@ -71,7 +71,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       state: absent
-      datastore: "{{ ds1 }}"
+      datastore: "{{ ro_datastore }}"
       validate_certs: no
     register: test_result_0004
 

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -17,10 +17,10 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] centos.iso"
+      iso_path: "[{{ ro_datastore }}] centos.iso"
   register: cdrom_vm
 
 - debug: var=cdrom_vm
@@ -38,11 +38,11 @@
     password: "{{ vcenter_password }}"
     folder: "vm"
     name: test_vm1
-    datastore: "{{ ds2 }}"
+    datastore: "{{ rw_datastore }}"
     datacenter: "{{ dc1 }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     state: present
   register: cdrom_vm
 
@@ -127,16 +127,16 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
   register: cdrom_vm
 
 - debug: var=cdrom_vm
@@ -165,13 +165,13 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     cdrom:
     - controller_type: ide
       controller_number: 0
       unit_number: 0
       type: iso
-      iso_path: "[{{ ds1 }}] centos.iso"
+      iso_path: "[{{ ro_datastore }}] centos.iso"
     - controller_type: ide
       controller_number: 0
       unit_number: 1
@@ -209,7 +209,7 @@
       controller_number: 0
       unit_number: 1
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     - controller_type: ide
       controller_number: 1
       unit_number: 0
@@ -251,16 +251,16 @@
         disk:
         - size_mb: 128
           type: thin
-          datastore: "{{ ds2 }}"
+          datastore: "{{ rw_datastore }}"
         - size_mb: 128
           type: thin
-          datastore: "{{ ds2 }}"
+          datastore: "{{ rw_datastore }}"
         - size_mb: 128
           type: thin
-          datastore: "{{ ds2 }}"
+          datastore: "{{ rw_datastore }}"
         cdrom:
           type: iso
-          iso_path: "[{{ ds1 }}] base.iso"
+          iso_path: "[{{ ro_datastore }}] base.iso"
       register: cdrom_vm
     - debug: var=cdrom_vm
     - name: assert the VM was created

--- a/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
+++ b/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
@@ -13,7 +13,7 @@
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
-    datastore: '{{ ds2 }}'
+    datastore: '{{ rw_datastore }}'
     hardware:
         num_cpus: 4
         memory_mb: 1028
@@ -32,11 +32,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: test_vm1
+    name: test_vm2
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
-    datastore: '{{ ds2 }}'
+    datastore: '{{ rw_datastore }}'
     hardware:
         num_cpus: 4
         memory_mb: 1028
@@ -59,7 +59,7 @@
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
-    datastore: '{{ ds2 }}'
+    datastore: '{{ rw_datastore }}'
     hardware:
         num_cpus: 4
         memory_mb: 1028

--- a/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -12,14 +12,14 @@
     disk:
     - size_gb: 1
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     hardware:
       memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     networks:
     - name: VM Network
 

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -23,7 +23,7 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: "{{ ds2 }}"
+      datastore: "{{ rw_datastore }}"
     vapp_properties:
     - id: prop_id1
       category: category

--- a/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
@@ -20,7 +20,7 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     cdrom:
       type: client
   register: vbs_vm
@@ -54,7 +54,7 @@
     disk:
     - size_mb: 128
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     cdrom:
       type: client
   register: vbs_vm
@@ -79,7 +79,7 @@
     disk:
     - size_mb: 256
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     hardware:
       virt_based_security: True
     state: present

--- a/test/integration/targets/vmware_guest_disk/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk/tasks/main.yml
@@ -16,7 +16,7 @@
     validate_certs: no
     name: "{{ virtual_machines[0].name }}"
     disk:
-        - datastore: "{{ ds1 }}"
+        - datastore: "{{ rw_datastore }}"
           disk_mode: "invalid_disk_mode"
           scsi_controller: 0
           scsi_type: 'paravirtual'
@@ -44,7 +44,7 @@
     validate_certs: no
     name: "{{ virtual_machines[0].name }}"
     disk:
-        - datastore: "{{ ds1 }}"
+        - datastore: "{{ rw_datastore }}"
           disk_mode: "independent_persistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'
@@ -52,7 +52,7 @@
           state: present
           type: eagerzeroedthick
           unit_number: 2
-        - datastore: "{{ ds1 }}"
+        - datastore: "{{ rw_datastore }}"
           disk_mode: "independent_nonpersistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'
@@ -60,7 +60,7 @@
           state: present
           type: eagerzeroedthick
           unit_number: 3
-        - datastore: "{{ ds1 }}"
+        - datastore: "{{ rw_datastore }}"
           disk_mode: "persistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -24,7 +24,7 @@
       disk:
       - size_gb: 1
         type: thin
-        datastore: '{{ ds2 }}'
+        datastore: '{{ rw_datastore }}'
       hardware:
         version: latest
         memory_mb: 1024
@@ -32,7 +32,7 @@
         scsi: paravirtual
       cdrom:
         type: iso
-        iso_path: "[{{ ds1 }}] fedora.iso"
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
       networks:
       - name: VM Network
 

--- a/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -22,14 +22,14 @@
     disk:
     - size_gb: 1
       type: thin
-      datastore: '{{ ds2 }}'
+      datastore: '{{ rw_datastore }}'
     hardware:
       memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ds1 }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     networks:
     - name: VM Network
 

--- a/test/integration/targets/vmware_guest_serial_port/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_serial_port/tasks/main.yml
@@ -51,7 +51,7 @@
     - type: 'device'
       device_name: '/dev/char/serial/uart0'
     - type: 'file'
-      file_path: '[{{ ds2 }}]/file1'
+      file_path: '[{{ rw_datastore }}]/file1'
       yield_on_poll:  True
   register: create_multiple_ports
  

--- a/test/integration/targets/vmware_host_datastore/tasks/main.yml
+++ b/test/integration/targets/vmware_host_datastore/tasks/main.yml
@@ -5,16 +5,16 @@
       vars:
         setup_attach_host: true
 
-    - name: Mount NFS (ds1) datastores without esxi_hostname
+    - name: Mount NFS (ro_datastore) datastores without esxi_hostname
       vmware_host_datastore:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        datastore_name: '{{ ds1 }}'
-        datastore_type: '{{ infra.datastores[ds1].type }}'
-        nfs_server: '{{ infra.datastores[ds1].server }}'
-        nfs_path: '{{ infra.datastores[ds1].path }}'
-        nfs_ro: '{{ infra.datastores[ds1].ro }}'
+        datastore_name: '{{ ro_datastore }}'
+        datastore_type: '{{ infra.datastores[ro_datastore].type }}'
+        nfs_server: '{{ infra.datastores[ro_datastore].server }}'
+        nfs_path: '{{ infra.datastores[ro_datastore].path }}'
+        nfs_ro: '{{ infra.datastores[ro_datastore].ro }}'
         state: present
         validate_certs: no
       ignore_errors: true
@@ -25,17 +25,17 @@
           - mount_vmware_host_datastore is failed
           - mount_vmware_host_datastore.msg == "esxi_hostname is mandatory with a vcenter"
 
-    - name: Mount NFS (ds1) datastores with non existing host in esxi_hostname
+    - name: Mount NFS (ro_datastore) datastores with non existing host in esxi_hostname
       vmware_host_datastore:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         esxi_hostname: 'nohost'
-        datastore_name: '{{ ds1 }}'
-        datastore_type: '{{ infra.datastores[ds1].type }}'
-        nfs_server: '{{ infra.datastores[ds1].server }}'
-        nfs_path: '{{ infra.datastores[ds1].path }}'
-        nfs_ro: '{{ infra.datastores[ds1].ro }}'
+        datastore_name: '{{ ro_datastore }}'
+        datastore_type: '{{ infra.datastores[ro_datastore].type }}'
+        nfs_server: '{{ infra.datastores[ro_datastore].server }}'
+        nfs_path: '{{ infra.datastores[ro_datastore].path }}'
+        nfs_ro: '{{ infra.datastores[ro_datastore].ro }}'
         state: present
         validate_certs: no
       ignore_errors: true
@@ -46,17 +46,17 @@
           - mount_vmware_host_datastore is failed
           - mount_vmware_host_datastore.msg == "Failed to find ESXi hostname nohost"
 
-    - name: Mount NFS (ds1) datastores on esxi1 using esxi_hostname
+    - name: Mount NFS (ro_datastore) datastores on esxi1 using esxi_hostname
       vmware_host_datastore:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         esxi_hostname: '{{ esxi1 }}'
-        datastore_name: '{{ ds1 }}'
-        datastore_type: '{{ infra.datastores[ds1].type }}'
-        nfs_server: '{{ infra.datastores[ds1].server }}'
-        nfs_path: '{{ infra.datastores[ds1].path }}'
-        nfs_ro: '{{ infra.datastores[ds1].ro }}'
+        datastore_name: '{{ ro_datastore }}'
+        datastore_type: '{{ infra.datastores[ro_datastore].type }}'
+        nfs_server: '{{ infra.datastores[ro_datastore].server }}'
+        nfs_path: '{{ infra.datastores[ro_datastore].path }}'
+        nfs_ro: '{{ infra.datastores[ro_datastore].ro }}'
         state: present
         validate_certs: no
       register: mount_vmware_host_datastore
@@ -65,16 +65,16 @@
         that:
           - mount_vmware_host_datastore is changed
 
-    - name: Mount NFS (ds1) datastores to ESXi directly
+    - name: Mount NFS (ro_datastore) datastores to ESXi directly
       vmware_host_datastore:
         hostname: '{{ esxi1 }}'
         username: '{{ esxi_user }}'
         password: '{{ esxi_password }}'
-        datastore_name: '{{ ds1 }}'
-        datastore_type: '{{ infra.datastores[ds1].type }}'
-        nfs_server: '{{ infra.datastores[ds1].server }}'
-        nfs_path: '{{ infra.datastores[ds1].path }}'
-        nfs_ro: '{{ infra.datastores[ds2].ro }}'
+        datastore_name: '{{ ro_datastore }}'
+        datastore_type: '{{ infra.datastores[ro_datastore].type }}'
+        nfs_server: '{{ infra.datastores[ro_datastore].server }}'
+        nfs_path: '{{ infra.datastores[ro_datastore].path }}'
+        nfs_ro: '{{ infra.datastores[ro_datastore].ro }}'
         state: present
         validate_certs: no
       register: mount_vmware_host_datastore


### PR DESCRIPTION
##### SUMMARY

In the VMware tests, we call the datastores `ds1` and `ds2`. The first
one is read-only, the second is read-write and can be used to deploy
VMs. The naming convention was not clear enough and source of a lot
confusion and mistake.

We now have two better names:

- ro_datastore, which is ... read-only
- rw_datastore, the one that we can use to deploy new VM.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware
test/integration/targets/prepare_vmware_tests
