### PR TITLE
module_defaults: add tree missing vmware modules

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -1429,3 +1429,9 @@ groupings:
   - vmware
   vsphere_file:
   - vmware
+  vmware_guest_register_operation:
+  - vmware
+  vmware_guest_serial_port:
+  - vmware
+  vmware_guest_tools_info:
+  - vmware


### PR DESCRIPTION
##### SUMMARY

The following modules a new, and were not yet in `module_defaults.yml`:

- vmware_guest_register_operation
- vmware_guest_serial_port
- vmware_guest_tools_info

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

module_defaults
<!--- Write the short name of the module, plugin, task or feature below -->