### PR TITLE
k8s: persist refreshed tokens (#63219)

### DIFF
--- a/changelogs/fragments/65473-k8s-persist-refreshed-tokens.yaml
+++ b/changelogs/fragments/65473-k8s-persist-refreshed-tokens.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - k8s modules - Option to save refreshed tokens to kube config file.

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -123,6 +123,9 @@ AUTH_ARG_SPEC = {
         'aliases': ['key_file'],
     },
     'proxy': {},
+    'persist_config': {
+        'type': 'bool',
+    },
 }
 
 # Map kubernetes-client parameters to ansible parameters
@@ -138,6 +141,7 @@ AUTH_ARG_MAP = {
     'cert_file': 'client_cert',
     'key_file': 'client_key',
     'proxy': 'proxy',
+    'persist_config': 'persist_config',
 }
 
 
@@ -179,13 +183,13 @@ class K8sAnsibleMixin(object):
             # We have enough in the parameters to authenticate, no need to load incluster or kubeconfig
             pass
         elif auth_set('kubeconfig') or auth_set('context'):
-            kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
+            kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'), persist_config=auth.get('persist_config'))
         else:
             # First try to do incluster config, then kubeconfig
             try:
                 kubernetes.config.load_incluster_config()
             except kubernetes.config.ConfigException:
-                kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
+                kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'), persist_config=auth.get('persist_config'))
 
         # Override any values in the default configuration with Ansible parameters
         configuration = kubernetes.client.Configuration()

--- a/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
+++ b/lib/ansible/plugins/doc_fragments/k8s_auth_options.py
@@ -72,6 +72,19 @@ options:
     - The URL of an HTTP proxy to use for the connection. Can also be specified via K8S_AUTH_PROXY environment variable.
     - Please note that this module does not pick up typical proxy settings from the environment (e.g. HTTP_PROXY).
     version_added: "2.9"
+  persist_config:
+    description:
+    - Whether or not to save the kube config refresh tokens.
+      Can also be specified via K8S_AUTH_PERSIST_CONFIG environment variable.
+    - When the k8s context is using a user credentials with refresh tokens (like oidc or gke/gcloud auth),
+      the token is refreshed by the k8s python client library but not saved by default. So the old refresh token can
+      expire and the next auth might fail. Setting this flag to true will tell the k8s python client to save the
+      new refresh token to the kube config file.
+    - Default to false.
+    - Please note that the current version of the k8s python client library does not support setting this flag to True yet.
+    - "The fix for this k8s python library is here: https://github.com/kubernetes-client/python-base/pull/169"
+    type: bool
+    version_added: "2.10"
 notes:
   - "The OpenShift Python client wraps the K8s Python client, providing full access to
     all of the APIS and models available on both platforms. For API version details and


### PR DESCRIPTION
When the ansible k8s module is refreshing the tokens from the local kube
config, it should save those token to the kube config file.

If this is not done, this might break the next kube client call as the
token in the local kube config file is not valid anymore and refreshing
can fail.

This commit is adding an env var K8S_AUTH_PERSIST_CONFIG that can be
used to set this flag to true (default is false, same as current
behavior).

Backport of https://github.com/ansible/ansible/pull/63219

(cherry picked from commit 49b457016e3e8254627e1d742b4efe5c86050407)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

