### PR TITLE
link from quickstart page to Network Getting Started

### DIFF
--- a/docs/docsite/rst/user_guide/quickstart.rst
+++ b/docs/docsite/rst/user_guide/quickstart.rst
@@ -16,3 +16,5 @@ Enjoy, and be sure to visit the rest of the documentation to learn more.
        A step by step introduction to Ansible
    `Ansible Automation for SysAdmins <https://opensource.com/downloads/ansible-quickstart>`_
        A downloadable guide for getting started with Ansible
+   :ref:`network_getting_started`
+       A guide for network engineers using Ansible for the first time


### PR DESCRIPTION
##### SUMMARY
Adds a link from the main Quick Start page to the Network Getting Started section. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
