### PR TITLE
Fix typo in a changelog fragment of #64902

### DIFF
--- a/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
+++ b/changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - "roles - Ensure that ``allow_duplidates: true`` enables to run single
+  - "roles - Ensure that ``allow_duplicates: true`` enables to run single
     role multiple times (https://github.com/ansible/ansible/issues/64902)"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix typo in a changelog fragment

But I submitted backport PRs (#65492, #65493) which are in review . 
Should I do cherry-pick this commit and push it to the backport PRs again?

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
changelogs/fragments/64902-fix-allow-duplicates-in-single-role.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
None
```
