### PR TITLE
remove some tests from zuul/vmware/vcenter_only

### DIFF
--- a/test/integration/targets/vmware_drs_rule_facts/aliases
+++ b/test/integration/targets/vmware_drs_rule_facts/aliases
@@ -1,4 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_drs_rule_info/aliases
+++ b/test/integration/targets/vmware_drs_rule_info/aliases
@@ -1,4 +1,3 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_acceptance/aliases
+++ b/test/integration/targets/vmware_host_acceptance/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_active_directory/aliases
+++ b/test/integration/targets/vmware_host_active_directory/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_host_powerstate/aliases
+++ b/test/integration/targets/vmware_host_powerstate/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only


### PR DESCRIPTION
##### SUMMARY

We cannot run the following tests without any ESXi host:

- vmware_drs_rule_info
- vmware_drs_rule_facts
- vmware_host_acceptance
- vmware_host_active_directory
- vmware_host_powerstate

This commit adjusts the alias definition.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_drs_rule_info
vmware_drs_rule_facts
vmware_host_acceptance
vmware_host_active_directory
vmware_host_powerstate