### PR TITLE
win_dns_client - only configure ip enabled adapters

### DIFF
--- a/changelogs/fragments/win_dns_client-ipenabled.yaml
+++ b/changelogs/fragments/win_dns_client-ipenabled.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dns_client - Only configure network adapters that are IP Enabled - https://github.com/ansible/ansible/issues/58958


### PR DESCRIPTION
##### SUMMARY
We can only set the DNS servers on IP enabled network adapters. This PR makes sure we error out on adapters that are not IP enabled if explicitly specified and we don't include them when `adapter_names: '*'` is set.

It also tries to simplify the get config process by getting the DNS server info as well as the interface index in 1 step instead of being done in multiple locations. This cleans the code up a bit by centralising the get operation in 1 place as well as improves the performance by reducing the number of WMI calls being made.

Fixes https://github.com/ansible/ansible/issues/58958
Supersedes https://github.com/ansible/ansible/pull/59466

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dns_client