### PR TITLE
Use a context manager in docker.ImageManager.

### DIFF
--- a/changelogs/fragments/65609-docker-context-manager.yml
+++ b/changelogs/fragments/65609-docker-context-manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - docker_image - improve file handling when loading images from disk.


### PR DESCRIPTION
##### SUMMARY
There are some semantic changes in this PR because `FileNotFoundError` is not available in Python 2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloud, docker.

##### ADDITIONAL INFORMATION
