### PR TITLE
Fix ansible-galaxy man page generation

### DIFF
--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -48,7 +48,7 @@ ACTIONS
 -------
 {% for action in actions %}
 **{{ action }}**
-  {{ (actions[action]['desc']|default(' '))}}
+  {{ (actions[action]['desc']|default(' ')) |replace('\n', ' ')}}
 
 {% if actions[action]['options'] %}
 {% for option in actions[action]['options']|sort(attribute='options') %}


### PR DESCRIPTION
The Action list was misformatted, leading to an error message in the man
page.

https://bugzilla.redhat.com/show_bug.cgi?id=1717110

#
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
/cc @acozine
