### PR TITLE
Add aws elb multiple host header support

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -720,7 +720,7 @@ class ELBListenerRules(object):
                         current_condition['SourceIpConfig']['Values'][0] == condition['SourceIpConfig']['Values'][0]):
                     condition_found = True
                     break
-            elif current_condition['Field'] == condition['Field'] and current_condition['Values'][0] == condition['Values'][0]:
+            elif current_condition['Field'] == condition['Field'] and current_condition['Values'] == condition['Values']:
                 condition_found = True
                 break
 
@@ -735,7 +735,7 @@ class ELBListenerRules(object):
         modified_rule = {}
 
         # Priority
-        if int(current_rule['Priority']) != new_rule['Priority']:
+        if int(current_rule['Priority']) != int(new_rule['Priority']):
             modified_rule['Priority'] = new_rule['Priority']
 
         # Actions
@@ -757,8 +757,6 @@ class ELBListenerRules(object):
             if len(current_rule['Actions']) == 1 and len(new_rule['Actions']) == 1:
                 if current_rule['Actions'] != new_rule['Actions']:
                     modified_rule['Actions'] = new_rule['Actions']
-                    print("modified_rule:")
-                    print(new_rule['Actions'])
             # if actions have multiple elements, we'll have to order them first before comparing.
             # multiple actions will have an 'Order' key for this purpose
             else:

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -297,7 +297,7 @@ EXAMPLES = '''
               - Field: host-header
                 Values:
                   - "hostname.domain.com"
-                  - "alternate.domain.com
+                  - "alternate.domain.com"
             Priority: '4'
             Actions:
               - TargetGroupName: test-target-group

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -293,6 +293,15 @@ EXAMPLES = '''
                   ContentType: "text/plain"
                   MessageBody: "This is the page you're looking for"
                   StatusCode: "200"
+          - Conditions:
+              - Field: host-header
+                Values:
+                  - "hostname.domain.com"
+                  - "alternate.domain.com
+            Priority: '4'
+            Actions:
+              - TargetGroupName: test-target-group
+                Type: forward
     state: present
 
 # Remove an ELB

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -117,9 +117,6 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 3
-  - name:
-    debug:
-      msg: "{{ alb }}"
 
   - name: add a rule that uses the host header condition to the listener
     elb_application_lb:
@@ -145,14 +142,6 @@
                   Type: forward
       <<: *aws_connection_info
     register: alb
-
-  - name:
-    debug:
-      msg: "{{ alb }}"
-
-  - name:
-    debug:
-      msg: Number of alb rules "{{ alb.listeners[0].rules|length }}"
 
   - assert:
       that:
@@ -191,9 +180,6 @@
         - alb.changed
         - alb.listeners[0].rules|length == 4
         - '{{ alb|json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 2 }}'
-  - name:
-    debug:
-      msg: "{{ alb }}"
 
   - name: remove the rule
     elb_application_lb:

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -190,6 +190,7 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 4
+        - '{{ alb|json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 2 }}'
   - name:
     debug:
       msg: "{{ alb }}"

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -117,6 +117,81 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 3
+  - name:
+    debug:
+      msg: "{{ alb }}"
+
+  - name: add a rule that uses the host header condition to the listener
+    elb_application_lb:
+      name: "{{ alb_name }}"
+      subnets: "{{ alb_subnets }}"
+      security_groups: "{{ sec_group.group_id }}"
+      state: present
+      purge_rules: no
+      listeners:
+        - Protocol: HTTP
+          Port: 80
+          DefaultActions:
+            - Type: forward
+              TargetGroupName: "{{ tg_name }}"
+          Rules:
+            - Conditions:
+                - Field: host-header
+                  Values:
+                    - 'local.mydomain.com'
+              Priority: '3'
+              Actions:
+                - TargetGroupName: "{{ tg_name }}"
+                  Type: forward
+      <<: *aws_connection_info
+    register: alb
+
+  - name:
+    debug:
+      msg: "{{ alb }}"
+
+  - name:
+    debug:
+      msg: Number of alb rules "{{ alb.listeners[0].rules|length }}"
+
+  - assert:
+      that:
+        - alb.changed
+        - alb.listeners[0].rules|length == 4
+
+  - name: test replacing the rule that uses the host header condition with multiple host header conditions
+    elb_application_lb:
+      name: "{{ alb_name }}"
+      subnets: "{{ alb_subnets }}"
+      security_groups: "{{ sec_group.group_id }}"
+      purge_rules: no
+      state: present
+      listeners:
+        - Protocol: HTTP
+          Port: 80
+          DefaultActions:
+            - Type: forward
+              TargetGroupName: "{{ tg_name }}"
+          Rules:
+            - Conditions:
+                - Field: host-header
+                  Values:
+                    - 'local.mydomain.com'
+                    - 'alternate.mydomain.com'
+              Priority: '3'
+              Actions:
+                - TargetGroupName: "{{ tg_name }}"
+                  Type: forward
+      <<: *aws_connection_info
+    register: alb
+
+  - assert:
+      that:
+        - alb.changed
+        - alb.listeners[0].rules|length == 4
+  - name:
+    debug:
+      msg: "{{ alb }}"
 
   - name: remove the rule
     elb_application_lb:

--- a/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
+++ b/test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml
@@ -158,6 +158,7 @@
       that:
         - alb.changed
         - alb.listeners[0].rules|length == 4
+        - '{{ alb|json_query("listeners[].rules[].conditions[].host_header_config.values[]")|length  == 1 }}'
 
   - name: test replacing the rule that uses the host header condition with multiple host header conditions
     elb_application_lb:


### PR DESCRIPTION
##### SUMMARY
Adds support of multiple host header values. This allows elb rules to look for the existence of multiple host-headers associated with a particular elb rule.

- Removes a print statement that caused incorrectly formatted JSON to be returned
- Casts a string as an integer in rule priority comparison
- Compare all current_condition values to condition values.

Fixes #65020
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
elbv2