### PR TITLE
nxos_l3_interfaces: fix states, add new minor attributes

### DIFF
--- a/lib/ansible/module_utils/network/nxos/argspec/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/l3_interfaces/l3_interfaces.py
@@ -39,6 +39,9 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
         'config': {
             'elements': 'dict',
             'options': {
+                'dot1q': {
+                    'type': 'int'
+                },
                 'ipv4': {
                     'elements': 'dict',
                     'options': {
@@ -69,7 +72,13 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
                 'name': {
                     'required': True,
                     'type': 'str'
-                }
+                },
+                'redirects': {
+                    'type': 'bool',
+                },
+                'unreachables': {
+                    'type': 'bool',
+                },
             },
             'type': 'list'
         },

--- a/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -14,6 +14,7 @@ created
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from copy import deepcopy
 from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import to_list, remove_empties
 from ansible.module_utils.network.nxos.facts.facts import Facts
@@ -100,7 +101,7 @@ class L3_interfaces(ConfigBase):
                 if get_interface_type(w['name']) == 'management':
                     self._module.fail_json(msg="The 'management' interface is not allowed to be managed by this module")
                 want.append(remove_empties(w))
-        have = existing_l3_interfaces_facts
+        have = deepcopy(existing_l3_interfaces_facts)
         resp = self.set_state(want, have)
         return to_list(resp)
 
@@ -234,10 +235,10 @@ class L3_interfaces(ConfigBase):
         overridden = True if state == 'overridden' else False
 
         # Create secondary and primary wants/haves
-        sec_w = [ i for i in want if i.get('secondary')]
-        sec_h = [ i for i in have if i.get('secondary')]
-        pri_w = [ i for i in want if not i.get('secondary')]
-        pri_h = [ i for i in have if not i.get('secondary')]
+        sec_w = [i for i in want if i.get('secondary')]
+        sec_h = [i for i in have if i.get('secondary')]
+        pri_w = [i for i in want if not i.get('secondary')]
+        pri_h = [i for i in have if not i.get('secondary')]
         pri_w = pri_w[0] if pri_w else {}
         pri_h = pri_h[0] if pri_h else {}
         cmds = []
@@ -272,7 +273,7 @@ class L3_interfaces(ConfigBase):
         # 3. process remaining secondaries last
         sec_w_to_chg = self.diff_list_of_dicts(sec_w, sec_h)
         for i in sec_w_to_chg:
-            cmd = 'ip address %s secondary' %i['address']
+            cmd = 'ip address %s secondary' % i['address']
             cmd += ' tag %s' % i['tag'] if i['tag'] else ''
             cmds.append(cmd)
 

--- a/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
@@ -83,6 +83,8 @@ class L3_interfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
         config['name'] = intf
+        config['redirects'] = utils.parse_conf_cmd_arg(conf, 'no ip redirects', False, True)
+        config['unreachables'] = utils.parse_conf_cmd_arg(conf, 'ip unreachables', True, False)
         ipv4_match = re.compile(r'\n  ip address (.*)')
         matches = ipv4_match.findall(conf)
         if matches:

--- a/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
@@ -83,6 +83,7 @@ class L3_interfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
         config['name'] = intf
+        config['dot1q'] = utils.parse_conf_arg(conf, 'encapsulation dot1[qQ]')
         config['redirects'] = utils.parse_conf_cmd_arg(conf, 'no ip redirects', False, True)
         config['unreachables'] = utils.parse_conf_cmd_arg(conf, 'ip unreachables', True, False)
         ipv4_match = re.compile(r'\n  ip address (.*)')

--- a/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
@@ -53,6 +53,11 @@ options:
           - Full name of L3 interface, i.e. Ethernet1/1.
         type: str
         required: true
+      dot1q:
+        description:
+          - Configures IEEE 802.1Q VLAN encapsulation on a subinterface.
+        type: int
+        version_added: 2.10
       ipv4:
         description:
           - IPv4 address and attributes of the L3 interface.
@@ -86,6 +91,16 @@ options:
             description:
               - URIB route tag value for local/direct routes.
             type: int
+      redirects:
+        description:
+          - Enables/disables ip redirects
+        type: bool
+        version_added: 2.10
+      unreachables:
+        description:
+          - Enables/disables ip redirects
+        type: bool
+        version_added: 2.10
 
   state:
     description:
@@ -119,6 +134,10 @@ EXAMPLES = """
         ipv6:
           - address: fd5d:12c9:2201:2::1/64
             tag: 6
+      - name: Ethernet1/7.42
+        dot1q: 42
+        redirects: False
+        unreachables: False
     state: merged
 
 # After state:
@@ -127,8 +146,12 @@ EXAMPLES = """
 # interface Ethernet1/6
 #   ip address 192.168.22.1/24 tag 5
 #   ip address 10.1.1.1/24 secondary tag 10
-# interfaqce Ethernet1/6
+# interface Ethernet1/6
 #   ipv6 address fd5d:12c9:2201:2::1/64 tag 6
+# interface Ethernet1/7.42
+#   encapsulation dot1q 42
+#   no ip redirects
+#   no ip unreachables
 
 
 # Using replaced

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -48,6 +48,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"unknown command"),
         re.compile(br"user not present"),
         re.compile(br"invalid (.+?)at '\^' marker", re.I),
+        re.compile(br"configuration not allowed .+ at '\^' marker"),
         re.compile(br"[B|b]aud rate of console should be.* (\d*) to increase [a-z]* level", re.I),
     ]
 

--- a/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
@@ -1,6 +1,4 @@
 ---
-- set_fact: nxos_int4="{{ intdataraw[4].interface }}"
-
 # mgmt0 is included in L3 facts but excluded from result.before/after, so check
 # for an IP on mgmt0 to account for the possible extra interface in facts.
 - set_fact:

--- a/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
@@ -1,11 +1,18 @@
 ---
-# mgmt0 is included in L3 facts but excluded from result.before/after, so check
-# for an IP on mgmt0 to account for the possible extra interface in facts.
+# The interface-count asserts need to also account for mgmt0 which is a reserved
+# interface; i.e. it will be included in L3 facts when it has non-default values
+# but excluded from result.before/after because it's not allowed to be managed.
 - set_fact:
