### PR TITLE
Fix ansible-test handling of git submodules.

### DIFF
--- a/changelogs/fragments/ansible-test-git-submodule.yml
+++ b/changelogs/fragments/ansible-test-git-submodule.yml
@@ -1,0 +1,5 @@
+bugfixes:
+    - ansible-test now properly handles enumeration of git submodules.
+      Enumeration is now done with ``git submodule status --recursive`` without specifying ``.`` for the path, since that could cause the command to fail.
+      Instead, relative paths outside the current directory are filtered out of the results.
+      Errors from ``git`` commands will now once again be reported as errors instead of warnings.

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -39,9 +39,19 @@ class Git:
 
     def get_submodule_paths(self):  # type: () -> t.List[str]
         """Return a list of submodule paths recursively."""
-        cmd = ['submodule', 'status', '--recursive', '.']
+        cmd = ['submodule', 'status', '--recursive']
         output = self.run_git_split(cmd, '\n')
         submodule_paths = [re.search(r'^.[0-9a-f]+ (?P<path>[^ ]+)', line).group('path') for line in output]
+
+        # status is returned for all submodules in the current git repository relative to the current directory
+        # when the current directory is not the root of the git repository this can yield relative paths which are not below the current directory
+        # this can occur when multiple collections are in a git repo and some collections are submodules when others are not
+        # specifying "." as the path to enumerate would limit results to the current directory, but can cause the git command to fail with the error:
+        #   error: pathspec '.' did not match any file(s) known to git
+        # this can occur when the current directory contains no files tracked by git
+        # instead we'll filter out the relative paths, since we're only interested in those at or below the current directory
+        submodule_paths = [path for path in submodule_paths if not path.startswith('../')]
+
         return submodule_paths
 
     def get_file_names(self, args):

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -8,9 +8,7 @@ from . import types as t
 
 from .util import (
     SubprocessError,
-    display,
     raw_command,
-    to_text,
 )
 
 
@@ -126,8 +124,4 @@ class Git:
         :type str_errors: str
         :rtype: str
         """
-        try:
-            return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]
-        except SubprocessError as spe:
-            display.warning(to_text(spe.message))
-            return spe.stdout
+        return raw_command([self.git] + cmd, cwd=self.root, capture=True, str_errors=str_errors)[0]


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test handling of git submodules.

Enumeration is now done with `git submodule status --recursive` without specifying `.` for the path, since that could cause the command to fail. Instead, relative paths outside the current directory are filtered out of the results. Errors from `git` commands will now once again be reported as errors instead of warnings.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
