### PR TITLE
Fix typo in docs for lvol module: activate -> active

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -43,7 +43,7 @@ options:
     default: present
   active:
     description:
-    - Whether the volume is activate and visible to the host.
+    - Whether the volume is active and visible to the host.
     type: bool
     default: 'yes'
     version_added: "2.2"


### PR DESCRIPTION
##### SUMMARY

There was a typo in the docs for the lvol module.  This fixes it so it reads correctly in English

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lvol

##### ADDITIONAL INFORMATION
