### PR TITLE
Preserve multiple filename extensions in temporary filenames (#64612)

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1574,8 +1574,15 @@ def fetch_file(module, url, data=None, headers=None, method=None,
     '''
     # download file
     bufsize = 65536
-    file_name, file_ext = os.path.splitext(str(url.rsplit('/', 1)[1]))
-    fetch_temp_file = tempfile.NamedTemporaryFile(dir=module.tmpdir, prefix=file_name, suffix=file_ext, delete=False)
+    # We try to preserve all filename extensions here to preserve things like
+    # .tar.gz so that code that makes assumptions about a file's contents based
+    # on whether a filename has multiple extensions doesn't get confused.
+    file_name = str(url.rsplit('/', 1)[1])
+    file_parts = file_name[1:].split('.', 1)  # [1:] avoids splitting ".hiddenfile"
+    file_exts = "." + file_parts[1] if len(file_parts) > 1 else ""
+    if file_exts:
+        file_name = file_name[:len(file_exts) - 1]
+    fetch_temp_file = tempfile.NamedTemporaryFile(dir=module.tmpdir, prefix=file_name, suffix=file_exts, delete=False)
     module.add_cleanup_file(fetch_temp_file.name)
     try:
         rsp, info = fetch_url(module, url, data, headers, method, use_proxy, force, last_mod_time, timeout)


### PR DESCRIPTION
Fixes #64612

Without this change `fetch_file` will insert random characters between
the ".tar" and ".gz" in "filename.tar.gz". For modules such as the
'unarchive' module this can cause problems since code can make
assumptions on filename contents based on the presense of multiple
filename extensions.

Unfortunately we can't use pathlib until Python 2 support is dropped
otherwise we could do something simpler like:

    file_name = str(url.rsplit('/', 1)[1])
    file_exts = "".join(pathlib.Path(file_name).suffixes
    if file_exts:
        file_name = file_name[:len(file_exts)-1]

This new code actually tries to maintain compatibility with pathlib
in that it will treat ".foo" as having a base of ".foo" with no
extension, rather than treating it as a base of "" with a ".foo"
extension.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
