### PR TITLE
module_utils/redhat.py: use string values for ConfigParser

### DIFF
--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -69,9 +69,9 @@ class RegistrationBase(object):
             cfg.read([tmpfile])
 
             if enabled:
-                cfg.set('main', 'enabled', 1)
+                cfg.set('main', 'enabled', '1')
             else:
-                cfg.set('main', 'enabled', 0)
+                cfg.set('main', 'enabled', '0')
 
             fd = open(tmpfile, 'w+')
             cfg.write(fd)


### PR DESCRIPTION
##### SUMMARY
Python 3 ConfigParser up to version 3.7 requires keys values
to be strings. RHEL 8 and CentOS 8 ship with Python 3.6.
Since Python version 3.7 automatic conversion is performed.

Fixes the error message:
> Failed to register with 'https://spacewalk/XMLRPC': option values must be strings"

This bugfix is for rhn_register and analogous to #54815

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
module_utils/redhat.py

##### ADDITIONAL INFORMATION