### PR TITLE
cloudformation - use mutually_exclusive for on_create_failure and disable_rollback

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -399,15 +399,11 @@ def create_stack(module, stack_params, cfn, events_limit):
 
     # 'DisableRollback', 'TimeoutInMinutes', 'EnableTerminationProtection' and
     # 'OnFailure' only apply on creation, not update.
-    #
-    # 'OnFailure' and 'DisableRollback' are incompatible with each other, so
-    # throw error if both are defined
-    if module.params.get('on_create_failure') is None:
-        stack_params['DisableRollback'] = module.params['disable_rollback']
-    else:
-        if module.params['disable_rollback']:
-            module.fail_json(msg="You can specify either 'on_create_failure' or 'disable_rollback', but not both.")
+    if module.params.get('on_create_failure') is not None:
         stack_params['OnFailure'] = module.params['on_create_failure']
+    else:
+        stack_params['DisableRollback'] = module.params['disable_rollback']
+
     if module.params.get('create_timeout') is not None:
         stack_params['TimeoutInMinutes'] = module.params['create_timeout']
     if module.params.get('termination_protection') is not None:
@@ -675,7 +671,8 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        mutually_exclusive=[['template_url', 'template', 'template_body']],
+        mutually_exclusive=[['template_url', 'template', 'template_body'],
+                            ['disable_rollback', 'on_create_failure']],
         supports_check_mode=True
     )
     if not HAS_BOTO3:

--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -146,25 +146,6 @@ def test_missing_template_body():
     assert "Either 'template', 'template_body' or 'template_url' is required when the stack does not exist." == m.exit_kwargs['msg']
 
 
-def test_disable_rollback_and_on_failure_defined():
-    m = FakeModule(
-        on_create_failure='DELETE',
-        disable_rollback=True,
-    )
-    with pytest.raises(Exception) as exc_info:
-        cfn_module.create_stack(
-            module=m,
-            stack_params={'TemplateBody': ''},
-            cfn=None,
-            events_limit=default_events_limit
-        )
-        pytest.fail('Expected module to fail with both on_create_failure and disable_rollback defined')
-
-    assert exc_info.match('FAIL')
-    assert not m.exit_args
-    assert "You can specify either 'on_create_failure' or 'disable_rollback', but not both." == m.exit_kwargs['msg']
-
-
 def test_on_create_failure_delete(maybe_sleep, placeboify):
     m = FakeModule(
         on_create_failure='DELETE',


### PR DESCRIPTION
##### SUMMARY
Use the `mutually_exclusive` predicate to ensure that only one of `on_create_failure` and `disable_rollback` is provided.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloudformation

##### ADDITIONAL INFORMATION
Tests done -
1. pass in both and make sure the task fails with proper message
2. pass in neither of the two parameters and make sure the stack gets created
3. pass in one at a time and make sure the module works as expected