### PR TITLE
synchronize: don't change paths with : in the name

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
     def _get_absolute_path(self, path):
         original_path = path
 
-        if path.startswith('rsync://'):
+        if ':' in path:
             return path
 
         if self._task._role is not None:


### PR DESCRIPTION
##### SUMMARY
Previously the synchronize action tried to make the src and dest
absolute if it doesn't start with 'rsync://'. For the following task:
```
- synchronize:
    mode: pull
    src: "user@host:artifacts/"
    dest: artifacts/
```
The current directory was prepended to the src. This change treats all
paths including the ':' character as absolute, i.e. doesn't change them.

Fixes #25337

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchronize action / module