### PR TITLE
Allow cpanm to install correct version

### DIFF
--- a/lib/ansible/modules/packaging/language/cpanm.py
+++ b/lib/ansible/modules/packaging/language/cpanm.py
@@ -147,6 +147,7 @@ def _build_cmd_line(
     installdeps,
     cpanm,
     use_sudo,
+    version,
 ):
     # this code should use "%s" like everything else and just return early but not fixing all of it now.
     # don't copy stuff like this
@@ -231,6 +232,7 @@ def main():
             installdeps,
             cpanm,
             use_sudo,
+            version,
         )
 
         rc_cpanm, out_cpanm, err_cpanm = module.run_command(cmd, check_rc=False)


### PR DESCRIPTION
##### SUMMARY

Previous version argument was used to check the system version, and
there was no use in the module installation. This patch gives users to
specify which version of Perl module they want to install with cpanm
version operators such as @, ~ and == [0].

Also, this PR fixes #56208.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

cpanm

\[0]: https://metacpan.org/pod/distribution/App-cpanminus/lib/App/cpanminus/fatscript.pm#COMMANDS