### PR TITLE
vmware_guest: relax the requirements of the tests

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/boot_firmware_d1_c1_f0.yml
@@ -12,9 +12,9 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
-        num_cpus: 4
+        num_cpus: 1
         boot_firmware: "bios"
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -43,9 +43,9 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
+          num_cpus: 1
           boot_firmware: "bios"
-          memory_mb: 512
+          memory_mb: 128
         disk:
           - size: 1gb
             type: thin
@@ -69,9 +69,9 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
-        num_cpus: 4
+        num_cpus: 1
         boot_firmware: "efi"
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -100,9 +100,9 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
+          num_cpus: 1
           boot_firmware: "efi"
-          memory_mb: 512
+          memory_mb: 128
         disk:
           - size: 1gb
             type: thin

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -11,7 +11,7 @@
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     disk:
@@ -121,7 +121,7 @@
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     disk:
@@ -159,7 +159,7 @@
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     disk:
@@ -245,7 +245,7 @@
         resource_pool: Resources
         guest_id: centos64Guest
         hardware:
-          memory_mb: 512
+          memory_mb: 128
           num_cpus: 1
           scsi: paravirtual
         disk:

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -13,14 +13,14 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
-        num_cpus: 4
-        num_cpu_cores_per_socket: 2
-        memory_mb: 512
+        num_cpus: 1
+        num_cpu_cores_per_socket: 1
+        memory_mb: 128
         hotadd_memory: true
         hotadd_cpu: false
         # vcsim does not support these settings, so commenting
         # till the time.
-        # memory_reservation: 512
+        # memory_reservation: 128
         # memory_reservation_lock: False
         # nested_virt: True
         # hotremove_cpu: True
@@ -55,9 +55,9 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
-        num_cpus: 4
-        num_cpu_cores_per_socket: 2
-        memory_mb: 512
+        num_cpus: 1
+        num_cpu_cores_per_socket: 1
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -85,7 +85,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 2
-        memory_mb: 1024
+        memory_mb: 128
     state: present
     folder: '{{ f0 }}'
   register: clone_d1_c1_f0_modify
@@ -109,7 +109,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 2
-        memory_mb: 1024
+        memory_mb: 128
     state: present
     folder: '{{ f0 }}'
   register: clone_d1_c1_f0_remodify

--- a/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - when: vcsim is not defined
-  block: 
+  block:
     - name: create new virtual machine with invalid guest id
       vmware_guest:
         validate_certs: False
@@ -15,9 +15,9 @@
         datacenter: "{{ dc1 }}"
         hardware:
             num_cpus: 1
-            memory_mb: 512
+            memory_mb: 128
         disk:
-            - size: 10gb
+            - size: 1gb
               type: thin
               datastore: "{{ rw_datastore }}"
         state: present

--- a/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_nw_d1_c1_f0.yml
@@ -12,8 +12,8 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
-        num_cpus: 4
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -11,7 +11,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -62,7 +62,7 @@
     cluster: "{{ ccr1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -115,7 +115,7 @@
     resource_pool: DC0_C0_RP1
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin
@@ -167,7 +167,7 @@
     esxi_hostname: '{{ esxi1 }}'
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin

--- a/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_mode_d1_c1_f0.yml
@@ -13,7 +13,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: eagerzeroedthick
@@ -42,7 +42,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: eagerzeroedthick
@@ -73,7 +73,7 @@
       datacenter: "{{ dc1 }}"
       hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
       disk:
         - size: 1gb
           type: eagerzeroedthick

--- a/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_size_d1_c1_f0.yml
@@ -13,7 +13,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 0gb
           type: eagerzeroedthick

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -13,7 +13,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: eagerzeroedthick

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -13,7 +13,7 @@
     datacenter: "{{ dc1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     disk:
         - size: 1gb
           type: thin

--- a/test/integration/targets/vmware_guest/tasks/max_connections.yml
+++ b/test/integration/targets/vmware_guest/tasks/max_connections.yml
@@ -15,8 +15,8 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
-          memory_mb: 512
+          num_cpus: 1
+          memory_mb: 128
           max_connections: 4
         disk:
           - size: 1gb

--- a/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
+++ b/test/integration/targets/vmware_guest/tasks/mem_reservation.yml
@@ -15,8 +15,8 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
-          memory_mb: 512
+          num_cpus: 1
+          memory_mb: 128
           mem_reservation: 0
         disk:
           - size: 1gb
@@ -55,8 +55,8 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
-          memory_mb: 512
+          num_cpus: 1
+          memory_mb: 128
           memory_reservation: 0
         disk:
           - size: 1gb
