### PR TITLE
ec2_placement_group: Make name 'required'

### DIFF
--- a/changelogs/fragments/65555-amazon-sanity-required.yml
+++ b/changelogs/fragments/65555-amazon-sanity-required.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_placement_group - make `name` a required field.

--- a/lib/ansible/modules/cloud/amazon/ec2_placement_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_placement_group.py
@@ -170,7 +170,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            name=dict(type='str'),
+            name=dict(required=True, type='str'),
             state=dict(default='present', choices=['present', 'absent']),
             strategy=dict(default='cluster', choices=['cluster', 'spread'])
         )

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -492,7 +492,6 @@ lib/ansible/modules/cloud/alicloud/ali_instance.py validate-modules:parameter-ty
 lib/ansible/modules/cloud/alicloud/ali_instance_info.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/alicloud/ali_instance_info.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/alicloud/ali_instance_info.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/cloud/amazon/ec2_placement_group.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/amazon/iam.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/amazon/iam_cert.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/amazon/iam_policy.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
##### SUMMARY
Previously you'd get one of the following behaviours:
- A boto3 error
- Nothing would change
- An error that you're not allowed to change the strategy
    
 Some of the behaviour would depend on the random order that AWS returns the list of all Placement Groups

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ec2_placement_group

##### ADDITIONAL INFORMATION