### PR TITLE
iam_cert: make 'name' a required option

### DIFF
--- a/changelogs/fragments/65558-iam_cert-require-name.yml
+++ b/changelogs/fragments/65558-iam_cert-require-name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- iam_cert - make `name` a required field.

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -245,7 +245,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         state=dict(required=True, choices=['present', 'absent']),
-        name=dict(),
+        name=dict(required=True),
         cert=dict(),
         key=dict(no_log=True),
         cert_chain=dict(),

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -494,7 +494,6 @@ lib/ansible/modules/cloud/alicloud/ali_instance_info.py validate-modules:doc-req
 lib/ansible/modules/cloud/alicloud/ali_instance_info.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/amazon/ec2_placement_group.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/amazon/iam.py validate-modules:doc-required-mismatch
-lib/ansible/modules/cloud/amazon/iam_cert.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/amazon/iam_policy.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/atomic/atomic_container.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/atomic/atomic_container.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
Without it we'd always throw a boto error

##### SUMMARY

Make 'name' a required field to match the documentation.  Without it we always threw an exception.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_cert

##### ADDITIONAL INFORMATION
