### PR TITLE
AWS NLB: Deprecate current default behaviour of 'absent'

### DIFF
--- a/changelogs/fragments/56468-deprecate-lnb-absent.yml
+++ b/changelogs/fragments/56468-deprecate-lnb-absent.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- 'elb_network_lb: The current default value of the `state` option has been deprecated and will change from absent to present in Ansible 2.14'

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -78,6 +78,7 @@ The following functionality will change in Ansible 2.14. Please update update yo
 * The :ref:`docker_container <docker_container_module>` module's ``network_mode`` option will be set by default to the name of the first network in ``networks`` if at least one network is given and ``networks_cli_compatible`` is ``true`` (will be default from Ansible 2.12 on). Set to an explicit value to avoid deprecation warnings if you specify networks and set ``networks_cli_compatible`` to ``true``. The current default (not specifying it) is equivalent to the value ``default``.
 * :ref:`iam_policy <iam_policy_module>`: the default value for the ``skip_duplicates`` option will change from ``true`` to ``false``.  To maintain the existing behavior explicitly set it to ``true``.
 * :ref:`iam_role <iam_role_module>`: the ``purge_policies`` option (also know as ``purge_policy``) default value will change from ``true`` to ``false``
+* :ref:`elb_network_lb <elb_network_lb_module>`: the default behaviour for the ``state`` option will change from ``absent`` to ``present``.  To maintain the existing behavior explicitly set state to ``absent``.
 
 
 The following modules will be removed in Ansible 2.14. Please update your playbooks accordingly.

--- a/lib/ansible/modules/cloud/amazon/elb_network_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_network_lb.py
@@ -110,6 +110,9 @@ options:
   state:
     description:
       - Create or destroy the load balancer.
+      - The current default is C(absent).  However, this behavior is inconsistent with other modules
+        and as such the default will change to C(present) in 2.14.
+        To maintain the existing behavior explicitly set I(state=absent).
     choices: [ 'present', 'absent' ]
     type: str
   tags:
@@ -435,6 +438,12 @@ def main():
     if state == 'present':
         if module.params.get("subnets") is None and module.params.get("subnet_mappings") is None:
             module.fail_json(msg="'subnets' or 'subnet_mappings' is required when state=present")
+
+    if state is None:
+        # See below, unless state==present we delete.  Ouch.
+        module.deprecate('State currently defaults to absent.  This is inconsistent with other modules'
+                         ' and the default will be changed to `present` in Ansible 2.14',
+                         version='2.14')
 
     # Quick check of listeners parameters
     listeners = module.params.get("listeners")


### PR DESCRIPTION
##### SUMMARY

The current default behaviour for NLBs is to *delete* the NLB if no state is defined.  This is inconsistent with other modules.  Deprecate the current behaviour and prep for a default of 'present' once we hit 2.14

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/elb_network_lb.py

##### ADDITIONAL INFORMATION

