### PR TITLE
Specify priority for VMs in Azure VM scale sets

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -254,6 +254,14 @@ options:
             - timeout time for termination notification event
             - in range between 5 and 15
         version_added: "2.10"
+    priority:
+        description:
+            - If you want to request low-priority VMs for the VMSS, set this to "Low". The default is "Regular"
+        default: Regular
+        choices:
+            - Regular
+            - Low
+        version_added: "2.10"
 
 extends_documentation_fragment:
     - azure
@@ -533,7 +541,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                       product=dict(type='str', required=True), name=dict(type='str', required=True),
                       promotion_code=dict(type='str'))),
             scale_in_policy=dict(type='str', choices=['Default', 'OldestVM', 'NewestVM']),
-            terminate_event_timeout_minutes=dict(type='int')
+            terminate_event_timeout_minutes=dict(type='int'),
+            priority=dict(type='str', choices=['Regular', 'Low'], default='Regular')
         )
 
         self.resource_group = None
@@ -570,6 +579,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
         self.plan = None
         self.scale_in_policy = None
         self.terminate_event_timeout_minutes = None
+        self.priority = None
 
         mutually_exclusive = [('load_balancer', 'application_gateway')]
         self.results = dict(
@@ -881,6 +891,7 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                         ),
                         plan=plan,
                         virtual_machine_profile=self.compute_models.VirtualMachineScaleSetVMProfile(
+                            priority=self.priority,
                             os_profile=os_profile,
                             storage_profile=self.compute_models.VirtualMachineScaleSetStorageProfile(
                                 os_disk=self.compute_models.VirtualMachineScaleSetOSDisk(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds support to create VMSS with low-priority VMs through a new optional
parameter. The default is to create a VMSS with Regular priority VMs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualmachine_scaleset

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-use-low-priority