### PR TITLE
Update k8s_scale for openshift >= 0.9

### DIFF
--- a/changelogs/fragments/k8s_scale.yml
+++ b/changelogs/fragments/k8s_scale.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - k8s_scale has been fixed to work with recent versions of openshift python module
+  - k8s now correctly fails if a new replicaset fails to even create new pods

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -468,7 +468,9 @@ class KubernetesRawModule(KubernetesAnsibleModule):
             # Furthermore deployment.status.availableReplicas == deployment.status.replicas == None if status is empty
             return (deployment.status and deployment.status.replicas is not None and
                     deployment.status.availableReplicas == deployment.status.replicas and
-                    deployment.status.observedGeneration == deployment.metadata.generation)
+                    deployment.status.observedGeneration == deployment.metadata.generation and
+                    not deployment.status.unAvailableReplicas
+                    )
 
         def _pod_ready(pod):
             return (pod.status and pod.status.containerStatuses is not None and

--- a/test/integration/targets/k8s/defaults/main.yml
+++ b/test/integration/targets/k8s/defaults/main.yml
@@ -5,6 +5,7 @@ k8s_pod_metadata:
     app: "{{ k8s_pod_name }}"
 
 k8s_pod_spec:
+  serviceAccount: "{{ k8s_pod_service_account }}"
   containers:
     - image: "{{ k8s_pod_image }}"
       imagePullPolicy: Always
@@ -29,4 +30,5 @@ k8s_pod_template:
   metadata: "{{ k8s_pod_metadata }}"
   spec: "{{ k8s_pod_spec }}"
 
+k8s_pod_service_account: default
 k8s_openshift: yes

--- a/test/integration/targets/k8s/tasks/apply.yml
+++ b/test/integration/targets/k8s/tasks/apply.yml
@@ -269,6 +269,147 @@
           - k8s_service_5.result.spec.ports | length == 1
           - k8s_service_5.result.spec.ports[0].port == 8081
 
+    - name: add a serviceaccount
+      k8s:
+        definition:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: scale-deploy
+            namespace: "{{ apply_namespace }}"
+
+    - name: add a deployment
+      k8s:
+        definition:
+          apiVersion: extensions/v1beta1
+          kind: Deployment
+          metadata:
+            name: scale-deploy
+            namespace: "{{ apply_namespace }}"
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: "{{ k8s_pod_name }}"
+            template: "{{ k8s_pod_template }}"
+        wait: yes
+        apply: yes
+      vars:
+        k8s_pod_name: scale-deploy
+        k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:v0.10.0-green
+        k8s_pod_service_account: scale-deploy
+        k8s_pod_ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+
+    - name: scale the deployment
+      k8s_scale:
+        api_version: extensions/v1beta1
+        kind: Deployment
+        name: scale-deploy
+        namespace: "{{ apply_namespace }}"
+        replicas: 0
+
+    - name: wait for pods to scale down
+      pause:
+        seconds: 30
+
+    - name: get pods in scale-deploy
+      k8s_info:
+        kind: Pod
+        label_selectors:
+          - app=scale-deploy
+        namespace: "{{ apply_namespace }}"
+      register: scale_down_deploy_pods
+
+    - name: ensure that scale down took effect
+      assert:
+        that:
+          - scale_down_deploy_pods.resources | length == 0
+
+    - name: reapply the earlier deployment
+      k8s:
+        definition:
+          apiVersion: extensions/v1beta1
+          kind: Deployment
+          metadata:
+            name: scale-deploy
+            namespace: "{{ apply_namespace }}"
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: "{{ k8s_pod_name }}"
+            template: "{{ k8s_pod_template }}"
+        wait: yes
+        apply: yes
+      vars:
+        k8s_pod_name: scale-deploy
+        k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:v0.10.0-green
+        k8s_pod_service_account: scale-deploy
+        k8s_pod_ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+      register: reapply_after_scale
+
+    - name: get pods in scale-deploy
+      k8s_info:
+        kind: Pod
+        label_selectors:
+          - app=scale-deploy
+        namespace: "{{ apply_namespace }}"
+      register: scale_up_deploy_pods
+
+    - name: ensure that reapply after scale worked
+      assert:
+        that:
+          - reapply_after_scale is changed
+          - scale_up_deploy_pods.resources | length == 1
+
+    - name: remove the serviceaccount
+      k8s:
+        state: absent
+        definition:
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: scale-deploy
+            namespace: "{{ apply_namespace }}"
+
+    - name: update the earlier deployment
+      k8s:
+        definition:
+          apiVersion: extensions/v1beta1
+          kind: Deployment
+          metadata:
+            name: scale-deploy
+            namespace: "{{ apply_namespace }}"
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: "{{ k8s_pod_name }}"
+            template: "{{ k8s_pod_template }}"
+        wait: yes
+        apply: yes
+      vars:
+        k8s_pod_name: scale-deploy
+        k8s_pod_image: gcr.io/kuar-demo/kuard-amd64:v0.10.0-purple
+        k8s_pod_service_account: scale-deploy
+        k8s_pod_ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+      register: deploy_after_serviceaccount_removal
+      ignore_errors: yes
+
+    - name: ensure that updating deployment after service account removal failed
+      assert:
+        that:
+          - deploy_after_serviceaccount_removal is failed
+
   always:
     - name: remove namespace
       k8s:

--- a/test/integration/targets/k8s/tasks/full_test.yml
+++ b/test/integration/targets/k8s/tasks/full_test.yml
@@ -4,8 +4,8 @@
 
 # Kubernetes resources
 
-- include_tasks: delete.yml
 - include_tasks: apply.yml
+- include_tasks: delete.yml
 - include_tasks: waiter.yml
 
 - block:

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - pip:
     name:
-      - openshift>=0.9.2
+      - git+git://github.com/willthames/openshift-restclient-python@apply_fixes#egg=openshift
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -32,7 +32,7 @@
 - pip:
     name:
       - kubernetes-validate==1.12.0
-      - openshift>=0.9.2
+      - git+git://github.com/willthames/openshift-restclient-python@apply_fixes#egg=openshift
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
@@ -74,7 +74,7 @@
 
 - pip:
     name:
-      - openshift>=0.9.2
+      - git+git://github.com/willthames/openshift-restclient-python@apply_fixes#egg=openshift
       - coverage
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"


### PR DESCRIPTION
##### SUMMARY

k8s_scale should work with recent openshift library versions

Add tests for k8s_scale that also test a fix for
deployment waits in the subtle edge case where a service account
no longer exists and no new pods can be created as a result

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s_scale
