### PR TITLE
[stable-2.9] Fix setup_mysql_db for CentOS 8 (#64864)

### DIFF
--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -35,10 +35,11 @@
         - '{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}{{ python_suffix }}.yml'
         - '{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml'
         - '{{ ansible_facts.os_family }}-{{ ansible_facts.distribution_major_version }}{{ python_suffix }}.yml'
+        - '{{ ansible_facts.os_family }}-{{ ansible_facts.distribution_major_version }}.yml'
         - '{{ ansible_facts.distribution }}{{ python_suffix }}.yml'
         - '{{ ansible_facts.os_family }}{{ python_suffix }}.yml'
         - 'default{{ python_suffix }}.yml'
-      paths: vars
+      paths: "{{ role_path }}/vars"
 
 - name: install mysqldb_test rpm dependencies
   yum:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64864 for Ansible 2.9
(cherry picked from commit 477fa63f68)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_mysql_db/`