### PR TITLE
nxos_gir: fix for timeout issue

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -34,6 +34,7 @@ import re
 import sys
 from copy import deepcopy
 
+from ansible import constants as C
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network.common.utils import to_list, ComplexList
@@ -620,6 +621,19 @@ class HttpApi:
 
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = list()
+
+        if self._module._name == 'nxos_gir':
+            connection = self._connection
+            if connection.transport == 'local':
+                persistent_command_timeout = C.PERSISTENT_COMMAND_TIMEOUT
+            else:
+                persistent_command_timeout = connection.get_option('persistent_command_timeout')
+
+            if persistent_command_timeout < 200:
+                command_timeout = 200
+                self._connection.set_option('persistent_command_timeout', command_timeout)
+                msg = "PERSISTENT_COMMAND_TIMEOUT needs to be 200 or more seconds for this module."
+                self._module.warn(msg)
 
         self.check_edit_config_capability(candidate, commit, replace, comment)
 

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -264,8 +264,13 @@ class Connection(NetworkConnectionBase):
         '''
         Sends the command to the device over api
         '''
+
+        t1 = self.get_option('timeout')
+        t2 = self.get_option('persistent_command_timeout')
+
         url_kwargs = dict(
-            timeout=self.get_option('timeout'), validate_certs=self.get_option('validate_certs'),
+            timeout=t1 if t1 > t2 else t2,
+            validate_certs=self.get_option('validate_certs'),
             use_proxy=self.get_option("use_proxy"),
             headers={},
         )

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -265,11 +265,8 @@ class Connection(NetworkConnectionBase):
         Sends the command to the device over api
         '''
 
-        t1 = self.get_option('timeout')
-        t2 = self.get_option('persistent_command_timeout')
-
         url_kwargs = dict(
-            timeout=t1 if t1 > t2 else t2,
+            timeout=self.get_option('persistent_command_timeout'),
             validate_certs=self.get_option('validate_certs'),
             use_proxy=self.get_option("use_proxy"),
             headers={},

--- a/test/integration/targets/nxos_gir/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_gir/tests/common/sanity.yaml
@@ -1,22 +1,18 @@
 ---
 - debug: msg="START connection={{ ansible_connection }} nxos_gir sanity test"
-- debug: msg="Using provider={{ connection.transport }}"
-  when: ansible_connection == "local"
 
 - set_fact: gir_run="true"
 - set_fact: gir_run="false"
   when: platform is search("N35")
-#- name: "Setup"
-#  nxos_gir: &setup
-#    system_mode_maintenance: false
-#    provider: "{{ connection }}"
-#  ignore_errors: yes
+- name: "Setup"
+  nxos_gir: &setup
+    system_mode_maintenance: false
+  ignore_errors: yes
 
 - block:
   - name: "Put system in maintenance mode with reload reset reason"
     nxos_gir: &reset_reason
       system_mode_maintenance_on_reload_reset_reason: manual_reload
-      provider: "{{ connection }}"
     register: result
 
   - assert: &true
@@ -35,7 +31,6 @@
     nxos_gir: &remove_reason
       system_mode_maintenance_on_reload_reset_reason: manual_reload
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -49,7 +44,6 @@
   - name: "Put system in maintenance mode with timeout"
     nxos_gir: &mtime
       system_mode_maintenance_timeout: 30
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -64,7 +58,6 @@
     nxos_gir: &remove_timeout
       system_mode_maintenance_timeout: 30
       state: absent
-      provider: "{{ connection }}"
     register: result
 
   - assert: *true
@@ -75,13 +68,12 @@
 
   - assert: *false
 
-#  - name: "Put system in maintenance mode"
-#    nxos_gir: &configure_system_mode_maintenance
-#      system_mode_maintenance: true
-#      provider: "{{ connection }}"
-#    register: result
-#
-#  - assert: *true
+  - name: "Put system in maintenance mode"
+    nxos_gir: &configure_system_mode_maintenance
+      system_mode_maintenance: true
+    register: result
+
+  - assert: *true
 
   when: gir_run
 
@@ -94,26 +86,23 @@
   - name: "Remove snapshots"
     nxos_snapshot:
       action: delete_all
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: "Remove other config1"
     nxos_config:
       lines: no configure maintenance profile normal-mode
       match: none
-      provider: "{{ connection }}"
     ignore_errors: yes
 
   - name: "Remove other config2"
     nxos_config:
       lines: no configure maintenance profile maintenance-mode
       match: none
-      provider: "{{ connection }}"
     ignore_errors: yes
 
-#  - name: "Put system back in normal mode"
-#    nxos_gir: *setup
-#    register: result
-#    ignore_errors: yes
+  - name: "Put system back in normal mode"
+    nxos_gir: *setup
+    register: result
+    ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_gir sanity test"


### PR DESCRIPTION
##### SUMMARY
nxos_gir "system mode maintenance" command needs more than 120 seconds to succeed.
One needs to set persistent_timeout env variables to avoid timeout errors for the above command. However, with the timeouts set in env, only localNxapi was working fine. Ansible HttpApi still hit timeout and bailed out.

HttpApi was not making use of persistent_timeout set in env, it was only considering the module parameter "timeout" to set the timeout on the connection. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_gir

