### PR TITLE
ufw: report changed even if ufw disabled (#65443)

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -491,20 +491,21 @@ def main():
         elif command == 'default':
             if params['direction'] not in ['outgoing', 'incoming', 'routed', None]:
                 module.fail_json(msg='For default, direction must be one of "outgoing", "incoming" and "routed", or direction must not be specified.')
-            if module.check_mode:
-                regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'
-                extract = re.search(regexp, pre_state)
-                if extract is not None:
-                    current_default_values = {}
-                    current_default_values["incoming"] = extract.group(1)
-                    current_default_values["outgoing"] = extract.group(2)
-                    current_default_values["routed"] = extract.group(3)
-                    v = current_default_values[params['direction'] or 'incoming']
-                    if v not in (value, 'disabled'):
-                        changed = True
-                else:
+
+            regexp = r'Default: (deny|allow|reject) \(incoming\), (deny|allow|reject) \(outgoing\), (deny|allow|reject|disabled) \(routed\)'
+            extract = re.search(regexp, pre_state)
+            if extract:
+                current_default_values = {}
+                current_default_values["incoming"] = extract.group(1)
+                current_default_values["outgoing"] = extract.group(2)
+                current_default_values["routed"] = extract.group(3)
+                v = current_default_values[params['direction'] or 'incoming']
+                if v not in (value, 'disabled'):
                     changed = True
             else:
+                changed = True
+
+            if not module.check_mode:
                 execute(cmd + [[command], [value], [params['direction']]])
 
         elif command == 'rule':


### PR DESCRIPTION
##### SUMMARY

The `ufw` module currently relies on the output returned by `ufw status
verbose` to determine whether changes have been made.

When `ufw` is disabled (i.e., `ENABLED=no` in `/etc/ufw/ufw.conf`), however, this is not possible to determine:

```
  $ sudo ufw status verbose
  Status: inactive
```

The result of this is that tasks which *do* effect changes are falsely reported as "`ok`", not "`changed`". With this change (which is mostly just re-arranging the existing code), we simply set "`changed = True`" ourselves -- as is currently done in the "`command == 'logging'`" case.

This fixes #65443, "ufw: Policy is changed; Ansible reports "ok" (not "changed"). An example showing the incorrectly reported status is included there.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ufw.py`

##### ADDITIONAL INFORMATION

See issue #65443 for background information.