### PR TITLE
[stable-2.9] Fix setup_rpm integration tests for CentOS 8 (#64862)

### DIFF
--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -6,52 +6,30 @@
       - ansible_distribution in ['RedHat']
       - ansible_distribution_major_version is version('7', '==')
 
-  - name: Install rpmfluff and deps
-    package:
-      name: "{{ item }}"
-    with_items:
-      - python{{ ansible_python_version.split(".")[0] }}-rpmfluff
-      - createrepo
-    when:
-      - ansible_distribution in ['Fedora']
+  - name: Include distribution specific variables
+    include_vars: "{{ lookup('first_found', params) }}"
+    vars:
+      params:
+        files:
+          - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_version }}.yml"
+          - "{{ ansible_facts.os_family }}-{{ ansible_facts.distribution_major_version }}.yml"
+          - "{{ ansible_facts.distribution }}.yml"
+          - "{{ ansible_facts.os_family }}.yml"
+          - default.yml
+        paths:
+          - "{{ role_path }}/vars"
 
   - name: Install rpmfluff and deps
-    package:
-      name: "{{ item }}"
-    with_items:
-      - python-rpmfluff
-      - createrepo_c
-      - createrepo  # used by el6 version of rpmfluff
-    when:
-      - ansible_distribution not in ['Fedora']
-      - ansible_python["version"]["major"] == 2
-
-  - name: Install rpmfluff and deps
-    package:
-      name: "{{ item }}"
-    with_items:
-      - python3-rpmfluff
-      - createrepo_c
-      - createrepo  # used by el6 version of rpmfluff
-    when:
-      - ansible_distribution not in ['Fedora']
-      - ansible_python["version"]["major"] == 3
-      - not (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+    action: "{{ ansible_facts.pkg_mgr }}"
+    args:
+      name: "{{ rpm_repo_packages }}"
 
   - name: Install rpmfluff from pip on RHEL 8 and later
     pip:
       name: rpmfluff
     when:
-      - ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>=')
-
-  - name: Install packages needed on RHEL 8 and later
-    dnf:
-      name: "{{ item }}"
-    with_items:
-      - createrepo_c
-      - rpm-build
-    when:
-      - ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>=')
+      - ansible_facts.distribution in ['RedHat', 'CentOS']
+      - ansible_facts.distribution_major_version is version('8', '>=')
 
   - name: Copy script for creating a repo
     copy:

--- a/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
@@ -1,0 +1,3 @@
+rpm_repo_packages:
+  - "{{ 'python' ~ rpm_repo_python_major_version ~ '-rpmfluff' }}"
+  - createrepo

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
@@ -1,0 +1,4 @@
+rpm_repo_packages:
+  - python-rpmfluff
+  - createrepo_c
+  - createrepo

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
@@ -1,0 +1,4 @@
+rpm_repo_packages:
+  - python-rpmfluff
+  - createrepo_c
+  - createrepo

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-8.yml
@@ -1,0 +1,4 @@
+rpm_repo_packages:
+  - rpm-build
+  - createrepo_c
+  - createrepo

--- a/test/integration/targets/setup_rpm_repo/vars/main.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/main.yml
@@ -1,0 +1,1 @@
+rpm_repo_python_major_version: "{{ ansible_facts.python_version.split('.')[0] }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64862 for Ansible 2.9
(cherry picked from commit 5d2a3ecbc4)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_rpm_repo/`