### PR TITLE
postgresql_privs - fix sort comparison

### DIFF
--- a/changelogs/fragments/postgresol_privs-fix-status-sorting.yaml
+++ b/changelogs/fragments/postgresol_privs-fix-status-sorting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_privs - sort results before comparing so that the values are compared and not the result of ``.sort()`` (https://github.com/ansible/ansible/pull/65125)

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -780,7 +780,9 @@ class Connection(object):
         executed_queries.append(query)
         self.cursor.execute(query)
         status_after = get_status(objs)
-        return status_before.sort() != status_after.sort()
+        status_before.sort()
+        status_after.sort()
+        return status_before != status_after
 
 
 class QueryBuilder(object):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The result of `.sort()` is `None`, not the sorted object. The comparison was comparing the result of the `.sort()` method and not the sorted values.

This bug was introduced in #65061.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/database/postgresql/postgresql_privs.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
We also have an issue where tests are not being run, which is how #65061 got merged.