### PR TITLE
Fix ansible-galaxy man page generation (#65478)

### DIFF
--- a/docs/templates/man.j2
+++ b/docs/templates/man.j2
@@ -48,7 +48,7 @@ ACTIONS
 -------
 {% for action in actions %}
 **{{ action }}**
-  {{ (actions[action]['desc']|default(' '))}}
+  {{ (actions[action]['desc']|default(' ')) |replace('\n', ' ')}}
 
 {% if actions[action]['options'] %}
 {% for option in actions[action]['options']|sort(attribute='options') %}


### PR DESCRIPTION
The Action list was misformatted, leading to an error message in the man
page.

https://bugzilla.redhat.com/show_bug.cgi?id=1717110
(cherry picked from commit 9973121f44ec25abbf8c7c0f91dd98a127d0d071)

##### SUMMARY
Backport of #65478

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
See https://bugzilla.redhat.com/show_bug.cgi?id=1717110
