### PR TITLE
Fix argument name in example of documentation for module known_hosts

### DIFF
--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
 
 - name: Another way to call known_hosts
   known_hosts:
-    hostname: host1.example.com   # or 10.9.8.77
+    name: host1.example.com   # or 10.9.8.77
     key: host1.example.com,10.9.8.77 ssh-rsa ASDeararAIUHI324324  # some key gibberish
     path: /etc/ssh/ssh_known_hosts
     state: present


### PR DESCRIPTION
##### SUMMARY
The second example of the documentation uses an argument "hostname" that does not exist in this module.
It should be replaced by argument "name"


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
known_hosts