### PR TITLE
[2.9] Fixed argument spec for multiple modules

### DIFF
--- a/changelogs/fragments/spec_fix.yml
+++ b/changelogs/fragments/spec_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fixed typos in various modules regarding argument_spec data types.

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -633,7 +633,7 @@ def main():
         on_create_failure=dict(default=None, required=False, choices=['DO_NOTHING', 'ROLLBACK', 'DELETE']),
         create_timeout=dict(default=None, type='int'),
         template_url=dict(default=None, required=False),
-        template_body=dict(default=None, require=False),
+        template_body=dict(default=None, required=False),
         template_format=dict(default=None, choices=['json', 'yaml'], required=False),
         create_changeset=dict(default=False, type='bool'),
         changeset_name=dict(default=None, required=False),

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -474,7 +474,7 @@ def main():
                                 'dw2.large', 'dw2.8xlarge'], required=False),
         username=dict(required=False),
         password=dict(no_log=True, required=False),
-        db_name=dict(require=False),
+        db_name=dict(required=False),
         cluster_type=dict(choices=['multi-node', 'single-node'], default='single-node'),
         cluster_security_groups=dict(aliases=['security_groups'], type='list'),
         vpc_security_group_ids=dict(aliases=['vpc_security_groups'], type='list'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permission_info.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permission_info.py
@@ -121,7 +121,7 @@ def _permissions_service(connection, module):
 def main():
     argument_spec = ovirt_info_full_argument_spec(
         authz_name=dict(required=True, aliases=['domain']),
-        user_name=dict(rdefault=None),
+        user_name=dict(default=None),
         group_name=dict(default=None),
         namespace=dict(default=None),
     )

--- a/lib/ansible/modules/database/aerospike/aerospike_migrations.py
+++ b/lib/ansible/modules/database/aerospike/aerospike_migrations.py
@@ -193,7 +193,7 @@ def run_module():
         connect_timeout=dict(type='int', required=False, default=1000),
         consecutive_good_checks=dict(type='int', required=False, default=3),
         sleep_between_checks=dict(type='int', required=False, default=60),
-        tries_limit=dict(type='int', requires=False, default=300),
+        tries_limit=dict(type='int', required=False, default=300),
         local_only=dict(type='bool', required=True),
         min_cluster_size=dict(type='int', required=False, default=1),
         target_cluster_size=dict(type='int', required=False, default=None),

--- a/lib/ansible/modules/monitoring/librato_annotation.py
+++ b/lib/ansible/modules/monitoring/librato_annotation.py
@@ -152,7 +152,7 @@ def main():
             source=dict(required=False),
             description=dict(required=False),
             start_time=dict(required=False, default=None, type='int'),
-            end_time=dict(require=False, default=None, type='int'),
+            end_time=dict(required=False, default=None, type='int'),
             links=dict(type='list')
         )
     )

--- a/lib/ansible/modules/monitoring/logicmonitor_facts.py
+++ b/lib/ansible/modules/monitoring/logicmonitor_facts.py
@@ -549,7 +549,7 @@ def main():
             user=dict(required=True, default=None),
             password=dict(required=True, default=None, no_log=True),
 
