### PR TITLE
Fixed superfluous warning message about show_per_host_start in dense callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -396,6 +396,9 @@ class CallbackModule_dense(CallbackModule_default):
         sys.stdout.write('cleanup.')
         sys.stdout.flush()
 
+    def v2_runner_on_start(self, host, task):
+        pass
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
         self._add_host(result, 'failed')
 


### PR DESCRIPTION
##### SUMMARY
Added v2_runner_on_start method in dense callback plugin order to remove the warning message

```
task 1.[WARNING]: Failure using method (v2_runner_on_start) in callback plugin
(<ansible.plugins.callback.dense.CallbackModule_dense object at 0x1105c6890>): 'show_per_host_start'

```
Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dense

