### PR TITLE
Add Filename and Line number to ansible_failed_task

### DIFF
--- a/changelogs/fragments/64625-show-failed-task-path.yml
+++ b/changelogs/fragments/64625-show-failed-task-path.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - callback - When a task fails, display the path to the task file and the line number of the task.
+  - default callback - add ``dispaly_failed_path`` option to display the path to the task file and the line number of the task when a task fails

--- a/changelogs/fragments/64625-show-failed-task-path.yml
+++ b/changelogs/fragments/64625-show-failed-task-path.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - callback - When a task fails, display the path to the task file and the line number of the task.

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -57,8 +57,7 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('display_ok_hosts', True),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
-                  ('check_mode_markers', False),
-                  ('always_display_failed_task_path', False),)
+                  ('check_mode_markers', False),)
 
 
 class CallbackModule(CallbackBase):
@@ -79,6 +78,10 @@ class CallbackModule(CallbackBase):
         self._last_task_name = None
         self._task_type_cache = {}
         super(CallbackModule, self).__init__()
+
+    def _print_task_path(self, path):
+        if path:
+            self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
@@ -107,7 +110,7 @@ class CallbackModule(CallbackBase):
             self._process_items(result)
 
         else:
-            if self._display.verbosity < 2 and self.always_display_failed_task_path:
+            if self._display.verbosity < 2 and self.get_option('display_failed_path'):
                 self._print_task_path(result._task.get_path())
             if delegated_vars:
                 self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
@@ -245,10 +248,6 @@ class CallbackModule(CallbackBase):
         if self._display.verbosity >= 2:
             self._print_task_path(task.get_path())
         self._last_task_banner = task._uuid
-
-    def _print_task_path(self, path):
-        if path:
-            self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
 
     def v2_playbook_on_cleanup_task_start(self, task):
         self._task_start(task, prefix='CLEANUP TASK')

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -57,7 +57,8 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('display_ok_hosts', True),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
-                  ('check_mode_markers', False),)
+                  ('check_mode_markers', False),
+                  ('always_display_failed_task_path', False),)
 
 
 class CallbackModule(CallbackBase):
@@ -106,6 +107,8 @@ class CallbackModule(CallbackBase):
             self._process_items(result)
 
         else:
+            if self._display.verbosity < 2 and self.always_display_failed_task_path:
+                self._print_task_path(result._task.get_path())
             if delegated_vars:
                 self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
                                                                             self._dump_results(result._result)),
@@ -240,11 +243,12 @@ class CallbackModule(CallbackBase):
             checkmsg = ""
         self._display.banner(u"%s [%s%s]%s" % (prefix, task_name, args, checkmsg))
         if self._display.verbosity >= 2:
-            path = task.get_path()
-            if path:
-                self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
-
+            self._print_task_path(task.get_path())
         self._last_task_banner = task._uuid
+    
+    def _print_task_path(self, path):
+        if path:
+            self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
 
     def v2_playbook_on_cleanup_task_start(self, task):
         self._task_start(task, prefix='CLEANUP TASK')

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -245,7 +245,7 @@ class CallbackModule(CallbackBase):
         if self._display.verbosity >= 2:
             self._print_task_path(task.get_path())
         self._last_task_banner = task._uuid
-    
+
     def _print_task_path(self, path):
         if path:
             self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -72,7 +72,7 @@ class ModuleDocFragment(object):
         type: bool
         default: no
         env:
-          - name: ANSIBLE_DISPLAY_FAILED_TASK
+          - name: ANSIBLE_DISPLAY_FAILED_PATH
         ini:
           - key: display_failed_path
             section: defaults

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -66,4 +66,15 @@ class ModuleDocFragment(object):
           - key: show_per_host_start
             section: defaults
         version_added: '2.9'
+      always_display_failed_task_path:
+        name: Always display failed tasks paths
+        description: 'Display failed tasks path even in non verbose mode'
+        type: bool
+        default: no
+        env:
+          - name: ANSIBLE_ALWAYS_DISPLAY_FAILED_TASK_PATH
+        ini:
+          - key: always_display_failed_task_path
+            section: defaults
+        version_added: 'x.y'
 '''

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -66,15 +66,15 @@ class ModuleDocFragment(object):
           - key: show_per_host_start
             section: defaults
         version_added: '2.9'
-      always_display_failed_task_path:
-        name: Always display failed tasks paths
-        description: 'Display failed tasks path even in non verbose mode'
+      display_failed_path:
+        name: Display path to failed tasks
+        description: 'When a task fails, display the path to the task file and the line number of the task.'
         type: bool
         default: no
         env:
-          - name: ANSIBLE_ALWAYS_DISPLAY_FAILED_TASK_PATH
+          - name: ANSIBLE_DISPLAY_FAILED_TASK
         ini:
-          - key: always_display_failed_task_path
+          - key: display_failed_path
             section: defaults
         version_added: '2.10'
 '''

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -76,5 +76,5 @@ class ModuleDocFragment(object):
         ini:
           - key: always_display_failed_task_path
             section: defaults
