### PR TITLE
fix not working examples in os_group_info.py

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_group_info.py
+++ b/lib/ansible/modules/cloud/openstack/os_group_info.py
@@ -47,39 +47,55 @@ options:
 
 EXAMPLES = '''
 # Gather info about previously created groups
-- os_group_info:
-    cloud: awesomecloud
-  register: openstack_groups
-- debug:
-    var: openstack_groups
+- name: gather info
+  hosts: localhost
+  tasks:
+    - name: Gather info about previously created groups
+      os_group_info:
+        cloud: awesomecloud
+      register: openstack_groups
+    - debug:
+        var: openstack_groups
 
 # Gather info about a previously created group by name
-- os_group_info:
-    cloud: awesomecloud
-    name: demogroup
-  register: openstack_groups
-- debug:
-    var: openstack_groups
+- name: gather info
+  hosts: localhost
+  tasks:
+    - name: Gather info about a previously created group by name
+      os_group_info:
+        cloud: awesomecloud
+        name: demogroup
+      register: openstack_groups
+    - debug:
+        var: openstack_groups
 
 # Gather info about a previously created group in a specific domain
-- os_group_info:
-    cloud: awesomecloud
-    name: demogroup
-    domain: admindomain
-  register: openstack_groups
-- debug:
-    var: openstack_groups
+- name: gather info
+  hosts: localhost
+  tasks:
+    - name: Gather info about a previously created group in a specific domain
+      os_group_info:
+        cloud: awesomecloud
+        name: demogroup
+        domain: admindomain
+      register: openstack_groups
+    - debug:
+        var: openstack_groups
 
 # Gather info about a previously created group in a specific domain with filter
-- os_group_info:
-    cloud: awesomecloud
-    name: demogroup
-    domain: admindomain
-    filters:
-      enabled: False
-  register: openstack_groups
-- debug:
-    var: openstack_groups
+- name: gather info
+  hosts: localhost
+  tasks:
+    - name: Gather info about a previously created group in a specific domain with filter
+      os_group_info:
+        cloud: awesomecloud
+        name: demogroup
+        domain: admindomain
+        filters:
+          enabled: False
+      register: openstack_groups
+    - debug:
+        var: openstack_groups
 '''
 
 


### PR DESCRIPTION
##### SUMMARY

In the examples "host: localhost" was missing to get the examples working.

Also adjusted the "style" of the examples to meet the examples from

https://docs.ansible.com/ansible/latest/modules/os_server_module.html

for having consistency in the examples.

##### ISSUE TYPE

+label: docsite_pr

##### SUMMARY

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

os_group_info

