### PR TITLE
Fix action plugin issue with network connection type in common collection

### DIFF
--- a/changelogs/fragments/network_action_plugin_fixes.yml
+++ b/changelogs/fragments/network_action_plugin_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes in network action plugins to work in network connection plugin and modules in collection

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -36,7 +36,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'aireos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'aireos_config' else False
 
         if self._play_context.connection != 'local':
             return dict(

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -36,7 +36,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'aruba_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'aruba_config' else False
 
         if self._play_context.connection != 'local':
             return dict(

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -37,7 +37,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'asa_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'asa_config' else False
 
         if self._play_context.connection == 'local':
             provider = load_provider(asa_provider_spec, self._task.args)

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -43,11 +43,13 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'bigip_imish_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'bigip_imish_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
         socket_path = None
         transport = 'rest'
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning("'provider' is unnecessary when using 'network_cli' and will be ignored")
@@ -83,7 +85,7 @@ class ActionModule(ActionNetworkModule):
 
                 task_vars['ansible_socket'] = socket_path
 
-        if (self._play_context.connection == 'local' and transport == 'cli') or self._play_context.connection == 'network_cli':
+        if (self._play_context.connection == 'local' and transport == 'cli') or persistent_connection == 'network_cli':
             # make sure we are in the right cli context which should be
             # enable mode and not config module
             if socket_path is None:

--- a/lib/ansible/plugins/action/bigiq.py
+++ b/lib/ansible/plugins/action/bigiq.py
@@ -43,8 +43,9 @@ class ActionModule(_ActionModule):
     def run(self, tmp=None, task_vars=None):
         socket_path = None
         transport = 'rest'
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning("'provider' is unnecessary when using 'network_cli' and will be ignored")
@@ -78,7 +79,7 @@ class ActionModule(_ActionModule):
 
                 task_vars['ansible_socket'] = socket_path
 
-        if (self._play_context.connection == 'local' and transport == 'cli') or self._play_context.connection == 'network_cli':
+        if (self._play_context.connection == 'local' and transport == 'cli') or persistent_connection == 'network_cli':
             # make sure we are in the right cli context which should be
             # enable mode and not config module
             if socket_path is None:

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -31,8 +31,10 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'ce_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'ce_config' else False
         socket_path = None
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
         if self._play_context.connection == 'local':
             provider = load_provider(ce_provider_spec, self._task.args)
@@ -55,7 +57,7 @@ class ActionModule(ActionNetworkModule):
                     username=pc.remote_user,
                     password=pc.password
                 )
-                if self._task.action in ['ce_netconf'] or self._task.action not in CLI_SUPPORTED_MODULES:
+                if module_name in ['ce_netconf'] or module_name not in CLI_SUPPORTED_MODULES:
                     pc.connection = 'netconf'
                 display.vvv('using connection plugin %s (was local)' % pc.connection, pc.remote_addr)
                 connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
@@ -72,14 +74,14 @@ class ActionModule(ActionNetworkModule):
                 # make sure a transport value is set in args
                 self._task.args['transport'] = transport
                 self._task.args['provider'] = provider
-        elif self._play_context.connection in ('netconf', 'network_cli'):
+        elif persistent_connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                 del self._task.args['provider']
 
-            if (self._play_context.connection == 'network_cli' and self._task.action not in CLI_SUPPORTED_MODULES) or \
-                    (self._play_context.connection == 'netconf' and self._task.action in CLI_SUPPORTED_MODULES):
+            if (persistent_connection == 'network_cli' and module_name not in CLI_SUPPORTED_MODULES) or \
+                    (persistent_connection == 'netconf' and module_name in CLI_SUPPORTED_MODULES):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module."
                         % (self._play_context.connection, self._task.action)}
 

--- a/lib/ansible/plugins/action/cli_command.py
+++ b/lib/ansible/plugins/action/cli_command.py
@@ -25,7 +25,7 @@ from ansible.plugins.action.normal import ActionModule as _ActionModule
 class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
