### PR TITLE
[2.8] openssl_csr: make sure privatekey_path is specified when state is present

### DIFF
--- a/changelogs/fragments/65435-openssl_csr-privatekey_path-required.yml
+++ b/changelogs/fragments/65435-openssl_csr-privatekey_path-required.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_csr - the module will now enforce that ``privatekey_path`` is specified when ``state=present``."

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -44,8 +44,8 @@ options:
     privatekey_path:
         description:
             - The path to the private key to use when signing the certificate signing request.
+            - Required if I(state) is C(present).
         type: path
-        required: true
     privatekey_passphrase:
         description:
             - The passphrase for the private key.
@@ -851,7 +851,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'present']),
             digest=dict(type='str', default='sha256'),
-            privatekey_path=dict(type='path', require=True),
+            privatekey_path=dict(type='path'),
             privatekey_passphrase=dict(type='str', no_log=True),
             version=dict(type='int', default=1),
             force=dict(type='bool', default=False),
@@ -878,6 +878,7 @@ def main():
             backup=dict(type='bool', default=False),
             select_crypto_backend=dict(type='str', default='auto', choices=['auto', 'cryptography', 'pyopenssl']),
         ),
+        required_if=[('state', 'present', ['privatekey_path'])],
         add_file_common_args=True,
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY
Backport of #65435 to stable-2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_csr
