### PR TITLE
Add unwrap_var function to remove unsafe wrappers

### DIFF
--- a/changelogs/fragments/65002.yml
+++ b/changelogs/fragments/65002.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- YAML parsing - Create common utils for loading and dumping YAML that prefer the C extensions if available
+- Unsafe Proxy - Introduce recursive function to unwrap unsafe objects for use with external Python APIs

--- a/docs/docsite/rst/dev_guide/testing/sanity/unwrap-unsafe.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/unwrap-unsafe.rst
@@ -1,0 +1,17 @@
+unwrap-unsafe
+=============
+
+Use of ``unwrap_var`` is strictly monitored for improper use, that could
+cause future security issues.
+
+Unsafe designations are very important to Ansible, to ensure that unsafe data
+is not templated. Allowing unsafe data to be templated could cause adverse
+security issues.
+
+``unwrap_var`` should be used minimally, and only in very specific cases,
+such as when passing data to a remote Python API where the receiving python
+code does not understand our subclasses, potentially due to performing type
+checks like ``if type(value) == 'str':``
+
+Use of ``unwrap_var`` is not required to convert values to JSON, as the
+default JSON encoder will implicitly ignore the subclass.

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -11,14 +11,13 @@ import os
 import os.path
 import sys
 import time
-import yaml
 
 import ansible
 from ansible import constants as C
 from ansible.module_utils._text import to_native
 from ansible.release import __version__
 from ansible.utils.path import unfrackpath
-
+from ansible.utils.yaml import safe_load
 
 #
 # Special purpose OptionParsers
@@ -105,7 +104,8 @@ def _git_repo_info(repo_path):
         # Check if the .git is a file. If it is a file, it means that we are in a submodule structure.
         if os.path.isfile(repo_path):
             try:
-                gitdir = yaml.safe_load(open(repo_path)).get('gitdir')
+                with open(repo_path) as f:
+                    gitdir = safe_load(f).get('gitdir')
                 # There is a possibility the .git file to have an absolute path.
                 if os.path.isabs(gitdir):
                     repo_path = gitdir

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -19,6 +19,7 @@ from ansible.release import __version__
 from ansible.utils.path import unfrackpath
 from ansible.utils.yaml import safe_load
 
+
 #
 # Special purpose OptionParsers
 #

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -10,7 +10,6 @@ import re
 import shutil
 import textwrap
 import time
-import yaml
 
 from yaml.error import YAMLError
 
@@ -45,6 +44,7 @@ from ansible.playbook.role.requirement import RoleRequirement
 from ansible.template import Templar
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_versioned_doclink
+from ansible.utils.yaml import safe_dump, safe_load
 
 display = Display()
 urlparse = six.moves.urllib.parse.urlparse
@@ -439,7 +439,7 @@ class GalaxyCLI(CLI):
             # Config definitions are looked up dynamically based on the C.GALAXY_SERVER_LIST entry. We look up the
             # section [galaxy_server.<server>] for the values url, username, password, and token.
             config_dict = dict((k, server_config_def(server_key, k, req)) for k, req in server_def)
-            defs = AnsibleLoader(yaml.safe_dump(config_dict)).get_single_data()
+            defs = AnsibleLoader(safe_dump(config_dict)).get_single_data()
             C.config.initialize_plugin_configuration_definitions('galaxy_server', server_key, defs)
 
             server_options = C.config.get_plugin_options('galaxy_server', server_key)
@@ -559,7 +559,7 @@ class GalaxyCLI(CLI):
         display.vvv("Reading requirement file at '%s'" % requirements_file)
         with open(b_requirements_file, 'rb') as req_obj:
             try:
-                file_requirements = yaml.safe_load(req_obj)
+                file_requirements = safe_load(req_obj)
             except YAMLError as err:
                 raise AnsibleError(
                     "Failed to parse the requirements yml at '%s' with the following error:\n%s"
@@ -584,7 +584,7 @@ class GalaxyCLI(CLI):
                 with open(b_include_path, 'rb') as f_include:
                     try:
                         return [GalaxyRole(self.galaxy, self.api, **r) for r in
-                                (RoleRequirement.role_yaml_parse(i) for i in yaml.safe_load(f_include))]
+                                (RoleRequirement.role_yaml_parse(i) for i in safe_load(f_include))]
                     except Exception as e:
                         raise AnsibleError("Unable to load data from include requirements file: %s %s"
                                            % (to_native(requirements_file), to_native(e)))

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -14,13 +14,6 @@ import tempfile
 import traceback
 from collections import namedtuple
 
