### PR TITLE
Fix examples to use from_yaml filter with lookup

### DIFF
--- a/lib/ansible/modules/clustering/k8s/k8s.py
+++ b/lib/ansible/modules/clustering/k8s/k8s.py
@@ -207,24 +207,24 @@ EXAMPLES = '''
     If the definition file has been encrypted with Ansible Vault it will automatically be decrypted.
   k8s:
     state: present
-    definition: "{{ lookup('file', '/testing/deployment.yml') }}"
+    definition: "{{ lookup('file', '/testing/deployment.yml') | from_yaml }}"
 
 - name: Read definition file from the Ansible controller file system after Jinja templating
   k8s:
     state: present
-    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+    definition: "{{ lookup('template', '/testing/deployment.yml') | from_yaml }}"
 
 - name: fail on validation errors
   k8s:
     state: present
-    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+    definition: "{{ lookup('template', '/testing/deployment.yml')  | from_yaml }}"
     validate:
       fail_on_error: yes
 
 - name: warn on validation errors, check for unexpected properties
   k8s:
     state: present
-    definition: "{{ lookup('template', '/testing/deployment.yml') }}"
+    definition: "{{ lookup('template', '/testing/deployment.yml') | from_yaml }}"
     validate:
       fail_on_error: no
       strict: yes


### PR DESCRIPTION
##### SUMMARY
The k8s documentation says to use `from_yaml` filter when using `lookup` from node executor but the examples do otherwise.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
+label: affecs_2.9
+label: affecs_2.10

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
module k8s

##### ADDITIONAL INFORMATION
apply to ansible devel branch and downward.
