### PR TITLE
fix typo in eos_interfaces Examples

### DIFF
--- a/lib/ansible/modules/network/eos/eos_interfaces.py
+++ b/lib/ansible/modules/network/eos/eos_interfaces.py
@@ -121,7 +121,7 @@ EXAMPLES = """
         enabled: True
       - name: Ethernet2
         description: 'Configured by Ansible'
-        enable: False
+        enabled: False
     state: merged
 
 # After state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In  Examples using `state: merged`, The `enable` should be `enabled`.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- eos_interfaces
