### PR TITLE
Inventory CLI - Ignore settings for when vars plugins should run

### DIFF
--- a/changelogs/fragments/65073-fix-inventory-cli-loading-vars-plugins.yaml
+++ b/changelogs/fragments/65073-fix-inventory-cli-loading-vars-plugins.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ansible-inventory - Fix regression loading vars plugins. (https://github.com/ansible/ansible/issues/65064)
+  - ansible-inventory - Fix long standing bug not loading vars plugins for group vars relative to the playbook
+    dir when the '--playbook-dir' and '--export' flags are used together.

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -37,7 +37,7 @@ Using vars plugins
 
 By default, vars plugins are used on demand automatically after they are enabled.
 
-Starting in Ansible 2.10, vars plugins can be made to run at specific times.
+Starting in Ansible 2.10, vars plugins can be made to run at specific times. `ansible-inventory` does not use these settings, and always loads vars plugins.
 
 The global setting ``RUN_VARS_PLUGINS`` can be set in ``ansible.cfg`` using ``run_vars_plugins`` in the ``defaults`` section or by the ``ANSIBLE_RUN_VARS_PLUGINS`` environment variable. The default option, ``demand``, runs any enabled vars plugins relative to inventory sources whenever variables are demanded by tasks. You can use the option ``start`` to run any enabled vars plugins relative to inventory sources after importing that inventory source instead.
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -190,7 +190,7 @@ class InventoryCLI(CLI):
         # get info from inventory source
         res = group.get_vars()
 
-        res = combine_vars(res, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [group], 'inventory'))
+        res = combine_vars(res, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [group], 'all'))
 
         if group.priority != 1:
             res['ansible_group_priority'] = group.priority
@@ -203,7 +203,7 @@ class InventoryCLI(CLI):
             # only get vars defined directly host
             hostvars = host.get_vars()
 
-            hostvars = combine_vars(hostvars, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [host], 'inventory'))
+            hostvars = combine_vars(hostvars, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [host], 'all'))
         else:
             # get all vars flattened by host, but skip magic hostvars
             hostvars = self.vm.get_vars(host=host, include_hostvars=False, stage='inventory')

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -18,7 +18,7 @@ from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.loader import vars_loader
 from ansible.utils.vars import combine_vars
 from ansible.utils.display import Display
-from ansible.vars.plugins import get_vars_from_inventory_sources
+from ansible.vars.plugins import get_vars_from_inventory_sources, get_vars_from_path
 
 display = Display()
 
@@ -190,7 +190,10 @@ class InventoryCLI(CLI):
         # get info from inventory source
         res = group.get_vars()
 
+        # Always load vars plugins
         res = combine_vars(res, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [group], 'all'))
+        if context.CLIARGS['basedir']:
+            res = combine_vars(res, get_vars_from_path(self.loader, context.CLIARGS['basedir'], [group], 'all'))
 
         if group.priority != 1:
             res['ansible_group_priority'] = group.priority
@@ -203,10 +206,13 @@ class InventoryCLI(CLI):
             # only get vars defined directly host
             hostvars = host.get_vars()
 
+            # Always load vars plugins
             hostvars = combine_vars(hostvars, get_vars_from_inventory_sources(self.loader, self.inventory._sources, [host], 'all'))
+            if context.CLIARGS['basedir']:
+                hostvars = combine_vars(hostvars, get_vars_from_path(self.loader, context.CLIARGS['basedir'], [host], 'all'))
         else:
             # get all vars flattened by host, but skip magic hostvars
-            hostvars = self.vm.get_vars(host=host, include_hostvars=False, stage='inventory')
+            hostvars = self.vm.get_vars(host=host, include_hostvars=False)
 
         return self._remove_internal(hostvars)
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -212,7 +212,7 @@ class InventoryCLI(CLI):
                 hostvars = combine_vars(hostvars, get_vars_from_path(self.loader, context.CLIARGS['basedir'], [host], 'all'))
         else:
             # get all vars flattened by host, but skip magic hostvars
-            hostvars = self.vm.get_vars(host=host, include_hostvars=False)
+            hostvars = self.vm.get_vars(host=host, include_hostvars=False, stage='all')
 
         return self._remove_internal(hostvars)
 

--- a/test/integration/targets/collections/vars_plugin_tests.sh
+++ b/test/integration/targets/collections/vars_plugin_tests.sh
@@ -63,14 +63,6 @@ grep -v '"collection": "adjacent"' out.txt
 grep -v '"collection": "collection_root_user"' out.txt
 grep -v '"adj_var": "value"' out.txt
 
-# Test vars plugins that support the stage setting run for inventory when stage is set to 'inventory'
-ANSIBLE_VARS_PLUGIN_STAGE=inventory ansible-inventory -i a.statichost.yml --list --playbook-dir=./ | tee out.txt
-
-grep -v '"v1_vars_plugin": true' out.txt
-grep -v '"vars_req_whitelist": true' out.txt
-grep '"v2_vars_plugin": true' out.txt
-grep '"name": "v2_vars_plugin"' out.txt
-
 # Test that the global setting allows v1 and v2 plugins to run after importing inventory
 ANSIBLE_RUN_VARS_PLUGINS=start ansible-inventory -i a.statichost.yml --list --playbook-dir=./ | tee out.txt
 


### PR DESCRIPTION
##### SUMMARY
Just always run vars plugins for inventory CLI.
Fixes #65064

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/inventory.py