### PR TITLE
Fix using a URL for galaxy collection install

### DIFF
--- a/changelogs/fragments/collection-install-url.yaml
+++ b/changelogs/fragments/collection-install-url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Fix ``collection install`` when installing from a URL or a file - https://github.com/ansible/ansible/issues/65109

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -4,7 +4,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import errno
 import fnmatch
 import json
 import operator

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import errno
 import fnmatch
 import json
 import operator
@@ -827,9 +828,13 @@ def _get_collection_info(dep_map, existing_collections, collection, requirement,
     if os.path.isfile(to_bytes(collection, errors='surrogate_or_strict')):
         display.vvvv("Collection requirement '%s' is a tar artifact" % to_text(collection))
         b_tar_path = to_bytes(collection, errors='surrogate_or_strict')
-    elif urlparse(collection).scheme:
+    elif urlparse(collection).scheme.lower() in ['http', 'https']:
         display.vvvv("Collection requirement '%s' is a URL to a tar artifact" % collection)
-        b_tar_path = _download_file(collection, b_temp_path, None, validate_certs)
+        try:
+            b_tar_path = _download_file(collection, b_temp_path, None, validate_certs)
+        except urllib_error.URLError as err:
+            raise AnsibleError("Failed to download collection tar from '%s': %s"
+                               % (to_native(collection), to_native(err)))
 
     if b_tar_path:
         req = CollectionRequirement.from_tar(b_tar_path, force, parent=parent)

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -890,6 +890,29 @@ def test_collection_install_in_collection_dir(collection_install, monkeypatch):
     assert mock_install.call_args[0][7] is False
 
 
+def test_collection_install_with_url(collection_install):
+    mock_install, dummy, output_dir = collection_install
+
+    galaxy_args = ['ansible-galaxy', 'collection', 'install', 'https://foo/bar/foo-bar-v1.0.0.tar.gz',
+                   '--collections-path', output_dir]
+    GalaxyCLI(args=galaxy_args).run()
+
+    collection_path = os.path.join(output_dir, 'ansible_collections')
+    assert os.path.isdir(collection_path)
+
+    assert mock_install.call_count == 1
+    assert mock_install.call_args[0][0] == [('https://foo/bar/foo-bar-v1.0.0.tar.gz', '*', None)]
+    assert mock_install.call_args[0][1] == collection_path
+    assert len(mock_install.call_args[0][2]) == 1
+    assert mock_install.call_args[0][2][0].api_server == 'https://galaxy.ansible.com'
+    assert mock_install.call_args[0][2][0].validate_certs is True
+    assert mock_install.call_args[0][3] is True
+    assert mock_install.call_args[0][4] is False
+    assert mock_install.call_args[0][5] is False
+    assert mock_install.call_args[0][6] is False
+    assert mock_install.call_args[0][7] is False
+
+
 def test_collection_install_name_and_requirements_fail(collection_install):
     test_path = collection_install[2]
     expected = 'The positional collection_name arg and --requirements-file are mutually exclusive.'


### PR DESCRIPTION
##### SUMMARY
There was a problem with how we parsed the collection name from the command line where it expected it to be the collection name itself. This makes sure we check to see if it's a URL before splitting it by `:` to get the version. It also gives someone 

Fixes https://github.com/ansible/ansible/issues/65109

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection install