### PR TITLE
Add zones info to hostvars for Azure inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/azure_rm.py
+++ b/lib/ansible/plugins/inventory/azure_rm.py
@@ -539,6 +539,7 @@ class AzureHost(object):
             private_ipv4_addresses=[],
             id=self._vm_model['id'],
             location=self._vm_model['location'],
+            zones=self._vm_model.get("zones", None),
             name=self._vm_model['name'],
             powerstate=self._powerstate,
             provisioning_state=self._vm_model['properties']['provisioningState'].lower(),


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We have `location` variable, but `zones` is missing - it can be helpful.
If host does not have zone set implicitly the value is missing from API respons. I believe it is better to set it to null/none rather than simply skip it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