-from yaml import load as yaml_load
-try:
-    # use C version if possible for speedup
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
-
 from ansible.config.data import ConfigData
 from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.module_utils._text import to_text, to_bytes, to_native
@@ -32,6 +25,7 @@ from ansible.parsing.quoting import unquote
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.utils import py3compat
 from ansible.utils.path import cleanup_tmp_file, makedirs_safe, unfrackpath
+from ansible.utils.yaml import safe_load
 
 
 Plugin = namedtuple('Plugin', 'name type')
@@ -296,7 +290,7 @@ class ConfigManager(object):
         yml_file = to_bytes(yml_file)
         if os.path.exists(yml_file):
             with open(yml_file, 'rb') as config_def:
-                return yaml_load(config_def, Loader=SafeLoader) or {}
+                return safe_load(config_def) or {}
         raise AnsibleError(
             "Missing base YAML definition file (bad install?): %s" % to_native(yml_file))
 
@@ -327,7 +321,7 @@ class ConfigManager(object):
             # FIXME: this should eventually handle yaml config files
             # elif ftype == 'yaml':
             #     with open(cfile, 'rb') as config_stream:
-            #         self._parsers[cfile] = yaml.safe_load(config_stream)
+            #         self._parsers[cfile] = safe_load(config_stream)
             else:
                 raise AnsibleOptionsError("Unsupported configuration file type: %s" % to_native(ftype))
 

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -24,11 +24,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import yaml
 
 import ansible.constants as C
 from ansible import context
 from ansible.module_utils._text import to_bytes
+from ansible.utils.yaml import safe_load
 
 #      default_readme_template
 #      default_meta_template
@@ -37,7 +37,7 @@ from ansible.module_utils._text import to_bytes
 def get_collections_galaxy_meta_info():
     meta_path = os.path.join(os.path.dirname(__file__), 'data', 'collections_galaxy_meta.yml')
     with open(to_bytes(meta_path, errors='surrogate_or_strict'), 'rb') as galaxy_obj:
-        return yaml.safe_load(galaxy_obj)
+        return safe_load(galaxy_obj)
 
 
 class Galaxy(object):

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -16,7 +16,6 @@ import tarfile
 import tempfile
 import threading
 import time
-import yaml
 
 from collections import namedtuple
 from contextlib import contextmanager
@@ -37,12 +36,13 @@ from ansible.galaxy.api import CollectionVersionMetadata, GalaxyError
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils import six
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.urls import open_url
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 from ansible.utils.galaxy import scm_archive_collection
 from ansible.utils.hashing import secure_hash, secure_hash_s
 from ansible.utils.version import SemanticVersion
-from ansible.module_utils.urls import open_url
+from ansible.utils.yaml import safe_dump, safe_load
 
 urlparse = six.moves.urllib.parse.urlparse
 urldefrag = six.moves.urllib.parse.urldefrag
@@ -611,7 +611,7 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
             requirements_path = os.path.join(output_path, 'requirements.yml')
             display.display("Writing requirements.yml file of downloaded collections to '%s'" % requirements_path)
             with open(to_bytes(requirements_path, errors='surrogate_or_strict'), mode='wb') as req_fd:
-                req_fd.write(to_bytes(yaml.safe_dump({'collections': requirements}), errors='surrogate_or_strict'))
+                req_fd.write(to_bytes(safe_dump({'collections': requirements}), errors='surrogate_or_strict'))
 
 
 def publish_collection(collection_path, api, wait, timeout):
@@ -870,7 +870,7 @@ def _get_galaxy_yml(b_galaxy_yml_path):
 
     try:
         with open(b_galaxy_yml_path, 'rb') as g_yaml:
-            galaxy_yml = yaml.safe_load(g_yaml)
+            galaxy_yml = safe_load(g_yaml)
     except YAMLError as err:
         raise AnsibleError("Failed to parse the galaxy.yml at '%s' with the following error:\n%s"
                            % (to_native(b_galaxy_yml_path), to_native(err)))

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -27,7 +27,6 @@ import datetime
 import os
 import tarfile
 import tempfile
