### PR TITLE
postgresql_db: add executed_commands returned value

### DIFF
--- a/changelogs/fragments/65542-postgresql_db_add_executed_commands_return_val.yml
+++ b/changelogs/fragments/65542-postgresql_db_add_executed_commands_return_val.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_db - add the ``executed_commands`` returned value (https://github.com/ansible/ansible/pull/65542).

--- a/test/integration/targets/postgresql_db/tasks/postgresql_db_general.yml
+++ b/test/integration/targets/postgresql_db/tasks/postgresql_db_general.yml
@@ -89,6 +89,7 @@
   - assert:
       that:
       - result is changed
+      - result.executed_commands == ['CREATE DATABASE "{{ db_name }}" TABLESPACE "{{ db_tablespace }}"']
 
   - name: postgresql_db_tablespace - Check actual DB tablespace, rowcount must be 1
     <<: *task_parameters

--- a/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -122,7 +122,7 @@
 - assert:
     that:
       - result is changed
-      - result.executed_commands == ["CREATE DATABASE \"{{ db_name }}\" TEMPLATE \"template0\" ENCODING 'LATIN1' LC_COLLATE 'pt_BR{{ locale_latin_suffix }}' LC_CTYPE 'es_ES{{ locale_latin_suffix }}' CONNECTION LIMIT 100"]
+      - result.executed_commands == ["CREATE DATABASE \"{{ db_name }}\" TEMPLATE \"template0\" ENCODING 'LATIN1' LC_COLLATE 'pt_BR{{ locale_latin_suffix }}' LC_CTYPE 'es_ES{{ locale_latin_suffix }}' CONNECTION LIMIT 100"] or result.executed_commands == ["CREATE DATABASE \"{{ db_name }}\" TEMPLATE \"template0\" ENCODING E'LATIN1' LC_COLLATE E'pt_BR{{ locale_latin_suffix }}' LC_CTYPE E'es_ES{{ locale_latin_suffix }}' CONNECTION LIMIT 100"]
 
 - name: Check that the DB has all of our options
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
+++ b/test/integration/targets/postgresql_db/tasks/postgresql_db_initial.yml
@@ -14,7 +14,8 @@
   assert:
     that:
        - result is changed
-       - "result.db == db_name"
+       - result.db == "{{ db_name }}"
+       - result.executed_commands == ['CREATE DATABASE "{{ db_name }}"']
 
 - name: Check that database created
   become_user: "{{ pg_user }}"
@@ -53,6 +54,7 @@
   assert:
     that:
        - result is changed
+       - result.executed_commands == ['DROP DATABASE "{{ db_name }}"']
 
 - name: Check that database was destroyed
   become_user: "{{ pg_user }}"
@@ -115,6 +117,12 @@
     lc_ctype: 'es_ES{{ locale_latin_suffix }}'
     template: 'template0'
     login_user: "{{ pg_user }}"
+  register: result
+
+- assert:
+    that:
+      - result is changed
+      - result.executed_commands == ["CREATE DATABASE \"{{ db_name }}\" TEMPLATE \"template0\" ENCODING 'LATIN1' LC_COLLATE 'pt_BR{{ locale_latin_suffix }}' LC_CTYPE 'es_ES{{ locale_latin_suffix }}' CONNECTION LIMIT 100"]
 
 - name: Check that the DB has all of our options
   become_user: "{{ pg_user }}"
@@ -186,6 +194,7 @@
 - assert:
     that:
       - result is changed
+      - result.executed_commands == ['ALTER DATABASE "{{ db_name }}" CONNECTION LIMIT 200']
 
 - name: Check that conn_limit has actually been set / updated to 200
   become_user: "{{ pg_user }}"
@@ -239,6 +248,12 @@
     state: "present"
     owner: "{{ db_user1 }}"
     login_user: "{{ pg_user }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.executed_commands == ['CREATE DATABASE "{{ db_name }}" OWNER "{{ db_user1 }}"']
 
 - name: Check that the user owns the newly created DB
   become_user: "{{ pg_user }}"
@@ -265,6 +280,11 @@
     owner: "{{ db_user2 }}"
     login_user: "{{ pg_user }}"
   register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.executed_commands == ['ALTER DATABASE "{{ db_name }}" OWNER TO "{{ db_user2 }}"']
 
 - name: Check the previous step
   become_user: "{{ pg_user }}"


### PR DESCRIPTION
##### SUMMARY
postgresql_db: add executed_commands returned value

Now we can see what actually is going on

Examples:
```
executed_commands": [
        "CREATE DATABASE \"ansible_db\" TEMPLATE \"template0\" ENCODING 'LATIN1' LC_COLLATE 'pt_BR' LC_CTYPE 'es_ES' CONNECTION LIMIT 100"
    ]
```
```
executed_commands": [
        "ALTER DATABASE \"ansible_db\" OWNER TO \"ansible.db.user2\""
    ]
```
```
executed_commands": [
        "/bin/pg_dump ansible_db --host=localhost --port=5432 --username=ansible.db.user1 -n public  > /tmp/dbdata.sql"
    ]
```
```
executed_commands": [
        "/bin/psql --dbname=ansible_db --host=localhost --port=5432 --username=ansible.db.user1 --file=/tmp/dbdata.sql -n public  < /tmp/dbdata.sql"
    ]
```
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_db.py```