### PR TITLE
Document common return value `diff`

### DIFF
--- a/docs/docsite/rst/reference_appendices/common_return_values.rst
+++ b/docs/docsite/rst/reference_appendices/common_return_values.rst
@@ -24,6 +24,11 @@ changed
 ```````
 A boolean indicating if the task had to make changes.
 
+diff
+````
+
+Information on differences between the previous and current state. Often a dictionary with entries ``before`` and ``after``, which will then be formatted by the callback plugin to a diff view.
+
 failed
 ``````
 A boolean that indicates if the task was failed or not.


### PR DESCRIPTION
##### SUMMARY
It is not listed in https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/reference_appendices/common_return_values.rst