-            collector=dict(require=False, default=None),
+            collector=dict(required=False, default=None),
             hostname=dict(required=False, default=None),
             displayname=dict(required=False, default=None),
             fullpath=dict(required=False, default=None)

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -190,8 +190,8 @@ def main():
         argument_spec=dict(
             name=dict(required=False),
             service_id=dict(required=True),
-            service_key=dict(require=False),
-            integration_key=dict(require=False),
+            service_key=dict(required=False),
+            integration_key=dict(required=False),
             api_key=dict(required=True),
             state=dict(required=True,
                        choices=['triggered', 'acknowledged', 'resolved']),

--- a/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
@@ -293,7 +293,7 @@ def main():
     argument_spec.update(
         leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
         access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
-        description=dict(typ='str'),
+        description=dict(type='str'),
         leaf_port_blk=dict(type='str', aliases=['leaf_port_blk_name']),
         leaf_port_blk_description=dict(type='str'),
         from_port=dict(type='str', aliases=['from', 'fromPort', 'from_port_range']),

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -236,7 +236,7 @@ def main():
         filter=dict(type='str', aliases=['filter_name']),  # Not required for querying all objects
         subject=dict(type='str', aliases=['contract_subject', 'subject_name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
-        log=dict(tyep='str', choices=['log', 'none'], aliases=['directive']),
+        log=dict(type='str', choices=['log', 'none'], aliases=['directive']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
     )
 

--- a/lib/ansible/modules/network/icx/icx_logging.py
+++ b/lib/ansible/modules/network/icx/icx_logging.py
@@ -508,7 +508,7 @@ def main():
                 'notifications',
                 'warnings']),
         facility=dict(
-            typr='str',
+            type='str',
             choices=[
                 'auth',
                 'cron',

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
@@ -294,7 +294,7 @@ def main():
         expression=dict(type='dict'),
         options=dict(type='dict'),
         enabled=dict(type='bool'),
-        state=dict(require=False, default='present',
+        state=dict(required=False, default='present',
                    choices=['present', 'absent']),
     )
     # add the manageiq connection arguments to the arguments

--- a/lib/ansible/modules/storage/netapp/na_ontap_autosupport.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_autosupport.py
@@ -144,7 +144,7 @@ class NetAppONTAPasup(object):
             node_name=dict(required=True, type='str'),
             transport=dict(required=False, type='str', choices=['smtp', 'http', 'https']),
             noteto=dict(required=False, type='list'),
-            post_url=dict(reuired=False, type='str'),
+            post_url=dict(required=False, type='str'),
             support=dict(required=False, type='bool'),
             mail_hosts=dict(required=False, type='list'),
             from_address=dict(required=False, type='str'),

--- a/lib/ansible/modules/storage/netapp/na_ontap_vscan_scanner_pool.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_vscan_scanner_pool.py
@@ -94,7 +94,7 @@ class NetAppOntapVscanScannerPool(object):
         self.argument_spec.update(dict(
             state=dict(choices=['present', 'absent'], default='present'),
             vserver=dict(required=True, type='str'),
-            hostnames=dict(requried=False, type='list'),
+            hostnames=dict(required=False, type='list'),
             privileged_users=dict(required=False, type='list'),
             scanner_pool=dict(required=True, type='str'),
             scanner_policy=dict(required=False, choices=['primary', 'secondary', 'idle'])

--- a/lib/ansible/modules/storage/netapp/netapp_e_syslog.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_syslog.py
@@ -121,7 +121,7 @@ class Syslog(object):
             port=dict(type="int", default=514, required=False),
             protocol=dict(choices=["tcp", "tls", "udp"], default="udp", required=False),
             components=dict(type="list", required=False, default=["auditLog"]),
-            test=dict(type="bool", default=False, require=False),
+            test=dict(type="bool", default=False, required=False),
             log_path=dict(type="str", required=False),
         ))
 

--- a/lib/ansible/modules/storage/netapp/netapp_e_volume.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume.py
@@ -295,7 +295,7 @@ class NetAppESeriesVolume(NetAppESeriesModule):
             write_cache_enable=dict(type="bool", default=True),
             cache_without_batteries=dict(type="bool", default=False),
             workload_name=dict(type="str", required=False),
-            metadata=dict(type="dict", require=False),
+            metadata=dict(type="dict", required=False),
             wait_for_initialization=dict(type="bool", default=False),
             initialization_timeout=dict(type="int", required=False))
 


### PR DESCRIPTION
##### SUMMARY

This change contains fixes for argument spec and respective datatypes.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of https://github.com/ansible/ansible/pull/65496

(cherry picked from commit 96df2bdcf360b3130a5c33eae13c0d066765a355)


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/spec_fix.yml
lib/ansible/modules/cloud/amazon/cloudformation.py
lib/ansible/modules/cloud/amazon/redshift.py
lib/ansible/modules/cloud/ovirt/ovirt_permission_info.py
lib/ansible/modules/database/aerospike/aerospike_migrations.py
lib/ansible/modules/monitoring/librato_annotation.py
lib/ansible/modules/monitoring/logicmonitor_facts.py
lib/ansible/modules/monitoring/pagerduty_alert.py
lib/ansible/modules/network/aci/aci_access_port_to_interface_policy_leaf_profile.py
lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
lib/ansible/modules/network/icx/icx_logging.py
lib/ansible/modules/remote_management/manageiq/manageiq_alerts.py
lib/ansible/modules/storage/netapp/na_ontap_autosupport.py
lib/ansible/modules/storage/netapp/na_ontap_vscan_scanner_pool.py
lib/ansible/modules/storage/netapp/netapp_e_syslog.py
lib/ansible/modules/storage/netapp/netapp_e_volume.py
