### PR TITLE
Proxmox KVM: agent info implementation

### DIFF
--- a/changelogs/fragments/65142-proxmox_kvm_agent_info_implementation.yml
+++ b/changelogs/fragments/65142-proxmox_kvm_agent_info_implementation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_kvm - add feature agent_info for getting additional data from hosts with QEMU Guest Agent installed.

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -36,6 +36,7 @@ options:
       - Can be used only with state C(current) and returns data only when QEMU Guest Agent is enabled and installed on guest.
     type: list
     choices: [ "fsinfo", "hostname", "memory_block_info", "memory_blocks", "osinfo", "time", "timezone", "users", "vcpus", "info", "network_interfaces" ]
+    version_added: 2.10
   args:
     description:
       - Pass arbitrary arguments to kvm.
@@ -895,22 +896,9 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
     return False
 
 
-<<<<<<< HEAD
 def proxmox_version(proxmox):
     apireturn = proxmox.version.get()
     return LooseVersion(apireturn['version'])
-=======
-def parse_pve_version(pve_str_version):
-  version_dict = {
-    'major': 0,
-    'minor': 0,
-    'revision': 0
-  }
-  if '-' in pve_str_version:
-    pve_str_version, version_dict['revision'] = pve_str_version.split('-')
-  version_dict['major'], version_dict['minor'] = pve_str_version.split('.')
-  return { key: int(version_dict[key]) for key in version_dict }
->>>>>>> Fix for getting PVE major version and agent info implementation
 
 
 def main():
@@ -1029,11 +1017,7 @@ def main():
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
         global PVE_MAJOR_VERSION
-<<<<<<< HEAD
-        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
-=======
-        PVE_MAJOR_VERSION = parse_pve_version(proxmox.version.get()['version'])['major']
->>>>>>> Fix for getting PVE major version and agent info implementation
+	      PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 
@@ -1245,7 +1229,7 @@ def main():
             current = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status']
             status['status'] = current
             if agent_info is not None:
