### PR TITLE
Fix KeyError for missing password

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -337,15 +337,7 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
-    warnings = list()
-    if module.params['password'] and not module.params['configured_password']:
-        warnings.append(
-            'The "password" argument is used to authenticate the current connection. ' +
-            'To set a user password use "configured_password" instead.'
-        )
-
     result = {'changed': False}
-    result['warnings'] = warnings
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/test/integration/targets/nxos_user/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_user/tests/common/sanity.yaml
@@ -95,7 +95,7 @@
 
   - name: tearDown
     nxos_user: &tear
-      name: ansible
+      name: "{{ ansible_user }}"
       purge: yes
       provider: "{{ connection }}"
     register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix KeyError for password

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Traceback (most recent call last):
  File "/home/zuul/.ansible/tmp/ansible-local-18185o2i5gpv3/ansible-tmp-1575493126.9313893-235076820443659/AnsiballZ_nxos_user.py", line 116, in <module>
    _ansiballz_main()
  File "/home/zuul/.ansible/tmp/ansible-local-18185o2i5gpv3/ansible-tmp-1575493126.9313893-235076820443659/AnsiballZ_nxos_user.py", line 108, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/zuul/.ansible/tmp/ansible-local-18185o2i5gpv3/ansible-tmp-1575493126.9313893-235076820443659/AnsiballZ_nxos_user.py", line 54, in invoke_module
    runpy.run_module(mod_name='ansible.modules.network.nxos.nxos_user', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_nxos_user_payload_iv33p1sn/ansible_nxos_user_payload.zip/ansible/modules/network/nxos/nxos_user.py", line 379, in <module>
  File "/tmp/ansible_nxos_user_payload_iv33p1sn/ansible_nxos_user_payload.zip/ansible/modules/network/nxos/nxos_user.py", line 341, in main
KeyError: 'password'

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```