### PR TITLE
avoid an uncaught FIPS-related import-time exception

### DIFF
--- a/lib/ansible/module_utils/compat/paramiko.py
+++ b/lib/ansible/module_utils/compat/paramiko.py
@@ -9,6 +9,24 @@ PARAMIKO_IMPORT_ERR = None
 
 paramiko = None
 try:
+    # if paramiko *is* installed, it attempts to generate an x25519 key at
+    # import time; this isn't supported on platforms where FIPS is enabled
+    # this code exists to properly detect FIPS-enablement on certain RHEL
+    # platforms so that ansible-playbook can run
+    #
+    # related: https://github.com/pyca/cryptography/pull/5024
+    from cryptography.hazmat.backends.openssl.backend import Backend
+    def _x25519_supported(self):
+        fips_mode = getattr(self._lib, "FIPS_mode", lambda: 0)
+        mode = fips_mode()
+        if mode:
+            return False
+        if mode == 0:
+            # OpenSSL without FIPS pushes an error on the error stack
+            self._lib.ERR_clear_error()
+        return self._lib.CRYPTOGRAPHY_OPENSSL_110_OR_GREATER
+    Backend.x25519_supported = _x25519_supported
+
     import paramiko
 except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
     PARAMIKO_IMPORT_ERR = err


### PR DESCRIPTION
- install ansible *and* paramiko
- enable FIPS mode
- run ansible-playbook
- kaboom

primarily adapted from an open upstream cryptography PR:
https://github.com/pyca/cryptography/pull/5024/files#diff-29b17fd6522fb7c1388d06f421d77734R155

```
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 92, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/usr/lib/python3.6/site-packages/ansible/cli/playbook.py", line 15, in <module>
    from ansible.executor.playbook_executor import PlaybookExecutor
  File "/usr/lib/python3.6/site-packages/ansible/executor/playbook_executor.py", line 26, in <module>
    from ansible.executor.task_queue_manager import TaskQueueManager
  File "/usr/lib/python3.6/site-packages/ansible/executor/task_queue_manager.py", line 34, in <module>
    from ansible.playbook.play_context import PlayContext
  File "/usr/lib/python3.6/site-packages/ansible/playbook/play_context.py", line 31, in <module>
    from ansible.module_utils.compat.paramiko import paramiko
  File "/usr/lib/python3.6/site-packages/ansible/module_utils/compat/paramiko.py", line 12, in <module>
    import paramiko
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/paramiko/__init__.py", line 22, in <module>
    from paramiko.transport import SecurityOptions, Transport
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/paramiko/transport.py", line 129, in <module>
    class Transport(threading.Thread, ClosingContextManager):
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/paramiko/transport.py", line 190, in Transport
    if KexCurve25519.is_available():
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/paramiko/kex_curve25519.py", line 30, in is_available
    X25519PrivateKey.generate()
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/cryptography/hazmat/primitives/asymmetric/x25519.py", line 44, in generate
    return backend.x25519_generate_key()
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 2173, in x25519_generate_key
    evp_pkey = self._evp_pkey_keygen_gc(self._lib.NID_X25519)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 2161, in _evp_pkey_keygen_gc
    self.openssl_assert(evp_pkey_ctx != self._ffi.NULL)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 125, in openssl_assert
    return binding._openssl_assert(self._lib, ok)
  File "/var/lib/awx/venv/ansible/lib/python3.6/site-packages/cryptography/hazmat/bindings/openssl/binding.py", line 78, in _openssl_assert
    errors_with_text
cryptography.exceptions.InternalError: Unknown OpenSSL error. This error is commonly encountered when another library is not cleaning up the OpenSSL error stack. If you are using cryptography with another library that uses OpenSSL try disabling it before reporting a bug. Otherwise please file an issue at https://github.com/pyca/cryptography/issues with information on how to reproduce this. ([_OpenSSLErrorWithText(code=101306568, lib=6, func=157, reason=200, reason_text=b'error:0609D0C8:digital envelope routines:int_ctx_new:disabled for FIPS')])```