### PR TITLE
Backport/2.8/65065 plugins/netconf/ce.py to fix a bug(failed to get veriosn information via neocnf). #65065

### DIFF
--- a/changelogs/fragments/65065-plugins-netconf-ce-fix.yaml
+++ b/changelogs/fragments/65065-plugins-netconf-ce-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - plugins-netconf-ce - Fix failed to get version information.

--- a/lib/ansible/plugins/netconf/ce.py
+++ b/lib/ansible/plugins/netconf/ce.py
@@ -55,14 +55,26 @@ class Netconf(NetconfBase):
     def get_device_info(self):
         device_info = dict()
         device_info['network_os'] = 'ce'
-        ele = new_ele('get-software-information')
-        data = self.execute_rpc(to_xml(ele))
-        reply = to_ele(to_bytes(data, errors='surrogate_or_strict'))
-        sw_info = reply.find('.//software-information')
+        filter_xml = '''<filter type="subtree">
+                          <system xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+                            <systemInfo>
+                              <sysName></sysName>
+                              <sysContact></sysContact>
+                              <productVer></productVer>
+                              <platformVer></platformVer>
+                              <productName></productName>
+                            </systemInfo>
+                          </system>
+                        </filter>'''
+        data = self.get(filter_xml)
+        data = re.sub(r'xmlns=".+?"', r'', data)
+        reply = fromstring(to_bytes(data, errors='surrogate_or_strict'))
+        sw_info = reply.find('.//systemInfo')
 
-        device_info['network_os_version'] = self.get_text(sw_info, 'ce-version')
-        device_info['network_os_hostname'] = self.get_text(sw_info, 'host-name')
-        device_info['network_os_model'] = self.get_text(sw_info, 'product-model')
+        device_info['network_os_version'] = self.get_text(sw_info, 'productVer')
+        device_info['network_os_hostname'] = self.get_text(sw_info, 'sysName')
+        device_info['network_os_platform_version'] = self.get_text(sw_info, 'platformVer')
+        device_info['network_os_platform'] = self.get_text(sw_info, 'productName')
 
         return device_info
 


### PR DESCRIPTION
…rmation via neocnf). (#65065)

* fix version fail.

* add a changelog fragment.

* Update ce.py

* Rename plugins-netconf-ce-fix.yaml to 65065-plugins-netconf-ce-fix.yaml

* Update ce.py

Backport of https://github.com/ansible/ansible/pull/65065

(cherry picked from commit da8ec327cc20b72f68b049de6a0b53b088fc15dd)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
