### PR TITLE
Splunk: Add validate_certs parameter in Splunk callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -186,7 +186,7 @@ class CallbackModule(CallbackBase):
                                   'authentication token can be provided using the '
                                   '`SPLUNK_AUTHTOKEN` environment variable or '
                                   'in the ansible.cfg file.')
-                                  
+
         self.validate_certs = self.get_option('validate_certs')
 
     def v2_playbook_on_start(self, playbook):

--- a/lib/ansible/plugins/callback/splunk.py
+++ b/lib/ansible/plugins/callback/splunk.py
@@ -55,6 +55,7 @@ DOCUMENTATION = '''
             key: validate_certs
         default: True
         type: bool
+        version_added: "2.10"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow SSL certificate validation as a configurable parameter for splunk Callback plugin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/splunk.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
