### PR TITLE
AnsibleAWSModule related cleanup (batch 1)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_acm.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm.py
@@ -224,12 +224,9 @@ arns:
 
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils.aws.acm import ACMServiceManager
-from ansible.module_utils._text import to_bytes, to_text
-from ssl import PEM_cert_to_DER_cert
+from ansible.module_utils._text import to_text
 import base64
-import traceback
 import re  # regex library
 
 
@@ -262,8 +259,7 @@ def PEM_body_to_DER(module, pem):
     try:
         der = base64.b64decode(to_text(pem))
     except (ValueError, TypeError) as e:
-        module.fail_json(msg="Unable to decode certificate chain",
-                         exception=traceback.format_exc())
+        module.fail_json_aws(e, msg="Unable to decode certificate chain")
     return der
 
 
@@ -323,9 +319,7 @@ def main():
     else:
         tags = None
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='acm',
-                        region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client('acm')
 
     # fetch the list of certificates currently in ACM
     certificates = acm.get_certificates(client=client,

--- a/lib/ansible/modules/cloud/amazon/aws_acm_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_info.py
@@ -265,7 +265,6 @@ certificates:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils.aws.acm import ACMServiceManager
 
 
@@ -282,9 +281,7 @@ def main():
     if module._name == 'aws_acm_facts':
         module.deprecate("The 'aws_acm_facts' module has been renamed to 'aws_acm_info'", version='2.13')
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='acm',
-                        region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client('acm')
 
     certificates = acm_info.get_certificates(client, module,
                                              domain_name=module.params['domain_name'],

--- a/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
@@ -290,7 +290,7 @@ creation_time:
 '''  # NOQA
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import _camel_to_snake, camel_dict_to_snake_dict, ec2_argument_spec
+from ansible.module_utils.ec2 import _camel_to_snake, camel_dict_to_snake_dict
 
 try:
     import botocore
@@ -480,8 +480,7 @@ def create_scaling_policy(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
+    argument_spec = dict(
         state=dict(type='str', required=True, choices=['present', 'absent']),
         policy_name=dict(type='str', required=True),
         service_namespace=dict(type='str', required=True, choices=['appstream', 'dynamodb', 'ec2', 'ecs', 'elasticmapreduce']),

--- a/lib/ansible/modules/cloud/amazon/aws_config_aggregation_authorization.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_aggregation_authorization.py
@@ -62,8 +62,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import AWSRetry
 
 
 def resource_exists(client, module, params):

--- a/lib/ansible/modules/cloud/amazon/aws_config_delivery_channel.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_delivery_channel.py
@@ -76,8 +76,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
 
 
 # this waits for an IAM role to become fully available, at the cost of

--- a/lib/ansible/modules/cloud/amazon/aws_config_recorder.py
+++ b/lib/ansible/modules/cloud/amazon/aws_config_recorder.py
@@ -91,8 +91,7 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, AWSRetry
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
 
 
 def resource_exists(client, module, params):

--- a/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
+++ b/lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
@@ -238,14 +238,12 @@ EXAMPLES = '''
 import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.direct_connect import DirectConnectError, delete_virtual_interface
-from ansible.module_utils.ec2 import (AWSRetry, HAS_BOTO3, boto3_conn,
-                                      ec2_argument_spec, get_aws_connection_info,
-                                      camel_dict_to_snake_dict)
+from ansible.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
-    # handled by HAS_BOTO3
+    # handled by AnsibleAWSModule
     pass
 
 
@@ -459,8 +457,7 @@ def ensure_state(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(required=True, choices=['present', 'absent']),
         id_to_associate=dict(required=True, aliases=['link_aggregation_group_id', 'connection_id']),
         public=dict(type='bool'),
@@ -474,7 +471,7 @@ def main():
         cidr=dict(type='list'),
         virtual_gateway_id=dict(),
         virtual_interface_id=dict()
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_one_of=[['virtual_interface_id', 'name']],
@@ -484,8 +481,7 @@ def main():
                                            ['public', True, ['customer_address']],
                                            ['public', True, ['cidr']]])
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    connection = boto3_conn(module, conn_type='client', resource='directconnect', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    connection = module.client('directconnect')
 
     try:
         changed, latest_state = ensure_state(connection, module)

--- a/lib/ansible/modules/cloud/amazon/aws_elasticbeanstalk_app.py
+++ b/lib/ansible/modules/cloud/amazon/aws_elasticbeanstalk_app.py
@@ -93,7 +93,6 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 
 
 def describe_app(ebs, app_name, module):
@@ -147,15 +146,11 @@ def filter_empty(**kwargs):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-
-    argument_spec.update(
-        dict(
-            app_name=dict(aliases=['name'], type='str', required=False),
-            description=dict(),
-            state=dict(choices=['present', 'absent'], default='present'),
-            terminate_by_force=dict(type='bool', default=False, required=False)
-        )
+    argument_spec = dict(
+        app_name=dict(aliases=['name'], type='str', required=False),
+        description=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+        terminate_by_force=dict(type='bool', default=False, required=False)
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
@@ -169,9 +164,8 @@ def main():
         module.fail_json(msg='Module parameter "app_name" is required')
 
     result = {}
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    ebs = boto3_conn(module, conn_type='client', resource='elasticbeanstalk',
-                     region=region, endpoint=ec2_url, **aws_connect_params)
+
+    ebs = module.client('elasticbeanstalk')
 
     app = describe_app(ebs, app_name, module)
 

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -396,7 +396,6 @@ statement_label = {
 }
 
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict
 from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
 from ansible.module_utils.ec2 import compare_aws_tags, compare_policies
@@ -926,25 +925,22 @@ def assert_policy_shape(policy):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            alias=dict(aliases=['key_alias']),
-            policy_mode=dict(aliases=['mode'], choices=['grant', 'deny'], default='grant'),
-            policy_role_name=dict(aliases=['role_name']),
-            policy_role_arn=dict(aliases=['role_arn']),
-            policy_grant_types=dict(aliases=['grant_types'], type='list'),
-            policy_clean_invalid_entries=dict(aliases=['clean_invalid_entries'], type='bool', default=True),
-            key_id=dict(aliases=['key_arn']),
-            description=dict(),
-            enabled=dict(type='bool', default=True),
-            tags=dict(type='dict', default={}),
-            purge_tags=dict(type='bool', default=False),
-            grants=dict(type='list', default=[]),
-            policy=dict(),
-            purge_grants=dict(type='bool', default=False),
-            state=dict(default='present', choices=['present', 'absent']),
-        )
+    argument_spec = dict(
+        alias=dict(aliases=['key_alias']),
+        policy_mode=dict(aliases=['mode'], choices=['grant', 'deny'], default='grant'),
+        policy_role_name=dict(aliases=['role_name']),
+        policy_role_arn=dict(aliases=['role_arn']),
+        policy_grant_types=dict(aliases=['grant_types'], type='list'),
+        policy_clean_invalid_entries=dict(aliases=['clean_invalid_entries'], type='bool', default=True),
+        key_id=dict(aliases=['key_arn']),
+        description=dict(),
+        enabled=dict(type='bool', default=True),
+        tags=dict(type='dict', default={}),
+        purge_tags=dict(type='bool', default=False),
+        grants=dict(type='list', default=[]),
+        policy=dict(),
+        purge_grants=dict(type='bool', default=False),
+        state=dict(default='present', choices=['present', 'absent']),
     )
 
     module = AnsibleAWSModule(

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -130,12 +130,11 @@ delete_parameter:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info
 
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 def update_parameter(client, module, args):
@@ -225,8 +224,7 @@ def delete_parameter(client, module):
 
 
 def setup_client(module):
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    connection = boto3_conn(module, conn_type='client', resource='ssm', region=region, endpoint=ec2_url, **aws_connect_params)
+    connection = module.client('ssm')
     return connection
 
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_condition.py
@@ -404,7 +404,6 @@ except ImportError:
     pass  # handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_policies
 from ansible.module_utils.aws.waf import run_func_with_change_token_backoff, MATCH_LOOKUP
 from ansible.module_utils.aws.waf import get_rule_with_backoff, list_rules_with_backoff, list_regional_rules_with_backoff
@@ -704,24 +703,20 @@ def main():
         ip_address=dict(),
         regex_pattern=dict(),
     )
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            type=dict(required=True, choices=['byte', 'geo', 'ip', 'regex', 'size', 'sql', 'xss']),
-            filters=dict(type='list'),
-            purge_filters=dict(type='bool', default=False),
-            waf_regional=dict(type='bool', default=False),
-            state=dict(default='present', choices=['present', 'absent']),
-        ),
+    argument_spec = dict(
+        name=dict(required=True),
+        type=dict(required=True, choices=['byte', 'geo', 'ip', 'regex', 'size', 'sql', 'xss']),
+        filters=dict(type='list'),
+        purge_filters=dict(type='bool', default=False),
+        waf_regional=dict(type='bool', default=False),
+        state=dict(default='present', choices=['present', 'absent']),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=[['state', 'present', ['filters']]])
     state = module.params.get('state')
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
-    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client(resource)
 
     condition = Condition(client, module)
 

--- a/lib/ansible/modules/cloud/amazon/aws_waf_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_info.py
@@ -120,25 +120,20 @@ wafs:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 from ansible.module_utils.aws.waf import list_web_acls, get_web_acl
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=False),
-            waf_regional=dict(type='bool', default=False),
-        )
+    argument_spec = dict(
+        name=dict(required=False),
+        waf_regional=dict(type='bool', default=False)
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'aws_waf_facts':
         module.deprecate("The 'aws_waf_facts' module has been renamed to 'aws_waf_info'", version='2.13')
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
-    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client(resource)
     web_acls = list_web_acls(client, module)
     name = module.params['name']
     if name:

--- a/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
+++ b/lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
@@ -169,7 +169,7 @@ import re
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.waiters import get_waiter
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.module_utils.aws.waf import list_rules_with_backoff, list_web_acls_with_backoff, list_regional_web_acls_with_backoff, \
     run_func_with_change_token_backoff, list_regional_rules_with_backoff
 
@@ -332,25 +332,21 @@ def ensure_web_acl_absent(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True),
-            default_action=dict(choices=['block', 'allow', 'count']),
-            metric_name=dict(),
-            state=dict(default='present', choices=['present', 'absent']),
-            rules=dict(type='list'),
-            purge_rules=dict(type='bool', default=False),
-            waf_regional=dict(type='bool', default=False),
-        ),
+    argument_spec = dict(
+        name=dict(required=True),
+        default_action=dict(choices=['block', 'allow', 'count']),
+        metric_name=dict(),
+        state=dict(default='present', choices=['present', 'absent']),
+        rules=dict(type='list'),
+        purge_rules=dict(type='bool', default=False),
+        waf_regional=dict(type='bool', default=False)
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=[['state', 'present', ['default_action', 'rules']]])
     state = module.params.get('state')
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     resource = 'waf' if not module.params['waf_regional'] else 'waf-regional'
-    client = boto3_conn(module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client(resource)
     if state == 'present':
         (changed, results) = ensure_web_acl_present(client, module)
     else:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -1379,10 +1379,8 @@ from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.aws.cloudfront_facts import CloudFrontFactsServiceManager
 from ansible.module_utils.common.dict_transformations import recursive_diff
-from ansible.module_utils.ec2 import get_aws_connection_info
-from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, compare_aws_tags
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
-from ansible.module_utils.ec2 import snake_dict_to_camel_dict, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import compare_aws_tags, ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, snake_dict_to_camel_dict
 import datetime
 
 try:
@@ -1396,7 +1394,7 @@ except ImportError:
 try:
     import botocore
 except ImportError:
-    pass
+    pass  # caught by AnsibleAWSModule
 
 
 def change_dict_key_name(dictionary, old_key, new_key):
@@ -2089,17 +2087,15 @@ class CloudFrontValidationManager(object):
             attempts = 1 + int(wait_timeout / 60)
             waiter.wait(Id=distribution_id, WaiterConfig={'MaxAttempts': attempts})
         except botocore.exceptions.WaiterError as e:
-            self.module.fail_json(msg="Timeout waiting for CloudFront action. Waited for {0} seconds before timeout. "
-                                  "Error: {1}".format(to_text(wait_timeout), to_native(e)))
+            self.module.fail_json_aws(e, msg="Timeout waiting for CloudFront action."
+                                      " Waited for {0} seconds before timeout.".format(to_text(wait_timeout)))
 
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             self.module.fail_json_aws(e, msg="Error getting distribution {0}".format(distribution_id))
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
         caller_reference=dict(),
         comment=dict(),
@@ -2130,7 +2126,7 @@ def main():
         default_origin_path=dict(),
         wait=dict(default=False, type='bool'),
         wait_timeout=dict(default=1800, type='int')
-    ))
+    )
 
     result = {}
     changed = True
