### PR TITLE
2.9: Fix ansible_failed_{task,result} undefined in rescue (#64831)

### DIFF
--- a/changelogs/fragments/64789-regression-rescue-vars-not-defined.yml
+++ b/changelogs/fragments/64789-regression-rescue-vars-not-defined.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix regression when ``ansible_failed_task`` and ``ansible_failed_result`` are not defined in the rescue block (https://github.com/ansible/ansible/issues/64789)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -510,7 +510,7 @@ class StrategyBase:
                     if state and iterator.get_active_state(state).run_state == iterator.ITERATING_RESCUE:
                         self._tqm._stats.increment('rescued', original_host.name)
                         self._variable_manager.set_nonpersistent_facts(
-                            original_host,
+                            original_host.name,
                             dict(
                                 ansible_failed_task=original_task.serialize(),
                                 ansible_failed_result=task_result._result,

--- a/test/integration/targets/blocks/block_rescue_vars.yml
+++ b/test/integration/targets/blocks/block_rescue_vars.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - block:
+        - name: EXPECTED FAILURE
+          fail:
+      rescue:
+        - name: Assert that ansible_failed_task is defined
+          assert:
+            that:
+              - ansible_failed_task is defined
+
+        - name: Assert that ansible_failed_result is defined
+          assert:
+            that:
+              - ansible_failed_result is defined

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -37,3 +37,5 @@ env python -c \
     'import sys, re; sys.stdout.write(re.sub("\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]", "", sys.stdin.read()))' \
     <block_test.out >block_test_wo_colors.out
 [ "$(grep -c 'TEST COMPLETE' block_test.out)" = "$(grep -E '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]
+
+ansible-playbook -vv block_rescue_vars.yml


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/64831

<!--- Describe the change below, including rationale and design decisions -->
This is a fix for a regression introduced by Perfy. Since then we mainly
operate on host.name instead of the Host object. In a call to
set_nonpersistent_facts where we set ansible_failed_task and
ansible_failed_result variables we were still passing the object which
led to those vars being undefined.

Fixes #64789

(cherry picked from commit 5c0b2c151ce7d7f2a4df2f1525d3eb6302a2e790)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
` lib/ansible/plugins/strategy/__init__.py`