### PR TITLE
[service] Apply default arguments to service action before removing unused ones

### DIFF
--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -62,7 +62,8 @@ class ActionModule(ActionBase):
 
             if module != 'auto':
                 # run the 'service' module
-                new_module_args = self._task.args.copy()
+                # get defaults for specific module
+                new_module_args = get_action_args_with_defaults(module, self._task.args, self._task.module_defaults, self._templar)
                 if 'use' in new_module_args:
                     del new_module_args['use']
 
@@ -71,9 +72,6 @@ class ActionModule(ActionBase):
                         if unused in new_module_args:
                             del new_module_args[unused]
                             self._display.warning('Ignoring "%s" as it is not used in "%s"' % (unused, module))
-
-                # get defaults for specific module
-                new_module_args = get_action_args_with_defaults(module, new_module_args, self._task.module_defaults, self._templar)
 
                 self._display.vvvv("Running %s" % module)
                 result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If some of the unused arguments (like "use" for service module) are
present as default arguments for the module then module would fail
because of unknown parameters.
This is the case for "use" parameter for "service" module - if default
service manager is defined using "use" for "service" module then "use"
argument will be passed to "service" module and module will fail.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Set default value for `use` in `module_defaults` in Playbook for `service` module.
2. Use `service` module in Playbook.
3. `use` parameter is incorrectly passed down to `service` module which causes following error:
```
fatal: [host]: FAILED! => changed=false 
  msg: 'Unsupported parameters for (service) module: use Supported parameters include: arguments, enabled, name, pattern, runlevel, sleep, state'
```

After this change is merged, default arguments will be applied to task arguments before removal of unused arguments (and `use`). 

<!--- Paste verbatim command output below, e.g. before and after your change -->
Minimal example which shows use-case when the issue occurs:
```
- name: Example Play.
  hosts: all
  become: yes
  module_defaults:
    service:
      use: 'openrc'
  tasks:
    - name: Change service state.
      service:
        name: lvmetad
        enabled: yes
        runlevel: default
```

I've tested the changes using my local playbooks against v2.9.0 Ansible version. Version in this PR has been rebased onto `devel` branch (without conflicts).