### PR TITLE
EXOS: Change exos_lldp_interfaces supported_by to community

### DIFF
--- a/lib/ansible/modules/network/exos/exos_lldp_interfaces.py
+++ b/lib/ansible/modules/network/exos/exos_lldp_interfaces.py
@@ -31,7 +31,7 @@ __metaclass__ = type
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'status': ['preview'],
-    'supported_by': 'network'
+    'supported_by': 'community'
 }
 
 DOCUMENTATION = """


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Change `exos_lldp_interfaces` supported_by to `community` from `network`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
exos_lldp_interfaces.py