### PR TITLE
WIP: Update cloud integration tests to use python3.8

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -136,55 +136,55 @@ matrix:
     - env: T=linux/ubuntu1804/4
 
     - env: T=aws/2.7/1
-    - env: T=aws/3.6/1
+    - env: T=aws/3.8/1
 
     - env: T=aws/2.7/2
-    - env: T=aws/3.6/2
+    - env: T=aws/3.8/2
 
     - env: T=azure/2.7/1
-    - env: T=azure/3.6/1
+    - env: T=azure/3.8/1
 
     - env: T=azure/2.7/2
-    - env: T=azure/3.6/2
+    - env: T=azure/3.8/2
 
     - env: T=azure/2.7/3
-    - env: T=azure/3.6/3
+    - env: T=azure/3.8/3
 
     - env: T=azure/2.7/4
-    - env: T=azure/3.6/4
+    - env: T=azure/3.8/4
 
     - env: T=azure/2.7/5
-    - env: T=azure/3.6/5
+    - env: T=azure/3.8/5
 
     - env: T=azure/2.7/6
-    - env: T=azure/3.6/6
+    - env: T=azure/3.8/6
 
     - env: T=azure/2.7/7
-    - env: T=azure/3.6/7
+    - env: T=azure/3.8/7
 
     - env: T=azure/2.7/8
-    - env: T=azure/3.6/8
+    - env: T=azure/3.8/8
 
     - env: T=azure/2.7/9
-    - env: T=azure/3.6/9
+    - env: T=azure/3.8/9
 
     - env: T=azure/2.7/10
-    - env: T=azure/3.6/10
+    - env: T=azure/3.8/10
 
     - env: T=vcenter/2.7/1
-    - env: T=vcenter/3.6/1
+    - env: T=vcenter/3.8/1
 
     - env: T=cs/2.7/1
-    - env: T=cs/3.6/1
+    - env: T=cs/3.8/1
 
     - env: T=tower/2.7/1
     - env: T=tower/3.6/1
 
     - env: T=cloud/2.7/1
-    - env: T=cloud/3.6/1
+    - env: T=cloud/3.8/1
 
     - env: T=hcloud/2.7/1
-    - env: T=hcloud/3.6/1
+    - env: T=hcloud/3.8/1
 branches:
   except:
     - "*-patch-*"

--- a/shippable.yml
+++ b/shippable.yml
@@ -181,7 +181,7 @@ matrix:
     - env: T=tower/3.6/1
 
     - env: T=cloud/2.7/1
-    - env: T=cloud/3.8/1
+    - env: T=cloud/3.6/1
 
     - env: T=hcloud/2.7/1
     - env: T=hcloud/3.8/1


### PR DESCRIPTION
##### SUMMARY
We should be able to run the cloud tests on python3.8, try it out.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
shippable.yml

##### ADDITIONAL INFORMATION
#65024 A potentially python3.8 specific bug is found in `ec2_instance`, we should be testing the latest python.