### PR TITLE
Fix the error when the subject is not provided 

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sns.py
+++ b/lib/ansible/modules/cloud/amazon/sns.py
@@ -191,9 +191,11 @@ def main():
 
     sns_kwargs = dict(
         Message=module.params['msg'],
-        Subject=module.params['subject'],
-        MessageStructure=module.params['message_structure'],
+        MessageStructure=module.params['message_structure']
     )
+  
+    if module.params['subject']:
+        sns_kwargs.update({"Subject": module.params['subject']})
 
     if module.params['message_attributes']:
         if module.params['message_structure'] != 'string':


### PR DESCRIPTION
Fix the error when the subject is not provided 
"msg": "Failed to publish message: Parameter validation failed:\nInvalid type for parameter Subject, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>"

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Update the cloud/amazon/sns.py

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module amazon

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1) Create a playbook with the step.
  sns:
    msg:  "{{event | to_json}}"
    topic: "topic"
    region: "{{region}}"
    validate_certs: no
2) Run the playbook , and a error occurs 

    "msg": "Failed to publish message: Parameter validation failed:\nInvalid type for parameter Subject, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>"
