### PR TITLE
Add 'bhyve' as a valid brand for SmartOS vmadm

### DIFF
--- a/lib/ansible/modules/cloud/smartos/vmadm.py
+++ b/lib/ansible/modules/cloud/smartos/vmadm.py
@@ -33,10 +33,10 @@ options:
       - Whether or not a VM is booted when the system is rebooted.
   brand:
     required: true
-    choices: [ joyent, joyent-minimal, kvm, lx ]
+    choices: [ joyent, joyent-minimal, lx, kvm, bhyve ]
     default: joyent
     description:
-      - Type of virtual machine.
+      - Type of virtual machine. The C(bhyve) option was added in Ansible 2.10.
   boot:
     required: false
     description:
@@ -641,7 +641,7 @@ def main():
         brand=dict(
             default='joyent',
             type='str',
-            choices=['joyent', 'joyent-minimal', 'kvm', 'lx']
+            choices=['joyent', 'joyent-minimal', 'lx', 'kvm', 'bhyve']
         ),
         cpu_type=dict(
             default='qemu64',


### PR DESCRIPTION
##### SUMMARY
SmartOS/illumos added support for bhyve some time ago. The interface via `vmadm(1m)` is the same as KVM and the other brands, but the module is unable to create/manage bhyve VMs because `bhyve` is not a valid choice for `brand`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmadm

##### ADDITIONAL INFORMATION
Playbook:
```yaml
- hosts: all
  tasks:
    - vmadm:
        alias: guest
        brand: bhyve
        ...
```

Before:
```
failed: [smartos] (item={'name': 'guest', 'brand': 'bhyve', ...} => {"msg": "value of brand must be one of: joyent, joyent-minimal, kvm, lx, got: bhyve"}
```

After:
```
ok: [smartos] => (item={'name': 'guest', 'brand': 'bhyve', ...})
```