### PR TITLE
IBM Spectrum Virtulize Family Storages support for Ansible

### DIFF
--- a/lib/ansible/module_utils/ibm_svc_utils.py
+++ b/lib/ansible/module_utils/ibm_svc_utils.py
@@ -74,7 +74,7 @@ class IBMSVCRestApi(object):
 
         # Make sure we can connect via the RestApi
         self.token = self._svc_authorize()
-        self.debug("_connect token={}".format(self.token))
+        self.debug("_connect token=%s", self.token)
         if not self.token:
             self.module.fail_json(msg='Failed to obtain access token')
 
@@ -92,9 +92,9 @@ class IBMSVCRestApi(object):
             hostname = '{}.{}'.format(self.clustername, self.domain)
         else:
             hostname = self.clustername
-        return getattr(self, '_resturl',
-                       None) or "{protocol}://{host}:{port}/rest".format(
-            protocol=self.protocol, host=hostname, port=self.port)
+        return (getattr(self, '_resturl', None)
+                or "{protocol}://{host}:{port}/rest".format(
+                    protocol=self.protocol, host=hostname, port=self.port))
 
     @property
     def token(self):
@@ -133,31 +133,31 @@ class IBMSVCRestApi(object):
             postfix = '/'.join([postfix] + [quote(str(a)) for a in cmdargs])
         url = '/'.join([self.resturl] + [postfix])
         r['url'] = url  # Pass back in result for error handling
-        self.debug("_svc_rest: url={}".format(url))
+        self.debug("_svc_rest: url=%s", url)
 
         payload = cmdopts if cmdopts else None
         data = jsonify(payload, encoding="utf-8")
         r['data'] = cmdopts  # Original payload data has nicer formatting
-        self.debug("_svc_rest: payload={}".format(payload))
+        self.debug("_svc_rest: payload=%s", payload)
 
         try:
             o = open_url(url, method=method, headers=headers,
                          validate_certs=self.validate_certs, data=bytes(data))
         except HTTPError as e:
-            self.debug('_svc_rest: httperror {}'.format(str(e)))
+            self.debug('_svc_rest: httperror %s', str(e))
             r['code'] = e.getcode()
             r['out'] = e.read()
-            r['err'] = "HTTPError {}".format(str(e))
+            r['err'] = "HTTPError %s", str(e)
             return r
         except Exception as e:
-            self.debug('_svc_rest: exception : {}'.format(str(e)))
-            r['err'] = "Exception {}".format(str(e))
+            self.debug('_svc_rest: exception : %s', str(e))
+            r['err'] = "Exception %s", str(e)
             return r
 
         try:
             j = json.load(o)
         except ValueError as e:
-            self.debug("_svc_rest: value error pass: {}".format(str(e)))
+            self.debug("_svc_rest: value error pass: %s", str(e))
             # pass, will mean both data and error are None.
             return r
 
@@ -226,7 +226,7 @@ class IBMSVCRestApi(object):
         """
 
         rest = self._svc_token_wrap(cmd, cmdopts, cmdargs)
-        self.debug("svc_run_command rest={}".format(rest))
+        self.debug("svc_run_command rest=%s", rest)
 
         if rest['err']:
             msg = rest
@@ -249,7 +249,7 @@ class IBMSVCRestApi(object):
         """
 
         rest = self._svc_token_wrap(cmd, cmdopts, cmdargs)
-        self.debug("svc_obj_info rest={}".format(rest))
+        self.debug("svc_obj_info rest=%s", rest)
 
         if rest['code']:
             if rest['code'] == 500:

--- a/lib/ansible/module_utils/ibm_svc_utils.py
+++ b/lib/ansible/module_utils/ibm_svc_utils.py
@@ -177,9 +177,6 @@ class IBMSVCRestApi(object):
 
         rest = self._svc_rest(method='POST', headers=headers, cmd='auth',
                               cmdopts=None, cmdargs=None)
-        assert rest is not None
-        assert 'err' in rest
-        assert 'out' in rest
 
         if rest['err']:
             return None

--- a/lib/ansible/module_utils/ibm_svc_utils.py
+++ b/lib/ansible/module_utils/ibm_svc_utils.py
@@ -89,7 +89,7 @@ class IBMSVCRestApi(object):
     @property
     def resturl(self):
         if self.domain:
