### PR TITLE
openssl_privatekey: fix bug in format handling

### DIFF
--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -377,7 +377,7 @@ class PrivateKeyBase(crypto_utils.OpenSSLObject):
             return False
 
         if not self._check_format():
-            if ignore_conversion or self.format_mismatch != 'convert':
+            if not ignore_conversion or self.format_mismatch != 'convert':
                 return False
 
         return True
@@ -678,6 +678,7 @@ class PrivateKeyCryptography(PrivateKeyBase):
 
     def _check_size_and_type(self):
         privatekey = self._load_privatekey()
+        self.privatekey = privatekey
 
         if isinstance(privatekey, cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey):
             return self.type == 'RSA' and self.size == privatekey.key_size

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -394,15 +394,17 @@
   - name: Generate privatekey_fmt_2 - auto format (ignore)
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_2.pem'
+      type: X448
       format: auto_ignore
       select_crypto_backend: '{{ select_crypto_backend }}'
-    register: privatekey_fmt_1_step_5
+    register: privatekey_fmt_2_step_5
 
   - name: Generate privatekey_fmt_2 - auto format (no ignore)
     openssl_privatekey:
       path: '{{ output_dir }}/privatekey_fmt_2.pem'
+      type: X448
       format: auto
       select_crypto_backend: '{{ select_crypto_backend }}'
-    register: privatekey_fmt_1_step_6
+    register: privatekey_fmt_2_step_6
 
   when: 'select_crypto_backend == "cryptography" and cryptography_version.stdout is version("2.6", ">=")'

--- a/test/integration/targets/openssl_privatekey/tasks/main.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yml
@@ -61,7 +61,7 @@
 
   - import_tasks: ../tests/validate.yml
     vars:
-      select_crypto_backend: pyopenssl
+      select_crypto_backend: cryptography
 
   when: cryptography_version.stdout is version('0.5', '>=')
 


### PR DESCRIPTION
##### SUMMARY
The test validation didn't run for the format tests, and thus some errors went undetected.

(This is a new feature for 2.10, thus no changelog.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_privatekey
