### PR TITLE
[2.9] Handle LibraryError exception in postgresql_db

### DIFF
--- a/changelogs/fragments/65223-postgresql_db-exception-added.yml
+++ b/changelogs/fragments/65223-postgresql_db-exception-added.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_db - Removed exception for 'LibraryError' (https://github.com/ansible/ansible/issues/65223).

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -547,9 +547,6 @@ def main():
                 db_connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
             cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-        except pgutils.LibraryError as e:
-            module.fail_json(msg="unable to connect to database: {0}".format(to_native(e)), exception=traceback.format_exc())
-
         except TypeError as e:
             if 'sslrootcert' in e.args[0]:
                 module.fail_json(msg='Postgresql server must be at least version 8.4 to support sslrootcert. Exception: {0}'.format(to_native(e)),


### PR DESCRIPTION
##### SUMMARY
* Added changes into changelogs/fragments
* Removed no longer used 'LibraryError'.

Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

Backport of https://github.com/ansible/ansible/pull/65229

(cherry picked from commit 5f8ec4d46e1fec49eca5c2f351141ed5da6d259e)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
postgresql_db

