### PR TITLE
Fixed KeyError at deletionProtection in 'gcp_compute_instance'

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -1468,7 +1468,7 @@ def deletion_protection_update(module, request, response):
         ''.join(
             [
                 "https://www.googleapis.com/compute/v1/",
-                "projects/{project}/zones/{zone}/instances/{name}/setDeletionProtection?deletionProtection={deletionProtection}",
+                "projects/{project}/zones/{zone}/instances/{name}/setDeletionProtection?deletionProtection={deletion_protection}",
             ]
         ).format(**module.params),
         {},


### PR DESCRIPTION
Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Replaced `deletionProtection` with `deletion_protection` to minimize `KeyError`
Fixes #65291 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_instance
