### PR TITLE
postgresql_publication: use query params with cursor object

### DIFF
--- a/changelogs/fragments/65404-postgresql_publication_user_query_params_with_cursor.yml
+++ b/changelogs/fragments/65404-postgresql_publication_user_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_publication - use query params arg with cursor object (https://github.com/ansible/ansible/issues/65404).

--- a/lib/ansible/modules/database/postgresql/postgresql_publication.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_publication.py
@@ -431,15 +431,15 @@ class PgPublication():
                      "p.pubupdate , p.pubdelete, p.pubtruncate FROM pg_publication AS p "
                      "JOIN pg_catalog.pg_roles AS r "
                      "ON p.pubowner = r.oid "
-                     "WHERE p.pubname = '%s'" % self.name)
+                     "WHERE p.pubname = %(pname)s")
         else:
             query = ("SELECT r.rolname AS pubowner, p.puballtables, p.pubinsert, "
                      "p.pubupdate , p.pubdelete FROM pg_publication AS p "
                      "JOIN pg_catalog.pg_roles AS r "
                      "ON p.pubowner = r.oid "
-                     "WHERE p.pubname = '%s'" % self.name)
+                     "WHERE p.pubname = %(pname)s")
 
-        result = exec_sql(self, query, add_to_executed=False)
+        result = exec_sql(self, query, query_params={'pname': self.name}, add_to_executed=False)
         if result:
             return result[0]
         else:
@@ -452,8 +452,8 @@ class PgPublication():
             List of dicts with published tables.
         """
         query = ("SELECT schemaname, tablename "
-                 "FROM pg_publication_tables WHERE pubname = '%s'" % self.name)
-        return exec_sql(self, query, add_to_executed=False)
+                 "FROM pg_publication_tables WHERE pubname = %(pname)s")
+        return exec_sql(self, query, query_params={'pname': self.name}, add_to_executed=False)
 
     def __pub_add_table(self, table, check_mode=False):
         """Add a table to the publication.

--- a/test/integration/targets/postgresql_publication/aliases
+++ b/test/integration/targets/postgresql_publication/aliases
@@ -1,3 +1,6 @@
 destructive
 shippable/posix/group4
 skip/osx
+skip/freebsd
+skip/opensuse
+skip/centos


### PR DESCRIPTION
##### SUMMARY
1. postgresql_publication: use query params with cursor object
2. skip several distributions by adding them to the alias file because they are extra

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_publication.py```
