### PR TITLE
terraform workspace list failure warns instead of fails

### DIFF
--- a/changelogs/fragments/65044-fix-terraform-no-workspace.yaml
+++ b/changelogs/fragments/65044-fix-terraform-no-workspace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- terraform module - fixes usage for providers not supporting workspaces

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -209,7 +209,7 @@ def get_workspace_context(bin_path, project_path):
     command = [bin_path, 'workspace', 'list', '-no-color']
     rc, out, err = module.run_command(command, cwd=project_path)
     if rc != 0:
-        module.fail_json(msg="Failed to list Terraform workspaces:\r\n{0}".format(err))
+        module.warn("Failed to list Terraform workspaces:\r\n{0}".format(err))
     for item in out.split('\n'):
         stripped_item = item.strip()
         if not stripped_item:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The terraform module fails when using a terraform backend that doesn't support workspaces.
This change prints a warning instead failing. This way, it will work with those backends. It should not have bad effects on others since the remaining actions would fail if there is another workspace issue (trying to use an inexistent workspace, for example).
Fixes #64788

Another pull request exists to solve this issue by configuring a `null` workspace: #57402. I considered that the module should work without specifying a fake workspace parameter, hence this PR.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See #64788 

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
TASK [apply configuration] *************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to list Terraform workspaces:\r\nworkspaces not supported\n"}
```
After:
```
TASK [apply configuration] *******************************************
[WARNING]: Failed to list Terraform workspaces:  workspaces not supported

ok: [localhost]
```