### PR TITLE
change to mode: getmaster

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -168,9 +168,16 @@ EXAMPLES = r'''
   mysql_replication:
     mode: stopslave
 
-- name: Get master binlog file name and binlog position
+
+- name: replication "show  master status;"
   mysql_replication:
     mode: getmaster
+    login_unix_socket: /var/run/mysqld/mysqld.sock
+  register: masterstatus
+  become: yes
+- debug: var=masterstatus.File
+- debug: var=masterstatus.Position
+
 
 - name: Change master to master server 192.0.2.1 and use binary log 'mysql-bin.000009' with position 4578
   mysql_replication:


### PR DESCRIPTION
##### SUMMARY
<!--- I guess use next commands for getting master binlog file name and binlog position instead of the your  -->

-  Get master binlog file name and binlog position
 

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We use module mysql_replication and output master data using debug

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_replication
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
It helps to see master data
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
#comments are optional
### parent task -  Get master binlog file name and binlog position
- name: replication "show  master status;"
  mysql_replication:
    mode: getmaster
#    login_unix_socket: /var/run/mysqld/mysqld.sock
  register: masterstatus
#  become: yes
- debug: var=masterstatus.File
- debug: var=masterstatus.Position
```
