### PR TITLE
vmware_guest: Revert custom value customization in guest

### DIFF
--- a/changelogs/fragments/vmware_guest_restore_custom_values.yml
+++ b/changelogs/fragments/vmware_guest_restore_custom_values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Revert customization of guest custom value behavior (https://github.com/ansible/ansible/issues/64291).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1716,27 +1716,29 @@ class PyVmomiHelper(PyVmomi):
             self.configspec.vAppConfig = new_vmconfig_spec
             self.change_detected = True
 
-    def customize_customvalues(self, vm_obj):
+    def customize_customvalues(self, vm_obj, config_spec):
         if len(self.params['customvalues']) == 0:
             return
 
+        vm_custom_spec = config_spec
+        vm_custom_spec.extraConfig = []
+
+        changed = False
         facts = self.gather_facts(vm_obj)
         for kv in self.params['customvalues']:
             if 'key' not in kv or 'value' not in kv:
                 self.module.exit_json(msg="customvalues items required both 'key' and 'value' fields.")
 
-            key_id = None
-            for field in self.content.customFieldsManager.field:
-                if field.name == kv['key']:
-                    key_id = field.key
-                    break
-
-            if not key_id:
-                self.module.fail_json(msg="Unable to find custom value key %s" % kv['key'])
-
             # If kv is not kv fetched from facts, change it
             if kv['key'] not in facts['customvalues'] or facts['customvalues'][kv['key']] != kv['value']:
-                self.content.customFieldsManager.SetField(entity=vm_obj, key=key_id, value=kv['value'])
+                option = vim.option.OptionValue()
+                option.key = kv['key']
+                option.value = kv['value']
+
+                vm_custom_spec.extraConfig.append(option)
+                changed = True
+
+            if changed:
                 self.change_detected = True
 
     def customize_vm(self, vm_obj):
@@ -2518,7 +2520,12 @@ class PyVmomiHelper(PyVmomi):
                     return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'annotation'}
 
             if self.params['customvalues']:
-                self.customize_customvalues(vm_obj=vm)
+                vm_custom_spec = vim.vm.ConfigSpec()
+                self.customize_customvalues(vm_obj=vm, config_spec=vm_custom_spec)
+                task = vm.ReconfigVM_Task(vm_custom_spec)
+                self.wait_for_task(task)
+                if task.info.state == 'error':
+                    return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'customvalues'}
 
             if self.params['wait_for_ip_address'] or self.params['wait_for_customization'] or self.params['state'] in ['poweredon', 'restarted']:
                 set_vm_power_state(self.content, vm, 'poweredon', force=False)
@@ -2556,7 +2563,7 @@ class PyVmomiHelper(PyVmomi):
         self.configure_disks(vm_obj=self.current_vm_obj)
         self.configure_network(vm_obj=self.current_vm_obj)
         self.configure_cdrom(vm_obj=self.current_vm_obj)
-        self.customize_customvalues(vm_obj=self.current_vm_obj)
+        self.customize_customvalues(vm_obj=self.current_vm_obj, config_spec=self.configspec)
         self.configure_resource_alloc_info(vm_obj=self.current_vm_obj)
         self.configure_vapp_properties(vm_obj=self.current_vm_obj)
 


### PR DESCRIPTION
##### SUMMARY

Due to confusion between 'Custom Attributes' and 'Advanced options',
this change got in devel. Revert to original behavior i.e. customizing
custom values using vmware_guest is done in this PR.

Fixes: #64291

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/vmware_guest_restore_custom_values.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
