### PR TITLE
openssl_csr: make sure privatekey_path is specified when state is present

### DIFF
--- a/changelogs/fragments/65435-openssl_csr-privatekey_path-required.yml
+++ b/changelogs/fragments/65435-openssl_csr-privatekey_path-required.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_csr - the module will now enforce that ``privatekey_path`` is specified when ``state=present``."

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -48,8 +48,8 @@ options:
     privatekey_path:
         description:
             - The path to the private key to use when signing the certificate signing request.
+            - Required if I(state) is C(present).
         type: path
-        required: true
     privatekey_passphrase:
         description:
             - The passphrase for the private key.
@@ -1002,7 +1002,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'present']),
             digest=dict(type='str', default='sha256'),
-            privatekey_path=dict(type='path', require=True),
+            privatekey_path=dict(type='path'),
             privatekey_passphrase=dict(type='str', no_log=True),
             version=dict(type='int', default=1),
             force=dict(type='bool', default=False),
@@ -1035,6 +1035,7 @@ def main():
             select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'cryptography', 'pyopenssl']),
         ),
         required_together=[('authority_cert_issuer', 'authority_cert_serial_number')],
+        required_if=[('state', 'present', ['privatekey_path'])],
         add_file_common_args=True,
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY
Due to a typo (`require=True` instead of `required=True`), the `privatekey_path` option is currently **not** required for `openssl_csr`. Unfortunately, simply fixing that typo destroys some valid use-cases: for `state=absent`, it makes sense to not have `privatekey_path` specified.

For that reason I'm making the logic a bit more complicated: make `privatekey_path` required if `state` is `present`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
