### PR TITLE
Disable path exist check for remote filesystems

### DIFF
--- a/changelogs/fragments/65544-mount-allow-remote-fstypes.yaml
+++ b/changelogs/fragments/65544-mount-allow-remote-fstypes.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - mount - Added verify_src option to allow mounting of remote or special file systems.


### PR DESCRIPTION
##### SUMMARY
This fixes the incorrect
   "Unable to mount ip:/path as it does not exist"
message when mounting remote cephfs and nfs targets.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
Try to mount any remote filesystem like cephfs to a local directory.
The ansible script will fail due to the src does not exist.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before:  error "Unable to mount ip:/path as it does not exist"
after: success
```
