### PR TITLE
Add verify subcommand to 'ansible-galaxy collection'

### DIFF
--- a/changelogs/fragments/65618-ansible-galaxy-collection-verify.yaml
+++ b/changelogs/fragments/65618-ansible-galaxy-collection-verify.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+    - ansible-galaxy - Add a `verify` subcommand to `ansible-galaxy collection` to compare the checksums
+      of the files listed in the MANIFEST.json and FILES.json of the local collection with the collection
+      found on the galaxy server.

--- a/changelogs/fragments/65618-ansible-galaxy-collection-verify.yaml
+++ b/changelogs/fragments/65618-ansible-galaxy-collection-verify.yaml
@@ -1,4 +1,4 @@
 minor_changes:
-    - ansible-galaxy - Add a `verify` subcommand to `ansible-galaxy collection` to compare the checksums
-      of the files listed in the MANIFEST.json and FILES.json of the local collection with the collection
-      found on the galaxy server.
+    - ansible-galaxy - Add a `verify` subcommand to `ansible-galaxy collection`. The collection found on
+      the galaxy server is downloaded to a tempfile to compare the checksums of the files listed in the
+      MANIFEST.json and the FILES.json with the contents of the installed collection.

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -47,6 +47,47 @@ Configuring the ``ansible-galaxy`` client
 
 .. _using_collections:
 
+Verifying collections
+=====================
+
+Verifying collections with ``ansible-galaxy``
+---------------------------------------------
+
+Once installed, you can verify that the content of the collection matches with that of the server.
+
+.. code-block:: bash
+
+   ansible-galaxy collection verify my_namespace.my_collection
+
+Add the version if you want to verify the contents of a version other than the latest. Pre-release versions also require this.
+
+.. code-block:: bash
+
+   ansible-galaxy collection verify my_namespace.my_collection:1.0.0
+
+In addition to the my_namespace.my_collection:version format, you can verify collections by providing a requirements.yml file, a tarball, a URL to a tarball, or the directory of the installed collection.
+If you have dependencies listed in your requirements.yml you will need to verify those separately.
+
+.. code-block:: bash
+
+   ansible-galaxy collection verify -r requirements.yml
+
+   ansible-galaxy collection verify /path/to/my_namespace_my_collection-1.0.0.tar.gz
+
+   ansible-galaxy collection verify https://../../my_namespace_my_collection-1.0.0.tar.gz
+
+   ansible-galaxy collection verify collections/ansible_collections/my_namespace/my_collection
+
+Use extra verbosity (-vvv) to display the location of the installed collection and the remote collection used for validation. It will also display the version being validated if you used the implicit latest.
+
+.. code-block:: bash
+
+   ansible-galaxy collection verify my_namespace.my_collection -vvv
+   ...
+   Verifying 'my_namespace.my_collection:1.0.0'.
+   Installed collection found at '/path/to/ansible_collections/my_namespace/my_collection/'
+   Remote collection found at 'https://galaxy.ansible.com/download/my_namespace-my_collection-1.0.0.tar.gz'
+
 Using collections in a Playbook
 ===============================
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -53,7 +53,7 @@ Verifying collections
 Verifying collections with ``ansible-galaxy``
 ---------------------------------------------
 
-Once installed, you can verify that the content of the installed collection matches the content of the collection on the server.
+Once installed, you can verify that the content of the installed collection matches the content of the collection on the server. This feature expects that the collection is installed in one of the configured collection paths and that the collection exists on one of the configured galaxy servers.
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -53,20 +53,40 @@ Verifying collections
 Verifying collections with ``ansible-galaxy``
 ---------------------------------------------
 
-Once installed, you can verify that the content of the collection matches with that of the server.
+Once installed, you can verify that the content of the installed collection matches the content of the collection on the server.
 
 .. code-block:: bash
 
    ansible-galaxy collection verify my_namespace.my_collection
 
