### PR TITLE
Add new states for nxos resource modules

### DIFF
--- a/lib/ansible/module_utils/network/common/cfg/base.py
+++ b/lib/ansible/module_utils/network/common/cfg/base.py
@@ -13,6 +13,12 @@ from ansible.module_utils.network.common.network import get_resource_connection
 class ConfigBase(object):
     """ The base class for all resource modules
     """
+    ACTION_STATES = ['merged', 'replaced', 'overridden', 'deleted']
+
     def __init__(self, module):
         self._module = module
-        self._connection = get_resource_connection(module)
+        self.state = module.params['state']
+        self._connection = None
+
+        if self.state not in ['rendered', 'parsed']:
+            self._connection = get_resource_connection(module)

--- a/lib/ansible/module_utils/network/common/facts/facts.py
+++ b/lib/ansible/module_utils/network/common/facts/facts.py
@@ -20,7 +20,9 @@ class FactsBase(object):
         self._warnings = []
         self._gather_subset = module.params.get('gather_subset')
         self._gather_network_resources = module.params.get('gather_network_resources')
-        self._connection = get_resource_connection(module)
+        self._connection = None
+        if module.params['state'] not in ['rendered', 'parsed']:
+            self._connection = get_resource_connection(module)
 
         self.ansible_facts = {'ansible_network_resources': {}}
         self.ansible_facts['ansible_net_gather_network_resources'] = list()

--- a/lib/ansible/module_utils/network/nxos/argspec/bfd_interfaces/bfd_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/bfd_interfaces/bfd_interfaces.py
@@ -48,8 +48,9 @@ class Bfd_interfacesArgs(object):  # pylint: disable=R0903
             },
             'type': 'list'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/interfaces/interfaces.py
@@ -73,8 +73,9 @@ class InterfacesArgs(object):  # pylint: disable=R0903
             },
             'type': 'list'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/l2_interfaces/l2_interfaces.py
@@ -65,8 +65,9 @@ class L2_interfacesArgs(object):  # pylint: disable=R0903
             },
             'type': 'list'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/l3_interfaces/l3_interfaces.py
@@ -73,8 +73,9 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
             },
             'type': 'list'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/lacp/lacp.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/lacp/lacp.py
@@ -61,8 +61,9 @@ class LacpArgs(object):
             },
             'type': 'dict'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'deleted'],
+            'choices': ['merged', 'replaced', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/lacp_interfaces/lacp_interfaces.py
@@ -82,8 +82,9 @@ class Lacp_interfacesArgs(object):
             },
             'type': 'list'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+            'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/lag_interfaces/lag_interfaces.py
@@ -44,6 +44,7 @@ class Lag_interfacesArgs(object):
                                                         'type': 'list'},
                                             'name': {'required': True, 'type': 'str'}},
                                 'type': 'list'},
-                     'state': {'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+                     'running_config': {'type': 'str'},
+                     'state': {'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
                                'default': 'merged',
                                'type': 'str'}}

--- a/lib/ansible/module_utils/network/nxos/argspec/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/lldp_global/lldp_global.py
@@ -101,8 +101,9 @@ class Lldp_globalArgs(object):  # pylint: disable=R0903
             },
             'type': 'dict'
         },
+        'running_config': {'type': 'str'},
         'state': {
-            'choices': ['merged', 'replaced', 'deleted'],
+            'choices': ['merged', 'replaced', 'deleted', 'rendered', 'gathered', 'parsed'],
             'default': 'merged',
             'type': 'str'
         }

--- a/lib/ansible/module_utils/network/nxos/argspec/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/argspec/vlans/vlans.py
@@ -46,6 +46,7 @@ class VlansArgs(object):
                                             'state': {'choices': ['active', 'suspend'],
                                                       'type': 'str'}},
                                 'type': 'list'},
-                     'state': {'choices': ['merged', 'replaced', 'overridden', 'deleted'],
+                     'running_config': {'type': 'str'},
+                     'state': {'choices': ['merged', 'replaced', 'overridden', 'deleted', 'rendered', 'gathered', 'parsed'],
                                'default': 'merged',
                                'type': 'str'}}

--- a/lib/ansible/module_utils/network/nxos/config/bfd_interfaces/bfd_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/bfd_interfaces/bfd_interfaces.py
@@ -36,12 +36,12 @@ class Bfd_interfaces(ConfigBase):
     def __init__(self, module):
         super(Bfd_interfaces, self).__init__(module)
 
-    def get_bfd_interfaces_facts(self):
+    def get_bfd_interfaces_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :returns: A list of interface configs and a platform string
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources, data=data)
         bfd_interfaces_facts = facts['ansible_network_resources'].get('bfd_interfaces', [])
         platform = facts.get('ansible_net_platform', '')
         return bfd_interfaces_facts, platform
@@ -59,18 +59,35 @@ class Bfd_interfaces(ConfigBase):
         warnings = list()
         cmds = list()
 
-        existing_bfd_interfaces_facts, platform = self.get_bfd_interfaces_facts()
-        cmds.extend(self.set_config(existing_bfd_interfaces_facts, platform))
-        if cmds:
+        if self.state in self.ACTION_STATES:
+            existing_bfd_interfaces_facts, platform = self.get_bfd_interfaces_facts()
+        else:
+            existing_interfaces_facts, platform = [], ''
+
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            cmds.extend(self.set_config(existing_bfd_interfaces_facts, platform))
+
+        if cmds and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self.edit_config(cmds)
             result['changed'] = True
-        result['commands'] = cmds
 
-        changed_bfd_interfaces_facts, platform = self.get_bfd_interfaces_facts()
-        result['before'] = existing_bfd_interfaces_facts
-        if result['changed']:
-            result['after'] = changed_bfd_interfaces_facts
+        if self.state in self.ACTION_STATES:
+            result['commands'] = cmds
+
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_bfd_interfaces_facts, platform = self.get_bfd_interfaces_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = cmds
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_bfd_interfaces_facts(data=self._module.params['running_config'])
+        else:
+            changed_bfd_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = existing_bfd_interfaces_facts
+            if result['changed']:
+                result['after'] = changed_bfd_interfaces_facts
 
         result['warnings'] = warnings
         return result
@@ -112,20 +129,19 @@ class Bfd_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+        if self.state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(self.state))
 
         cmds = list()
-        if state == 'overridden':
+        if self.state == 'overridden':
             cmds.extend(self._state_overridden(want, have))
-        elif state == 'deleted':
+        elif self.state == 'deleted':
             cmds.extend(self._state_deleted(want, have))
         else:
             for w in want:
-                if state == 'merged':
+                if self.state == 'merged' or self.state == 'rendered':
                     cmds.extend(self._state_merged(flatten_dict(w), have))
-                elif state == 'replaced':
+                elif self.state == 'replaced':
                     cmds.extend(self._state_replaced(flatten_dict(w), have))
         return cmds
 

--- a/lib/ansible/module_utils/network/nxos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/interfaces/interfaces.py
@@ -44,13 +44,13 @@ class Interfaces(ConfigBase):
     def __init__(self, module):
         super(Interfaces, self).__init__(module)
 
-    def get_interfaces_facts(self):
+    def get_interfaces_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources, data=data)
         interfaces_facts = facts['ansible_network_resources'].get('interfaces')
         if not interfaces_facts:
             return []
@@ -66,19 +66,35 @@ class Interfaces(ConfigBase):
         commands = list()
         warnings = list()
 
-        existing_interfaces_facts = self.get_interfaces_facts()
-        commands.extend(self.set_config(existing_interfaces_facts))
-        if commands:
+        if self.state in self.ACTION_STATES:
+            existing_interfaces_facts = self.get_interfaces_facts()
+        else:
+            existing_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            commands.extend(self.set_config(existing_interfaces_facts))
+
+        if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self._connection.edit_config(commands)
             result['changed'] = True
-        result['commands'] = commands
 
-        changed_interfaces_facts = self.get_interfaces_facts()
+        if self.state in self.ACTION_STATES:
+            result['commands'] = commands
 
