### PR TITLE
Handle InternalError raised by cryptography when running in FIPS mode

### DIFF
--- a/changelogs/fragments/fips-paramiko-import-error.yaml
+++ b/changelogs/fragments/fips-paramiko-import-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko - catch and handle ``cryptography.exceptions.InternalError`` to prevent stack trace when running on RHEL 8 in FIPS mode

--- a/changelogs/fragments/fips-paramiko-import-error.yaml
+++ b/changelogs/fragments/fips-paramiko-import-error.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - paramiko - catch and handle ``cryptography.exceptions.InternalError`` to prevent stack trace when running on RHEL 8 in FIPS mode
+  - paramiko - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/lib/ansible/module_utils/compat/paramiko.py
+++ b/lib/ansible/module_utils/compat/paramiko.py
@@ -5,8 +5,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from cryptography.exceptions import InternalError
-
 PARAMIKO_IMPORT_ERR = None
 
 paramiko = None
@@ -15,5 +13,5 @@ try:
 # paramiko and gssapi are incompatible and raise AttributeError not ImportError
 # When running in FIPS mode, cryptography raises InternalError
 # https://bugzilla.redhat.com/show_bug.cgi?id=1778939
-except (ImportError, AttributeError, InternalError) as err:  
+except (ImportError, AttributeError, Exception) as err:
     PARAMIKO_IMPORT_ERR = err

--- a/lib/ansible/module_utils/compat/paramiko.py
+++ b/lib/ansible/module_utils/compat/paramiko.py
@@ -13,5 +13,5 @@ try:
 # paramiko and gssapi are incompatible and raise AttributeError not ImportError
 # When running in FIPS mode, cryptography raises InternalError
 # https://bugzilla.redhat.com/show_bug.cgi?id=1778939
-except (ImportError, AttributeError, Exception) as err:
+except Exception as err:
     PARAMIKO_IMPORT_ERR = err

--- a/lib/ansible/module_utils/compat/paramiko.py
+++ b/lib/ansible/module_utils/compat/paramiko.py
@@ -5,10 +5,15 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from cryptography.exceptions import InternalError
+
 PARAMIKO_IMPORT_ERR = None
 
 paramiko = None
 try:
     import paramiko
-except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# When running in FIPS mode, cryptography raises InternalError
+# https://bugzilla.redhat.com/show_bug.cgi?id=1778939
+except (ImportError, AttributeError, InternalError) as err:  
     PARAMIKO_IMPORT_ERR = err


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #65459

There is a bug in the logic in `cryptography` that assumes the presence of an algorithm based on the `openssl` version.

Research from @wenottingham:

>TL;DR: the mere presence of paramiko in the ansible venv causes ansible to explode on startup, due to:

>ansible: see if paramiko is available if we need it
>ansible: import paramiko
>paramiko: check for key algorithms
>paramiko: is x25519 available?
>paramiko: let's generate a key to find out
>cryptography: is x25519 available?
>cryptography: well, your openssl is new enough, so I guess so
>cryptography: ok, generating a key
>openssl: HA HA HA DISABLED BY FIPS kaboom


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/compat/paramiko.py`
##### ADDITIONAL INFORMATION
I'm not sure about how to add tests for this.