### PR TITLE
ec2_instance - update tests related to termination protection

### DIFF
--- a/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
+++ b/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
@@ -2,7 +2,7 @@
 
     - name: Create instance with termination protection (check mode)
       ec2_instance:
-        name: "{{ resource_prefix }}-instance-termination-protection-check-mode"
+        name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_image }}"
         tags:
           TestId: "{{ resource_prefix }}"
@@ -19,20 +19,9 @@
           - "{{ create_instance_check_mode_results.changed }}"
           - "{{ create_instance_check_mode_results.spec.DisableApiTermination }}"
 
-    - name: Get info on instances created in the earlier task
-      ec2_instance_info:
-        filters:
-          "tag:Name": "{{ resource_prefix }}-instance-termination-protection-check-mode"
-      register: ec2_instance_info_results
-
-    - name: Confirm check mode does not actually create the instance
-      assert:
-        that:
-          - "{{ ec2_instance_info_results.instances | length }} == 0"
-
     - name: Create instance with termination protection
       ec2_instance:
-        name: "{{ resource_prefix }}-instance-termination-protection"
+        name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_image }}"
         tags:
           TestId: "{{ resource_prefix }}"
@@ -51,14 +40,121 @@
           - "'{{ create_instance_results.instances.0.state.name }}' in ['running', 'pending']"
           - "'{{ create_instance_results.spec.DisableApiTermination }}'"
 
-    - name: Set termination protection to false for the instance
+    - name: Create instance with termination protection (check mode) (idempotent)
       ec2_instance:
-        name: "{{ resource_prefix }}-instance-termination-protection"
+        name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_image }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
         vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: yes
+      register: create_instance_check_mode_results
+
+    - name: Check the returned value for the earlier task
+      assert:
+        that:
+          - "{{ not create_instance_check_mode_results.changed }}"
+
+    - name: Create instance with termination protection (idempotent)
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+        state: running
+        wait: yes
+      register: create_instance_results
+
+    - name: Check return values of the create instance task
+      assert:
+        that:
+          - "{{ not create_instance_results.changed }}"
+          - "{{ create_instance_results.instances | length }} > 0"
+
+    - name: Try to terminate the instance (expected to fail)
+      ec2_instance:
+        filters:
+          tag:Name: "{{ resource_prefix }}-termination-protection"
+        state: absent
+      failed_when: "'Unable to terminate instances' not in terminate_instance_results.msg"
+      register: terminate_instance_results
+
+    # https://github.com/ansible/ansible/issues/67716
+    # Updates to termination protection in check mode has a bug (listed above)
+
+    - name: Set termination protection to false
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
         termination_protection: false
         instance_type: "{{ ec2_instance_type }}"
-      register: alter_instance_results
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      register: set_termination_protection_results
+
+    - name: Check return value
+      assert:
+        that:
+          - "{{ set_termination_protection_results.changed }}"
+          - "{{ not set_termination_protection_results.changes[0].DisableApiTermination.Value }}"
+
+    - name: Set termination protection to false (idempotent)
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        termination_protection: false
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      register: set_termination_protection_results
+
+    - name: Check return value
+      assert:
+        that:
+          - "{{ not set_termination_protection_results.changed }}"
+
+    - name: Set termination protection to true
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      register: set_termination_protection_results
+
+    - name: Check return value
+      assert:
+        that:
+          - "{{ set_termination_protection_results.changed }}"
+          - "{{ set_termination_protection_results.changes[0].DisableApiTermination.Value }}"
+
+    - name: Set termination protection to true (idempotent)
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      register: set_termination_protection_results
+
+    - name: Check return value
+      assert:
+        that:
+          - "{{ not set_termination_protection_results.changed }}"
+
+    - name: Set termination protection to false (so we can terminate instance)
+      ec2_instance:
+        name: "{{ resource_prefix }}-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        termination_protection: false
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+      register: set_termination_protection_results
 
     - name: Terminate the instance
       ec2_instance:
@@ -67,6 +163,14 @@
         state: absent
 
   always:
+
+    - name: Set termination protection to false (so we can terminate instance) (cleanup)
+      ec2_instance:
+        filters:
+          tag:TestId: "{{ resource_prefix }}"
+        termination_protection: false
+      ignore_errors: yes
+
     - name: Terminate instance
       ec2_instance:
         filters:

--- a/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
+++ b/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
@@ -10,6 +10,8 @@
         vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
+        state: running
+        wait: yes
       check_mode: yes
       register: create_instance_check_mode_results
 
@@ -37,7 +39,7 @@
       assert:
         that:
           - "{{ create_instance_results.instances | length }} > 0"
-          - "'{{ create_instance_results.instances.0.state.name }}' in ['running', 'pending']"
+          - "'{{ create_instance_results.instances.0.state.name }}' == 'running'"
           - "'{{ create_instance_results.spec.DisableApiTermination }}'"
 
     - name: Create instance with termination protection (check mode) (idempotent)
