### PR TITLE
[stable-2.8] Disable failing hcloud tests.

### DIFF
--- a/test/integration/targets/hcloud_image_facts/aliases
+++ b/test/integration/targets/hcloud_image_facts/aliases
@@ -1,2 +1,3 @@
 cloud/hcloud
 shippable/hcloud/group1
+disabled


### PR DESCRIPTION
##### SUMMARY
[stable-2.8] Disable failing hcloud tests.

Backport of https://github.com/ansible/ansible/pull/65485

(cherry picked from commit 85722c360fd56d3627c0853353d25300989860a6)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hcloud integration tests:

- hcloud_image_facts
