### PR TITLE
Fix RuntimeError in ec2_group_info

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -140,7 +140,7 @@ def main():
 
     # Replace filter key underscores with dashes, for compatibility, except if we're dealing with tags
     sanitized_filters = module.params.get("filters")
-    for key in sanitized_filters:
+    for key in list(sanitized_filters):
         if not key.startswith("tag:"):
             sanitized_filters[key.replace("_", "-")] = sanitized_filters.pop(key)
 


### PR DESCRIPTION
Modifying dictionary while iterating over it

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use list function to get keys from dictionary to iterate over when mapping the the filter names
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_group_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
