### PR TITLE
VMware: Unable to get tags for VM in vmware_vm_info

### DIFF
--- a/changelogs/fragments/vmware_vm_info_fix_tag.yml
+++ b/changelogs/fragments/vmware_vm_info_fix_tag.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix added to get all tags for VM using vmware_vm_info module (https://github.com/ansible/ansible/issues/64815).

--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -177,7 +177,7 @@ class VmwareRestClient(object):
             return tags
         dynamic_managed_object = DynamicID(type=type, id=mid)
 
-        temp_tags_model = self.get_tags_for_object(dynamic_managed_object)
+        temp_tags_model = self.get_tags_for_object(dobj=dynamic_managed_object)
 
         category_service = self.api_client.tagging.Category
 


### PR DESCRIPTION
##### SUMMARY

Fixes: #64815

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/vmware_vm_info_fix_tag.yml
lib/ansible/module_utils/vmware_rest_client.py
