### PR TITLE
Mark yum tests as unstable

### DIFF
--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group4
 skip/freebsd
 skip/osx
+unstable


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fedora 31 tests are failing due to a missing packages error. I am unable to duplicate this issue when running locally, so it is possibly an issue with a mirror that is being used when run from Shippable.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/yum/aliases`
##### ADDITIONAL INFORMATION
Related to #65650