-        if self._play_context.connection != 'network_cli':
+        if self._play_context.connection.split('.')[-1] != 'network_cli':
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/cli_config.py
+++ b/lib/ansible/plugins/action/cli_config.py
@@ -28,7 +28,7 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         self._config_module = True
-        if self._play_context.connection != 'network_cli':
+        if self._play_context.connection.split('.')[-1] != 'network_cli':
             return {'failed': True, 'msg': 'Connection type %s is not valid for cli_config module' % self._play_context.connection}
 
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/cnos.py
+++ b/lib/ansible/plugins/action/cnos.py
@@ -34,7 +34,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'cnos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'cnos_config' else False
 
         if self._play_context.connection == 'local':
             provider = load_provider(cnos_provider_spec, self._task.args)

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -38,9 +38,11 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'dellos10_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'dellos10_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -38,10 +38,12 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'dellos6_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'dellos6_config' else False
         socket_path = None
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -38,10 +38,12 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'dellos9_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'dellos9_config' else False
         socket_path = None
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/edgeos_config.py
+++ b/lib/ansible/plugins/action/edgeos_config.py
@@ -29,7 +29,8 @@ class ActionModule(ActionNetworkModule):
 
         self._config_module = True
 
-        if self._play_context.connection != 'network_cli':
-            return {'failed': True, 'msg': 'Connection type %s is not valid for this module. Must use network_cli.' % self._play_context.connection}
+        if self._play_context.connection.split('.')[-1] != 'network_cli':
+            return {'failed': True, 'msg': 'Connection type %s is not valid for this module. Must use fully qualified'
+                                           ' name of network_cli connection type.' % self._play_context.connection}
 
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/enos.py
+++ b/lib/ansible/plugins/action/enos.py
@@ -34,7 +34,8 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'enos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'enos_config' else False
 
         if self._play_context.connection == 'local':
             provider = load_provider(enos_provider_spec, self._task.args)

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -30,7 +30,6 @@ from ansible.utils.display import Display
 
 display = Display()
 
-
 class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
@@ -38,8 +37,9 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'eos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection in ('network_cli', 'httpapi'):
+        if persistent_connection in ('network_cli', 'httpapi'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -30,6 +30,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
+
 class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):

--- a/lib/ansible/plugins/action/exos.py
+++ b/lib/ansible/plugins/action/exos.py
@@ -32,12 +32,14 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'exos_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'exos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection not in ('network_cli', 'httpapi'):
+        if persistent_connection not in ('network_cli', 'httpapi'):
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
 
-        if self._play_context.connection == 'network_cli' and self._task.action not in self.EXOS_NETWORK_CLI_MODULES:
+        if persistent_connection == 'network_cli' and module_name not in self.EXOS_NETWORK_CLI_MODULES:
             return {'failed': True, 'msg': "Connection type %s is not valid for this module" % self._play_context.connection}
 
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -37,8 +37,9 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'ios_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -38,6 +38,7 @@ class ActionModule(ActionNetworkModule):
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'iosxr_config' else False
         force_cli = module_name in ('iosxr_netconf', 'iosxr_config', 'iosxr_command', 'iosxr_facts')
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
         if self._play_context.connection == 'local':
             provider = load_provider(iosxr_provider_spec, self._task.args)
@@ -71,7 +72,7 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-        elif self._play_context.connection in ('netconf', 'network_cli'):
+        elif persistent_connection in ('netconf', 'network_cli'):
             if force_cli and self._play_context.connection != 'network_cli':
                 return {'failed': True, 'msg': 'Connection type %s is not valid for module %s' %
                         (self._play_context.connection, module_name)}

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -73,7 +73,7 @@ class ActionModule(ActionNetworkModule):
 
             task_vars['ansible_socket'] = socket_path
         elif persistent_connection in ('netconf', 'network_cli'):
-            if force_cli and self._play_context.connection != 'network_cli':
+            if force_cli and persistent_connection != 'network_cli':
                 return {'failed': True, 'msg': 'Connection type %s is not valid for module %s' %
                         (self._play_context.connection, module_name)}
             provider = self._task.args.get('provider', {})

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -35,9 +35,11 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'ironware_config' else False
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'ironware_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -39,6 +39,7 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'junos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
         if self._play_context.connection == 'local':
             provider = load_provider(junos_provider_spec, self._task.args)
