### PR TITLE
postgresql_query: fix UTF-8 support in SQL files

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -270,7 +270,7 @@ def main():
 
     if path_to_script:
         try:
-            query = open(path_to_script, 'r').read()
+            query = to_native(open(path_to_script, 'rb').read())
         except Exception as e:
             module.fail_json(msg="Cannot read file '%s' : %s" % (path_to_script, to_native(e)))
 


### PR DESCRIPTION
##### SUMMARY
    
Fix UTF-8 support when reading of `path_to_file` argument on Python 3.

Fixes #65367

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

postgresql_query

##### ADDITIONAL INFORMATION

See  #65367


