### PR TITLE
Add support for Aurora snapshots

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2014 Ansible Project
 # Copyright (c) 2017, 2018, 2019 Will Thames
 # Copyright (c) 2017, 2018 Michael De La Rue
+# Copyright (c) 2019 Joel Stuedle
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,15 +17,21 @@ DOCUMENTATION = '''
 ---
 module: rds_snapshot
 version_added: "2.9"
-short_description: manage Amazon RDS snapshots.
+short_description: manage Amazon RDS/Aurora snapshots.
 description:
      - Creates or deletes RDS snapshots.
 options:
+  snapshot_type:
+    description:
+      - Specify cluster or instance snapshot.
+    default: instance
+    choices [ 'aurora', 'instance' ]
+    type: str
   state:
     description:
       - Specify the desired state of the snapshot.
     default: present
-    choices: [ 'present', 'absent']
+    choices: [ 'present', 'absent' ]
     type: str
   db_snapshot_identifier:
     description:
@@ -39,6 +46,12 @@ options:
       - Database instance identifier. Required when state is present.
     aliases:
       - instance_id
+    type: str
+  db_cluster_identifier:
+    description:
+      - Database cluster identifier (Aurora). Required when snapshot_type is aurora.
+    aliases:
+      - cluster_id
     type: str
   wait:
     description:
@@ -59,12 +72,18 @@ options:
       - whether to remove tags not present in the C(tags) parameter.
     default: True
     type: bool
+  fail_on_not_exists:
+    description:
+      - whether to fail if trying to delete a non-existent snapshot.
+      default: False
+      type: bool
 requirements:
     - "python >= 2.6"
     - "boto3"
 author:
     - "Will Thames (@willthames)"
     - "Michael De La Rue (@mikedlr)"
+    - "Joel Stuedle (@jtstuedle)"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -72,14 +91,30 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # Create snapshot
-- rds_snapshot:
+- name: Create RDS snapshot
+  rds_snapshot:
     db_instance_identifier: new-database
     db_snapshot_identifier: new-database-snapshot
 
 # Delete snapshot
+- name: Delete RDS snapshot
 - rds_snapshot:
     db_snapshot_identifier: new-database-snapshot
     state: absent
+    
+# Create Aurora cluster snapshot
+- name: Create Aurora cluster snapshot
+  rds_snapshot:
+    type: aurora
+    db_cluster_identifier: default-cluster
+    db_snapshot_identifier: new-cluster-snapshot
+
+# Delete Aurora cluster snapshot
+- name: Delete Aurora cluster snapshot
+  rds_snapshot:
+    type: aurora
+    state: absent
+    db_snapshot_identifier: new-cluster-snapshot
 '''
 
 RETURN = '''
@@ -93,6 +128,34 @@ availability_zone:
   returned: always
   type: str
   sample: us-west-2a
+availability_zones:
+  description: Provides the list of Availability Zones (AZs) where instances in the DB cluster snapshot can be restored.
+  returned: always
+  type: list
+  sample: [ 'us-east-2a', 'us-east-2b', 'us-east-2c' ]
+cluster_create_time:
+  description: Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).
+  type: datetime
+db_cluster_identifier:
+  description: Specifies the DB cluster identifier of the DB cluster that this DB cluster snapshot was created from.
+  returned: always
+  type: str
+  sample: test-cluster
+db_cluster_snapshot:
+  description: Contains the details for an Amazon RDS DB cluster snapshot
+  returned: always
+  type: dict
+  sample: example-cluster-snapshot
+db_cluster_snapshot_identifier:
+  description: Specifies the identifier for the DB cluster snapshot.
+  returned: always
+  type: str
+  sample: example-snapshot-identifier
+db_cluster_snapshot_arn:
+  description: The Amazon Resource Name (ARN) for the DB cluster snapshot.
+  returned: always
+  type: str
+  sample: arn:aws:rds:us-west-2:123456789012:snapshot:ansible-test-16638696-test-snapshot
 db_instance_identifier:
   description: Database from which the snapshot was created.
   returned: always
@@ -143,6 +206,10 @@ license_model:
   returned: always
   type: str
   sample: general-public-license
+kms_key_id:
+  description: If StorageEncrypted is true, the AWS KMS key identifier for the encrypted DB cluster snapshot.
+  returned: always
+  type: str
 master_username:
   description: Master username of the database.
   returned: always
@@ -183,6 +250,10 @@ status:
   returned: always
   type: str
   sample: available
+storage_encrypted:
+  description: Specifies whether the DB cluster snapshot is encrypted.
+  returned: always
+  type: bool
 storage_type:
   description: Storage type of the database.
   returned: always
@@ -210,20 +281,32 @@ from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry, compare_aws_tags
 from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
 
-
-def get_snapshot(client, module, snapshot_id):
-    try:
-        response = client.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)
-    except client.exceptions.DBSnapshotNotFoundFault:
-        return None
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg="Couldn't get snapshot {0}".format(snapshot_id))
-    return response['DBSnapshots'][0]
-
+def get_snapshot(client, module):
+  snapshot_id = module.params.get('db_snapshot_identifier')
+  try:
+    if module.params.get('snapshot_type') == 'aurora':
+      db_cluster_identifier = module.params.get('db_cluster_identifier')
+      response = client.describe_db_cluster_snapshots(DBClusterIdentifier=db_cluster_identifier,
+                                                        DBClusterSnapshotIdentifier=snapshot_id)
+      return response['DBClusterSnapshots']
+    else:
+      response = client.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)
+      return response['DBSnapshots']
+  except client.exceptions.DBSnapshotNotFoundFault:
+    return None
+  except client.exceptions.DBClusterSnapshotNotFoundFault:
+    return None
+  except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    module.fail_json_aws(e, msg="Couldn't get snapshot {0}".format(snapshot_id))
+  return response
 
 def snapshot_to_facts(client, module, snapshot):
     try:
-        snapshot['Tags'] = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot['DBSnapshotArn'],
+        if module.params.get('snapshot_type') == 'aurora':
+            snapshot['Tags'] = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot['DBClusterSnapshotArn'],
+                                                                                            aws_retry=True)['TagList'])
+        else:
+            snapshot['Tags'] = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot['DBSnapshotArn'],
                                                                                         aws_retry=True)['TagList'])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, "Couldn't get tags for snapshot %s" % snapshot['DBSnapshotIdentifier'])
@@ -232,121 +315,177 @@ def snapshot_to_facts(client, module, snapshot):
 
     return camel_dict_to_snake_dict(snapshot, ignore_list=['Tags'])
 
-
 def wait_for_snapshot_status(client, module, db_snapshot_id, waiter_name):
     if not module.params['wait']:
         return
     timeout = module.params['wait_timeout']
     try:
+      if module.params['snapshot_type'] == 'aurora':
+        db_cluster_identifier = module.params['db_cluster_identifier']
+        client.get_waiter(waiter_name).wait(DBClusterIdentifier=db_cluster_identifier,DBClusterSnapshotIdentifier=db_snapshot_id,
+                                            WaiterConfig=dict(
+                                                Delay=5,
+                                                MaxAttempts=int((timeout + 2.5) / 5)
+                                            ))
+      else:
         client.get_waiter(waiter_name).wait(DBSnapshotIdentifier=db_snapshot_id,
                                             WaiterConfig=dict(
                                                 Delay=5,
                                                 MaxAttempts=int((timeout + 2.5) / 5)
                                             ))
     except botocore.exceptions.WaiterError as e:
-        if waiter_name == 'db_snapshot_deleted':
-            msg = "Failed to wait for DB snapshot {0} to be deleted".format(db_snapshot_id)
-        else:
-            msg = "Failed to wait for DB snapshot {0} to be available".format(db_snapshot_id)
-        module.fail_json_aws(e, msg=msg)
+      if waiter_name == 'db_snapshot_deleted' or waiter_name == 'db_cluster_snapshot_deleted':
+        msg = "Failed to wait for DB snapshot {0} to be deleted".format(db_snapshot_id)
+      else:
+        msg = "Failed to wait for DB snapshot {0} to be available".format(db_snapshot_id)
+      module.fail_json_aws(e, msg=msg)
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed with an unexpected error while waiting for the DB cluster {0}".format(db_snapshot_id))
 
-
 def ensure_snapshot_absent(client, module):
-    snapshot_name = module.params.get('db_snapshot_identifier')
-    changed = False
+  fn_args = dict()
+  if module.params.get('snapshot_type') == 'aurora':
+    fn_args['DBClusterSnapshotIdentifier'] = module.params.get('db_snapshot_identifier')
+  else:
+    fn_args['DBSnapshotIdentifier'] = module.params.get('db_snapshot_identifier')
+  changed = False
 
-    snapshot = get_snapshot(client, module, snapshot_name)
-    if snapshot and snapshot['Status'] != 'deleting':
+  snapshot = get_snapshot(client, module)
+  
+  if snapshot:
+    if module.params.get('snapshot_type') == 'aurora':
+      if snapshot[0].get('Status') != 'deleting':
         try:
-            client.delete_db_snapshot(DBSnapshotIdentifier=snapshot_name)
-            changed = True
+          client.delete_db_cluster_snapshot(**fn_args)
+          changed = True
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="trying to delete snapshot")
+          module.fail_json_aws(e, msg="trying to delete cluster snapshot")
+    else:
+      try:
+        client.delete_db_snapshot(**fn_args)
+        changed = True
+      except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+          module.fail_json_aws(e, msg="trying to delete snapshot")
 
-    # If we're not waiting for a delete to complete then we're all done
-    # so just return
-    if not snapshot or not module.params.get('wait'):
-        return dict(changed=changed)
+  elif not snapshot and module.params.get('fail_on_not_exists'):
+    module.fail_json_aws(snapshot,msg="cannot delete nonexistent snapshot")
+
+  # If we're not waiting for a delete to complete then we're all done
+  # so just return
+  elif not snapshot or not module.params.get('wait'):
+    return dict(changed=changed)
+
+  try:
+    if module.params.get('snapshot_type') == 'aurora':
+      wait_for_snapshot_status(client, module, module.params.get('db_snapshot_identifier'), 'db_cluster_snapshot_deleted')
+      return dict(changed=changed)
+    else:
+      wait_for_snapshot_status(client, module, module.params.get('db_snapshot_identifier'), 'db_snapshot_deleted')
+      return dict(changed=changed)
+  except client.exceptions.DBSnapshotNotFoundFault:
+    return dict(changed=changed)
+  except client.exceptions.DBClusterSnapshotNotFoundFault:
+    return dict(changed=changed)
+  except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    module.fail_json_aws(e, "awaiting snapshot deletion")
+        
+def ensure_tags(client, module, snapshot, existing_tags, tags, purge_tags):
+  if tags is None:
+    return False
+
+  if module.params.get('snapshot_type') == 'aurora':
+    resource_arn = snapshot[0].get('DBClusterSnapshotArn')
+  else:
+    resource_arn = snapshot[0].get('DBSnapshotArn')
+
+  tags_to_add, tags_to_remove = compare_aws_tags(existing_tags, tags, purge_tags)
+  changed = bool(tags_to_add or tags_to_remove)
+  if tags_to_add:
     try:
-        wait_for_snapshot_status(client, module, snapshot_name, 'db_snapshot_deleted')
-        return dict(changed=changed)
-    except client.exceptions.DBSnapshotNotFoundFault:
-        return dict(changed=changed)
+      client.add_tags_to_resource(ResourceName=resource_arn, Tags=ansible_dict_to_boto3_tag_list(tags_to_add))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, "awaiting snapshot deletion")
-
-
-def ensure_tags(client, module, resource_arn, existing_tags, tags, purge_tags):
-    if tags is None:
-        return False
-    tags_to_add, tags_to_remove = compare_aws_tags(existing_tags, tags, purge_tags)
-    changed = bool(tags_to_add or tags_to_remove)
-    if tags_to_add:
-        try:
-            client.add_tags_to_resource(ResourceName=resource_arn, Tags=ansible_dict_to_boto3_tag_list(tags_to_add))
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, "Couldn't add tags to snapshot {0}".format(resource_arn))
-    if tags_to_remove:
-        try:
-            client.remove_tags_from_resource(ResourceName=resource_arn, TagKeys=tags_to_remove)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, "Couldn't remove tags from snapshot {0}".format(resource_arn))
-    return changed
-
+      module.fail_json_aws(e, "Couldn't add tags to snapshot {0}".format(resource_arn))
+  if tags_to_remove:
+    try:
+      client.remove_tags_from_resource(ResourceName=resource_arn, TagKeys=tags_to_remove)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+      module.fail_json_aws(e, "Couldn't remove tags from snapshot {0}".format(resource_arn))
+  return changed
 
 def ensure_snapshot_present(client, module):
-    db_instance_identifier = module.params.get('db_instance_identifier')
-    snapshot_name = module.params.get('db_snapshot_identifier')
-    changed = False
-    snapshot = get_snapshot(client, module, snapshot_name)
-    if not snapshot:
-        try:
-            snapshot = client.create_db_snapshot(DBSnapshotIdentifier=snapshot_name,
-                                                 DBInstanceIdentifier=db_instance_identifier)['DBSnapshot']
-            changed = True
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="trying to create db snapshot")
+  fn_args= dict()
+  if module.params.get('snapshot_type') == 'aurora':
+    fn_args['DBClusterSnapshotIdentifier'] = module.params.get('db_snapshot_identifier')
+    fn_args['DBClusterIdentifier'] = module.params.get('db_cluster_identifier')
+  else:
+    fn_args['DBSnapshotIdentifier'] = module.params.get('db_snapshot_identifier')
+    fn_args['DBInstanceIdentifier'] = module.params.get('db_instance_identifier')
 
-    if module.params.get('wait'):
-        wait_for_snapshot_status(client, module, snapshot_name, 'db_snapshot_available')
 
-    existing_tags = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot['DBSnapshotArn'],
+  if module.params['tags'] and module.params['tags'] is not None:
+    fn_args['Tags'] = ansible_dict_to_boto3_tag_list(module.params['tags'])
+  changed = False
+
+  try:
+    if module.params.get('snapshot_type') == 'aurora':
+      response = client.create_db_cluster_snapshot(**fn_args)
+    else:
+      response = client.create_db_snapshot(**fn_args)
+  except client.exceptions.DBClusterSnapshotAlreadyExistsFault as e:
+    module.fail_json_aws(e, msg="Failed to create cluster snapshot. A cluster snapshot with this snapshot_identifier already exists")
+  except client.exceptions.DBSnapshotAlreadyExistsFault as e:
+    module.fail_json_aws(e, msg="Failed to create cluster snapshot. A cluster snapshot with this snapshot_identifier already exists")
+  except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    module.fail_json_aws(e, msg="Failed to create cluster or instance snapshot")
+
+  snapshot = get_snapshot(client, module)
+  if module.params.get('snapshot_type') == 'aurora':
+    existing_tags = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot[0].get('DBClusterSnapshotArn'),
                                                                                  aws_retry=True)['TagList'])
-    desired_tags = module.params['tags']
-    purge_tags = module.params['purge_tags']
-    changed |= ensure_tags(client, module, snapshot['DBSnapshotArn'], existing_tags, desired_tags, purge_tags)
+  else:
+    existing_tags = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot[0].get('DBSnapshotArn'),
+                                                                                 aws_retry=True)['TagList'])                                                                                 
+  desired_tags = module.params.get('tags')
+  purge_tags = module.params.get('purge_tags')
+  changed |= ensure_tags(client, module, snapshot, existing_tags, desired_tags, purge_tags)
 
-    snapshot = get_snapshot(client, module, snapshot_name)
+  snapshot = get_snapshot(client, module)  
 
-    return dict(changed=changed, **snapshot_to_facts(client, module, snapshot))
+  relevant_response = dict(rds=snapshot)
 
+  return relevant_response
 
 def main():
-
     module = AnsibleAWSModule(
         argument_spec=dict(
+            snapshot_type=dict(choices=['instance', 'aurora'], default='instance'),
             state=dict(choices=['present', 'absent'], default='present'),
             db_snapshot_identifier=dict(aliases=['id', 'snapshot_id'], required=True),
             db_instance_identifier=dict(aliases=['instance_id']),
+            db_cluster_identifier=dict(aliases=['cluster_id']),
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='int', default=300),
             tags=dict(type='dict'),
             purge_tags=dict(type='bool', default=True),
+            fail_on_not_exists=dict(type='bool', default=False)
         ),
-        required_if=[['state', 'present', ['db_instance_identifier']]]
+        required_if=[
+          ['snapshot_type', 'aurora', [ "db_cluster_identifier" ]],
+          ['snapshot_type', 'instance', [ "db_instance_identifier" ]]
+        ],
+        mutually_exclusive=[
+         [ 'db_cluster_identifier', 'db_instance_identifier' ] 
+        ]
     )
 
     client = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
 
     if module.params['state'] == 'absent':
-        ret_dict = ensure_snapshot_absent(client, module)
+      ret_dict = ensure_snapshot_absent(client, module)
     else:
-        ret_dict = ensure_snapshot_present(client, module)
-
-    module.exit_json(**ret_dict)
-
+      ret_dict = ensure_snapshot_present(client, module)
+    t1 = False 
+    module.exit_json(test=t1,d=ret_dict)
 
 if __name__ == '__main__':
-    main()
+  main()

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -12,7 +12,6 @@ __metaclass__ = type
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
-
 DOCUMENTATION = '''
 ---
 module: rds_snapshot
