### PR TITLE
prepare_vmware_tests: ensure 'VM Network' exists

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -17,3 +17,14 @@
     esxi_hostname: '{{ item }}'
     state: absent
   with_items: "{{ esxi_hosts }}"
+
+- name: Add Management Network VM Portgroup
+  vmware_portgroup:
+    hostname: '{{ item }}'
+    username: '{{ esxi_user }}'
+    password: '{{ esxi_password }}'
+    esxi_hostname: 'item'
+    switch: "vSwitch0"
+    portgroup: VM Network
+    validate_certs: no
+  with_items: "{{ esxi_hosts }}"


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/263

##### SUMMARY

Depending on the ESXi configuration, the 'VM Network' may missing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

prepare_vmware_tests