### PR TITLE
Update generator.py documentation

### DIFF
--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -38,18 +38,20 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
     # inventory.config file in YAML format
+    # remember to enable this inventory plugin in the ansible.cfg before using
+    # View the output using `ansible-inventory -i inventory.config --list`
     plugin: generator
     strict: False
     hosts:
-        name: "{{ operation }}-{{ application }}-{{ environment }}-runner"
+        name: "{{ operation }}_{{ application }}_{{ environment }}_runner"
         parents:
-          - name: "{{ operation }}-{{ application }}-{{ environment }}"
+          - name: "{{ operation }}_{{ application }}_{{ environment }}"
             parents:
-              - name: "{{ operation }}-{{ application }}"
+              - name: "{{ operation }}_{{ application }}"
                 parents:
                   - name: "{{ operation }}"
                   - name: "{{ application }}"
-              - name: "{{ application }}-{{ environment }}"
+              - name: "{{ application }}_{{ environment }}"
                 parents:
                   - name: "{{ application }}"
                     vars:


### PR DESCRIPTION
##### SUMMARY
- Removed the dashes and replaced with underscores to  avoid the `DEPRECATION WARNING` below when it's ran
- Added a reminder to add the plugin to the ansible.cfg file as it's not enabled by default
- Added an example of how to use the code in the file comments

```
[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group 
names by default, this will change, but still be user configurable on deprecation. This feature will be 
removed in version 2.10. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
```


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
