### PR TITLE
Allow template import to create groups

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -544,6 +544,9 @@ class Template(object):
                 'updateExisting': True,
                 'deleteMissing': True
             },
+            'groups': {
+                'createMissing': True
+            },
             'httptests': {
                 'createMissing': True,
                 'updateExisting': True,


### PR DESCRIPTION
##### SUMMARY
Template importing only works if the groups already exist, or are explicitly specified with `template_groups`.
This is inconvenient, as it is not possible to manage groups directly in the template files.
Zabbix API allows specifying [`groups`](https://www.zabbix.com/documentation/4.0/manual/api/reference/configuration/import#parameters) parameter, which creates groups, as specified in the template itself.

This pull request enables that parameter.

Successfully tested with Zabbix 4.0.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template