### PR TITLE
Fix search_obj_in_list traceback for non-existent keys

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -597,7 +597,7 @@ def validate_config(spec, data):
 
 def search_obj_in_list(name, lst, key='name'):
     for item in lst:
-        if item[key] == name:
+        if item.get(key) == name:
             return item
     return None
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- This fix makes sure that search_obj_in_list doesn't traceback if the key doesn't exist in the any of the entries in the passed list.

- Since this affects all the platforms, raising a separate PR to avoid long CI runs for RM PRs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
network/common/utils.py

