### PR TITLE
hashi_vault lookup to return v2 kv store information in a dictionary including metadata and data

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -105,6 +105,11 @@ EXAMPLES = """
   debug:
     msg: "{{ lookup('hashi_vault', 'secret=secret/data/hello token=my_vault_token url=http://myvault_url:8200') }}"
 
+- name: Return a specific  version from a KV v2 engine secret 
+  debug:
+    msg: "{{ lookup('hashi_vault', 'secret=secret/data/hello version=1 token=my_vault_token url=http://myvault_url:8200') }}"
+
+
 
 """
 
@@ -215,7 +220,11 @@ class HashiVault:
             raise AnsibleError("The secret %s doesn't seem to exist for hashi_vault lookup" % self.secret)
 
         if self.secret_field == '':
-            return data['data']
+            # Return all secret engine v2 information (eg. metadata and data)
+            if 'metadata' in data:
+                return data
+            else: 
+                return data['data']
 
         if self.secret_field not in data['data']:
             raise AnsibleError("The secret %s does not contain the field '%s'. for hashi_vault lookup" % (self.secret, self.secret_field))

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -225,7 +225,7 @@ class HashiVault:
             if 'metadata' in data:
                 return data
             # Return the v1 lookup data
-            else: 
+            else:
                 return data['data']
 
         if self.secret_field not in data['data']:
@@ -233,8 +233,8 @@ class HashiVault:
 
         # Return metadata along with the requested secret_field data for a v2 lookup
         if 'metadata' in data:
-            return { 'metadata': data['metadata'],
-                     'data': data['data'][self.secret_field]}
+            return {'metadata': data['metadata'],
+                    'data': data['data'][self.secret_field]}
         else:
             # Return the v1 lookup data
             return data['data'][self.secret_field]

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
@@ -10,7 +10,7 @@
     - name: 'Check secret values'
       fail:
         msg: 'unexpected secret values'
-      when: secret1['value'] != 'foo1' or secret2['value'] != 'foo2'
+      when: secret1['data']['value'] != 'foo1' or secret2['data']['value'] != 'foo2'
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -23,7 +23,7 @@
     - name: 'Check secret kv2 values'
       fail:
         msg: 'unexpected secret values'
-      when: kv2_secret1['value'] != 'foo1' or kv2_secret2['value'] != 'foo2'
+      when: kv2_secret1['data']['value'] != 'foo1' or kv2_secret2['data']['value'] != 'foo2'
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent update to fix specific key lookups for version 2 KV credential stores changed the way 
version 2 KV store lookups worked when not specifying a lookup key/field.  This means the fix for version 2 KV credential lookups with a key/field cannot be backported into ansible 2.8 or 2.9.

This PR returns the original v2 KV credential returned data to original state and maintains the fix of the previous PR.

A future PR will be to implement a new option to this lookup allowing specific credential versions to be requested from a v2 KV store.

Data for V2 KV lookups are now returned as:

```
{ 'metadata': ...,
  'data': ...
}
```
See example below in additional information.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Related PRs:
* https://github.com/ansible/ansible/pull/64288 (merged)
* https://github.com/ansible/ansible/pull/41132

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashi_vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example playbook: 
```paste below
---
- name: Lookup Hashicorp Vault
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Debug output v2 secret engine (v2 all credentials and meta data)
      debug:
        msg: "Vault detail {{ lookup('hashi_vault', 'secret=secret/data/test: auth_method=approle validate_certs=no')}}"
      ignore_errors: true


    - name: Debug output v2 secret engine (v2 specific credential and meta data)
      debug:
        msg: "Vault detail {{ lookup('hashi_vault', 'secret=secret/data/test:foo auth_method=approle validate_certs=no')}}"
      ignore_errors: true

    - name: Debug output v1 secret engine (v1 all credentials)
      debug:
        msg: "Vault detail {{ lookup('hashi_vault', 'secret=kv1/test: auth_method=approle validate_certs=no')}}"
      ignore_errors: true

    - name: Debug output v1 secret engine (v1 specific credential)
      debug:
        msg: "Vault detail {{ lookup('hashi_vault', 'secret=kv1/test:foo1 auth_method=approle validate_certs=no')}}"
      ignore_errors: true
```

Output after this PR:
```
PLAY [Lookup Hashicorp Vault] ***********************************************************************************************

TASK [Debug output v2 secret engine (v2 all credentials and meta data)] *****************************************************
ok: [localhost] => {
    "msg": "Vault detail {'data': {'foo': 'baz', 'pub': 'bar'}, 'metadata': {'created_time': '2019-11-26T04:42:51.5506236Z', 'deletion_time': '', 'destroyed': False, 'version': 1}}"
}

TASK [Debug output v2 secret engine (v2 specific credential and meta data)] *************************************************
ok: [localhost] => {
    "msg": "Vault detail {'metadata': {'created_time': '2019-11-26T04:42:51.5506236Z', 'deletion_time': '', 'destroyed': False, 'version': 1}, 'data': 'baz'}"
}

TASK [Debug output v1 secret engine (v1 all credentials)] *******************************************************************
ok: [localhost] => {
    "msg": "Vault detail {'foo1': 'bar', 'pub1': 'bar'}"
}

TASK [Debug output v1 secret engine (v1 specific credential)] ***************************************************************
ok: [localhost] => {
    "msg": "Vault detail bar"
```

Output before this PR:

```
PLAY [Lookup Hashicorp Vault] ***********************************************************************************************

TASK [Orig Debug output v2 secret engine (v2)
] ************************************************
ok: [localhost] => {
    "msg": "Vault detail {'foo': 'baz', 'pub': 'bar'}"
}

TASK [Orig Debug output v2 secret engine (v2 specific credential)] *********************************************
ok: [localhost] => {
    "msg": "Vault detail baz"
}

TASK [Orig Debug output v1 secret engine (v1 all credentials)] **************************************************************
ok: [localhost] => {
    "msg": "Vault detail {'foo1': 'bar', 'pub1': 'bar'}"
}

TASK [Orig Debug output v1 secret engine (v1 specific credential)] **********************************************************
ok: [localhost] => {
    "msg": "Vault detail bar"
}
```

