### PR TITLE
[stable-2.9] Add or later to the license expressed in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ and has contributions from over 4000 users (and growing). Thanks everyone!
 License
 =======
 
-GNU General Public License v3.0
+GNU General Public License v3.0 or later
 
 See `COPYING <COPYING>`_ to see the full text.
 


### PR DESCRIPTION
This is a clarification, not a relicensing.

Our source code says "GPLv3+" or "version 3 of the License, or later".
Our documentation says GPLv3+:

https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/dev_guide/developing_modules_checklist.rst#contributing-to-ansible-objective-requirements

We were just lazy when we wrote the README and left out the "or later".
this update to the README brings it in line with what everything else
says.

Backport of https://github.com/ansible/ansible/pull/65124

(cherry picked from commit a15fb26)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
