### PR TITLE
gitlab module: Fix research for group/project/parent_group

### DIFF
--- a/changelogs/fragments/65120-fix-gitlab-ressource-path-interpretation.yml
+++ b/changelogs/fragments/65120-fix-gitlab-ressource-path-interpretation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix research of sub ressources like subGroups and project in groups
+  - Fix idempotency on modules gitlab_group, gitlab_project, gitlab_user, gitlab_hook and gitlab_deploy_key

--- a/lib/ansible/module_utils/gitlab.py
+++ b/lib/ansible/module_utils/gitlab.py
@@ -52,26 +52,36 @@ def request(module, api_url, project, path, access_token, private_token, rawdata
         return False, str(status) + ": " + content
 
 
-def findProject(gitlab_instance, identifier):
+def findProject(gitlab_instance, parent, identifier):
     try:
-        project = gitlab_instance.projects.get(identifier)
+        projects = parent.projects.list(search=identifier)
+        if len(projects) <= 0:
+            raise Exception("No project found in this parent : %s." % to_native(parent.name))
+
+        project = projects[0]
     except Exception as e:
-        current_user = gitlab_instance.user
         try:
-            project = gitlab_instance.projects.get(current_user.username + '/' + identifier)
+            project = gitlab_instance.projects.get(identifier)
         except Exception as e:
             return None
 
-    return project
+    return gitlab_instance.projects.get(project.id)
 
 
-def findGroup(gitlab_instance, identifier):
+def findGroup(gitlab_instance, parent, identifier):
     try:
-        project = gitlab_instance.groups.get(identifier)
-    except Exception as e:
-        return None
+        groups = parent.subgroups.list(search=identifier)
+        if len(groups) <= 0:
+            raise Exception("No project found in this parent : %s." % to_native(parent.name))
 
-    return project
+        group = groups[0]
+    except Exception as e:
+        try:
+            group = gitlab_instance.groups.get(identifier)
+        except Exception as e:
+            return None
+
+    return gitlab_instance.groups.get(group.id)
 
 
 def gitlabAuthentication(module):

--- a/lib/ansible/modules/source_control/gitlab/gitlab_deploy_key.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_deploy_key.py
@@ -273,7 +273,7 @@ def main():
 
     gitlab_deploy_key = GitLabDeployKey(module, gitlab_instance)
 
-    project = findProject(gitlab_instance, project_identifier)
+    project = findProject(gitlab_instance, None, project_identifier)
 
     if project is None:
         module.fail_json(msg="Failed to create deploy key: project %s doesn't exists" % project_identifier)

--- a/lib/ansible/modules/source_control/gitlab/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_group.py
@@ -242,9 +242,9 @@ class GitLabGroup(object):
     @param name Name of the groupe
     @param full_path Complete path of the Group including parent group path. <parent_path>/<group_path>
     '''
-    def existsGroup(self, project_identifier):
+    def existsGroup(self, namespace, project_identifier):
         # When group/user exists, object will be stored in self.groupObject.
-        group = findGroup(self._gitlab, project_identifier)
+        group = findGroup(self._gitlab, namespace, project_identifier)
         if group:
             self.groupObject = group
             return True
@@ -298,13 +298,13 @@ def main():
 
     parent_group = None
     if parent_identifier:
-        parent_group = findGroup(gitlab_instance, parent_identifier)
+        parent_group = findGroup(gitlab_instance, None, parent_identifier)
         if not parent_group:
             module.fail_json(msg="Failed create GitLab group: Parent group doesn't exists")
 
-        group_exists = gitlab_group.existsGroup(parent_group.full_path + '/' + group_path)
+        group_exists = gitlab_group.existsGroup(parent_group, group_path)
     else:
-        group_exists = gitlab_group.existsGroup(group_path)
+        group_exists = gitlab_group.existsGroup(None, group_path)
 
     if state == 'absent':
         if group_exists:

--- a/lib/ansible/modules/source_control/gitlab/gitlab_hook.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_hook.py
@@ -257,7 +257,11 @@ class GitLabHook(object):
 
         for arg_key, arg_value in arguments.items():
             if arguments[arg_key] is not None:
-                if getattr(hook, arg_key) != arguments[arg_key]:
+                if arg_key != 'token':
+                    if getattr(hook, arg_key) != arguments[arg_key]:
+                        setattr(hook, arg_key, arguments[arg_key])
+                        changed = True
+                else:
                     setattr(hook, arg_key, arguments[arg_key])
                     changed = True
 
@@ -347,7 +351,7 @@ def main():
 
     gitlab_hook = GitLabHook(module, gitlab_instance)
 
-    project = findProject(gitlab_instance, project_identifier)
+    project = findProject(gitlab_instance, None, project_identifier)
 
     if project is None:
         module.fail_json(msg="Failed to create hook: project %s doesn't exists" % project_identifier)

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -263,7 +263,7 @@ class GitLabProject(object):
     '''
     def existsProject(self, namespace, path):
         # When project exists, object will be stored in self.projectObject.
-        project = findProject(self._gitlab, namespace.full_path + '/' + path)
+        project = findProject(self._gitlab, namespace, path)
         if project:
             self.projectObject = project
             return True
@@ -326,16 +326,16 @@ def main():
     gitlab_project = GitLabProject(module, gitlab_instance)
 
     if group_identifier:
-        group = findGroup(gitlab_instance, group_identifier)
+        group = findGroup(gitlab_instance, None, group_identifier)
         if group is None:
             module.fail_json(msg="Failed to create project: group %s doesn't exists" % group_identifier)
 
         namespace = gitlab_instance.namespaces.get(group.id)
-        project_exists = gitlab_project.existsProject(namespace, project_path)
+        project_exists = gitlab_project.existsProject(group, project_path)
     else:
         user = gitlab_instance.users.list(username=gitlab_instance.user.username)[0]
         namespace = gitlab_instance.namespaces.get(user.id)
-        project_exists = gitlab_project.existsProject(namespace, project_path)
+        project_exists = gitlab_project.existsProject(user, project_path)
 
     if state == 'absent':
         if project_exists:

--- a/lib/ansible/modules/source_control/gitlab/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_user.py
@@ -313,7 +313,7 @@ class GitLabUser(object):
     @param access_level GitLab access_level to assign
     '''
     def assignUserToGroup(self, user, group_identifier, access_level):
-        group = findGroup(self._gitlab, group_identifier)
+        group = findGroup(self._gitlab, None, group_identifier)
 
         if self._module.check_mode:
             return True

--- a/test/units/modules/source_control/gitlab/gitlab.py
+++ b/test/units/modules/source_control/gitlab/gitlab.py
@@ -191,7 +191,7 @@ def resp_get_group(url, request):
                '"web_url": "http://example.com/diaspora/diaspora-client",'
                '"readme_url": "http://example.com/diaspora/diaspora-client/blob/master/README.md",'
                '"tag_list": ["example","disapora client"],"name": "Diaspora Client",'
-               '"name_with_namespace": "Diaspora / Diaspora Client","path": "diaspora-client",'
+               '"name_with_namespace": "Diaspora / Diaspora Client",'
                '"path_with_namespace": "diaspora/diaspora-client","created_at": "2013-09-30T13:46:02Z",'
                '"last_activity_at": "2013-09-30T13:46:02Z","forks_count": 0,'
                '"avatar_url": "http://example.com/uploads/project/avatar/4/uploads/avatar.png",'
@@ -385,10 +385,10 @@ def resp_get_project(url, request):
     return response(200, content, headers, None, 5, request)
 
 
-@urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects/foo-bar%2Fdiaspora-client", method="get")
-def resp_get_project_by_name(url, request):
+@urlmatch(scheme="http", netloc="localhost", path="/api/v4/groups/1/projects", method="get", query="search=diaspora-client")
+def resp_get_project_in_group_by_name(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('{"id": 1,"description": null, "default_branch": "master",'
+    content = ('[{"id": 1,"description": null, "default_branch": "master",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -398,7 +398,7 @@ def resp_get_project_by_name(url, request):
                '"path_with_namespace": "diaspora/diaspora-client","created_at": "2013-09-30T13:46:02Z",'
                '"last_activity_at": "2013-09-30T13:46:02Z","forks_count": 0,'
                '"avatar_url": "http://example.com/uploads/project/avatar/4/uploads/avatar.png",'
-               '"star_count": 0}')
+               '"star_count": 0}]')
     content = content.encode("utf-8")
     return response(200, content, headers, None, 5, request)
 

--- a/test/units/modules/source_control/gitlab/test_gitlab_group.py
+++ b/test/units/modules/source_control/gitlab/test_gitlab_group.py
@@ -53,13 +53,13 @@ class TestGitlabGroup(GitlabModuleTestCase):
 
     @with_httmock(resp_get_group)
     def test_exist_group(self):
-        rvalue = self.moduleUtil.existsGroup(1)
+        rvalue = self.moduleUtil.existsGroup(None, 1)
 
         self.assertEqual(rvalue, True)
 
     @with_httmock(resp_get_missing_group)
     def test_exist_group(self):
-        rvalue = self.moduleUtil.existsGroup(1)
+        rvalue = self.moduleUtil.existsGroup(None, 1)
 
         self.assertEqual(rvalue, False)
 
@@ -99,7 +99,7 @@ class TestGitlabGroup(GitlabModuleTestCase):
     @with_httmock(resp_find_group_project)
     @with_httmock(resp_delete_group)
     def test_delete_group(self):
-        self.moduleUtil.existsGroup(1)
+        self.moduleUtil.existsGroup(None, 1)
 
         print(self.moduleUtil.groupObject.projects)
 

--- a/test/units/modules/source_control/gitlab/test_gitlab_project.py
+++ b/test/units/modules/source_control/gitlab/test_gitlab_project.py
@@ -56,6 +56,7 @@ class TestGitlabProject(GitlabModuleTestCase):
 
     @with_httmock(resp_get_group)
     @with_httmock(resp_get_project_in_group_by_name)
+    @with_httmock(resp_get_project)
     def test_project_exist(self):
         group = self.gitlab_instance.groups.get(1)
 
@@ -93,6 +94,7 @@ class TestGitlabProject(GitlabModuleTestCase):
 
     @with_httmock(resp_get_group)
     @with_httmock(resp_get_project_in_group_by_name)
+    @with_httmock(resp_get_project)
     @with_httmock(resp_delete_project)
     def test_delete_project(self):
         group = self.gitlab_instance.groups.get(1)

--- a/test/units/modules/source_control/gitlab/test_gitlab_project.py
+++ b/test/units/modules/source_control/gitlab/test_gitlab_project.py
@@ -20,8 +20,9 @@ pytestmark = []
 try:
     from .gitlab import (GitlabModuleTestCase,
                          python_version_match_requirement,
-                         resp_get_group, resp_get_project_by_name, resp_create_project,
-                         resp_get_project, resp_delete_project, resp_get_user)
+                         resp_get_group, resp_get_project_in_group_by_name,
+                         resp_create_project, resp_get_project, resp_delete_project,
+                         resp_get_user)
 
     # GitLab module requirements
     if python_version_match_requirement():
@@ -31,7 +32,7 @@ except ImportError:
     # Need to set these to something so that we don't fail when parsing
     GitlabModuleTestCase = object
     resp_get_group = _dummy
-    resp_get_project_by_name = _dummy
+    resp_get_project_in_group_by_name = _dummy
     resp_create_project = _dummy
     resp_get_project = _dummy
     resp_delete_project = _dummy
@@ -54,7 +55,7 @@ class TestGitlabProject(GitlabModuleTestCase):
         self.moduleUtil = GitLabProject(module=self.mock_module, gitlab_instance=self.gitlab_instance)
 
     @with_httmock(resp_get_group)
-    @with_httmock(resp_get_project_by_name)
+    @with_httmock(resp_get_project_in_group_by_name)
     def test_project_exist(self):
         group = self.gitlab_instance.groups.get(1)
 
@@ -91,12 +92,14 @@ class TestGitlabProject(GitlabModuleTestCase):
         self.assertEqual(newProject.name, "New Name")
 
     @with_httmock(resp_get_group)
-    @with_httmock(resp_get_project_by_name)
+    @with_httmock(resp_get_project_in_group_by_name)
     @with_httmock(resp_delete_project)
     def test_delete_project(self):
         group = self.gitlab_instance.groups.get(1)
 
-        self.moduleUtil.existsProject(group, "diaspora-client")
+        rvalue = self.moduleUtil.existsProject(group, "diaspora-client")
+
+        self.assertEqual(rvalue, True)
 
         rvalue = self.moduleUtil.deleteProject()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some current GitLab modules are broken because of a bad implementation of the `python-gitlab` library.
The two functions `findGroup` and `findProject` in the GitLab module utils doesn't support passing ressources path with `/`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes  #65113

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_group
gitlab_project
gitlab_user
gitlab_hook
gitlab_deploy_key
gitlab module_utils

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
