### PR TITLE
Update gcp_compute_instance.py

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -577,6 +577,11 @@ EXAMPLES = '''
     - auto_delete: 'true'
       boot: 'true'
       source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
     metadata:
       startup-script-url: gs:://graphite-playground/bootstrap.sh
       cost-center: '12345'


### PR DESCRIPTION
##### SUMMARY
Creating an instance with Local SSDs in NVMe mode is a bit confusing which requires strict yaml configuration structure.

Without it creation process ends up with similar error like `Invalid value for field 'resource.disks[0].source': ''. Source url of disk is missing.`.
Google SERP leads to a closed [issue #29869](https://github.com/ansible/ansible/issues/29869) which doesn't have explanation either.

I think the exact Local SSD configuration is meant to be here.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
