### PR TITLE
Fix empty and zeroed memory variables on Windows

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -315,7 +315,9 @@ if($gather_subset.Contains('memory')) {
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.SizeStoredInPagingFiles / 1024))
+        ansible_memfree_mb = ([math]::ceiling($win32_os.FreePhysicalMemory / 1024))
+        ansible_swapfree_mb = ([math]::round($win32_os.FreeSpaceInPagingFiles / 1024))
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -315,9 +315,9 @@ if($gather_subset.Contains('memory')) {
     $ansible_facts += @{
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
-        ansible_swaptotal_mb = ([math]::round($win32_os.SizeStoredInPagingFiles / 1024))
         ansible_memfree_mb = ([math]::ceiling($win32_os.FreePhysicalMemory / 1024))
-        ansible_swapfree_mb = ([math]::round($win32_os.FreeSpaceInPagingFiles / 1024))
+        ansible_pagefiletotal_mb = ([math]::round($win32_os.SizeStoredInPagingFiles / 1024))
+        ansible_pagefilefree_mb = ([math]::round($win32_os.FreeSpaceInPagingFiles / 1024))
     }
 }
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -316,6 +316,7 @@ if($gather_subset.Contains('memory')) {
         # Win32_PhysicalMemory is empty on some virtual platforms
         ansible_memtotal_mb = ([math]::ceiling($win32_cs.TotalPhysicalMemory / 1024 / 1024))
         ansible_memfree_mb = ([math]::ceiling($win32_os.FreePhysicalMemory / 1024))
+        ansible_swaptotal_mb = ([math]::round($win32_os.TotalSwapSpaceSize / 1024))
         ansible_pagefiletotal_mb = ([math]::round($win32_os.SizeStoredInPagingFiles / 1024))
         ansible_pagefilefree_mb = ([math]::round($win32_os.FreeSpaceInPagingFiles / 1024))
     }


### PR DESCRIPTION
##### SUMMARY
The CIM elements about swap information are for Unix platform implementations of Powershell. CIM has separate elements for the "Windows swap".  This fixes memory information being non-present or zero.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/windows/setup.ps1

##### ADDITIONAL INFORMATION
Before:
```
        "ansible_memtotal_mb": 32573,
        "ansible_reboot_pending": true,
        "ansible_swaptotal_mb": 0,
        "ansible_system": "Win32NT",
```
After:
```
        "ansible_memfree_mb": 22123,
        "ansible_memtotal_mb": 32573,
        "ansible_reboot_pending": true,
        "ansible_swapfree_mb": 32531,
        "ansible_swaptotal_mb": 35638,
        "ansible_system": "Win32NT",
```
