### PR TITLE
vmware_rest_client: pass object to get_tags_for_dynamic_obj

### DIFF
--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -162,7 +162,7 @@ class VmwareRestClient(object):
 
         return tags
 
-    def get_tags_for_dynamic_obj(self, mid=None):
+    def get_tags_for_dynamic_obj(self, dobj=None):
         """
         Return list of tag object details associated with object
         Args:
@@ -172,10 +172,10 @@ class VmwareRestClient(object):
 
         """
         tags = []
-        if mid is None:
+        if dobj is None:
             return tags
 
-        temp_tags_model = self.get_tags_for_object(dobj=mid)
+        temp_tags_model = self.get_tags_for_object(dobj)
 
         category_service = self.api_client.tagging.Category
 
@@ -199,7 +199,8 @@ class VmwareRestClient(object):
         Returns: List of tag object associated with the given cluster
 
         """
-        return self.get_tags_for_dynamic_obj(mid=cluster_mid)
+        dobj = DynamicID(type='cluster', id=cluster_mid)
+        return self.get_tags_for_dynamic_obj(dobj)
 
     def get_tags_for_hostsystem(self, hostsystem_mid=None):
         """
@@ -210,7 +211,8 @@ class VmwareRestClient(object):
         Returns: List of tag object associated with the given host system
 
         """
-        return self.get_tags_for_dynamic_obj(mid=hostsystem_mid)
+        dobj = DynamicID(type='HostSystem', id=hostsystem_mid)
+        return self.get_tags_for_dynamic_obj(dobj)
 
     def get_tags_for_vm(self, vm_mid=None):
         """
@@ -221,7 +223,8 @@ class VmwareRestClient(object):
         Returns: List of tag object associated with the given virtual machine
 
         """
-        return self.get_tags_for_dynamic_obj(mid=vm_mid)
+        dobj = DynamicID(type='VirtualMachine', id=vm_mid)
+        return self.get_tags_for_dynamic_obj(dobj)
 
     def get_vm_tags(self, tag_service=None, tag_association_svc=None, vm_mid=None):
         """

--- a/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
@@ -210,7 +210,7 @@ class VmwareTagManager(VmwareRestClient):
                                                      tag_assoc_svc=self.tag_association_svc,
                                                      dobj=self.dynamic_managed_object)
 
-        _temp_prev_tags = ["%s:%s" % (tag['category_name'], tag['name']) for tag in self.get_tags_for_dynamic_obj(mid=self.dynamic_managed_object)]
+        _temp_prev_tags = ["%s:%s" % (tag['category_name'], tag['name']) for tag in self.get_tags_for_dynamic_obj(self.dynamic_managed_object)]
         results['tag_status']['previous_tags'] = _temp_prev_tags
         results['tag_status']['desired_tags'] = self.tag_names
 
@@ -265,7 +265,7 @@ class VmwareTagManager(VmwareRestClient):
                     except Error as error:
                         self.module.fail_json(msg="%s" % self.get_error_message(error))
 
-        _temp_curr_tags = ["%s:%s" % (tag['category_name'], tag['name']) for tag in self.get_tags_for_dynamic_obj(mid=self.dynamic_managed_object)]
+        _temp_curr_tags = ["%s:%s" % (tag['category_name'], tag['name']) for tag in self.get_tags_for_dynamic_obj(self.dynamic_managed_object)]
         results['tag_status']['current_tags'] = _temp_curr_tags
         results['changed'] = changed
         self.module.exit_json(**results)


### PR DESCRIPTION
##### SUMMARY

This patch fix the `vmware_cluster_info` functional-tests.
`get_tags_for_dynamic_obj()` expects an object, not the object ID in a
string.

Without this patch `get_tags_for_object()` will raise the following
exception:

```
vmware.vapi.exception.CoreException: Expected VapiStruct instance or python dictionary, but received str
```

The patch partially reverts changes introduce in:
https://github.com/ansible/ansible/commit/35cc26f8c0447ab1ad4427eafcc7283c4356370d

See: http://vmware.github.io/vsphere-automation-sdk-rest/6.5/operations/com/vmware/cis/tagging/tag_association.list_attached_tags-operation.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/vmware_rest_client.py
lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
vmware_cluster_info