### PR TITLE
ufw: add support for interface_in and interface_out

### DIFF
--- a/changelogs/fragments/63903-ufw.yaml
+++ b/changelogs/fragments/63903-ufw.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ufw - accept ``interface_in`` and ``interface_out`` as parameters.

--- a/test/integration/targets/ufw/tasks/main.yml
+++ b/test/integration/targets/ufw/tasks/main.yml
@@ -7,8 +7,10 @@
 - name: Install iptables (SuSE only)
   package:
     name: iptables
+  become: yes
   when: ansible_os_family == 'Suse'
 - name: Install ufw
+  become: yes
   package:
     name: ufw
 
@@ -17,6 +19,7 @@
   - include_tasks: run-test.yml
     with_fileglob:
     - "tests/*.yml"
+  become: yes
 
   # Cleanup
   always:

--- a/test/integration/targets/ufw/tasks/tests/interface.yml
+++ b/test/integration/targets/ufw/tasks/tests/interface.yml
@@ -1,0 +1,81 @@
+- name: Enable
+  ufw:
+    state: enabled
+
+- name: Route with interface in and out
+  ufw:
+    rule: allow
+    route: yes
+    interface_in: foo
+    interface_out: bar
+    proto: tcp
+    from_ip: 1.1.1.1
+    to_ip: 8.8.8.8
+    from_port: 1111
+    to_port: 2222
+
+- name: Route with interface in
+  ufw:
+    rule: allow
+    route: yes
+    interface_in: foo
+    proto: tcp
+    from_ip: 1.1.1.1
+    from_port: 1111
+
+- name: Route with interface out
+  ufw:
+    rule: allow
+    route: yes
+    interface_out: bar
+    proto: tcp
+    from_ip: 1.1.1.1
+    from_port: 1111
+
+- name: Non-route with interface in
+  ufw:
+    rule: allow
+    interface_in: foo
+    proto: tcp
+    from_ip: 1.1.1.1
+    from_port: 3333
+
+- name: Non-route with interface out
+  ufw:
+    rule: allow
+    interface_out: bar
+    proto: tcp
+    from_ip: 1.1.1.1
+    from_port: 4444
+
+- name: Check result
+  shell: ufw status |grep -E '(ALLOW|DENY|REJECT|LIMIT)' |sed -E 's/[ \t]+/ /g'
+  register: ufw_status
+
+- assert:
+    that:
+      - '"8.8.8.8 2222/tcp on bar ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
+      - '"Anywhere ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
+      - '"Anywhere on bar ALLOW FWD 1.1.1.1 1111/tcp " in stdout'
+      - '"Anywhere on foo ALLOW 1.1.1.1 3333/tcp " in stdout'
+      - '"Anywhere ALLOW OUT 1.1.1.1 4444/tcp on bar " in stdout'
+  vars:
+    stdout: '{{ ufw_status.stdout_lines }}'
+
+- name: Non-route with interface_in and interface_out
+  ufw:
+    rule: allow
+    interface_in: foo
+    interface_out: bar
+    proto: tcp
+    from_ip: 1.1.1.1
+    from_port: 1111
+    to_ip: 8.8.8.8
+    to_port: 2222
+  ignore_errors: yes
+  register: ufw_non_route_iface
+
+- assert:
+    that:
+      - ufw_non_route_iface is failed
+      - '"Only route rules" in ufw_non_route_iface.msg'

