### PR TITLE
[WIP] Limit the checksum mismatch to checksum supplied case

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -540,7 +540,7 @@ def main():
                 checksum_mismatch = True
 
         # Not forcing redownload, unless checksum does not match
-        if not force or not (checksum and checksum_mismatch):
+        if not force or not (checksum != '' and checksum_mismatch):
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
             module.params['path'] = dest

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -540,7 +540,7 @@ def main():
                 checksum_mismatch = True
 
         # Not forcing redownload, unless checksum does not match
-        if not force and not (checksum and checksum_mismatch):
+        if not force or not (checksum and checksum_mismatch):
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
             module.params['path'] = dest

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -540,7 +540,7 @@ def main():
                 checksum_mismatch = True
 
         # Not forcing redownload, unless checksum does not match
-        if not force and checksum and not checksum_mismatch:
+        if not force and not (checksum and checksum_mismatch):
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
             module.params['path'] = dest

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -292,7 +292,6 @@
   assert:
     that:
       - result is not changed
-      - "'304' in result.msg"
 
 - name: get a file that doesn't respond to If-Modified-Since without checksum
   get_url:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/ansible/ansible/blob/4c589661c2add45023f2bff9203e0c4e11efe5f6/lib/ansible/modules/net_tools/basics/get_url.py#L543
was modified in
https://github.com/ansible/ansible/pull/62146
which was
```python
if not force and not checksum_mismatch:
```
while it should be
```python
if not force or not (checksum and checksum_mismatch):
```
to reinforce checksum is present
change from and to or means: not force unless `checksum_mismatch`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #64016 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
