### PR TITLE
Add missing version_added in checkpoint documentation

### DIFF
--- a/lib/ansible/plugins/httpapi/checkpoint.py
+++ b/lib/ansible/plugins/httpapi/checkpoint.py
@@ -21,6 +21,7 @@ options:
       - Specifies the domain of the Check Point device
     vars:
       - name: ansible_checkpoint_domain
+    version_added: "2.10"
 """
 
 import json


### PR DESCRIPTION
##### SUMMARY

Domain is newly added in 2.10 release, specify this in the
documentation section in Checkpoint httpapi connection plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request


- Docs Pull Request




##### COMPONENT NAME
lib/ansible/plugins/httpapi/checkpoint.py
