### PR TITLE
Bugfix in flatten filter - all elements after None are skipped

### DIFF
--- a/changelogs/fragments/65329-flatten-filter-bugfix.yml
+++ b/changelogs/fragments/65329-flatten-filter-bugfix.yml
@@ -1,0 +1,4 @@
+---
+
+bugfixes:
+  - flatten filter now properly handles (skips) null values

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -461,7 +461,7 @@ def flatten(mylist, levels=None):
     for element in mylist:
         if element in (None, 'None', 'null'):
             # ignore undefined items
-            break
+            continue
         elif is_sequence(element):
             if levels is None:
                 ret.extend(flatten(element))

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -189,7 +189,7 @@
           - flat_two == [1, 2, 3, 4, [5], 6, 7]
           - flat_tuples == [1, 2, 3, 4]
   vars:
-    orig_list: [1, 2, [3, [4, [5]], 6], 7]
+    orig_list: [1, 2, [3, null, [4, [5]], 6], 7]
 
 - name: Test base64 filter
   assert:
@@ -239,10 +239,10 @@
   assert:
     that:
             - "'00' | random_mac is match('^00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
-            - "'00:00' | random_mac is match('^00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"  
+            - "'00:00' | random_mac is match('^00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
             - "'00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
             - "'00:00:00:00' | random_mac is match('^00:00:00:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]:[a-f0-9][a-f0-9]$')"
-            - "'00:00:00:00:00' | random_mac is match('^00:00:00:00:00:[a-f0-9][a-f0-9]$')"  
+            - "'00:00:00:00:00' | random_mac is match('^00:00:00:00:00:[a-f0-9][a-f0-9]$')"
             - "'00:00:00' | random_mac != '00:00:00' | random_mac"
 
 - name: Verify random_mac filter with seed


### PR DESCRIPTION
`break` causes all items after None/null to be skipped, it should be `continue`.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If any element of list is None/null all following are skipped because loop is broken.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request