-    mgmt:
-      "{{ intdataraw|selectattr('interface', 'equalto', 'mgmt0')|list}}"
-- set_fact:
-    rsvd_intf_len:
-      "{{ 1 if (mgmt and 'ip_addr' in mgmt[0]) else 0}}"
+    # Zuul CI skips prepare_nxos but will have dhcp configured on mgmt0
+    rsvd_intf_len: 1
+
+- block:
+  - set_fact:
+      mgmt:
+        "{{ intdataraw|selectattr('interface', 'equalto', 'mgmt0')|list}}"
+  - set_fact:
+      rsvd_intf_len:
+        "{{ 1 if (mgmt and 'ip_addr' in mgmt[0]) else 0}}"
+  when: prepare_nxos_tests_task | default(True) | bool
 
 - { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tasks/main.yaml
@@ -1,2 +1,13 @@
 ---
+- set_fact: nxos_int4="{{ intdataraw[4].interface }}"
+
+# mgmt0 is included in L3 facts but excluded from result.before/after, so check
+# for an IP on mgmt0 to account for the possible extra interface in facts.
+- set_fact:
+    mgmt:
+      "{{ intdataraw|selectattr('interface', 'equalto', 'mgmt0')|list}}"
+- set_fact:
+    rsvd_intf_len:
+      "{{ 1 if (mgmt and 'ip_addr' in mgmt[0]) else 0}}"
+
 - { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -26,6 +26,7 @@
           ip address 192.168.10.2/24
           no ip redirects
           ip unreachables
+    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -9,6 +9,7 @@
 - name: setup1
   cli_config: &cleanup
     config: |
+      no system default switchport
       default interface {{ test_int4 }}
       interface {{ test_int4 }}
         no switchport

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -10,6 +10,9 @@
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
+      interface {{ test_int1 }}
+        no switchport
+  ignore_errors: yes
 
 - name: setup2 cleanup all L3 interfaces on device
   nxos_l3_interfaces:
@@ -19,14 +22,11 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ test_int1 }}
-          no switchport
         interface {{ subint1 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
           ip unreachables
-    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -64,6 +64,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+    ignore_errors: yes
 
   - name: teardown cleanup all L3 interfaces on device
     nxos_l3_interfaces:

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -2,20 +2,30 @@
 - debug:
     msg: "Start nxos_l3_interfaces deleted integration tests connection={{ ansible_connection }}"
 
-- set_fact: test_int1="{{ nxos_int1 }}"
+- set_fact:
+    test_int1: "{{ nxos_int1 }}"
+    subint1: "{{ nxos_int1 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
 
+- name: setup2 cleanup all L3 interfaces on device
+  nxos_l3_interfaces:
+    state: deleted
+
 - block:
-  - name: setup2
+  - name: setup3
     cli_config:
       config: |
         interface {{ test_int1 }}
           no switchport
+        interface {{ subint1 }}
+          encapsulation dot1q 42
           ip address 192.168.10.2/24
+          no ip redirects
+          ip unreachables
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -34,9 +44,12 @@
         - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
         - "result.after|length == 0"
         - "result.changed == true"
-        - "'interface {{ test_int1 }}' in result.commands"
+        - "'interface {{ subint1 }}' in result.commands"
+        - "'no encapsulation dot1q' in result.commands"
+        - "'ip redirects' in result.commands"
+        - "'no ip unreachables' in result.commands"
         - "'no ip address' in result.commands"
-        - "result.commands|length == 2"
+        - "result.commands|length == 5"
 
   - name: Idempotence - deleted
     nxos_l3_interfaces: *deleted
@@ -50,3 +63,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+
+  - name: teardown cleanup all L3 interfaces on device
+    nxos_l3_interfaces:
+      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -3,14 +3,14 @@
     msg: "Start nxos_l3_interfaces deleted integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int1: "{{ nxos_int1 }}"
-    subint1: "{{ nxos_int1 }}.42"
+    test_int4: "{{ nxos_int4 }}"
+    subint4: "{{ nxos_int4 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
-      default interface {{ test_int1 }}
-      interface {{ test_int1 }}
+      default interface {{ test_int4 }}
+      interface {{ test_int4 }}
         no switchport
   ignore_errors: yes
 
@@ -22,7 +22,7 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ subint1 }}
+        interface {{ subint4 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
@@ -42,10 +42,10 @@
 
   - assert:
       that:
-        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
         - "result.after|length == 0"
         - "result.changed == true"
-        - "'interface {{ subint1 }}' in result.commands"
+        - "'interface {{ subint4 }}' in result.commands"
         - "'no encapsulation dot1q' in result.commands"
         - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
@@ -63,9 +63,7 @@
 
   always:
   - name: teardown
-    cli_config: *cleanup
+    cli_config:
+      config: |
+        no interface {{ subint4 }}
     ignore_errors: yes
-
-  - name: teardown cleanup all L3 interfaces on device
-    nxos_l3_interfaces:
-      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/deleted.yaml
@@ -3,15 +3,15 @@
     msg: "Start nxos_l3_interfaces deleted integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int4: "{{ nxos_int4 }}"
-    subint4: "{{ nxos_int4 }}.42"
+    test_int3: "{{ nxos_int3 }}"
+    subint3: "{{ nxos_int3 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       no system default switchport
-      default interface {{ test_int4 }}
-      interface {{ test_int4 }}
+      default interface {{ test_int3 }}
+      interface {{ test_int3 }}
         no switchport
   ignore_errors: yes
 
@@ -23,7 +23,7 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ subint4 }}
+        interface {{ subint3 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
@@ -46,7 +46,7 @@
         - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
         - "result.after|length == 0"
         - "result.changed == true"
-        - "'interface {{ subint4 }}' in result.commands"
+        - "'interface {{ subint3 }}' in result.commands"
         - "'no encapsulation dot1q' in result.commands"
         - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
@@ -66,5 +66,5 @@
   - name: teardown
     cli_config:
       config: |
-        no interface {{ subint4 }}
+        no interface {{ subint3 }}
     ignore_errors: yes

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -10,19 +10,15 @@
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
+      interface {{ test_int1 }}
+        no switchport
+  ignore_errors: yes
 
 - name: setup2 cleanup all L3 states on all interfaces
   nxos_l3_interfaces:
     state: deleted
 
 - block:
-  - name: setup3
-    cli_config:
-      config: |
-        interface {{ test_int1 }}
-          no switchport
-    ignore_errors: yes
-
   - name: Merged
     nxos_l3_interfaces: &merged
       config:
@@ -73,6 +69,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+    ignore_errors: yes
 
   - name: teardown2 cleanup all L3 states on all interfaces
     nxos_l3_interfaces:

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -3,14 +3,14 @@
     msg: "Start nxos_l3_interfaces merged integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int1: "{{ nxos_int1 }}"
-    subint1: "{{ nxos_int1 }}.42"
+    test_int4: "{{ nxos_int4 }}"
+    subint4: "{{ nxos_int4 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
-      default interface {{ test_int1 }}
-      interface {{ test_int1 }}
+      default interface {{ test_int4 }}
+      interface {{ test_int4 }}
         no switchport
   ignore_errors: yes
 
@@ -22,7 +22,7 @@
   - name: Merged
     nxos_l3_interfaces: &merged
       config:
-        - name: "{{ subint1 }}"
+        - name: "{{ subint4 }}"
           dot1q: 42
           redirects: false
           unreachables: true
@@ -35,7 +35,7 @@
       that:
         - "result.changed == true"
         - "result.before|length == 0"
-        - "'interface {{ subint1 }}' in result.commands"
+        - "'interface {{ subint4 }}' in result.commands"
         - "'encapsulation dot1q 42' in result.commands"
         - "'no ip redirects' in result.commands"
         - "'ip unreachables' in result.commands"
@@ -49,13 +49,9 @@
         - '!min'
       gather_network_resources: l3_interfaces
 
-  # The nxos_l3_interfaces module should never attempt to modify the mgmt interface ip.
-  # The module will still collect facts about the interface however so in this case
-  # the facts will contain all l3 enabled interfaces including mgmt) but the after state in
-  # result will only contain the modification
   - assert:
       that:
-        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
 
   - name: Idempotence - Merged
     nxos_l3_interfaces: *merged
@@ -68,9 +64,7 @@
 
   always:
   - name: teardown
-    cli_config: *cleanup
+    cli_config:
+      config: |
+        no interface {{ subint4 }}
     ignore_errors: yes
-
-  - name: teardown2 cleanup all L3 states on all interfaces
-    nxos_l3_interfaces:
-      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -3,15 +3,15 @@
     msg: "Start nxos_l3_interfaces merged integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int4: "{{ nxos_int4 }}"
-    subint4: "{{ nxos_int4 }}.42"
+    test_int3: "{{ nxos_int3 }}"
+    subint3: "{{ nxos_int3 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       no system default switchport
-      default interface {{ test_int4 }}
-      interface {{ test_int4 }}
+      default interface {{ test_int3 }}
+      interface {{ test_int3 }}
         no switchport
   ignore_errors: yes
 
@@ -23,7 +23,7 @@
   - name: Merged
     nxos_l3_interfaces: &merged
       config:
-        - name: "{{ subint4 }}"
+        - name: "{{ subint3 }}"
           dot1q: 42
           redirects: false
           unreachables: true
@@ -36,7 +36,7 @@
       that:
         - "result.changed == true"
         - "result.before|length == 0"
-        - "'interface {{ subint4 }}' in result.commands"
+        - "'interface {{ subint3 }}' in result.commands"
         - "'encapsulation dot1q 42' in result.commands"
         - "'no ip redirects' in result.commands"
         - "'ip unreachables' in result.commands"
@@ -67,5 +67,5 @@
   - name: teardown
     cli_config:
       config: |
-        no interface {{ subint4 }}
+        no interface {{ subint3 }}
     ignore_errors: yes

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -9,6 +9,7 @@
 - name: setup1
   cli_config: &cleanup
     config: |
+      no system default switchport
       default interface {{ test_int4 }}
       interface {{ test_int4 }}
         no switchport

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -21,6 +21,7 @@
       config: |
         interface {{ test_int1 }}
           no switchport
+    ignore_errors: yes
 
   - name: Merged
     nxos_l3_interfaces: &merged

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/merged.yaml
@@ -2,15 +2,21 @@
 - debug:
     msg: "Start nxos_l3_interfaces merged integration tests connection={{ ansible_connection }}"
 
-- set_fact: test_int1="{{ nxos_int1 }}"
+- set_fact:
+    test_int1: "{{ nxos_int1 }}"
+    subint1: "{{ nxos_int1 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
 
+- name: setup2 cleanup all L3 states on all interfaces
+  nxos_l3_interfaces:
+    state: deleted
+
 - block:
-  - name: setup2
+  - name: setup3
     cli_config:
       config: |
         interface {{ test_int1 }}
@@ -19,7 +25,10 @@
   - name: Merged
     nxos_l3_interfaces: &merged
       config:
-        - name: "{{ test_int1 }}"
+        - name: "{{ subint1 }}"
+          dot1q: 42
+          redirects: false
+          unreachables: true
           ipv4:
             - address: 192.168.10.2/24
       state:  merged
@@ -29,9 +38,12 @@
       that:
         - "result.changed == true"
         - "result.before|length == 0"
-        - "'interface {{ test_int1 }}' in result.commands"
+        - "'interface {{ subint1 }}' in result.commands"
+        - "'encapsulation dot1q 42' in result.commands"
+        - "'no ip redirects' in result.commands"
+        - "'ip unreachables' in result.commands"
         - "'ip address 192.168.10.2/24' in result.commands"
-        - "result.commands|length == 2"
+        - "result.commands|length == 5"
 
   - name: Gather l3_interfaces facts
     nxos_facts:
@@ -60,3 +72,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+
+  - name: teardown2 cleanup all L3 states on all interfaces
+    nxos_l3_interfaces:
+      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
@@ -12,6 +12,13 @@
       default interface {{ test_int1 }}
       default interface {{ test_int2 }}
       default interface {{ test_int3 }}
+      interface {{ test_int1 }}
+        no switchport
+      interface {{ test_int2 }}
+        no switchport
+      interface {{ test_int3 }}
+        no switchport
+  ignore_errors: yes
 
 - name: setup2 cleanup all L3 states on all interfaces
   nxos_l3_interfaces:
@@ -22,14 +29,9 @@
     cli_config:
       config: |
         interface {{ test_int1 }}
-          no switchport
           ip address 192.168.10.2/24 tag 5
         interface {{ test_int2 }}
-          no switchport
           ip address 10.1.1.1/24
-        interface {{ test_int3 }}
-          no switchport
-    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -78,3 +80,8 @@
   always:
   - name: teardown
     cli_config: *cleanup
+    ignore_errors: yes
+
+  - name: teardown cleanup all L3 interfaces on device
+    nxos_l3_interfaces:
+      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
@@ -9,6 +9,7 @@
 - name: setup1
   cli_config: &cleanup
     config: |
+      no system default switchport
       default interface {{ test_int1 }}
       default interface {{ test_int2 }}
       default interface {{ test_int3 }}

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
@@ -51,7 +51,7 @@
 
   - assert:
       that:
-        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
         - "result.changed == true"
         - "'interface {{ test_int1 }}' in result.commands"
         - "'no ip address' in result.commands"
@@ -66,7 +66,7 @@
 
   - assert:
       that:
-        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
 
   - name: Idempotence - Overridden
     nxos_l3_interfaces: *overridden
@@ -81,7 +81,3 @@
   - name: teardown
     cli_config: *cleanup
     ignore_errors: yes
-
-  - name: teardown cleanup all L3 interfaces on device
-    nxos_l3_interfaces:
-      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
@@ -29,6 +29,7 @@
           ip address 10.1.1.1/24
         interface {{ test_int3 }}
           no switchport
+    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/overridden.yaml
@@ -13,8 +13,12 @@
       default interface {{ test_int2 }}
       default interface {{ test_int3 }}
 
+- name: setup2 cleanup all L3 states on all interfaces
+  nxos_l3_interfaces:
+    state: deleted
+
 - block:
-  - name: setup2
+  - name: setup3
     cli_config:
       config: |
         interface {{ test_int1 }}

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -41,10 +41,14 @@
       config:
         - name: "{{ subint3 }}"
           dot1q: 442
-          redirects: true
+          # Note: device auto-disables redirects when secondaries are present
+          redirects: false
           unreachables: false
           ipv4:
             - address: 192.168.20.2/24
+              tag: 5
+            - address: 192.168.200.2/24
+              secondary: True
       state: replaced
     register: result
 
@@ -54,9 +58,9 @@
         - "result.changed == true"
         - "'interface {{ subint3 }}' in result.commands"
         - "'encapsulation dot1q 442' in result.commands"
-        - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
-        - "'ip address 192.168.20.2/24' in result.commands"
+        - "'ip address 192.168.20.2/24 tag 5' in result.commands"
+        - "'ip address 192.168.200.2/24 secondary' in result.commands"
         - "result.commands|length == 5"
 
   - name: Gather l3_interfaces post facts
@@ -68,6 +72,36 @@
 
   - name: Idempotence - Replaced
     nxos_l3_interfaces: *replaced
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.commands|length == 0"
+
+  - name: Replaced with no optional attrs specified
+    nxos_l3_interfaces: &replaced_no_attrs
+      config:
+        - name: "{{ subint3 }}"
+      state: replaced
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface {{ subint3 }}' in result.commands"
+        - "'no encapsulation dot1q' in result.commands"
+        - "'no ip address' in result.commands"
+
+  - assert:
+      that:
+        # 'ip redirects' normally auto-enables due to rmv'ing the secondaries;
+        # this behavior is unreliable on legacy platforms thus command is explicit.
+        - "'ip redirects' in result.commands"
+    when: platform is match('N[3567]')
+
+  - name: Idempotence - Replaced with no attrs specified
+    nxos_l3_interfaces: *replaced_no_attrs
     register: result
 
   - assert:

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -26,6 +26,7 @@
           ip address 192.168.10.2/24
           no ip redirects
           ip unreachables
+    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -43,9 +44,6 @@
           unreachables: false
           ipv4:
             - address: 192.168.20.2/24
-          ipv6:
-            - address: "fd5d:12c9:2201:1::1/64"
-              tag: 6
       state: replaced
     register: result
 
@@ -58,8 +56,7 @@
         - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
         - "'ip address 192.168.20.2/24' in result.commands"
-        - "'ipv6 address fd5d:12c9:2201:1::1/64 tag 6' in result.commands"
-        - "result.commands|length == 6"
+        - "result.commands|length == 5"
 
   - name: Gather l3_interfaces post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -2,20 +2,30 @@
 - debug:
     msg: "Start nxos_l3_interfaces replaced integration tests connection={{ ansible_connection }}"
 
-- set_fact: test_int1="{{ nxos_int1 }}"
+- set_fact:
+    test_int1: "{{ nxos_int1 }}"
+    subint1: "{{ nxos_int1 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
 
+- name: setup2 cleanup all L3 states on all interfaces
+  nxos_l3_interfaces:
+    state: deleted
+
 - block:
-  - name: setup2
+  - name: setup3
     cli_config:
       config: |
         interface {{ test_int1 }}
           no switchport
+        interface {{ subint1 }}
+          encapsulation dot1q 42
           ip address 192.168.10.2/24
+          no ip redirects
+          ip unreachables
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -27,7 +37,12 @@
   - name: Replaced
     nxos_l3_interfaces: &replaced
       config:
-        - name: "{{ test_int1 }}"
+        - name: "{{ subint1 }}"
+          dot1q: 442
+          redirects: true
+          unreachables: false
+          ipv4:
+            - address: 192.168.20.2/24
           ipv6:
             - address: "fd5d:12c9:2201:1::1/64"
               tag: 6
@@ -38,10 +53,13 @@
       that:
         - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
         - "result.changed == true"
-        - "'interface {{ test_int1 }}' in result.commands"
-        - "'no ip address' in result.commands"
+        - "'interface {{ subint1 }}' in result.commands"
+        - "'encapsulation dot1q 442' in result.commands"
+        - "'ip redirects' in result.commands"
+        - "'no ip unreachables' in result.commands"
+        - "'ip address 192.168.20.2/24' in result.commands"
         - "'ipv6 address fd5d:12c9:2201:1::1/64 tag 6' in result.commands"
-        - "result.commands|length == 3"
+        - "result.commands|length == 6"
 
   - name: Gather l3_interfaces post facts
     nxos_facts: *facts
@@ -62,3 +80,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+
+  - name: teardown2 cleanup all L3 states on all interfaces
+    nxos_l3_interfaces:
+      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -9,6 +9,7 @@
 - name: setup1
   cli_config: &cleanup
     config: |
+      no system default switchport
       default interface {{ test_int4 }}
       interface {{ test_int4 }}
         no switchport

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -3,14 +3,14 @@
     msg: "Start nxos_l3_interfaces replaced integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int1: "{{ nxos_int1 }}"
-    subint1: "{{ nxos_int1 }}.42"
+    test_int4: "{{ nxos_int4 }}"
+    subint4: "{{ nxos_int4 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
-      default interface {{ test_int1 }}
-      interface {{ test_int1 }}
+      default interface {{ test_int4 }}
+      interface {{ test_int4 }}
         no switchport
   ignore_errors: yes
 
@@ -22,7 +22,7 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ subint1 }}
+        interface {{ subint4 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
@@ -38,7 +38,7 @@
   - name: Replaced
     nxos_l3_interfaces: &replaced
       config:
-        - name: "{{ subint1 }}"
+        - name: "{{ subint4 }}"
           dot1q: 442
           redirects: true
           unreachables: false
@@ -49,9 +49,9 @@
 
   - assert:
       that:
-        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
         - "result.changed == true"
-        - "'interface {{ subint1 }}' in result.commands"
+        - "'interface {{ subint4 }}' in result.commands"
         - "'encapsulation dot1q 442' in result.commands"
         - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
@@ -63,7 +63,7 @@
 
   - assert:
       that:
-        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length - 1)"
+        - "result.after|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
 
   - name: Idempotence - Replaced
     nxos_l3_interfaces: *replaced
@@ -76,9 +76,7 @@
 
   always:
   - name: teardown
-    cli_config: *cleanup
+    cli_config:
+      config: |
+        no interface {{ subint4 }}
     ignore_errors: yes
-
-  - name: teardown2 cleanup all L3 states on all interfaces
-    nxos_l3_interfaces:
-      state: deleted

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -10,6 +10,9 @@
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
+      interface {{ test_int1 }}
+        no switchport
+  ignore_errors: yes
 
 - name: setup2 cleanup all L3 states on all interfaces
   nxos_l3_interfaces:
@@ -19,14 +22,11 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ test_int1 }}
-          no switchport
         interface {{ subint1 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
           ip unreachables
-    ignore_errors: yes
 
   - name: Gather l3_interfaces facts
     nxos_facts: &facts
@@ -77,6 +77,7 @@
   always:
   - name: teardown
     cli_config: *cleanup
+    ignore_errors: yes
 
   - name: teardown2 cleanup all L3 states on all interfaces
     nxos_l3_interfaces:

--- a/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l3_interfaces/tests/cli/replaced.yaml
@@ -3,15 +3,15 @@
     msg: "Start nxos_l3_interfaces replaced integration tests connection={{ ansible_connection }}"
 
 - set_fact:
-    test_int4: "{{ nxos_int4 }}"
-    subint4: "{{ nxos_int4 }}.42"
+    test_int3: "{{ nxos_int3 }}"
+    subint3: "{{ nxos_int3 }}.42"
 
 - name: setup1
   cli_config: &cleanup
     config: |
       no system default switchport
-      default interface {{ test_int4 }}
-      interface {{ test_int4 }}
+      default interface {{ test_int3 }}
+      interface {{ test_int3 }}
         no switchport
   ignore_errors: yes
 
@@ -23,7 +23,7 @@
   - name: setup3
     cli_config:
       config: |
-        interface {{ subint4 }}
+        interface {{ subint3 }}
           encapsulation dot1q 42
           ip address 192.168.10.2/24
           no ip redirects
@@ -39,7 +39,7 @@
   - name: Replaced
     nxos_l3_interfaces: &replaced
       config:
-        - name: "{{ subint4 }}"
+        - name: "{{ subint3 }}"
           dot1q: 442
           redirects: true
           unreachables: false
@@ -52,7 +52,7 @@
       that:
         - "result.before|length == (ansible_facts.network_resources.l3_interfaces|length|int - rsvd_intf_len|int)"
         - "result.changed == true"
-        - "'interface {{ subint4 }}' in result.commands"
+        - "'interface {{ subint3 }}' in result.commands"
         - "'encapsulation dot1q 442' in result.commands"
         - "'ip redirects' in result.commands"
         - "'no ip unreachables' in result.commands"
@@ -79,5 +79,5 @@
   - name: teardown
     cli_config:
       config: |
-        no interface {{ subint4 }}
+        no interface {{ subint3 }}
     ignore_errors: yes

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -85,7 +85,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         self.execute_module({'failed': True, 'msg': "The 'mgmt0' interface is not allowed to be managed by this module"})
 
     def test_2(self):
-        # Change existing config states
+        # basic tests
         existing = dedent('''\
           interface mgmt0
             ip address 10.0.0.254/24
@@ -109,12 +109,11 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         merged = ['interface Ethernet1/1', 'ip address 192.168.1.1/24']
         deleted = ['interface Ethernet1/1', 'no ip address',
                    'interface Ethernet1/2', 'no ip address']
-        overridden = ['interface Ethernet1/1', 'no ip address',
-                      'interface Ethernet1/2', 'no ip address',
-                      'interface Ethernet1/3', 'no ip address',
-                      'interface Ethernet1/1', 'ip address 192.168.1.1/24']
-        replaced = ['interface Ethernet1/1', 'no ip address', 'ip address 192.168.1.1/24',
-                    'interface Ethernet1/2', 'no ip address']
+        replaced = ['interface Ethernet1/1', 'ip address 192.168.1.1/24',
+                    'interface Ethernet1/2', 'no ip address 10.1.2.1/24']
+        overridden = ['interface Ethernet1/1', 'ip address 192.168.1.1/24',
+                      'interface Ethernet1/2', 'no ip address 10.1.2.1/24',
+                      'interface Ethernet1/3', 'no ip address']
 
         playbook['state'] = 'merged'
         set_module_args(playbook, ignore_provider_arg)
@@ -124,13 +123,374 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=deleted)
 
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced)
+
         playbook['state'] = 'overridden'
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=overridden)
 
-        # TBD: 'REPLACED' BEHAVIOR IS INCORRECT,
-        #      IT IS WRONGLY IGNORING ETHERNET1/2.
-        #      ****************** SKIP TEST FOR NOW *****************
-        # playbook['state'] = 'replaced'
-        # set_module_args(playbook, ignore_provider_arg)
-        # self.execute_module(changed=True, commands=replaced)
+    def test_3(self):
+        # encap testing
+        existing = dedent('''\
+          interface mgmt0
+            ip address 10.0.0.254/24
+          interface Ethernet1/1.41
+            encapsulation dot1q 4100
+            ip address 10.1.1.1/24
+          interface Ethernet1/1.42
+            encapsulation dot1q 42
+          interface Ethernet1/1.44
+            encapsulation dot1q 44
+          interface Ethernet1/1.45
+            encapsulation dot1q 45
+            ip address 10.5.5.5/24
+            ipv6 address 10::5/128
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/1.41', dot1q=41, ipv4=[{'address': '10.2.2.2/24'}]),
+            dict(name='Ethernet1/1.42', dot1q=42),
+            dict(name='Ethernet1/1.43', dot1q=43, ipv6=[{'address': '10::2/128'}]),
+            dict(name='Ethernet1/1.44')
+        ])
+        # Expected result commands for each 'state'
+        merged = [
+            'interface Ethernet1/1.41', 'encapsulation dot1q 41', 'ip address 10.2.2.2/24',
+            'interface Ethernet1/1.43', 'encapsulation dot1q 43', 'ipv6 address 10::2/128',
+        ]
+        deleted = [
+            'interface Ethernet1/1.41', 'no encapsulation dot1q', 'no ip address',
+            'interface Ethernet1/1.42', 'no encapsulation dot1q',
+            'interface Ethernet1/1.44', 'no encapsulation dot1q'
+        ]
+        replaced = [
+            'interface Ethernet1/1.41', 'encapsulation dot1q 41', 'ip address 10.2.2.2/24',
+            # 42 no chg
+            'interface Ethernet1/1.43', 'encapsulation dot1q 43', 'ipv6 address 10::2/128',
+            'interface Ethernet1/1.44', 'no encapsulation dot1q'
+        ]
+        overridden = [
+            'interface Ethernet1/1.41', 'encapsulation dot1q 41', 'ip address 10.2.2.2/24',
+            # 42 no chg
+            'interface Ethernet1/1.44', 'no encapsulation dot1q',
+            'interface Ethernet1/1.45', 'no encapsulation dot1q', 'no ip address', 'no ipv6 address',
+            'interface Ethernet1/1.43', 'encapsulation dot1q 43', 'ipv6 address 10::2/128'
+        ]
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=merged)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)
+
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced)
+
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden)
+
+    def test_4(self):
+        # IPv4-centric testing
+        existing = dedent('''\
+          interface mgmt0
+            ip address 10.0.0.254/24
+          interface Ethernet1/1
+            ip address 10.1.1.1/24 tag 11
+            ip address 10.2.2.2/24 secondary tag 12
+            ip address 10.3.3.3/24 secondary
+            ip address 10.4.4.4/24 secondary tag 14
+            ip address 10.5.5.5/24 secondary tag 15
+            ip address 10.6.6.6/24 secondary tag 16
+          interface Ethernet1/2
+            ip address 10.12.12.12/24
+          interface Ethernet1/3
+            ip address 10.13.13.13/24
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/1',
+                 ipv4=[{'address': '10.1.1.1/24', 'secondary':True}, # prim->sec
+                       {'address': '10.2.2.2/24', 'secondary':True}, # rmv tag
+                       {'address': '10.3.3.3/24', 'tag': 3},         # become prim
+                       {'address': '10.4.4.4/24', 'secondary':True, 'tag': 14}, # no chg
+                       {'address': '10.5.5.5/24', 'secondary':True, 'tag': 55}, # chg tag
+                       {'address': '10.7.7.7/24', 'secondary':True, 'tag': 77}  # new ip
+                      ]),
+            dict(name='Ethernet1/2'),
+            dict(name='Ethernet1/4',
+                 ipv4=[{'address': '10.40.40.40/24'},
+                       {'address': '10.41.41.41/24', 'secondary':True}
+                      ]),
+        ])
+        # Expected result commands for each 'state'
+        merged = [
+            'interface Ethernet1/1',
+            'no ip address 10.5.5.5/24 secondary',
+            'no ip address 10.2.2.2/24 secondary',
+            'no ip address 10.3.3.3/24 secondary',
+            'ip address 10.3.3.3/24 tag 3',  # Changes primary
+            'ip address 10.1.1.1/24 secondary',
+            'ip address 10.2.2.2/24 secondary',
+            'ip address 10.7.7.7/24 secondary tag 77',
+            'ip address 10.5.5.5/24 secondary tag 55',
+            'interface Ethernet1/4',
+            'ip address 10.40.40.40/24',
+            'ip address 10.41.41.41/24 secondary'
+        ]
+        deleted = [
+            'interface Ethernet1/1', 'no ip address',
+            'interface Ethernet1/2', 'no ip address'
+        ]
+        replaced = [
+            'interface Ethernet1/1',
+            'no ip address 10.5.5.5/24 secondary',
+            'no ip address 10.2.2.2/24 secondary',
+            'no ip address 10.3.3.3/24 secondary',
+            'ip address 10.3.3.3/24 tag 3',  # Changes primary
+            'ip address 10.1.1.1/24 secondary',
+            'ip address 10.2.2.2/24 secondary',
+            'ip address 10.7.7.7/24 secondary tag 77',
+            'ip address 10.5.5.5/24 secondary tag 55',
+            'interface Ethernet1/2',
+            'no ip address 10.12.12.12/24',
+            'interface Ethernet1/4',
+            'ip address 10.40.40.40/24',
+            'ip address 10.41.41.41/24 secondary'
+        ]
+        overridden = [
+            'interface Ethernet1/1',
+            'no ip address 10.6.6.6/24 secondary',
+            'no ip address 10.5.5.5/24 secondary',
+            'no ip address 10.2.2.2/24 secondary',
+            'no ip address 10.3.3.3/24 secondary',
+            'ip address 10.3.3.3/24 tag 3',  # Changes primary
+            'ip address 10.1.1.1/24 secondary',
+            'ip address 10.2.2.2/24 secondary',
+            'ip address 10.7.7.7/24 secondary tag 77',
+            'ip address 10.5.5.5/24 secondary tag 55',
+            'interface Ethernet1/2',
+            'no ip address 10.12.12.12/24',
+            'interface Ethernet1/3',
+            'no ip address',
+            'interface Ethernet1/4',
+            'ip address 10.40.40.40/24',
+            'ip address 10.41.41.41/24 secondary'
+        ]
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=merged)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)
+
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced)
+        #
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden)
+
+    def test_5(self):
+        # IPv6-centric testing
+        existing = dedent('''\
+          interface Ethernet1/1
+            ipv6 address 10::1/128
+            ipv6 address 10::2/128 tag 12
+            ipv6 address 10::3/128 tag 13
+            ipv6 address 10::4/128 tag 14
+          interface Ethernet1/2
+            ipv6 address 10::12/128
+          interface Ethernet1/3
+            ipv6 address 10::13/128
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/1',
+                 ipv6=[{'address': '10::1/128'},              # no chg
+                       {'address': '10::3/128'},              # tag rmv
+                       {'address': '10::4/128', 'tag': 44},   # tag chg
+                       {'address': '10::5/128',},             # new addr
+                       {'address': '10::6/128', 'tag': 66}]), # new addr+tag
+           dict(name='Ethernet1/2'),
+        ])
+        # Expected result commands for each 'state'
+        merged = [
+            'interface Ethernet1/1',
+            'ipv6 address 10::4/128 tag 44',
+            'ipv6 address 10::5/128',
+            'ipv6 address 10::6/128 tag 66',
+        ]
+        deleted = [
+            'interface Ethernet1/1', 'no ipv6 address',
+            'interface Ethernet1/2', 'no ipv6 address',
+        ]
+        replaced = [
+            'interface Ethernet1/1',
+            'no ipv6 address 10::3/128',
+            'no ipv6 address 10::2/128',
+            'ipv6 address 10::4/128 tag 44',
+            'ipv6 address 10::3/128',
+            'ipv6 address 10::5/128',
+            'ipv6 address 10::6/128 tag 66',
+            'interface Ethernet1/2',
+            'no ipv6 address 10::12/128'
+        ]
+        overridden = [
+            'interface Ethernet1/1',
+            'no ipv6 address 10::3/128',
+            'no ipv6 address 10::2/128',
+            'ipv6 address 10::4/128 tag 44',
+            'ipv6 address 10::3/128',
+            'ipv6 address 10::5/128',
+            'ipv6 address 10::6/128 tag 66',
+            'interface Ethernet1/2',
+            'no ipv6 address 10::12/128',
+            'interface Ethernet1/3',
+            'no ipv6 address'
+        ]
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=merged)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)
+        #
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced)
+        #
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden)
+
+    def test_6(self):
+        # misc tests
+        existing = dedent('''\
+          interface Ethernet1/1
+            ip address 10.1.1.1/24
+            no ip redirects
+            ip unreachables
+          interface Ethernet1/2
+          interface Ethernet1/3
+          interface Ethernet1/4
+          interface Ethernet1/5
+            no ip redirects
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/1', redirects=True, unreachables=False,
+                 ipv4=[{'address': '192.168.1.1/24'}]),
+            dict(name='Ethernet1/2'),
+            dict(name='Ethernet1/3', redirects=True, unreachables=False), # defaults
+            dict(name='Ethernet1/4', redirects=False, unreachables=True),
+        ])
+        merged = [
+            'interface Ethernet1/1',
+            'ip redirects',
+            'no ip unreachables',
+            'ip address 192.168.1.1/24',
+            'interface Ethernet1/4',
+            'no ip redirects',
+            'ip unreachables'
+        ]
+        deleted = [
+            'interface Ethernet1/1',
+            'ip redirects',
+            'no ip unreachables',
+            'no ip address'
+        ]
+        replaced = [
+            'interface Ethernet1/1',
+            'ip redirects',
+            'no ip unreachables',
+            'ip address 192.168.1.1/24',
+            'interface Ethernet1/4',
+            'no ip redirects',
+            'ip unreachables'
+        ]
+        overridden = [
+            'interface Ethernet1/1',
+            'ip redirects',
+            'no ip unreachables',
+            'ip address 192.168.1.1/24',
+            'interface Ethernet1/5',
+            'ip redirects',
+            'interface Ethernet1/4',
+            'no ip redirects',
+            'ip unreachables'
+        ]
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=merged)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)
+
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced)
+
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden)
+
+    def test_7(self):
+        # idempotence
+        existing = dedent('''\
+          interface Ethernet1/1
+            ip address 10.1.1.1/24
+            ip address 10.2.2.2/24 secondary tag 2
+            ip address 10.3.3.3/24 secondary tag 3
+            ip address 10.4.4.4/24 secondary
+            ipv6 address 10::1/128
+            ipv6 address 10::2/128 tag 2
+            no ip redirects
+            ip unreachables
+          interface Ethernet1/2
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/1', redirects=False, unreachables=True,
+                 ipv4=[{'address': '10.1.1.1/24'},
+                       {'address': '10.2.2.2/24', 'secondary': True, 'tag': 2},
+                       {'address': '10.3.3.3/24', 'secondary': True, 'tag': 3},
+                       {'address': '10.4.4.4/24', 'secondary': True}],
+                 ipv6=[{'address': '10::1/128'},
+                       {'address': '10::2/128', 'tag': 2}],
+                ),
+            dict(name='Ethernet1/2')
+        ])
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=False)
+
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=False)
+
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=False)
+
+        # Modify output for deleted idempotence test
+        existing = dedent('''\
+          interface Ethernet1/1
+          interface Ethernet1/2
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=False)

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -215,18 +215,16 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
         playbook = dict(config=[
             dict(name='Ethernet1/1',
-                 ipv4=[{'address': '10.1.1.1/24', 'secondary':True}, # prim->sec
-                       {'address': '10.2.2.2/24', 'secondary':True}, # rmv tag
-                       {'address': '10.3.3.3/24', 'tag': 3},         # become prim
-                       {'address': '10.4.4.4/24', 'secondary':True, 'tag': 14}, # no chg
-                       {'address': '10.5.5.5/24', 'secondary':True, 'tag': 55}, # chg tag
-                       {'address': '10.7.7.7/24', 'secondary':True, 'tag': 77}  # new ip
-                      ]),
+                 ipv4=[{'address': '10.1.1.1/24', 'secondary': True},  # prim->sec
+                       {'address': '10.2.2.2/24', 'secondary': True},  # rmv tag
+                       {'address': '10.3.3.3/24', 'tag': 3},           # become prim
+                       {'address': '10.4.4.4/24', 'secondary': True, 'tag': 14},  # no chg
+                       {'address': '10.5.5.5/24', 'secondary': True, 'tag': 55},  # chg tag
+                       {'address': '10.7.7.7/24', 'secondary': True, 'tag': 77}]),  # new ip
             dict(name='Ethernet1/2'),
             dict(name='Ethernet1/4',
                  ipv4=[{'address': '10.40.40.40/24'},
-                       {'address': '10.41.41.41/24', 'secondary':True}
-                      ]),
+                       {'address': '10.41.41.41/24', 'secondary': True}]),
         ])
         # Expected result commands for each 'state'
         merged = [
@@ -315,12 +313,12 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
         playbook = dict(config=[
             dict(name='Ethernet1/1',
-                 ipv6=[{'address': '10::1/128'},              # no chg
-                       {'address': '10::3/128'},              # tag rmv
-                       {'address': '10::4/128', 'tag': 44},   # tag chg
-                       {'address': '10::5/128',},             # new addr
-                       {'address': '10::6/128', 'tag': 66}]), # new addr+tag
-           dict(name='Ethernet1/2'),
+                 ipv6=[{'address': '10::1/128'},               # no chg
+                       {'address': '10::3/128'},               # tag rmv
+                       {'address': '10::4/128', 'tag': 44},    # tag chg
+                       {'address': '10::5/128'},               # new addr
+                       {'address': '10::6/128', 'tag': 66}]),  # new addr+tag
+            dict(name='Ethernet1/2'),
         ])
         # Expected result commands for each 'state'
         merged = [
@@ -392,7 +390,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
             dict(name='Ethernet1/1', redirects=True, unreachables=False,
                  ipv4=[{'address': '192.168.1.1/24'}]),
             dict(name='Ethernet1/2'),
-            dict(name='Ethernet1/3', redirects=True, unreachables=False), # defaults
+            dict(name='Ethernet1/3', redirects=True, unreachables=False),  # defaults
             dict(name='Ethernet1/4', redirects=False, unreachables=True),
         ])
         merged = [
@@ -469,8 +467,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
                        {'address': '10.3.3.3/24', 'secondary': True, 'tag': 3},
                        {'address': '10.4.4.4/24', 'secondary': True}],
                  ipv6=[{'address': '10::1/128'},
-                       {'address': '10::2/128', 'tag': 2}],
-                ),
+                       {'address': '10::2/128', 'tag': 2}]),
             dict(name='Ethernet1/2')
         ])
         playbook['state'] = 'merged'

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -491,3 +491,25 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         playbook['state'] = 'deleted'
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=False)
+
+    def test_8(self):
+        # no 'config' key in playbook
+        existing = dedent('''\
+          interface Ethernet1/1
+            ip address 10.1.1.1/24
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict()
+
+        for i in ['merged', 'replaced', 'overridden']:
+            playbook['state'] = i
+            set_module_args(playbook, ignore_provider_arg)
+            self.execute_module(failed=True)
+
+        deleted = [
+            'interface Ethernet1/1',
+            'no ip address',
+        ]
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted)

