### PR TITLE
VMware: vmware_dvs_portgroup - Add PVLAN support

### DIFF
--- a/changelogs/fragments/65256-adds-pvlan-support-to-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/65256-adds-pvlan-support-to-vmware_dvs_portgroup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_dvs_portgroup - Added pvlan support.

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -45,6 +45,7 @@ options:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
             - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
+            - 'If C(vlan_pvlan) is configured to be I(true) then C(vlan_id) identifies a private vlan.
             - The valid C(vlan_id) range is from 0 to 4094. Overlapping ranges are allowed.
         required: True
         type: str
@@ -74,6 +75,13 @@ options:
     vlan_trunk:
         description:
             - Indicates whether this is a VLAN trunk or not.
+        required: False
+        default: False
+        type: bool
+        version_added: '2.5'
+    vlan_pvlan:
+        description:
+            - Indicates whether the C(vlan_id) is a PVLAN or not.
         required: False
         default: False
         type: bool
@@ -155,6 +163,20 @@ EXAMPLES = '''
     password: '{{ vcenter_password }}'
     portgroup_name: vlan-123-portrgoup
     switch_name: dvSwitch
+    vlan_id: 123
+    num_ports: 120
+    portgroup_type: earlyBinding
+    state: present
+  delegate_to: localhost
+
+- name: Create pvlan portgroup
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: vlan-123-portrgoup
+    switch_name: dvSwitch
+    vlan_pvlan: True
     vlan_id: 123
     num_ports: 120
     portgroup_type: earlyBinding
@@ -276,8 +298,19 @@ class VMwareDvsPortgroup(PyVmomi):
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
             config.defaultPortConfig.vlan.vlanId = list(map(lambda x: vim.NumericRange(start=x[0], end=x[1]), self.create_vlan_list()))
         else:
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+            if int(self.module.params['vlan_id']) not in range(0, 4095):
+                # Check if valid VLAN provided
+                self.module.fail_json(msg="vlan_id %s specified is incorrect. The valid vlan_id range is from 0 to 4094." % self.module.params['vlan_id'])
+
+            # Check if private vlan
+            if self.module.params['vlan_pvlan']:
+                config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+            else:
+                config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+            
+            # Set VLAN
             config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
+
         config.defaultPortConfig.vlan.inherited = False
         config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
         config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
@@ -447,6 +480,7 @@ def main():
             portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             vlan_trunk=dict(type='bool', default=False),
+            vlan_pvlan=dict(type='bool', default=False),
             network_policy=dict(
                 type='dict',
                 options=dict(

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -85,7 +85,7 @@ options:
         required: False
         default: False
         type: bool
-        version_added: '2.5'
+        version_added: '2.10'
     network_policy:
         description:
             - Dictionary which configures the different security values for portgroup.

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -565,7 +565,7 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[
             ['vlan_trunk', 'vlan_pvlan'],
-        ]   
+        ]
     )
 
     vmware_dvs_portgroup = VMwareDvsPortgroup(module)

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -306,12 +306,13 @@ class VMwareDvsPortgroup(PyVmomi):
 
             # Check if private vlan
             if self.module.params['vlan_pvlan']:
+                # Set pvlan
                 config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+                config.defaultPortConfig.vlan.pvlanId = int(self.module.params['vlan_id'])
             else:
+                # Set VLAN
                 config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
-
-            # Set VLAN
-            config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
+                config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
 
         config.defaultPortConfig.vlan.inherited = False
         config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
@@ -430,16 +431,17 @@ class VMwareDvsPortgroup(PyVmomi):
                 return 'update'
             if map(lambda x: (x.start, x.end), defaultPortConfig.vlan.vlanId) != self.create_vlan_list():
                 return 'update'
+        elif self.module.params['vlan_pvlan']:
+            # Check pvlan
+            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+                return 'update'
+            # check if config vlanid matches param pvlanid
+            if defaultPortConfig.vlan.pvlanId != int(self.module.params['vlan_id']):
+                return 'update'
         else:
-            if self.module.params['vlan_pvlan']:
-                # Check pvlan
-                if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
-                    return 'update'
-            else:
-                # Check vlan
-                if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
-                    return 'update'
-
+            # Check vlan
+            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+                return 'update'
             # check if config vlanid matches param vlanid
             if defaultPortConfig.vlan.vlanId != int(self.module.params['vlan_id']):
                 return 'update'

--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -45,7 +45,7 @@ options:
         description:
             - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
             - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
-            - 'If C(vlan_pvlan) is configured to be I(true) then C(vlan_id) identifies a private vlan.
+            - 'If C(vlan_pvlan) is configured to be I(true) then C(vlan_id) identifies a private vlan.'
             - The valid C(vlan_id) range is from 0 to 4094. Overlapping ranges are allowed.
         required: True
         type: str
@@ -307,7 +307,7 @@ class VMwareDvsPortgroup(PyVmomi):
                 config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
             else:
                 config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
-            
+
             # Set VLAN
             config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
 


### PR DESCRIPTION
##### SUMMARY
Adds support for pvlan assignment to portgroups.

Fixes: #47649

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
I added the flag `vlan_pvlan` to mimic the existing `vlan_trunk` flag.

A better fix would be to create a `vlan_type` flag and allow it to be either `trunk` or `pvlan` but that would break existing configuration and I didn't want to make that decision
