### PR TITLE
VMware: Add advanced settings to vmware_cluster_ha

### DIFF
--- a/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
+++ b/changelogs/fragments/58824-vmware_cluster_ha-advanced-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_ha - Implemented HA advanced settings (https://github.com/ansible/ansible/issues/61421)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -841,6 +841,30 @@ def is_truthy(value):
     return False
 
 
+# options is the dict as defined in the module parameters, current_options is
+# the list of the currently set options as returned by the vSphere API.
+def option_diff(options, current_options):
+    current_options_dict = {}
+    for option in current_options:
+        current_options_dict[option.key] = option.value
+
+    change_option_list = []
+    for option_key, option_value in options.items():
+        if is_boolean(option_value):
+            option_value = VmomiSupport.vmodlTypes['bool'](is_truthy(option_value))
+        elif isinstance(option_value, int):
+            option_value = VmomiSupport.vmodlTypes['int'](option_value)
+        elif isinstance(option_value, float):
+            option_value = VmomiSupport.vmodlTypes['float'](option_value)
+        elif isinstance(option_value, str):
+            option_value = VmomiSupport.vmodlTypes['string'](option_value)
+
+        if option_key not in current_options_dict or current_options_dict[option_key] != option_value:
+            change_option_list.append(vim.option.OptionValue(key=option_key, value=option_value))
+
+    return change_option_list
+
+
 def quote_obj_name(object_name=None):
     """
     Replace special characters in object name

--- a/test/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -127,14 +127,48 @@
     that:
         - "{{ cluster_ha_result_0006.changed == true }}"
 
-# Delete test cluster
-- name: Delete test cluster
-  vmware_cluster:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: test_cluster_ha
-    state: absent
-  when: vcsim is not defined
+- when: vcsim is not defined
+  block:
+  - name: Change advanced setting "number of heartbeat datastores" (check-mode)
+    vmware_cluster_ha: &change_num_heartbeat_ds
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_ha
+      advanced_settings:
+          'das.heartbeatDsPerHost': '4'
+    check_mode: yes
+    register: change_num_heartbeat_ds_check
+
+  - assert:
+      that:
+        - change_num_heartbeat_ds_check.changed
+
+  - name: Change advanced setting "number of heartbeat datastores"
+    vmware_cluster_ha: *change_num_heartbeat_ds
+    register: change_num_heartbeat_ds
+
+  - assert:
+      that:
+        - change_num_heartbeat_ds.changed
+
+  - name: Change advanced setting "number of heartbeat datastores" again
+    vmware_cluster_ha: *change_num_heartbeat_ds
+    register: change_num_heartbeat_ds_again
+
+  - assert:
+      that:
+        - not change_num_heartbeat_ds_again.changed
+
+  # Delete test cluster
+  - name: Delete test cluster
+    vmware_cluster:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_ha
+      state: absent


### PR DESCRIPTION
##### SUMMARY

Add advanced settings [(Advanced configuration options for VMware High Availability in vSphere 5.x and 6.x)](https://kb.vmware.com/kb/2033250) on the cluster level to vmware_cluster_ha.

Fixes #61421

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_ha

##### ADDITIONAL INFORMATION
Example:
```
- name: Change advanced setting "number of heartbeat datastores"
    vmware_cluster_ha:
      hostname: "{{ vcenter_hostname }}"
      username: "{{ vcenter_username }}"
      password: "{{ vcenter_password }}"
      datacenter_name: datacenter
      cluster_name: cluster
      enable_ha: yes
      advanced_settings:
          'das.heartbeatDsPerHost': '4'
```
