### PR TITLE
ansible-galaxy - Add User-Agent to requests

### DIFF
--- a/changelogs/fragments/galaxy-collections.yaml
+++ b/changelogs/fragments/galaxy-collections.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Set ``User-Agent`` to Ansible version when interacting with Galaxy or Automation Hub

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -13,6 +13,7 @@ import time
 
 from ansible import context
 from ansible.errors import AnsibleError
+from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote as urlquote, urlencode, urlparse
@@ -184,7 +185,7 @@ class GalaxyAPI:
         try:
             display.vvvv("Calling Galaxy at %s" % url)
             resp = open_url(to_native(url), data=args, validate_certs=self.validate_certs, headers=headers,
-                            method=method, timeout=20)
+                            method=method, timeout=20, http_agent='ansible-galaxy/%s' % ansible_version)
         except HTTPError as e:
             raise GalaxyError(e, error_context_msg)
         except Exception as e:

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -33,6 +33,7 @@ from ansible.galaxy import get_collections_galaxy_meta_info
 from ansible.galaxy.api import CollectionVersionMetadata, GalaxyError
 from ansible.module_utils import six
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash, secure_hash_s
@@ -876,7 +877,7 @@ def _download_file(url, b_path, expected_hash, validate_certs, headers=None):
     display.vvv("Downloading %s to %s" % (url, to_text(b_path)))
     # Galaxy redirs downloads to S3 which reject the request if an Authorization header is attached so don't redir that
     resp = open_url(to_native(url, errors='surrogate_or_strict'), validate_certs=validate_certs, headers=headers,
-                    unredirected_headers=['Authorization'])
+                    unredirected_headers=['Authorization'], http_agent='ansible-galaxy/%s' % ansible_version)
 
     with open(b_file_path, 'wb') as download_file:
         data = resp.read(bufsize)


### PR DESCRIPTION
##### SUMMARY
When trying to install to talk to Automation Hub it is failing for all instances of `ansible-galaxy`. There seems to have been a change on the backend that now does not work with the generic `User-Agent` we send (`Python-urllib/<ver>`). This PR makes sure we set a `User-Agent` to `ansible-galaxy/<ansible ver>` to bypass this issue.

On the plus side it also allows us to see what Ansible clients are connecting to Galaxy and AH.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy