### PR TITLE
cloudstack: add support for SSL CA cert files

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -35,6 +35,7 @@ def cs_argument_spec():
         api_http_method=dict(choices=['get', 'post'], default=os.environ.get('CLOUDSTACK_METHOD')),
         api_timeout=dict(type='int', default=os.environ.get('CLOUDSTACK_TIMEOUT')),
         api_region=dict(default=os.environ.get('CLOUDSTACK_REGION') or 'cloudstack'),
+        api_ssl_verify=dict(default=os.environ.get('CLOUDSTACK_VERIFY')),
     )
 
 
@@ -125,6 +126,7 @@ class AnsibleCloudStack:
             'secret': self.module.params.get('api_secret') or config.get('secret'),
             'timeout': self.module.params.get('api_timeout') or config.get('timeout') or 10,
             'method': self.module.params.get('api_http_method') or config.get('method') or 'get',
+            'verify': self.module.params.get('api_ssl_verify') or config.get('verify'),
         }
         self.result.update({
             'api_region': api_region,
@@ -132,6 +134,7 @@ class AnsibleCloudStack:
             'api_key': api_config['key'],
             'api_timeout': int(api_config['timeout']),
             'api_http_method': api_config['method'],
+            'api_ssl_verify': api_config['verify'],
         })
         if not all([api_config['endpoint'], api_config['key'], api_config['secret']]):
             self.fail_json(msg="Missing api credentials: can not authenticate")

--- a/lib/ansible/plugins/doc_fragments/cloudstack.py
+++ b/lib/ansible/plugins/doc_fragments/cloudstack.py
@@ -51,6 +51,14 @@ options:
       - If not given, the C(CLOUDSTACK_REGION) env variable is considered.
     type: str
     default: cloudstack
+  api_ssl_verify:
+    description:
+      - CA authority cert file.
+      - If not given, the C(CLOUDSTACK_VERIFY) env variable is considered.
+      - As the last option, the value is taken from the ini config file, also see the notes.
+      - Fallback value is C(null) if not specified.
+    type: str
+    version_added: '2.10'
 requirements:
   - python >= 2.6
   - cs >= 0.6.10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Cloudstack modules don't pass the `verify` config item to the cs module.
It makes them fail when the Cloudstack endpoint requires a CA cert file.

This PR add support for `CLOUDSTACK_VERIFY` environment variable and for the cloudstack.ini `verify` option.

For consistency, I also added the new common parameter 'api_ssl_verify' which allows to specify the CA cert file path as a parameter of the modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudstack.py
