### PR TITLE
galaxy - print HTTP reason on unknown error

### DIFF
--- a/changelogs/fragments/galaxy-error-reason.yaml
+++ b/changelogs/fragments/galaxy-error-reason.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Return the HTTP code reason if no error msg was returned by the server - https://github.com/ansible/ansible/issues/64850

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -110,7 +110,7 @@ class GalaxyError(AnsibleError):
 
         url_split = self.url.split('/')
         if 'v2' in url_split:
-            galaxy_msg = err_info.get('message', 'Unknown error returned by Galaxy server.')
+            galaxy_msg = err_info.get('message', http_error.reason)
             code = err_info.get('code', 'Unknown')
             full_error_msg = u"%s (HTTP Code: %d, Message: %s Code: %s)" % (message, self.http_code, galaxy_msg, code)
         elif 'v3' in url_split:
@@ -120,7 +120,7 @@ class GalaxyError(AnsibleError):
 
             message_lines = []
             for error in errors:
-                error_msg = error.get('detail') or error.get('title') or 'Unknown error returned by Galaxy server.'
+                error_msg = error.get('detail') or error.get('title') or http_error.reason
                 error_code = error.get('code') or 'Unknown'
                 message_line = u"(HTTP Code: %d, Message: %s Code: %s)" % (self.http_code, error_msg, error_code)
                 message_lines.append(message_line)
@@ -128,7 +128,7 @@ class GalaxyError(AnsibleError):
             full_error_msg = "%s %s" % (message, ', '.join(message_lines))
         else:
             # v1 and unknown API endpoints
-            galaxy_msg = err_info.get('default', 'Unknown error returned by Galaxy server.')
+            galaxy_msg = err_info.get('default', http_error.reason)
             full_error_msg = u"%s (HTTP Code: %d, Message: %s)" % (message, self.http_code, galaxy_msg)
 
         self.message = to_native(full_error_msg)

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -214,8 +214,8 @@ def test_initialise_unknown(monkeypatch):
 
     api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/", token=GalaxyToken(token='my_token'))
 
-    expected = "Error when finding available api versions from test (%s) (HTTP Code: 500, Message: Unknown " \
-               "error returned by Galaxy server.)" % api.api_server
+    expected = "Error when finding available api versions from test (%s) (HTTP Code: 500, Message: msg)" \
+        % api.api_server
     with pytest.raises(AnsibleError, match=re.escape(expected)):
         api.authenticate("github_token")
 
@@ -292,15 +292,13 @@ def test_publish_collection(api_version, collection_url, collection_artifact, mo
 
 @pytest.mark.parametrize('api_version, collection_url, response, expected', [
     ('v2', 'collections', {},
-     'Error when publishing collection to test (%s) (HTTP Code: 500, Message: Unknown error returned by Galaxy '
-     'server. Code: Unknown)'),
+     'Error when publishing collection to test (%s) (HTTP Code: 500, Message: msg Code: Unknown)'),
     ('v2', 'collections', {
         'message': u'Galaxy error messäge',
         'code': 'GWE002',
     }, u'Error when publishing collection to test (%s) (HTTP Code: 500, Message: Galaxy error messäge Code: GWE002)'),
     ('v3', 'artifact/collections', {},
-     'Error when publishing collection to test (%s) (HTTP Code: 500, Message: Unknown error returned by Galaxy '
-     'server. Code: Unknown)'),
+     'Error when publishing collection to test (%s) (HTTP Code: 500, Message: msg Code: Unknown)'),
     ('v3', 'artifact/collections', {
         'errors': [
             {

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -403,7 +403,7 @@ def test_build_requirement_from_name_401_unauthorized(galaxy_server, monkeypatch
 
     monkeypatch.setattr(galaxy_server, 'get_collection_versions', mock_open)
 
-    expected = "error (HTTP Code: 401, Message: Unknown error returned by Galaxy server.)"
+    expected = "error (HTTP Code: 401, Message: msg)"
     with pytest.raises(api.GalaxyError, match=re.escape(expected)):
         collection.CollectionRequirement.from_name('namespace.collection', [galaxy_server, galaxy_server], '*', False)
 


### PR DESCRIPTION
##### SUMMARY
If a HTTP error is raised when calling Galaxy, fallback to returning the HTTP status code reason if not message was returned by the server. This at least gives user's some context as to what may have gone wrong instead of a generic unknown error message.

For example when trying to install a collection from AH but have the wrong credentials, the host would originally print

```
ERROR! Error when finding available api versions from automation_hub (https://cloud.redhat.com/api/automation-hub/) (HTTP Code: 401, Message: Unknown error returned by Galaxy server.)
```

With the changes here, it now prints

```
ERROR! Error when finding available api versions from automation_hub (https://cloud.redhat.com/api/automation-hub/) (HTTP Code: 401, Message: Unauthorized)
```

Fixes https://github.com/ansible/ansible/issues/64850

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy/api.py