### PR TITLE
DeleteUser: do not disable user if already disabled

### DIFF
--- a/changelogs/fragments/64797-fix-error-deleting-redfish-acct.yaml
+++ b/changelogs/fragments/64797-fix-error-deleting-redfish-acct.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - redfish_command - fix error when deleting a disabled Redfish account (https://github.com/ansible/ansible/issues/64684)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -991,7 +991,7 @@ class RedfishUtils(object):
             return {'ret': True, 'changed': False}
 
         payload = {'UserName': ''}
-        if 'Enabled' in data:
+        if data.get('Enabled', False):
             payload['Enabled'] = False
         response = self.patch_request(self.root_uri + uri, payload)
         if response['ret'] is False:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When deleting an account via PATCH, the DeleteUser command will disable the account in addition to deleting it. But the PATCH payload still contains `"Enabled": false` even if the account is already disabled. This may cause some Redfish services to emit an error like the one seen in issue #64684.

The code was updated to not include `"Enabled": false` in the PATCH request if the `Enabled` property was already set to false.

Fixes #64684 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See issue #64684 for reproduction details.

After the change, the error is no longer seen.

<!--- Paste verbatim command output below, e.g. before and after your change -->
