### PR TITLE
display - Fix up tracebacks on 3rd party loggers when log path is set

### DIFF
--- a/changelogs/fragments/logging-traceback.yaml
+++ b/changelogs/fragments/logging-traceback.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- display logging - Fix issue where 3rd party modules will print tracebacks when attempting to log information when ``ANSIBLE_LOG_PATH`` is set - https://github.com/ansible/ansible/issues/65249
+- display logging - Re-added the ``name`` attribute to the log formatter so that the source of the log can be seen
+- display logging - Fixed up the logging formatter to use the proper prefixes for ``u=user`` and ``p=process``


### PR DESCRIPTION
##### SUMMARY
The PR https://github.com/ansible/ansible/pull/56311 slightly tweaked the way we display logs with a custom attribute in the formatter. This causes issues when a 3rd party library would try and log some information at the `INFO` level as they most likely did not pass in `user` as an extra_var to the log call.

This PR makes sure that each handler attached to the root have a filter that injects the `user` attribute so they don't print the traceback.

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib64/python2.7/logging/__init__.py", line 467, in format
    s = self._fmt % record.__dict__
KeyError: 'user'
```

It also fixes up the `user` and `process` formatter to be under the correct prefix and re-adds the `name` attribute which was present before #56311. Having `name` is helpful to determine the source of the log, i.e. not from Ansible.

Fixes https://github.com/ansible/ansible/issues/65249
Closes https://github.com/ansible/ansible/pull/65218

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
display