### PR TITLE
[2.8] acme_certificate: Fix ACME v1 support when modify_account is set to false

### DIFF
--- a/changelogs/fragments/64648-acme_certificate-acmev1.yml
+++ b/changelogs/fragments/64648-acme_certificate-acmev1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "acme_certificate - fix misbehavior when ACME v1 is used with ``modify_account`` set to ``false``."

--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -511,9 +511,6 @@ class ACMEClient(object):
         Return the authorization object of the new authorization
         https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-6.4
         '''
-        if self.account.uri is None:
-            return
-
         new_authz = {
             "resource": "new-authz",
             "identifier": {"type": identifier_type, "value": identifier},


### PR DESCRIPTION
##### SUMMARY
Backport of #64648 to stable-2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
acme_certificate
