### PR TITLE
module postgresql_privs now reports the correct status of a change when using type=default_privs

### DIFF
--- a/changelogs/fragments/64371-postgresql_privs-always-reports-as-changed-when-using-default_privs.yml
+++ b/changelogs/fragments/64371-postgresql_privs-always-reports-as-changed-when-using-default_privs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs.py - fix reports as changed behavior of module when using ``type=default_privs`` (https://github.com/ansible/ansible/issues/64371).

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: Ansible Project
+# Copyright: (c) 2019, Tobias Birkefeld (@tcraxs) <t@craxs.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -194,6 +195,7 @@ extends_documentation_fragment:
 
 author:
 - Bernhard Weitzhofer (@b6d)
+- Tobias Birkefeld (@tcraxs)
 '''
 
 EXAMPLES = r'''
@@ -778,7 +780,7 @@ class Connection(object):
         executed_queries.append(query)
         self.cursor.execute(query)
         status_after = get_status(objs)
-        return status_before != status_after
+        return status_before.sort() != status_after.sort()
 
 
 class QueryBuilder(object):


### PR DESCRIPTION
##### SUMMARY
`postgresql_privs` now reports the correct status of a change when using `type=default_privs`

"Fixes #64371 "

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
postgresql_privs