### PR TITLE
nxos_bgp_neighbor_af next_hop_third_party only supported for eBGP peers.

### DIFF
--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -81,7 +81,7 @@
       max_prefix_threshold: default
       max_prefix_warning: False
       next_hop_self: False
-      next_hop_third_party: True
+      next_hop_third_party: False
       prefix_list_in: default
       prefix_list_out: default
       send_community: 'none'
@@ -204,6 +204,7 @@
       send_community: 'standard'
       soft_reconfiguration_in: "{{soft_reconfiguration_ina|default(omit)}}"
       soo: '3:3'
+      next_hop_third_party: True
       provider: "{{ connection }}"
       state: present
     register: result


### PR DESCRIPTION
Please cherry-pick this into stable-2.9.

##### SUMMARY
The nxos_bgp_neighbor_af test tries to set the `next_hop_third_party` property to true in the context of a iBGP neighbor.  This property is only  supported for eBGP peers and will fail with a message indicating this fact in more recent versions of NX-OS.

The test fix sets the property to false in the task that validates iBGP and set the property to true in the eBGP task.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_bgp_neighbor_af
