### PR TITLE
print() stmts results an task failure, even if the task itself was successfull

### DIFF
--- a/lib/ansible/module_utils/aws/elbv2.py
+++ b/lib/ansible/module_utils/aws/elbv2.py
@@ -777,13 +777,9 @@ class ELBListenerRules(object):
 
                 if current_actions_sorted != new_actions_sorted_no_secret:
                     modified_rule['Actions'] = new_rule['Actions']
-                    print("modified_rule:")
-                    print(new_rule['Actions'])
         # If the action lengths are different, then replace with the new actions
         else:
             modified_rule['Actions'] = new_rule['Actions']
-            print("modified_rule:")
-            print(new_rule['Actions'])
 
         # Conditions
         modified_conditions = []


### PR DESCRIPTION

##### SUMMARY

There are `print()` statements, which results in task errors, even if the task itself was successfull.

This fix should also be backported.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

elb_application_lb

