### PR TITLE
throttle: fix linear based strategies

### DIFF
--- a/changelogs/fragments/65422-fix-throttle-with-linear-strategy.yml
+++ b/changelogs/fragments/65422-fix-throttle-with-linear-strategy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "throttle: the linear strategy didn't always stuck with the throttle limit"

--- a/test/integration/targets/throttle/group_vars/all.yml
+++ b/test/integration/targets/throttle/group_vars/all.yml
@@ -1,0 +1,4 @@
+---
+throttledir: '{{ base_throttledir }}/{{ subdir }}'
+base_throttledir: "{{ lookup('env', 'OUTPUT_DIR') }}/throttle.dir"
+subdir: "{{ test_id if lookup('env', 'SELECTED_STRATEGY') in ['free', 'host_pinned'] else '' }}"

--- a/test/integration/targets/throttle/runme.sh
+++ b/test/integration/targets/throttle/runme.sh
@@ -3,5 +3,5 @@
 set -eux
 
 # https://github.com/ansible/ansible/pull/42528
-ANSIBLE_STRATEGY='linear' ansible-playbook test_throttle.yml -vv -i inventory --forks 12 "$@"
-ANSIBLE_STRATEGY='free' ansible-playbook test_throttle.yml -vv -i inventory --forks 12 "$@"
+SELECTED_STRATEGY='linear' ansible-playbook test_throttle.yml -vv -i inventory --forks 12 "$@"
+SELECTED_STRATEGY='free' ansible-playbook test_throttle.yml -vv -i inventory --forks 12 "$@"

--- a/test/integration/targets/throttle/test_throttle.py
+++ b/test/integration/targets/throttle/test_throttle.py
@@ -24,6 +24,7 @@ try:
     if len(throttlelist) > max_throttle:
         print(throttlelist)
         raise ValueError("Too many concurrent tasks: %d/%d" % (len(throttlelist), max_throttle))
+    time.sleep(1.5)
 finally:
     # remove the file, then wait to make sure it's gone
     os.unlink(throttlefile)

--- a/test/integration/targets/throttle/test_throttle.yml
+++ b/test/integration/targets/throttle/test_throttle.yml
@@ -1,59 +1,84 @@
 ---
 - hosts: localhosts
   gather_facts: false
-  vars:
-    throttledir: "{{ lookup('env', 'OUTPUT_DIR') }}/throttle.dir/"
+  strategy: linear
+  run_once: yes
   tasks:
-    - name: Clean throttledir '{{ throttledir }}'
+    - name: Clean base throttledir '{{ base_throttledir }}'
       file:
         state: absent
-        path: '{{ throttledir }}'
+        path: '{{ base_throttledir }}'
       ignore_errors: yes
-      run_once: yes
+
     - name: Create throttledir '{{ throttledir }}'
       file:
         state: directory
         path: '{{ throttledir }}'
-      run_once: yes
+      loop: "{{ range(1, test_count|int)|list }}"
+      loop_control:
+        loop_var: test_id
+      vars:
+        test_count: "{{ 9 if lookup('env', 'SELECTED_STRATEGY') in ['free', 'host_pinned'] else 2 }}"
+
+- hosts: localhosts
+  gather_facts: false
+  strategy: "{{ lookup('env', 'SELECTED_STRATEGY') }}"
+  tasks:
     - block:
       - name: "Test 1 (max throttle: 3)"
         script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 3"
+        vars:
+          test_id: 1
       throttle: 3
     - block:
       - name: "Test 2 (max throttle: 5)"
         script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 5"
         throttle: 5
+        vars:
+          test_id: 2
       - block:
         - name: "Test 3 (max throttle: 8)"
           script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 8"
           throttle: 8
         throttle: 6
+        vars:
+           test_id: 3
       - block:
         - block:
           - name: "Test 4 (max throttle: 8)"
             script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 8"
             throttle: 8
+            vars:
+              test_id: 4
           throttle: 6
         throttle: 12
       throttle: 15
     - block:
-      - name: "Test 1 (max throttle: 3)"
+      - name: "Teat 5 (max throttle: 3)"
         script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 3"
+        vars:
+          test_id: 5
       throttle: 3
     - block:
-      - name: "Test 2 (max throttle: 5)"
+      - name: "Test 6 (max throttle: 5)"
         script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 5"
         throttle: 5
+        vars:
+          test_id: 6
       - block:
-        - name: "Test 3 (max throttle: 6)"
+        - name: "Test 7 (max throttle: 6)"
           script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 6"
           throttle: 6
+          vars:
+            test_id: 7
         throttle: 3
       - block:
         - block:
-          - name: "Test 4 (max throttle: 8)"
+          - name: "Test 8 (max throttle: 8)"
             script: "test_throttle.py {{throttledir}} {{inventory_hostname}} 8"
             throttle: 8
+            vars:
+              test_id: 8
           throttle: 6
         throttle: 4
       throttle: 2

--- a/test/units/plugins/strategy/test_strategy_base.py
+++ b/test/units/plugins/strategy/test_strategy_base.py
@@ -195,6 +195,7 @@ class TestStrategyBase(unittest.TestCase):
 
         mock_task = MagicMock()
         mock_task._uuid = 'abcd'
+        mock_task.throttle = 0
 
         try:
             strategy_base = StrategyBase(tqm=tqm)


### PR DESCRIPTION
##### SUMMARY

In some case, when using a linear based strategy, throttle isn't respected because the index of the current worker isn't reset once a task has been fully processed. 

Integration tests updated: they didn't detected this issue.

Thanks to @mscherer for his guidance in fixing this issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/linear.py

##### ADDITIONAL INFORMATION
First I push the commits with the tests updated, in order to demonstrate the issue. Once the CI results are available, I will push a fix proposal.

A reproducer:
* inventory
    ```ini
    [all]
    host1
    host2
    host3
    host4
    host5
    host6
    
    [all:vars]
    ansible_host=localhost
    ```
* playbook
    ```yaml
    - hosts: all
      gather_facts: no
      vars:
        ansible_python_interpreter: python3
      tasks:
        - debug:
          run_once: yes
    
        - shell: sleep 1
          throttle: 1
    ```
* run
    ```
    $ ansible-playbook -i hosts play.yml -v -c local 
    Using ansible.cfg as config file
    
    PLAY [all] ***
    
    TASK [debug] ***
    ok: [host1] => {
        "msg": "Hello world!"
    }
    
    TASK [shell] ***
    changed: [host2] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003406", "end": "2019-12-02 14:44:19.416303", "rc": 0, "start": "2019-12-02 14:44:18.412897", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [host1] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003300", "end": "2019-12-02 14:44:19.418906", "rc": 0, "start": "2019-12-02 14:44:18.415606", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [host3] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003267", "end": "2019-12-02 14:44:20.618891", "rc": 0, "start": "2019-12-02 14:44:19.615624", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [host4] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003613", "end": "2019-12-02 14:44:21.808557", "rc": 0, "start": "2019-12-02 14:44:20.804944", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [host5] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003710", "end": "2019-12-02 14:44:23.016357", "rc": 0, "start": "2019-12-02 14:44:22.012647", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    changed: [host6] => {"changed": true, "cmd": "sleep 1", "delta": "0:00:01.003721", "end": "2019-12-02 14:44:24.232574", "rc": 0, "start": "2019-12-02 14:44:23.228853", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
    ```
Task was executed in parallel on `host1`  and `host2`.