### PR TITLE
[stable-2.9] Fix plugin paths for ansible-test pylint test. (#65526)

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-plugin-paths.yml
+++ b/changelogs/fragments/ansible-test-pylint-plugin-paths.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now properly recognizes modules and module_utils in collections when using the ``blacklist`` plugin for the ``pylint`` sanity test

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/blacklist.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/blacklist.py
@@ -3,10 +3,15 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
+import os
+
 import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.interfaces import IAstroidChecker
+
+ANSIBLE_TEST_MODULES_PATH = os.environ['ANSIBLE_TEST_MODULES_PATH']
+ANSIBLE_TEST_MODULE_UTILS_PATH = os.environ['ANSIBLE_TEST_MODULE_UTILS_PATH']
 
 
 class BlacklistEntry:
@@ -50,7 +55,7 @@ def is_module_path(path):
     :type path: str
     :rtype: bool
     """
-    return '/lib/ansible/modules/' in path or '/lib/ansible/module_utils/' in path
+    return path.startswith(ANSIBLE_TEST_MODULES_PATH) or path.startswith(ANSIBLE_TEST_MODULE_UTILS_PATH)
 
 
 class AnsibleBlacklistChecker(BaseChecker):

--- a/test/lib/ansible_test/_internal/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/sanity/pylint.py
@@ -224,6 +224,9 @@ class PylintTest(SanitySingleVersion):
         env = ansible_environment(args)
         env['PYTHONPATH'] += os.path.pathsep + os.path.pathsep.join(append_python_path)
 
+        # expose plugin paths for use in custom plugins
+        env.update(dict(('ANSIBLE_TEST_%s_PATH' % k.upper(), os.path.abspath(v) + os.path.sep) for k, v in data_context().content.plugin_paths.items()))
+
         if paths:
             display.info('Checking %d file(s) in context "%s" with config: %s' % (len(paths), context, rcfile), verbosity=1)
 


### PR DESCRIPTION
##### SUMMARY

Fix plugin paths for ansible-test pylint test.

Backport of https://github.com/ansible/ansible/pull/65526

(cherry picked from commit fb69d68)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
