### PR TITLE
Always set the discovered interpreter on the delegated host

### DIFF
--- a/changelogs/fragments/64906-always-delegate-fact-prefixes.yml
+++ b/changelogs/fragments/64906-always-delegate-fact-prefixes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- Fact Delegation - Add ability to indicate which facts must always be delegated. Primarily
+  for ``discovered_interpreter_python`` right now, but extensible later.
+  (https://github.com/ansible/ansible/issues/61002)


### PR DESCRIPTION
##### SUMMARY
Always set the discovered interpreter on the delegated host. Fixes #63180
Fixes #61002


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/strategy/__init__.py
```

##### ADDITIONAL INFORMATION
Needs:

1. tests, if this is actually possible
1. changelog