@@ -95,8 +95,8 @@
         guest_id: centos64Guest
         datacenter: "{{ dc1 }}"
         hardware:
-          num_cpus: 4
-          memory_mb: 512
+          num_cpus: 1
+          memory_mb: 128
           memory_reservation: 0
         disk:
           - size: 1gb

--- a/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -20,8 +20,8 @@
     networks:
       - name: "Non existent VM"
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: non_existent_network
@@ -53,8 +53,8 @@
         type: static
         ip: 10.10.10.10
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: no_netmask
@@ -86,8 +86,8 @@
         type: static
         netmask: 255.255.255.0
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: no_ip
@@ -119,8 +119,8 @@
         netmask: 255.255.255
         type: static
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: no_network_name
@@ -152,8 +152,8 @@
         ip: 10.10.10.10
         netmask: 255.255.255
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: no_network
@@ -186,8 +186,8 @@
         netmask: 255.255.255
         device_type: abc
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: invalid_device_type
@@ -221,8 +221,8 @@
         device_type: e1000
         mac: abcdef
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: invalid_mac
@@ -257,8 +257,8 @@
         mac: 01:23:45:67:89:ab
         type: aaaaa
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: invalid_network_type
@@ -293,8 +293,8 @@
         mac: 01:23:45:67:89:ab
         type: dhcp
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: invalid_dhcp_network_type
@@ -324,8 +324,8 @@
     networks:
       - name: "VM Network"
     hardware:
-        num_cpus: 3
-        memory_mb: 512
+        num_cpus: 1
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: no_network_type

--- a/test/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -3,9 +3,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Testcase to check #38605
-- set_fact:
-    vm_name: "VM_{{ 10000 | random }}"
-
 - name: Deploy VM first VM
   vmware_guest:
     hostname: "{{ vcenter_hostname }}"
@@ -21,7 +18,7 @@
         datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
     networks:
       - name: 'VM Network'
@@ -49,7 +46,7 @@
         datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
     networks:
       - name: 'VM Network'

--- a/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -17,7 +17,7 @@
         template: "{{ virtual_machines[0].name }}"
         name: test_vm1
         disk:
-          - size: 10gb
+          - size: 1gb
             datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
@@ -44,7 +44,7 @@
         folder: "{{ f0 }}"
         name: test_vm2
         disk:
-          - size: 10gb
+          - size: 1gb
             datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
@@ -70,7 +70,7 @@
         folder: "{{ f0 }}"
         name: test_vm2
         disk:
-          - size: 10gb
+          - size: 1gb
             datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
@@ -96,7 +96,7 @@
         folder: "{{ f0 }}"
         name: test_vm3
         disk:
-          - size: 10gb
+          - size: 1gb
             datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:
@@ -122,7 +122,7 @@
         folder: "{{ f0 }}"
         name: test_vm3
         disk:
-          - size: 10gb
+          - size: 1gb
             datastore: "{{ rw_datastore }}"
         guest_id: rhel7_64guest
         hardware:

--- a/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/test/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -34,7 +34,7 @@
         switch_name: "{{ dvswitch1 }}"
     hardware:
         num_cpus: 1
-        memory_mb: 512
+        memory_mb: 128
     state: poweredoff
     folder: "{{ f0 }}"
   register: vm_with_portgroup

--- a/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
+++ b/test/integration/targets/vmware_guest/tasks/remove_vm_from_inventory.yml
@@ -13,9 +13,9 @@
     datacenter: "{{ dc1 }}"
     folder: F0
     hardware:
-      num_cpus: 4
-      num_cpu_cores_per_socket: 2
-      memory_mb: 512
+      num_cpus: 1
+      num_cpu_cores_per_socket: 1
+      memory_mb: 128
     disk:
       - size: 1gb
         type: thin

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -17,7 +17,7 @@
     resource_pool: Resources
     guest_id: centos64Guest
     hardware:
-      memory_mb: 512
+      memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
     disk:

--- a/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
@@ -11,7 +11,7 @@
     resource_pool: Resources
     guest_id: windows9_64Guest
     hardware:
-      memory_mb: 1024
+      memory_mb: 128
       num_cpus: 1
       virt_based_security: True
       version: 14
@@ -46,7 +46,7 @@
     resource_pool: Resources
     guest_id: windows9Server64Guest
     hardware:
-      memory_mb: 1024
+      memory_mb: 128
       num_cpus: 1
       version: 14
       boot_firmware: efi


### PR DESCRIPTION
##### SUMMARY

- 128MB or RAM is enough for most of the cases
- 1VCPU is also enough
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest
<!--- Write the short name of the module, plugin, task or feature below -->
