### PR TITLE
Backport 2.9: nxos_bgp_neighbor_af Test fix (#65132)

### DIFF
--- a/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tests/common/sanity.yaml
@@ -81,7 +81,7 @@
       max_prefix_threshold: default
       max_prefix_warning: False
       next_hop_self: False
-      next_hop_third_party: True
+      next_hop_third_party: False
       prefix_list_in: default
       prefix_list_out: default
       send_community: 'none'
@@ -204,6 +204,7 @@
       send_community: 'standard'
       soft_reconfiguration_in: "{{soft_reconfiguration_ina|default(omit)}}"
       soo: '3:3'
+      next_hop_third_party: True
       provider: "{{ connection }}"
       state: present
     register: result


### PR DESCRIPTION
(cherry picked from commit 89954e6ef51c10e42b13613ee6e26983d76d82c9)

Backport of https://github.com/ansible/ansible/pull/65132

##### SUMMARY
- Test fix for nxos_bgp_neighbor_af module.
- No changelog added since this is a test change backport.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
 test/integration/targets/nxos_bgp_neighbor_af/tests/