-              status['agent_info'], status['agent_info_warnings'] = get_vm_agent_info(proxmox, node, vmid, agent_info)
+                status['agent_info'], status['agent_info_warnings'] = get_vm_agent_info(proxmox, node, vmid, agent_info)
             if status:
                 module.exit_json(changed=False, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
         except Exception as e:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -36,7 +36,7 @@ options:
       - Can be used only with state C(current) and returns data only when QEMU Guest Agent is enabled and installed on guest.
     type: list
     choices: [ "fsinfo", "hostname", "memory_block_info", "memory_blocks", "osinfo", "time", "timezone", "users", "vcpus", "info", "network_interfaces" ]
-    version_added: 2.10
+    version_added: "2.10"
   args:
     description:
       - Pass arbitrary arguments to kvm.

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -668,16 +668,16 @@ from ansible.module_utils._text import to_native
 
 VZ_TYPE = 'qemu'
 AGENT_INFO_API_MAP = {
-  'fsinfo': 'get-fsinfo',
-  'hostname': 'get-host-name',
-  'memory_block_info': 'get-memory-block-info',
-  'memory_blocks': 'get-memory-blocks',
-  'osinfo': 'get-osinfo',
-  'time': 'get-time',
-  'timezone': 'get-timezone',
-  'users': 'get-users',
-  'vcpus': 'get-vcpus',
-  'network_interfaces': 'network-get-interfaces'
+    'fsinfo': 'get-fsinfo',
+    'hostname': 'get-host-name',
+    'memory_block_info': 'get-memory-block-info',
+    'memory_blocks': 'get-memory-blocks',
+    'osinfo': 'get-osinfo',
+    'time': 'get-time',
+    'timezone': 'get-timezone',
+    'users': 'get-users',
+    'vcpus': 'get-vcpus',
+    'network_interfaces': 'network-get-interfaces'
 }
 
 
@@ -741,31 +741,31 @@ def get_vminfo(module, proxmox, node, vmid, **kwargs):
     results['devices'] = devices
     results['vmid'] = int(vmid)
 
-  
+
 def get_vm_agent_info(proxmox, node, vmid, agent_info):
-  info = {}
-  warn = []
-  proxmox_vm_agent = getattr(proxmox.nodes(node), VZ_TYPE)(vmid).agent
-  for info_key in agent_info:
-    try:
-      info[info_key] = proxmox_vm_agent.get(get_agent_info_api_endpoint(info_key))['result']
-    except Exception as e:
-      if isinstance(e.args, tuple) and len(e.args) > 0:
-        warn.append('Agent info not available for \'%s\': %s' % (info_key, get_agent_info_api_error_message(e.args)))
-      else:
-        warn.append('Not able to get agent info for \'%s\', unkown error.' % info_key)
-  return info, warn
+    info = {}
+    warn = []
+    proxmox_vm_agent = getattr(proxmox.nodes(node), VZ_TYPE)(vmid).agent
+    for info_key in agent_info:
+        try:
+            info[info_key] = proxmox_vm_agent.get(get_agent_info_api_endpoint(info_key))['result']
+        except Exception as e:
+            if isinstance(e.args, tuple) and len(e.args) > 0:
+                warn.append('Agent info not available for \'%s\': %s' % (info_key, get_agent_info_api_error_message(e.args)))
+            else:
+                warn.append('Not able to get agent info for \'%s\', unkown error.' % info_key)
+    return info, warn
 
 
 def get_agent_info_api_endpoint(info_key):
-  return AGENT_INFO_API_MAP[info_key] if info_key in AGENT_INFO_API_MAP else info_key
+    return AGENT_INFO_API_MAP[info_key] if info_key in AGENT_INFO_API_MAP else info_key
 
 
 def get_agent_info_api_error_message(error_tuple):
-  error, = error_tuple
-  if '500' in error:
-    return 'Server returned no data.'
-  return 'Unkown error - is instance running?'
+    error, = error_tuple
+    if '500' in error:
+        return 'Server returned no data.'
+    return 'Unkown error - is instance running?'
 
 
 def settings(module, proxmox, vmid, node, name, timeout, **kwargs):
@@ -873,7 +873,7 @@ def start_vm(module, proxmox, vm, vmid, timeout):
         timeout -= 1
         if timeout == 0:
             module.fail_json(msg='Reached timeout while waiting for starting VM. Last line in task before timeout: %s'
-                             % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+                                 % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
 
         time.sleep(1)
     return False
@@ -891,7 +891,7 @@ def stop_vm(module, proxmox, vm, vmid, timeout, force):
         timeout -= 1
         if timeout == 0:
             module.fail_json(msg='Reached timeout while waiting for stopping VM. Last line in task before timeout: %s'
-                             % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+                                 % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
         time.sleep(1)
     return False
 
@@ -906,7 +906,9 @@ def main():
         argument_spec=dict(
             acpi=dict(type='bool', default='yes'),
             agent=dict(type='bool'),
-            agent_info=dict(type='list', choices=['fsinfo', 'hostname', 'memory_block_info', 'memory_blocks', 'osinfo', 'time', 'timezone', 'users', 'vcpus', 'info', 'network_interfaces'], default=None),
+            agent_info=dict(type='list',
+                            choices=['fsinfo', 'hostname', 'memory_block_info', 'memory_blocks', 'osinfo', 'time',
+                                     'timezone', 'users', 'vcpus', 'info', 'network_interfaces'], default=None),
             args=dict(type='str', default=None),
             api_host=dict(required=True),
             api_user=dict(required=True),
@@ -1017,7 +1019,7 @@ def main():
         proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
         global VZ_TYPE
         global PVE_MAJOR_VERSION
-	      PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
+        PVE_MAJOR_VERSION = 3 if proxmox_version(proxmox) < LooseVersion('4.0') else 4
     except Exception as e:
         module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 
@@ -1213,7 +1215,7 @@ def main():
                 timeout -= 1
                 if timeout == 0:
                     module.fail_json(msg='Reached timeout while waiting for removing VM. Last line in task before timeout: %s'
-                                     % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+                                         % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
 
                 time.sleep(1)
         except Exception as e:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -643,10 +643,10 @@ agent_info_warnings:
     returned: success
     type: list
     sample: '[
-      "Agent info not available for 'osinfo': Server returned no data.",
-      "Agent info not available for 'time': Server returned no data.",
-      "Agent info not available for 'timezone': Server returned no data.",
-      "Agent info not available for 'vcpus': Server returned no data."
+      "Agent info not available for ''osinfo'': Server returned no data.",
+      "Agent info not available for ''time'': Server returned no data.",
+      "Agent info not available for ''timezone'': Server returned no data.",
+      "Agent info not available for ''vcpus'': Server returned no data."
     ]'
 '''
 


### PR DESCRIPTION
##### SUMMARY
- Fix for getting real PVE major version instead of hardcoded 3 or 4. Also supported getting of minor and revision number. It also fixes compatibility with never PVE version strings (they include revision number as opposed to the older ones).
- Implemented `agent_info` option which can only be used in conjunction with state `current`. It allows to fetch data from QEMU Guest Agent, so that VM can be deployed and later used for further examination in the same role/task.

##### ISSUE TYPE
- Feature Pull Request