### PR TITLE
Close subprocess stdout and stderr in the ssh connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1014,9 +1014,11 @@ class Connection(ConnectionBase):
                 # Otherwise there may still be outstanding data to read.
         finally:
             selector.close()
-            # close stdin after process is terminated and stdout/stderr are read
-            # completely (see also issue #848)
+            # close stdin, stdout, and stderr after process is terminated and
+            # stdout/stderr are read completely (see also issues #848, #64768).
             stdin.close()
+            p.stdout.close()
+            p.stderr.close()
 
         if C.HOST_KEY_CHECKING:
             if cmd[0] == b"sshpass" and p.returncode == 6:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Eliminate `ResourceWarning: unclosed file` by closing all
file handles of each subprocess used by the SSH connection
plugin to execute commands.

Fixes #64768 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/ssh.py
