### PR TITLE
azure_rm_virtualmachine: fixing issue #63844

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -162,7 +162,6 @@ options:
         choices:
             - ReadOnly
             - ReadWrite
-        default: ReadOnly
         aliases:
             - disk_caching
     os_disk_size_gb:
@@ -819,8 +818,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             storage_account_name=dict(type='str', aliases=['storage_account']),
             storage_container_name=dict(type='str', aliases=['storage_container'], default='vhds'),
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
-            os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
-                                 default='ReadOnly'),
+            os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite']),
             os_disk_size_gb=dict(type='int'),
             managed_disk_type=dict(type='str', choices=['Standard_LRS', 'StandardSSD_LRS', 'Premium_LRS']),
             os_disk_name=dict(type='str'),
@@ -1240,6 +1238,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             requested_storage_uri,
                             self.storage_container_name,
                             self.storage_blob_name)
+                    # disk caching
+                    if not self.os_disk_caching:
+                        self.os_disk_caching = 'ReadOnly'
 
                     if not self.short_hostname:
                         self.short_hostname = self.name


### PR DESCRIPTION
##### SUMMARY

Fixes #63844 

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
azure_rm_virtualmachine

##### ADDITIONAL INFORMATION

Since the default value of os_disk_caching is ReadOnly, even user didn't provide this parameter to
the playbook, it will be automatically set and lead to mis-update the os disk caching state if the
current state is not ReadOnly. The fix is quite simple, remove the default setting for this parameter,
and the underlie azure service will handle the case if the parameter is not provided.
