### PR TITLE
Thresholds need to be passed for the log alert type

### DIFF
--- a/lib/ansible/modules/monitoring/datadog/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog/datadog_monitor.py
@@ -343,7 +343,7 @@ def install_monitor(module):
 
     if module.params['type'] == "service check":
         options["thresholds"] = module.params['thresholds'] or {'ok': 1, 'critical': 1, 'warning': 1}
-    if module.params['type'] == "metric alert" and module.params['thresholds'] is not None:
+    if module.params['type'] in [ "metric alert", "log alert" ] and module.params['thresholds'] is not None:
         options["thresholds"] = module.params['thresholds']
 
     monitor = _get_monitor(module)

--- a/lib/ansible/modules/monitoring/datadog/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog/datadog_monitor.py
@@ -343,7 +343,7 @@ def install_monitor(module):
 
     if module.params['type'] == "service check":
         options["thresholds"] = module.params['thresholds'] or {'ok': 1, 'critical': 1, 'warning': 1}
-    if module.params['type'] in [ "metric alert", "log alert" ] and module.params['thresholds'] is not None:
+    if module.params['type'] in ["metric alert", "log alert"] and module.params['thresholds'] is not None:
         options["thresholds"] = module.params['thresholds']
 
     monitor = _get_monitor(module)


### PR DESCRIPTION
##### SUMMARY
It will allow us the create monitors with thresholds, if we don't do this, it messes up the treshold monitoring.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
datadog_monitor

##### ADDITIONAL INFORMATION

Without this patch, if we create a monitor of type log alert the thresholds will be set to the wrong values, which requires a manual intervention to fix the monitor in datadog.

```
- name: '{{ dd_prefix }} IAM User(s) being created on AWS'
  datadog_monitor:
    name: '{{ dd_prefix }} IAM User(s) being created on AWS'
    state: present
    type: log alert
    query: logs("@eventName:CreateUser -@requestParameters.permissionsBoundary:arn\:aws\:iam\:\:* -@error.kind:AccessDenied").index("main").rollup("count").last("30m")
      >= 1
    message: '[[#is_alert]]

      One or more IAM users are being created on AWS. Please check accordingly. Username [[requestParameters.userName]] [[requestParameters.userName]]

      [[/is_alert]]  {{ dd_opsgenie_channel }} {{ dd_slack_channel }}'
    thresholds:
      critical: 1.0
    no_data_timeframe: 2
    new_host_delay: 300
    renotify_interval: 0
    timeout_h: 0
    api_key: '{{ dd_api_key }}'
    app_key: '{{ dd_app_key }}'
  run_once: 'true'
  delegate_to: localhost
  become: 'false'
```
