### PR TITLE
vmware_guest_disk/test: use less disk space

### DIFF
--- a/test/integration/targets/vmware_guest_disk/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk/tasks/main.yml
@@ -48,7 +48,7 @@
           disk_mode: "independent_persistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'
-          size_gb: 10
+          size_gb: 1
           state: present
           type: eagerzeroedthick
           unit_number: 2
@@ -56,7 +56,7 @@
           disk_mode: "independent_nonpersistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'
-          size_gb: 10
+          size_gb: 1
           state: present
           type: eagerzeroedthick
           unit_number: 3
@@ -64,13 +64,13 @@
           disk_mode: "persistent"
           scsi_controller: 0
           scsi_type: 'paravirtual'
-          size_gb: 10
+          size_gb: 1
           state: present
           type: eagerzeroedthick
           unit_number: 4
   register: test_create_disk2
 
-- debug: 
+- debug:
     msg: "{{ test_create_disk2 }}"
 
 - name: assert that changes were made


### PR DESCRIPTION
##### SUMMARY

Reduce the amount of space that is used on the datastore during the
test. This allow use to use lighter storage environment during the test.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_disk
<!--- Write the short name of the module, plugin, task or feature below -->