### PR TITLE
Patch: fix seports to allow integers or string

### DIFF
--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -156,9 +156,13 @@ def semanage_port_get_type(seport, port, proto):
     :rtype: tuple
     :return: Tuple containing the SELinux type and MLS/MCS level, or None if not found.
     """
-    ports = port.split('-', 1)
-    if len(ports) == 1:
-        ports.extend(ports)
+    if isinstance(port, str):
+        ports = port.split('-', 1)
+        if len(ports) == 1:
+            ports.extend(ports)
+    else:
+        ports = (port, port)
+
     key = (int(ports[0]), int(ports[1]), proto)
 
     records = seport.get_all()


### PR DESCRIPTION
##### SUMMARY
I was unable to use seport with numbered ports.

Fixes #60968

Concurrently added the same check the Selinux python utils: https://github.com/SELinuxProject/selinux/pull/189

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
seport

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```paste below
- name: Permit Nginx to listen on 8050
  seport:
    ports:
      - 8050-8052
      - 443
      - 80
    proto: tcp
    setype: http_port_t
    state: present
    reload: yes
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
**pre Change**
```
{"changed": false, "module_stderr": "Shared connection to localhost closed.
", "module_stdout": "Traceback (most recent call last):
  File \"/home/eis/.ansible/tmp/ansible-tmp-1574300490.251246-265170046283270/AnsiballZ_seport.py\", line 102, in <module>
    _ansiballz_main()
  File \"/home/eis/.ansible/tmp/ansible-tmp-1574300490.251246-265170046283270/AnsiballZ_seport.py\", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File \"/home/eis/.ansible/tmp/ansible-tmp-1574300490.251246-265170046283270/AnsiballZ_seport.py\", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.system.seport', init_globals=None, run_name='__main__', alter_sys=True)
  File \"/usr/lib64/python3.7/runpy.py\", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File \"/usr/lib64/python3.7/runpy.py\", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File \"/usr/lib64/python3.7/runpy.py\", line 85, in _run_code
    exec(code, run_globals)
  File \"/tmp/ansible_seport_payload_rsxr600w/ansible_seport_payload.zip/ansible/modules/system/seport.py\", line 311, in <module>
  File \"/tmp/ansible_seport_payload_rsxr600w/ansible_seport_payload.zip/ansible/modules/system/seport.py\", line 301, in main
  File \"/tmp/ansible_seport_payload_rsxr600w/ansible_seport_payload.zip/ansible/modules/system/seport.py\", line 212, in semanage_port_add
  File \"/usr/lib/python3.7/site-packages/seobject.py\", line 1149, in add
    self.__add(port, proto, serange, type)
  File \"/usr/lib/python3.7/site-packages/seobject.py\", line 1098, in __add
    (k, proto_d, low, high) = self.__genkey(port, proto)
  File \"/usr/lib/python3.7/site-packages/seobject.py\", line 1068, in __genkey
    ports = port.split(\"-\")
AttributeError: 'int' object has no attribute 'split'n
", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

**Post Change**
```paste below
task path: /home/eis/AnsibleTower-awx/ansible/roles/awx/tasks/main.yml:23                                                                                                                                                                    <localhost> ESTABLISH SSH CONNECTION FOR USER: eis                                                                                                                                                                                           <localhost> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb localhost '/bin/sh -c '"'"'echo ~eis && sleep 0'"'"''                                                                                                                          <localhost> (0, b'/home/eis\n', b'')                                                                                                                                                                                                         <localhost> ESTABLISH SSH CONNECTION FOR USER: eis                                                                                                                                                                                           <localhost> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746 `" && echo ansible-tmp-1574304761.8228998-127816148453746="` echo /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746 `" ) && sleep 0'"'"''                                                                                                                               <localhost> (0, b'ansible-tmp-1574304761.8228998-127816148453746=/home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746\n', b'')                                                                                              Using module file /srv/ansible/lib64/python3.7/site-packages/ansible/modules/system/seport.py                                                                                                                                                <localhost> PUT /home/eis/.ansible/tmp/ansible-local-34171kcsvluim/tmpat3imjkc TO /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/AnsiballZ_seport.py                                                                  <localhost> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb '[localhost]'                                                                                                                                                            <localhost> (0, b'sftp> put /home/eis/.ansible/tmp/ansible-local-34171kcsvluim/tmpat3imjkc /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/AnsiballZ_seport.py\n', b'')                                                <localhost> ESTABLISH SSH CONNECTION FOR USER: eis                                                                                                                                                                                           <localhost> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb localhost '/bin/sh -c '"'"'chmod u+x /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/ /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/AnsiballZ_seport.py && sleep 0'"'"''                                                                                                                                                                                                      <localhost> (0, b'', b'')                                                                                                                                                                                                                    <localhost> ESTABLISH SSH CONNECTION FOR USER: eis                                                                                                                                                                                           <localhost> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb -tt localhost '/bin/sh -c '"'"'sudo -H -S -n  -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-axqxkonfpogkpfrfgqkzhmxmnhrifbla ; /usr/bin/python /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/AnsiballZ_seport.py'"'"'"'"'"'"'"'"' && sleep 0'"'"''                                                                                                                                        Escalation succeeded                                                                                                                                                                                                                         <localhost> (0, b'\r\n{"ports": ["8050-8052", 443, 80], "proto": "tcp", "setype": "http_port_t", "state": "present", "changed": true, "invocation": {"module_args": {"ports": ["8050-8052", 443, 80], "proto": "tcp", "setype": "http_port_t", "state": "present", "reload": true, "ignore_selinux_state": false}}}\r\n', b'Shared connection to localhost closed.\r\n')                                                                                                                  <localhost> ESTABLISH SSH CONNECTION FOR USER: eis                                                                                                                                                                                           <localhost> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="eis"' -o ConnectTimeout=10 -o ControlPath=/home/eis/.ansible/cp/0e9b8a8fdb localhost '/bin/sh -c '"'"'rm -f -r /home/eis/.ansible/tmp/ansible-tmp-1574304761.8228998-127816148453746/ > /dev/null 2>&1 && sleep 0'"'"''                                   <localhost> (0, b'', b'')                                                                                                                                                                                                                    changed: [localhost] => {                                                                                                                                                                                                                        "changed": true,                                                                                                                                                                                                                             "invocation": {                                                                                                                                                                                                                                  "module_args": {                                                                                                                                                                                                                                 "ignore_selinux_state": false,                                                                                                                                                                                                               "ports": [
                "8050-8052",
                443,
                80
            ],
            "proto": "tcp",
            "reload": true,
            "setype": "http_port_t",
            "state": "present"
        }
    },
    "ports": [
        "8050-8052",
        443,
        80
    ],
    "proto": "tcp",
    "setype": "http_port_t",
    "state": "present"
}
```
