### PR TITLE
[stable-2.7] Ensure `allow_duplicates: true` enables to run single role multiple times (#64902)

### DIFF
--- a/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
+++ b/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - "roles - Ensure that ``allow_duplidates: true`` enables to run single
+    role multiple times (https://github.com/ansible/ansible/issues/64902)"

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -196,11 +196,9 @@ class Play(Base, Taggable, Become):
         for ri in role_includes:
             roles.append(Role.load(ri, play=self))
 
-        return self._extend_value(
-            self.roles,
-            roles,
-            prepend=True
-        )
+        self.roles[:0] = roles
+
+        return self.roles
 
     def _load_vars_prompt(self, attr, ds):
         new_ds = preprocess_vars(ds)

--- a/test/integration/targets/include_import/roles/dup_allowed_role/meta/main.yml
+++ b/test/integration/targets/include_import/roles/dup_allowed_role/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/test/integration/targets/include_import/roles/dup_allowed_role/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/dup_allowed_role/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- debug:
+    msg: "Tasks file inside role"

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -83,3 +83,7 @@ test "$(grep -c '"item=foo"' test_include_dupe_loop.out)" = 3
 ansible-playbook public_exposure/playbook.yml -i inventory "$@"
 ansible-playbook public_exposure/no_bleeding.yml -i inventory "$@"
 ansible-playbook public_exposure/no_overwrite_roles.yml -i inventory "$@"
+
+# https://github.com/ansible/ansible/issues/64902
+ansible-playbook tasks/test_allow_single_role_dup.yml 2>&1 | tee test_allow_single_role_dup.out
+test "$(grep -c 'ok=3' test_allow_single_role_dup.out)" = 1

--- a/test/integration/targets/include_import/tasks/test_allow_single_role_dup.yml
+++ b/test/integration/targets/include_import/tasks/test_allow_single_role_dup.yml
@@ -1,0 +1,8 @@
+---
+- name: test for allow_duplicates with single role
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - dup_allowed_role
+    - dup_allowed_role
+    - dup_allowed_role


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport of #65063 to stable-2.7

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
allow_duplicate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
None
```
