### PR TITLE
Handle gfid tag when producing ansible heal facts

### DIFF
--- a/lib/ansible/modules/storage/glusterfs/gluster_heal_info.py
+++ b/lib/ansible/modules/storage/glusterfs/gluster_heal_info.py
@@ -114,7 +114,7 @@ def get_self_heal_status(name):
             br_dict['status'] = line.split(":")[1].strip()
         elif 'Number' in line:
             br_dict['no_of_entries'] = line.split(":")[1].strip()
-        elif line.startswith('/') or '\n' in line:
+        elif line.startswith('/') or line.startswith('<') or '\n' in line:
             continue
         else:
             br_dict and heal_info.append(br_dict)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Now we ignore lines beginning with / or < which will produce the requires json format.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65095 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Gluster_heal
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
After the fix, the output now looks like:
```paste below
{
  "ansible_facts": {
    "glusterfs": {
      "heal_info": [
        {
          "brick": " headwig.lab.eng.blr.redhat.com:/gluster_bricks/vmstore/vmstore",
          "no_of_entries": "-",
          "status": "Transport endpoint is not connected"
        },
        {
          "brick": " fisher.lab.eng.blr.redhat.com:/gluster_bricks/vmstore/vmstore",
          "no_of_entries": "2",
          "status": "Connected"
        },
        {
          "brick": " pinstripe.lab.eng.blr.redhat.com:/gluster_bricks/vmstore/vmstore",
          "no_of_entries": "2",
          "status": "Connected"
        }
      ],
      "rebalance": "",
      "status_filter": "self-heal",
      "volume": "vmstore"
    }
  },
  "ansible_loop_var": "item",
  "attempts": 2,
  "changed": false,
  "invocation": {
    "module_args": {
      "name": "vmstore",
      "status_filter": "self-heal"
    }
  },
  "item": "vmstore"
}


```
