### PR TITLE
display - remove extra new line after warning message

### DIFF
--- a/changelogs/fragments/warnings-remove-extra-newline.yaml
+++ b/changelogs/fragments/warnings-remove-extra-newline.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display - remove extra new line after warnings (https://github.com/ansible/ansible/pull/65199)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -151,14 +151,15 @@ class Display(with_metaclass(Singleton, object)):
         """
 
         nocolor = msg
-        if color:
-            msg = stringc(msg, color)
 
         if not log_only:
             if not msg.endswith(u'\n') and newline:
                 msg2 = msg + u'\n'
             else:
                 msg2 = msg
+
+            if color:
+                msg2 = stringc(msg2, color)
 
             msg2 = to_bytes(msg2, encoding=self._output_encoding(stderr=stderr))
             if sys.version_info >= (3,):

--- a/test/units/utils/display/test_display.py
+++ b/test/units/utils/display/test_display.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ansible.utils.display import Display
+
+
+def test_display(capsys, mocker):
+    """ Test default call to display() """
+
+    # Disable logging
+    mocker.patch('ansible.utils.display.logger', return_value=None)
+
+    d = Display()
+    d.display(u'Some displayed message')
+    out, err = capsys.readouterr()
+    assert out == 'Some displayed message\n'
+
+
+def test_display_color_warning(capsys, mocker):
+    """ Test displaying a warning message """
+
+    # Disable logging
+    mocker.patch('ansible.utils.display.logger', return_value=None)
+
+    # Warning message wrapped in bright purple color code
+    msg = u'[WARNING] This is a warning'
+    colorized_msg = u'\x1b[1;35m%s\x1b[0m\n\x1b[1;35m\x1b[0m' % msg
+    mocker.patch('ansible.utils.display.stringc', return_value=colorized_msg)
+
+    d = Display()
+    d.display(msg, color='bright purple', stderr=True)
+    out, err = capsys.readouterr()
+
+    assert err == colorized_msg

--- a/test/units/utils/display/test_display.py
+++ b/test/units/utils/display/test_display.py
@@ -9,9 +9,7 @@ __metaclass__ = type
 from ansible.utils.display import Display
 
 
-def test_display(capsys, mocker):
-    """ Test default call to display() """
-
+def test_display_basic_message(capsys, mocker):
     # Disable logging
     mocker.patch('ansible.utils.display.logger', return_value=None)
 
@@ -19,21 +17,4 @@ def test_display(capsys, mocker):
     d.display(u'Some displayed message')
     out, err = capsys.readouterr()
     assert out == 'Some displayed message\n'
-
-
-def test_display_color_warning(capsys, mocker):
-    """ Test displaying a warning message """
-
-    # Disable logging
-    mocker.patch('ansible.utils.display.logger', return_value=None)
-
-    # Warning message wrapped in bright purple color code
-    msg = u'[WARNING] This is a warning'
-    colorized_msg = u'\x1b[1;35m%s\x1b[0m\n\x1b[1;35m\x1b[0m' % msg
-    mocker.patch('ansible.utils.display.stringc', return_value=colorized_msg)
-
-    d = Display()
-    d.display(msg, color='bright purple', stderr=True)
-    out, err = capsys.readouterr()
-
-    assert err == colorized_msg
+    assert err == ''

--- a/test/units/utils/display/test_warning.py
+++ b/test/units/utils/display/test_warning.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.utils.display import Display
+
+
+def test_warning(capsys):
+    d = Display()
+    d.warning(u'bad things will happen')
+    out, err = capsys.readouterr()
+    assert d._warns == {'[WARNING]: bad things will happen\n': 1}
+    assert err == '[WARNING]: bad things will happen\n'
+
+
+def test_warning_formatted(capsys):
+    d = Display()
+    d.warning(u'bad things will happen', formatted=True)
+    out, err = capsys.readouterr()
+    assert d._warns == {'\n[WARNING]: \nbad things will happen': 1}
+    assert err == '\n[WARNING]: \nbad things will happen\n'

--- a/test/units/utils/display/test_warning.py
+++ b/test/units/utils/display/test_warning.py
@@ -5,20 +5,38 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import pytest
+
 from ansible.utils.display import Display
 
 
-def test_warning(capsys):
-    d = Display()
-    d.warning(u'bad things will happen')
-    out, err = capsys.readouterr()
-    assert d._warns == {'[WARNING]: bad things will happen\n': 1}
-    assert err == '[WARNING]: bad things will happen\n'
+@pytest.fixture
+def warning_message():
+    warning_message = 'bad things will happen'
+    expected_warning_message = '[WARNING]: {0}\n'.format(warning_message)
+    return warning_message, expected_warning_message
 
 
-def test_warning_formatted(capsys):
+def test_warning(capsys, mocker, warning_message):
+    warning_message, expected_warning_message = warning_message
+
+    mocker.patch('ansible.utils.color.ANSIBLE_COLOR', True)
+    mocker.patch('ansible.utils.color.parsecolor', return_value=u'1;35')  # value for 'bright purple'
+
     d = Display()
-    d.warning(u'bad things will happen', formatted=True)
+    d.warning(warning_message)
     out, err = capsys.readouterr()
-    assert d._warns == {'\n[WARNING]: \nbad things will happen': 1}
-    assert err == '\n[WARNING]: \nbad things will happen\n'
+    assert d._warns == {expected_warning_message: 1}
+    assert err == '\x1b[1;35m{0}\x1b[0m\n\x1b[1;35m\x1b[0m'.format(expected_warning_message.rstrip('\n'))
+
+
+def test_warning_no_color(capsys, mocker, warning_message):
+    warning_message, expected_warning_message = warning_message
+
+    mocker.patch('ansible.utils.color.ANSIBLE_COLOR', False)
+
+    d = Display()
+    d.warning(warning_message)
+    out, err = capsys.readouterr()
+    assert d._warns == {expected_warning_message: 1}
+    assert err == expected_warning_message


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The message string was being checked for an ending newline _after_ being wrapped in color characters. This means an extra newline was always inserted even if the message already had a new line.

Example output:
```
PLAY [Local testing playbook] *********************************************************************************

TASK [testmodule] *********************************************************************************************
[WARNING]: Some warning

[WARNING]: Some other warning two

[WARNING]: Some other warning

```

What's going on in the code:
```
 0.1s display:
      msg='\x1b[1;35m[WARNING]: Some warning\x1b[0m\n\x1b[1;35m\x1b[0m'
                                                    ^ There is already a new line here, but it's not at the end
 0.1s display:
      msg2='\x1b[1;35m[WARNING]: Some warning\x1b[0m\n\x1b[1;35m\x1b[0m\n'
                                                     ^                  ^ Now there are two new lines
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/utils/display.py`
##### ADDITIONAL INFORMATION
I'm not sure we need to add a new line to the end of the string in `warning()`. Removing the `+ "\n"` is how I initially fixed this, but that wasn't the actual bug.
