### PR TITLE
[backport 2.9] gitlab module: set max version for python-gitlab lib

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab_deploy_key.py
@@ -25,7 +25,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
 extends_documentation_fragment:
     - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -25,7 +25,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
 extends_documentation_fragment:
     - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab_hook.py
@@ -26,7 +26,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
 extends_documentation_fragment:
     - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -26,7 +26,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
 extends_documentation_fragment:
     - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab_project_variable.py
@@ -24,7 +24,7 @@ author:
   - "Markus Bergholz (@markuman)"
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
 extends_documentation_fragment:
   - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -34,7 +34,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab >= 1.5.0
+  - python-gitlab <= 1.12.1
 extends_documentation_fragment:
     - auth_basic
 options:

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -26,7 +26,7 @@ author:
   - Guillaume Martinez (@Lunik)
 requirements:
   - python >= 2.7
-  - python-gitlab python module
+  - python-gitlab python module <= 1.12.1
   - administrator rights on the GitLab server
 extends_documentation_fragment:
     - auth_basic


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the documentation for limiting the `python-gitlab` python library version to `1.12.1`
Allow to limit the impact of #64770 in Ansible 2.9
This limitation will be removed in Ansible 2.10 with #64989

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_group
gitlab_deploy_key
gitlab_hook
gitlab_project
gitlab_project_variable
gitlab_runner
gitlab_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
