### PR TITLE
Link to LTS version of Zabbix docs

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 RETURN = '''
 ---
 hosts:
-  description: List of Zabbix hosts. See https://www.zabbix.com/documentation/3.4/manual/api/reference/host/get for list of host values.
+  description: List of Zabbix hosts. See https://www.zabbix.com/documentation/4.0/manual/api/reference/host/get for list of host values.
   returned: success
   type: dict
   sample: [ { "available": "1", "description": "", "disable_until": "0", "error": "", "flags": "0", "groups": ["1"], "host": "Host A", ... } ]


### PR DESCRIPTION
##### SUMMARY
Zabbix 3.4 is not supported anymore.
Change the link to 4.0, which is the latest Long Term Support version.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zabbix_host_info