### PR TITLE
Backport of 64807: Fix postgres_user not commiting changes when groups is set

### DIFF
--- a/changelogs/fragments/64807-postgresql_user_fix_not_commiting_changes_when_groups_is_set.yml
+++ b/changelogs/fragments/64807-postgresql_user_fix_not_commiting_changes_when_groups_is_set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_user - fix the module doesn't correctly commit changes if groups is set (https://github.com/ansible/ansible/issues/64806). 

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -940,7 +940,7 @@ def main():
             target_roles = []
             target_roles.append(user)
             pg_membership = PgMembership(module, cursor, target_roles, groups)
-            changed = pg_membership.grant()
+            changed = pg_membership.grant() or changed
 
     else:
         if user_exists(cursor, user):


### PR DESCRIPTION
##### SUMMARY
Backport of #64807: Fix postgres_user not commiting changes when groups is set

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_user.py```
