### PR TITLE
mysql_db: add the executed_commands returned value

### DIFF
--- a/changelogs/fragments/65498-mysql_db_add_executed_commands_return_val.yml
+++ b/changelogs/fragments/65498-mysql_db_add_executed_commands_return_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``executed_commands`` returned value (https://github.com/ansible/ansible/pull/65498).

--- a/test/integration/targets/mysql_db/tasks/main.yml
+++ b/test/integration/targets/mysql_db/tasks/main.yml
@@ -38,8 +38,9 @@
 - name: assert output message that database exist
   assert:
     that:
-       - "result.changed == true"
-       - "result.db =='{{ db_name }}'"
+       - result is changed
+       - result.db == '{{ db_name }}'
+       - result.executed_commands == ["CREATE DATABASE `{{ db_name }}`"]
 
 - name: run command to test state=present for a database name (expect db_name in stdout)
   command: mysql "-e show databases like '{{ db_name }}';"
@@ -59,8 +60,9 @@
 - name: assert output message that database does not exist
   assert:
     that:
-       - "result.changed == true"
-       - "result.db =='{{ db_name }}'"
+       - result is changed
+       - result.db == '{{ db_name }}'
+       - result.executed_commands == ["DROP DATABASE `{{ db_name }}`"]
 
 - name: run command to test state=absent for a database name (expect db_name not in stdout)
   command: mysql "-e show databases like '{{ db_name }}';"
@@ -96,7 +98,10 @@
   register: result
 
 - name: assert output message created a database
-  assert: { that: "result.changed == true" }
+  assert:
+    that:
+    - result is changed
+    - result.executed_commands == ["CREATE DATABASE `en{{ db_name }}` CHARACTER SET 'utf8'"]
 
 - name: test database was created
   command: mysql "-e SHOW CREATE DATABASE en{{ db_name }};"
@@ -121,7 +126,10 @@
   register: result
 
 - name: assert output message that database was created
-  assert: { that: "result.changed == true" }
+  assert:
+    that:
+    - result is changed
+    - result.executed_commands == ["CREATE DATABASE `en{{ db_name }}` CHARACTER SET 'binary'"]
 
 - name: run command to test database was created
   command: mysql "-e SHOW CREATE DATABASE en{{ db_name }};"
@@ -228,7 +236,10 @@
   ignore_errors: true
 
 - name: assert output message that database was deleted using user1
-  assert: { that: "result.changed == true" }
+  assert:
+    that:
+    - result is changed
+    - result.executed_commands == ["DROP DATABASE `{{ db_user1 }}`"]
 
 - name: run command to test database was deleted using user1
   command: mysql "-e show databases like '{{ db_name }}';"


### PR DESCRIPTION
##### SUMMARY
mysql_db: add the executed_commands returned value

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_db.py```

##### EXAMPLES
```
    "executed_commands": [
        "CREATE DATABASE `endata` CHARACTER SET 'utf8'"
    ]
```
```
    "executed_commands": [
        "/usr/bin/mysqldump --socket=/var/lib/mysql/mysql.sock --databases data --skip-lock-tables --quick --ignore-table=data.department > /tmp/dbdata.sql"
```
```
    "executed_commands": [
        "CREATE DATABASE `data`", 
        "/usr/bin/mysql --socket=/var/lib/mysql/mysql.sock --one-database data < /tmp/dbdata.sql"
    ],
```