### PR TITLE
vmware_drs_rule_info test depends on the ESXi host

### DIFF
--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,4 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_rule_info/aliases
+++ b/test/integration/targets/vmware_drs_rule_info/aliases
@@ -1,4 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/253

##### SUMMARY

We cannot run the test without any ESXi host. This commit adjusts the
alias definition.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME

vmware_drs_rule_facts
vmware_drs_rule_info