-        result['before'] = existing_interfaces_facts
-        if result['changed']:
-            result['after'] = changed_interfaces_facts
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_interfaces_facts = self.get_interfaces_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = commands
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_interfaces_facts(data=self._module.params['running_config'])
+        else:
+            changed_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = existing_interfaces_facts
+            if result['changed']:
+                result['after'] = changed_interfaces_facts
 
         result['warnings'] = warnings
         return result
@@ -110,20 +126,20 @@ class Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+        if self.state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(self.state))
 
         commands = list()
-        if state == 'overridden':
+        if self.state == 'overridden':
             commands.extend(self._state_overridden(want, have))
-        elif state == 'deleted':
+        elif self.state == 'deleted':
             commands.extend(self._state_deleted(want, have))
+
         else:
             for w in want:
-                if state == 'merged':
+                if self.state == 'merged' or self.state == 'rendered':
                     commands.extend(self._state_merged(w, have))
-                elif state == 'replaced':
+                elif self.state == 'replaced':
                     commands.extend(self._state_replaced(w, have))
         return commands
 

--- a/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l3_interfaces/l3_interfaces.py
@@ -41,13 +41,13 @@ class L3_interfaces(ConfigBase):
     def __init__(self, module):
         super(L3_interfaces, self).__init__(module)
 
-    def get_l3_interfaces_facts(self):
+    def get_l3_interfaces_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources, data=data)
         l3_interfaces_facts = facts['ansible_network_resources'].get('l3_interfaces')
 
         if not l3_interfaces_facts:
@@ -66,20 +66,35 @@ class L3_interfaces(ConfigBase):
         result = {'changed': False}
         commands = list()
         warnings = list()
+        if self.state in self.ACTION_STATES:
+            existing_l3_interfaces_facts = self.get_l3_interfaces_facts()
+        else:
+            existing_l3_interfaces_facts = []
 
-        existing_l3_interfaces_facts = self.get_l3_interfaces_facts()
-        commands.extend(self.set_config(existing_l3_interfaces_facts))
-        if commands:
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            commands.extend(self.set_config(existing_l3_interfaces_facts))
+
+        if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self.edit_config(commands)
             result['changed'] = True
-        result['commands'] = commands
 
-        changed_l3_interfaces_facts = self.get_l3_interfaces_facts()
+        if self.state in self.ACTION_STATES:
+            result['commands'] = commands
 
-        result['before'] = existing_l3_interfaces_facts
-        if result['changed']:
-            result['after'] = changed_l3_interfaces_facts
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_l3_interfaces_facts = self.get_l3_interfaces_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = commands
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_l3_interfaces_facts(data=self._module.params['running_config'])
+        else:
+            changed_l3_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = existing_l3_interfaces_facts
+            if result['changed']:
+                result['after'] = changed_l3_interfaces_facts
 
         result['warnings'] = warnings
         return result
@@ -113,20 +128,19 @@ class L3_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+        if self.state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(self.state))
 
         commands = list()
-        if state == 'overridden':
+        if self.state == 'overridden':
             commands.extend(self._state_overridden(want, have))
-        elif state == 'deleted':
+        elif self.state == 'deleted':
             commands.extend(self._state_deleted(want, have))
         else:
             for w in want:
-                if state == 'merged':
+                if self.state == 'merged' or self.state == 'rendered':
                     commands.extend(self._state_merged(w, have))
-                elif state == 'replaced':
+                elif self.state == 'replaced':
                     commands.extend(self._state_replaced(w, have))
         return commands
 

--- a/lib/ansible/module_utils/network/nxos/config/lacp_interfaces/lacp_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/lacp_interfaces/lacp_interfaces.py
@@ -43,13 +43,13 @@ class Lacp_interfaces(ConfigBase):
     def __init__(self, module):
         super(Lacp_interfaces, self).__init__(module)
 
-    def get_lacp_interfaces_facts(self):
+    def get_lacp_interfaces_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources, data=data)
         lacp_interfaces_facts = facts['ansible_network_resources'].get('lacp_interfaces')
         if not lacp_interfaces_facts:
             return []
