### PR TITLE
consul_acl: allow setting rules for *_prefix where supported

### DIFF
--- a/lib/ansible/modules/clustering/consul/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul/consul_acl.py
@@ -187,7 +187,10 @@ from collections import defaultdict
 from ansible.module_utils.basic import to_text, AnsibleModule
 
 
-RULE_SCOPES = ["agent", "event", "key", "keyring", "node", "operator", "query", "service", "session"]
+RULE_SCOPES = [
+    "agent", "agent_prefix", "event", "event_prefix", "key", "key_prefix", "keyring", "node", "node_prefix", "operator", "query", "query_prefix",
+    "service", "service_prefix", "session", "session_prefix",
+]
 
 MANAGEMENT_PARAMETER_NAME = "mgmt_token"
 HOST_PARAMETER_NAME = "host"


### PR DESCRIPTION
##### SUMMARY
In most cases you can specify _prefix for a consul ACL resource, e.g. you can specify `key` and `key_prefix`. the _prefix functionality allows you to paint with a larger brush, if you want. I believe this functionality was introduced in https://github.com/hashicorp/consul/pull/4791, which was merged into consul in October 2018, and made it into the 1.4 release of Consul.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
consul_acl module

##### ADDITIONAL INFORMATION
Play:

```
  tasks:
    - name: Create tokens to allow service definitions
      consul_acl:
        name: "{{ item }}"
        host: "{{ consul_host }}"
        mgmt_token: "{{ consul_master_token }}"
        rules:
          - key_prefix: "_rexec"
            policy: "write"
          - service_prefix: ""
            policy: "write"
      with_items:
        - service_definitions-2019-12
        - service_definitions-2020-06
        - service_definitions-2021-12
        - service_definitions-2022-06
```

Before:

```
TASK [Create tokens to allow service definitions] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: A rule requires one of agent/event/key/keyring/node/operator/query/service/session and a policy.
failed: [localhost] (item=service_definitions-2019-12) => {"changed": false, "item": "service_definitions-2019-12", "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 113, in <module>\n  File \"<stdin>\", line 105, in _ansiballz_main\n  File \"<stdin>\", line 48, in invoke_module\n  File \"/var/folders/st/x25b_d6n14x2_z9d6dbnt5z40000gr/T/ansible_consul_acl_payload_w7YMsq/__main__.py\", line 661, in <module>\n  File \"/var/folders/st/x25b_d6n14x2_z9d6dbnt5z40000gr/T/ansible_consul_acl_payload_w7YMsq/__main__.py\", line 637, in main\n  File \"/var/folders/st/x25b_d6n14x2_z9d6dbnt5z40000gr/T/ansible_consul_acl_payload_w7YMsq/__main__.py\", line 424, in decode_rules_as_yml\nValueError: A rule requires one of agent/event/key/keyring/node/operator/query/service/session and a policy.\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After:

```
TASK [Create tokens to allow service definitions] ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
changed: [localhost] => (item=service_definitions-2019-12)
changed: [localhost] => (item=service_definitions-2020-06)
changed: [localhost] => (item=service_definitions-2021-12)
changed: [localhost] => (item=service_definitions-2022-06)
```