### PR TITLE
Meraki - Remove type comparison for idempotency check

### DIFF
--- a/changelogs/fragments/meraki-dont-compare-type.yml
+++ b/changelogs/fragments/meraki-dont-compare-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - meraki - Idempotency check no longer compares types of objects 

--- a/lib/ansible/module_utils/network/meraki/meraki.py
+++ b/lib/ansible/module_utils/network/meraki/meraki.py
@@ -230,9 +230,6 @@ class MerakiModule(object):
         if optional_ignore is not None:
             self.ignored_keys = self.ignored_keys + optional_ignore
 
-        if type(original) != type(proposed):
-            # self.fail_json(msg="Types don't match")
-            return True
         if isinstance(original, list):
             if len(original) != len(proposed):
                 # self.fail_json(msg="Length of lists don't match")


### PR DESCRIPTION
##### SUMMARY
The algorithm used to compare the types of the objects. However, the type of data returned has changed which has caused a lot of idempotency problems. This removes the type check.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
meraki