@@ -65,19 +65,35 @@ class Lacp_interfaces(ConfigBase):
         commands = list()
         warnings = list()
 
-        existing_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
-        commands.extend(self.set_config(existing_lacp_interfaces_facts))
-        if commands:
+        if self.state in self.ACTION_STATES:
+            existing_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
+        else:
+            existing_lacp_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            commands.extend(self.set_config(existing_lacp_interfaces_facts))
+
+        if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self._connection.edit_config(commands)
             result['changed'] = True
-        result['commands'] = commands
 
-        changed_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
+        if self.state in self.ACTION_STATES:
+            result['commands'] = commands
 
-        result['before'] = existing_lacp_interfaces_facts
-        if result['changed']:
-            result['after'] = changed_lacp_interfaces_facts
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_lacp_interfaces_facts = self.get_lacp_interfaces_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = commands
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_lacp_interfaces_facts(data=self._module.params['running_config'])
+        else:
+            changed_lacp_interfaces_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = existing_lacp_interfaces_facts
+            if result['changed']:
+                result['after'] = changed_lacp_interfaces_facts
 
         result['warnings'] = warnings
         return result
@@ -111,20 +127,19 @@ class Lacp_interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
-            self._module.fail_json(msg='config is required for state {0}'.format(state))
+        if self.state in ('overridden', 'merged', 'replaced') and not want:
+            self._module.fail_json(msg='config is required for state {0}'.format(self.state))
         commands = list()
 
-        if state == 'overridden':
+        if self.state == 'overridden':
             commands.extend(self._state_overridden(want, have))
-        elif state == 'deleted':
+        elif self.state == 'deleted':
             commands.extend(self._state_deleted(want, have))
         else:
             for w in want:
-                if state == 'merged':
+                if self.state == 'merged' or self.state == 'rendered':
                     commands.extend(self._state_merged(flatten_dict(w), have))
-                elif state == 'replaced':
+                elif self.state == 'replaced':
                     commands.extend(self._state_replaced(flatten_dict(w), have))
         return commands
 

--- a/lib/ansible/module_utils/network/nxos/config/lldp_global/lldp_global.py
+++ b/lib/ansible/module_utils/network/nxos/config/lldp_global/lldp_global.py
@@ -34,14 +34,14 @@ class Lldp_global(ConfigBase):
     def __init__(self, module):
         super(Lldp_global, self).__init__(module)
 
-    def get_lldp_global_facts(self):
+    def get_lldp_global_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
         facts, _warnings = Facts(self._module).get_facts(
-            self.gather_subset, self.gather_network_resources)
+            self.gather_subset, self.gather_network_resources, data=data)
         lldp_global_facts = facts['ansible_network_resources'].get(
             'lldp_global')
         if not lldp_global_facts:
@@ -58,19 +58,36 @@ class Lldp_global(ConfigBase):
         commands = list()
         warnings = list()
 
-        existing_lldp_global_facts = self.get_lldp_global_facts()
-        commands.extend(self.set_config(existing_lldp_global_facts))
-        if commands:
+        if self.state in self.ACTION_STATES:
+            existing_lldp_global_facts = self.get_lldp_global_facts()
+        else:
+            existing_lldp_global_facts = []
+
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            commands.extend(self.set_config(existing_lldp_global_facts))
+
+        if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self._connection.edit_config(commands)
             result['changed'] = True
-        result['commands'] = commands
 
-        changed_lldp_global_facts = self.get_lldp_global_facts()
+        if self.state in self.ACTION_STATES:
+            result['commands'] = commands
 
-        result['before'] = dict(existing_lldp_global_facts)
-        if result['changed']:
-            result['after'] = dict(changed_lldp_global_facts)
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_lldp_global_facts = self.get_lldp_global_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = commands
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_lldp_global_facts(data=self._module.params['running_config'])
+        else:
+            changed_lldp_global_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = dict(existing_lldp_global_facts)
+            if result['changed']:
+                result['after'] = dict(changed_lldp_global_facts)
+
         result['warnings'] = warnings
         return result
 
