### PR TITLE
Fix lookup_passwordstore integration test for CentOS 8

### DIFF
--- a/test/integration/targets/lookup_passwordstore/tasks/main.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/main.yml
@@ -1,6 +1,7 @@
 - block:
-    - include: "package.yml"
-    - include: "tests.yml"
+    - include_tasks: package.yml
+    - include_tasks: tests.yml
   when:
-    - not (ansible_distribution == 'RedHat')  # requires EPEL
-    - not (ansible_distribution == 'CentOS' and ansible_distribution_version is version_compare('7', '<'))
+    # The pass package is no longer available in EPEL, so only test on Fedora, OpenSUSE, FreeBSD, macOS, and Ubuntu
+    # https://lists.zx2c4.com/pipermail/password-store/2019-July/003689.html
+    - ansible_facts.distribution in ['FreeBSD', 'MacOSX', 'openSUSE Leap', 'Ubuntu']

--- a/test/integration/targets/lookup_passwordstore/tasks/package.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/package.yml
@@ -1,29 +1,29 @@
-- name: "Install package"
-  apt:
-    name: pass
-    state: present
-  when: ansible_pkg_mgr == 'apt'
+- name: Include distribution specific variables
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_facts.distribution }}.yml"
+        - "{{ ansible_facts.os_family }}.yml"
+        - default.yml
+      paths:
+        - "{{ role_path }}/vars"
 
-- name: "Install package"
-  yum:
-    name: pass
+- name: Install package
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: "{{ passwordstore_packages }}"
     state: present
-  when: ansible_pkg_mgr == 'yum'
-
-- name: "Install package"
-  dnf:
-    name: pass
-    state: present
-  when: ansible_pkg_mgr == 'dnf'
+  when: ansible_facts.pkg_mgr in ['apt', 'dnf', 'yum', 'pkgng']
 
 - block:
   # OpenSUSE Leap>=15.0 don't include password-store in main repo
-  - name: add security:privacy repo
+  - name: SUSE | Add security:privacy repo
     template:
       src: security-privacy.repo.j2
       dest: /etc/zypp/repos.d/security:privacy.repo
 
-  - name: "Install package"
+  - name: SUSE | Install package
     zypper:
       name: password-store
       state: present
@@ -31,37 +31,28 @@
       disable_gpg_check: yes
   when: ansible_pkg_mgr == 'zypper'
 
-- name: "Install package"
-  pkgng:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - "gnupg"
-    - "password-store"
-  when: ansible_pkg_mgr == 'pkgng'
+- name: Install on macOS
+  when: ansible_facts.distribution == 'MacOSX'
+  block:
+    - name: MACOS | Find brew binary
+      command: which brew
+      register: brew_which
 
+    - name: MACOS | Get owner of brew binary
+      stat:
+        path: "{{ brew_which.stdout }}"
+      register: brew_stat
 
-- name: Find brew binary
-  command: which brew
-  register: brew_which
-  when: ansible_distribution in ['MacOSX']
-- name: Get owner of brew binary
-  stat:
-    path: "{{ brew_which.stdout }}"
-  register: brew_stat
-  when: ansible_distribution in ['MacOSX']
-- name: "Install package"
-  homebrew:
-    name: "{{ item }}"
-    state: present
-    update_homebrew: no
-  with_items:
-    - "gnupg2"
-    - "pass"
-  become: yes
-  become_user: "{{ brew_stat.stat.pw_name }}"
-  when: ansible_pkg_mgr == 'homebrew'
-  # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
-  # proper solution can be found
-  environment:
-    HOMEBREW_NO_AUTO_UPDATE: True
+    - name: MACOS | Install package
+      homebrew:
+        name:
+          - gnupg2
+          - pass
+        state: present
+        update_homebrew: no
+      become: yes
+      become_user: "{{ brew_stat.stat.pw_name }}"
+      # Newer versions of brew want to compile a package which takes a long time. Do not upgrade homebrew until a
+      # proper solution can be found
+      environment:
+        HOMEBREW_NO_AUTO_UPDATE: True

--- a/test/integration/targets/lookup_passwordstore/vars/Debian.yml
+++ b/test/integration/targets/lookup_passwordstore/vars/Debian.yml
@@ -1,0 +1,2 @@
+passwordstore_packages:
+  - pass

--- a/test/integration/targets/lookup_passwordstore/vars/Fedora.yml
+++ b/test/integration/targets/lookup_passwordstore/vars/Fedora.yml
@@ -1,0 +1,2 @@
+passwordstore_packages:
+  - pass

--- a/test/integration/targets/lookup_passwordstore/vars/FreeBSD.yml
+++ b/test/integration/targets/lookup_passwordstore/vars/FreeBSD.yml
@@ -1,0 +1,3 @@
+passwordstore_packages:
+  - gnupg
+  - password-store


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`pass` is no longer packaged in EPEL
https://lists.zx2c4.com/pipermail/password-store/2019-July/003689.html
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/lookup_passwordstore/`