### PR TITLE
vmware/test: set vmware/scenario/vcenter_only alias

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -1,3 +1,7 @@
+- fail:
+    msg: "No ESXi hosts defined. esxi_hosts is empty."
+  when: "esxi_hosts|length == 0"
+
 - name: Add ESXi Hosts to vCenter
   vmware_host:
     datacenter_name: '{{ dc1 }}'

--- a/test/integration/targets/vcenter_folder/aliases
+++ b/test/integration/targets/vcenter_folder/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vcenter_license/aliases
+++ b/test/integration/targets/vcenter_license/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_about_facts/aliases
+++ b/test/integration/targets/vmware_about_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_about_info/aliases
+++ b/test/integration/targets/vmware_about_info/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_cluster_drs/aliases
+++ b/test/integration/targets/vmware_cluster_drs/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_cluster_ha/aliases
+++ b/test/integration/targets/vmware_cluster_ha/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_cluster_vsan/aliases
+++ b/test/integration/targets/vmware_cluster_vsan/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_content_deploy_template/aliases
+++ b/test/integration/targets/vmware_content_deploy_template/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 unsupported
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_datastore_cluster/aliases
+++ b/test/integration/targets/vmware_datastore_cluster/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_group_facts/aliases
+++ b/test/integration/targets/vmware_drs_group_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_group_info/aliases
+++ b/test/integration/targets/vmware_drs_group_info/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_rule_info/aliases
+++ b/test/integration/targets/vmware_drs_rule_info/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvs_portgroup/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvs_portgroup_facts/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup_facts/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvs_portgroup_find/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup_find/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvs_portgroup_info/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup_info/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvswitch_nioc/aliases
+++ b/test/integration/targets/vmware_dvswitch_nioc/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvswitch_pvlans/aliases
+++ b/test/integration/targets/vmware_dvswitch_pvlans/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_dvswitch_uplink_pg/aliases
+++ b/test/integration/targets/vmware_dvswitch_uplink_pg/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_evc_mode/aliases
+++ b/test/integration/targets/vmware_evc_mode/aliases
@@ -1,2 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_export_ovf/aliases
+++ b/test/integration/targets/vmware_export_ovf/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_folder_info/aliases
+++ b/test/integration/targets/vmware_folder_info/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_acceptance/aliases
+++ b/test/integration/targets/vmware_host_acceptance/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_active_directory/aliases
+++ b/test/integration/targets/vmware_host_active_directory/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_auto_start/aliases
+++ b/test/integration/targets/vmware_host_auto_start/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 unsupported
 skip/python2.6
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_powerstate/aliases
+++ b/test/integration/targets/vmware_host_powerstate/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_inventory/aliases
+++ b/test/integration/targets/vmware_inventory/aliases
@@ -4,3 +4,4 @@ destructive
 needs/file/contrib/inventory/vmware_inventory.py
 needs/file/contrib/inventory/vmware_inventory.ini
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_local_role_manager/aliases
+++ b/test/integration/targets/vmware_local_role_manager/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_local_user_manager/aliases
+++ b/test/integration/targets/vmware_local_user_manager/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_resource_pool_facts/aliases
+++ b/test/integration/targets/vmware_resource_pool_facts/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_resource_pool_info/aliases
+++ b/test/integration/targets/vmware_resource_pool_info/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_tag/aliases
+++ b/test/integration/targets/vmware_tag/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
 unsupported
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_vcenter_settings/aliases
+++ b/test/integration/targets/vmware_vcenter_settings/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_vcenter_statistics/aliases
+++ b/test/integration/targets/vmware_vcenter_statistics/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_vsan_health_info/aliases
+++ b/test/integration/targets/vmware_vsan_health_info/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 unsupported
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only


### PR DESCRIPTION
##### SUMMARY

Add the `vmware/scenario/vcenter_only` alias to be able to identify the
vmware test roles that can be tested with just on vcenter instance.

Also, add a check to be sure we don't try to attach ESXi hosts if none
has been defined.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware
<!--- Write the short name of the module, plugin, task or feature below -->