### PR TITLE
[stable-2.9] Use newer version of podman on RHEL (#64934)

### DIFF
--- a/test/integration/targets/setup_podman/defaults/main.yml
+++ b/test/integration/targets/setup_podman/defaults/main.yml
@@ -1,0 +1,1 @@
+podman_package: podman-1.4.*

--- a/test/integration/targets/setup_podman/tasks/main.yml
+++ b/test/integration/targets/setup_podman/tasks/main.yml
@@ -1,7 +1,4 @@
 - block:
-    - name: Include distribution specific variables
-      include_vars: "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
-
     - name: Enable extras repo
       command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version] | default('echo') }}"
 
@@ -10,6 +7,10 @@
         name: "{{ podman_package }}"
         state: present
       when: ansible_facts.pkg_mgr in ['yum', 'dnf']
+
+    - name: Get podman version
+      command: podman --version
+
   when:
     - ansible_facts.distribution == 'RedHat'
     - ansible_facts.virtualization_type != 'docker'

--- a/test/integration/targets/setup_podman/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-7.yml
@@ -1,1 +1,0 @@
-podman_package: podman-1.3.*

--- a/test/integration/targets/setup_podman/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-8.yml
@@ -1,1 +1,0 @@
-podman_package: '@container-tools:1.0'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64934 for Ansible 2.9
(cherry picked from commit a385ad321b)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_podman/`