@@ -50,6 +52,8 @@
         vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
+        state: running
+        wait: yes
       check_mode: yes
       register: create_instance_check_mode_results
 

--- a/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
+++ b/test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
@@ -1,101 +1,76 @@
 - block:
-  - name: "Make termination-protected instance in the testing subnet created in the test VPC"
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-protected-instance-in-vpc"
-      image_id: "{{ ec2_ami_image }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      termination_protection: true
-      instance_type: "{{ ec2_instance_type }}"
-      wait: yes
-    register: in_test_vpc
 
-  - name: "Make termination-protected instance in the testing subnet created in the test VPC(check mode)"
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-protected-instance-in-vpc-checkmode"
-      image_id: "{{ ec2_ami_image }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      termination_protection: true
-      instance_type: "{{ ec2_instance_type }}"
-    check_mode: yes
+    - name: Create instance with termination protection (check mode)
+      ec2_instance:
+        name: "{{ resource_prefix }}-instance-termination-protection-check-mode"
+        image_id: "{{ ec2_ami_image }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: yes
+      register: create_instance_check_mode_results
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-protected-instance-in-vpc"
-        "instance-state-name": "running"
-    register: presented_instance_fact
+    - name: Check the returned value for the earlier task
+      assert:
+        that:
+          - "{{ create_instance_check_mode_results.changed }}"
+          - "{{ create_instance_check_mode_results.spec.DisableApiTermination }}"
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-protected-instance-in-vpc-checkmode"
-    register: checkmode_instance_fact
+    - name: Get info on instances created in the earlier task
+      ec2_instance_info:
+        filters:
+          "tag:Name": "{{ resource_prefix }}-instance-termination-protection-check-mode"
+      register: ec2_instance_info_results
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - "{{ presented_instance_fact.instances | length }} > 0"
-        - "'{{ presented_instance_fact.instances.0.state.name }}' in ['running', 'pending']"
-        - "{{ checkmode_instance_fact.instances | length }} == 0"
+    - name: Confirm check mode does not actually create the instance
+      assert:
+        that:
+          - "{{ ec2_instance_info_results.instances | length }} == 0"
 
-  - name: "Try to terminate the instance"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-protected-instance-in-vpc"
-      image_id: "{{ ec2_ami_image }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      termination_protection: true
-      instance_type: "{{ ec2_instance_type }}"
-    register: bad_terminate
-    ignore_errors: yes
+    - name: Create instance with termination protection
+      ec2_instance:
+        name: "{{ resource_prefix }}-instance-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        termination_protection: true
+        instance_type: "{{ ec2_instance_type }}"
+        state: running
+        wait: yes
+      register: create_instance_results
 
-  - name: "Cannot terminate protected instance"
-    assert:
-      that:
-        - bad_terminate is failed
+    - name: Check return values of the create instance task
+      assert:
+        that:
+          - "{{ create_instance_results.instances | length }} > 0"
+          - "'{{ create_instance_results.instances.0.state.name }}' in ['running', 'pending']"
+          - "'{{ create_instance_results.spec.DisableApiTermination }}'"
 
-  - name: "Alter termination protection setting"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-protected-instance-in-vpc"
-      image_id: "{{ ec2_ami_image }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      termination_protection: false
-      instance_type: "{{ ec2_instance_type }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
+    - name: Set termination protection to false for the instance
+      ec2_instance:
+        name: "{{ resource_prefix }}-instance-termination-protection"
+        image_id: "{{ ec2_ami_image }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        termination_protection: false
+        instance_type: "{{ ec2_instance_type }}"
+      register: alter_instance_results
 
-  - name: "Try to terminate the instance again (should work)"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-protected-instance-in-vpc"
-      image_id: "{{ ec2_ami_image }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: terminate_results
-
-  - assert:
-      that: terminate_results is not failed
+    - name: Terminate the instance
+      ec2_instance:
+        filters:
+          tag:TestId: "{{ resource_prefix }}"
+        state: absent
 
   always:
-  - name: "Terminate termination_protection instances"
-    ec2_instance:
-      state: absent
-      filters:
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-      wait: yes
-    ignore_errors: yes
+    - name: Terminate instance
+      ec2_instance:
+        filters:
+          tag:TestId: "{{ resource_prefix }}"
+        state: absent
+        wait: false
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Updates the ec2_instance tests related to termination protection.

- Followed the convention of running a task in check mode before actually running it
- Verified the returned attributes for tasks where possible. This will catch any patches that change the return values. For instance, we return `.spec.DisableApiTermination` when `termination_protection` is set to `true`. Before the test was only trying to terminate the instance, but now by checking the return values we will also catch any potential backward incompatibilities.
- Task names have been updated to make their purpose clearer

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_instance

