### PR TITLE
[stable-2.9] user - compare macOS user properties using same type (#62973)

### DIFF
--- a/changelogs/fragments/user-fix-value-comparison-on-macos.yaml
+++ b/changelogs/fragments/user-fix-value-comparison-on-macos.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix comparison on macOS so module does not improperly report a change (https://github.com/ansible/ansible/issues/62969)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -420,8 +420,8 @@ import subprocess
 import time
 
 from ansible.module_utils import distro
-from ansible.module_utils._text import to_native, to_bytes, to_text
 from ansible.module_utils.basic import load_platform_subclass, AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native, to_text
 
 try:
     import spwd
@@ -2303,7 +2303,7 @@ class DarwinUser(User):
         for field in self.fields:
             if field[0] in self.__dict__ and self.__dict__[field[0]]:
                 current = self._get_user_property(field[1])
-                if current is None or current != self.__dict__[field[0]]:
+                if current is None or current != to_text(self.__dict__[field[0]]):
                     cmd = self._get_dscl()
                     cmd += ['-create', '/Users/%s' % self.name, field[1], self.__dict__[field[0]]]
                     (rc, _err, _out) = self.execute_command(cmd)

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -55,6 +55,33 @@
       - user_test0_1 is not changed
       - '"ansibulluser" in user_names.stdout_lines'
 
+# test adding user with uid
+# https://github.com/ansible/ansible/issues/62969
+- name: remove the test user
+  user:
+    name: ansibulluser
+    state: absent
+
+- name: try to create a user with uid
+  user:
+    name: ansibulluser
+    state: present
+    uid: 572
+  register: user_test01_0
+
+- name: create the user again
+  user:
+    name: ansibulluser
+    state: present
+    uid: 572
+  register: user_test01_1
+
+- name: validate results for testcase 0
+  assert:
+    that:
+      - user_test01_0 is changed
+      - user_test01_1 is not changed
+
 # test user add with password
 - name: add an encrypted password for user
   user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #62973 for Ansible 2.9
(cherry picked from commit c73288ad5387a728349fae772aa9d1769af73a13)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/user.py`