### PR TITLE
[Backport 2.8] gitlab_runner: fix idempotency for shared runners

### DIFF
--- a/changelogs/fragments/65176-gitlab-runner-idempotency.yaml
+++ b/changelogs/fragments/65176-gitlab-runner-idempotency.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gitlab_runner - fix idempotency for shared runner

--- a/lib/ansible/modules/source_control/gitlab_runner.py
+++ b/lib/ansible/modules/source_control/gitlab_runner.py
@@ -258,10 +258,10 @@ class GitLabRunner(object):
     @param description Description of the runner
     '''
     def findRunner(self, description):
-        runners = self._gitlab.runners.list(as_list=False)
+        runners = self._gitlab.runners.all(as_list=False)
         for runner in runners:
-            if (runner.description == description):
-                return self._gitlab.runners.get(runner.id)
+            if (runner['description'] == description):
+                return self._gitlab.runners.get(runner['id'])
 
     '''
     @param description Description of the runner


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport #65176 - gitlab_runner : fix idempotency for shared runners

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65144
Fixes #60635

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gitlab_runner

##### ADDITIONAL INFORMATION
