### PR TITLE
VMware: Updated module compatibility with vsphere version.

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
@@ -19,7 +19,9 @@ module: vmware_content_deploy_template
 short_description: Deploy Virtual Machine from template stored in content library.
 description:
 - Module to deploy virtual machine from template in content library.
-- Content Library feature is introduced in vSphere 6.0 version, so this module is not supported in the earlier versions of vSphere.
+- Content Library feature is introduced in vSphere 6.0 version.
+- vmtx templates feature is introduced in vSphere 67U1 and APIs for clone template from content library in 67U2.
+- This module does not work with vSphere version older than 67U2.
 - All variables and VMware object names are case sensitive.
 version_added: '2.9'
 author:


### PR DESCRIPTION
##### SUMMARY
Updated module compatibility with vsphere version. 
Answers query in issue https://github.com/ansible/ansible/issues/65244

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_content_deploy_template.py

##### ADDITIONAL INFORMATION
Content Library feature is introduced in vSphere 6.0 version.
Vmtx teamplates feature is introduced in vSphere 67U1 and APIs for clone template from content library in 67U2.This module doesnt work with vsphere version older than 67U2.

Existing version supported version was confusing the user.
