### PR TITLE
Fix iosxr netconf plugin get device info

### DIFF
--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -55,22 +55,24 @@ class Netconf(NetconfBase):
         ])
 
         install_filter = build_xml('install', install_meta, opcode='filter')
+        try:
+            reply = self.get(install_filter)
+            resp = remove_namespaces(re.sub('<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
+            ele_boot_variable = etree_find(resp, 'boot-variable/boot-variable')
+            if ele_boot_variable is not None:
+                device_info['network_os_image'] = re.split('[:|,]', ele_boot_variable.text)[1]
+            ele_package_name = etree_find(reply, 'package-name')
+            if ele_package_name is not None:
+                device_info['network_os_package'] = ele_package_name.text
+                device_info['network_os_version'] = re.split('-', ele_package_name.text)[-1]
 
-        reply = self.get(install_filter)
-        ele_boot_variable = etree_find(reply, 'boot-variable/boot-variable')
-        if ele_boot_variable is not None:
-            device_info['network_os_image'] = re.split('[:|,]', ele_boot_variable.text)[1]
-        ele_package_name = etree_find(reply, 'package-name')
-        if ele_package_name is not None:
-            device_info['network_os_package'] = ele_package_name.text
-            device_info['network_os_version'] = re.split('-', ele_package_name.text)[-1]
-
-        hostname_filter = build_xml('host-names', opcode='filter')
-
-        reply = self.get(hostname_filter)
-        hostname_ele = etree_find(reply, 'host-name')
-        device_info['network_os_hostname'] = hostname_ele.text if hostname_ele is not None else None
-
+            hostname_filter = build_xml('host-names', opcode='filter')
+            reply = self.get(hostname_filter)
+            resp = remove_namespaces(re.sub('<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
+            hostname_ele = etree_find(resp.strip(), 'host-name')
+            device_info['network_os_hostname'] = hostname_ele.text if hostname_ele is not None else None
+        except Exception as exc:
+            self._connection.queue_message('vvvv', 'Fail to retrieve device info %s' % exc)
         return device_info
 
     def get_capabilities(self):

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -57,7 +57,7 @@ class Netconf(NetconfBase):
         install_filter = build_xml('install', install_meta, opcode='filter')
         try:
             reply = self.get(install_filter)
-            resp = remove_namespaces(re.sub('<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
+            resp = remove_namespaces(re.sub(r'<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
             ele_boot_variable = etree_find(resp, 'boot-variable/boot-variable')
             if ele_boot_variable is not None:
                 device_info['network_os_image'] = re.split('[:|,]', ele_boot_variable.text)[1]
@@ -68,7 +68,7 @@ class Netconf(NetconfBase):
 
             hostname_filter = build_xml('host-names', opcode='filter')
             reply = self.get(hostname_filter)
-            resp = remove_namespaces(re.sub('<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
+            resp = remove_namespaces(re.sub(r'<\?xml version="1.0" encoding="UTF-8"\?>', '', reply))
             hostname_ele = etree_find(resp.strip(), 'host-name')
             device_info['network_os_hostname'] = hostname_ele.text if hostname_ele is not None else None
         except Exception as exc:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/64634

*  Catch exception if the xml payload to get
   device info is not valid for iosxr version
   running on remote host.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/plugins/netconf/iosxr.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