@@ -2145,8 +2141,7 @@ def main():
         ]
     )
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='cloudfront', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client('cloudfront')
 
     validation_mgr = CloudFrontValidationManager(module)
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py
@@ -138,8 +138,6 @@ location:
   sample: https://cloudfront.amazonaws.com/2017-03-25/distribution/E1ZID6KZJECZY7/invalidation/I2G9MOWJZFV622
 '''
 
-from ansible.module_utils.ec2 import get_aws_connection_info
-from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn
 from ansible.module_utils.ec2 import snake_dict_to_camel_dict
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -159,11 +157,7 @@ class CloudFrontInvalidationServiceManager(object):
 
     def __init__(self, module):
         self.module = module
-        self.create_client('cloudfront')
-
-    def create_client(self, resource):
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-        self.client = boto3_conn(self.module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        self.client = module.client('cloudfront')
 
     def create_invalidation(self, distribution_id, invalidation_batch):
         current_invalidation_response = self.get_invalidation(distribution_id, invalidation_batch['CallerReference'])
@@ -251,14 +245,12 @@ class CloudFrontInvalidationValidationManager(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-
-    argument_spec.update(dict(
+    argument_spec = dict(
         caller_reference=dict(),
         distribution_id=dict(),
         alias=dict(),
         target_paths=dict(required=True, type='list')
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False, mutually_exclusive=[['distribution_id', 'alias']])
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_origin_access_identity.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_origin_access_identity.py
@@ -122,8 +122,6 @@ location:
 
 '''
 
