### PR TITLE
Add support for populating ansible_user from EC2 tag

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -37,7 +37,7 @@ destination_variable = public_dns_name
 #hostname_variable = tag_Name
 
 # This allows you to configure the ansible_user from an EC2 variable. This is
-# useful in heterogenuous environments, where by instances originate from
+# useful in heterogeneous environments, where by instances originate from
 # different AMIs/distros (i.e. Debian, Ubuntu, CentOS, etc). Tags should be
 # written as 'tag_TAGNAME'.
 #username_variable = tag_Username

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -31,10 +31,16 @@ regions_exclude = us-gov-west-1, cn-north-1
 # in the event of a collision.
 destination_variable = public_dns_name
 
-# This allows you to override the inventory_name with an ec2 variable, instead
+# This allows you to override the inventory_name with an EC2 variable, instead
 # of using the destination_variable above. Addressing (aka ansible_ssh_host)
 # will still use destination_variable. Tags should be written as 'tag_TAGNAME'.
 #hostname_variable = tag_Name
+
+# This allows you to configure the ansible_user from an EC2 variable. This is
+# useful in heterogenuous environments, where by instances originate from
+# different AMIs/distros (i.e. Debian, Ubuntu, CentOS, etc). Tags should be
+# written as 'tag_TAGNAME'.
+#username_variable = tag_Username
 
 # For server inside a VPC, using DNS names may not make sense. When an instance
 # has 'subnet_id' set, this variable is used. If the subnet is public, setting

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -221,6 +221,7 @@ DEFAULTS = {
     'group_by_tag_none': 'True',
     'group_by_vpc_id': 'True',
     'hostname_variable': '',
+    'username_variable': '',
     'iam_role': '',
     'include_rds_clusters': 'False',
     'nested_groups': 'False',
@@ -375,6 +376,7 @@ class Ec2Inventory(object):
         self.destination_variable = config.get('ec2', 'destination_variable')
         self.vpc_destination_variable = config.get('ec2', 'vpc_destination_variable')
         self.hostname_variable = config.get('ec2', 'hostname_variable')
+        self.username_variable = config.get('ec2', 'username_variable')
 
         if config.has_option('ec2', 'destination_format') and \
            config.has_option('ec2', 'destination_format_tags'):
@@ -932,6 +934,14 @@ class Ec2Inventory(object):
             else:
                 hostname = getattr(instance, self.hostname_variable)
 
+        # Set the username
+        username = None
+        if self.username_variable:
+            if self.username_variable.startswith('tag_'):
+                username = instance.tags.get(self.username_variable[4:], None)
+            else:
+                username = getattr(instance, self.username_variable)
+
         # set the hostname from route53
         if self.route53_enabled and self.route53_hostnames:
             route53_names = self.get_instance_route53_names(instance)
@@ -1079,6 +1089,7 @@ class Ec2Inventory(object):
         self.push(self.inventory, 'ec2', hostname)
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_user'] = username
         self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
     def add_rds_instance(self, instance, region):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This PR adds support for configuring the `ansible_user` variable from an EC2 tag.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
EC2 dynamic inventory script

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Consider a deployment that consists of a number of EC2 instances that have been created from a number of different AMIs, for instance some community ones. These will all have different default usernames:


| Distro | default username |
| --- | --- | 
|  Debian | `admin` |
| Ubuntu | `ubuntu` |
| CentOS | `centos` |

By adding an EC2 tag (say `Username`), and then configuring this in `ec2.ini`: 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
username_variable = tag_Username
```

The value will now be used as the `ansible_user` inventory variable.
