### PR TITLE
vmware_guest: fix the name of the test VMs

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
@@ -8,7 +8,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: new_vm_1
+    name: test_vm1
     template: "{{ virtual_machines[0].name }}"
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
@@ -31,7 +31,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: new_vm_2
+    name: test_vm2
     template: "{{ virtual_machines[0].name }}"
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"

--- a/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
+++ b/test/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
@@ -9,7 +9,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: test_vm_version12
+    name: test_vm1
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
@@ -32,7 +32,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: test_vm_version_latest
+    name: test_vm1
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
@@ -55,7 +55,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: test_vm_version12
+    name: test_vm1
     guest_id: centos7_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"


### PR DESCRIPTION
##### SUMMARY

The test VM names must be deterministic, this way, the teardown playbook
can clean up the resources after the test execution.

See: https://docs.ansible.com/ansible/latest/dev_guide/platforms/vmware_guidelines.html#vm-names-should-be-predictable

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest