### PR TITLE
Handle unset check and run flags in sysptach.py

### DIFF
--- a/lib/ansible/modules/system/syspatch.py
+++ b/lib/ansible/modules/system/syspatch.py
@@ -114,6 +114,9 @@ def syspatch_run(module):
     elif module.params['apply']:
         check_flag = ['-c']
         run_flag = []
+    else:
+        run_flag = []
+        check_flag = []
 
     # Run check command
     rc, out, err = module.run_command(cmd + check_flag)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #65216

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

syspatch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
**Before:**

$ ansible -m syspatch -i ${_inv} all
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'check_flag' referenced before assignment
[WARNING]: Platform openbsd on host my-host.example.com is using the discovered Python interpreter at
/usr/local/bin/python3.7, but future installation of another Python interpreter could change this. See
https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information.

my-host.example.com | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/local/bin/python3.7"
    },
    "changed": false,
    "module_stderr": "Shared connection to my-host.example.com closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/home/solvaholic/.ansible/tmp/ansible-tmp-1574521389.9093022-276136147869340/AnsiballZ_syspatch.py\", line 102, in <module>\r\n    _ansiballz_main()\r\n  File \"/home/solvaholic/.ansible/tmp/ansible-tmp-1574521389.9093022-276136147869340/AnsiballZ_syspatch.py\", line 94, in _ansiballz_main\r\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\r\n  File \"/home/solvaholic/.ansible/tmp/ansible-tmp-1574521389.9093022-276136147869340/AnsiballZ_syspatch.py\", line 40, in invoke_module\r\n    runpy.run_module(mod_name='ansible.modules.system.syspatch', init_globals=None, run_name='__main__', alter_sys=True)\r\n  File \"/usr/local/lib/python3.7/runpy.py\", line 205, in run_module\r\n    return _run_module_code(code, init_globals, run_name, mod_spec)\r\n  File \"/usr/local/lib/python3.7/runpy.py\", line 96, in _run_module_code\r\n    mod_name, mod_spec, pkg_name, script_name)\r\n  File \"/usr/local/lib/python3.7/runpy.py\", line 85, in _run_code\r\n    exec(code, run_globals)\r\n  File \"/tmp/ansible_syspatch_payload_lrzy77oi/ansible_syspatch_payload.zip/ansible/modules/system/syspatch.py\", line 169, in <module>\r\n  File \"/tmp/ansible_syspatch_payload_lrzy77oi/ansible_syspatch_payload.zip/ansible/modules/system/syspatch.py\", line 165, in main\r\n  File \"/tmp/ansible_syspatch_payload_lrzy77oi/ansible_syspatch_payload.zip/ansible/modules/system/syspatch.py\", line 95, in run_module\r\n  File \"/tmp/ansible_syspatch_payload_lrzy77oi/ansible_syspatch_payload.zip/ansible/modules/system/syspatch.py\", line 119, in syspatch_run\r\nUnboundLocalError: local variable 'check_flag' referenced before assignment\r\n",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

**After:**

$ ansible -m syspatch -i ${_inv} all
[WARNING]: Platform openbsd on host my-host.example.com is using the discovered Python interpreter at
/usr/local/bin/python3.7, but future installation of another Python interpreter could change this. See
https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information.

my-host.example.com | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/local/bin/python3.7"
    },
    "changed": false,
    "msg": "Command ['/usr/sbin/syspatch'] failed rc=1, out=, err=syspatch: need root privileges\n"
}
```