-from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec
-from ansible.module_utils.ec2 import boto3_conn
 from ansible.module_utils.aws.cloudfront_facts import CloudFrontFactsServiceManager
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule
@@ -147,14 +145,7 @@ class CloudFrontOriginAccessIdentityServiceManager(object):
 
     def __init__(self, module):
         self.module = module
-        self.create_client('cloudfront')
-
-    def create_client(self, resource):
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self.module, boto3=True)
-            self.client = boto3_conn(self.module, conn_type='client', resource=resource, region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except (ClientError, BotoCoreError) as e:
-            self.module.fail_json_aws(e, msg="Unable to establish connection.")
+        self.client = module.client('cloudfront')
 
     def create_origin_access_identity(self, caller_reference, comment):
         try:
@@ -242,14 +233,12 @@ class CloudFrontOriginAccessIdentityValidationManager(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
         origin_access_identity_id=dict(),
         caller_reference=dict(),
         comment=dict(),
-    ))
+    )
 
     result = {}
     e_tag = None

--- a/lib/ansible/modules/cloud/amazon/dms_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/dms_endpoint.py
@@ -168,8 +168,7 @@ RETURN = ''' # '''
 __metaclass__ = type
 import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, HAS_BOTO3, \
-    camel_dict_to_snake_dict, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
 try:
     import botocore
 except ImportError:
