### PR TITLE
Fix encrypt command output when using --stdin-name

### DIFF
--- a/changelogs/fragments/65122-fix-encrypt_string-stdin-name-ouput-tty.yml
+++ b/changelogs/fragments/65122-fix-encrypt_string-stdin-name-ouput-tty.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault - Fix ``encrypt_string`` output in a tty when using ``--sdtin-name`` option (https://github.com/ansible/ansible/issues/65121)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -318,6 +318,9 @@ class VaultCLI(CLI):
             if stdin_text == '':
                 raise AnsibleOptionsError('stdin was empty, not encrypting')
 
+            if not stdin_text.endswith("\n"):
+                display.display("\n")
+
             b_plaintext = to_bytes(stdin_text)
 
             # defaults to None

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -318,7 +318,7 @@ class VaultCLI(CLI):
             if stdin_text == '':
                 raise AnsibleOptionsError('stdin was empty, not encrypting')
 
-            if not stdin_text.endswith("\n"):
+            if sys.stdout.isatty() and not stdin_text.endswith("\n"):
                 display.display("\n")
 
             b_plaintext = to_bytes(stdin_text)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix https://github.com/ansible/ansible/issues/65121

Add a new line after reading input if input doesn't end with a new line

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible/lib/ansible/cli/vault.py`