### PR TITLE
vmware: vmware_vm_inventory use port value when with_tags:True

### DIFF
--- a/changelogs/fragments/vmware_vm_inventory_port.yml
+++ b/changelogs/fragments/vmware_vm_inventory_port.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- In vmware_vm_inventory plugin, use port value while connecting to vCenter when using "with_tags:True" (https://github.com/ansible/ansible/issues/64096).

--- a/changelogs/fragments/vmware_vm_inventory_port.yml
+++ b/changelogs/fragments/vmware_vm_inventory_port.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- In vmware_vm_inventory plugin, use port value while connecting to vCenter when using "with_tags:True" (https://github.com/ansible/ansible/issues/64096).
+- vmware_vm_inventory inventory plugin, use the port value while connecting to vCenter (https://github.com/ansible/ansible/issues/64096).

--- a/lib/ansible/plugins/inventory/vmware_vm_inventory.py
+++ b/lib/ansible/plugins/inventory/vmware_vm_inventory.py
@@ -163,12 +163,15 @@ class BaseVMwareInventory:
             # Disable warning shown at stdout
             requests.packages.urllib3.disable_warnings()
 
-        client = create_vsphere_client(server=self.hostname,
+        server = self.hostname
+        if self.port:
+            server += ":" + str(self.port)
+        client = create_vsphere_client(server=server,
                                        username=self.username,
                                        password=self.password,
                                        session=session)
         if client is None:
-            raise AnsibleError("Failed to login to %s using %s" % (self.hostname, self.username))
+            raise AnsibleError("Failed to login to %s using %s" % (server, self.username))
         return client
 
     def _login(self):


### PR DESCRIPTION
##### SUMMARY

If user specifies a port number in vmware_vm_inventory plugin configuration,
then use that port to connect to vCenter rather than connecting to 443 which
is default port.

Fixes: #64096

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/vmware_vm_inventory_port.yml
lib/ansible/plugins/inventory/vmware_vm_inventory.py