@@ -221,18 +220,6 @@ def endpoint_exists(endpoint):
     :return: bool
     """
     return bool(len(endpoint['Endpoints']))
-
-
-def get_dms_client(aws_connect_params, client_region, ec2_url):
-    client_params = dict(
-        module=module,
-        conn_type='client',
-        resource='dms',
-        region=client_region,
-        endpoint=ec2_url,
-        **aws_connect_params
-    )
-    return boto3_conn(**client_params)
 
 
 def delete_dms_endpoint(connection):
@@ -443,13 +430,10 @@ def main():
     )
     exit_message = None
     changed = False
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     state = module.params.get('state')
-    aws_config_region, ec2_url, aws_connect_params = \
-        get_aws_connection_info(module, boto3=True)
-    dmsclient = get_dms_client(aws_connect_params, aws_config_region, ec2_url)
+
+    dmsclient = module.client('dms')
     endpoint = describe_endpoints(dmsclient,
                                   module.params.get('endpointidentifier'))
     if state == 'present':

--- a/lib/ansible/modules/cloud/amazon/dms_replication_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/dms_replication_subnet_group.py
@@ -58,11 +58,10 @@ EXAMPLES = '''
 '''
 
 RETURN = ''' # '''
-__metaclass__ = type
+
 import traceback
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, HAS_BOTO3, \
-    camel_dict_to_snake_dict, get_aws_connection_info, AWSRetry
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
 try:
     import botocore
 except ImportError:
@@ -98,18 +97,6 @@ def replication_subnet_group_delete(module, connection):
     subnetid = module.params.get('identifier')
     delete_parameters = dict(ReplicationSubnetGroupIdentifier=subnetid)
     return connection.delete_replication_subnet_group(**delete_parameters)
-
-
-def get_dms_client(module, aws_connect_params, client_region, ec2_url):
-    client_params = dict(
-        module=module,
-        conn_type='client',
-        resource='dms',
-        region=client_region,
-        endpoint=ec2_url,
-        **aws_connect_params
-    )
-    return boto3_conn(**client_params)
 
 
 def replication_subnet_exists(subnet):
@@ -205,13 +192,9 @@ def main():
     )
     exit_message = None
     changed = False
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     state = module.params.get('state')
-    aws_config_region, ec2_url, aws_connect_params = \
-        get_aws_connection_info(module, boto3=True)
-    dmsclient = get_dms_client(module, aws_connect_params, aws_config_region, ec2_url)
+    dmsclient = module.client('dms')
     subnet_group = describe_subnet_group(dmsclient,
                                          module.params.get('identifier'))
     if state == 'present':

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -140,15 +140,13 @@ image_id:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
 from ansible.module_utils._text import to_native
 
 try:
     from botocore.exceptions import ClientError, NoCredentialsError, WaiterError, BotoCoreError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # caught by AnsibleAWSModule
 
 
 def copy_image(module, ec2):
@@ -206,8 +204,7 @@ def copy_image(module, ec2):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         source_region=dict(required=True),
         source_image_id=dict(required=True),
         name=dict(default='default'),
@@ -216,7 +213,7 @@ def main():
         kms_key_id=dict(type='str', required=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=600),
-        tags=dict(type='dict')),
+        tags=dict(type='dict'),
         tag_equality=dict(type='bool', default=False))
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_info.py
@@ -205,11 +205,10 @@ images:
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
-    pass
+    pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info, ansible_dict_to_boto3_filter_list,
-                                      camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict)
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, boto3_tag_list_to_ansible_dict
 
 
 def list_ec2_images(ec2_client, module):
@@ -261,27 +260,19 @@ def list_ec2_images(ec2_client, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            image_ids=dict(default=[], type='list', aliases=['image_id']),
-            filters=dict(default={}, type='dict'),
-            owners=dict(default=[], type='list', aliases=['owner']),
-            executable_users=dict(default=[], type='list', aliases=['executable_user']),
-            describe_image_attributes=dict(default=False, type='bool')
-        )
+    argument_spec = dict(
+        image_ids=dict(default=[], type='list', aliases=['image_id']),
+        filters=dict(default={}, type='dict'),
+        owners=dict(default=[], type='list', aliases=['owner']),
+        executable_users=dict(default=[], type='list', aliases=['executable_user']),
+        describe_image_attributes=dict(default=False, type='bool')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._module._name == 'ec2_ami_facts':
         module._module.deprecate("The 'ec2_ami_facts' module has been renamed to 'ec2_ami_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        ec2_client = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-    else:
-        module.fail_json(msg="region must be specified")
+    ec2_client = module.client('ec2')
 
     list_ec2_images(ec2_client, module)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py
@@ -111,7 +111,6 @@ RETURN = '''
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
 
 try:
     import botocore
@@ -228,28 +227,23 @@ def delete_lifecycle_hook(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            autoscaling_group_name=dict(required=True, type='str'),
-            lifecycle_hook_name=dict(required=True, type='str'),
-            transition=dict(type='str', choices=['autoscaling:EC2_INSTANCE_TERMINATING', 'autoscaling:EC2_INSTANCE_LAUNCHING']),
-            role_arn=dict(type='str'),
-            notification_target_arn=dict(type='str'),
-            notification_meta_data=dict(type='str'),
-            heartbeat_timeout=dict(type='int'),
-            default_result=dict(default='ABANDON', choices=['ABANDON', 'CONTINUE']),
-            state=dict(default='present', choices=['present', 'absent'])
-        )
+    argument_spec = dict(
+        autoscaling_group_name=dict(required=True, type='str'),
+        lifecycle_hook_name=dict(required=True, type='str'),
+        transition=dict(type='str', choices=['autoscaling:EC2_INSTANCE_TERMINATING', 'autoscaling:EC2_INSTANCE_LAUNCHING']),
+        role_arn=dict(type='str'),
+        notification_target_arn=dict(type='str'),
+        notification_meta_data=dict(type='str'),
+        heartbeat_timeout=dict(type='int'),
+        default_result=dict(default='ABANDON', choices=['ABANDON', 'CONTINUE']),
+        state=dict(default='present', choices=['present', 'absent'])
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               required_if=[['state', 'present', ['transition']]])
     state = module.params.get('state')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    connection = boto3_conn(module, conn_type='client', resource='autoscaling', region=region, endpoint=ec2_url, **aws_connect_params)
+    connection = module.client('autoscaling')
 
     changed = False
 

--- a/lib/ansible/modules/cloud/amazon/ec2_customer_gateway_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_customer_gateway_info.py
@@ -88,9 +88,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                      boto3_conn, boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict,
-                                      ec2_argument_spec, get_aws_connection_info)
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
 
 
 def date_handler(obj):
@@ -119,12 +117,9 @@ def list_customer_gateways(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            customer_gateway_ids=dict(default=[], type='list'),
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        customer_gateway_ids=dict(default=[], type='list'),
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
@@ -133,9 +128,7 @@ def main():
     if module._module._name == 'ec2_customer_gateway_facts':
         module._module.deprecate("The 'ec2_customer_gateway_facts' module has been renamed to 'ec2_customer_gateway_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
+    connection = module.client('ec2')
 
     list_customer_gateways(connection, module)
 


### PR DESCRIPTION
##### SUMMARY

Boto3 modules already using AnsibleAWSModule are currently running chunks of duplicate/deprecated code.

AnsibleAWSModule related cleanup:
- remove ec2_argument_spec() use (AnsibleAWSModule adds it automatically)
- remove HAS_BOTO3 (AnsibleAWSModule handles it)
- fetch boto3 clients using module.client()
- remove unused imports

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_acm.py
lib/ansible/modules/cloud/amazon/aws_acm_info.py
lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py
lib/ansible/modules/cloud/amazon/aws_config_aggregation_authorization.py
lib/ansible/modules/cloud/amazon/aws_config_delivery_channel.py
lib/ansible/modules/cloud/amazon/aws_config_recorder.py
lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py
lib/ansible/modules/cloud/amazon/aws_elasticbeanstalk_app.py
lib/ansible/modules/cloud/amazon/aws_kms.py
lib/ansible/modules/cloud/amazon/aws_s3.py
lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
lib/ansible/modules/cloud/amazon/aws_waf_condition.py
lib/ansible/modules/cloud/amazon/aws_waf_info.py
lib/ansible/modules/cloud/amazon/aws_waf_rule.py
lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py
lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py
lib/ansible/modules/cloud/amazon/cloudfront_origin_access_identity.py
lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
lib/ansible/modules/cloud/amazon/dms_endpoint.py
lib/ansible/modules/cloud/amazon/dms_replication_subnet_group.py
lib/ansible/modules/cloud/amazon/ec2_ami.py
lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
lib/ansible/modules/cloud/amazon/ec2_ami_info.py
lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py
lib/ansible/modules/cloud/amazon/ec2_customer_gateway_info.py


##### ADDITIONAL INFORMATION