@@ -76,7 +77,7 @@ class ActionModule(ActionNetworkModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             task_vars['ansible_socket'] = socket_path
-        elif self._play_context.connection in ('netconf', 'network_cli'):
+        elif persistent_connection in ('netconf', 'network_cli'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 # for legacy reasons provider value is required for junos_facts(optional) and junos_package
@@ -85,8 +86,8 @@ class ActionModule(ActionNetworkModule):
                     display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)
                     del self._task.args['provider']
 
-            if (self._play_context.connection == 'network_cli' and module_name not in CLI_SUPPORTED_MODULES) or \
-                    (self._play_context.connection == 'netconf' and module_name in CLI_SUPPORTED_MODULES[0:2]):
+            if (persistent_connection == 'network_cli' and module_name not in CLI_SUPPORTED_MODULES) or \
+                    (persistent_connection == 'netconf' and module_name in CLI_SUPPORTED_MODULES[0:2]):
                 return {'failed': True, 'msg': "Connection type '%s' is not valid for '%s' module. "
                                                "Please see https://docs.ansible.com/ansible/latest/network/user_guide/platform_junos.html"
                                                % (self._play_context.connection, module_name)}

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -39,13 +39,15 @@ class ActionModule(ActionBase):
         socket_path = None
         play_context = copy.deepcopy(self._play_context)
         play_context.network_os = self._get_network_os(task_vars)
+        persistent_connection = play_context.connection.split('.')[-1]
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 
-        if play_context.connection != 'network_cli':
+        if persistent_connection != 'network_cli':
             # It is supported only with network_cli
             result['failed'] = True
-            result['msg'] = ('please use network_cli connection type for net_get module')
+            result['msg'] = ('connection type %s is not valid for net_get module,'
+                             ' please use fully qualified name of network_cli connection type' % play_context.connection)
             return result
 
         try:

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -37,9 +37,8 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         socket_path = None
-        play_context = copy.deepcopy(self._play_context)
-        play_context.network_os = self._get_network_os(task_vars)
-        persistent_connection = play_context.connection.split('.')[-1]
+        network_os = self._get_network_os(task_vars)
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 
@@ -47,7 +46,7 @@ class ActionModule(ActionBase):
             # It is supported only with network_cli
             result['failed'] = True
             result['msg'] = ('connection type %s is not valid for net_get module,'
-                             ' please use fully qualified name of network_cli connection type' % play_context.connection)
+                             ' please use fully qualified name of network_cli connection type' % self._play_context.connection)
             return result
 
         try:

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -38,13 +38,15 @@ class ActionModule(ActionBase):
         socket_path = None
         play_context = copy.deepcopy(self._play_context)
         play_context.network_os = self._get_network_os(task_vars)
+        persistent_connection = play_context.connection.split('.')[-1]
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 
-        if play_context.connection != 'network_cli':
+        if persistent_connection != 'network_cli':
             # It is supported only with network_cli
             result['failed'] = True
-            result['msg'] = ('please use network_cli connection type for net_put module')
+            result['msg'] = ('connection type %s is not valid for net_put module,'
+                             ' please use fully qualified name of network_cli connection type' % play_context.connection)
             return result
 
         try:

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -36,9 +36,8 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         socket_path = None
-        play_context = copy.deepcopy(self._play_context)
-        play_context.network_os = self._get_network_os(task_vars)
-        persistent_connection = play_context.connection.split('.')[-1]
+        network_os = self._get_network_os(task_vars).split('.')[-1]
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
         result = super(ActionModule, self).run(task_vars=task_vars)
 
@@ -46,7 +45,7 @@ class ActionModule(ActionBase):
             # It is supported only with network_cli
             result['failed'] = True
             result['msg'] = ('connection type %s is not valid for net_put module,'
-                             ' please use fully qualified name of network_cli connection type' % play_context.connection)
+                             ' please use fully qualified name of network_cli connection type' % self._play_context.connection)
             return result
 
         try:
@@ -117,7 +116,7 @@ class ActionModule(ActionBase):
             )
         except Exception as exc:
             if to_text(exc) == "No response from server":
-                if play_context.network_os == 'iosxr':
+                if network_os == 'iosxr':
                     # IOSXR sometimes closes socket prematurely after completion
                     # of file transfer
                     result['msg'] = 'Warning: iosxr scp server pre close issue. Please check dest'

--- a/lib/ansible/plugins/action/netconf.py
+++ b/lib/ansible/plugins/action/netconf.py
@@ -35,11 +35,12 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'netconf_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection not in ['netconf', 'local'] and module_name == 'netconf_config':
+        if persistent_connection not in ['netconf', 'local'] and module_name == 'netconf_config':
             return {'failed': True, 'msg': 'Connection type %s is not valid for netconf_config module. '
                                            'Valid connection type is netconf or local (deprecated)' % self._play_context.connection}
