### PR TITLE
Module ec2-instance parameter "wait" seems to be default false

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -38,7 +38,7 @@ options:
   wait:
     description:
       - Whether or not to wait for the desired state (use wait_timeout to customize this).
-    default: true
+    default: false
     type: bool
   wait_timeout:
     description:


### PR DESCRIPTION
##### SUMMARY
Parameter "wait" has default "false" in my experience, so I changed its default value.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### ISSUE TYPE
- Docs Pull Request
