### PR TITLE
postgresql_ext: use query_params

### DIFF
--- a/changelogs/fragments/64994-postgresql_ext_use_query_params.yml
+++ b/changelogs/fragments/64994-postgresql_ext_use_query_params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_ext - use query parameters with cursor object (https://github.com/ansible/ansible/pull/64994).

--- a/test/integration/targets/postgresql_ext/aliases
+++ b/test/integration/targets/postgresql_ext/aliases
@@ -1,3 +1,7 @@
 destructive
 shippable/posix/group4
 skip/osx
+skip/centos
+skip/redhat
+skip/freebsd
+skip/opensuse


### PR DESCRIPTION
##### SUMMARY
1. postgresql_ext: use query_params for queries where single quotes are used to prevent SQL injections

2. added skipped distributions to the alias file because in tasks/main.yml the tests are already restricted to use only Fedora and Ubuntu

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_ext.py```
```test/integration/targets/postgresql_ext/aliases```