### PR TITLE
Remove timeout from nxos_rollback tests

### DIFF
--- a/test/integration/targets/nxos_config/tests/common/save.yaml
+++ b/test/integration/targets/nxos_config/tests/common/save.yaml
@@ -17,7 +17,6 @@
 - name: save config
   nxos_config:
     save_when: always
-    timeout: 300
     provider: "{{ connection }}"
   register: result
 
@@ -28,7 +27,6 @@
 - name: save should always run
   nxos_config:
     save_when: always
-    timeout: 300
     provider: "{{ connection }}"
   register: result
 

--- a/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_linkagg/tests/common/sanity.yaml
@@ -200,6 +200,5 @@
     feature: lacp
     provider: "{{ connection }}"
     state: disabled
-    timeout: 60
 
 - debug: msg="END connection={{ ansible_connection }} nxos_linkagg sanity test"

--- a/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_rollback/tests/common/sanity.yaml
@@ -16,13 +16,11 @@
   nxos_rollback:
     checkpoint_file: backup.cfg
     provider: "{{ connection }}"
-    timeout: 300
 
 - name: rollback to the previously created checkpoint file
   nxos_rollback:
     rollback_to: backup.cfg
     provider: "{{ connection }}"
-    timeout: 300
 
 - name: cleanup checkpoint file
   nxos_config: *delete


### PR DESCRIPTION
This fixes the following:

  Unsupported parameters for (nxos_rollback) module: timeout unsupported

Signed-off-by: Paul Belanger <pabelanger@redhat.com>