### PR TITLE
Fixes vcenter_folder remove folder

### DIFF
--- a/changelogs/fragments/65363-vcenter_folder_remove_folder_fix.yml
+++ b/changelogs/fragments/65363-vcenter_folder_remove_folder_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vcenter_folder - remove folder with multiple levels of parents (https://github.com/ansible/ansible/pull/65363).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes folder handling when removing folder from vcenter.
Previous implementation can remove only first or second level of parent folders.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vcenter_folder

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
