### PR TITLE
Iap prompt fix

### DIFF
--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -25,9 +25,7 @@ import re
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
-from ansible.utils.display import Display
 
-display = Display()
 
 class TerminalModule(TerminalBase):
 

--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -41,6 +41,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"[pP]assword:$"),
         re.compile(br"(?<=\s)[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\s*#\s*$"),
         re.compile(br"[\r\n]?[\w\+\-\.:\/\[\]]+(?:\([^\)]+\)){0,3}(?:[>#]) ?$"),
+        re.compile(br"[\r\n]?[\w]*(.+)?#(?:\s*)$")
     ]
 
     terminal_stderr_re = [

--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -25,7 +25,9 @@ import re
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
+from ansible.utils.display import Display
 
+display = Display()
 
 class TerminalModule(TerminalBase):
 
@@ -66,4 +68,4 @@ class TerminalModule(TerminalBase):
         try:
             self._exec_cli_command(b'no pag')
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to set terminal parameters')
+            self._connection.queue_message('warning', 'Unable to configure paging, command responses may be truncated')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. Adding the regex for Aruba Instant CLI prompt. 
2. Replacing the AnsibleConnectionFailure to Warning message for "no paging" command in the "on_open_shell" definition. Paging command is removed in latest version of Aruba Instant OS. But it still exists in some other Aruba products.

This fixes #61433 and fixes #56449

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/terminal/aruba.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Before the fix

1. socket timeout error because of terminal prompt mismatch
 
```
Traceback (most recent call last):
File "/usr/bin/ansible-connection", line 70, in start
self.connection._connect()
File "/usr/lib/python2.7/dist-packages/ansible/plugins/connection/network_cli.py", line 318, in _connect
newline=self._terminal.terminal_inital_prompt_newline)
File "/usr/lib/python2.7/dist-packages/ansible/plugins/connection/network_cli.py", line 393, in receive
data = self._ssh_shell.recv(256)
File "/usr/lib/python2.7/dist-packages/paramiko/channel.py", line 615, in recv
raise socket.timeout()
timeout
fatal: [172.29.23.57]: FAILED! => {
"msg": ""
}
```

2. Ansible Connection Failure because of "no pag" command

```
PLAY [Sample Playbook for Aruba] ***************************************************************************************************************************

TASK [aruba_command example] ******************************************************************************************************************************************************
fatal: [iap]: FAILED! => {"msg": "unable to set terminal parameters"}

PLAY RECAP ***********************************************************************************************************************************************************************
iap                 : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```

After the fix, 

1. socket does not timeout

2. shows the warning message for exception of "no pag" command, instead of task failure.

```

PLAY [Sample Playbook for Aruba] ***************************************************************************************************************************

TASK [aruba_command example] ******************************************************************************************************************************************************
 [WARNING]: Unable to configure paging, command responses may be truncated

ok: [iap] => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "stdout": ["Aruba Operating System Software.\nArubaOS (MODEL: 515), Version 8.6.0.0\nWebsite: http://www.arubanetworks.com\n(c) Copyright 2019 Hewlett Packard Enterprise Development LP.\nCompiled on 2019-10-31 at 11:28:04 PDT (build 73006) by p4build\nFIPS Mode :disabled\n\nAP uptime is 2 hours 28 minutes 10 seconds\nReboot Time and Cause: AP Reboot reason:  Warm-reset"], "stdout_lines": [["Aruba Operating System Software.", "ArubaOS (MODEL: 515), Version 8.6.0.0", "Website: http://www.arubanetworks.com", "(c) Copyright 2019 Hewlett Packard Enterprise Development LP.", "Compiled on 2019-10-31 at 11:28:04 PDT (build 73006) by p4build", "FIPS Mode :disabled", "", "AP uptime is 2 hours 28 minutes 10 seconds", "Reboot Time and Cause: AP Reboot reason:  Warm-reset"]]}

PLAY RECAP ***********************************************************************************************************************************************************************
iap                 : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