-Add the version if you want to verify the contents of a version other than the latest. Pre-release versions also require this.
+The output of the `ansible-galaxy collection verify` command is quiet if it is successful. If a collection has been modified, the altered files are listed under the collection name.
+
+.. code-block:: bash
+
+    ansible-galaxy collection verify my_namespace.my_collection
+    Collection my_namespace.my_collection contains modified content in the following files:
+    my_namespace.my_collection
+        plugins/inventory/my_inventory.py
+        plugins/modules/my_module.py
+
+You can use the -vvv flag to display additional verbosity, such as the version and path of the installed collection, the URL of the remote collection used for validation, and successful verification output.
+
+.. code-block:: bash
+
+   ansible-galaxy collection verify my_namespace.my_collection -vvv
+   ...
+   Verifying 'my_namespace.my_collection:1.0.0'.
+   Installed collection found at '/path/to/ansible_collections/my_namespace/my_collection/'
+   Remote collection found at 'https://galaxy.ansible.com/download/my_namespace-my_collection-1.0.0.tar.gz'
+   Successfully verified that checksums for 'my_namespace.my_collection:1.0.0' match the remote collection
+
+If you have a pre-release or non-latest version of a collection installed you should include the specific version to verify. If the version is omitted, the installed collection is verified against the lastest version available on the server.
 
 .. code-block:: bash
 
    ansible-galaxy collection verify my_namespace.my_collection:1.0.0
 
-In addition to the my_namespace.my_collection:version format, you can verify collections by providing a requirements.yml file, a tarball, a URL to a tarball, or the directory of the installed collection.
-If you have dependencies listed in your requirements.yml you will need to verify those separately.
+In addition to the my_namespace.collection_name:version format, you can provide the collection to verify as a path or URL to a tar.gz file, a directory to an installed collection, or in a requirements.yml file. Dependencies listed in requirements.yml are not included in the verify process and should be verified separately.
 
 .. code-block:: bash
 
@@ -78,15 +98,6 @@ If you have dependencies listed in your requirements.yml you will need to verify
 
    ansible-galaxy collection verify collections/ansible_collections/my_namespace/my_collection
 
-Use extra verbosity (-vvv) to display the location of the installed collection and the remote collection used for validation. It will also display the version being validated if you used the implicit latest.
-
-.. code-block:: bash
-
-   ansible-galaxy collection verify my_namespace.my_collection -vvv
-   ...
-   Verifying 'my_namespace.my_collection:1.0.0'.
-   Installed collection found at '/path/to/ansible_collections/my_namespace/my_collection/'
-   Remote collection found at 'https://galaxy.ansible.com/download/my_namespace-my_collection-1.0.0.tar.gz'
 
 Using collections in a Playbook
 ===============================

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -59,7 +59,7 @@ Once installed, you can verify that the content of the installed collection matc
 
    ansible-galaxy collection verify my_namespace.my_collection
 
-The output of the `ansible-galaxy collection verify` command is quiet if it is successful. If a collection has been modified, the altered files are listed under the collection name.
+The output of the ``ansible-galaxy collection verify`` command is quiet if it is successful. If a collection has been modified, the altered files are listed under the collection name.
 
 .. code-block:: bash
 
@@ -69,7 +69,7 @@ The output of the `ansible-galaxy collection verify` command is quiet if it is s
         plugins/inventory/my_inventory.py
         plugins/modules/my_module.py
 
-You can use the -vvv flag to display additional verbosity, such as the version and path of the installed collection, the URL of the remote collection used for validation, and successful verification output.
+You can use the ``-vvv`` flag to display additional information, such as the version and path of the installed collection, the URL of the remote collection used for validation, and successful verification output.
 
 .. code-block:: bash
 
@@ -86,7 +86,7 @@ If you have a pre-release or non-latest version of a collection installed you sh
 
    ansible-galaxy collection verify my_namespace.my_collection:1.0.0
 
-In addition to the my_namespace.collection_name:version format, you can provide the collection to verify as a path or URL to a tar.gz file, a directory to an installed collection, or in a requirements.yml file. Dependencies listed in requirements.yml are not included in the verify process and should be verified separately.
+In addition to the my_namespace.collection_name:version format, you can provide the collection to verify as a path or URL to a tar.gz file, a directory to an installed collection, or in a ``requirements.yml`` file. Dependencies listed in ``requirements.yml`` are not included in the verify process and should be verified separately.
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -86,17 +86,13 @@ If you have a pre-release or non-latest version of a collection installed you sh
 
    ansible-galaxy collection verify my_namespace.my_collection:1.0.0
 
