### PR TITLE
display - Fix up tracebacks on 3rd party loggers when log path is set (#65582) - 2.9

### DIFF
--- a/changelogs/fragments/logging-traceback.yaml
+++ b/changelogs/fragments/logging-traceback.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- display logging - Fix issue where 3rd party modules will print tracebacks when attempting to log information when ``ANSIBLE_LOG_PATH`` is set - https://github.com/ansible/ansible/issues/65249
+- display logging - Re-added the ``name`` attribute to the log formatter so that the source of the log can be seen
+- display logging - Fixed up the logging formatter to use the proper prefixes for ``u=user`` and ``p=process``


### PR DESCRIPTION
(cherry picked from commit b7822276424d26565c33954db7436a5f6ab8063c)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/65582

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
display