### PR TITLE
Fix: Homebrew module's some functions ignored check_mode option

### DIFF
--- a/changelogs/fragments/65387-homebrew_check_mode_option.yml
+++ b/changelogs/fragments/65387-homebrew_check_mode_option.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - homebrew - fix Homebrew module's some functions ignored check_mode option (https://github.com/ansible/ansible/pull/65387).

--- a/lib/ansible/modules/packaging/os/homebrew.py
+++ b/lib/ansible/modules/packaging/os/homebrew.py
@@ -500,6 +500,11 @@ class Homebrew(object):
 
     # updated -------------------------------- {{{
     def _update_homebrew(self):
+        if self.module.check_mode:
+            self.changed = True
+            self.message = 'Homebrew would be updated.'
+            raise HomebrewException(self.message)
+
         rc, out, err = self.module.run_command([
             self.brew_path,
             'update',
@@ -526,6 +531,11 @@ class Homebrew(object):
 
     # _upgrade_all --------------------------- {{{
     def _upgrade_all(self):
+        if self.module.check_mode:
+            self.changed = True
+            self.message = 'Homebrew packages would be upgraded.'
+            raise HomebrewException(self.message)
+
         rc, out, err = self.module.run_command([
             self.brew_path,
             'upgrade',

--- a/lib/ansible/modules/packaging/os/homebrew.py
+++ b/lib/ansible/modules/packaging/os/homebrew.py
@@ -504,7 +504,6 @@ class Homebrew(object):
             self.changed = True
             self.message = 'Homebrew would be updated.'
             raise HomebrewException(self.message)
-
         rc, out, err = self.module.run_command([
             self.brew_path,
             'update',
@@ -535,7 +534,6 @@ class Homebrew(object):
             self.changed = True
             self.message = 'Homebrew packages would be upgraded.'
             raise HomebrewException(self.message)
-
         rc, out, err = self.module.run_command([
             self.brew_path,
             'upgrade',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fixes #65352 
  - In the `homebrew` module, following functions ignore check_mode option.
    - update_homebrew
    - upgrade_all
  - Even if check_mode is enabled, Homebrew and Formulae are actually updated.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Homebrew module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- I was referring to homebrew_cask module's function "_upgrade_all()".
- I wanted to include logic to determine if homebrew and packages will be actually updated or none(already newest version), but I couldn't...

<!--- Paste verbatim command output below, e.g. before and after your change -->
test.yml
```
---
- hosts: localhost
  tasks:
    - name: Update homebrew
      homebrew:
        update_homebrew: yes
      check_mode: true
    - name: Upgrade homebrew
      homebrew:
        upgrade_all: yes
      check_mode: true
```

```
$ ansible-playbook -C test.yml -vvv

(snip)
TASK [Update homebrew] *************************************************************************************************************************************
task path: /Users/Saori_/Works/ansible-contribute-test/test.yml:4
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: Saori_
<127.0.0.1> EXEC /bin/sh -c 'echo ~Saori_ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946 `" && echo ansible-tmp-1575112456.500833-201016108334946="` echo /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946 `" ) && sleep 0'
Using module file /Users/Saori_/Works/ansible-contribute-test/library/homebrew.py
<127.0.0.1> PUT /Users/Saori_/.ansible/tmp/ansible-local-84809deq96yg0/tmphlb7kf2t TO /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946/AnsiballZ_homebrew.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946/ /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946/AnsiballZ_homebrew.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/Users/Saori_/.anyenv/envs/pyenv/versions/3.7.3/bin/python3.7 /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946/AnsiballZ_homebrew.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /Users/Saori_/.ansible/tmp/ansible-tmp-1575112456.500833-201016108334946/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "install_options": [],
            "name": null,
            "path": "/usr/local/bin",
            "state": "present",
            "update_homebrew": true,
            "upgrade_all": false
        }
    },
    "msg": "Homebrew would be updated."
}

TASK [Upgrade homebrew] ************************************************************************************************************************************
task path: /Users/Saori_/Works/ansible-contribute-test/test.yml:7
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: Saori_
<127.0.0.1> EXEC /bin/sh -c 'echo ~Saori_ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978 `" && echo ansible-tmp-1575112457.484122-231437873409978="` echo /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978 `" ) && sleep 0'
Using module file /Users/Saori_/Works/ansible-contribute-test/library/homebrew.py
<127.0.0.1> PUT /Users/Saori_/.ansible/tmp/ansible-local-84809deq96yg0/tmp2qwafv9u TO /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978/AnsiballZ_homebrew.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978/ /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978/AnsiballZ_homebrew.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/Users/Saori_/.anyenv/envs/pyenv/versions/3.7.3/bin/python3.7 /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978/AnsiballZ_homebrew.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /Users/Saori_/.ansible/tmp/ansible-tmp-1575112457.484122-231437873409978/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "install_options": [],
            "name": null,
            "path": "/usr/local/bin",
            "state": "present",
            "update_homebrew": false,
            "upgrade_all": true
        }
    },
    "msg": "Homebrew packages would be upgraded."
}
META: ran handlers
META: ran handlers

```