### PR TITLE
win_disk_facts - Set output array order to be by disk number property

### DIFF
--- a/changelogs/fragments/win_disk_facts-Set-output-array-order-by-disk-number.yml
+++ b/changelogs/fragments/win_disk_facts-Set-output-array-order-by-disk-number.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "win_disk_facts - Set output array order to be by disk number property - https://github.com/ansible/ansible/issues/63998"

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -244,5 +244,8 @@ foreach ($disk in $disks) {
     $result.ansible_facts.ansible_disks += $disk_info
 }
 
+# Sort by disk number property
+$result.ansible_facts.ansible_disks = @() + ($result.ansible_facts.ansible_disks | Sort-Object -Property Number)
+
 # Return result
 Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -245,7 +245,7 @@ foreach ($disk in $disks) {
 }
 
 # Sort by disk number property
-$result.ansible_facts.ansible_disks = @() + ($result.ansible_facts.ansible_disks | Sort-Object -Property Number)
+$result.ansible_facts.ansible_disks = @() + ($result.ansible_facts.ansible_disks | Sort-Object -Property {$_.Number})
 
 # Return result
 Exit-Json -obj $result


### PR DESCRIPTION
##### SUMMARY
Not really a bug but not a feature either.

Fixes #63998

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_disk_facts.ps1

##### ADDITIONAL INFORMATION
