### PR TITLE
VMware: vmware_deploy_ovf selecting wrong datastore in a multi-datacenter environment

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -166,8 +166,8 @@ def get_parent_datacenter(obj):
     return datacenter
 
 
-def find_datastore_by_name(content, datastore_name):
-    return find_object_by_name(content, datastore_name, [vim.Datastore])
+def find_datastore_by_name(content, datastore_name, datacenter_name=None):
+    return find_object_by_name(content, datastore_name, [vim.Datastore], datacenter_name)
 
 
 def find_dvs_by_name(content, switch_name, folder=None):
@@ -1311,16 +1311,18 @@ class PyVmomi(object):
             return False
         return True
 
-    def find_datastore_by_name(self, datastore_name):
+    def find_datastore_by_name(self, datastore_name, datacenter_name=None):
         """
         Get datastore managed object by name
         Args:
             datastore_name: Name of datastore
+            datacenter_name: Name of datacenter where the datastore resides.  This is needed because Datastores can be
+            shared across Datacenters, so we need to specify the datacenter to assure we get the correct Managed Object Reference
 
         Returns: datastore managed object if found else None
 
         """
-        return find_datastore_by_name(self.content, datastore_name=datastore_name)
+        return find_datastore_by_name(self.content, datastore_name=datastore_name, datacenter_name=datacenter_name)
 
     # Datastore cluster
     def find_datastore_cluster_by_name(self, datastore_cluster_name):

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -338,7 +338,7 @@ class VMwareDeployOvf(PyVmomi):
             if datastore:
                 self.datastore = datastore
         else:
-            self.datastore = self.find_datastore_by_name(self.params['datastore'])
+            self.datastore = self.find_datastore_by_name(self.params['datastore'], self.datacenter)
 
         if not self.datastore:
             self.module.fail_json(msg='%(datastore)s could not be located' % self.params)


### PR DESCRIPTION
##### SUMMARY
Fixes #63920. When trying to deploy an OVA to a shared datastore that resides in the 2nd datacenter in a multi-datacenter environment, vmware_deploy_ovf was returning the datastore managed object Id from the 1st datacenter.  Update the code to pass the datacenter so we get the datastore managed object Id from the passed in datacenter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/modules/cloud/vmware/vmware_deploy_ovf.py
ansible/module_utils/vmware.py

##### ADDITIONAL INFORMATION
