### PR TITLE
VMware: Fix state parameter in vmware_host_lockdown module

### DIFF
--- a/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
+++ b/changelogs/fragments/vmware_host_lockdown_typo_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Correct datatype for state in vmware_host_lockdown module.

--- a/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
@@ -198,7 +198,7 @@ def main():
     argument_spec.update(
         cluster_name=dict(type='str', required=False),
         esxi_hostname=dict(type='list', required=False),
-        state=dict(str='str', default='present', choices=['present', 'absent'], required=False),
+        state=dict(type='str', default='present', choices=['present', 'absent'], required=False),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY

Changed 'str' to 'type' in Argument_spec which is valid parameter.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/vmware_host_lockdown_typo_fix.yml
lib/ansible/modules/cloud/vmware/vmware_host_lockdown.py