-            hostname = '{}.{}'.format(self.clustername, self.domain)
+            hostname = '%s.%s' % (self.clustername, self.domain)
         else:
             hostname = self.clustername
         return (getattr(self, '_resturl', None)

--- a/lib/ansible/module_utils/ibm_svc_utils.py
+++ b/lib/ansible/module_utils/ibm_svc_utils.py
@@ -1,0 +1,266 @@
+# Copyright (C) 2019 IBM CORPORATION
+# Author(s): John Hetherington <john.hetherington@uk.ibm.com>
+#
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+''' Support class for IBM SVC ansible modules '''
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import logging
+
+from ansible.module_utils.basic import jsonify
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.parse import quote
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+
+def svc_argument_spec():
+    """
+    Returns argument_spec of options common to ibm_svc_*-modules
+
+    :returns: argument_spec
+    :rtype: dict
+    """
+    return dict(
+        clustername=dict(type='str', required=True),
+        domain=dict(type='str', default=None),
+        validate_certs=dict(type='bool', default=False),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+        log_path=dict(type='str')
+    )
+
+
+class IBMSVCRestApi(object):
+    """ Communicate with SVC via RestApi
+    SVC commands usually have the format
+    $ command -opt1 value1 -opt2 value2 arg1 arg2 arg3
+    to use the RestApi we transform this into
+    https://host:7443/rest/command/arg1/arg2/arg3 data={'opt1':'value1', 'opt2':'value2'}
+    """
+    def __init__(self, module, clustername, domain, username, password, validate_certs, log_path):
+        """ Initialize module with what we need for initial connection
+        :param clustername: name of the SVC cluster
+        :type clustername: string
+        :param domain: domain name to make a fully qualified host name
+        :type domain: string
+        :param username: SVC username 
+        :type username: string
+        :param password: Password for user
+        :type password: string
+        :param validate_certs: whether or not the connection is insecure
+        :type validate_certs: bool
+        """
+        self.module = module
+        self.clustername = clustername
+        self.domain = domain
+        self.username = username
+        self.password = password
+        self.validate_certs = validate_certs
+
+        # logging setup
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Make sure we can connect via the RestApi
+        self.token = self._svc_authorize()
+        self.debug("_connect token={}".format(self.token))
+        if not self.token:
+            self.module.fail_json(msg='Failed to obtain access token')
+
+
+    @property
+    def port(self):
+        return getattr(self, '_port', None) or '7443'
+
+
+    @property
+    def protocol(self):
+        return getattr(self, '_protocol', None) or 'https'
+
+
+    @property
+    def resturl(self):
+        if self.domain:
+            hostname = '{}.{}'.format(self.clustername,self.domain)
+        else:
+            hostname = self.clustername
+        return getattr(self, '_resturl', None) or "{protocol}://{host}:{port}/rest".format(protocol=self.protocol, host=hostname, port=self.port)
+
+
+    @property
+    def token(self):
+        return getattr(self, '_token', None) or None
+
+    @token.setter
+    def token(self, value):
+        return setattr(self, '_token', value)
+
+
+    def _svc_rest(self, method, headers, cmd, cmdopts, cmdargs):
+        """ Run SVC command with token info added into header
+        :param method: http method, POST or GET
+        :type method: string
+        :param headers: http headers
+        :type headers: dict
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name paramter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :return: dict of command results 
+        :rtype: dict
+        """
+
+        # Catch any output or errors and pass back to the caller to deal with.
+        r = {
+            'url'   : None,
+            'code'  : None,
+            'err'   : None,
+            'out'   : None,
+            'data'  : None
+        }
+
+        postfix = cmd
+        if cmdargs:
+            postfix = '/'.join([postfix] + [quote(str(a)) for a in cmdargs])
+        url = '/'.join([self.resturl] + [postfix])
+        r['url']  = url # Pass back in result for error handling 
+        self.debug("_svc_rest: url={}".format(url))
+
+        payload = cmdopts if cmdopts else None
+        data=jsonify(payload, encoding="utf-8")
+        r['data'] = cmdopts # Original payload data has nicer formatting
+        self.debug("_svc_rest: payload={}".format(payload))
+
+        try:
+            o = open_url(url, method=method, headers=headers, validate_certs=self.validate_certs, data=bytes(data))
+        except HTTPError as e:
+            self.debug('_svc_rest: httperror {}'.format(str(e)))
+            r['code'] = e.getcode()
+            r['out'] = e.read()
+            r['err'] = "HTTPError {}".format(str(e))
+            return r 
+        except Exception as e:
+            self.debug('_svc_rest: exception : {}'.format(str(e)))
+            r['err'] = "Exception {}".format(str(e))
+            return r 
+
+        try:
+            j = json.load(o)
+        except ValueError:
+            self.debug("_svc_rest: value error pass: {}".format(str(e)))
+            # pass, will mean both data and error are None.
+            return r
+
+        r['out'] = j
+        return r
+
+
+    def _svc_authorize(self):
+        """ Obtain a token if we are authoized to connect
+        :return: None or token string
+        """
+
+        headers={
+            'Content-Type':   'application/json',
+            'X-Auth-Username': self.username,
+            'X-Auth-Password': self.password
+        }
+
+        rest = self._svc_rest(method='POST', headers=headers, cmd='auth', cmdopts=None, cmdargs=None)
+        assert rest is not None
+        assert 'err' in rest
+        assert 'out' in rest
+
+        if rest['err']:
+            return None
+
+        out = rest['out']
+        if out:
+            if 'token' in out:
+                return out['token']
+
+        return None
+
+
+    def _svc_token_wrap(self, cmd, cmdopts, cmdargs):
+        """ Run SVC command with token info added into header
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name paramter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :type cmdargs: list
+        :returns: command results 
+        """
+
+        if self.token is None:
+            self.module.fail_json(msg="No authorize token")
+            # Abort
+
+        headers={
+            'Content-Type': 'application/json',
+            'X-Auth-Token': self.token
+        }
+
+        return self._svc_rest(method='POST', headers=headers, cmd=cmd, cmdopts=cmdopts, cmdargs=cmdargs)
+
+
+    def svc_run_command(self, cmd, cmdopts, cmdargs):
+        """ Generic execute a SVC command
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name parameter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named parameters
+        :type cmdargs: list
+        :returns: command output
+        """
+
+        rest = self._svc_token_wrap(cmd, cmdopts, cmdargs)
+        self.debug("svc_run_command rest={}".format(rest))
+
+        if rest['err']:
+            msg=rest
+            self.module.fail_json(msg=msg)
+            # Aborts
+
+        # Might be None
+        return rest['out']
+
+
+    def svc_obj_info(self, cmd, cmdopts, cmdargs):
+        """ Obtain information about an SVC object via the ls command
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name parameter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :type cmdargs: list
+        :returns: command output
+        :rtype: dict
+        """
+
+        rest = self._svc_token_wrap(cmd, cmdopts, cmdargs)
+        self.debug("svc_obj_info rest={}".format(rest))
+       
+        if rest['code']:
+            if rest['code'] == 500:
+                # Object did not exist, which is quite valid.
+                return None
+
+        # Fail for anything else  
+        if rest['err']:
+            self.module.fail_json(msg=rest)
+            # Aborts
+
+        # Might be None
+        return rest['out']
+

--- a/lib/ansible/modules/storage/ibm/ibm_svc_host.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_host.py
@@ -9,12 +9,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import logging
-from traceback import format_exc
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
-from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
@@ -126,6 +120,13 @@ EXAMPLES = '''
 
 RETURN = '''
 '''
+
+import logging
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
 
 
 class IBMSVChost(object):

--- a/lib/ansible/modules/storage/ibm/ibm_svc_host.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_host.py
@@ -1,0 +1,336 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 IBM CORPORATION
+# Author(s): Chun Yao <chunyao@cn.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_host
+short_description: Manage host commands
+version_added: "2.7"
+
+description:
+  - Ansible interface to managing host commands mkhost, chhost, rmhost
+
+options:
+    name:
+        description:
+            - host name H(host).
+        required: true
+        type: str
+    state:
+        description:
+            - Whether to create (H(present)), or remove (H(absent)) a host.
+        choices: [ absent, present ]
+        required: true
+        type: str
+    clustername:
+        description:
+            - clustername for IBM SVC storage
+        type: str
+    domain:
+        description:
+            - domain for IBM SVC storage
+        type: str
+    username:
+        description:
+            - rest api username
+        required: true
+        type: str
+    password:
+        description:
+            - rest api password
+        required: true
+        type: str
+    fcwwpn:
+        description:
+            - fcwwpn for this host
+        required: false
+        type: str
+    iscsiname:
+        description:
+            - iscsiname
+        required: false
+        type: str
+    iogrp:
+        description:
+            - iogrp
+        default: '0:1:2:3'
+        type: str
+    protocol:
+        description:
+            - Protocol.
+        default: 'scsi'
+        type: str
+        choices: [ "scsi", "nvme", "iscsi" ]
+    type:
+        description:
+            - This is host type
+        default:
+        type: str
+    log_path:
+        description:
+            - For extra logging
+        type: str
+    validate_certs:
+        description:
+            - validate_certs
+        type: bool
+author:
+    - Chun Yao (@chunyao)
+'''
+
+EXAMPLES = '''
+- name: Define a new host
+  ibm_svc_host:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        name: host4test
+        state: present
+        fcwwpn: 100000109B570216
+        iscsiname: iqn.1994-05.com.redhat:2e358e438b8a
+        iogrp: 0:1:2:3
+        protocol: scsi
+        type: generic
+
+- name: Delete host
+  ibm_svc_host:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        name: host4test
+        state: absent
+'''
+
+RETURN = '''
+'''
+
+import logging
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class IBMSVChost(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+                fcwwpn=dict(type='str', required=False),
+                iscsiname=dict(type='str', required=False),
+                iogrp=dict(type='str', default='0:1:2:3'),
+                protocol=dict(type='str', default='scsi', choices=['scsi', 'nvme', 'iscsi']),
+                type=dict(type='str')
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional
+        self.fcwwpn = self.module.params['fcwwpn']
+        self.iscsiname = self.module.params['iscsiname']
+        self.iogrp = self.module.params['iogrp']
+        self.protocol = self.module.params['protocol']
+        self.type = self.module.params['type']
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path
+        )
+
+    def get_existing_host(self):
+        merged_result = {}
+
+        data = self.restapi.svc_obj_info(cmd='lshost', cmdopts=None, cmdargs=[self.name])
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    # TBD: Implement a more generic way to check for properties to modify.
+    def host_probe(self, data):
+        props = []
+
+        # TBD: The parameter is fcwwpn but the view has fcwwpn label.
+        if self.type:
+            if self.type != data['type']:
+                props += ['type']
+
+        if props is []:
+            props = None
+
+        self.debug("host_probe props='%s'", data)
+        return props
+
+    def host_create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        if (not self.fcwwpn) and (not self.iscsiname):
+            self.module.fail_json(msg="You must pass in fcwwpn or iscsiname to the module.")
+        if self.fcwwpn and self.iscsiname:
+            self.module.fail_json(msg="You must not pass in both fcwwpn and iscsiname to the module.")
+
+        if not self.protocol:
+            self.module.fail_json(msg="You must pass in protocol to the module.")
+
+        self.debug("creating host '%s'", self.name)
+
+        # Make command
+        cmd = 'mkhost'
+        cmdopts = {}
+        if self.fcwwpn:
+            cmdopts['fcwwpn'] = self.fcwwpn
+        elif self.iscsiname:
+            cmdopts['iscsiname'] = self.iscsiname
+
+        if self.protocol:
+            cmdopts['protocol'] = self.protocol
+        if self.iogrp:
+            cmdopts['iogrp'] = self.iogrp
+        if self.type:
+            cmdopts['type'] = self.type
+
+        cmdopts['name'] = self.name
+        self.debug("creating host command '%s' opts '%s'", self.fcwwpn, self.type)
+
+        # Run command
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.debug("create host result '%s'", result)
+
+        if 'message' in result:
+            self.changed = True
+            self.debug("create host result message '%s'", (result['message']))
+        else:
+            self.module.fail_json(
+                msg="Failed to create host [%s]" % self.name)
+
+    def host_update(self, modify):
+        # update the host
+        self.debug("updating host '%s'", self.name)
+
+        cmd = 'chhost'
+        cmdopts = {}
+
+        # TBD: Be smarter handling many properties.
+        if 'type' in modify:
+            cmdopts['type'] = self.type
+        cmdargs = [self.name]
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chhost does not output anything when successful.
+        self.changed = True
+
+    def host_delete(self):
+        self.debug("deleting host '%s'", self.name)
+
+        cmd = 'rmhost'
+        cmdopts = None
+        cmdargs = [self.name]
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chhost does not output anything when successful.
+        self.changed = True
+
+    def apply(self):
+        changed = False
+        msg = None
+
+        host_data = self.get_existing_host()
+
+        if host_data:
+            if self.state == 'absent':
+                self.debug("CHANGED: host exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # This is where we detect if chhost should be called
+                modify = self.host_probe(host_data)
+                if modify:
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.debug("CHANGED: host does not exist, but requested state is 'present'")
+                changed = True
+
+        if changed:
+            if self.module.check_mode:
+                self.debug('skipping changes due to check mode')
+            else:
+                if self.state == 'present':
+                    if not host_data:
+                        self.host_create()
+                        msg = "host %s has been created." % (self.name)
+                    else:
+                        # This is where we would modify
+                        self.host_update(modify)
+                        msg = "host [%s] has been modified." % (self.name)
+                elif self.state == 'absent':
+                    self.host_delete()
+                    msg = "host [%s] has been deleted." % (self.name)
+        else:
+            self.debug("exiting with no changes")
+            if self.state == 'absent':
+                msg = "host [%s] did not exist." % (self.name)
+            else:
+                msg = "host [%s] already exists." % (self.name)
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVChost()
+    try:
+        v.apply()
+    except Exception as e:
+        v.debug("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/ibm/ibm_svc_mdisk.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_mdisk.py
@@ -1,0 +1,305 @@
+#!/usr/bin/python
+# Copyright (C) 2018 IBM CORPORATION
+# Author(s): John Hetherington <john.hetherington@uk.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_mdisk
+short_description: Manage mdisk commands
+description:
+  - Ansible interface to manage mdisk related commands
+version_added: "2.7"
+options:
+  name:
+    description:
+      - Create mdisk name C(mdisk1).
+    required: true
+    type: str
+  state:
+    description:
+      - Whether to create (C(present)), or remove (C(absent)) the mdisk.
+    choices: [ absent, present ]
+    required: true
+    type: str
+  clustername:
+    description:
+      - name of host cluster
+    type: str
+  domain:
+    description:
+      - domain for IBM SVC storage
+    type: str
+  username:
+    description:
+      - rest api username
+    type: str
+    required: true
+  password:
+    description:
+      - rest api password
+    type: str
+    required: true
+  drive:
+    description:
+      - Drive or drives to use as members of the raid array
+    type: str
+  mdiskgrp:
+    description:
+      - The storage pool to which you want to add the mdisk
+    type: str
+  log_path:
+    description:
+      - Debug logging to this file
+    type: str
+  validate_certs:
+    description:
+      - validate_certs
+    type: bool
+  level:
+    description:
+      - level
+    type: str
+    choices: ['raid0', 'raid1', 'raid5', 'raid6', 'raid10']
+  encrypt:
+    description:
+      - encrypt
+    type: str
+    default: 'no'
+    choices: ['yes', 'no']
+author:
+    - John Hetherington(@John)
+'''
+EXAMPLES = '''
+- name: Create new array mdisk named mdisk20
+  mdisk:
+    name: mdisk20
+    state: present
+    clustername: mcr-tb5-29-cl
+    username: superuser
+    password: letmein
+    level: raid0
+    drive: '5:6'
+    encrypt: no
+    mdiskgrp: pool20
+
+- name: Delete mdisk named mdisk20
+  mdisk:
+    name: mdisk20
+    state: absent
+    clustername: mcr-tb5-29-cl
+    username: superuser
+    password: letmein
+    mdiskgrp: pool20
+'''
+RETURN = '''
+'''
+
+import json
+import logging
+import time
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+
+
+class IBMSVCmdisk(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+                level=dict(type='str', choices=['raid0', 'raid1', 'raid5', 'raid6', 'raid10']),
+                drive=dict(type='str', default=None),
+                encrypt=dict(type='str', default='no', choices=['yes', 'no']),
+                mdiskgrp=dict(type='str', required=True)
+            )
+        )
+
+        mutually_exclusive = []
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    mutually_exclusive=mutually_exclusive,
+                                    supports_check_mode=True)
+        p = self.module.params
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional
+        self.level = self.module.params.get('level', None)
+        self.drive = self.module.params.get('drive', None)
+        self.encrypt = self.module.params.get('encrypt', None)
+        self.mdiskgrp = self.module.params.get('mdiskgrp', None)
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path
+        )
+
+    def mdisk_exists(self):
+        return self.restapi.svc_obj_info(cmd='lsmdisk', cmdopts=None, cmdargs=[self.name])
+
+    def mdisk_create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        # For now we create mdisk via mkarray which needs these options
+        # level, drive, mdiskgrp
+        if not self.level:
+            self.module.fail_json(msg="You must pass in level to the module.")
+        if not self.drive:
+            self.module.fail_json(msg="You must pass in drive to the module.")
+        if not self.mdiskgrp:
+            self.module.fail_json(msg="You must pass in mdiskgrp to the module.")
+
+        self.debug("creating mdisk '%s'", self.name)
+
+        # Make command
+        cmd = 'mkarray'
+        cmdopts = {}
+        if self.level:
+            cmdopts['level'] = self.level
+        if self.drive:
+            cmdopts['drive'] = self.drive
+        if self.encrypt:
+            cmdopts['encrypt'] = self.encrypt
+        cmdopts['name'] = self.name
+        cmdargs = [self.mdiskgrp]
+        self.debug("creating mdisk command=%s opts=%s args=%s", cmd, cmdopts, cmdargs)
+
+        # Run command
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+        self.debug("create mdisk result %s", result)
+
+        if 'message' in result:
+            self.changed = True
+            self.debug("create mdisk result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to create mdisk [%s]" % (self.name))
+
+    def mdisk_delete(self):
+        self.debug("deleting mdisk '%s'", self.name)
+        cmd = 'rmmdisk'
+        cmdopts = {}
+        cmdopts['mdisk'] = self.name
+        cmdargs = [self.mdiskgrp]
+
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmkdiskgrp does not output anything when successful.
+        self.changed = True
+
+    def mdisk_update(self, modify):
+        # update the mdisk
+        self.debug("updating mdisk '%s'", self.name)
+
+        cmd = 'chmdisk'
+        cmdopts = {}
+        # chmdisk does not like mdisk arrays.
+        cmdargs = [self.name]
+
+        # TBD: Implement changed logic.
+        # result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmkdiskgrp does not output anything when successful.
+        self.changed = True
+
+    # TBD: Implement a more generic way to check for properties to modify.
+    def mdisk_probe(self, data):
+        props = []
+
+        if self.encrypt:
+            if self.encrypt != data['encrypt']:
+                props += ['encrypt']
+
+        if props is []:
+            props = None
+
+        self.debug("mdisk_probe props='%s'", data)
+        return props
+
+    def apply(self):
+        changed = False
+        msg = None
+
+        mdisk_data = self.mdisk_exists()
+
+        if mdisk_data:
+            if self.state == 'absent':
+                self.debug("CHANGED: mdisk exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # This is where we detect if chmdisk should be called.
+                modify = self.mdisk_probe(mdisk_data)
+                if modify:
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.debug("CHANGED: mdisk does not exist, but requested state is 'present'")
+                changed = True
+
+        if changed:
+            if self.module.check_mode:
+                self.debug('skipping changes due to check mode')
+            else:
+                if self.state == 'present':
+                    if not mdisk_data:
+                        self.mdisk_create()
+                        msg = "Mdisk group [%s] has been created." % (self.name)
+                    else:
+                        # This is where we would modify
+                        self.mdisk_update(modify)
+                        msg = "Mdisk group [%s] has been modified." % (self.name)
+
+                elif self.state == 'absent':
+                    self.mdisk_delete()
+                    msg = "Volume [%s] has been deleted." % (self.name)
+        else:
+            self.debug("exiting with no changes")
+            if self.state == 'absent':
+                msg = "Mdisk group [%s] did not exist." % (self.name)
+            else:
+                msg = "Mdisk group [%s] already exists." % (self.name)
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCmdisk()
+    try:
+        v.apply()
+    except Exception as e:
+        v.debug("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/ibm/ibm_svc_mdisk.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_mdisk.py
@@ -7,11 +7,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import logging
-from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -108,6 +103,12 @@ EXAMPLES = '''
 '''
 RETURN = '''
 '''
+
+import logging
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
 
 
 class IBMSVCmdisk(object):

--- a/lib/ansible/modules/storage/ibm/ibm_svc_mdiskgrp.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_mdiskgrp.py
@@ -7,12 +7,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import logging
-from traceback import format_exc
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -128,6 +122,13 @@ EXAMPLES = '''
 '''
 RETURN = '''
 '''
+
+import logging
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
 
 
 class IBMSVCmdiskgrp(object):

--- a/lib/ansible/modules/storage/ibm/ibm_svc_mdiskgrp.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_mdiskgrp.py
@@ -1,0 +1,338 @@
+#!/usr/bin/python
+# Copyright (C) 2018 IBM CORPORATION
+# Author(s): John Hetherington <john.hetherington@uk.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_mdiskgrp
+short_description: Manage mdiskgrp commands
+description:
+  - Ansible interface to managing mdiskgrp commands mkmdiskgrp, chmdiskgrp, rmmdiskgrp
+version_added: "2.7"
+options:
+  name:
+    description:
+      - Mdisk group name C(pool).
+    required: true
+    type: str
+  state:
+    description:
+      - Whether to create (C(present)), or remove (C(absent)) an mdisk group.
+    choices: [ absent, present ]
+    required: true
+    type: str
+  clustername:
+    description:
+      - description
+    required: true
+    type: str
+  domain:
+    description:
+    - rest api
+    type: str
+    required: true
+  username:
+    description:
+    - rest api username
+    type: str
+    required: true
+  password:
+    description:
+    - rest api password
+    type: str
+    required: true
+  datareduction:
+    description:
+    - Define whether to use data reduction pools on the mdisk group
+    type: str
+    default: 'no'
+    choices: ['yes', 'no']
+  easytier:
+    description:
+    - Define whether to use easyier with the mdisk group
+    type: str
+    default: 'off'
+    choices: ['on', 'off', 'auto']
+  encrypt:
+    description:
+    - Define whether to use encryption with the mdisk group
+    type: str
+    default: 'no'
+    choices: ['yes', 'no']
+  ext:
+    description:
+    - Group size
+    type: int
+  log_path:
+    description:
+    - For extra logging
+    type: str
+  validate_certs:
+    description:
+      - validate_certs
+    type: bool
+  parentmdiskgrp:
+    description:
+      - parentmdiskgrp for sub pool
+    type: str
+  unit:
+    description:
+      - unit for sub pool
+    type: str
+  size:
+    description:
+      - size for sub pool
+    type: int
+author:
+    - John Hetherington(@John)
+'''
+EXAMPLES = '''
+- name: Create new mdiskgrp named pool1
+  mdiskgrp:
+    name: pool1
+    state: present
+    clustername: mcr-fab3-04
+    domain:
+    username: superuser
+    password: letmein
+    datareduction: no
+    easytier: auto
+    encrypt: no
+    ext: 1024
+
+- name: Delete mdiskgrp named pool1
+  mdiskgrp:
+    name: pool1
+    state: absent
+    clustername: mcr-fab3-04
+    domain:
+    username: superuser
+    password: letmein
+'''
+RETURN = '''
+'''
+
+import json
+import logging
+import time
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+
+
+class IBMSVCmdiskgrp(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+                datareduction=dict(type='str', default='no', choices=['yes', 'no']),
+                easytier=dict(type='str', default='off', choices=['on', 'off', 'auto']),
+                encrypt=dict(type='str', default='no', choices=['yes', 'no']),
+                ext=dict(type='int'),
+                parentmdiskgrp=dict(type='str'),
+                size=dict(type='int'),
+                unit=dict(type='str')
+            )
+        )
+
+        mutually_exclusive = []
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    mutually_exclusive=mutually_exclusive,
+                                    supports_check_mode=True)
+        p = self.module.params
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional
+        self.datareduction = self.module.params.get('datareduction', None)
+        self.easytier = self.module.params.get('easytier', None)
+        self.encrypt = self.module.params.get('encrypt', None)
+        self.ext = self.module.params.get('ext', None)
+
+        self.parentmdiskgrp = self.module.params.get('parentmdiskgrp', None)
+        self.size = self.module.params.get('size', None)
+        self.unit = self.module.params.get('unit', None)
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path
+        )
+
+    def mdiskgrp_exists(self):
+        return self.restapi.svc_obj_info(cmd='lsmdiskgrp', cmdopts=None, cmdargs=[self.name])
+
+    def mdiskgrp_create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        # So ext is optional to mkmdiskgrp but make required in ansible
+        # until all options for create are implemented.
+        # if not self.ext:
+        #    self.module.fail_json(msg="You must pass in ext to the module.")
+
+        self.debug("creating mdisk group '%s'", self.name)
+
+        # Make command
+        cmd = 'mkmdiskgrp'
+        cmdopts = {}
+
+        if self.parentmdiskgrp:
+            cmdopts['parentmdiskgrp'] = self.parentmdiskgrp
+            if self.size:
+                cmdopts['size'] = self.size
+            if self.unit:
+                cmdopts['unit'] = self.unit
+        else:
+            if self.datareduction:
+                cmdopts['datareduction'] = self.datareduction
+            if self.easytier:
+                cmdopts['easytier'] = self.easytier
+            if self.encrypt:
+                cmdopts['encrypt'] = self.encrypt
+            if self.ext:
+                cmdopts['ext'] = str(self.ext)
+        cmdopts['name'] = self.name
+        self.debug("creating mdisk group command %s opts %s", cmd, cmdopts)
+
+        # Run command
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.debug("creating mdisk group result %s", result)
+
+        if 'message' in result:
+            self.changed = True
+            self.debug("creating mdisk group command result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to create mdisk group [%s]" % (self.name))
+
+    def mdiskgrp_delete(self):
+        self.debug("deleting mdiskgrp '%s'", self.name)
+
+        cmd = 'rmmdiskgrp'
+        cmdopts = None
+        cmdargs = [self.name]
+
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmkdiskgrp does not output anything when successful.
+        self.changed = True
+
+    def mdiskgrp_update(self, modify):
+        # updte the mdisk group
+        self.debug("updating mdiskgrp '%s'", self.name)
+
+        cmd = 'chmdiskgrp'
+        cmdopts = {}
+        # TBD: Be smarter handling many properties.
+        # if 'easytier' in modify:
+        #    cmdopts['easytier'] = self.easytier
+        # cmdargs = [self.name]
+
+        # result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmkdiskgrp does not output anything when successful.
+        self.changed = True
+
+    # TBD: Implement a more generic way to check for properties to modify.
+    def mdiskgrp_probe(self, data):
+        props = []
+
+        # TBD: The parameter is easytier but the view has easy_tier label.
+        # if self.easytier:
+        #    if self.easytier != data['easy_tier']:
+        #        props += ['easytier']
+
+        if props is []:
+            props = None
+
+        self.debug("mdiskgrp_probe props='%s'", data)
+        return props
+
+    def apply(self):
+        changed = False
+        msg = None
+
+        mdiskgrp_data = self.mdiskgrp_exists()
+
+        if mdiskgrp_data:
+            if self.state == 'absent':
+                self.debug("CHANGED: mdisk group exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # This is where we detect if chmdiskgrp should be called.
+                modify = self.mdiskgrp_probe(mdiskgrp_data)
+                if modify:
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.debug("CHANGED: mdisk group does not exist, but requested state is 'present'")
+                changed = True
+
+        if changed:
+            if self.module.check_mode:
+                self.debug('skipping changes due to check mode')
+            else:
+                if self.state == 'present':
+                    if not mdiskgrp_data:
+                        self.mdiskgrp_create()
+                        msg = "Mdisk group [%s] has been created." % (self.name)
+                    else:
+                        # This is where we would modify
+                        self.mdiskgrp_update(modify)
+                        msg = "Mdisk group [%s] has been modified." % (self.name)
+
+                elif self.state == 'absent':
+                    self.mdiskgrp_delete()
+                    msg = "Volume [%s] has been deleted." % (self.name)
+        else:
+            self.debug("exiting with no changes")
+            if self.state == 'absent':
+                msg = "Mdisk group [%s] did not exist." % (self.name)
+            else:
+                msg = "Mdisk group [%s] already exists." % (self.name)
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCmdiskgrp()
+    try:
+        v.apply()
+    except Exception as e:
+        v.debug("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/ibm/ibm_svc_vdisk.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_vdisk.py
@@ -9,12 +9,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import logging
-from traceback import format_exc
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
-from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
@@ -118,6 +112,13 @@ EXAMPLES = '''
 '''
 RETURN = '''
 '''
+
+import logging
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
 
 
 class IBMSVCvdisk(object):

--- a/lib/ansible/modules/storage/ibm/ibm_svc_vdisk.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_vdisk.py
@@ -1,0 +1,321 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 IBM CORPORATION
+# Author(s): Jamie Jordan <jamie.jordan@ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_vdisk
+short_description: Manage vdisk commands
+description:
+  - Ansible interface to managing vdisk commands mkvdisk, chvdisk, rmvdisk
+version_added: "2.7"
+options:
+  name:
+    description:
+      - vdisk name C(volume).
+    required: true
+    type: str
+  state:
+    description:
+      - Whether to create (C(present)), or remove (C(absent)) a vdisk group.
+    choices: [ absent, present ]
+    required: true
+    type: str
+  clustername:
+    description:
+      - description
+    required: true
+    type: str
+  domain:
+    description:
+    - rest api
+    type: str
+    required: true
+  username:
+    description:
+    - rest api username
+    type: str
+    required: true
+  password:
+    description:
+    - rest api password
+    type: str
+    required: true
+  mdiskgrp:
+    description:
+    - Specify pool for adding the vdisk to by name or ID
+    type: str
+  easytier:
+    description:
+    - Define whether to use easyier with the vdisk
+    type: str
+    default: 'off'
+    choices: [ 'on', 'off', 'auto' ]
+  size:
+    description:
+    - Define size of vdisk
+    type: str
+  unit:
+    description:
+    - Define unit of storage for the size option.
+    type: str
+    choices: [ b, kb, mb, gb, tb, pb ]
+    default: mb
+  validate_certs:
+    description:
+    - validate_certs
+    type: bool
+  log_path:
+    description:
+    - For extra logging
+    type: str
+author:
+    - Jamie Jordan(@Jamie)
+'''
+
+EXAMPLES = '''
+- name: execute mkvdisk
+  ibm_svc_vdisk:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        name: volume0
+        state: present
+        mdiskgrp: 0
+        easytier: 'off'
+        size: "4294967296"
+        unit: b
+
+- name: execute rmvdisk
+  ibm_svc_vdisk:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        name: volume0
+        state: absent
+'''
+RETURN = '''
+'''
+import logging
+from traceback import format_exc
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCvdisk(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+                mdiskgrp=dict(type='str', required=False),
+                size=dict(type='str', required=False),
+                unit=dict(type='str', default='mb', choices=['b', 'kb', 'mb', 'gb', 'tb', 'pb']),
+                easytier=dict(type='str', default='off', choices=['on', 'off', 'auto'])
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Required
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional
+        self.mdiskgrp = self.module.params['mdiskgrp']
+        self.size = self.module.params['size']
+        self.unit = self.module.params['unit']
+        self.easytier = self.module.params.get('easytier', None)
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path
+        )
+
+    def get_existing_vdisk(self):
+        merged_result = {}
+
+        data = self.restapi.svc_obj_info(cmd='lsvdisk', cmdopts=None, cmdargs=[self.name])
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    # TBD: Implement a more generic way to check for properties to modify.
+    def vdisk_probe(self, data):
+        props = []
+
+        # TBD: The parameter is easytier but the view has easy_tier label.
+        if self.easytier:
+            if self.easytier != data['easy_tier']:
+                props += ['easytier']
+
+        if props is []:
+            props = None
+
+        self.debug("vdisk_probe props='%s'", data)
+        return props
+
+    def vdisk_create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        if not self.mdiskgrp:
+            self.module.fail_json(msg="You must pass in mdiskgrp to the module.")
+        if not self.size:
+            self.module.fail_json(msg="You must pass in size to the module.")
+        if not self.unit:
+            self.module.fail_json(msg="You must pass in unit to the module.")
+
+        self.debug("creating vdisk '%s'", self.name)
+
+        # Make command
+        cmd = 'mkvdisk'
+        cmdopts = {}
+        if self.mdiskgrp:
+            cmdopts['mdiskgrp'] = self.mdiskgrp
+        if self.size:
+            cmdopts['size'] = self.size
+        if self.unit:
+            cmdopts['unit'] = self.unit
+        if self.easytier:
+            cmdopts['easytier'] = self.easytier
+        cmdopts['name'] = self.name
+        self.debug("creating vdisk command %s opts %s", cmd, cmdopts)
+
+        # Run command
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.debug("create vdisk result %s", result)
+
+        if 'message' in result:
+            self.changed = True
+            self.debug("create vdisk result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to create vdisk [%s]" % self.name)
+
+    def vdisk_update(self, modify):
+        # update the vdisk
+        self.debug("updating vdisk '%s'", self.name)
+
+        cmd = 'chvdisk'
+        cmdopts = {}
+
+        # TBD: Be smarter handling many properties.
+        if 'easytier' in modify:
+            cmdopts['easytier'] = self.easytier
+        cmdargs = [self.name]
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chvdisk does not output anything when successful.
+        self.changed = True
+
+    def vdisk_delete(self):
+        self.debug("deleting vdisk '%s'", self.name)
+
+        cmd = 'rmvdisk'
+        cmdopts = None
+        cmdargs = [self.name]
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmvdisk does not output anything when successful.
+        self.changed = True
+
+    def apply(self):
+        changed = False
+        msg = None
+
+        vdisk_data = self.get_existing_vdisk()
+
+        if vdisk_data:
+            if self.state == 'absent':
+                self.debug("CHANGED: vdisk exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # This is where we detect if chvdisk should be called
+                modify = self.vdisk_probe(vdisk_data)
+                if modify:
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.debug("CHANGED: vdisk does not exist, but requested state is 'present'")
+                changed = True
+
+        if changed:
+            if self.module.check_mode:
+                self.debug('skipping changes due to check mode')
+            else:
+                if self.state == 'present':
+                    if not vdisk_data:
+                        self.vdisk_create()
+                        msg = "vdisk %s has been created." % (self.name)
+                    else:
+                        # This is where we would modify
+                        self.vdisk_update(modify)
+                        msg = "vdisk [%s] has been modified." % (self.name)
+                elif self.state == 'absent':
+                    self.vdisk_delete()
+                    msg = "vdisk [%s] has been deleted." % (self.name)
+        else:
+            self.debug("exiting with no changes")
+            if self.state == 'absent':
+                msg = "vdisk [%s] did not exist." % (self.name)
+            else:
+                msg = "vdisk [%s] already exists." % (self.name)
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCvdisk()
+    try:
+        v.apply()
+    except Exception as e:
+        v.debug("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/ibm/ibm_svc_vol_map.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_vol_map.py
@@ -1,0 +1,289 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 IBM CORPORATION
+# Author(s): Chun Yao <chunyao@cn.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: ibm_svc_vol_map
+short_description: Manage vdisk commands
+description:
+  - Ansible interface to managing vdisk commands mkvdisk, chvdisk, rmvdisk
+version_added: "2.7"
+options:
+  volname:
+    description:
+      - vdisk name C(volname).
+    required: true
+    type: str
+  host:
+    description:
+      - host name H(host).
+    required: true
+    type: str
+  state:
+    description:
+      - Whether to create (C(present)), or remove (C(absent)) a vdisk group.
+    choices: [ absent, present ]
+    required: true
+    type: str
+  clustername:
+    description:
+      - description
+    required: true
+    type: str
+  domain:
+    description:
+    - rest api
+    type: str
+    required: true
+  username:
+    description:
+    - rest api username
+    type: str
+    required: true
+  password:
+    description:
+    - rest api password
+    type: str
+    required: true
+  log_path:
+    description:
+    - For extra logging
+    type: str
+  validate_certs:
+    description:
+    - validate_certs
+    type: bool
+author:
+    - Chun Yao(@Chunyao)
+'''
+
+EXAMPLES = '''
+- name: map volume to host
+  ibm_svc_vol_map:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        volname: volume0
+        host: host4test
+        state: present
+
+- name: unmap volume from host
+  ibm_svc_vol_map:
+        clustername: mcr-tb5-cluster-03
+        domain: stglab.manchester.uk.ibm.com
+        username: superuser
+        password: passw0rd
+        log_path: /tmp/playbook.debug
+        volname: volume0
+        host: host4test
+        state: absent
+'''
+RETURN = '''
+'''
+
+import logging
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class IBMSVCvdiskhostmap(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                volname=dict(type='str', required=True),
+                host=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec,
+                                    supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.debug = self._logger.debug
+        if log_path:
+            logging.basicConfig(level=logging.DEBUG, filename=log_path)
+
+        # Required
+        self.volname = self.module.params['volname']
+        self.host = self.module.params['host']
+        self.state = self.module.params['state']
+
+        # Optional
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path
+        )
+
+    def get_existing_vdiskhostmap(self):
+        merged_result = {}
+
+        data = self.restapi.svc_obj_info(cmd='lsvdiskhostmap', cmdopts=None, cmdargs=[self.volname])
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+
+        return merged_result
+
+    # TBD: Implement a more generic way to check for properties to modify.
+    def vdiskhostmap_probe(self, data):
+        props = []
+        self.debug("vdiskhostmap_probe props='%s'", data)
+        # TBD: The parameter is easytier but the view has easy_tier label.
+
+        if (self.host != data['host_name']):
+            props += ['host']
+
+        if (self.volname != data['name']):
+            props += ['volname']
+
+        if props is []:
+            props = None
+
+        self.debug("vdiskhostmap_probe props='%s'", data)
+        return props
+
+    def vdiskhostmap_create(self):
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        if not self.volname:
+            self.module.fail_json(msg="You must pass in volname to the module.")
+        if not self.host:
+            self.module.fail_json(msg="You must pass in host name to the module.")
+
+        self.debug("creating vdiskhostmap '%s' '%s'", self.volname, self.host)
+
+        # Make command
+        cmd = 'mkvdiskhostmap'
+        cmdopts = {}
+        cmdopts['host'] = self.host
+        cmdargs = [self.volname]
+
+        self.debug("creating vdiskhostmap command %s opts %s args %s", cmd, cmdopts, cmdargs)
+
+        # Run command
+        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+        self.debug("create vdiskhostmap result %s", result)
+
+        if 'message' in result:
+            self.changed = True
+            self.debug("create vdiskhostmap result message %s", result['message'])
+        else:
+            self.module.fail_json(
+                msg="Failed to create vdiskhostmap [%s]" % self.name)
+
+    def vdiskhostmap_update(self, modify):
+        # update the vdiskhostmap
+        self.debug("updating vdiskhostmap")
+
+        if 'host_name' in modify:
+            self.debug("host name is changed. ")
+
+        if 'volname' in modify:
+            self.debug("vol name is changed. ")
+
+        self.changed = True
+
+    def vdiskhostmap_delete(self):
+        self.debug("deleting vdiskhostmap '%s'", self.volname)
+
+        cmd = 'rmvdiskhostmap'
+        cmdopts = {}
+        cmdopts['host'] = self.host
+        cmdargs = [self.volname]
+
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs)
+
+        # Any error will have been raised in svc_run_command
+        # chmvdisk does not output anything when successful.
+        self.changed = True
+
+    def apply(self):
+        changed = False
+        msg = None
+
+        vdiskhostmap_data = self.get_existing_vdiskhostmap()
+        self.debug("Chun 1 : '%s'", vdiskhostmap_data)
+
+        if vdiskhostmap_data:
+            if self.state == 'absent':
+                self.debug("CHANGED: vdiskhostmap exists, but requested state is 'absent'")
+                changed = True
+            elif self.state == 'present':
+                # This is where we detect if chvdisk should be called
+                modify = self.vdiskhostmap_probe(vdiskhostmap_data)
+                if modify:
+                    changed = True
+        else:
+            if self.state == 'present':
+                self.debug("CHANGED: vdiskhostmap does not exist, but requested state is 'present'")
+                changed = True
+
+        if changed:
+            if self.module.check_mode:
+                self.debug('skipping changes due to check mode')
+            else:
+                if self.state == 'present':
+                    if not vdiskhostmap_data:
+                        self.vdiskhostmap_create()
+                        msg = "vdiskhostmap %s %s has been created." % (self.volname, self.host)
+                    else:
+                        # This is where we would modify
+                        self.vdiskhostmap_update(modify)
+                        msg = "vdiskhostmap [%s] has been modified." % (self.volname)
+                elif self.state == 'absent':
+                    self.vdiskhostmap_delete()
+                    msg = "vdiskhostmap [%s] has been deleted." % (self.volname)
+        else:
+            self.debug("exiting with no changes")
+            if self.state == 'absent':
+                msg = "vdiskhostmap [%s] did not exist." % (self.volname)
+            else:
+                msg = "vdiskhostmap [%s] already exists." % (self.volname)
+
+        self.module.exit_json(msg=msg, changed=changed)
+
+
+def main():
+    v = IBMSVCvdiskhostmap()
+    try:
+        v.apply()
+    except Exception as e:
+        v.debug("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/ibm/ibm_svc_vol_map.py
+++ b/lib/ansible/modules/storage/ibm/ibm_svc_vol_map.py
@@ -9,11 +9,6 @@
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-import logging
-from traceback import format_exc
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
-from ansible.module_utils._text import to_native
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
@@ -100,6 +95,12 @@ EXAMPLES = '''
 '''
 RETURN = '''
 '''
+
+import logging
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec
+from ansible.module_utils._text import to_native
 
 
 class IBMSVCvdiskhostmap(object):


### PR DESCRIPTION
##### SUMMARY
Add the following files into ansible for IBM Spectrum Virtualize family to support host,mdisk, mdiskgrp, vdisk and map.
/lib/ansible/module_utils/ibm_svc_utils.py
/lib/ansible/modules/storage/ibm/ibm_svc_host.py
/lib/ansible/modules/storage/ibm/ibm_svc_mdisk.py
/lib/ansible/modules/storage/ibm/ibm_svc_mdiskgrp.py
/lib/ansible/modules/storage/ibm/ibm_svc_vdisk.py
/lib/ansible/modules/storage/ibm/ibm_svc_vol_map.py

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
Spectrum Virtualize storage from IBM

##### ADDITIONAL INFORMATION
N/A
```paste below

```
