### PR TITLE
[stable-2.9] Fix and reenable hcloud tests

### DIFF
--- a/test/integration/targets/hcloud_image_info/aliases
+++ b/test/integration/targets/hcloud_image_info/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_image_info/defaults/main.yml
+++ b/test/integration/targets/hcloud_image_info/defaults/main.yml
@@ -3,4 +3,4 @@
 ---
 hcloud_prefix: "tests"
 hcloud_test_image_name: "always-there-snapshot"
-hcloud_test_image_id: 3439221
+hcloud_test_image_id: 10164049

--- a/test/integration/targets/hcloud_rdns/aliases
+++ b/test/integration/targets/hcloud_rdns/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled

--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,3 +1,2 @@
 cloud/hcloud
 shippable/hcloud/group1
-disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Fix and reenable hcloud tests

Backport of https://github.com/ansible/ansible/pull/65491

(cherry picked from commit 5ad61ed7c1222b9b7820e07e1b6b0230954edb53)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

hcloud integration tests