### PR TITLE
parted: support fs_type

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -96,6 +96,11 @@ options:
     type: str
     choices: [ absent, present, info ]
     default: info
+  fs_type:
+    description:
+     - If specified, will set filesystem type to given partition
+    default: 'ext4'
+    version_added: '2.8'
 notes:
   - When fetching information about a new disk and when the version of parted
     installed on the system is before version 3.1, the module queries the kernel
@@ -549,6 +554,7 @@ def main():
             part_type=dict(type='str', default='primary', choices=['extended', 'logical', 'primary']),
             part_start=dict(type='str', default='0%'),
             part_end=dict(type='str', default='100%'),
+            'fs_type': {'default': 'ext4', 'type': 'str'},
 
             # name <partition> <name> command
             name=dict(type='str'),
@@ -579,6 +585,7 @@ def main():
     name = module.params['name']
     state = module.params['state']
     flags = module.params['flags']
+    fs_type = module.params['fs_type']
 
     # Parted executable
     parted_exec = module.get_bin_path('parted', True)
@@ -611,8 +618,9 @@ def main():
 
         # Create partition if required
         if part_type and not part_exists(current_parts, 'num', number):
-            script += "mkpart %s %s %s " % (
+            script += "mkpart %s %s %s %s " % (
                 part_type,
+                fs_type,
                 part_start,
                 part_end
             )

--- a/test/units/modules/system/test_parted.py
+++ b/test/units/modules/system/test_parted.py
@@ -163,7 +163,7 @@ class TestParted(ModuleTestCase):
             'state': 'present',
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 100%')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext4 0% 100%')
 
     def test_create_new_partition_1G(self):
         set_module_args({
@@ -173,7 +173,7 @@ class TestParted(ModuleTestCase):
             'part_end': '1GiB',
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 1GiB')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext4 0% 1GiB')
 
     def test_remove_partition_number_1(self):
         set_module_args({
@@ -218,10 +218,11 @@ class TestParted(ModuleTestCase):
             'flags': ["boot"],
             'state': 'present',
             'part_start': '257GiB',
+            'fs_type': 'ext3',
             '_ansible_check_mode': True,
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 257GiB 100% unit KiB set 4 boot on')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext3 257GiB 100% unit KiB set 4 boot on')
 
     def test_create_label_gpt(self):
         # Like previous test, current implementation use parted to create the partition and
@@ -237,4 +238,4 @@ class TestParted(ModuleTestCase):
             '_ansible_check_mode': True,
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict2):
-            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')
+            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary ext4 0% 100% unit KiB name 1 \'"lvmpartition"\' set 1 lvm on')


### PR DESCRIPTION
##### SUMMARY
This is a rebase of #47879 to be based on the current state of the `devel` branch, since the original author of that PR hasn't rebased it in a while. If #47879 is merged, this PR can be safely closed.

And in case this PR is merged instead of #47879:

Fixes #28126 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
parted

##### ADDITIONAL INFORMATION
See #47879 for more info, but this would support the `fs-type` argument of `parted`. (https://www.gnu.org/software/parted/manual/html_node/mkpart.html has details).