### PR TITLE
vmware_guest: do not use autoselect_datastore in test

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
@@ -18,7 +18,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: "{{ f0 }}"
   register: clone_d1_c1_f0
@@ -49,7 +49,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: poweredoff
         folder: "{{ f0 }}"
       register: clone_d1_c1_f0
@@ -75,7 +75,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: "{{ f0 }}"
   register: clone_d1_c1_f0
@@ -106,7 +106,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: poweredoff
         folder: "{{ f0 }}"
       register: clone_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
@@ -19,7 +19,7 @@
     disk:
       - size_gb: 1
         type: thin
-        autoselect_datastore: True
+        datastore: "{{ rw_datastore }}"
     state: poweredoff
 
 - name: convert to VM template
@@ -47,10 +47,10 @@
     disk:
       - size_gb: 2
         type: thin
-        autoselect_datastore: True
+        datastore: "{{ rw_datastore }}"
       - size_gb: 3
         type: thin
-        autoselect_datastore: True
+        datastore: "{{ rw_datastore }}"
     template: clone_resize_disks_original
     state: poweredoff
   register: l_clone_template_modify_disks

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -32,7 +32,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: '{{ f0 }}'
   register: clone_d1_c1_f0
@@ -61,7 +61,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: '{{ f0 }}'
   register: clone_d1_c1_f0_recreate

--- a/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
@@ -19,7 +19,7 @@
         disk:
             - size: 10gb
               type: thin
-              autoselect_datastore: True
+              datastore: "{{ rw_datastore }}"
         state: present
         folder: "{{ f0 }}"
       register: invalid_guest_0001_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
@@ -17,7 +17,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     networks:
         - name: 'VM Network'
           device_type: vmxnet3

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -15,7 +15,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: F0
   register: clone_rp_d1_c1_f0
@@ -66,7 +66,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: F0
   register: clone_rpc_d1_c1_f0
@@ -119,7 +119,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: F0
   register: clone_rpcp_d1_c1_f0
@@ -171,7 +171,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: F0
   register: clone_rph_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -17,7 +17,7 @@
     disk:
         - size: 1gb
           type: eagerzeroedthick
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
           disk_mode: 'invalid_disk_mode'
     state: poweredoff
     folder: "{{ f0 }}"
@@ -46,7 +46,7 @@
     disk:
         - size: 1gb
           type: eagerzeroedthick
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
           disk_mode: 'independent_persistent'
     state: poweredoff
     folder: "{{ f0 }}"
@@ -77,7 +77,7 @@
       disk:
         - size: 1gb
           type: eagerzeroedthick
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
           disk_mode: 'independent_persistent'
       state: poweredoff
       folder: "{{ f0 }}"

--- a/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
@@ -17,7 +17,7 @@
     disk:
         - size: 0gb
           type: eagerzeroedthick
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: "{{ f0 }}"
   register: disk_size_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -17,10 +17,10 @@
     disk:
         - size: 1gb
           type: eagerzeroedthick
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     state: poweredoff
     folder: F0
   register: disk_type_d1_c1_f0

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -17,7 +17,7 @@
     disk:
         - size: 1gb
           type: thin
-          autoselect_datastore: True
+          datastore: "{{ rw_datastore }}"
     networks:
         - name: VM Network
           ip: 192.168.10.12

--- a/test/integration/targets/vmware_guest/tasks/max_connections.yml
+++ b/test/integration/targets/vmware_guest/tasks/max_connections.yml
@@ -21,7 +21,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: present
         folder: "{{ f0 }}"
       register: mk_conn_result_0001

--- a/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
+++ b/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
@@ -21,7 +21,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: present
         folder: "{{ virtual_machines[0].folder }}"
       register: mem_reserve_result_0001
@@ -61,7 +61,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: present
         folder: "{{ virtual_machines[0].folder }}"
       register: memory_reserve_result_0003
@@ -101,7 +101,7 @@
         disk:
           - size: 1gb
             type: thin
-            autoselect_datastore: True
+            datastore: "{{ rw_datastore }}"
         state: present
         folder: "{{ virtual_machines[0].folder }}"
       register: no_memory_reserve_result_0005

--- a/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -16,7 +16,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "Non existent VM"
     hardware:
@@ -47,7 +47,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         type: static
@@ -80,7 +80,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         type: static
@@ -113,7 +113,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - ip: 10.10.10.10
         netmask: 255.255.255
@@ -146,7 +146,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - vlan: non_existing_vlan
         ip: 10.10.10.10
@@ -179,7 +179,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         ip: 10.10.10.10
@@ -213,7 +213,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         ip: 10.10.10.10
@@ -248,7 +248,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         ip: 10.10.10.10
@@ -284,7 +284,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
         ip: 10.10.10.10
@@ -320,7 +320,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: "VM Network"
     hardware:

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -18,7 +18,7 @@
     name: test_vm1
     disk:
       - size: 10mb
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
       memory_mb: 512
@@ -46,7 +46,7 @@
     name: test_vm1
     disk:
       - size: 10mb
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
       memory_mb: 512

--- a/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -18,7 +18,7 @@
         name: test_vm1
         disk:
           - size: 10gb
-            autoselect_datastore: yes
+            datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
           memory_mb: 128
@@ -45,7 +45,7 @@
         name: test_vm2
         disk:
           - size: 10gb
-            autoselect_datastore: yes
+            datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
           memory_mb: 128
@@ -71,7 +71,7 @@
         name: test_vm2
         disk:
           - size: 10gb
-            autoselect_datastore: yes
+            datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
           memory_mb: 128
@@ -97,7 +97,7 @@
         name: test_vm3
         disk:
           - size: 10gb
-            autoselect_datastore: yes
+            datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
           memory_mb: 128
@@ -123,7 +123,7 @@
         name: test_vm3
         disk:
           - size: 10gb
-            autoselect_datastore: yes
+            datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
           memory_mb: 128

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -28,7 +28,7 @@
     disk:
       - size: 3mb
         type: thin
-        autoselect_datastore: yes
+        datastore: "{{ rw_datastore }}"
     networks:
       - name: portgroup_network
         switch_name: "{{ dvswitch1 }}"

--- a/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
+++ b/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
@@ -19,7 +19,7 @@
     disk:
       - size: 1gb
         type: thin
-        autoselect_datastore: True
+        datastore: "{{ rw_datastore }}"
     state: present
   register: create_vm_for_test
 


### PR DESCRIPTION
##### SUMMARY

Disable the use of `autoselect_datastore` until https://github.com/ansible/ansible/issues/58541
is fixed.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest
<!--- Write the short name of the module, plugin, task or feature below -->