-        elif self._play_context.connection not in ['netconf'] and module_name != 'netconf_config':
+        elif persistent_connection not in ['netconf'] and module_name != 'netconf_config':
             return {'failed': True, 'msg': 'Connection type %s is not valid for %s module. '
                                            'Valid connection type is netconf.' % (self._play_context.connection, module_name)}
 

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -39,9 +39,9 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'nxos_config' else False
-        socket_path = None
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if (self._play_context.connection == 'httpapi' or self._task.args.get('provider', {}).get('transport') == 'nxapi') \
+        if (persistent_connection == 'httpapi' or self._task.args.get('provider', {}).get('transport') == 'nxapi') \
                 and module_name in ('nxos_file_copy', 'nxos_nxapi'):
             return {'failed': True, 'msg': "Transport type 'nxapi' is not valid for '%s' module." % (module_name)}
 
@@ -71,7 +71,7 @@ class ActionModule(ActionNetworkModule):
                 msg += ' Current persistent_connect_timeout setting:' + str(persistent_connect_timeout)
                 return {'failed': True, 'msg': msg}
 
-        if self._play_context.connection in ('network_cli', 'httpapi'):
+        if persistent_connection in ('network_cli', 'httpapi'):
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using %s and will be ignored' % self._play_context.connection)

--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -466,10 +466,10 @@ class ActionModule(ActionBase):
         self.play_context = copy.deepcopy(self._play_context)
         self.results = super(ActionModule, self).run(task_vars=task_vars)
 
-        if self.play_context.connection != 'network_cli':
+        if self.play_context.connection.split('.')[-1] != 'network_cli':
             # Plugin is supported only with network_cli
             self.results['failed'] = True
-            self.results['msg'] = ('Connection type must be <network_cli>')
+            self.results['msg'] = 'Connection type must be fully qualified name for network_cli connection type, got %s' % self.play_context.connection
             return self.results
 
         # Get playbook values

--- a/lib/ansible/plugins/action/slxos.py
+++ b/lib/ansible/plugins/action/slxos.py
@@ -31,7 +31,10 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'slxos_config' else False
-        if self._play_context.connection not in ('network_cli'):
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'slxos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
+
+        if persistent_connection not in ('network_cli'):
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -36,8 +36,11 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'sros_config' else False
-        if self._play_context.connection == 'network_cli':
+        module_name = self._task.action.split('.')[-1]
+        persistent_connection = self._play_context.connection.split('.')[-1]
+
+        self._config_module = True if module_name == 'sros_config' else False
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')

--- a/lib/ansible/plugins/action/voss.py
+++ b/lib/ansible/plugins/action/voss.py
@@ -27,7 +27,10 @@ class ActionModule(ActionNetworkModule):
     def run(self, tmp=None, task_vars=None):
         del tmp  # tmp no longer has any effect
 
-        self._config_module = True if self._task.action == 'voss_config' else False
-        if self._play_context.connection not in ('network_cli'):
+        module_name = self._task.action.split('.')[-1]
+        self._config_module = True if module_name == 'voss_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
+
+        if persistent_connection not in ('network_cli'):
             return {'failed': True, 'msg': 'Connection type %s is not valid for this module' % self._play_context.connection}
         return super(ActionModule, self).run(task_vars=task_vars)

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -37,8 +37,9 @@ class ActionModule(ActionNetworkModule):
 
         module_name = self._task.action.split('.')[-1]
         self._config_module = True if module_name == 'vyos_config' else False
+        persistent_connection = self._play_context.connection.split('.')[-1]
 
-        if self._play_context.connection == 'network_cli':
+        if persistent_connection == 'network_cli':
             provider = self._task.args.get('provider', {})
             if any(provider.values()):
                 display.warning('provider is unnecessary when using network_cli and will be ignored')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  For network connection in common collection the value of
   ansible_connection is the FQCN of the connection type
   For example ansible_connection=network.common.network_cli

*  Add fix in supported network action plugins to extract
   the connection name from FQCN
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/action/cli_command.py
plugins/action/cli_config.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/junos.py
plugins/action/net_get.py
plugins/action/net_put.py
plugins/action/netconf.py
plugins/action/nxos.py
plugins/action/vyos.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