@@ -96,12 +113,11 @@ class Lldp_global(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state == 'deleted':
+        if self.state == 'deleted':
             commands = self._state_deleted(have)
-        elif state == 'merged':
+        elif self.state == 'merged' or self.state == 'rendered':
             commands = self._state_merged(want, have)
-        elif state == 'replaced':
+        elif self.state == 'replaced':
             commands = self._state_replaced(want, have)
         return commands
 

--- a/lib/ansible/module_utils/network/nxos/config/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/config/vlans/vlans.py
@@ -39,13 +39,13 @@ class Vlans(ConfigBase):
     def __init__(self, module):
         super(Vlans, self).__init__(module)
 
-    def get_vlans_facts(self):
+    def get_vlans_facts(self, data=None):
         """ Get the 'facts' (the current configuration)
 
         :rtype: A dictionary
         :returns: The current configuration as a dictionary
         """
-        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources)
+        facts, _warnings = Facts(self._module).get_facts(self.gather_subset, self.gather_network_resources, data=data)
         vlans_facts = facts['ansible_network_resources'].get('vlans')
         if not vlans_facts:
             return []
@@ -61,19 +61,35 @@ class Vlans(ConfigBase):
         commands = list()
         warnings = list()
 
-        existing_vlans_facts = self.get_vlans_facts()
-        commands.extend(self.set_config(existing_vlans_facts))
-        if commands:
+        if self.state in self.ACTION_STATES:
+            existing_vlans_facts = self.get_vlans_facts()
+        else:
+            existing_vlans_facts = []
+
+        if self.state in self.ACTION_STATES or self.state == 'rendered':
+            commands.extend(self.set_config(existing_vlans_facts))
+
+        if commands and self.state in self.ACTION_STATES:
             if not self._module.check_mode:
                 self._connection.edit_config(commands)
             result['changed'] = True
-        result['commands'] = commands
 
-        changed_vlans_facts = self.get_vlans_facts()
+        if self.state in self.ACTION_STATES:
+            result['commands'] = commands
 
-        result['before'] = existing_vlans_facts
-        if result['changed']:
-            result['after'] = changed_vlans_facts
+        if self.state in self.ACTION_STATES or self.state == 'gathered':
+            changed_vlans_facts = self.get_vlans_facts()
+        elif self.state == 'rendered':
+            result['rendered'] = commands
+        elif self.state == 'parsed':
+            result['parsed'] = self.get_vlans_facts(data=self._module.params['running_config'])
+        else:
+            changed_vlans_facts = []
+
+        if self.state in self.ACTION_STATES:
+            result['before'] = existing_vlans_facts
+            if result['changed']:
+                result['after'] = changed_vlans_facts
 
         result['warnings'] = warnings
         return result
@@ -104,20 +120,19 @@ class Vlans(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        state = self._module.params['state']
-        if state in ('overridden', 'merged', 'replaced') and not want:
+        if self.state in ('overridden', 'merged', 'replaced') and not want:
             self._module.fail_json(msg='config is required for state {0}'.format(state))
 
         commands = list()
-        if state == 'overridden':
+        if self.state == 'overridden':
             commands.extend(self._state_overridden(want, have))
-        elif state == 'deleted':
+        elif self.state == 'deleted':
             commands.extend(self._state_deleted(want, have))
         else:
             for w in want:
-                if state == 'merged':
+                if self.state == 'merged' or self.state == 'rendered':
                     commands.extend(self._state_merged(w, have))
-                elif state == 'replaced':
+                elif self.state == 'replaced':
                     commands.extend(self._state_replaced(w, have))
         return commands
 

--- a/lib/ansible/modules/network/nxos/nxos_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_interfaces.py
@@ -94,16 +94,43 @@ options:
           - Associate SVI with anycast gateway under VLAN configuration mode.
             Applicable for SVI interfaces only.
         type: bool
-
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | section ^interface)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | section ^interface) executed
+        on device. For state I(parsed) active connection to remote host is not required.
     type: str
     choices:
       - merged
       - replaced
       - overridden
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -256,6 +283,27 @@ commands:
   returned: always
   type: list
   sample: ['interface Ethernet1/1', 'mtu 1800']