--- a/test/units/modules/system/test_ufw.py
+++ b/test/units/modules/system/test_ufw.py
@@ -52,6 +52,7 @@ dry_mode_cmd_with_port_700 = {
     "ufw --dry-run allow from any to any port 7000 proto tcp": skippg_adding_existing_rules,
     "ufw --dry-run delete allow from any to any port 7000 proto tcp": "",
     "ufw --dry-run delete allow from any to any port 7001 proto tcp": user_rules_with_port_7000,
+    "ufw --dry-run route allow in on foo out on bar from 1.1.1.1 port 7000 to 8.8.8.8 port 7001 proto tcp": "",
     "ufw --dry-run allow in on foo from any to any port 7003 proto tcp": "",
     "ufw --dry-run allow in on foo from 1.1.1.1 port 7002 to 8.8.8.8 port 7003 proto tcp": "",
     "ufw --dry-run allow out on foo from any to any port 7004 proto tcp": "",
@@ -172,6 +173,80 @@ class TestUFW(unittest.TestCase):
         })
         result = self.__getResult(do_nothing_func_port_7000)
         self.assertFalse(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_detailed_route(self):
+        set_module_args({
+            'rule': 'allow',
+            'route': 'yes',
+            'interface_in': 'foo',
+            'interface_out': 'bar',
+            'proto': 'tcp',
+            'from_ip': '1.1.1.1',
+            'to_ip': '8.8.8.8',
+            'from_port': '7000',
+            'to_port': '7001',
+            '_ansible_check_mode': True
+        })
+
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_ambiguous_route(self):
+        set_module_args({
+            'rule': 'allow',
+            'route': 'yes',
+            'interface_in': 'foo',
+            'interface_out': 'bar',
+            'direction': 'in',
+            'interface': 'baz',
+            '_ansible_check_mode': True
+        })
+
+        with self.assertRaises(AnsibleFailJson) as result:
+            self.__getResult(do_nothing_func_port_7000)
+
+        exc = result.exception.args[0]
+        self.assertTrue(exc['failed'])
+        self.assertIn('mutually exclusive', exc['msg'])
+
+    def test_check_mode_add_interface_in(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7003',
+            'interface_in': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_interface_out(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7004',
+            'interface_out': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_non_route_interface_both(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7004',
+            'interface_in': 'foo',
+            'interface_out': 'bar',
+            '_ansible_check_mode': True
+        })
+
+        with self.assertRaises(AnsibleFailJson) as result:
+            self.__getResult(do_nothing_func_port_7000)
+
+        exc = result.exception.args[0]
+        self.assertTrue(exc['failed'])
+        self.assertIn('combine', exc['msg'])
 
     def test_check_mode_add_direction_in(self):
         set_module_args({

--- a/test/units/modules/system/test_ufw.py
+++ b/test/units/modules/system/test_ufw.py
@@ -52,6 +52,10 @@ dry_mode_cmd_with_port_700 = {
     "ufw --dry-run allow from any to any port 7000 proto tcp": skippg_adding_existing_rules,
     "ufw --dry-run delete allow from any to any port 7000 proto tcp": "",
     "ufw --dry-run delete allow from any to any port 7001 proto tcp": user_rules_with_port_7000,
+    "ufw --dry-run allow in on foo from any to any port 7003 proto tcp": "",
+    "ufw --dry-run allow in on foo from 1.1.1.1 port 7002 to 8.8.8.8 port 7003 proto tcp": "",
+    "ufw --dry-run allow out on foo from any to any port 7004 proto tcp": "",
+    "ufw --dry-run allow out on foo from 1.1.1.1 port 7003 to 8.8.8.8 port 7004 proto tcp": "",
     grep_config_cli: user_rules_with_port_7000
 }
 
@@ -168,6 +172,60 @@ class TestUFW(unittest.TestCase):
         })
         result = self.__getResult(do_nothing_func_port_7000)
         self.assertFalse(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_direction_in(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7003',
+            'direction': 'in',
+            'interface': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_direction_in_with_ip(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'from_ip': '1.1.1.1',
+            'from_port': '7002',
+            'to_ip': '8.8.8.8',
+            'to_port': '7003',
+            'direction': 'in',
+            'interface': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_direction_out(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'port': '7004',
+            'direction': 'out',
+            'interface': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
+
+    def test_check_mode_add_direction_out_with_ip(self):
+        set_module_args({
+            'rule': 'allow',
+            'proto': 'tcp',
+            'from_ip': '1.1.1.1',
+            'from_port': '7003',
+            'to_ip': '8.8.8.8',
+            'to_port': '7004',
+            'direction': 'out',
+            'interface': 'foo',
+            '_ansible_check_mode': True
+        })
+        result = self.__getResult(do_nothing_func_port_7000)
+        self.assertTrue(result.exception.args[0]['changed'])
 
     def test_check_mode_delete_existing_rules(self):
 


### PR DESCRIPTION
##### SUMMARY

The UFW module has support for specifying `direction` and `interface`
for UFW rules.  Rules with these parameters are built such that
per-interface filtering only apply to a single direction based on the
value of `direction`.

Not being able to specify multiple interfaces complicates things for
`routed` rules where one might want to apply filtering only for a
specific combination of `in` and `out` interfaces.

This commit introduces two new parameters to the UFW module:
`interface_in` and `interface_out`.  These rules are mutually exclusive
with the old `direction` and `interface` parameter because of the
ambiguity of having e.g.:

    direction: XXX
    interface: foo
    interface_XXX: bar

Fixes #63903


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/ufw.py

##### ADDITIONAL INFORMATION