### PR TITLE
Add new parameter for 'git submodule update' that fixes a performance issue.

### DIFF
--- a/changelogs/fragments/65634-git-submodule-performance-fix.yml
+++ b/changelogs/fragments/65634-git-submodule-performance-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - git - add an ability to just run git submodule update without fetching every submodule (https://github.com/ansible/ansible/pull/65634)


### PR DESCRIPTION
##### SUMMARY
Currently, if you use ansible with git submodules every time you update the supermodule you must use recursive=True or ansible will not run 'git submodule update'. Problem with recursive=True is that it fetches every submodule even if there are changes in only one of them. This causes a huge performance issue with repositories that have a lot of submodules.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
git

##### ADDITIONAL INFORMATION
Since our product consists of thousands of small modules, handle our customer and testing deployments with git submodules. A typical customer has from 5-100 modules. When we're testing customer environments we may have to do the submodule pull every 20 minutes.

Example situation: A git supermodule having 78 submodules and only one new commit having only one of the submodules changed.

* Currently with the parameter recursive=True running the git task takes 228 seconds. 
* After this change with recursive=False and update_submodules=True it takes 18 seconds.

That's a 92% decrease in time spent in that git task and the result is exactly the same. 