### PR TITLE
postgresql_schema: use query_params with cursor object

### DIFF
--- a/changelogs/fragments/65679-postgresql_schema_user_query_params_with_cursor.yml
+++ b/changelogs/fragments/65679-postgresql_schema_user_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_schema - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65679).

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -165,15 +165,15 @@ def set_owner(cursor, schema, owner):
 def get_schema_info(cursor, schema):
     query = ("SELECT schema_owner AS owner "
              "FROM information_schema.schemata "
-             "WHERE schema_name = '%s'" % schema)
-    cursor.execute(query)
+             "WHERE schema_name = %(schema)s")
+    cursor.execute(query, {'schema': schema})
     return cursor.fetchone()
 
 
 def schema_exists(cursor, schema):
     query = ("SELECT schema_name FROM information_schema.schemata "
-             "WHERE schema_name = '%s'" % schema)
-    cursor.execute(query)
+             "WHERE schema_name = %(schema)s")
+    cursor.execute(query, {'schema': schema})
     return cursor.rowcount == 1
 
 


### PR DESCRIPTION
##### SUMMARY
postgresql_schema: use query_params with cursor object

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_schema.py```
