### PR TITLE
[WIP] galaxy: parse collection versions according to semver

### DIFF
--- a/lib/ansible/galaxy/semantic_version.py
+++ b/lib/ansible/galaxy/semantic_version.py
@@ -1,0 +1,54 @@
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import re
+from distutils.version import LooseVersion
+from functools import total_ordering
+
+
+@total_ordering
+class SemanticVersion(object):
+    """
+    Minimal implementation of the semver.org specification.
+
+    Inspired from https://github.com/rbarrois/python-semanticversion
+
+    """
+    version_re = re.compile(r'^(\d+)\.(\d+)\.(\d+)(?:-([0-9a-zA-Z.-]+))?(?:\+([0-9a-zA-Z.-]+))?$')
+
+    def __init__(self, version_string):
+        self.version_string = version_string
+
+    @property
+    def is_prerelease(self):
+        """Return True if this is a pre-release. """
+        match = self.version_re.match(self.version_string)
+        if not match:
+            return False
+        _, _, _, prerelease, _ = match.groups()
+        return bool(prerelease)
+
+    @property
+    def loose_version(self):
+        """ Return a distutils.version.LooseVersion for this version. """
+        match = self.version_re.match(self.version_string)
+        major, minor, patch, _, _ = match.groups()
+        return LooseVersion('%s.%s.%s' % (major, minor, patch))
+
+    def __eq__(self, other):
+        if self.is_prerelease or other.is_prerelease:
+            # TODO: compare prereleases according to semver spec
+            raise NotImplementedError('distutils cannot compare semver prereleases')
+        return self.loose_version == other.loose_version
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __lt__(self, other):
+        return self.loose_version < other.loose_version
+
+    def __str__(self):
+        return self.version_string
+
+    def __repr__(self):
+        return "SemanticVersion(%s)" % self.version_string


### PR DESCRIPTION
##### SUMMARY
Swap out the distutils StrictVersion regex for a custom regex that is compatible with semver.

This allows ansible-galaxy to respect version numbers with build metadata, like "0.0.0+git.asdf"

Related: #64905

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
As described at https://github.com/ansible/ansible/issues/64905 and https://github.com/ansible/galaxy/issues/2137 , the ansible-galaxy client does not currently implement the full semver specification, particularly the areas of pre-releases and build metadata.

This pull request changes the ansible-galaxy client to use a custom regex copied from the python-semanticversion library ([semantic_version/base.py](https://github.com/rbarrois/python-semanticversion/blob/da55cf15dd71a0d9a839e7507e4fc69396c8326d/semantic_version/base.py#L81)) and implements just enough of the other parts of the specification to hide pre-releases.

This is not complete or well-tested, but it works for my simple use-case of installing "0.0.0+git.asdf" snapshot versions that I've uploaded to [my Galaxy collection project](https://galaxy.ansible.com/ktdreyer/koji_ansible). I welcome feedback on this approach.