-In addition to the my_namespace.collection_name:version format, you can provide the collection to verify as a path or URL to a tar.gz file, a directory to an installed collection, or in a ``requirements.yml`` file. Dependencies listed in ``requirements.yml`` are not included in the verify process and should be verified separately.
+In addition to the namespace.collection_name:version format, you can provide the collections to verify in a ``requirements.yml`` file. Dependencies listed in ``requirements.yml`` are not included in the verify process and should be verified separately.
 
 .. code-block:: bash
 
    ansible-galaxy collection verify -r requirements.yml
 
-   ansible-galaxy collection verify /path/to/my_namespace_my_collection-1.0.0.tar.gz
-
-   ansible-galaxy collection verify https://../../my_namespace_my_collection-1.0.0.tar.gz
-
-   ansible-galaxy collection verify collections/ansible_collections/my_namespace/my_collection
+Verifying against tar.gz files is not supported. If your ``requirements.yml`` contains paths to tarfiles or URLs for installation, you can use the ``--ignore-errors`` flag to ensure that all collections using the namespace.name format in the file are processed.
 
 
 Using collections in a Playbook

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -86,13 +86,13 @@ If you have a pre-release or non-latest version of a collection installed you sh
 
    ansible-galaxy collection verify my_namespace.my_collection:1.0.0
 
-In addition to the namespace.collection_name:version format, you can provide the collections to verify in a ``requirements.yml`` file. Dependencies listed in ``requirements.yml`` are not included in the verify process and should be verified separately.
+In addition to the ``namespace.collection_name:version`` format, you can provide the collections to verify in a ``requirements.yml`` file. Dependencies listed in ``requirements.yml`` are not included in the verify process and should be verified separately.
 
 .. code-block:: bash
 
    ansible-galaxy collection verify -r requirements.yml
 
-Verifying against tar.gz files is not supported. If your ``requirements.yml`` contains paths to tarfiles or URLs for installation, you can use the ``--ignore-errors`` flag to ensure that all collections using the namespace.name format in the file are processed.
+Verifying against ``tar.gz`` files is not supported. If your ``requirements.yml`` contains paths to tar files or URLs for installation, you can use the ``--ignore-errors`` flag to ensure that all collections using the ``namespace.name`` format in the file are processed.
 
 
 Using collections in a Playbook

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -80,7 +80,7 @@ You can use the -vvv flag to display additional verbosity, such as the version a
    Remote collection found at 'https://galaxy.ansible.com/download/my_namespace-my_collection-1.0.0.tar.gz'
    Successfully verified that checksums for 'my_namespace.my_collection:1.0.0' match the remote collection
 
-If you have a pre-release or non-latest version of a collection installed you should include the specific version to verify. If the version is omitted, the installed collection is verified against the lastest version available on the server.
+If you have a pre-release or non-latest version of a collection installed you should include the specific version to verify. If the version is omitted, the installed collection is verified against the latest version available on the server.
 
 .. code-block:: bash
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -239,18 +239,18 @@ class GalaxyCLI(CLI):
 
     def add_verify_options(self, parser, parents=None):
         galaxy_type = 'collection'
-        verify_parser = parser.add_parser('verify', parents=parents,
-                help='Compare checksums with the collection(s) found on the server and the installed copy. This does not verify dependencies.')
+        verify_parser = parser.add_parser('verify', parents=parents, help='Compare checksums with the collection(s) '
+                                          'found on the server and the installed copy. This does not verify dependencies.')
         verify_parser.set_defaults(func=self.execute_verify)
 
         verify_parser.add_argument('-p', '--collections-path', dest='collections_path', default=C.COLLECTIONS_PATHS[0],
-                help='The path to the directory containing your collections.')
-        verify_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*',
-                help='The collection(s) name or path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.')
+                                   help='The path to the directory containing your collections.')
+        verify_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*', help='The collection(s) name or '
+                                   'path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.')
         verify_parser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
-                help='Ignore errors during verification and continue with the next specified collection.')
+                                   help='Ignore errors during verification and continue with the next specified collection.')
         verify_parser.add_argument('-r', '--requirements-file', dest='requirements',
-                help='A file containing a list of collections to be verified.')
+                                   help='A file containing a list of collections to be verified.')
 
     def add_install_options(self, parser, parents=None):
         galaxy_type = 'collection' if parser.metavar == 'COLLECTION_ACTION' else 'role'
