### PR TITLE
Set a deprecation warning and version for option sha256sum

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -78,7 +78,8 @@ options:
       - If a SHA-256 checksum is passed to this parameter, the digest of the
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
-        This option is deprecated. Use C(checksum) instead.
+        This option is deprecated and will be removed in version 2.14. Use
+        option C(checksum) instead.
     default: ''
     version_added: "1.3"
   checksum:
@@ -449,6 +450,9 @@ def main():
 
     if module.params.get('thirsty'):
         module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead', version='2.13')
+
+    if module.params.get('sha256sum'):
+        module.deprecate('The parameter "sha256sum" has been deprecated and will be removed, use "checksum" instead', version='2.14')
 
     url = module.params['url']
     dest = module.params['dest']


### PR DESCRIPTION
##### SUMMARY
The option `sha256sum` was declared deprecated more than 2 years ago without
setting a removal version. Set a deprecation for 2.14.

fixes #65636

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url
