### PR TITLE
added missing logout to zabbix_user_info module

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_user_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_user_info.py
@@ -21,8 +21,8 @@ version_added: '2.10'
 description:
     - This module allows you to search for Zabbix user entries.
 requirements:
-    - python >= 2.6
-    - zabbix-api
+    - "python >= 2.6"
+    - "zabbix-api >= 0.5.4"
 options:
     alias:
         description:
@@ -89,6 +89,7 @@ zabbix_user:
   }
 '''
 
+import atexit
 import traceback
 
 try:
@@ -160,6 +161,7 @@ def main():
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
                         validate_certs=validate_certs)
         zbx.login(login_user, login_password)
+        atexit.register(zbx.logout)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 


### PR DESCRIPTION
##### SUMMARY
Module `zabbix_user_info` doesn't properly logout after exit and leaves open sessions behind on Zabbix server that are not cleanable by housekeeping.

See #58525 and #58459

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_user_info

##### ADDITIONAL INFORMATION
```paste below
ansible 2.10.0.dev0
```