### PR TITLE
include_vars: Check NoneType for raw_params

### DIFF
--- a/changelogs/fragments/include_vars_fix_none.yml
+++ b/changelogs/fragments/include_vars_fix_none.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Check NoneType for raw_params before proceeding in include_vars (https://github.com/ansible/ansible/issues/64939).

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -257,10 +257,12 @@ class AnsibleFileNotFound(AnsibleRuntimeError):
         self.file_name = file_name
         self.paths = paths
 
+        if message:
+            message += "\n"
         if self.file_name:
-            if message:
-                message += "\n"
             message += "Could not find or access '%s'" % to_text(self.file_name)
+        else:
+            message += "Could not find file"
 
         if self.paths and isinstance(self.paths, Sequence):
             searched = to_text('\n\t'.join(self.paths))

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -50,7 +50,9 @@ class ActionModule(ActionBase):
         self.source_dir = self._task.args.get('dir', None)
         self.source_file = self._task.args.get('file', None)
         if not self.source_dir and not self.source_file:
-            self.source_file = self._task.args.get('_raw_params').rstrip('\n')
+            self.source_file = self._task.args.get('_raw_params')
+            if self.source_file:
+                self.source_file = self.source_file.rstrip('\n')
 
         self.depth = self._task.args.get('depth', None)
         self.files_matching = self._task.args.get('files_matching', None)

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -138,3 +138,17 @@
   assert:
     that:
       - "service_name ==  'my_custom_service'"
+
+- name: Check NoneType for raw params and file
+  include_vars:
+    file: "{{ lookup('first_found', possible_files, errors='ignore') }}"
+  vars:
+    possible_files:
+    - "does_not_exist.yml"
+  ignore_errors: True
+  register: include_with_non_existent_file
+
+- name: Verify that file and raw_params provide correct error message to user
+  assert:
+    that:
+      - "'Could not find file' in include_with_non_existent_file.message"


### PR DESCRIPTION
##### SUMMARY

Lookup 'first_found' returns empty list which results in
raw_params checking. Check NoneType for 'raw_params' before
proceeding.

Fixes: #64939

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/include_vars_fix_none.yml
lib/ansible/errors/__init__.py
lib/ansible/plugins/action/include_vars.py
test/integration/targets/include_vars/tasks/main.yml
