### PR TITLE
Add SimpleUpdate command

### DIFF
--- a/lib/ansible/modules/remote_management/redfish/redfish_command.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_command.py
@@ -119,6 +119,42 @@ options:
       - The ID of the System, Manager or Chassis to modify
     type: str
     version_added: "2.10"
+  update_image_uri:
+    required: false
+    description:
+      - The URI of the image for the update
+    type: str
+    version_added: "2.10"
+  update_protocol:
+    required: false
+    description:
+      - The protocol for the update
+    type: str
+    version_added: "2.10"
+  update_targets:
+    required: false
+    description:
+      - The list of target resource URIs to apply the update to
+    type: list
+    elements: str
+    version_added: "2.10"
+  update_creds:
+    required: false
+    description:
+      - The credentials for retrieving the update image
+    type: dict
+    suboptions:
+      username:
+        required: false
+        description:
+          - The username for retrieving the update image
+        type: str
+      password:
+        required: false
+        description:
+          - The password for retrieving the update image
+        type: str
+    version_added: "2.10"
 
 author: "Jose Delarosa (@jose-delarosa)"
 '''
@@ -302,6 +338,30 @@ EXAMPLES = '''
       baseuri: "{{ baseuri }}"
       username: "{{ username }}"
       password: "{{ password }}"
+
+  - name: Simple update
+    redfish_command:
+      category: Update
+      command: SimpleUpdate
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      update_image_uri: https://example.com/myupdate.img
+
+  - name: Simple update with additional options
+    redfish_command:
+      category: Update
+      command: SimpleUpdate
+      baseuri: "{{ baseuri }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      update_image_uri: //example.com/myupdate.img
+      update_protocol: FTP
+      update_targets:
+        - /redfish/v1/UpdateService/FirmwareInventory/BMC
+      update_creds:
+        username: operator
+        password: supersecretpwd
 '''
 
 RETURN = '''
@@ -327,6 +387,7 @@ CATEGORY_COMMANDS_ALL = {
                  "UpdateAccountServiceProperties"],
     "Sessions": ["ClearSessions"],
     "Manager": ["GracefulRestart", "ClearLogs"],
+    "Update": ["SimpleUpdate"]
 }
 
 
@@ -349,7 +410,17 @@ def main():
             timeout=dict(type='int', default=10),
             uefi_target=dict(),
             boot_next=dict(),
-            resource_id=dict()
+            resource_id=dict(),
+            update_image_uri=dict(),
+            update_protocol=dict(),
+            update_targets=dict(type='list', elements='str', default=[]),
+            update_creds=dict(
+                type='dict',
+                options=dict(
+                    username=dict(),
+                    password=dict()
+                )
+            )
         ),
         supports_check_mode=False
     )
@@ -374,6 +445,14 @@ def main():
 
     # System, Manager or Chassis ID to modify
     resource_id = module.params['resource_id']
+
+    # update options
+    update_opts = {
+        'update_image_uri': module.params['update_image_uri'],
+        'update_protocol': module.params['update_protocol'],
+        'update_targets': module.params['update_targets'],
+        'update_creds': module.params['update_creds']
+    }
 
     # Build root URI
     root_uri = "https://" + module.params['baseuri']
@@ -465,6 +544,16 @@ def main():
 
         for command in command_list:
             result = MANAGER_COMMANDS[command]()
+
+    elif category == "Update":
+        # execute only if we find UpdateService resources
+        resource = rf_utils._find_updateservice_resource()
+        if resource['ret'] is False:
+            module.fail_json(msg=resource['msg'])
+
+        for command in command_list:
+            if command == "SimpleUpdate":
+                result = rf_utils.simple_update(update_opts)
 
     # Return data back or fail with proper message
     if result['ret'] is True:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added new Redfish command SimpleUpdate as described in feature issue #63925.

I did some investigation and came to the conclusion that spinning up an HTTP server in the module (as mentioned in #63925) would not be the best approach. This would not scale well in scenarios where playbooks are used to perform updates to hundreds or thousands of services. And Ansible already has very good modules for spinning up HTTP servers. The best approach would be to leverage that existing well-supported capability.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #63925

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

A couple of sample play snippets:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  - name: Simple update
    redfish_command:
      category: Update
      command: SimpleUpdate
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
      update_image_uri: https://example.com/myupdate.img
```

```
  - name: Simple update with additional options
    redfish_command:
      category: Update
      command: SimpleUpdate
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
      update_image_uri: //example.com/myupdate.img
      update_protocol: FTP
      update_targets:
        - /redfish/v1/UpdateService/FirmwareInventory/BMC
      update_creds:
        username: operator
        password: supersecretpwd
```
