### PR TITLE
vmware/test: switch the `ro` of the two datastore

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/vars/common.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/common.yml
@@ -1,8 +1,6 @@
 ---
 dc1: DC0
 ccr1: DC0_C0
-rw_datastore: LocalDS_0
-ro_datastore: LocalDS_1
 f0: F0
 switch1: switch1
 esxi1: '{{ esxi_hosts[0] }}'

--- a/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/real_lab.yml
@@ -2,18 +2,20 @@
 esxi_hosts:
   - esxi1.test
   - esxi2.test
+rw_datastore: rw_datastore
+ro_datastore: ro_datastore
 esxi_password: '{{ esxi1_password }}'
 infra:
   datastores:
-    LocalDS_0:
-      type: nfs
-      server: datastore.test
-      path: /srv/share/isos
-      ro: false
-    LocalDS_1:
+    rw_datastore:
       type: nfs
       server: datastore.test
       path: /srv/share/vms
+      ro: false
+    ro_datastore:
+      type: nfs
+      server: datastore.test
+      path: /srv/share/isos
       ro: true
 virtual_machines:
   - name: DC0_H0_VM0

--- a/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
@@ -3,6 +3,8 @@ esxi_hosts:
   - DC0_C0_H0
   - DC0_C0_H1
   - DC0_C0_H2
+rw_datastore: LocalDS_0
+ro_datastore: LocalDS_1
 virtual_machines:
   - name: DC0_H0_VM0
     folder: /F0/DC0/vm/F0


### PR DESCRIPTION
##### SUMMARY

The `ro_datastore` was actually using the value of `rw_datastore`.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->