### PR TITLE
Correct win_dns_client test option name

### DIFF
--- a/test/integration/targets/win_dns_client/tasks/main.yml
+++ b/test/integration/targets/win_dns_client/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: set a single IPv4 address (check mode)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single_check
   check_mode: yes
@@ -29,7 +29,7 @@
 
 - name: set a single IPv4 address
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single
 
@@ -46,7 +46,7 @@
 
 - name: set a single IPv4 address (idempotent)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single_again
 
@@ -57,7 +57,7 @@
 
 - name: change IPv4 address to another value (check mode)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.6
   register: change_single_check
   check_mode: yes
@@ -75,7 +75,7 @@
 
 - name: change IPv4 address to another value
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.6
   register: change_single
 
@@ -92,7 +92,7 @@
 
 - name: set multiple IPv4 addresses (check mode)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
     - 192.168.34.7
     - 192.168.34.8
@@ -112,7 +112,7 @@
 
 - name: set multiple IPv4 addresses
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
     - 192.168.34.7
     - 192.168.34.8
@@ -131,7 +131,7 @@
 
 - name: set multiple IPv4 addresses (idempotent)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
     - 192.168.34.7
     - 192.168.34.8
@@ -144,7 +144,7 @@
 
 - name: reset IPv4 DNS back to DHCP (check mode)
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: []
   register: set_dhcp_check
   check_mode: yes
@@ -162,7 +162,7 @@
 
 - name: reset IPv4 DNS back to DHCP
   win_dns_client:
-    adapter_name: '{{ network_adapter_name }}'
+    adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: []
   register: set_dhcp
 


### PR DESCRIPTION
##### SUMMARY
The `win_dns_client` tests used the wrong module option to specify the adapter. While the tests aren't broken they are modifying all network adapters with the IPs configured which can break a system. This just fixes up the tests so it only modifies the test adapter created.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dns_client tests