### PR TITLE
Update iocage.py: remove 'docker'

### DIFF
--- a/lib/ansible/plugins/connection/iocage.py
+++ b/lib/ansible/plugins/connection/iocage.py
@@ -19,7 +19,6 @@ DOCUMENTATION = """
       remote_addr:
         description:
             - Path to the jail
-        default: The set user as per docker's configuration
         vars:
             - name: ansible_host
             - name: ansible_iocage_host


### PR DESCRIPTION
It seems to me as though the term 'docker' was copy/pasted in; I don't understand what it would mean in the context of iocage. As such, I think removal is best.

##### SUMMARY
Documentation change

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
iocage plugin
