### PR TITLE
ipa_sudorule; cmdgroup and runas functionality

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -263,6 +263,7 @@ class SudoRuleIPAClient(IPAClient):
     def sudorule_remove_run_as_group(self, name, item):
         return self._post_json(method='sudorule_remove_runasgroup', name=name, item={'group': item})
 
+
 def get_sudorule_dict(cmdcategory=None, description=None, hostcategory=None, ipaenabledflag=None, usercategory=None,
                       runasgroupcategory=None, runasusercategory=None):
     data = {}
@@ -335,8 +336,6 @@ def ensure(module, client):
         else:
             diff = client.get_diff(ipa_sudorule, module_sudorule)
             if len(diff) > 0:
-
-
                 changed = True
                 if not module.check_mode:
                     if 'cmdcategory' in diff:

--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -215,16 +215,13 @@ class SudoRuleIPAClient(IPAClient):
     def sudorule_add_allow_command(self, name, item):
         return self._post_json(method='sudorule_add_allow_command', name=name, item={'sudocmd': item})
 
-    def sudorule_remove_allow_command(self, name, item):
-        return self._post_json(method='sudorule_remove_allow_command', name=name, item={'sudocmd': item})
-
     def sudorule_add_allow_command_group(self, name, item):
         return self._post_json(method='sudorule_add_allow_command', name=name, item={'sudocmdgroup': item})
 
-    def sudorule_remove_allow_command_group(self, name, item):
-        return self._post_json(method='sudorule_remove_allow_command', name=name, item={'sudocmdgroup': item})
-
     def sudorule_remove_allow_command(self, name, item):
+        return self._post_json(method='sudorule_remove_allow_command', name=name, item={'sudocmd': item})
+
+    def sudorule_remove_allow_command_group(self, name, item):
         return self._post_json(method='sudorule_remove_allow_command', name=name, item={'sudocmdgroup': item})
 
     def sudorule_add_user(self, name, item):

--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -263,6 +263,7 @@ class SudoRuleIPAClient(IPAClient):
     def sudorule_remove_run_as_group(self, name, item):
         return self._post_json(method='sudorule_remove_runasgroup', name=name, item={'group': item})
 
+
 def get_sudorule_dict(cmdcategory=None, description=None, hostcategory=None, ipaenabledflag=None, usercategory=None,
                       runasgroupcategory=None, runasusercategory=None):
     data = {}


### PR DESCRIPTION
##### SUMMARY
Extends ipa_sudorule module with
- `cmdgroup` param; This allows referencing a command group created with ipa_sudocmdgroup.
- `runasuser` param
- `runasgroupofuser` param
- `runasgroup` param

Fixes the changed logic for `cmd` to correctly report when the list changes.
Enhances the parameter descriptions with mutually exclusive details.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ipa_sudorule

##### ADDITIONAL INFORMATION
It's possible to add individual sudo cmds to a sudo rule, or a command group:

ipa sudorule-add-allow-command has 2 sub parameters, `sudocmd` and `sudocmdgroup`.  This extends the module to add support for the second parameter, and makes the first more explicit.

See also https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/identity_management_guide/defining-sudorules


It's possible to specify whether a user may sudo as another user, or group - using runasuser (either entered individually or via groups) or and runasgroup.
