### PR TITLE
Fix py2/py3 compability issue for httpapi plugin fortios

### DIFF
--- a/lib/ansible/plugins/httpapi/fortios.py
+++ b/lib/ansible/plugins/httpapi/fortios.py
@@ -84,12 +84,21 @@ class HttpApi(HttpApiBase):
         """
 
         headers = {}
-
-        for attr, val in response.getheaders():
-            if attr == 'Set-Cookie' and 'APSCOOKIE_' in val:
+        resp_raw_headers = []
+        if hasattr(response.headers, '_headers'):
+            resp_raw_headers = response.headers._headers
+        else:
+            resp_raw_headers = [(attr, response.headers[attr]) for attr in response.headers]
+        for attr, val in resp_raw_headers:
+            if attr.lower() == 'set-cookie' and 'APSCOOKIE_' in val:
                 headers['Cookie'] = val
+                # XXX: In urllib2 all the 'set-cookie' headers are coalesced into one
+                x_ccsrftoken_position = val.find('ccsrftoken=')
+                if x_ccsrftoken_position != -1:
+                    token_string = val[x_ccsrftoken_position + len('ccsrftoken='):].split('\"')[1]
+                    self._ccsrftoken = token_string
 
-            elif attr == 'Set-Cookie' and 'ccsrftoken=' in val:
+            elif attr.lower() == 'set-cookie' and 'ccsrftoken=' in val:
                 csrftoken_search = re.search('\"(.*)\"', val)
                 if csrftoken_search:
                     self._ccsrftoken = csrftoken_search.group(1)
@@ -119,7 +128,11 @@ class HttpApi(HttpApiBase):
 
         try:
             response, response_data = self.connection.send(url, data, method=method)
-
-            return response.status, to_text(response_data.getvalue())
+            response_status = None
+            if hasattr(response, 'status'):
+                response_status = response.status
+            else:
+                response_status = response.headers.status
+            return response_status, to_text(response_data.getvalue())
         except Exception as err:
             raise Exception(err)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**symptom**: when enabling Httpapi plugin for fortios with python2.7, it reports error like: response does not have attribute 'getheaders()'.
**root casue**: the urllib2 in python2 and urllib3 in python3 is incompatible in http response structure, and six library does not resolve the conflict.  

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin: fortios

##### ADDITIONAL INFORMATION
the playbook to test with:
```
#cat test.yml
- hosts: fortigates
  connection: httpapi
  vars:
   vdom: "root"
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
  - name: Configure global attributes.
    fortios_system_global:
      vdom:  "{{ vdom }}"
      system_global:
        admintimeout: "23"
        hostname: "cheers"
```
**verification on python2**:
```
(verify_py2.7)
#ansible --version
ansible 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/BUGFIX/ansible/verify_py2.7/local/lib/python2.7/site-packages/ansible-2.10.0.dev0-py2.7.egg/ansible
  executable location = /root/BUGFIX/ansible/verify_py2.7/bin/ansible
  python version = 2.7.15+ (default, Oct  7 2019, 17:39:04) [GCC 7.4.0]

(verify_py2.7)
Nov-18 07:09:25 root@ubuntu0  ~/BUGFIX/httpapi_failure
#ansible-playbook -i host test.yml

PLAY [fortigates] *************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************************
ok: [fortigate01]

TASK [Configure global attributes.] *******************************************************************************************************************************************************************************************************************************************
changed: [fortigate01]

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
fortigate01                : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```


**verification on python3**:
```
(verify_py3.6)
Nov-18 07:11:50 root@ubuntu0  ~/BUGFIX/httpapi_failure
#ansible --version
ansible 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /root/BUGFIX/ansible/verify_py3.6/lib/python3.6/site-packages/ansible-2.10.0.dev0-py3.6.egg/ansible
  executable location = /root/BUGFIX/ansible/verify_py3.6/bin/ansible
  python version = 3.6.9 (default, Nov  7 2019, 10:44:02) [GCC 8.3.0]

(verify_py3.6)
Nov-18 07:11:59 root@ubuntu0  ~/BUGFIX/httpapi_failure
#ansible-playbook  -i host  test.yml

PLAY [fortigates] *************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************************
ok: [fortigate01]

TASK [Configure global attributes.] *******************************************************************************************************************************************************************************************************************************************
changed: [fortigate01]

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************************
fortigate01                : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```


**unit tests** 
```
#source hacking/env-setup
#ansible-test units --python 3.6 --vdev 
=========================================================================================================================== short test summary info ===========================================================================================================================
SKIPPED [1] /root/BUGFIX/ansible/test/units/module_utils/network/ftd/test_device.py:22: could not import 'kick': No module named 'kick'
SKIPPED [1] /root/BUGFIX/ansible/test/units/plugins/connection/test_connection.py:49: could not import 'ncclient': No module named 'ncclient'
SKIPPED [1] /root/BUGFIX/ansible/test/units/plugins/connection/test_netconf.py:31: could not import 'ncclient': No module named 'ncclient'
SKIPPED [1] /root/BUGFIX/ansible/test/units/plugins/connection/test_winrm.py:21: could not import 'winrm': No module named 'winrm'
SKIPPED [1] module_utils/basic/test_imports.py:84: literal_eval is available in every version of Python3
SKIPPED [5] module_utils/basic/test_log.py:38: python systemd bindings not installed
SKIPPED [2] module_utils/basic/test_log.py:113: python systemd bindings not installed
SKIPPED [5] module_utils/basic/test_log.py:130: python systemd bindings not installed
SKIPPED [1] module_utils/basic/test_log.py:139: python systemd bindings not installed
SKIPPED [3] /root/BUGFIX/ansible/test/units/module_utils/facts/test_facts.py:65: This test class needs to be updated to specify collector_class
SKIPPED [1] /root/BUGFIX/ansible/test/units/module_utils/facts/test_facts.py:47: This platform (DragonFly) does not have a fact_class.
SKIPPED [1] /root/BUGFIX/ansible/test/units/module_utils/facts/test_facts.py:55: This platform (DragonFly) does not have a fact_class.
SKIPPED [4] modules/cloud/cloudstack/test_cs_traffic_type.py: The cloudstack library, "cs", is needed to test cs_traffic_type
SKIPPED [1] modules/cloud/linode/test_linode.py: test_linode.py requires the `linode-python` module
SKIPPED [2] modules/network/f5/test_bigip_gtm_facts.py: F5 Ansible modules require the f5-sdk Python library
SKIPPED [3] modules/network/f5/test_bigip_security_address_list.py: F5 Ansible modules require the f5-sdk Python library
SKIPPED [3] modules/network/f5/test_bigip_security_port_list.py: F5 Ansible modules require the f5-sdk Python library
SKIPPED [61] modules/network/nuage/test_nuage_vspk.py: Nuage Ansible modules requires Python 2.7
SKIPPED [1] modules/packaging/os/test_rhn_register.py:68: none are available: libxml2, libxml
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:16: paramiko must be installed to test key creation
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:85: paramiko must be installed to test key creation
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:135: paramiko must be installed to test key creation
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:105: paramiko must be installed to test key creation
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:154: paramiko must be installed to test key creation
SKIPPED [1] modules/source_control/test_bitbucket_pipeline_known_host.py:55: paramiko must be installed to test key creation
SKIPPED [2] parsing/vault/test_vault.py:841: This test is not ready yet
SKIPPED [1] vars/test_module_response_deepcopy.py:40: No current support for this situation
FAILED test/units/module_utils/test_distribution_version.py::test_distribution_version[stdin21-Ubuntu 10.04 guess]
FAILED test/units/module_utils/test_distribution_version.py::test_distribution_version[stdin22-Ubuntu 14.04]
FAILED test/units/module_utils/test_distribution_version.py::test_distribution_version[stdin23-Ubuntu 12.04]
FAILED test/units/plugins/lookup/test_aws_secret.py::test_lookup_variable
FAILED test/units/plugins/lookup/test_aws_secret.py::test_warn_denied_variable
FAILED test/units/plugins/lookup/test_aws_ssm.py::test_lookup_variable
FAILED test/units/plugins/lookup/test_aws_ssm.py::test_path_lookup_variable
FAILED test/units/plugins/lookup/test_aws_ssm.py::test_return_none_for_missing_variable
FAILED test/units/plugins/lookup/test_aws_ssm.py::test_match_retvals_to_call_params_even_with_some_missing_variables
FAILED test/units/plugins/lookup/test_aws_ssm.py::test_warn_denied_variable
=================================================================================================== 10 failed, 10978 passed, 107 skipped, 21 warnings in 585.68s (0:09:45) ====================================================================================================






#source  hacking/env-setup
#ansible-test units --python 2.7  --venv
ERROR: No usable virtual environment support found.
(will add test result once there is a way to run units test with py2.7: 
https://github.com/ansible/ansible/pull/62886#issuecomment-554893992)
```

 @frankshen01 @mamunozgonzalez
