### PR TITLE
Remove openssl_csr sanity ignore.txt entry:

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1739,7 +1739,6 @@ lib/ansible/modules/crypto/acme/acme_account_info.py validate-modules:return-syn
 lib/ansible/modules/crypto/entrust/ecs_domain.py validate-modules:doc-required-mismatch
 lib/ansible/modules/crypto/openssh_cert.py validate-modules:doc-required-mismatch
 lib/ansible/modules/crypto/openssl_certificate.py validate-modules:doc-required-mismatch
-lib/ansible/modules/crypto/openssl_csr.py validate-modules:doc-required-mismatch
 lib/ansible/modules/crypto/openssl_publickey.py validate-modules:doc-required-mismatch
 lib/ansible/modules/database/influxdb/influxdb_database.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/database/influxdb/influxdb_database.py validate-modules:parameter-type-not-in-doc


### PR DESCRIPTION
> test/sanity/ignore.txt:1711:1: A100: Ignoring 'doc-required-mismatch' on 'lib/ansible/modules/crypto/openssl_csr.py' is unnecessary

##### SUMMARY

Tests (with ignore.txt entry) landed after fixup.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
test/sanity/ignore.txt


##### ADDITIONAL INFORMATION

See also #65437