### PR TITLE
Update playbooks_filters.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -33,6 +33,21 @@ It's also possible to change the indentation of both (new in version 2.2)::
     {{ some_variable | to_nice_json(indent=2) }}
     {{ some_variable | to_nice_yaml(indent=8) }}
 
+Note that to_nice_yaml(indent=n) only affects each new line that ``to_nice_yaml`` and ``to_json`` create, and does not take into account the line offset where the Jinja2 template is called. You should therefore incorporate a Jinja2 ``indent`` filter to get all lines with the expected indentation::
+
+      cisco_wireless_controllers:
+        {{ snmp_credentials.cisco_wireless_controllers | to_nice_yaml(indent=2) | indent(4) }}
+        walk:
+          - ...
+
+might produce the following (adding auth and version keys)
+
+      cisco_wireless_controllers:
+        auth:
+          community: whocares
+        version: 2
+        walk:
+          - ...
 
 ``to_yaml`` and ``to_nice_yaml`` filters use `PyYAML library`_ which has a default 80 symbol string length limit. That causes unexpected line break after 80th symbol (if there is a space after 80th symbol)
 To avoid such behaviour and generate long lines it is possible to use ``width`` option::


### PR DESCRIPTION
##### SUMMARY
Add an example of using to_nice_yaml(indent=n) with indent filter


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As a systems admin creating a playbook to inject configuration into YAML configuration files, I found using to_yaml and to_nice_yaml very difficult to use at the time and with a large number of issues reported about to_yaml and to_nice_yaml that I think this might help to prevent.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #16707 (doc fix)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

to_nice_yaml filter

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
