### PR TITLE
Fix iso_extract tests for CentOS 8

### DIFF
--- a/test/integration/targets/iso_extract/meta/main.yml
+++ b/test/integration/targets/iso_extract/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_epel

--- a/test/integration/targets/iso_extract/tasks/7zip.yml
+++ b/test/integration/targets/iso_extract/tasks/7zip.yml
@@ -21,72 +21,46 @@
   setup:
   become: yes
 
-- name: Add EPEL repository
-  yum_repository:
-    name: epel
-    description: EPEL yum repo
-    baseurl: https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+- name: Include distribution specific variables
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_facts.distribution }}.yml"
+        - "{{ ansible_facts.os_family }}.yml"
+        - default.yml
+      paths:
+        - "{{ role_path }}/vars"
+
+- name: "{{ ansible_facts.os_family | upper }} | Install 7zip package"
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: "{{ iso_extract_7zip_package }}"
     state: present
-  when: ansible_distribution in ['CentOS']
+  when: ansible_facts.distribution != 'MacOSX'
 
-- name: Install 7zip package if we are on Fedora
-  dnf:
-    name: p7zip-plugins
-    state: installed
-  become: yes
-  when: ansible_distribution in ['Fedora']
+- name: macOS
+  when: ansible_facts.distribution == 'MacOSX'
+  block:
+    - name: MACOS | Find brew binary
+      command: which brew
+      register: brew_which
+      when: ansible_distribution in ['MacOSX']
 
-- name: Install 7zip package if we are on CentOS
-  yum:
-    name: p7zip-plugins
-    state: installed
-    update_cache: yes
-  become: yes
-  when: ansible_distribution in ['CentOS']
+    - name: MACOS | Get owner of brew binary
+      stat:
+        path: "{{ brew_which.stdout }}"
+      register: brew_stat
+      when: ansible_distribution in ['MacOSX']
 
-- name: Install 7zip package if we are on OpenSUSE
-  zypper:
-    name: p7zip
-    state: installed
-    update_cache: yes
-  become: yes
-  when: ansible_distribution in ['openSUSE Leap']
-
-- name: Install 7zip package if we are on Ubuntu
-  apt:
-    name: p7zip-full
-    state: present
-    update_cache: yes
-  become: yes
-  when: ansible_distribution in ['Ubuntu']
-
-- name: Find brew binary
-  command: which brew
-  register: brew_which
-  when: ansible_distribution in ['MacOSX']
-
-- name: Get owner of brew binary
-  stat:
-    path: "{{ brew_which.stdout }}"
-  register: brew_stat
-  when: ansible_distribution in ['MacOSX']
-
-- name: Install 7zip package if we are on MacOSX
-  homebrew:
-    name: p7zip
-    state: present
-    update_homebrew: no
-  become: yes
-  become_user: "{{ brew_stat.stat.pw_name }}"
-  when: ansible_distribution in ['MacOSX']
-  # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
-  # proper solution can be found
-  environment:
-    HOMEBREW_NO_AUTO_UPDATE: True
-
-- name: Install 7zip package if we are on FreeBSD
-  pkgng:
-    name: p7zip
-    state: present
-  become: yes
-  when: ansible_distribution in ['FreeBSD']
+    - name: MACOS | Install 7zip package
+      homebrew:
+        name: p7zip
+        state: present
+        update_homebrew: no
+      become: yes
+      become_user: "{{ brew_stat.stat.pw_name }}"
+      # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
+      # proper solution can be found
+      environment:
+        HOMEBREW_NO_AUTO_UPDATE: True

--- a/test/integration/targets/iso_extract/tasks/main.yml
+++ b/test/integration/targets/iso_extract/tasks/main.yml
@@ -21,18 +21,18 @@
     output_dir_test: '{{ output_dir }}/test_iso_extract'
 
 - name: Install 7zip
-  include_tasks: 7zip.yml
+  import_tasks: 7zip.yml
 
 - name: Prepare environment
-  include_tasks: prepare.yml
+  import_tasks: prepare.yml
 
 - name: Test in normal mode
-  include_tasks: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: no
 
 - name: Prepare environment
-  include_tasks: prepare.yml
+  import_tasks: prepare.yml
 
 - name: Test in check-mode
   import_tasks: tests.yml

--- a/test/integration/targets/iso_extract/vars/FreeBSD.yml
+++ b/test/integration/targets/iso_extract/vars/FreeBSD.yml
@@ -1,0 +1,1 @@
+iso_extract_7zip_package: p7zip

--- a/test/integration/targets/iso_extract/vars/RedHat.yml
+++ b/test/integration/targets/iso_extract/vars/RedHat.yml
@@ -1,0 +1,1 @@
+iso_extract_7zip_package: p7zip-plugins

--- a/test/integration/targets/iso_extract/vars/Suse.yml
+++ b/test/integration/targets/iso_extract/vars/Suse.yml
@@ -1,0 +1,1 @@
+iso_extract_7zip_package: p7zip

--- a/test/integration/targets/iso_extract/vars/Ubuntu.yml
+++ b/test/integration/targets/iso_extract/vars/Ubuntu.yml
@@ -1,0 +1,1 @@
+iso_extract_7zip_package: p7zip-full

--- a/test/integration/targets/setup_epel/tasks/main.yml
+++ b/test/integration/targets/setup_epel/tasks/main.yml
@@ -1,3 +1,4 @@
 - name: Install EPEL
   yum:
     name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+  when: ansible_facts.distribution in ['RedHat', 'CentOS']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- use `setup_epel` role rather than task which contains correct URL now since it has changed for EL8
- add conditional to setup_epel to prevent attempted installation on non-RHEL distros
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/iso_extract/`