### PR TITLE
Backport of 65093, postgresql_lang: use query parameters with cursor.execute()

### DIFF
--- a/changelogs/fragments/65093-postgresql_lang_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65093-postgresql_lang_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_lang - use query params with cursor.execute (https://github.com/ansible/ansible/pull/65093).

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -179,23 +179,23 @@ executed_queries = []
 
 def lang_exists(cursor, lang):
     """Checks if language exists for db"""
-    query = "SELECT lanname FROM pg_language WHERE lanname = '%s'" % lang
-    cursor.execute(query)
+    query = "SELECT lanname FROM pg_language WHERE lanname = %(lang)s"
+    cursor.execute(query, {'lang': lang})
     return cursor.rowcount > 0
 
 
 def lang_istrusted(cursor, lang):
     """Checks if language is trusted for db"""
-    query = "SELECT lanpltrusted FROM pg_language WHERE lanname = '%s'" % lang
-    cursor.execute(query)
+    query = "SELECT lanpltrusted FROM pg_language WHERE lanname = %(lang)s"
+    cursor.execute(query, {'lang': lang})
     return cursor.fetchone()[0]
 
 
 def lang_altertrust(cursor, lang, trust):
     """Changes if language is trusted for db"""
-    query = "UPDATE pg_language SET lanpltrusted = '%s' WHERE lanname = '%s'" % (trust, lang)
-    executed_queries.append(query)
-    cursor.execute(query)
+    query = "UPDATE pg_language SET lanpltrusted = %(trust)s WHERE lanname = %(lang)s"
+    cursor.execute(query, {'trust': trust, 'lang': lang})
+    executed_queries.append(cursor.mogrify(query, {'trust': trust, 'lang': lang}))
     return True
 
 

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -107,7 +107,9 @@
 # depend only on Postgres version
 # (CentOS 6 repo contains the oldest PG version in these tests - 9.0):
 - import_tasks: postgresql_lang.yml
-  when: ansible_distribution == 'CentOS'
+  when:
+  - ansible_distribution == 'CentOS'
+  - postgres_version_resp.stdout is version('9.4', '>=')
 
 # dump/restore tests per format
 # ============================================================

--- a/test/integration/targets/postgresql/tasks/postgresql_lang.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_lang.yml
@@ -185,7 +185,7 @@
 - assert:
     that:
     - result is changed
-    - result.queries == ['CREATE TRUSTED LANGUAGE "plpythonu"', "UPDATE pg_language SET lanpltrusted = 'True' WHERE lanname = 'plpythonu'"]
+    - result.queries == ['CREATE TRUSTED LANGUAGE "plpythonu"', "UPDATE pg_language SET lanpltrusted = true WHERE lanname = 'plpythonu'"]
 
 - name: postgresql_lang - check that lang exists and it's trusted after previous step
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/postgresql_lang.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_lang.yml
@@ -181,6 +181,7 @@
     force_trust: yes
   register: result
   ignore_errors: yes
+  when: postgres_version_resp.stdout is version('9.4', '>=')
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Backport of #65093 , postgresql_lang: use query parameters with cursor.execute()

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_lang.py```
