### PR TITLE
Fix paramiko_ssh test for CentOS 8

### DIFF
--- a/test/integration/targets/setup_paramiko/install.yml
+++ b/test/integration/targets/setup_paramiko/install.yml
@@ -12,5 +12,6 @@
       include_tasks: "{{ item }}"
       with_first_found:
         - "install-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
+        - "install-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
         - "install-python-{{ ansible_python.version.major }}.yml"
         - "install-fail.yml"

--- a/test/integration/targets/setup_paramiko/uninstall.yml
+++ b/test/integration/targets/setup_paramiko/uninstall.yml
@@ -9,6 +9,7 @@
           include_tasks: "{{ item }}"
           with_first_found:
             - "uninstall-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
+            - "uninstall-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
             - "uninstall-{{ ansible_pkg_mgr }}-python-{{ ansible_python.version.major }}.yml"
             - "uninstall-{{ ansible_pkg_mgr }}.yml"
             - "uninstall-fail.yml"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes to make the integration test work in CentOS 8.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_paramiko/install.yml`