### PR TITLE
Fixed #65111 Replaced 'ansible_facts' by 'foreman_facts'

### DIFF
--- a/changelogs/fragments/65114-fixed-replaced-ansible_facts-by-foreman_facts.yaml
+++ b/changelogs/fragments/65114-fixed-replaced-ansible_facts-by-foreman_facts.yaml
@@ -1,2 +1,3 @@
 bugfixes:
-- foreman.py - replaced ansible_facts by foreman_facts. Inventory modules was trying to populate foreman's facts in ansible_facts var.
+- foreman inventory plugin - Populate host variable information using the "foreman_facts" key
+  rather than the internal "ansible_facts" key. (https://github.com/ansible/ansible/issues/65111)

--- a/changelogs/fragments/65114-fixed-replaced-ansible_facts-by-foreman_facts.yaml
+++ b/changelogs/fragments/65114-fixed-replaced-ansible_facts-by-foreman_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- foreman.py - replaced ansible_facts by foreman_facts. Inventory modules was trying to populate foreman's facts in ansible_facts var.

--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -229,7 +229,7 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
                 # set host vars from facts
                 if self.get_option('want_facts'):
-                    self.inventory.set_variable(host_name, 'ansible_facts', self._get_facts(host))
+                    self.inventory.set_variable(host_name, 'foreman_facts', self._get_facts(host))
 
                 strict = self.get_option('strict')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In order to solve out the problem mentioned in the issue #65111, I replaced the variable 'ansible_facts' by 'foreman_facts' in the Foreman's dynamic inventory plugin. Besides solving the problem, I guess 'foreman_facts' makes sense as the variable name which is supposed to contain the Foreman's facts.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Foreman's dynamic inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
