### PR TITLE
Fix and reenable hcloud tests

### DIFF
--- a/test/integration/targets/hcloud_image_info/aliases
+++ b/test/integration/targets/hcloud_image_info/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_image_info/defaults/main.yml
+++ b/test/integration/targets/hcloud_image_info/defaults/main.yml
@@ -3,4 +3,4 @@
 ---
 hcloud_prefix: "tests"
 hcloud_test_image_name: "always-there-snapshot"
-hcloud_test_image_id: 3439221
+hcloud_test_image_id: 10164049

--- a/test/integration/targets/hcloud_rdns/aliases
+++ b/test/integration/targets/hcloud_rdns/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some of our tests were disabled within #65485. This PR fixes and reenables them. We switched the project where the tests run yesterday and missed to add the static SSH key which is used by the tests. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- hcloud_image_info
- hcloud_rdns
- hcloud_server

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
