### PR TITLE
Bugfix 57471: Delete crontab file with name parameter

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -642,6 +642,9 @@ def main():
 
     # --- user input validation ---
 
+    if env and not name:
+        module.fail_json(msg="You must specify 'name' while working with environment variables (env=yes)")
+
     if (special_time or reboot) and \
        (True in [(x != '*') for x in [minute, hour, day, month, weekday]]):
         module.fail_json(msg="You must specify time and date fields or special time.")
@@ -668,7 +671,7 @@ def main():
         (backuph, backup_file) = tempfile.mkstemp(prefix='crontab')
         crontab.write(backup_file)
 
-    if crontab.cron_file and not name and not do_install:
+    if crontab.cron_file and not do_install:
         if module._diff:
             diff['after'] = ''
             diff['after_header'] = '/dev/null'

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -99,3 +99,26 @@
 
 - assert:
     that: remove_cron_file is not changed
+
+- name: Removing a cron file when the name is specified is allowed (#57471)
+  block:
+  - name: Cron file creation
+    cron:
+      cron_file: cron_filename
+      name: "integration test cron"
+      job: 'ls'
+      user: root
+
+  - name: Cron file deletion
+    cron:
+      cron_file: cron_filename
+      name: "integration test cron"
+      state: absent
+
+  - name: Check file succesfull deletion
+    stat:
+      path: /etc/cron.d/cron_filename
+    register: cron_file_stats
+
+  - assert:
+      that: not cron_file_stats.stat.exists


### PR DESCRIPTION
#### SUMMARY
Fixes the issue where deleting crontab file is not working when the *name* parameter is specified.
Added integration tests to validate that new behavior.

Fixes #57471

Aside from this bugfix, I also added user input validation regarding using environment variable (env=yes) without providing a *name*.

#### ISSUE TYPE
Bugfix Pull Request

#### COMPONENT NAME
Cron module.

#### ADDITIONAL INFORMATION
This bugfix development was initiated during the PyCon FR 2019 hackaton. Thanks a lot to @pilou- and @mscherer for their guidance and great on-boarding !

###### Bugfix
Running the newly added integration tests show that the cron file was not deleted prior to this bugfix, and now it is successfully removed.

###### Added user validation
When the user works with environment variable of the cron module without providing the *name* parameter, the next error was displayed:
```
$ ansible localhost -m cron -a "env=yes state=present job=1"
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: argument of type 'NoneType' is not iterable
localhost | FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n
[ . . . ]
line 687, in main\nTypeError: argument of type 'NoneType' is not iterable\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
With now added user validation:
```
$ ansible localhost -m cron -a "env=yes state=absent job=1"
[DEPRECATION WARNING]: The 'name' parameter will be required in future releases.. This feature will be removed in version 2.12. 
localhost | FAILED! => {
    "changed": false,
    "msg": "You must specify 'name' while working with environment variables (env=yes)"
}
```
Not using the *name* parameter is deprecated, but I think that until its usage is made mandatory that kind of user input should be tested.