+rendered:
+  description: The set of CLI commands generated from the value in C(config) option
+  returned: When C(state) is I(rendered)
+  type: list
+  sample: ['interface Ethernet1/1', 'mtu 1800']
+gathered:
+  description: The configuration as structured data transformed for the running configuration
+               fetched from remote host
+  returned: When C(state) is I(gathered)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
+parsed:
+  description: The configuration as structured data transformed for the value of
+               C(running_config) option
+  returned: When C(state) is I(parsed)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
 """
 
 
@@ -270,8 +318,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=InterfacesArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = Interfaces(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l2_interfaces.py
@@ -80,16 +80,43 @@ options:
               - List of allowed VLANs in a given trunk port. These are the only
                 VLANs that will be configured on the trunk.
             type: str
-
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | section ^interface)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | section ^interface) executed
+        on device. For state I(parsed) active connection to remote host is not required
     type: str
     choices:
       - merged
       - replaced
       - overridden
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -250,6 +277,27 @@ commands:
   returned: always
   type: list
   sample: ['command 1', 'command 2', 'command 3']
+rendered:
+  description: The set of CLI commands generated from the value in C(config) option
+  returned: When C(state) is I(rendered)
+  type: list
+  sample: ['interface Ethernet1/1', 'mtu 1800']
+gathered:
+  description: The configuration as structured data transformed for the running configuration
+               fetched from remote host
+  returned: When C(state) is I(gathered)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
+parsed:
+  description: The configuration as structured data transformed for the value of
+               C(running_config) option
+  returned: When C(state) is I(parsed)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
 """
 
 
@@ -264,8 +312,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=L2_interfacesArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = L2_interfaces(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_l3_interfaces.py
@@ -86,16 +86,43 @@ options:
             description:
               - URIB route tag value for local/direct routes.
             type: int
-
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | section ^interface)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | section ^interface) executed
+        on device. For state I(parsed) active connection to remote host is not required.
     type: str
     choices:
       - merged
       - replaced
       - overridden
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -224,6 +251,27 @@ commands:
   returned: always
   type: list
   sample: ['interface Ethernet1/2', 'ip address 192.168.0.1/2']
+rendered:
+  description: The set of CLI commands generated from the value in C(config) option
+  returned: When C(state) is I(rendered)
+  type: list
+  sample: ['interface Ethernet1/1', 'mtu 1800']
+gathered:
+  description: The configuration as structured data transformed for the running configuration
+               fetched from remote host
+  returned: When C(state) is I(gathered)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
+parsed:
+  description: The configuration as structured data transformed for the value of
+               C(running_config) option
+  returned: When C(state) is I(parsed)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
 """
 
 
@@ -238,8 +286,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=L3_interfacesArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = L3_interfaces(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_lacp.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp.py
@@ -72,14 +72,42 @@ options:
                   - The role for the Switch.
                 type: str
                 choices: ['primary', 'secondary']
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output recrviced from device by executing command
+        C(show running-config | include lacp)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | include lacp) executed
+        on device. For state I(parsed) active connection to remote host is not required
     type: str
     choices:
       - merged
       - replaced
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -163,6 +191,27 @@ commands:
   returned: always
   type: list
   sample: ['lacp system-priority 15', 'lacp system-mac 00c1.4c00.bd15 role primary']
+rendered:
+  description: The set of CLI commands generated from the value in C(config) option
+  returned: When C(state) is I(rendered)
+  type: list
+  sample: ['interface Ethernet1/1', 'mtu 1800']
+gathered:
+  description: The configuration as structured data transformed for the running configuration
+               fetched from remote host
+  returned: When C(state) is I(gathered)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
+parsed:
+  description: The configuration as structured data transformed for the value of
+               C(running_config) option
+  returned: When C(state) is I(parsed)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
 """
 
 
