### PR TITLE
Fix "replace: block" when there are no "parents"

### DIFF
--- a/lib/ansible/module_utils/network/common/config.py
+++ b/lib/ansible/module_utils/network/common/config.py
@@ -364,9 +364,14 @@ class NetworkConfig(object):
                         if p not in parents:
                             parents.append(p)
 
+            has_children = False
             updates = list()
             for item in parents:
+                if item.has_children:
+                    has_children = True
                 updates.extend(self._expand_block(item))
+            if not has_children:
+                updates = self.items
 
         visited = set()
         expanded = list()


### PR DESCRIPTION
##### SUMMARY
Fixes ansible/ansible#29716

As documented, the eos_config module as well as many others based on
`ansible.module_utils.network.common.config.NetworkConfig` take a parameter,
"replace". The choice value "block" says "If the replace argument is set to
I(block) then the entire command block is pushed to the device in configuration
mode if any line is not correct".

However, in practice, this doesn't seem to actually be happening, unless the
parsed ConfigLine items each have a parent associated with them.

This probably went unnoticed for so long because replacing blocks of
configuration on Cisco IOS and IOS-derivative CLIs (seemingly what the
NetworkConfig object abstracts) usually has some kind of parent associated with
it (e.g. "ip access-list ...."), in which case, the `replace: block`
functionality actually works.

The reports inside of ansible/ansible#29716 seem to be reflective of this same
issue.

This commit attempts to address the root cause. However, I dug into this issue and based my initial tests and fixes based on the `eos_config` module.
I also have a commit at https://github.com/jof/ansible/commit/86715615c959c9265226a8da25235031c34be159 which initially tries to just fix the `eos_config` module.
It could be merged instead, in case the scope of this change is too hard to test/verify.

To reproduce this issue, configure an Arista EOS device (version 4.21+ or so),
and setup some NTP servers.
For example:

    eos_config:
      diff_against: session
      replace: block
      before:
	- default ntp
      lines:
	- ntp server vrf MANAGEMENT 10.1.1.1 iburst
	- ntp server vrf MANAGEMENT 10.2.2.2 iburst
	- ntp server vrf MANAGEMENT 10.3.3.3 iburst

Run against a device with one of those servers missing:

    .....
    ntp server vrf MANAGEMENT 10.1.1.1 iburst
    ntp server vrf MANAGEMENT 10.3.3.3 iburst
    .....

Results in a diff like:

    --- system:/running-config
    +++ session:/ansible_1574184327-session-config
    @@ -31,6 +31,7 @@
     !
     ntp source vrf MANAGEMENT Management1
    -ntp server vrf MANAGEMENT 10.1.1.1 iburst
    -ntp server vrf MANAGEMENT 10.3.3.3 iburst
    +ntp server vrf MANAGEMENT 10.2.2.2 iburst
     !

Because the "before" line still ran ("default ntp"), which removes any
configured NTP servers. However, critically, ansible doesn't respect the
"replace: block" parameter and apply all lines to the device, and instead only
applies the lines that it detects as missing.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
eos_config, however, this affects to many other network modules that are based on `ansible.module_utils.network.common.config.NetworkConfig`