### PR TITLE
Zabbix: zabbix_host: fix #65304

### DIFF
--- a/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
+++ b/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - fixed inventory_mode key error, which occurs with Zabbix 4.4.1 or more (https://github.com/ansible/ansible/issues/65304).

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -680,6 +680,34 @@
       that:
           - "zabbix_host1 is not changed"
 
+- name: "test: change host inventory mode to disabled"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    inventory_mode: disabled
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: change host inventory mode to manual"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    inventory_mode: manual
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
 - name: "test: attempt to delete host created earlier"
   zabbix_host:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
##### SUMMARY
Since the position of the `inventory_mode` key has changed from zabbix 4.4.1, use `LooseVersion` to separate the processing.
Fixes https://github.com/ansible/ansible/issues/65304

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ADDITIONAL INFORMATION
tested on zabbix 3.0,3.2,3.4,4.0,4.2,4.4