@@ -177,8 +226,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=LacpArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = Lacp(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lacp_interfaces.py
@@ -107,15 +107,43 @@ options:
             description:
               - Enable lacp convergence for vPC port channels.
             type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | section ^interface)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | section ^interface) executed
+        on device. For state I(parsed) active connection to remote host is not required.
     type: str
     choices:
       - merged
       - replaced
       - overridden
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -233,6 +261,27 @@ commands:
   returned: always
   type: list
   sample: ['interface port-channel10', 'lacp min-links 5', 'lacp mode delay']
+rendered:
+  description: The set of CLI commands generated from the value in C(config) option
+  returned: When C(state) is I(rendered)
+  type: list
+  sample: ['interface Ethernet1/1', 'mtu 1800']
+gathered:
+  description: The configuration as structured data transformed for the running configuration
+               fetched from remote host
+  returned: When C(state) is I(gathered)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
+parsed:
+  description: The configuration as structured data transformed for the value of
+               C(running_config) option
+  returned: When C(state) is I(parsed)
+  type: list
+  sample: >
+    The configuration returned will always be in the same format
+    of the parameters above.
 """
 
 
@@ -247,8 +296,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=Lacp_interfacesArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = Lacp_interfaces(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
+++ b/lib/ansible/modules/network/nxos/nxos_lag_interfaces.py
@@ -73,15 +73,43 @@ options:
               - When true it forces link aggregation group members to match what
                 is declared in the members param. This can be used to remove members.
             type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | include channel-group)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion.
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | include channel-group) executed
+        on device. For state I(parsed) active connection to remote host is not required.
     type: str
     choices:
       - merged
       - replaced
       - overridden
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 notes:
   - Tested against NXOS 7.3.(0)D1(1) on VIRL.
@@ -220,8 +248,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=Lag_interfacesArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = Lag_interfaces(module).execute_module()
     module.exit_json(**result)

--- a/lib/ansible/modules/network/nxos/nxos_lldp_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_lldp_global.py
@@ -120,14 +120,42 @@ options:
                 description:
                   - Used to specify the system name TLV
                 type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source. There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison. This value of this option should be the
+        output received from device by executing command
+        C(show running-config | include lldp)
+    version_added: "2.10"
   state:
     description:
-      - The state of the configuration after module completion
+      - The state of the configuration after module completion. 
+      - The states I(rendered), I(gathered) and I(parsed) does not perform any
+        change on the device. 
+      - The state I(rendered) will transform the configuration in C(config) option to platform
+        specific CLI commands which will be returned in the I(rendered) key within the result.
+        For state I(rendered) active connection to remote host is not required.
+      - The state I(gathered) will fetch the running configuration from device and transform
+        it into structured data in the format as per the resource module argspec and the
+        value is returned in the I(gathered) key within the result.
+      - The state I(parsed) reads the configuration from C(running_config) option and transforms
+        it into JSON format as per the resource module parameters and the value is returned in
+        the I(parsed) key within the result. The value of C(running_config) option should be the
+        same format as the output of command I(show running-config | include lldp) executed
+        on device. For state I(parsed) active connection to remote host is not required.
     type: str
     choices:
       - merged
       - replaced
       - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
 """
 EXAMPLES = """
@@ -239,8 +267,13 @@ def main():
 
     :returns: the result form module invocation
     """
+    required_if = [['state', 'parsed', ['running_config']]]
+    mutually_exclusive = [('config', 'running_config')]
+
     module = AnsibleModule(argument_spec=Lldp_globalArgs.argument_spec,
-                           supports_check_mode=True)
+                           supports_check_mode=True,
+                           required_if=required_if,
+                           mutually_exclusive=mutually_exclusive)
 
     result = Lldp_global(module).execute_module()
     module.exit_json(**result)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Add renedered, gathered, parsed states
   for nxos resource modules
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_bfd_interfaces
nxos_interfaces
nxos_l2_interfaces
nxos_l3_interfaces
nxos_lacp
nxos_lacp_interfaces
nxos_lag_interfaces
nxos_lldp_global
nxos_telemetry
nxos_vlans

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