@@ -620,7 +620,6 @@ class GalaxyCLI(CLI):
                     name, dummy, requirement = collection_input.partition(':')
                 requirements.append((name, requirement or '*', None))
         return requirements
-
 
 ############################
 # execute actions

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -28,6 +28,7 @@ from ansible.galaxy.collection import (
     publish_collection,
     validate_collection_name,
     validate_collection_path,
+    verify_collections
 )
 from ansible.galaxy.login import GalaxyLogin
 from ansible.galaxy.role import GalaxyRole
@@ -117,6 +118,7 @@ class GalaxyCLI(CLI):
         self.add_build_options(collection_parser, parents=[common, force])
         self.add_publish_options(collection_parser, parents=[common])
         self.add_install_options(collection_parser, parents=[common, force])
+        self.add_verify_options(collection_parser, parents=[common])
 
         # Add sub parser for the Galaxy role actions
         role = type_parser.add_parser('role', help='Manage an Ansible Galaxy role.')
@@ -234,6 +236,21 @@ class GalaxyCLI(CLI):
         info_parser.set_defaults(func=self.execute_info)
 
         info_parser.add_argument('args', nargs='+', help='role', metavar='role_name[,version]')
+
+    def add_verify_options(self, parser, parents=None):
+        galaxy_type = 'collection'
+        verify_parser = parser.add_parser('verify', parents=parents,
+                help='Compare checksums with the collection(s) found on the server and the installed copy. This does not verify dependencies.')
+        verify_parser.set_defaults(func=self.execute_verify)
+
+        verify_parser.add_argument('-p', '--collections-path', dest='collections_path', default=C.COLLECTIONS_PATHS[0],
+                help='The path to the directory containing your collections.')
+        verify_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*',
+                help='The collection(s) name or path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.')
+        verify_parser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
+                help='Ignore errors during verification and continue with the next specified collection.')
+        verify_parser.add_argument('-r', '--requirements-file', dest='requirements',
+                help='A file containing a list of collections to be verified.')
 
     def add_install_options(self, parser, parents=None):
         galaxy_type = 'collection' if parser.metavar == 'COLLECTION_ACTION' else 'role'
@@ -583,6 +600,28 @@ class GalaxyCLI(CLI):
 
         return meta_value
 
+    def _require_one_of_collections_requirements(self, collections, requirements_file):
+        if collections and requirements_file:
+            raise AnsibleError("The positional collection_name arg and --requirements-file are mutually exclusive.")
+        elif not collections and not requirements_file:
+            raise AnsibleError("You must specify a collection name or a requirements file.")
+        elif requirements_file:
+            requirements_file = GalaxyCLI._resolve_path(requirements_file)
+            requirements = self._parse_requirements_file(requirements_file, allow_old_format=False)['collections']
+        else:
+            requirements = []
+            for collection_input in collections:
+                requirement = None
+                if os.path.isfile(to_bytes(collection_input, errors='surrogate_or_strict')) or \
+                        urlparse(collection_input).scheme.lower() in ['http', 'https']:
+                    # Arg is a file path or URL to a collection
+                    name = collection_input
+                else:
+                    name, dummy, requirement = collection_input.partition(':')
+                requirements.append((name, requirement or '*', None))
+        return requirements
+
+
 ############################
 # execute actions
 ############################
@@ -794,6 +833,30 @@ class GalaxyCLI(CLI):
 
         self.pager(data)
 
