### PR TITLE
[stable-2.9] Fix group integration test for CentOS 8 (#64858)

### DIFF
--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -193,6 +193,15 @@
     that:
     - not delete_group_again is changed
 
+- name: Ensure lgroupadd is present
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: libuser
+    state: present
+  when: ansible_facts.system in ['Linux']
+  tags:
+    - user_test_local_mode
+
 # https://github.com/ansible/ansible/issues/56481
 - block:
   - name: Test duplicate GID with local=yes
@@ -252,7 +261,7 @@
         - not create_local_group_gid_again is changed
         - create_local_group_gid_again.gid | int == 1337 | int
   always:
-    - name: Cleanup create local group with a gid 
+    - name: Cleanup create local group with a gid
       group:
         name: group1_local_test
         state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64858 for Ansible 2.9
(cherry picked from commit 5e3b6c84c7)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/group/`