### PR TITLE
Suppress warning when user directory(~) used on --playbook-dir option

### DIFF
--- a/changelogs/fragments/65262_ansible_inventory.yml
+++ b/changelogs/fragments/65262_ansible_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Suppress warning when user directory used in --playbook-dir option with ansible-inventory command (https://github.com/ansible/ansible/issues/65262).

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -42,7 +42,7 @@ def get_all_plugin_loaders():
 
 def add_all_plugin_dirs(path):
     ''' add any existing plugin dirs in the path provided '''
-    b_path = to_bytes(path, errors='surrogate_or_strict')
+    b_path = os.path.expanduser(to_bytes(path, errors='surrogate_or_strict'))
     if os.path.isdir(b_path):
         for name, obj in get_all_plugin_loaders():
             if obj.subdir:


### PR DESCRIPTION
Signed-off-by: Satyajit Bulage <sbulage@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Warning is given when `(~)` user directory is used `--playbook-dir` path.
Fixed #65262 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
loader
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ansible-inventory -i inventory --list --export --playbook-dir=~/invet_dir/
{
    "_meta": {
        "hostvars": {
            "192.168.122.139": {
                "ansible_ssh_user": "root"
            }
        }
    }, 
    "all": {
        "children": [
            "ungrouped"
        ]
    }, 
    "ungrouped": {
        "hosts": [
            "192.168.122.139"
        ]
    }
}

```
