### PR TITLE
On OpenBSD, use the actual number of online CPUs for facts

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -118,7 +118,7 @@ class OpenBSDHardware(Hardware):
     def get_processor_facts(self):
         cpu_facts = {}
         processor = []
-        for i in range(int(self.sysctl['hw.ncpu'])):
+        for i in range(int(self.sysctl['hw.ncpuonline'])):
             processor.append(self.sysctl['hw.model'])
 
         cpu_facts['processor'] = processor
@@ -129,8 +129,10 @@ class OpenBSDHardware(Hardware):
         # dmesg, however even those have proven to be unreliable.
         # So take a shortcut and report the logical number of processors in
         # 'processor_count' and 'processor_cores' and leave it at that.
-        cpu_facts['processor_count'] = self.sysctl['hw.ncpu']
-        cpu_facts['processor_cores'] = self.sysctl['hw.ncpu']
+        # Furthermore we use the actual number of online CPUs as multiple
+        # logical threads may be disabled with hw.smt=0 .
+        cpu_facts['processor_count'] = self.sysctl['hw.ncpuonline']
+        cpu_facts['processor_cores'] = self.sysctl['hw.ncpuonline']
 
         return cpu_facts
 


### PR DESCRIPTION
##### SUMMARY
This switches to use hw.ncpuonline instead of hw.ncpu when
showing the number of cpus/cores in the system

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`setup` module

##### ADDITIONAL INFORMATION
In OpenBSD it's possible to disable SMT since release 6.4 as such the number of detected physical CPUs/cores with `hw.ncpu` may not actually be the number of CPUs/cores which are in use. The `hw.ncpuonline` sysctl value does correctly reflect that.

I think it makes sense to switch to using this value instead of `hw.ncpu`.