### PR TITLE
Convert an integration test to yaml format

### DIFF
--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -95,7 +95,10 @@
       - result is failed
 
 - name: test https fetch
-  get_url: url="https://{{ httpbin_host }}/get" dest={{remote_tmp_dir}}/get_url.txt force=yes
+  get_url:
+    url: "https://{{ httpbin_host }}/get"
+    dest: "{{ remote_tmp_dir }}/get_url.txt"
+    force: yes
   register: result
 
 - name: assert the get_url call was successful


### PR DESCRIPTION
A unit test for `get_url` was still using the inline syntax.

##### SUMMARY
minor commit to just use same syntax than all other tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url

ansible version: 2.10