### PR TITLE
Fix typo in svn documentation path

### DIFF
--- a/lib/ansible/modules/source_control/subversion.py
+++ b/lib/ansible/modules/source_control/subversion.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
 - name: Get information about the repository whether or not it has already been cloned locally
 - subversion:
     repo: svn+ssh://an.example.org/path/to/repo
-    dest: /srv/checkout
+    dest: /src/checkout
     checkout: no
     update: no
 '''


### PR DESCRIPTION
##### SUMMARY

Fixes a typo in the svn documentation. Changes `/srv/checkout` to `/src/checkout`

https://docs.ansible.com/ansible/latest/modules/subversion_module.html

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Subversion
