### PR TITLE
Ensure `allow_duplicates: true` enables to run single role multiple times (#64902)

### DIFF
--- a/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
+++ b/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - roles - Ensure that `allow_duplidates: true` enables to run single role multiple times (https://github.com/ansible/ansible/issues/64902)
+  - roles - Ensure that ``allow_duplidates: true`` enables to run single role multiple times (https://github.com/ansible/ansible/issues/64902)

--- a/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
+++ b/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles - Ensure that `allow_duplidates: true` enables to run single role multiple times (https://github.com/ansible/ansible/issues/64902)

--- a/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
+++ b/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
@@ -1,2 +1,4 @@
+---
 bugfixes:
-  - roles - Ensure that ``allow_duplidates: true`` enables to run single role multiple times (https://github.com/ansible/ansible/issues/64902)
+  - "roles - Ensure that ``allow_duplidates: true`` enables to run single
+    role multiple times (https://github.com/ansible/ansible/issues/64902)"

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -201,11 +201,9 @@ class Play(Base, Taggable, CollectionSearch):
         for ri in role_includes:
             roles.append(Role.load(ri, play=self))
 
-        return self._extend_value(
-            self.roles,
-            roles,
-            prepend=True
-        )
+        self.roles[:0] = roles
+
+        return self.roles
 
     def _load_vars_prompt(self, attr, ds):
         new_ds = preprocess_vars(ds)

--- a/test/integration/targets/include_import/roles/dup_allowed_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/dup_allowed_role/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/test/integration/targets/include_import/roles/dup_allowed_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/dup_allowed_role/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- debug:
+    msg: "Tasks file inside role"

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -107,4 +107,4 @@ ansible-playbook valid_include_keywords/playbook.yml "$@"
 
 # https://github.com/ansible/ansible/issues/64902
 ansible-playbook tasks/test_allow_single_role_dup.yml 2>&1 | tee test_allow_single_role_dup.out
-test "$(grep -c 'Tasks file inside role' test_allow_single_role_dup.out)" = 3
+test "$(grep -c 'ok=3' test_allow_single_role_dup.out)" = 1

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -104,3 +104,7 @@ ansible-playbook test_loop_var_bleed.yaml "$@"
 
 # https://github.com/ansible/ansible/issues/56580
 ansible-playbook valid_include_keywords/playbook.yml "$@"
+
+# https://github.com/ansible/ansible/issues/64902
+ansible-playbook tasks/test_allow_single_role_dup.yml 2>&1 | tee test_allow_single_role_dup.out
+test "$(grep -c 'Tasks file inside role' test_allow_single_role_dup.out)" = 3

--- a/test/integration/targets/include_import/tasks/test_allow_single_role_dup.yml
+++ b/test/integration/targets/include_import/tasks/test_allow_single_role_dup.yml
@@ -1,0 +1,8 @@
+---
+- name: test for allow_duplicates with single role
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - dup_allowed_role
+    - dup_allowed_role
+    - dup_allowed_role


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ensure `allow_duplicates: true` enables to run single role multiple times(#64902)

Fixes #64902

* Change return value in `_load_roles`
* Add changelog fragment
* Add an integration test for the issue

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
allow_duplicates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
