### PR TITLE
Throw an error on unsupported vars_prompt keys

### DIFF
--- a/changelogs/fragments/vars_prompt_error_on_unsupported_key.yaml
+++ b/changelogs/fragments/vars_prompt_error_on_unsupported_key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- vars_prompt - throw error when encountering unsupported key

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -211,9 +211,11 @@ class Play(Base, Taggable, CollectionSearch):
         if new_ds is not None:
             for prompt_data in new_ds:
                 if 'name' not in prompt_data:
-                    raise AnsibleParserError("Invalid vars_prompt data structure", obj=ds)
-                else:
-                    vars_prompts.append(prompt_data)
+                    raise AnsibleParserError("Invalid vars_prompt data structure, missing 'name' key", obj=ds)
+                for key in prompt_data:
+                    if key not in ('name', 'prompt', 'default', 'private', 'confirm', 'encrypt', 'salt_size', 'salt', 'unsafe'):
+                        raise AnsibleParserError("Invalid vars_prompt data structure, found unsupported key '%s'" % key, obj=ds)
+                vars_prompts.append(prompt_data)
         return vars_prompts
 
     def _compile_roles(self):

--- a/test/integration/targets/vars_prompt/test-vars_prompt.py
+++ b/test/integration/targets/vars_prompt/test-vars_prompt.py
@@ -115,6 +115,12 @@ tests = [
      'test_spec': [
          [('prompting for variable:', '{{whole}}\r')],
          r'testhost.*ok=2']},
+
+    # Test unsupported keys
+    {'playbook': 'unsupported.yml',
+     'test_spec': [
+         [],
+         "Invalid vars_prompt data structure, found unsupported key 'when'"]},
 ]
 
 for t in tests:

--- a/test/integration/targets/vars_prompt/unsupported.yml
+++ b/test/integration/targets/vars_prompt/unsupported.yml
@@ -1,0 +1,18 @@
+- name: Test vars_prompt unsupported key
+  hosts: testhost
+  become: no
+  gather_facts: no
+  vars_prompt:
+    - name: input
+      prompt: prompting for variable
+      # Unsupported key for vars_prompt
+      when: foo is defined
+
+  tasks:
+    - name:
+      assert:
+        that:
+          - input is not defined
+
+    - debug:
+        var: input


### PR DESCRIPTION
##### SUMMARY
Ansible would previously silently ignore unsupported keys in vars_prompt, which is confusing to the user.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vars_prompt

##### ADDITIONAL INFORMATION
N/A