### PR TITLE
routeros_facts – fix for the crash when ipv6 is disabled

### DIFF
--- a/lib/ansible/modules/network/routeros/routeros_facts.py
+++ b/lib/ansible/modules/network/routeros/routeros_facts.py
@@ -290,6 +290,8 @@ class Interfaces(FactsBase):
 
     def populate_ipv6_interfaces(self, data):
         for key, value in iteritems(data):
+            if key is None:
+                break
             if 'ipv6' not in self.facts['interfaces'][key]:
                 self.facts['interfaces'][key]['ipv6'] = list()
             addr, subnet = value['address'].split("/")

--- a/test/units/modules/network/routeros/fixtures/routeros_facts/ipv6_address_print_detail_without-paging_no-ipv6
+++ b/test/units/modules/network/routeros/fixtures/routeros_facts/ipv6_address_print_detail_without-paging_no-ipv6
@@ -1,0 +1,1 @@
+bad command name address (line 1 column 7)

--- a/test/units/modules/network/routeros/test_routeros_facts.py
+++ b/test/units/modules/network/routeros/test_routeros_facts.py
@@ -107,3 +107,13 @@ class TestRouterosFactsModule(TestRouterosModule):
         self.assertEqual(
             len(result['ansible_facts']['ansible_net_neighbors'].keys()), 4
         )
+
+    def test_routeros_facts_interfaces_no_ipv6(self):
+        fixture = load_fixture(
+            'routeros_facts/ipv6_address_print_detail_without-paging_no-ipv6'
+        )
+        interfaces = self.module.Interfaces(module=self.module)
+        addresses = interfaces.parse_addresses(data=fixture)
+        result = interfaces.populate_ipv6_interfaces(data=addresses)
+
+        self.assertEqual(result, None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a bug in `routeros_facts` that leads to a crash when trying to fetch network interfaces if `ipv6` package is not enabled on the target router.

Fixes #64958.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`routeros_facts`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
