### PR TITLE
docker_container and docker_network: avoid None errors

### DIFF
--- a/changelogs/fragments/65018-docker-none-errors.yml
+++ b/changelogs/fragments/65018-docker-none-errors.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "docker_container - fix network idempotence comparison error."
+- "docker_network - fix idempotence comparison error."

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -2263,7 +2263,7 @@ class Container(DockerBaseClass):
                 ))
             else:
                 diff = False
-                network_info_ipam = network_info.get('IPAMConfig', {})
+                network_info_ipam = network_info.get('IPAMConfig') or {}
                 if network.get('ipv4_address') and network['ipv4_address'] != network_info_ipam.get('IPv4Address'):
                     diff = True
                 if network.get('ipv6_address') and network['ipv6_address'] != network_info_ipam.get('IPv6Address'):

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -562,6 +562,8 @@ class DockerNetworkManager(object):
             self.results['changed'] = True
 
     def is_container_connected(self, container_name):
+        if not self.existing_network:
+            return False
         return container_name in container_names_in_network(self.existing_network)
 
     def connect_containers(self):


### PR DESCRIPTION
##### SUMMARY
While trying something, I found two errors in docker_container and docker_network where `None` is subscripted or a method of `None` is called w.r.t. networks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_container
docker_network
