### PR TITLE
gitlab_runner: fix idempotency for shared runners

### DIFF
--- a/lib/ansible/modules/source_control/gitlab/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_runner.py
@@ -252,10 +252,10 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def findRunner(self, description):
-        runners = self._gitlab.runners.list(as_list=False)
+        runners = self._gitlab.runners.all(as_list=False)
         for runner in runners:
-            if (runner.description == description):
-                return self._gitlab.runners.get(runner.id)
+            if (runner['description'] == description):
+                return self._gitlab.runners.get(runner['id'])
 
     '''
     @param description Description of the runner


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Module is not idempotent for shared runners:
  - Doesn't update already created runner
  - Recreate runner each time
  - Doesn't delete runner

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65144
Fixes #60635

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_runner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
