### PR TITLE
VMware: Fix typo in fail_json in vmware_guest_powerstate

### DIFF
--- a/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
+++ b/changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed typo in vmware_guest_powerstate module (https://github.com/ansible/ansible/issues/65161).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
@@ -263,7 +263,7 @@ def main():
                                                                                          vm.name,
                                                                                          to_native(e.msg)))
             except vim.fault.DuplicateName as e:
-                module.exit_json(chanaged=False, details=to_native(e.msg))
+                module.exit_json(changed=False, details=to_native(e.msg))
             except vmodl.fault.InvalidArgument as e:
                 module.fail_json(msg="Failed to create scheduled task %s as specifications "
                                      "given are invalid: %s" % (module.params.get('state'),


### PR DESCRIPTION
##### SUMMARY

Fixed typo from "chanaged" to "changed"

Fixes: #65161

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/typo_fix_vmware_guest_powerstate.yml
lib/ansible/modules/cloud/vmware/vmware_guest_powerstate.py