@@ -25,7 +24,7 @@ options:
     description:
       - Specify cluster or instance snapshot.
     default: instance
-    choices [ 'aurora', 'instance' ]
+    choices: [ 'aurora', 'instance' ]
     type: str
   state:
     description:
@@ -88,7 +87,6 @@ extends_documentation_fragment:
     - aws
     - ec2
 '''
-
 EXAMPLES = '''
 # Create snapshot
 - name: Create RDS snapshot
@@ -116,7 +114,6 @@ EXAMPLES = '''
     state: absent
     db_snapshot_identifier: new-cluster-snapshot
 '''
-
 RETURN = '''
 allocated_storage:
   description: How much storage is allocated in GB.
@@ -322,7 +319,7 @@ def wait_for_snapshot_status(client, module, db_snapshot_id, waiter_name):
     try:
       if module.params['snapshot_type'] == 'aurora':
         db_cluster_identifier = module.params['db_cluster_identifier']
-        client.get_waiter(waiter_name).wait(DBClusterIdentifier=db_cluster_identifier,DBClusterSnapshotIdentifier=db_snapshot_id,
+        client.get_waiter(waiter_name).wait(DBClusterIdentifier=db_cluster_identifier, DBClusterSnapshotIdentifier=db_snapshot_id,
                                             WaiterConfig=dict(
                                                 Delay=5,
                                                 MaxAttempts=int((timeout + 2.5) / 5)
@@ -368,7 +365,7 @@ def ensure_snapshot_absent(client, module):
           module.fail_json_aws(e, msg="trying to delete snapshot")
 
   elif not snapshot and module.params.get('fail_on_not_exists'):
-    module.fail_json_aws(snapshot,msg="cannot delete nonexistent snapshot")
+    module.fail_json_aws(snapshot, msg="cannot delete nonexistent snapshot")
 
   # If we're not waiting for a delete to complete then we're all done
   # so just return
@@ -470,22 +467,21 @@ def main():
             fail_on_not_exists=dict(type='bool', default=False)
         ),
         required_if=[
-          ['snapshot_type', 'aurora', [ "db_cluster_identifier" ]],
-          ['snapshot_type', 'instance', [ "db_instance_identifier" ]]
+          ['snapshot_type', 'aurora', ["db_cluster_identifier"]],
+          ['snapshot_type', 'instance', ["db_instance_identifier"]]
         ],
         mutually_exclusive=[
-         [ 'db_cluster_identifier', 'db_instance_identifier' ] 
-        ]
+         ['db_cluster_identifier', 'db_instance_identifier']
+         ]
     )
-
     client = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
 
     if module.params['state'] == 'absent':
       ret_dict = ensure_snapshot_absent(client, module)
     else:
       ret_dict = ensure_snapshot_present(client, module)
-    t1 = False 
-    module.exit_json(test=t1,d=ret_dict)
+
+    module.exit_json(**ret_dict)
 
 if __name__ == '__main__':
   main()

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: rds_snapshot
-version_added: 2.9
+version_added: '2.9'
 short_description: manage Amazon RDS/Aurora snapshots.
 description:
      - Creates or deletes RDS snapshots.
@@ -24,7 +24,7 @@ options:
       - Specify cluster or instance snapshot.
     default: instance
     choices: ['instance', 'aurora']
-    version_added: 2.10
+    version_added: '2.10'
     type: str
   state:
     description:
@@ -45,14 +45,13 @@ options:
       - Database instance identifier. Required when state is present.
     aliases:
       - instance_id
-    version_added: 2.10
     type: str
   db_cluster_identifier:
     description:
       - Database cluster identifier (Aurora). Required when snapshot_type is aurora.
     aliases:
       - cluster_id
-    version_added: 2.10
+    version_added: '2.10'
     type: str
   wait:
     description:
@@ -77,6 +76,7 @@ options:
     description:
       - whether to fail if trying to delete a non-existent snapshot.
     default: False
+    version_added: '2.10'
     type: bool
 requirements:
     - "python >= 2.6"
@@ -328,8 +328,8 @@ def wait_for_snapshot_status(client, module, db_snapshot_id, waiter_name):
             db_cluster_identifier = module.params['db_cluster_identifier']
             client.get_waiter(waiter_name).wait(DBClusterIdentifier=db_cluster_identifier, DBClusterSnapshotIdentifier=db_snapshot_id,
                                                 WaiterConfig=dict(
-                                                Delay=5,
-                                                MaxAttempts=int((timeout + 2.5) / 5)
+                                                    Delay=5,
+                                                    MaxAttempts=int((timeout + 2.5) / 5)
                                                 ))
         else:
             client.get_waiter(waiter_name).wait(DBSnapshotIdentifier=db_snapshot_id,
@@ -447,10 +447,10 @@ def ensure_snapshot_present(client, module):
     snapshot = get_snapshot(client, module)
     if module.params.get('snapshot_type') == 'aurora':
         existing_tags = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot[0].get('DBClusterSnapshotArn'),
-                                                                                        aws_retry=True)['TagList'])
+                                                                                     aws_retry=True)['TagList'])
     else:
         existing_tags = boto3_tag_list_to_ansible_dict(client.list_tags_for_resource(ResourceName=snapshot[0].get('DBSnapshotArn'),
-                                                                                        aws_retry=True)['TagList'])
+                                                                                     aws_retry=True)['TagList'])
     desired_tags = module.params.get('tags')
     purge_tags = module.params.get('purge_tags')
     changed |= ensure_tags(client, module, snapshot, existing_tags, desired_tags, purge_tags)

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -8,7 +8,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
@@ -24,13 +23,13 @@ options:
     description:
       - Specify cluster or instance snapshot.
     default: instance
-    choices: [ 'aurora', 'instance' ]
+    choices: ['instance', 'aurora']
     type: str
   state:
     description:
       - Specify the desired state of the snapshot.
     default: present
-    choices: [ 'present', 'absent' ]
+    choices: ['present', 'absent']
     type: str
   db_snapshot_identifier:
     description:
@@ -56,7 +55,7 @@ options:
     description:
       - Whether or not to wait for snapshot creation or deletion.
     type: bool
-    default: 'no'
+    default: False
   wait_timeout:
     description:
       - how long before wait gives up, in seconds.
@@ -74,8 +73,8 @@ options:
   fail_on_not_exists:
     description:
       - whether to fail if trying to delete a non-existent snapshot.
-      default: False
-      type: bool
+    default: False
+    type: bool
 requirements:
     - "python >= 2.6"
     - "boto3"
@@ -132,7 +131,8 @@ availability_zones:
   sample: [ 'us-east-2a', 'us-east-2b', 'us-east-2c' ]
 cluster_create_time:
   description: Specifies the time when the DB cluster was created, in Universal Coordinated Time (UTC).
-  type: datetime
+  returned: always
+  type: str
 db_cluster_identifier:
   description: Specifies the DB cluster identifier of the DB cluster that this DB cluster snapshot was created from.
   returned: always
@@ -457,9 +457,9 @@ def main():
         argument_spec=dict(
             snapshot_type=dict(choices=['instance', 'aurora'], default='instance'),
             state=dict(choices=['present', 'absent'], default='present'),
-            db_snapshot_identifier=dict(aliases=['id', 'snapshot_id'], required=True),
-            db_instance_identifier=dict(aliases=['instance_id']),
-            db_cluster_identifier=dict(aliases=['cluster_id']),
+            db_snapshot_identifier=dict(type='str', aliases=['id', 'snapshot_id'], required=True),
+            db_instance_identifier=dict(type='str', aliases=['instance_id']),
+            db_cluster_identifier=dict(type='str', aliases=['cluster_id']),
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='int', default=300),
             tags=dict(type='dict'),


### PR DESCRIPTION
Added support into the module for creating and deleting Aurora snapshots in addition to regular RDS snapshots.

##### SUMMARY
Addresses #64765.

The new aurora functionality is implemented in a way that shouldn't affect or break any preexisting playbooks that use the rds_snapshot module - the default action is to use the 'instance' snapshot_type, which mimics the current module's behavior.

- Updated documentation to include new DBCluster* responses
- Added snapshot_type argument spec with choices of 'instance' or 'aurora'
- Utilized mutually_exclusive to ensure that db_cluster_identifier and db_instance_identifier are not paired as options for the module
- Added db_cluster_identifier argument spec with a required_if clause for when snapshot_type is 'aurora'
- Added to existing functions to check when snapshot_type is 'aurora' and use the appropriate cluster apis rather than the regular RDS apis
- Added a fail_on_not_exists flag to support failing if trying to delete a snapshot that didn't exist in the first place

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rds_snapshot

##### ADDITIONAL INFORMATION
