### PR TITLE
Use context manager in yum module.

### DIFF
--- a/changelogs/fragments/65376.yaml
+++ b/changelogs/fragments/65376.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - packaging_yum - replace legacy file handling with a file manager.

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -506,19 +506,11 @@ class YumRepo(object):
         if len(self.repofile.sections()):
             # Write data into the file
             try:
-                fd = open(self.params['dest'], 'w')
+                with open(self.params['dest'], 'w') as fd:
+                    self.repofile.write(fd)
             except IOError as e:
                 self.module.fail_json(
-                    msg="Cannot open repo file %s." % self.params['dest'],
-                    details=to_native(e))
-
-            self.repofile.write(fd)
-
-            try:
-                fd.close()
-            except IOError as e:
-                self.module.fail_json(
-                    msg="Cannot write repo file %s." % self.params['dest'],
+                    msg="Problems handling file %s." % self.params['dest'],
                     details=to_native(e))
         else:
             # Remove the file if there are not repos


### PR DESCRIPTION
##### SUMMARY

This is a semantic change. Python 2 does not have `FileNotFoundError`, like Python 3. I think the simplicity with just "Problems with file" is fine.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os, yum.

##### ADDITIONAL INFORMATION
