### PR TITLE
Fix tests which have unparsable yaml

### DIFF
--- a/test/integration/targets/ce_lldp_interface/tests/netconf/lldp_interface.yaml
+++ b/test/integration/targets/ce_lldp_interface/tests/netconf/lldp_interface.yaml
@@ -4,7 +4,7 @@
 
 - block:
   - name: Merge the provided configuration with the exisiting running configuration - basic-tlv
-    ce_lldp_interface: &merged
+    ce_lldp_interface: &merged1
       config:
         msg_interval: 8
         ifname: 10GE 1/0/1
@@ -17,7 +17,7 @@
           system_name: true
     register: result1
   - name: Merge the provided configuration with the existing running configuration (REPEAT)
-    ce_lldp_interface: *merged
+    ce_lldp_interface: *merged1
     register: result2
   - name: "Netconf get operation"
     ce_netconf:
@@ -53,7 +53,7 @@
         - "'<sysCapTxEnable>true</sysCapTxEnable>' in result3.endstate.result"
 
   - name: Merge the provided configuration with the exisiting running configuration - dot1-tlv
-    ce_lldp_interface: &merged
+    ce_lldp_interface: &merged2
       config:
         msg_interval: 8
         ifname: 10GE 1/0/1
@@ -66,7 +66,7 @@
           vlan_name_enable: true
     register: result1
   - name: Merge the provided configuration with the existing running configuration (REPEAT)
-    ce_lldp_interface: *merged
+    ce_lldp_interface: *merged2
     register: result2
   - name: "Netconf get operation"
     ce_netconf:

--- a/test/integration/targets/ce_static_route_bfd/tests/netconf/ce_static_route_bfd.yaml
+++ b/test/integration/targets/ce_static_route_bfd/tests/netconf/ce_static_route_bfd.yaml
@@ -3,7 +3,7 @@
     msg: "START ce_static_route_bfd presented integration tests on connection={{ ansible_connection }}"
 - include_tasks: cleanup.yaml
 - name: Config an ip route-static bfd 10GE1/0/1 3.3.3.3 min-rx-interval 50 min-tx-interval 50 detect-multiplier 5
-  ce_static_route_bfd: &merge
+  ce_static_route_bfd: &merge1
     function_flag: 'singleBFD'
     nhp_interface: 10GE1/0/1
     next_hop: 3.3.3.3
@@ -15,7 +15,7 @@
   register: result1
 - name: (repeat)Config an ip route-static bfd 10GE1/0/1 3.3.3.3 min-rx-interval 50 min-tx-interval 50 detect-multiplier 5
   ce_static_route_bfd:
-    <<: *merge
+    <<: *merge1
   register: result2
 
 - name: Assert the configuration is reflected on host
@@ -27,7 +27,7 @@
 
 # ip route-static bfd [ interface-type interface-number | vpn-instance vpn-instance-name ] nexthop-address
 - name: ip route-static bfd 10GE1/0/1 3.3.3.4
-  ce_static_route_bfd: &merge
+  ce_static_route_bfd: &merge2
     function_flag: 'singleBFD'
     nhp_interface: 10GE1/0/1
     next_hop: 3.3.3.4
@@ -35,7 +35,7 @@
   register: result1
 - name: (repeat)ip route-static bfd 10GE1/0/1 3.3.3.4
   ce_static_route_bfd:
-    <<: *merge
+    <<: *merge2
   register: result2
 - name: Assert the configuration is reflected on host
   assert:
@@ -44,7 +44,7 @@
       - "result2['changed'] == false"
 #ip route-static default-bfd { min-rx-interval {min-rx-interval} | min-tx-interval {min-tx-interval} | detect-multiplier {multiplier}}
 - name: Config an ip route-static default-bfd min-rx-interval 50 min-tx-interval 50 detect-multiplier 6
-  ce_static_route_bfd: &merge
+  ce_static_route_bfd: &merge3
     function_flag: 'globalBFD'
     min_tx_interval: 50
     min_rx_interval: 50
@@ -54,7 +54,7 @@
   register: result1
 - name: (repeat)Config an ip route-static default-bfd min-rx-interval 50 min-tx-interval 50 detect-multiplier 6
   ce_static_route_bfd:
-    <<: *merge
+    <<: *merge3
   register: result2
 - name: Assert the configuration is reflected on host
   assert:
@@ -63,7 +63,7 @@
       - "result2['changed'] == false"
 
 - name: undo ip route-static default-bfd
-  ce_static_route_bfd: &merge
+  ce_static_route_bfd: &merge4
     function_flag: 'globalBFD'
     aftype: v4
     state: absent
@@ -71,7 +71,7 @@
   register: result1
 - name: (repeat)undo ip route-static default-bfd
   ce_static_route_bfd:
-    <<: *merge
+    <<: *merge4
   register: result2
 - name: Assert the configuration is reflected on host
   assert:
@@ -80,7 +80,7 @@
       - "result2['changed'] == false"
 
 - name: Config an ipv4 static route 2.2.2.0/24 2.2.2.1 preference 1 tag 2 description test for staticBFD
-  ce_static_route_bfd: &merge
+  ce_static_route_bfd: &merge5
     function_flag: 'staticBFD'
     prefix: 2.2.2.2
     mask: 24
@@ -94,7 +94,7 @@
   register: result1
 - name: (repeat) Config an ipv4 static route 2.2.2.0/24 2.2.2.1 preference 1 tag 2 description test for staticBFD
   ce_static_route_bfd:
-    <<: *merge
+    <<: *merge5
   register: result2
 - name: Assert the configuration is reflected on host
   assert:

--- a/test/integration/targets/exos_command/tasks/main.yaml
+++ b/test/integration/targets/exos_command/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: httpapi.yaml, tags:['httpapi']}
+- {include: cli.yaml, tags: ['cli']}
+- {include: httpapi.yaml, tags: ['httpapi']}

--- a/test/integration/targets/exos_config/tasks/main.yaml
+++ b/test/integration/targets/exos_config/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: httpapi.yaml, tags:['httpapi']}
+- {include: cli.yaml, tags: ['cli']}
+- {include: httpapi.yaml, tags: ['httpapi']}

--- a/test/integration/targets/exos_facts/tasks/main.yaml
+++ b/test/integration/targets/exos_facts/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
-- { include: httpapi.yaml, tags:['httpapi']}
+- {include: cli.yaml, tags: ['cli']}
+- {include: httpapi.yaml, tags: ['httpapi']}


### PR DESCRIPTION
##### SUMMARY
Fix the yaml in integration test playbooks so that CSaffeLoader can load them

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
various integration tests

##### ADDITIONAL INFORMATION
A test for these conditions is present in: https://github.com/ansible/ansible/pull/65260

/cc @mattclay