### PR TITLE
Backport 2.9: Fix legacy facts keys having redundant underscore (#65167)

### DIFF
--- a/changelogs/fragments/65167_fix_nxos_facts_rendering.yaml
+++ b/changelogs/fragments/65167_fix_nxos_facts_rendering.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix nxos_facts rendering of keys (https://github.com/ansible/ansible/pull/65167) 

--- a/lib/ansible/module_utils/network/nxos/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/nxos/facts/legacy/base.py
@@ -563,44 +563,44 @@ class Legacy(FactsBase):
             if isinstance(data, dict):
                 self.facts.update(self.transform_dict(data, self.VERSION_MAP))
             else:
-                self.facts['_hostname'] = self.parse_hostname(data)
-                self.facts['_os'] = self.parse_os(data)
-                self.facts['_platform'] = self.parse_platform(data)
+                self.facts['hostname'] = self.parse_hostname(data)
+                self.facts['os'] = self.parse_os(data)
+                self.facts['platform'] = self.parse_platform(data)
 
         data = self.run('show interface', output='json')
         if data:
             if isinstance(data, dict):
-                self.facts['_interfaces_list'] = self.parse_structured_interfaces(data)
+                self.facts['interfaces_list'] = self.parse_structured_interfaces(data)
             else:
-                self.facts['_interfaces_list'] = self.parse_interfaces(data)
+                self.facts['interfaces_list'] = self.parse_interfaces(data)
 
         data = self.run('show vlan brief', output='json')
         if data:
             if isinstance(data, dict):
-                self.facts['_vlan_list'] = self.parse_structured_vlans(data)
+                self.facts['vlan_list'] = self.parse_structured_vlans(data)
             else:
-                self.facts['_vlan_list'] = self.parse_vlans(data)
+                self.facts['vlan_list'] = self.parse_vlans(data)
 
         data = self.run('show module', output='json')
         if data:
             if isinstance(data, dict):
-                self.facts['_module'] = self.parse_structured_module(data)
+                self.facts['module'] = self.parse_structured_module(data)
             else:
-                self.facts['_module'] = self.parse_module(data)
+                self.facts['module'] = self.parse_module(data)
 
         data = self.run('show environment fan', output='json')
         if data:
             if isinstance(data, dict):
-                self.facts['_fan_info'] = self.parse_structured_fan_info(data)
+                self.facts['fan_info'] = self.parse_structured_fan_info(data)
             else:
-                self.facts['_fan_info'] = self.parse_fan_info(data)
+                self.facts['fan_info'] = self.parse_fan_info(data)
 
         data = self.run('show environment power', output='json')
         if data:
             if isinstance(data, dict):
-                self.facts['_power_supply_info'] = self.parse_structured_power_supply_info(data)
+                self.facts['power_supply_info'] = self.parse_structured_power_supply_info(data)
             else:
-                self.facts['_power_supply_info'] = self.parse_power_supply_info(data)
+                self.facts['power_supply_info'] = self.parse_power_supply_info(data)
 
     def parse_structured_interfaces(self, data):
         objects = list()


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 62c4ff817431cb45c6bbafa01b378ac526c50d2e)

Add changelog for nxos_facts fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fix nxos_facts rendering double underscores for some keys.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_facts.py
