### PR TITLE
Cap requirements for network integration tests

### DIFF
--- a/test/integration/network-integration.requirements.txt
+++ b/test/integration/network-integration.requirements.txt
@@ -1,5 +1,4 @@
-pexpect # for _user test
-scp # for Cisco ios
-selectors2 # for ncclient
-ncclient # for Junos
-jxmlease # for Junos
+pexpect>=4.7.0 # ISC license
+scp>=0.13.2 # LGPL
+ncclient>=0.6.6 # Apache-2.0
+jxmlease>=1.0.1 # MIT

--- a/test/integration/network-integration.upper-constraints.txt
+++ b/test/integration/network-integration.upper-constraints.txt
@@ -1,0 +1,4 @@
+pexpect===4.7.0
+scp===0.13.2
+ncclient===0.6.6
+jxmlease===1.0.1


### PR DESCRIPTION
This commit adds a version for every requirement on the network
integration tests. On top of that it's also adding a constraints file
in order to avoid getting over cap per release.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>