### PR TITLE
[2.9] dnf: don't return fail_json['msg'] as list

### DIFF
--- a/changelogs/fragments/65302-dnf-msg-return.yml
+++ b/changelogs/fragments/65302-dnf-msg-return.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - dnf module - Ensure the modules exit_json['msg'] response is
+    always string, not sometimes a tuple.

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1158,7 +1158,7 @@ class DnfModule(YumDnf):
             else:
                 response['changed'] = True
                 if failure_response['failures']:
-                    failure_response['msg'] = 'Failed to install some of the specified packages',
+                    failure_response['msg'] = 'Failed to install some of the specified packages'
                     self.module.fail_json(**failure_response)
                 if self.module.check_mode:
                     response['msg'] = "Check mode: No changes made, but would have if not in check mode"
@@ -1188,7 +1188,7 @@ class DnfModule(YumDnf):
                         response['results'].append("Removed: {0}".format(package))
 
                 if failure_response['failures']:
-                    failure_response['msg'] = 'Failed to install some of the specified packages',
+                    failure_response['msg'] = 'Failed to install some of the specified packages'
                     self.module.exit_json(**response)
                 self.module.exit_json(**response)
         except dnf.exceptions.DepsolveError as e:


### PR DESCRIPTION
Although it's not enforced that fail_json['msg'] should be a string
[1], I think it is pretty strongly implied.

In this case the failure_response['msg'] is sent through as the
fail_json['msg'], and the trailing commas here turn it into a tuple.
It's not clear if this is a typo or intended, but it does cause
problems for callbacks that expect this as a string (e.g. [2]).

Since there seems no point to having these values as a tuple, remove
the trailing commas so they return a string as per everywhere else.

[1] https://github.com/ansible/ansible/blob/4c589661c2add45023f2bff9203e0c4e11efe5f6/lib/ansible/module_utils/basic.py#L2078
[2] https://review.opendev.org/#/c/696081

Backport of https://github.com/ansible/ansible/pull/65302

(cherry picked from commit f29baff3e5a28320c628211a91d8c6455e630e78)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