-import yaml
 from distutils.version import LooseVersion
 from shutil import rmtree
 
@@ -38,6 +37,7 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import open_url
 from ansible.playbook.role.requirement import RoleRequirement
 from ansible.utils.display import Display
+from ansible.utils.yaml import safe_dump, safe_load
 
 display = Display()
 
@@ -111,7 +111,7 @@ class GalaxyRole(object):
                     if os.path.isfile(meta_path):
                         try:
                             with open(meta_path, 'r') as f:
-                                self._metadata = yaml.safe_load(f)
+                                self._metadata = safe_load(f)
                         except Exception:
                             display.vvvvv("Unable to load metadata for %s" % self.name)
                             return False
@@ -130,7 +130,7 @@ class GalaxyRole(object):
             if os.path.isfile(info_path):
                 try:
                     f = open(info_path, 'r')
-                    self._install_info = yaml.safe_load(f)
+                    self._install_info = safe_load(f)
                 except Exception:
                     display.vvvvv("Unable to load Galaxy install info for %s" % self.name)
                     return False
@@ -162,7 +162,7 @@ class GalaxyRole(object):
         info_path = os.path.join(self.path, self.META_INSTALL)
         with open(info_path, 'w+') as f:
             try:
-                self._install_info = yaml.safe_dump(info, f)
+                self._install_info = safe_dump(info, f)
             except Exception:
                 return False
 
@@ -299,7 +299,7 @@ class GalaxyRole(object):
                     raise AnsibleError("this role does not appear to have a meta/main.yml file.")
                 else:
                     try:
-                        self._metadata = yaml.safe_load(role_tar_file.extractfile(meta_file))
+                        self._metadata = safe_load(role_tar_file.extractfile(meta_file))
                     except Exception:
                         raise AnsibleError("this role does not appear to have a valid meta/main.yml file.")
 
@@ -388,7 +388,7 @@ class GalaxyRole(object):
                 if os.path.isfile(meta_path):
                     try:
                         f = open(meta_path, 'r')
-                        self._requirements = yaml.safe_load(f)
+                        self._requirements = safe_load(f)
                     except Exception:
                         display.vvvvv("Unable to load requirements for %s" % self.name)
                     finally:

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -26,13 +26,12 @@ import os
 import json
 from stat import S_IRUSR, S_IWUSR
 
-import yaml
-
 from ansible import constants as C
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
+from ansible.utils.yaml import safe_dump, safe_load
 
 display = Display()
 
@@ -126,7 +125,7 @@ class GalaxyToken(object):
             action = 'Created'
 
         with open(self.b_file, 'r') as f:
-            config = yaml.safe_load(f)
+            config = safe_load(f)
 
         display.vvv('%s %s' % (action, to_text(self.b_file)))
 
@@ -141,7 +140,7 @@ class GalaxyToken(object):
 
     def save(self):
         with open(self.b_file, 'w') as f:
-            yaml.safe_dump(self.config, f, default_flow_style=False)
+            safe_dump(self.config, f, default_flow_style=False)
 
     def headers(self):
         headers = {}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -60,6 +60,11 @@ display = Display()
 
 UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 
+try:
+    yaml_SafeLoader = yaml.CSafeLoader
+except AttributeError:
+    yaml_SafeLoader = yaml.SafeLoader
+
 
 def to_yaml(a, *args, **kw):
     '''Make verbose, human readable yaml'''
@@ -211,14 +216,14 @@ def regex_escape(string, re_type='python'):
 def from_yaml(data):
     if isinstance(data, string_types):
         # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
-        return yaml.safe_load(unwrap_var(data))
+        return yaml.load(unwrap_var(data), Loader=yaml_SafeLoader)
     return data
 
 
 def from_yaml_all(data):
     if isinstance(data, string_types):
         # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
-        return yaml.safe_load_all(unwrap_var(data))
+        return yaml.load_all(unwrap_var(data), Loader=yaml_SafeLoader)
     return data
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -55,7 +55,7 @@ from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
 from ansible.utils.unsafe_proxy import unwrap_var
 from ansible.utils.vars import merge_hash
