### PR TITLE
Fix up broken Windows test when run with coverage

### DIFF
--- a/test/integration/targets/win_csharp_utils/library/ansible_process_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_process_tests.ps1
@@ -219,8 +219,9 @@ $tests = @{
     }
 
     "CreateProcess with unicode and us-ascii encoding" = {
-        $actual = [Ansible.Process.ProcessUtil]::CreateProcess($null, "cmd.exe /c echo 💩 café", $null, $null, '', 'us-ascii')
-        $actual.StandardOut | Assert-Equals -Expected "???? caf??`r`n"
+        $poop = [System.Char]::ConvertFromUtf32(0xE05A)  # Coverage breaks due to script parsing encoding issues with unicode chars, just use the code point instead
+        $actual = [Ansible.Process.ProcessUtil]::CreateProcess($null, "cmd.exe /c echo $poop café", $null, $null, '', 'us-ascii')
+        $actual.StandardOut | Assert-Equals -Expected "??? caf??`r`n"
         $actual.StandardError | Assert-Equals -Expected ""
         $actual.ExitCode | Assert-Equals -Expected 0
     }


### PR DESCRIPTION
##### SUMMARY
When we run with coverage we run the module from an actual file. This changes the way the PowerShell engine reads a string from a pure string value (non-coverage) to something relying on the BOM of the file with a fallback to the system's codepage if no BOM is specified. This test had a unicode character which would be read as different chars due to the different encoding applied which screwed up the test assertion.

No need to backport as this was a test added only in devel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_csharp_utils tests