### PR TITLE
Hide "[WARNING]: No inventory was parsed" message

### DIFF
--- a/changelogs/fragments/65499-no_inventory_parsed.yml
+++ b/changelogs/fragments/65499-no_inventory_parsed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add a new "INVENTORY_UNPARSED_WARNING" flag add to hide the "No inventory was parsed, only implicit localhost is available" warning

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -412,7 +412,7 @@ INVENTORY_UNPARSED_WARNING:
   ini:
   - {key: inventory_unparsed_warning, section: defaults}
   type: boolean
-  version_added: "2.10"
+  version_added: "2.14"
 DOC_FRAGMENT_PLUGIN_PATH:
   name: documentation fragment plugins path
   default: ~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -401,6 +401,18 @@ LOCALHOST_WARNING:
   - {key: localhost_warning, section: defaults}
   type: boolean
   version_added: "2.6"
+INVENTORY_UNPARSED_WARNING:
+  name: Warning when no inventory files can be parsed, resulting in an implicit inventory with only localhost
+  default: True
+  description:
+    - By default Ansible will issue a warning when no inventory was loaded and notes that
+      it will use an implicit localhost-only inventory.
+    - These warnings can be silenced by adjusting this setting to False.
+  env: [{name: ANSIBLE_INVENTORY_UNPARSED_WARNING}]
+  ini:
+  - {key: inventory_unparsed_warning, section: defaults}
+  type: boolean
+  version_added: "2.10"
 DOC_FRAGMENT_PLUGIN_PATH:
   name: documentation fragment plugins path
   default: ~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -229,7 +229,7 @@ class InventoryManager(object):
         else:
             if C.INVENTORY_UNPARSED_IS_FAILED:
                 raise AnsibleError("No inventory was parsed, please check your configuration and options.")
-            else:
+            elif C.INVENTORY_UNPARSED_WARNING:
                 display.warning("No inventory was parsed, only implicit localhost is available")
 
         for group in self.groups.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Similar to (and inspired by) #37871 this PR allows you to silence this message: `[WARNING]: No inventory was parsed, only implicit localhost is available`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/inventory/manager.py

##### ADDITIONAL INFORMATION
By adding this environment/config value, simple localhost-only targetting playbooks won't have warning messages. For example:

`IMPLICIT_LOCALHOST_WARNING=false ansible-playbook test.yml`