### PR TITLE
[stable-2.9] Fix firewalld integration tests for CentOS 8 (#64873)

### DIFF
--- a/test/integration/targets/firewalld/tasks/main.yml
+++ b/test/integration/targets/firewalld/tasks/main.yml
@@ -50,7 +50,7 @@
       when: check_output.rc == 0
 
   when:
-  - not (ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7)
-  - not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")
+  - ansible_facts.os_family == "RedHat" and ansible_facts.distribution_major_version is version('7', '>=')
+  - not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('14.04', '=='))
   # Firewalld package on OpenSUSE (15+) require Python 3, so we skip on OpenSUSE running py2 on these newer distros
   - not (ansible_os_family == "Suse" and ansible_distribution_major_version|int != 42 and ansible_python.version.major != 3)

--- a/test/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/test/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -22,10 +22,14 @@
     state: directory
 
 # firewalld service operation test cases
-- import_tasks: service_test_cases.yml
+- include_tasks: service_test_cases.yml
+  # Skipping on CentOS 8 due to https://github.com/ansible/ansible/issues/64750
+  when: not (ansible_facts.distribution == "CentOS" and ansible_distribution_major_version is version('8', '=='))
 
 # firewalld port operation test cases
-- import_tasks: port_test_cases.yml
+- include_tasks: port_test_cases.yml
+  # Skipping on CentOS 8 due to https://github.com/ansible/ansible/issues/64750
+  when: not (ansible_facts.distribution == "CentOS" and ansible_distribution_major_version is version('8', '=='))
 
 # firewalld source operation test cases
 - import_tasks: source_test_cases.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64873 for Ansible 2.9
(cherry picked from commit 79a38c8a3a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/firewalld`