### PR TITLE
add note to galaxy_server_list requiring forward slash on url

### DIFF
--- a/docs/docsite/rst/shared_snippets/galaxy_server_list.txt
+++ b/docs/docsite/rst/shared_snippets/galaxy_server_list.txt
@@ -9,10 +9,14 @@ You can configure this to use other servers (such as Red Hat Automation Hub or a
 
 To configure a Galaxy server list in ``ansible.cfg``:
 
+
 #. Add the ``server_list``  option under the ``[galaxy]`` section to one or more server names.
 #. Create a new section for each server name.
 #. Set the ``url`` option for each server name.
 
+.. note::
+    The ``url`` option for each server name must end with a forward slash ``/``.
+    
 For Automation Hub, you additionally need to:
 
 #. Set the ``auth_url`` option for each server name.


### PR DESCRIPTION
##### SUMMARY
This PR adds a note addressing requirement to add a forward slash '/' to the url for each server name under the galaxy_server.name option. 

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
Galaxy_server_list

##### ADDITIONAL INFORMATION
