### PR TITLE
Replaces a open/close to validate access with os.access in azure stor…

### DIFF
--- a/changelogs/fragments/65608.yml
+++ b/changelogs/fragments/65608.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - azure_storageblob - use os.access to check for read rights.

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -412,13 +412,10 @@ class AzureRMStorageBlob(AzureRMModuleBase):
     def src_is_valid(self):
         if not os.path.isfile(self.src):
             self.fail("The source path must be a file.")
-        try:
-            fp = open(self.src, 'r')
-            fp.close()
-        except IOError:
-            self.fail("Failed to access {0}. Make sure the file exists and that you have "
-                      "read access.".format(self.src))
-        return True
+        if os.access(self.src, os.R_OK):
+            return True
+        self.fail("Failed to access {0}. Make sure the file exists and that you have "
+                  "read access.".format(self.src))
 
     def dest_is_valid(self):
         if not self.check_mode:


### PR DESCRIPTION
…ageblob.

##### SUMMARY
Probably changes semantics according to some minds. I saw `os.access` used in other places in Ansible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure, cloud.

##### ADDITIONAL INFORMATION
