### PR TITLE
Added ability to specify plan information for images that require it.

### DIFF
--- a/changelogs/fragments/65335-add-plan-to-azure-vmscaleset-module.yaml
+++ b/changelogs/fragments/65335-add-plan-to-azure-vmscaleset-module.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - billingplan - added ability to use plan information for images that require billing plan details
+  - azure_rm_virtualmachinescaleset - added ability to use plan information for images that require billing plan details

--- a/changelogs/fragments/65335-add-plan-to-azure-vmscaleset-module.yaml
+++ b/changelogs/fragments/65335-add-plan-to-azure-vmscaleset-module.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - billingplan - added ability to use plan information for images that require billing plan details

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -926,8 +926,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                                 publisher_id=plan_publisher, offer_id=plan_product, plan_id=plan_name, parameters=term)
                         except Exception as exc:
                             self.fail(("Error accepting terms for virtual machine {0} with plan {1}. " +
-                                        "Only service admin/account admin users can purchase images " +
-                                        "from the marketplace. - {2}").format(self.name, self.plan, str(exc)))
+                                       "Only service admin/account admin users can purchase images " +
+                                       "from the marketplace. - {2}").format(self.name, self.plan, str(exc)))
 
                     self.log("Create virtual machine with parameters:")
                     self.create_or_update_vmss(vmss_resource)

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -291,7 +291,7 @@ EXAMPLES = '''
     resource_group: myResourceGroup
     name: testvmss
     vm_size: Standard_DS1_v2
-    capacity: 2
+    capacity: 3
     virtual_network_name: testvnet
     upgrade_policy: Manual
     subnet_name: testsubnet

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -514,8 +514,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             single_placement_group=dict(type='bool', default=True),
             zones=dict(type='list'),
             custom_data=dict(type='str'),
-            plan=dict(type='dict'),
-            accept_terms=dict(type='bool', default=False)
+            plan=dict(type='dict', options=dict(publisher=dict(type='str', required=true),product=dict(type='str', required=true),name=dict(type='str', required=true))),
+            accept_terms=dict(type='bool', default=False),
         )
 
         self.resource_group = None
@@ -665,9 +665,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             elif self.image:
                 self.fail("parameter error: expecting image to be a string or dict not {0}".format(type(self.image).__name__))
 
-            if self.plan:
-                if not self.plan.get('name') or not self.plan.get('product') or not self.plan.get('publisher'):
-                    self.fail("parameter error: plan must include name, product, and publisher")
 
             disable_ssh_password = not self.ssh_password_enabled
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -515,8 +515,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             zones=dict(type='list'),
             custom_data=dict(type='str'),
             plan=dict(type='dict', options=dict(publisher=dict(type='str', required=True),
-                                 product=dict(type='str', required=True), name=dict(type='str', required=True), 
-                                 promotion_code=dict(type='str'))),
+                product=dict(type='str', required=True), name=dict(type='str', required=True),
+                promotion_code=dict(type='str'))),
             accept_terms=dict(type='bool', default=False),
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -210,7 +210,7 @@ options:
     plan:
         description:
             - Third-party billing plan for the VM.
-        version_added: "2.5"
+        version_added: "2.10"
         type: dict
         suboptions:
             name:
@@ -235,7 +235,7 @@ options:
             - Only valid when a I(plan) is specified.
         type: bool
         default: false
-        version_added: "2.7"
+        version_added: "2.10"
     zones:
         description:
             - A list of Availability Zones for your virtual machine scale set.
@@ -853,9 +853,9 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                             capacity=self.capacity,
                             tier=self.tier,
                         ),
+                        plan=plan,
                         virtual_machine_profile=self.compute_models.VirtualMachineScaleSetVMProfile(
                             os_profile=os_profile,
-                            plan=plan,
                             storage_profile=self.compute_models.VirtualMachineScaleSetStorageProfile(
                                 os_disk=self.compute_models.VirtualMachineScaleSetOSDisk(
                                     managed_disk=managed_disk,

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -514,7 +514,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             single_placement_group=dict(type='bool', default=True),
             zones=dict(type='list'),
             custom_data=dict(type='str'),
-            plan=dict(type='dict', options=dict(publisher=dict(type='str', required=true),product=dict(type='str', required=true),name=dict(type='str', required=true))),
+            plan=dict(type='dict', options=dict(publisher=dict(type='str', required=True),
+                                               product=dict(type='str', required=True), name=dict(type='str', required=True))),
             accept_terms=dict(type='bool', default=False),
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -515,8 +515,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             zones=dict(type='list'),
             custom_data=dict(type='str'),
             plan=dict(type='dict', options=dict(publisher=dict(type='str', required=True),
-                product=dict(type='str', required=True), name=dict(type='str', required=True),
-                promotion_code=dict(type='str'))),
+                      product=dict(type='str', required=True), name=dict(type='str', required=True),
+                      promotion_code=dict(type='str'))),
             accept_terms=dict(type='bool', default=False),
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachinescaleset.py
@@ -515,7 +515,8 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
             zones=dict(type='list'),
             custom_data=dict(type='str'),
             plan=dict(type='dict', options=dict(publisher=dict(type='str', required=True),
-                                               product=dict(type='str', required=True), name=dict(type='str', required=True))),
+                                 product=dict(type='str', required=True), name=dict(type='str', required=True), 
+                                 promotion_code=dict(type='str'))),
             accept_terms=dict(type='bool', default=False),
         )
 
@@ -665,7 +666,6 @@ class AzureRMVirtualMachineScaleSet(AzureRMModuleBase):
                 image_reference = self.get_custom_image_reference(self.image)
             elif self.image:
                 self.fail("parameter error: expecting image to be a string or dict not {0}".format(type(self.image).__name__))
-
 
             disable_ssh_password = not self.ssh_password_enabled
 


### PR DESCRIPTION
##### SUMMARY
Added ability to specify billing plan information for images that require it. Images like CIS hardened images on Azure marketplace require plan field to be populated.
Fixes #65268 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachinescaleset

##### ADDITIONAL INFORMATION
Tests were done locally that:
1. generated the VM scale set with CIS image
2. generated VM scale set with standard Ubuntu image to prove nothing broke
3. as expected, failed to generate a scale set when specifying plan for image that does not require it
4. as expected, failed to generate a scale set when specifying image without required plan

The module azure_rm_virtualmachinescaleset handles plan information. Based on how plan and accept_terms was used I copied:
1. over documentation
2. over parameter definition
3. over code blocks for validating plan parameter
4. over code for accepting terms
and
added an example in the examples section.



