### PR TITLE
Make Docker and Podman play nice

### DIFF
--- a/test/integration/targets/inventory_docker_swarm/playbooks/swarm_cleanup.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/swarm_cleanup.yml
@@ -1,9 +1,18 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: yes
   tasks:
     - name: Make sure swarm is removed
       docker_swarm:
         state: absent
         force: yes
+
+    - name: remove docker pagkages
+      action: "{{ ansible_facts.pkg_mgr }}"
+      args:
+        name:
+          - docker
+          - docker-ce
+          - docker-ce-cli
+        state: absent

--- a/test/integration/targets/inventory_docker_swarm/playbooks/swarm_setup.yml
+++ b/test/integration/targets/inventory_docker_swarm/playbooks/swarm_setup.yml
@@ -1,10 +1,14 @@
 ---
 - hosts: 127.0.0.1
   connection: local
+  vars:
+    docker_skip_cleanup: yes
+
   tasks:
     - name: Setup docker
-      include_role:
+      import_role:
         name: setup_docker
+
     - name: Create a Swarm cluster
       docker_swarm:
         state: present

--- a/test/integration/targets/setup_docker/defaults/main.yml
+++ b/test/integration/targets/setup_docker/defaults/main.yml
@@ -1,6 +1,7 @@
 docker_cli_version: '0.0'
 docker_api_version: '0.0'
 docker_py_version: '0.0'
+docker_skip_cleanup: no
 docker_prereq_packages: []
 docker_packages:
   - docker-ce

--- a/test/integration/targets/setup_docker/defaults/main.yml
+++ b/test/integration/targets/setup_docker/defaults/main.yml
@@ -8,3 +8,8 @@ docker_packages:
 docker_pip_extra_packages: []
 docker_pip_packages:
   - docker
+
+docker_cleanup_packages:
+  - docker
+  - docker-ce
+  - docker-ce-cli

--- a/test/integration/targets/setup_docker/handlers/main.yml
+++ b/test/integration/targets/setup_docker/handlers/main.yml
@@ -1,0 +1,12 @@
+- name: remove pip packages
+  pip:
+    state: present
+    name: "{{ docker_pip_packages | union(docker_pip_extra_packages) }}"
+  listen: cleanup docker
+
+- name: remove docker pagkages
+  action: "{{ ansible_facts.pkg_mgr }}"
+  args:
+    name: "{{ docker_cleanup_packages }}"
+    state: absent
+  listen: cleanup docker

--- a/test/integration/targets/setup_docker/handlers/main.yml
+++ b/test/integration/targets/setup_docker/handlers/main.yml
@@ -3,6 +3,7 @@
     state: present
     name: "{{ docker_pip_packages | union(docker_pip_extra_packages) }}"
   listen: cleanup docker
+  when: not docker_skip_cleanup | bool
 
 - name: remove docker pagkages
   action: "{{ ansible_facts.pkg_mgr }}"
@@ -10,3 +11,4 @@
     name: "{{ docker_cleanup_packages }}"
     state: absent
   listen: cleanup docker
+  when: not docker_skip_cleanup | bool

--- a/test/integration/targets/setup_docker/tasks/Debian.yml
+++ b/test/integration/targets/setup_docker/tasks/Debian.yml
@@ -7,6 +7,7 @@
     name: "{{ docker_prereq_packages }}"
     state: present
     update_cache: yes
+  notify: cleanup docker
 
 - name: Add gpg key
   shell: curl -fsSL https://download.docker.com/linux/ubuntu/gpg >key && apt-key add key

--- a/test/integration/targets/setup_docker/tasks/Fedora.yml
+++ b/test/integration/targets/setup_docker/tasks/Fedora.yml
@@ -18,3 +18,4 @@
     name: "{{ docker_packages }}"
     state: present
     enablerepo: docker-ce-test
+  notify: cleanup docker

--- a/test/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -5,6 +5,7 @@
   yum:
     name: "{{ docker_prereq_packages }}"
     state: present
