### PR TITLE
Fix pacman stdout parsing in the Ansible module

### DIFF
--- a/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
+++ b/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacman - Fix pacman output parsing on localized environment. (https://github.com/ansible/ansible/issues/65237)

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -433,6 +433,7 @@ def main():
     )
 
     pacman_path = module.get_bin_path('pacman', True)
+    module.run_command_environ_update = dict(LC_ALL='C')
 
     p = module.params
 


### PR DESCRIPTION
##### SUMMARY

`pacman` output is localized and the Ansible module is parsing its output.
So, we need to force the locale.

Fixes #65237

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module `pacman`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
