### PR TITLE
Fix ec2 filter dict iteration for python3.8

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1393,7 +1393,7 @@ def find_instances(ec2, ids=None, filters=None):
     elif filters is None:
         module.fail_json(msg="No filters provided when they were required")
     elif filters is not None:
-        for key in filters.keys():
+        for key in list(filters.keys()):
             if not key.startswith("tag:"):
                 filters[key.replace("_", "-")] = filters.pop(key)
         return list(paginator.paginate(

--- a/lib/ansible/modules/cloud/amazon/ec2_vol_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol_info.py
@@ -108,7 +108,7 @@ def list_ec2_volumes(connection, module, region):
 
     # Replace filter key underscores with dashes, for compatibility, except if we're dealing with tags
     sanitized_filters = module.params.get("filters")
-    for key in sanitized_filters:
+    for key in list(sanitized_filters):
         if not key.startswith("tag:"):
             sanitized_filters[key.replace("_", "-")] = sanitized_filters.pop(key)
     volume_dict_array = []


### PR DESCRIPTION
##### SUMMARY
Python now throws a RuntimeError if dict keys are modified mid-iteration.
https://bugs.python.org/issue36452
Cast filter dicts to list before iteration.

Fixes #65024
Related #65434

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol_info
ec2_instance

##### ADDITIONAL INFORMATION
Integration tests run locally against python2.7, 3.6, 3.7, and 3.8.