+  notify: cleanup docker
 
 - name: Install epel repo which is missing on rhel-7 and is needed for pigz (needed for docker-ce 18)
   include_role:
@@ -29,6 +30,7 @@
   yum:
     name: "{{ docker_packages }}"
     state: present
+  notify: cleanup docker
 
 - name: Make sure the docker daemon is running (failure expected inside docker container)
   service:

--- a/test/integration/targets/setup_docker/tasks/RedHat-8.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-8.yml
@@ -5,6 +5,7 @@
   dnf:
     name: "{{ docker_prereq_packages }}"
     state: present
+  notify: cleanup docker
 
 - name: Set-up repository
   command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
@@ -15,6 +16,7 @@
   dnf:
     name: "{{ docker_packages }}"
     state: present
+  notify: cleanup docker
 
 - name: Make sure the docker daemon is running (failure expected inside docker container)
   service:

--- a/test/integration/targets/setup_docker/tasks/Suse.yml
+++ b/test/integration/targets/setup_docker/tasks/Suse.yml
@@ -4,3 +4,4 @@
     force: yes
     disable_gpg_check: yes
     update_cache: yes
+  notify: cleanup docker

--- a/test/integration/targets/setup_docker/tasks/main.yml
+++ b/test/integration/targets/setup_docker/tasks/main.yml
@@ -12,7 +12,7 @@
             - "{{ ansible_facts.os_family }}.yml"
             - default.yml
           paths:
-            - vars
+            - "{{ role_path }}/vars"
 
     - name: Include distribution specific tasks
       include_tasks: "{{ lookup('first_found', params) }}"
@@ -24,13 +24,14 @@
             - "{{ ansible_facts.distribution }}.yml"
             - "{{ ansible_facts.os_family }}.yml"
           paths:
-            - tasks
+            - "{{ role_path }}/tasks"
 
     - name: Install Python requirements
       pip:
         state: present
         name: "{{ docker_pip_packages | union(docker_pip_extra_packages) }}"
         extra_args: "-c {{ remote_constraints }}"
+      notify: cleanup docker
 
     # Detect docker CLI, API and docker-py versions
     - name: Check Docker CLI version

--- a/test/integration/targets/setup_podman/handlers/main.yml
+++ b/test/integration/targets/setup_podman/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: remove podman packages
+  yum:
+    name: 'podman*'
+    state: absent
+  listen: cleanup podman
+
+- name: remove extras repo
+  command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version]['disable'] | default('echo') }}"
+  listen: cleanup podman

--- a/test/integration/targets/setup_podman/tasks/main.yml
+++ b/test/integration/targets/setup_podman/tasks/main.yml
@@ -1,12 +1,14 @@
 - block:
     - name: Enable extras repo
-      command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version] | default('echo') }}"
+      command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version]['enable'] | default('echo') }}"
+      notify: cleanup podman
 
     - name: Install podman
       yum:
         name: "{{ podman_package }}"
         state: present
       when: ansible_facts.pkg_mgr in ['yum', 'dnf']
+      notify: cleanup podman
 
     - name: Get podman version
       command: podman --version

--- a/test/integration/targets/setup_podman/vars/main.yml
+++ b/test/integration/targets/setup_podman/vars/main.yml
@@ -1,2 +1,4 @@
 repo_command:
-  RedHat7: yum-config-manager --enable rhui-REGION-rhel-server-extras
+  RedHat7:
+    enable: yum-config-manager --enable rhui-REGION-rhel-server-extras
+    disable: yum-config-manager --disable rhui-REGION-rhel-server-extras


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`podman` 1.4 now installs `docker` man pages. Add handlers to `setup_docker` and `setup_podman` roles to remove packages, avoiding this conflict.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
[Here](https://app.shippable.com/github/ansible/ansible/runs/151023/76/tests) is an example of the failure.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_docker/`
`test/integration/targets/setup_podman/`
`test/integration/targets/inventory_docker_swarm/`