### PR TITLE
updated required zabbix-api version for zabbix modules

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -30,7 +30,7 @@ author:
     - Ruben Harutyunov (@K-DOT)
 
 requirements:
-    - zabbix-api
+    - "zabbix-api >= 0.5.4"
 
 options:
     name:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -27,7 +27,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     state:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
@@ -33,7 +33,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     hostgroup_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -28,7 +28,7 @@ author:
     - Eike Frost (@eikef)
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -34,7 +34,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -25,7 +25,7 @@ author:
     - Dean Hailin Song (!UNKNOWN)
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -23,7 +23,7 @@ version_added: "1.8"
 author: "Alexander Bulimov (@abulimov)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     state:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -38,7 +38,7 @@ description:
         C(zbx_trigger_draw_style) contains indicator draw style. Possible values are the same as for C(zbx_draw_style)."
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
     - pydotplus
     - webcolors
     - Pillow

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -22,7 +22,7 @@ version_added: "2.9"
 author:
     - Ruben Tsirunyan (@rubentsirunyan)
 requirements:
-    - zabbix-api
+    - "zabbix-api >= 0.5.4"
 
 options:
     name:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -36,7 +36,7 @@ author:
     - "Alen Komic (@akomic)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     proxy_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -26,7 +26,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     screens:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -27,7 +27,7 @@ author:
     - "Dusan Matejka (@D3DeFi)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     template_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template_info.py
@@ -20,8 +20,8 @@ version_added: '2.10'
 description:
     - This module allows you to search for Zabbix template.
 requirements:
-    - python >= 2.6
-    - zabbix-api
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
 options:
     template_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_user.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_user.py
@@ -21,8 +21,8 @@ version_added: '2.10'
 description:
     - This module allows you to create, modify and delete Zabbix users.
 requirements:
-    - python >= 2.6
-    - zabbix-api
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
 options:
     alias:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_valuemap.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_valuemap.py
@@ -23,7 +23,7 @@ version_added: '2.10'
 author:
     - "Ruben Tsirunyan (@rubentsirunyan)"
 requirements:
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     name:
         type: 'str'


### PR DESCRIPTION
##### SUMMARY
Method `logout()` was not supported in python module `zabbix-api <= 0.5.3`. This was fixed in version 0.5.4. 

Logout for ansible zabbix modules was introduced in #58525, but the requirements documentation wasn't updated with the changes themselves.

Fixes #64819

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_action
zabbix_group_info
zabbix_group
zabbix_host_info
zabbix_hostmacro
zabbix_host
zabbix_maintenance
zabbix_map
zabbix_mediatype
zabbix_proxy
zabbix_screen
zabbix_template_info
zabbix_template
zabbix_user
zabbix_valuemap

##### ADDITIONAL INFORMATION
```paste below
devel
```
