### PR TITLE
[stable-2.9] Handle InternalError raised by cryptography when running in FIPS mode (#65477)

### DIFF
--- a/changelogs/fragments/fips-paramiko-import-error.yaml
+++ b/changelogs/fragments/fips-paramiko-import-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/lib/ansible/module_utils/compat/paramiko.py
+++ b/lib/ansible/module_utils/compat/paramiko.py
@@ -10,5 +10,8 @@ PARAMIKO_IMPORT_ERR = None
 paramiko = None
 try:
     import paramiko
-except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# When running in FIPS mode, cryptography raises InternalError
+# https://bugzilla.redhat.com/show_bug.cgi?id=1778939
+except Exception as err:
     PARAMIKO_IMPORT_ERR = err


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #65477 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/compat/paramiko.py`