### PR TITLE
Flip p=/u= marker data

### DIFF
--- a/changelogs/fragments/65218-flip-log-marker-data.yml
+++ b/changelogs/fragments/65218-flip-log-marker-data.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "utils - correct user/pid markers in logging spec flipped in #56311 (https://github.com/ansible/ansible/issues/65218)."

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -62,7 +62,7 @@ logger = None
 if getattr(C, 'DEFAULT_LOG_PATH'):
     path = C.DEFAULT_LOG_PATH
     if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.INFO, format='%(asctime)s p=%(user)s u=%(process)d | %(message)s')
+        logging.basicConfig(filename=path, level=logging.INFO, format='%(asctime)s p=%(process)d u=%(user)s | %(message)s')
         logger = logging.LoggerAdapter(logging.getLogger('ansible'), {'user': getpass.getuser()})
         for handler in logging.root.handlers:
             handler.addFilter(FilterBlackList(getattr(C, 'DEFAULT_LOG_FILTER', [])))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR #56311 standardizes logging per Python best practices. The changes implemented flipped user/pid data for u= and p= markers, which breaks context-specific pattern matches in the logfile. This PR restores the context associations prior to a7837edcf26e1e8542109952a9117e145c4cba1d.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/utils/display.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
env ANSIBLE_LOG_PATH=/tmp/ansible-log.txt ansible -m debug -a msg=Hello localhost
cat /tmp/ansible-log.txt
```
**Incorrect logging format**:
```
2019-11-23 12:39:12,543 p=root u=10058 | localhost | SUCCESS => {
    "msg": "Hello"
}
```

**Corrected logging format**:
```
2019-11-23 12:42:44,342 p=10349 u=root | localhost | SUCCESS => {
    "msg": "Hello"
}
```