### PR TITLE
meraki_organization - Ignore URL parameter when comparing for…

### DIFF
--- a/changelogs/fragments/meraki_organization-ignore-url.yml
+++ b/changelogs/fragments/meraki_organization-ignore-url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - meraki_organization - Ignore the URL key when checking for idempotency

--- a/lib/ansible/modules/network/meraki/meraki_organization.py
+++ b/lib/ansible/modules/network/meraki/meraki_organization.py
@@ -208,7 +208,7 @@ def main():
                        'id': meraki.params['org_id'],
                        }
             original = get_org(meraki, meraki.params['org_id'], orgs)
-            if meraki.is_update_required(original, payload):
+            if meraki.is_update_required(original, payload, optional_ignore=['url']):
                 response = meraki.request(meraki.construct_path('update',
                                                                 org_id=meraki.params['org_id']
                                                                 ),


### PR DESCRIPTION
##### SUMMARY
Meraki added a URL parameter to the organization endpoint. This will ignore the key when comparing for idempotency.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki_organization
