### PR TITLE
Backport/2.9/65145 zabbix modules now require higher version of underlying python module

### DIFF
--- a/changelogs/fragments/65145-zabbix_modules_doc.yml
+++ b/changelogs/fragments/65145-zabbix_modules_doc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_* - underlying python module now required in version zabbix-api==0.5.4 (https://github.com/ansible/ansible/pull/65145)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -30,7 +30,7 @@ author:
     - Ruben Harutyunov (@K-DOT)
 
 requirements:
-    - zabbix-api
+    - "zabbix-api >= 0.5.4"
 
 options:
     name:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group.py
@@ -27,7 +27,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     state:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py
@@ -33,7 +33,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     hostgroup_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -28,7 +28,7 @@ author:
     - Eike Frost (@eikef)
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -34,7 +34,7 @@ author:
     - "Michael Miko (@RedWhiteMiko)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py
@@ -25,7 +25,7 @@ author:
     - Dean Hailin Song (!UNKNOWN)
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     host_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py
@@ -23,7 +23,7 @@ version_added: "1.8"
 author: "Alexander Bulimov (@abulimov)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     state:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_map.py
@@ -38,7 +38,7 @@ description:
         C(zbx_trigger_draw_style) contains indicator draw style. Possible values are the same as for C(zbx_draw_style)."
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
     - pydotplus
     - webcolors
     - Pillow

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -22,7 +22,7 @@ version_added: "2.9"
 author:
     - Ruben Tsirunyan (@rubentsirunyan)
 requirements:
-    - zabbix-api
+    - "zabbix-api >= 0.5.4"
 
 options:
     name:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -36,7 +36,7 @@ author:
     - "Alen Komic (@akomic)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     proxy_name:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_screen.py
@@ -26,7 +26,7 @@ author:
     - "Harrison Gu (@harrisongu)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     screens:
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -27,7 +27,7 @@ author:
     - "Dusan Matejka (@D3DeFi)"
 requirements:
     - "python >= 2.6"
-    - "zabbix-api >= 0.5.3"
+    - "zabbix-api >= 0.5.4"
 options:
     template_name:
         description:


### PR DESCRIPTION
##### SUMMARY
See #65145 

Updated documentation is visible in devel:
https://docs.ansible.com/ansible/devel/modules/zabbix_host_module.html 

But changes are affecting latest as well, which currently still shows older dep version:
https://docs.ansible.com/ansible/latest/modules/zabbix_host_module.html

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_action
zabbix_group
zabbix_group_info
zabbix_host
zabbix_host_info
zabbix_hostmacro
zabbix_maintenance
zabbix_map
zabbix_mediatype
zabbix_proxy
zabbix_screen
zabbix_template