### PR TITLE
apt target: use 'until' when the cache is updated

### DIFF
--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -4,6 +4,8 @@
 
 - name: install hello:{{ apt_foreign_arch }} with apt
   apt: pkg=hello:{{ apt_foreign_arch }} state=present update_cache=yes
+  register: apt_result
+  until: apt_result is success
 
 - name: uninstall hello:{{ apt_foreign_arch }} with apt
   apt: pkg=hello:{{ apt_foreign_arch }} state=absent purge=yes

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -88,6 +88,7 @@
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes
   register: apt_result
+  until: apt_result is success
 
 - name: check hello with dpkg
   shell: dpkg-query -l hello


### PR DESCRIPTION
##### SUMMARY

`apt` integration target can be unstable due to network/mirror issues ([example](https://app.shippable.com/github/ansible/ansible/runs/152248/73/console)), use until `keyword` in order to prevent these issues:

    TASK [apt : uninstall hello with apt] ***
    fatal: [testhost]: FAILED! => {
        "changed": false,
        "cmd": "apt-get update",
        "msg": "E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/source/Sources.gz File has unexpected size (354740 != 354745). Mirror sync in progress? [...]",
        "rc": 100,
        [...]

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/apt/tasks/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
