### PR TITLE
import_tasks: Raise an error when applying notify and register

### DIFF
--- a/changelogs/fragments/64935_import_tasks.yml
+++ b/changelogs/fragments/64935_import_tasks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- import_tasks - raise an error when invalid params are specified (https://github.com/ansible/ansible/issues/64935).

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -24,6 +24,10 @@ options:
       - If you need any of those to apply, use M(include_tasks) instead.
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
+  - Following are valid Task-level keywords - 'action', 'args', 'become', 'check_mode', 'collections', 'debugger',  'delegate_to',
+    'delegate_facts', 'diff', 'environment', 'ignore_errors', 'ignore_unreachable', 'module_defaults', 'name', 'no_log',
+    'remote_user', 'run_once', 'tags', 'vars', and 'when'.
+
 seealso:
 - module: import_playbook
 - module: import_role


### PR DESCRIPTION
##### SUMMARY

notify is not valid import_tasks attribute. Raise an error
when user specifies it.

Fixes: #64935

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/64935_import_tasks.yml
lib/ansible/playbook/task_include.py
