### PR TITLE
Mention that Python keywords are invalid Ansible variable names

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -30,6 +30,10 @@ Variable names should be letters, numbers, and underscores.  Variables should al
 
 ``foo-port``, ``foo port``, ``foo.port`` and ``12`` are not valid variable names.
 
+`Python keywords <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`_ are not valid variable names and thus should be avoided:
+
+``and``, ``as``, ``assert``, ``async``, ``await``, ``break``, ``class``, ``continue``, ``def``, ``del``, ``elif``, ``else``, ``except``, ``False``, ``finally``, ``for``, ``from``, ``global``, ``if``, ``import``, ``in``, ``is``, ``lambda``, ``None``, ``nonlocal``, ``not``, ``or``, ``pass``, ``raise``, ``return``, ``True``, ``try``, ``while``, ``with``, ``yield``.
+
 YAML also supports dictionaries which map keys to values.  For instance::
 
   foo:

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -32,7 +32,6 @@ Variable names should be letters, numbers, and underscores.  Variables should al
 
 `Python keywords <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`_  such as ``async`` and ``lambda`` are not valid variable names and thus must be avoided.
 
-
 YAML also supports dictionaries which map keys to values.  For instance::
 
   foo:

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -32,7 +32,6 @@ Variable names should be letters, numbers, and underscores.  Variables should al
 
 `Python keywords <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`_  such as ``async`` and ``lambda`` are not valid variable names and thus must be avoided.
 
-``and``, ``as``, ``assert``, ``async``, ``await``, ``break``, ``class``, ``continue``, ``def``, ``del``, ``elif``, ``else``, ``except``, ``False``, ``finally``, ``for``, ``from``, ``global``, ``if``, ``import``, ``in``, ``is``, ``lambda``, ``None``, ``nonlocal``, ``not``, ``or``, ``pass``, ``raise``, ``return``, ``True``, ``try``, ``while``, ``with``, ``yield``.
 
 YAML also supports dictionaries which map keys to values.  For instance::
 

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -30,7 +30,7 @@ Variable names should be letters, numbers, and underscores.  Variables should al
 
 ``foo-port``, ``foo port``, ``foo.port`` and ``12`` are not valid variable names.
 
-`Python keywords <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`_ are not valid variable names and thus should be avoided:
+`Python keywords <https://docs.python.org/3/reference/lexical_analysis.html#keywords>`_  such as ``async`` and ``lambda`` are not valid variable names and thus must be avoided.
 
 ``and``, ``as``, ``assert``, ``async``, ``await``, ``break``, ``class``, ``continue``, ``def``, ``del``, ``elif``, ``else``, ``except``, ``False``, ``finally``, ``for``, ``from``, ``global``, ``if``, ``import``, ``in``, ``is``, ``lambda``, ``None``, ``nonlocal``, ``not``, ``or``, ``pass``, ``raise``, ``return``, ``True``, ``try``, ``while``, ``with``, ``yield``.
 


### PR DESCRIPTION
##### SUMMARY
Upon resolving the cryptic `Invalid variable name in 'register' specified: 'return'` error message I noticed that the doc site doesn't mention that the Python keywords are not valid invalid variable name at all.  This patch fixes it.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### ADDITIONAL INFORMATION
The keywords are extracted from the Python 3.8 reference, and then sorted in lexicographical order.