+    def execute_verify(self):
+
+        collections = context.CLIARGS['args']
+        search_path = context.CLIARGS['collections_path']
+        ignore_certs = context.CLIARGS['ignore_certs']
+        ignore_errors = context.CLIARGS['ignore_errors']
+        requirements_file = context.CLIARGS['requirements']
+
+        requirements = self._require_one_of_collections_requirements(collections, requirements_file)
+
+        search_path = GalaxyCLI._resolve_path(search_path)
+        collections_path = C.COLLECTIONS_PATHS
+
+        if len([p for p in collections_path if p.startswith(search_path)]) == 0:
+            display.warning("The specified collections path '%s' is not part of the configured Ansible "
+                            "collections paths '%s'. The installed collection won't be picked up in an Ansible "
+                            "run." % (to_text(search_path), to_text(":".join(collections_path))))
+
+        if os.path.split(search_path)[1] != 'ansible_collections':
+            search_path = os.path.join(search_path, 'ansible_collections')
+
+        verify_collections(requirements, search_path, self.api_servers, (not ignore_certs), ignore_errors)
+        return 0
+
     def execute_install(self):
         """
         Install one or more roles(``ansible-galaxy role install``), or one or more collections(``ansible-galaxy collection install``).
@@ -811,25 +874,7 @@ class GalaxyCLI(CLI):
             no_deps = context.CLIARGS['no_deps']
             force_deps = context.CLIARGS['force_with_deps']
 
-            if collections and requirements_file:
-                raise AnsibleError("The positional collection_name arg and --requirements-file are mutually exclusive.")
-            elif not collections and not requirements_file:
-                raise AnsibleError("You must specify a collection name or a requirements file.")
-
-            if requirements_file:
-                requirements_file = GalaxyCLI._resolve_path(requirements_file)
-                requirements = self._parse_requirements_file(requirements_file, allow_old_format=False)['collections']
-            else:
-                requirements = []
-                for collection_input in collections:
-                    requirement = None
-                    if os.path.isfile(to_bytes(collection_input, errors='surrogate_or_strict')) or \
-                            urlparse(collection_input).scheme.lower() in ['http', 'https']:
-                        # Arg is a file path or URL to a collection
-                        name = collection_input
-                    else:
-                        name, dummy, requirement = collection_input.partition(':')
-                    requirements.append((name, requirement or '*', None))
+            requirements = self._require_one_of_collections_requirements(collections, requirements_file)
 
             output_path = GalaxyCLI._resolve_path(output_path)
             collections_path = C.COLLECTIONS_PATHS

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -850,8 +850,7 @@ class GalaxyCLI(CLI):
                             "collections paths '%s'. The installed collection won't be picked up in an Ansible "
                             "run." % (to_text(search_path), to_text(":".join(collections_path))))
 
-        if os.path.split(search_path)[1] != 'ansible_collections':
-            search_path = os.path.join(search_path, 'ansible_collections')
+        search_path = validate_collection_path(search_path)
 
         verify_collections(requirements, search_path, self.api_servers, (not ignore_certs), ignore_errors)
         return 0

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -118,7 +118,7 @@ class GalaxyCLI(CLI):
         self.add_build_options(collection_parser, parents=[common, force])
         self.add_publish_options(collection_parser, parents=[common])
         self.add_install_options(collection_parser, parents=[common, force])
-        self.add_verify_options(collection_parser, parents=[common])
+        self.add_verify_options(collection_parser, parents=[common, collections_path])
 
         # Add sub parser for the Galaxy role actions
         role = type_parser.add_parser('role', help='Manage an Ansible Galaxy role.')
@@ -243,9 +243,6 @@ class GalaxyCLI(CLI):
                                           'found on the server and the installed copy. This does not verify dependencies.')
         verify_parser.set_defaults(func=self.execute_verify)
 
-        verify_parser.add_argument('-p', '--collections-path', dest='collections_path', default=C.COLLECTIONS_PATHS,
-                                   type=opt_help.unfrack_path(pathsep=True), action=opt_help.PrependListAction,
-                                   help='The path to the directory containing your collections.')
         verify_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*', help='The collection(s) name or '
                                    'path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.')
         verify_parser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -207,9 +207,10 @@ class CollectionRequirement:
 
         # Compare installed version versus requirement version
         if self.latest_version != remote_collection.latest_version:
-            display.display("\n'%s' has a version mismatch" % to_text(self))
-            display.display("Found '%s'" % self.latest_version)
+            display.display("'%s' has a version mismatch" % to_text(self))
             display.display("Expected '%s'" % remote_collection.latest_version)
+            display.display("Found '%s'" % self.latest_version)
+            display.display("")
             return
 
         verified = True
@@ -282,9 +283,10 @@ class CollectionRequirement:
             actual_hash = self._get_hash(file_object)
 
         if expected_hash != actual_hash:
-            display.display("\n'%s' has a hash mismatch for '%s'" % (to_text(self), filename))
+            display.display("'%s' has a hash mismatch for '%s'" % (to_text(self), filename))
             display.display('Expected %s' % expected_hash)
             display.display('Found %s' % actual_hash)
+            display.display("")
             return False
         return True
 
@@ -600,9 +602,7 @@ def validate_collection_path(collection_path):
 def verify_collections(collections, search_path, apis, validate_certs, ignore_errors):
     existing_collections = _find_existing_collections(search_path)
 
-    current_collections = dict(
-            ('%s.%s' % (collection.namespace, collection.name), collection) for collection in existing_collections
-    )
+    current_collections = dict(('%s.%s' % (collection.namespace, collection.name), collection) for collection in existing_collections)
 
     with _display_progress():
         with _tempdir() as b_temp_path:

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -570,7 +570,7 @@ def verify_collections(collections, search_paths, apis, validate_certs, ignore_e
                     # Verify local collection exists before always downloading remote for comparison if it hasn't been yet
                     for search_path in search_paths:
                         b_search_path = to_bytes(
-                                os.path.join(search_path, remote_collection.namespace, remote_collection.name), errors='surrogate_or_strict'
+                            os.path.join(search_path, remote_collection.namespace, remote_collection.name), errors='surrogate_or_strict'
                         )
                         if os.path.isdir(b_search_path):
                             local_collection = CollectionRequirement.from_path(b_search_path, False)

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -561,6 +561,9 @@ def verify_collections(collections, search_paths, apis, validate_certs, ignore_e
                         b_temp_tar_path = _download_file(collection[0], b_temp_path, None, validate_certs)
                         remote_collection = CollectionRequirement.from_tar(b_temp_tar_path, False, parent=None)
                     else:
+                        # Check that it looks like a collection name
+                        if len(collection[0].split('.')) != 2:
+                            raise AnsibleError(message="'%s' is not a valid collection name. The format namespace.name is expected." % collection[0])
                         located_by_name = True
                         remote_collection = CollectionRequirement.from_name(collection[0], apis, collection[1], False, parent=None)
 

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -247,8 +247,11 @@ class CollectionRequirement:
     def _verify_file_hash(self, b_path, filename, expected_hash, error_queue):
         b_file_path = to_bytes(os.path.join(to_text(b_path), filename), errors='surrogate_or_strict')
 
-        with open(b_file_path, mode='rb') as file_object:
-            actual_hash = _consume_file(file_object)
+        if not os.path.isfile(b_file_path):
+            actual_hash = None
+        else:
+            with open(b_file_path, mode='rb') as file_object:
+                actual_hash = _consume_file(file_object)
 
         if expected_hash != actual_hash:
             error_queue.append(ModifiedContent(filename=filename, expected=expected_hash, installed=actual_hash))

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -542,7 +542,7 @@ def validate_collection_path(collection_path):
 
 
 def verify_collections(collections, search_path, apis, validate_certs, ignore_errors):
-    existing_collections = _find_existing_collections(search_path)
+    existing_collections = find_existing_collections(search_path)
 
     current_collections = dict(('%s.%s' % (collection.namespace, collection.name), collection) for collection in existing_collections)
 

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -843,6 +843,29 @@ def test_execute_verify(mock_verify_collections):
     assert ignore_errors is True
 
 
+def test_verify_file_hash_deleted_file(manifest_info):
+    data = to_bytes(json.dumps(manifest_info))
+    digest = sha256(data).hexdigest()
+
+    namespace = manifest_info['collection_info']['namespace']
+    name = manifest_info['collection_info']['name']
+    version = manifest_info['collection_info']['version']
+    server = 'http://galaxy.ansible.com'
+
+    error_queue = []
+
+    with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
+        with patch.object(collection.os.path, 'isfile', MagicMock(return_value=False)) as mock_isfile:
+            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
+            collection_req._verify_file_hash(b'path/', 'file', digest, error_queue)
+
+            assert mock_isfile.called_once
+
+    assert len(error_queue) == 1
+    assert error_queue[0].installed == None
+    assert error_queue[0].expected == digest
+
+
 def test_verify_file_hash_matching_hash(manifest_info):
 
     data = to_bytes(json.dumps(manifest_info))
@@ -856,8 +879,11 @@ def test_verify_file_hash_matching_hash(manifest_info):
     error_queue = []
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
-        collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
-        collection_req._verify_file_hash(b'path/', 'file', digest, error_queue)
+        with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
+            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
+            collection_req._verify_file_hash(b'path/', 'file', digest, error_queue)
+
+            assert mock_isfile.called_once
 
     assert error_queue == []
 
@@ -876,8 +902,11 @@ def test_verify_file_hash_mismatching_hash(manifest_info):
     error_queue = []
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
-        collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
-        collection_req._verify_file_hash(b'path/', 'file', different_digest, error_queue)
+        with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
+            collection_req = collection.CollectionRequirement(namespace, name, './', server, [version], version, False)
+            collection_req._verify_file_hash(b'path/', 'file', different_digest, error_queue)
+
+            assert mock_isfile.called_once
 
     assert len(error_queue) == 1
     assert error_queue[0].installed == digest
@@ -1000,6 +1029,7 @@ def test_verify_modified_manifest(monkeypatch, mock_collection, manifest_info):
     monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
     monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum_modified', 'files_manifest_checksum']))
     monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, {'files': []}]))
+    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
 
     with patch.object(collection.display, 'display') as mock_display:
         with patch.object(collection.display, 'vvv') as mock_debug:
@@ -1026,6 +1056,7 @@ def test_verify_modified_files_manifest(monkeypatch, mock_collection, manifest_i
     monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
     monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum', 'files_manifest_checksum_modified']))
     monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, {'files': []}]))
+    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
 
     with patch.object(collection.display, 'display') as mock_display:
         with patch.object(collection.display, 'vvv') as mock_debug:
@@ -1054,6 +1085,7 @@ def test_verify_modified_files(monkeypatch, mock_collection, manifest_info, file
     fakehashes = ['manifest_checksum', 'files_manifest_checksum', 'individual_file_checksum_modified']
     monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=fakehashes))
     monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, files_manifest_info]))
+    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
 
     with patch.object(collection.display, 'display') as mock_display:
         with patch.object(collection.display, 'vvv') as mock_debug:
@@ -1081,6 +1113,7 @@ def test_verify_identical(monkeypatch, mock_collection, manifest_info, files_man
     monkeypatch.setattr(collection, '_get_tar_file_hash', MagicMock(side_effect=['manifest_checksum']))
     monkeypatch.setattr(collection, '_consume_file', MagicMock(side_effect=['manifest_checksum', 'files_manifest_checksum', 'individual_file_checksum']))
     monkeypatch.setattr(collection, '_get_json_from_tar_file', MagicMock(side_effect=[manifest_info, files_manifest_info]))
+    monkeypatch.setattr(collection.os.path, 'isfile', MagicMock(return_value=True))
 
     with patch.object(collection.display, 'display') as mock_display:
         with patch.object(collection.display, 'vvv') as mock_debug:

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1139,7 +1139,7 @@ def test_verify_collections_not_installed_ignore_errors(mock_verify, mock_collec
 @patch.object(collection.CollectionRequirement, 'verify')
 def test_verify_collections_tarfile(mock_isfile, mock_verify, mock_collection, monkeypatch):
     local_collection = mock_collection()
-    monkeypatch.setattr(collection, '_find_existing_collections', MagicMock(return_value=[local_collection]))
+    monkeypatch.setattr(collection, 'find_existing_collections', MagicMock(return_value=[local_collection]))
 
     located_remote_from_tar = MagicMock(return_value=mock_collection(local=False))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_tar', located_remote_from_tar)
@@ -1168,7 +1168,7 @@ def test_verify_collections_tarfile(mock_isfile, mock_verify, mock_collection, m
 @patch.object(collection.CollectionRequirement, 'verify')
 def test_verify_collections_path(mock_isfile, mock_isdir, mock_verify, mock_collection, monkeypatch):
     local_collection = mock_collection()
-    monkeypatch.setattr(collection, '_find_existing_collections', MagicMock(return_value=[local_collection]))
+    monkeypatch.setattr(collection, 'find_existing_collections', MagicMock(return_value=[local_collection]))
 
     located_remote_from_path = MagicMock(return_value=mock_collection(local=False))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_path', located_remote_from_path)
@@ -1196,7 +1196,7 @@ def test_verify_collections_path(mock_isfile, mock_isdir, mock_verify, mock_coll
 @patch.object(collection.CollectionRequirement, 'verify')
 def test_verify_collections_url(mock_isfile, mock_isdir, mock_verify, mock_collection, monkeypatch):
     local_collection = mock_collection()
-    monkeypatch.setattr(collection, '_find_existing_collections', MagicMock(return_value=[local_collection]))
+    monkeypatch.setattr(collection, 'find_existing_collections', MagicMock(return_value=[local_collection]))
 
     remote_collection = mock_collection(local=False)
     located_remote_from_tar = MagicMock(return_value=remote_collection)
@@ -1221,7 +1221,7 @@ def test_verify_collections_url(mock_isfile, mock_isdir, mock_verify, mock_colle
 @patch.object(collection.CollectionRequirement, 'verify')
 def test_verify_collections_name(mock_isfile, mock_isdir, mock_verify, mock_collection, monkeypatch):
     local_collection = mock_collection()
-    monkeypatch.setattr(collection, '_find_existing_collections', MagicMock(return_value=[local_collection]))
+    monkeypatch.setattr(collection, 'find_existing_collections', MagicMock(return_value=[local_collection]))
 
     located_remote_from_name = MagicMock(return_value=mock_collection(local=False))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_name', located_remote_from_name)

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -862,7 +862,7 @@ def test_verify_file_hash_deleted_file(manifest_info):
             assert mock_isfile.called_once
 
     assert len(error_queue) == 1
-    assert error_queue[0].installed == None
+    assert error_queue[0].installed is None
     assert error_queue[0].expected == digest
 
 


### PR DESCRIPTION
##### SUMMARY
Adds the command `ansible-galaxy collection verify` to validate that the content of an installed collection is the same as the content of the collection on the server.

Note that this does not
  * verify dependencies listed in the requirements.yml
  * verify dir/file permissions
  * verify installations against tar.gz paths/urls

A requirements.yml file or multiple collections can be verified. When verifying multiple collections and one has a fatal error you can use --ignore-errors to continue verifying the rest.

The collection name argument for `ansible-galaxy collection verify` needs to be in the namespace.name format.

Some examples using the installed collection newswangerd.collection_demo:1.0.4

When verifying namespace.name without a version, it currently defaults to the latest
```
$ ansible-galaxy collection verify newswangerd.collection_demo
newswangerd.collection_demo has the version '1.0.4' but is being compared to '1.0.10'
```

To see details about the installed collection path and the server path use -vvv
Successful verification is quiet unless -vvv is used
```
$ ansible-galaxy collection verify newswangerd.collection_demo:1.0.4
$
```

After tampering with the installed collection.
```
$ ansible-galaxy collection verify newswangerd.collection_demo:1.0.4
Collection newswangerd.collection_demo contains modified content in the following files:
newswangerd.collection_demo
    MANIFEST.json
    FILES.json
    plugins/modules/real_facts.py
```
With extra verbosity the collection path and hash mismatches are shown:
```
$ ansible-galaxy collection verify newswangerd.collection_demo:1.0.4 -vvv
<...>
Collection newswangerd.collection_demo contains modified content in the following files:
newswangerd.collection_demo
/home/user/ansible/sample_collections/ansible_collections/newswangerd/collection_demo
    MANIFEST.json
    Expected: 6d1d1e56192673396e6cb04f92ab9e8cb3879d10e98bd8a6d9d5721d7b6d6ff1
    Found: 8ba47b3b6132cd1bf19063f474d50df3d5a19fc892055a298c5c203272781eea
    FILES.json
    Expected: 20f4ed17df2958eb48a6f3a32c99094b50566b95e8baaa31e17d31668607aa7d
    Found: 3405c19acc8d294e77677f06bdb7471717941b75074aef471d30d7ff1c9a83f8
    plugins/modules/real_facts.py
    Expected: 5f27fdc12026868f1f265f76a2aaecb8a0bcc353864ca36cd665f8af9392728e
    Found: 12186c36ce22f692a4e95444973c16e1bc494849330019ef33e81f599e743e88
```

Trying to verify a collection that doesn't exist on one of the enabled galaxy servers is fatal but can be made a warning with --ignore-errors:
```
$ ansible-galaxy collection verify test.doesnotexistonserver --ignore-errors
[WARNING]: Failed to verify collection test.doesnotexistonserver but skipping due to --ignore-errors being set. Error: Failed to find remote collection test.doesnotexistonserver:*
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py
lib/ansible/galaxy/collections.py
