### PR TITLE
all modules documentation should be valid yaml data

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -25,10 +25,10 @@ author:
 options:
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See \
-      U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html) for \
-      possible filters. Filter names and values are case sensitive. You can also use underscores (_) \
-      instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
+        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html) for
+        possible filters. Filter names and values are case sensitive. You can also use underscores (_)
+        instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
     required: false
     default: {}
     type: dict

--- a/lib/ansible/modules/cloud/amazon/ec2_snapshot_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_snapshot_info.py
@@ -31,31 +31,31 @@ options:
     elements: str
   owner_ids:
     description:
-      - If you specify one or more snapshot owners, only snapshots from the specified owners and for which you have \
-      access are returned.
+      - If you specify one or more snapshot owners, only snapshots from the specified owners and for which you have
+        access are returned.
     required: false
     default: []
     type: list
     elements: str
   restorable_by_user_ids:
     description:
-      - If you specify a list of restorable users, only snapshots with create snapshot permissions for those users are \
-      returned.
+      - If you specify a list of restorable users, only snapshots with create snapshot permissions for those users are
+        returned.
     required: false
     default: []
     type: list
     elements: str
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See \
-      U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html) for possible filters. Filter \
-      names and values are case sensitive.
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
+        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html) for possible filters. Filter
+        names and values are case sensitive.
     required: false
     type: dict
     default: {}
 notes:
-  - By default, the module will return all snapshots, including public ones. To limit results to snapshots owned by \
-  the account use the filter 'owner-id'.
+  - By default, the module will return all snapshots, including public ones. To limit results to snapshots owned by
+    the account use the filter 'owner-id'.
 
 extends_documentation_fragment:
     - aws

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_info.py
@@ -30,9 +30,9 @@ options:
     type: list
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See \
-      U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html) for possible filters. Filter \
-      names and values are case sensitive.
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
+        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html) for possible filters. Filter
+        names and values are case sensitive.
     required: false
     default: {}
     type: dict

--- a/lib/ansible/modules/cloud/pubnub/pubnub_blocks.py
+++ b/lib/ansible/modules/cloud/pubnub/pubnub_blocks.py
@@ -57,7 +57,7 @@ options:
     description:
       - "Name of PubNub account for from which C(application) will be used to
       manage blocks."
-      - "User\'s account will be used if value not set or empty."
+      - "User's account will be used if value not set or empty."
     required: false
     version_added: '2.4'
   application:
@@ -82,9 +82,9 @@ options:
     required: true
   description:
     description:
-        - "Short block description which will be later visible on
-        admin.pubnub.com. Used only if block doesn\'t exists and won\'t change
-        description for existing block."
+        - Short block description which will be later visible on
+          admin.pubnub.com. Used only if block doesn't exists and won't change
+          description for existing block.
     required: false
     default: 'New block'
   event_handlers:

--- a/lib/ansible/modules/monitoring/statusio_maintenance.py
+++ b/lib/ansible/modules/monitoring/statusio_maintenance.py
@@ -99,8 +99,8 @@ options:
             - The maintenance id number when deleting a maintenance window
     minutes:
         description:
-            - The length of time in UTC that the maintenance will run \
-            (starting from playbook runtime)
+            - The length of time in UTC that the maintenance will run
+              (starting from playbook runtime)
         default: 10
     start_date:
         description:

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
@@ -116,11 +116,11 @@ options:
 
     httprequest:
         description:
-            - "HTTP request to send to the server (for example, C(\\"HEAD /file.html\\"))."
+          - 'HTTP request to send to the server (for example, C("HEAD /file.html")).'
 
     rtsprequest:
         description:
-            - "RTSP request to send to the server (for example, C(\\"OPTIONS *\\"))."
+          - 'RTSP request to send to the server (for example, C("OPTIONS *")).'
 
     customheaders:
         description:

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
@@ -315,7 +315,7 @@ options:
                 persistence sessions (persistence type RULE). Can be either an expression or the name of a named
                 expression.
             - "Example:"
-            - "C(HTTP.RES.HEADER(\\"setcookie\\").VALUE(0).TYPECAST_NVLIST_T('=',';').VALUE(\\"server1\\"))."
+            - 'C(HTTP.RES.HEADER("setcookie").VALUE(0).TYPECAST_NVLIST_T("=",";").VALUE("server1")).'
 
     persistmask:
         description:

--- a/lib/ansible/modules/storage/netapp/na_ontap_lun_copy.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_lun_copy.py
@@ -13,7 +13,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 DOCUMENTATION = '''
-
 module: na_ontap_lun_copy
 
 short_description: NetApp ONTAP copy LUNs
@@ -23,36 +22,36 @@ version_added: '2.8'
 author: NetApp Ansible Team (@carchi8py) <ng-ansibleteam@netapp.com>
 
 description:
-- Copy LUNs on NetApp ONTAP.
+  - Copy LUNs on NetApp ONTAP.
 
 options:
 
   state:
     description:
-    - Whether the specified LUN should exist or not.
+      - Whether the specified LUN should exist or not.
     choices: ['present']
     default: present
 
   destination_vserver:
     description:
-    - the name of the Vserver that will host the new LUN.
+      - Specifies the name of the Vserver that will host the new LUN.
     required: true
 
   destination_path:
     description:
-    - Specifies the full path to the new LUN.
+      - Specifies the full path to the new LUN.
     required: true
 
   source_path:
     description:
-    - Specifies the full path to the source LUN.
+      - Specifies the full path to the source LUN.
     required: true
 
   source_vserver:
     description:
-    - Specifies the name of the vserver hosting the LUN to be copied.
+      - Specifies the name of the vserver hosting the LUN to be copied.
+'''
 
-  '''
 EXAMPLES = """
 - name: Copy LUN
   na_ontap_lun_copy:


### PR DESCRIPTION
##### SUMMARY
In case of usage DOCUMENTATION strings from modules for 3rd party integration, all these strings should be valid YAML data.
For instance, I'm trying to update [emacs-ansible](https://github.com/k1LoW/emacs-ansible) package from ancient 1.8 version to current devel version and face a lot of issues trying to generate snippets from documentation code.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
