### PR TITLE
[2.9] VMware: Fix get_tags_for_vm API in vmware_vm_info module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_info.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_info.py
@@ -205,7 +205,7 @@ class VmwareVmInfo(PyVmomi):
 
     def get_tag_info(self, vm_dynamic_obj):
         vmware_client = VmwareRestClient(self.module)
-        return vmware_client.get_tags_for_vm(vm_id=vm_dynamic_obj._moId)
+        return vmware_client.get_tags_for_vm(vm_mid=vm_dynamic_obj._moId)
 
     def get_vm_attributes(self, vm):
         return dict((x.name, v.value) for x in self.custom_field_mgr


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of https://github.com/ansible/ansible/pull/61697

(cherry picked from commit e7c6134fd03770e6c92008dbc9f633a28c897934)


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_vm_info.py