--- a/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
+++ b/test/units/modules/network/nxos/test_nxos_l3_interfaces.py
@@ -48,17 +48,22 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         self.mock_edit_config = patch('ansible.module_utils.network.nxos.config.l3_interfaces.l3_interfaces.L3_interfaces.edit_config')
         self.edit_config = self.mock_edit_config.start()
 
+        self.mock_get_platform_type = patch('ansible.module_utils.network.nxos.config.l3_interfaces.l3_interfaces.L3_interfaces.get_platform_type')
+        self.get_platform_type = self.mock_get_platform_type.start()
+
     def tearDown(self):
         super(TestNxosL3InterfacesModule, self).tearDown()
         self.mock_FACT_LEGACY_SUBSETS.stop()
         self.mock_get_resource_connection_config.stop()
         self.mock_get_resource_connection_facts.stop()
         self.mock_edit_config.stop()
+        self.mock_get_platform_type.stop()
 
-    def load_fixtures(self, commands=None, device=''):
+    def load_fixtures(self, commands=None, device='N9K'):
         self.mock_FACT_LEGACY_SUBSETS.return_value = dict()
         self.get_resource_connection_config.return_value = None
         self.edit_config.return_value = None
+        self.get_platform_type.return_value = device
 
     # ---------------------------
     # L3_interfaces Test Cases
