### PR TITLE
Fix units_modules examples to avoid undefined vairable.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -332,7 +332,7 @@ testing for the correct exception::
         })
 
         with self.assertRaises(AnsibleExitJson) as result:
-            my_module.main()
+            self.module.main()
 
 The same technique can be used to replace :meth:`module.fail_json` (which is used for failure
 returns from modules) and for the ``aws_module.fail_json_aws()`` (used in modules for Amazon
@@ -390,7 +390,6 @@ mock for :meth:`Ansible.get_bin_path`::
     from ansible.module_utils import basic
     from ansible.module_utils._text import to_bytes
     from ansible.modules.namespace import my_module
-    self.module = my_module
 
 
     def set_module_args(args):
@@ -440,6 +439,7 @@ mock for :meth:`Ansible.get_bin_path`::
                                                      get_bin_path=get_bin_path)
             self.mock_module_helper.start()
             self.addCleanup(self.mock_module_helper.stop)
+            self.module = my_module
 
         def test_module_fail_when_required_args_missing(self):
             with self.assertRaises(AnsibleFailJson):

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -390,6 +390,7 @@ mock for :meth:`Ansible.get_bin_path`::
     from ansible.module_utils import basic
     from ansible.module_utils._text import to_bytes
     from ansible.modules.namespace import my_module
+    self.module = my_module
 
 
     def set_module_args(args):
@@ -459,7 +460,7 @@ mock for :meth:`Ansible.get_bin_path`::
                 mock_run_command.return_value = rc, stdout, stderr  # successful execution
 
                 with self.assertRaises(AnsibleExitJson) as result:
-                    my_module.main()
+                    self.module.main()
                 self.assertFalse(result.exception.args[0]['changed']) # ensure result is changed
 
             mock_run_command.assert_called_once_with('/usr/bin/my_command --value 10 --name test')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix units_modules.rst examples to avoid undefined vairable.

```
AttributeError: 'TestMyModule' object has no attribute 'module'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