-from ansible.utils.yaml import safe_load
+from ansible.utils.yaml import safe_load, safe_load_all
 
 display = Display()
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -55,15 +55,11 @@ from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
 from ansible.utils.unsafe_proxy import unwrap_var
 from ansible.utils.vars import merge_hash
+from ansible.utils.yaml import safe_load
 
 display = Display()
 
 UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
-
-try:
-    yaml_SafeLoader = yaml.CSafeLoader
-except AttributeError:
-    yaml_SafeLoader = yaml.SafeLoader
 
 
 def to_yaml(a, *args, **kw):
@@ -216,14 +212,14 @@ def regex_escape(string, re_type='python'):
 def from_yaml(data):
     if isinstance(data, string_types):
         # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
-        return yaml.load(unwrap_var(data), Loader=yaml_SafeLoader)
+        return safe_load(unwrap_var(data))
     return data
 
 
 def from_yaml_all(data):
     if isinstance(data, string_types):
         # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
-        return yaml.load_all(unwrap_var(data), Loader=yaml_SafeLoader)
+        return safe_load_all(unwrap_var(data))
     return data
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -53,6 +53,7 @@ from ansible.utils.display import Display
 from ansible.utils.encrypt import passlib_or_crypt
 from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
+from ansible.utils.unsafe_proxy import unwrap_var
 from ansible.utils.vars import merge_hash
 
 display = Display()
@@ -209,13 +210,15 @@ def regex_escape(string, re_type='python'):
 
 def from_yaml(data):
     if isinstance(data, string_types):
-        return yaml.safe_load(data)
+        # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
+        return yaml.safe_load(unwrap_var(data))
     return data
 
 
 def from_yaml_all(data):
     if isinstance(data, string_types):
-        return yaml.safe_load_all(data)
+        # We use ``unwrap_var`` here because the c pyyaml extension cannot handle AnsibleUnsafeText
+        return yaml.safe_load_all(unwrap_var(data))
     return data
 
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -39,12 +39,6 @@ except ImportError:
     Version = None
 
 try:
-    # use C version if possible for speedup
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
-
-try:
     import importlib.util
     imp = None
 except ImportError:

--- a/lib/ansible/utils/collection_loader/_collection_meta.py
+++ b/lib/ansible/utils/collection_loader/_collection_meta.py
@@ -4,16 +4,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from yaml import load
-try:
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
-
 try:
     from collections.abc import Mapping   # pylint: disable=ansible-bad-import-from
 except ImportError:
     from collections import Mapping  # pylint: disable=ansible-bad-import-from
+
+from ansible.utils.yaml import safe_load
 
 
 def _meta_yml_to_dict(yaml_string_data, content_id):
@@ -25,7 +21,7 @@ def _meta_yml_to_dict(yaml_string_data, content_id):
     :return: a Python dictionary representing the YAML dictionary content
     """
     # NB: content_id is passed in, but not used by this implementation
-    routing_dict = load(yaml_string_data, Loader=SafeLoader)
+    routing_dict = safe_load(yaml_string_data)
     if not routing_dict:
         routing_dict = {}
     if not isinstance(routing_dict, Mapping):

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -134,7 +134,7 @@ def wrap_var(v):
     elif isinstance(v, Set):
         return _wrap_set(v)
     elif isinstance(v, Mapping):
-        return_wrap_dict(v)
+        return _wrap_dict(v)
     elif is_sequence(v):
         return _wrap_sequence(v)
 

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -148,7 +148,7 @@ def to_unsafe_bytes(*args, **kwargs):
 
 def to_unsafe_text(*args, **kwargs):
     """Convert a value to text, and wrap with ``AnsibleUnsafeText``"""
-    return wrap_var(to_text(*args, **kwargs))
+    return AnsibleUnsafeText(to_text(*args, **kwargs))
 
 
 def unwrap_var(v):

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -166,6 +166,9 @@ def unwrap_var(v):
         return binary_type(v)
     elif isinstance(v, AnsibleUnsafeText):
         return text_type(v)
+    elif isinstance(v, (binary_type, text_type)):
+        # Forward thinking short circuit, to allow for other immutable sequences later
+        return v
     elif isinstance(v, Set):
         return set(unwrap_var(value) for value in v)
     elif isinstance(v, Mapping):

--- a/lib/ansible/utils/yaml.py
+++ b/lib/ansible/utils/yaml.py
@@ -1,0 +1,28 @@
+# (c) 2020 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+This file provides ease of use shortcuts for loading and dumping YAML,
+preferring the YAML compiled C extensions to reduce duplicated code.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from functools import partial
+
+import yaml
+
+try:
+    SafeLoader = yaml.CSafeLoader
+    SafeDumper = yaml.CSafeDumper
+except AttributeError:
+    SafeLoader = yaml.SafeLoader
+    SafeDumper = yaml.SafeDumper
+
+
+safe_load = partial(yaml.load, Loader=SafeLoader)
+safe_load_all = partial(yaml.load_all, Loader=SafeLoader)
+
+safe_dump = partial(yaml.dump, Dumper=SafeDumper)
+safe_dump_all = partial(yaml.dump_all, Dumper=SafeDumper)

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -377,6 +377,18 @@
       - "2|from_yaml == 2"
       - "'---\nbananas: yellow\n---\napples: red'|from_yaml_all|list == [{'bananas': 'yellow'}, {'apples': 'red'}]"
       - "2|from_yaml_all == 2"
+      - 'unsafe_yaml|from_yaml == {"bananas": "yellow", "apples": "red"}'
+      - 'unsafe_yaml_all|from_yaml_all|list == [{"bananas": "yellow"}, {"apples": "red"}]'
+  vars:
+    unsafe_yaml: !unsafe |
+      ---
+      bananas: yellow
+      apples: red
+    unsafe_yaml_all: !unsafe |
+      ---
+      bananas: yellow
+      ---
+      apples: red
 
 - name: Verify random raises on non-iterable input (failure expected)
   set_fact:

--- a/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.json
+++ b/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.json
@@ -1,0 +1,10 @@
+{
+    "extensions": [
+        ".py"
+    ],
+    "prefixes": [
+        "lib/ansible/",
+        "plugins/"
+    ],
+    "output": "path-line-column-message"
+}

--- a/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.json
+++ b/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.json
@@ -6,5 +6,5 @@
         "lib/ansible/",
         "plugins/"
     ],
-    "output": "path-line-column-message"
+    "output": "path-message"
 }

--- a/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import sys
+
+ASSERT_RE = re.compile(r'^.*\bunwrap_var\(')
+
+WHITELIST = frozenset((
+    'lib/ansible/utils/unsafe_proxy.py',
+))
+
+def main():
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
+        if path in WHITELIST:
+            continue
+        with open(path, 'r') as f:
+            for i, line in enumerate(f.readlines()):
+                matches = ASSERT_RE.findall(line)
+                if matches:
+                    lineno = i + 1
+                    colno = line.index('unwrap_var') + 1
+                    print(
+                        '%s:%d:%d: use of unwrap_var is strictly monitored for incorrect use: %s' % (path, lineno, colno, matches[0][colno - 1:])
+                    )
+
+
+if __name__ == '__main__':
+    main()

--- a/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
@@ -11,6 +11,7 @@ UNWRAP_RE = re.compile(r'^.*\bunwrap_var\(')
 # All changes to the whitelist need to be approved by an Ansible core committer
 WHITELIST = {
     'lib/ansible/utils/unsafe_proxy.py': 4,
+    'lib/ansible/plugins/filter/core.py': 2,
 }
 
 

--- a/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/unwrap-unsafe.py
@@ -13,11 +13,12 @@ WHITELIST = {
     'lib/ansible/utils/unsafe_proxy.py': 4,
 }
 
+
 def main():
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
         found = 0
         with open(path, 'r') as f:
-            for i, line in enumerate(f.readlines()):
+            for line in f.readlines():
                 matches = UNWRAP_RE.findall(line)
                 if matches:
                     found += 1

--- a/test/units/utils/test_unsafe_proxy.py
+++ b/test/units/utils/test_unsafe_proxy.py
@@ -143,7 +143,7 @@ def test_unwrap_var():
     assert not isinstance(out['dict']['text'], AnsibleUnsafe)
     assert not isinstance(out['list'][0], AnsibleUnsafe)
     assert not isinstance(next(iter(out['set'])), AnsibleUnsafe)
-    assert isinstance(out['tuple'][0], AnsibleUnsafe)
+    assert not isinstance(out['tuple'][0], AnsibleUnsafe)
     assert not isinstance(out['unwrapped_text'], AnsibleUnsafe)
     assert not isinstance(out['unwrapped_non_ascii'], AnsibleUnsafe)
     assert not isinstance(out['unwrapped_bytes'], AnsibleUnsafe)

--- a/test/units/utils/test_unsafe_proxy.py
+++ b/test/units/utils/test_unsafe_proxy.py
@@ -131,7 +131,10 @@ def test_unwrap_var():
         'tuple': (
             AnsibleUnsafeText(u'text'),
             AnsibleUnsafeBytes(b'bytes'),
-        )
+        ),
+        'unwrapped_text': u'text',
+        'unwrapped_bytes': b'bytes',
+        'unwrapped_non_ascii': u'café',
     }
 
     out = unwrap_var(value)
@@ -141,4 +144,7 @@ def test_unwrap_var():
     assert not isinstance(out['list'][0], AnsibleUnsafe)
     assert not isinstance(next(iter(out['set'])), AnsibleUnsafe)
     assert isinstance(out['tuple'][0], AnsibleUnsafe)
+    assert not isinstance(out['unwrapped_text'], AnsibleUnsafe)
+    assert not isinstance(out['unwrapped_non_ascii'], AnsibleUnsafe)
+    assert not isinstance(out['unwrapped_bytes'], AnsibleUnsafe)
     assert not isinstance(unwrap_var(AnsibleUnsafeText(u'text')), AnsibleUnsafe)

--- a/test/units/utils/test_unsafe_proxy.py
+++ b/test/units/utils/test_unsafe_proxy.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.six import PY3
-from ansible.utils.unsafe_proxy import AnsibleUnsafe, AnsibleUnsafeBytes, AnsibleUnsafeText, wrap_var
+from ansible.utils.unsafe_proxy import AnsibleUnsafe, AnsibleUnsafeBytes, AnsibleUnsafeText, unwrap_var, wrap_var
 
 
 def test_wrap_var_text():
@@ -108,3 +108,37 @@ def test_AnsibleUnsafeText():
 
 def test_AnsibleUnsafeBytes():
     assert isinstance(AnsibleUnsafeBytes(b'foo'), AnsibleUnsafe)
+
+
+def test_unwrap_var():
+    value = {
+        'text': AnsibleUnsafeText(u'text'),
+        'bytes': AnsibleUnsafeBytes(b'bytes'),
+        'dict': {
+            'text': AnsibleUnsafeText(u'text'),
+            'bytes': AnsibleUnsafeBytes(b'bytes'),
+        },
+        'list': [
+            AnsibleUnsafeText(u'text'),
+            AnsibleUnsafeBytes(b'bytes'),
+        ],
+        'set': set(
+            (
+                AnsibleUnsafeText(u'text'),
+                AnsibleUnsafeBytes(b'bytes'),
+            )
+        ),
+        'tuple': (
+            AnsibleUnsafeText(u'text'),
+            AnsibleUnsafeBytes(b'bytes'),
+        )
+    }
+
+    out = unwrap_var(value)
+    assert not isinstance(out['text'], AnsibleUnsafe)
+    assert not isinstance(out['bytes'], AnsibleUnsafe)
+    assert not isinstance(out['dict']['text'], AnsibleUnsafe)
+    assert not isinstance(out['list'][0], AnsibleUnsafe)
+    assert not isinstance(next(iter(out['set'])), AnsibleUnsafe)
+    assert isinstance(out['tuple'][0], AnsibleUnsafe)
+    assert not isinstance(unwrap_var(AnsibleUnsafeText(u'text')), AnsibleUnsafe)


### PR DESCRIPTION
##### SUMMARY
Fixes #70357
Add `unwrap_var` function to remove unsafe wrappers

Use of this new function should be strictly monitored, to ensure proper use.

TODO:

- [x] changelog
- [x] CI step to fail PRs that make use of `unwrap_var` unless some explicit acceptance is performed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/utils/unsafe_proxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