-        version_added: 'x.y'
+        version_added: '2.10'
 '''

--- a/test/integration/targets/callback_default/callback_default.out.display_failed_path.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.display_failed_path.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory test.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.display_failed_path.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.display_failed_path.stdout
@@ -1,0 +1,67 @@
+
+PLAY [testhost] ****************************************************************
+
+TASK [Changed task] ************************************************************
+changed: [testhost]
+
+TASK [Ok task] *****************************************************************
+ok: [testhost]
+
+TASK [Failed task] *************************************************************
+task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:16
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+...ignoring
+
+TASK [Skipped task] ************************************************************
+skipping: [testhost]
+
+TASK [Task with var in name (foo bar)] *****************************************
+changed: [testhost]
+
+TASK [Loop task] ***************************************************************
+changed: [testhost] => (item=foo-1)
+changed: [testhost] => (item=foo-2)
+changed: [testhost] => (item=foo-3)
+
+TASK [debug loop] **************************************************************
+changed: [testhost] => (item=debug-1) => {
+    "msg": "debug-1"
+}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+ok: [testhost] => (item=debug-3) => {
+    "msg": "debug-3"
+}
+skipping: [testhost] => (item=debug-4) 
+task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:38
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
+TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
+task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:54
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
+
+TASK [Rescue task] *************************************************************
+changed: [testhost]
+
+RUNNING HANDLER [Test handler 1] ***********************************************
+changed: [testhost]
+
+RUNNING HANDLER [Test handler 2] ***********************************************
+ok: [testhost]
+
+RUNNING HANDLER [Test handler 3] ***********************************************
+changed: [testhost]
+
+PLAY [testhost] ****************************************************************
+
+TASK [First free task] *********************************************************
+changed: [testhost]
+
+TASK [Second free task] ********************************************************
+changed: [testhost]
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+

--- a/test/integration/targets/callback_default/callback_default.out.display_failed_path.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.display_failed_path.stdout
@@ -8,7 +8,7 @@ TASK [Ok task] *****************************************************************
 ok: [testhost]
 
 TASK [Failed task] *************************************************************
-task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:16
+task path: TEST_FOLDER_PATH/test.yml:16
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
 ...ignoring
 
@@ -34,12 +34,12 @@ ok: [testhost] => (item=debug-3) => {
     "msg": "debug-3"
 }
 skipping: [testhost] => (item=debug-4) 
-task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:38
+task path: TEST_FOLDER_PATH/test.yml:38
 fatal: [testhost]: FAILED! => {"msg": "All items completed"}
 ...ignoring
 
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
-task path: /home/jegham/code/ansible/test/integration/targets/callback_default/test.yml:54
+task path: TEST_FOLDER_PATH/test.yml:54
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
 
 TASK [Rescue task] *************************************************************

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -15,6 +15,7 @@ set -eux
 
 run_test() {
 	local testname=$1
+	local TEST_FOLDER_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 	# The shenanigans with redirection and 'tee' are to capture STDOUT and
 	# STDERR separately while still displaying both to the console
@@ -23,6 +24,11 @@ run_test() {
 		2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2)
 	# Scrub deprication warning that shows up in Python 2.6 on CentOS 6
 	sed -i -e '/RandomPool_DeprecationWarning/d' "${OUTFILE}.${testname}.stderr"
+
+	# Printing task path includes absolute paths specific to the machine
+	# Replace any occurences of test folder path with TEST_FOLDER_PATH palceholder
+	sed -i -e "s#${TEST_FOLDER_PATH}#TEST_FOLDER_PATH#g" "${OUTFILE}.${testname}.stdout"
+
 
 	diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
 	diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -28,7 +28,9 @@ run_test() {
 
 	# Printing task path includes absolute paths specific to the machine
 	# Replace any occurences of test folder path with TEST_FOLDER_PATH palceholder
-	sed -i -e "s#${TEST_FOLDER_PATH}#TEST_FOLDER_PATH#g" "${OUTFILE}.${testname}.stdout"
+    if [[ $testname == "display_failed_path" ]]; then
+	  sed -i -e "s#${TEST_FOLDER_PATH}#TEST_FOLDER_PATH#g" "${OUTFILE}.${testname}.stdout"
+    fi
 
 
 	diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -15,7 +15,8 @@ set -eux
 
 run_test() {
 	local testname=$1
-	local TEST_FOLDER_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+	local TEST_FOLDER_PATH
+	TEST_FOLDER_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 	# The shenanigans with redirection and 'tee' are to capture STDOUT and
 	# STDERR separately while still displaying both to the console
@@ -63,15 +64,15 @@ diff_failure() {
 
 cleanup() {
 	if [[ $INIT = 0 ]]; then
-		rm -rf ${OUTFILE}.*
+		rm -rf "${OUTFILE}.*"
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stdout" ]]; then
-		rm -rf ${BASEFILE}.unreachable.stdout
+		rm -rf "${BASEFILE}.unreachable.stdout"
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stderr" ]]; then
-		rm -rf ${BASEFILE}.unreachable.stderr
+		rm -rf "${BASEFILE}.unreachable.stderr"
 	fi
 
 	# Restore TTY cols

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -57,15 +57,15 @@ diff_failure() {
 
 cleanup() {
 	if [[ $INIT = 0 ]]; then
-		rm -rf "${OUTFILE}.*"
+		rm -rf ${OUTFILE}.*
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stdout" ]]; then
-		rm -rf "${BASEFILE}.unreachable.stdout"
+		rm -rf ${BASEFILE}.unreachable.stdout
 	fi
 
 	if [[ -f "${BASEFILE}.unreachable.stderr" ]]; then
-		rm -rf "${BASEFILE}.unreachable.stderr"
+		rm -rf ${BASEFILE}.unreachable.stderr
 	fi
 
 	# Restore TTY cols
@@ -138,6 +138,12 @@ export ANSIBLE_DISPLAY_OK_HOSTS=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
 
 run_test failed_to_stderr
+
+# Display failed path
+export ANSIBLE_DISPLAY_FAILED_STDERR=0
+export ANSIBLE_DISPLAY_FAILED_PATH=True
+run_test display_failed_path
+export ANSIBLE_DISPLAY_FAILED_PATH=False
 
 # Default settings with unreachable tasks
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1


### PR DESCRIPTION
##### SUMMARY
Fixes #64625 

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
core

##### ADDITIONAL INFORMATION
**Default** behavior
```
(venv) tjegham@TSJ-Laptop:~/ansible$ ansible-playbook /tmp/fail.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available

[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************
ok: [localhost]

TASK [fail] *******************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "This has failed"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
When **ANSIBLE_ALWAYS_DISPLAY_FAILED_TASK_PATH** is set to **True**
```
(venv) tjegham@TSJ-Laptop:~/ansible$ env ANSIBLE_ALWAYS_DISPLAY_FAILED_TASK_PATH=True ansible-playbook /tmp/fail.yaml
[WARNING]: No inventory was parsed, only implicit localhost is available

[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************
ok: [localhost]

TASK [fail] *******************************************************************************************************************************************************************************************************
task path: /tmp/fail.yaml:3
fatal: [localhost]: FAILED! => {"changed": false, "msg": "This has failed"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
When **verbose**
```
(venv) tjegham@TSJ-Laptop:~/ansible$ ansible-playbook /tmp/fail.yaml -vv
ansible-playbook 2.10.0.dev0
  config file = None
  configured module search path = ['/home/tjegham/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tjegham/ansible/lib/ansible
  executable location = /home/tjegham/ansible/bin/ansible-playbook
  python version = 3.6.8 (default, Oct  7 2019, 12:59:55) [GCC 8.3.0]
No config file found; using defaults
[WARNING]: No inventory was parsed, only implicit localhost is available

[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAYBOOK: fail.yaml ***********************************************************************************************************************************************************************************************
1 plays in /tmp/fail.yaml

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************
task path: /tmp/fail.yaml:1
ok: [localhost]
META: ran handlers

TASK [fail] *******************************************************************************************************************************************************************************************************
task path: /tmp/fail.yaml:3
fatal: [localhost]: FAILED! => {"changed": false, "msg": "This has failed"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```