### PR TITLE
hostname - Add OpenSUSE Tumbleweed Linux distro

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -610,6 +610,12 @@ class OpenSUSELeapHostname(Hostname):
     strategy_class = SystemdStrategy
 
 
+class OpenSUSETumbleweedHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Opensuse-tumbleweed'
+    strategy_class = SystemdStrategy
+
+
 class AsteraHostname(Hostname):
     platform = 'Linux'
     distribution = '"astralinuxce"'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As done for other distros, let's also support OpenSUSE Tumbleweed (which is the OpenSUSE's rolling distro)
```
```
<!--- HINT: Include "Fixes #ngit@github.com:fidencio/ansible.gitnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hostname

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Using hostname module on OpenSUSE Tumbleweed results in the error shown below

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Configure hostname] **************************************************************************************************************
fatal: [libvirt-opensuse-tumbleweed]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Opensuse-tumbleweed)"}
```