### PR TITLE
vmware_guidelines: update isos image description

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -59,11 +59,13 @@ Your NFS server must expose the following directory structure:
     $ tree /srv/share/
     /srv/share/
     ├── isos
-    │   ├── base.iso
     │   ├── centos.iso
     │   └── fedora.iso
     └── vms
     2 directories, 3 files
+
+- `fedora.iso`: the latest Fedora Desktop ISO
+- `centos.iso`: the latest CentOS ISO
 
 On a Linux system, you can expose the directory over NFS with the following export file:
 

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -59,13 +59,11 @@ Your NFS server must expose the following directory structure:
     $ tree /srv/share/
     /srv/share/
     ├── isos
-    │   ├── centos.iso
     │   └── fedora.iso
     └── vms
     2 directories, 3 files
 
 - `fedora.iso`: the latest Fedora Desktop ISO
-- `centos.iso`: the latest CentOS ISO
 
 On a Linux system, you can expose the directory over NFS with the following export file:
 

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -20,7 +20,7 @@
       datastore: "{{ rw_datastore }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] centos.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
   register: cdrom_vm
 
 - debug: var=cdrom_vm
@@ -171,7 +171,7 @@
       controller_number: 0
       unit_number: 0
       type: iso
-      iso_path: "[{{ ro_datastore }}] centos.iso"
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
     - controller_type: ide
       controller_number: 0
       unit_number: 1
@@ -260,7 +260,7 @@
           datastore: "{{ rw_datastore }}"
         cdrom:
           type: iso
-          iso_path: "[{{ ro_datastore }}] base.iso"
+          iso_path: "[{{ ro_datastore }}] fedora.iso"
       register: cdrom_vm
     - debug: var=cdrom_vm
     - name: assert the VM was created


### PR DESCRIPTION
##### SUMMARY

- no more `base.iso` image
- explain how to get the two other images

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

./docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst