### PR TITLE
postgres.PgMembership: use query params in cursor.execute method

### DIFF
--- a/changelogs/fragments/65164-postgres_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65164-postgres_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgres - use query params with cursor.execute in module_utils.postgres.PgMembership class (https://github.com/ansible/ansible/pull/65164).

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -276,9 +276,9 @@ class PgMembership(object):
                  "JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid) "
                  "WHERE m.member = r.oid) "
                  "FROM pg_catalog.pg_roles r "
-                 "WHERE r.rolname = '%s'" % dst_role)
+                 "WHERE r.rolname = %(dst_role)s")
 
-        res = exec_sql(self, query, add_to_executed=False)
+        res = exec_sql(self, query, query_params={'dst_role': dst_role}, add_to_executed=False)
         membership = []
         if res:
             membership = res[0][0]


### PR DESCRIPTION
##### SUMMARY
postgres.PgMembership: use query params in cursor.execute method

this feature used by postgresql_user and postgresql_membership modules that have CI tests for this part

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/module_utils/postgres.py```
