### PR TITLE
pulp_repo: adjust version_added after backport was merged

### DIFF
--- a/lib/ansible/modules/packaging/os/pulp_repo.py
+++ b/lib/ansible/modules/packaging/os/pulp_repo.py
@@ -56,7 +56,7 @@ options:
     type: str
     aliases: [ importer_ssl_ca_cert, ca_cert ]
   feed_client_cert:
-    version_added: "2.10"
+    version_added: "2.9.2"
     description:
       - Certificate used as the client certificate when synchronizing the
         repository. This is used to communicate authentication information to
@@ -69,7 +69,7 @@ options:
     type: str
     aliases: [ importer_ssl_client_cert ]
   feed_client_key:
-    version_added: "2.10"
+    version_added: "2.9.2"
     description:
       - Private key to the certificate specified in I(importer_ssl_client_cert),
         assuming it is not included in the certificate file itself. This can be
@@ -574,12 +574,12 @@ def main():
         importer_ssl_client_cert = module.params['client_cert']
         module.deprecate("To specify client certificates to be used with the repo to sync, and not for communication with the "
                          "Pulp instance, use the new options `feed_client_cert` and `feed_client_key` (available since "
-                         "Ansible 2.10). Until Ansible 2.14, the default value for `feed_client_cert` will be taken from "
+                         "Ansible 2.9.2). Until Ansible 2.14, the default value for `feed_client_cert` will be taken from "
                          "`client_cert` if only the latter is specified", version="2.14")
     importer_ssl_client_key = module.params['feed_client_key']
     if importer_ssl_client_key is None and module.params['client_key'] is not None:
         importer_ssl_client_key = module.params['client_key']
-        module.deprecate("In Ansible 2.10 `feed_client_key` option was added. Until 2.14 the default value will come from client_key option", version="2.14")
+        module.deprecate("In Ansible 2.9.2 `feed_client_key` option was added. Until 2.14 the default value will come from client_key option", version="2.14")
     proxy_host = module.params['proxy_host']
     proxy_port = module.params['proxy_port']
     proxy_username = module.params['proxy_username']


### PR DESCRIPTION
##### SUMMARY
Adjust the `version_added`s to mention 2.9.2 instead of 2.10, as #65014 has been merged to `stable-2.9` for release in Ansible 2.9.2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pulp_repo