@@ -110,9 +115,9 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         deleted = ['interface Ethernet1/1', 'no ip address',
                    'interface Ethernet1/2', 'no ip address']
         replaced = ['interface Ethernet1/1', 'ip address 192.168.1.1/24',
-                    'interface Ethernet1/2', 'no ip address 10.1.2.1/24']
+                    'interface Ethernet1/2', 'no ip address']
         overridden = ['interface Ethernet1/1', 'ip address 192.168.1.1/24',
-                      'interface Ethernet1/2', 'no ip address 10.1.2.1/24',
+                      'interface Ethernet1/2', 'no ip address',
                       'interface Ethernet1/3', 'no ip address']
 
         playbook['state'] = 'merged'
@@ -201,6 +206,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
           interface mgmt0
             ip address 10.0.0.254/24
           interface Ethernet1/1
+            no ip redirects
             ip address 10.1.1.1/24 tag 11
             ip address 10.2.2.2/24 secondary tag 12
             ip address 10.3.3.3/24 secondary
@@ -211,6 +217,10 @@ class TestNxosL3InterfacesModule(TestNxosModule):
             ip address 10.12.12.12/24
           interface Ethernet1/3
             ip address 10.13.13.13/24
+          interface Ethernet1/5
+            no ip redirects
+            ip address 10.15.15.15/24
+            ip address 10.25.25.25/24 secondary
         ''')
         self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
         playbook = dict(config=[
@@ -225,6 +235,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
             dict(name='Ethernet1/4',
                  ipv4=[{'address': '10.40.40.40/24'},
                        {'address': '10.41.41.41/24', 'secondary': True}]),
+            dict(name='Ethernet1/5'),
         ])
         # Expected result commands for each 'state'
         merged = [
@@ -243,7 +254,8 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         ]
         deleted = [
             'interface Ethernet1/1', 'no ip address',
-            'interface Ethernet1/2', 'no ip address'
+            'interface Ethernet1/2', 'no ip address',
+            'interface Ethernet1/5', 'no ip address'
         ]
         replaced = [
             'interface Ethernet1/1',
@@ -256,10 +268,12 @@ class TestNxosL3InterfacesModule(TestNxosModule):
             'ip address 10.7.7.7/24 secondary tag 77',
             'ip address 10.5.5.5/24 secondary tag 55',
             'interface Ethernet1/2',
-            'no ip address 10.12.12.12/24',
+            'no ip address',
             'interface Ethernet1/4',
             'ip address 10.40.40.40/24',
-            'ip address 10.41.41.41/24 secondary'
+            'ip address 10.41.41.41/24 secondary',
+            'interface Ethernet1/5',
+            'no ip address'
         ]
         overridden = [
             'interface Ethernet1/1',
@@ -273,12 +287,14 @@ class TestNxosL3InterfacesModule(TestNxosModule):
             'ip address 10.7.7.7/24 secondary tag 77',
             'ip address 10.5.5.5/24 secondary tag 55',
             'interface Ethernet1/2',
-            'no ip address 10.12.12.12/24',
+            'no ip address',
             'interface Ethernet1/3',
             'no ip address',
             'interface Ethernet1/4',
             'ip address 10.40.40.40/24',
-            'ip address 10.41.41.41/24 secondary'
+            'ip address 10.41.41.41/24 secondary',
+            'interface Ethernet1/5',
+            'no ip address',
         ]
 
         playbook['state'] = 'merged'
@@ -292,7 +308,7 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         playbook['state'] = 'replaced'
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=replaced)
-        #
+
         playbook['state'] = 'overridden'
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=overridden)
@@ -513,3 +529,52 @@ class TestNxosL3InterfacesModule(TestNxosModule):
         playbook['state'] = 'deleted'
         set_module_args(playbook, ignore_provider_arg)
         self.execute_module(changed=True, commands=deleted)
+
+    def test_9(self):
+        # Platform specific checks
+        # 'ip redirects' has platform-specific behaviors
+        existing = dedent('''\
+          interface mgmt0
+            ip address 10.0.0.254/24
+          interface Ethernet1/3
+            ip address 10.13.13.13/24
+          interface Ethernet1/5
+            no ip redirects
+            ip address 10.15.15.15/24
+            ip address 10.25.25.25/24 secondary
+        ''')
+        self.get_resource_connection_facts.return_value = {self.SHOW_CMD: existing}
+        playbook = dict(config=[
+            dict(name='Ethernet1/3'),
+            dict(name='Ethernet1/5'),
+        ])
+        # Expected result commands for each 'state'
+        deleted = [
+            'interface Ethernet1/3', 'no ip address',
+            'interface Ethernet1/5', 'no ip address', 'ip redirects'
+        ]
+        replaced = [
+            'interface Ethernet1/3', 'no ip address',
+            'interface Ethernet1/5', 'no ip address', 'ip redirects'
+        ]
+        overridden = [
+            'interface Ethernet1/3', 'no ip address',
+            'interface Ethernet1/5', 'no ip address', 'ip redirects'
+        ]
+        platform = 'N3K'
+
+        playbook['state'] = 'merged'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=False, device=platform)
+
+        playbook['state'] = 'deleted'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=deleted, device=platform)
+
+        playbook['state'] = 'replaced'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=replaced, device=platform)
+
+        playbook['state'] = 'overridden'
+        set_module_args(playbook, ignore_provider_arg)
+        self.execute_module(changed=True, commands=overridden, device=platform)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible/pull/63014

##### SUMMARY

- Add new attributes to `nxos_l3_interfaces` module:
  - `dot1q` :  (`encapsulation dot1q ##`)
  - `redirects`:  (`ip redirects`)
  - `unreachables`: (`ip unreachables`)

- Fixes for broken states merged/deleted/replaced/overridden)
  - All of the states had idempotence issues
  - I made some major changes to the way ipv4/ipv6 address changes occur, particularly with `replaced`.
    - The biggest problem was that the original code does a wholesale `no ip address` when there's a change to just one address, say changing a `tag` on a single secondary would remove the all addresses on the interface. This creates an unacceptable level of churn on the device for such a minor change.
    - Another issue that comes with address changes is that the changes may have to occur in sequence; e.g. primaries must be created first but can't be removed while secondaries exist.
    - I added helper methods for ipv4 & ipv6 to make the minimum number of changes while ignoring addresses that are idempotent.
    - `replaced` was also ignoring interfaces in the `want` list when they had no attributes defined
    - `merged` was ignoring tag-only changes

Additional issues were found during testing. I added extensive test cases to the unit test to cover a variety of scenarios. Please refer to the test cases to help understand the code changes that were made. Thanks.

Ref #37375.

##### ISSUE TYPE
- Bugfix Pull Request
- with new attrs

##### COMPONENT NAME
`nxos_l3_interfaces`

##### ADDITIONAL INFORMATION
Tested on N3K,N6K,N7K,N9K,N9Kv (internal testbeds: `n9k-108,n6k-77,camden-nx-1,n7k-j,dt-n9k5-1,n3k-173,n3k-105,vergreen-nx-1,greensboro-nx-1,hamilton-nx-1`