### PR TITLE
Fixes error in regex example of wait_for module

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -157,7 +157,7 @@ EXAMPLES = r'''
     search_regex: completed (?P<task>\w+)
   register: waitfor
 - debug:
-    msg: Completed {{ waitfor['groupdict']['task'] }}
+    msg: Completed {{ waitfor['match_groupdict']['task'] }}
 
 - name: Wait until the lock file is removed
   wait_for:


### PR DESCRIPTION
##### SUMMARY
Variable name fixed in example with name "Wait until regex pattern matches in the file /tmp/foo and print the matched group".

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr