### PR TITLE
[2.9] solaris_zone: Allow only valid characters in zone name

### DIFF
--- a/changelogs/fragments/solaris_zone_name_fix.yml
+++ b/changelogs/fragments/solaris_zone_name_fix.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- "**SECURITY** - CVE-2019-14904 - solaris_zone module accepts zone name and performs actions related to that.
+   However, there is no user input validation done while performing actions. A malicious user could provide a
+   crafted zone name which allows executing commands into the server manipulating the module behaviour. Adding
+   user input validation as per Solaris Zone documentation fixes this issue."

--- a/lib/ansible/modules/system/solaris_zone.py
+++ b/lib/ansible/modules/system/solaris_zone.py
@@ -43,6 +43,10 @@ options:
   name:
     description:
       - Zone name.
+      - A zone name must be unique name.
+      - A zone name must begin with an alpha-numeric character.
+      - The name can contain alpha-numeric characters, underbars I(_), hyphens I(-), and periods I(.).
+      - The name cannot be longer than 64 characters.
     type: str
     required: true
   path:
@@ -147,6 +151,7 @@ EXAMPLES = '''
 
 import os
 import platform
+import re
 import tempfile
 import time
 
@@ -182,6 +187,11 @@ class Zone(object):
         (self.os_major, self.os_minor) = platform.release().split('.')
         if int(self.os_minor) < 10:
             self.module.fail_json(msg='This module requires Solaris 10 or later')
+
+        match = re.match('^[a-zA-Z0-9][-_.a-zA-Z0-9]{0,62}$', self.name)
+        if not match:
+            self.module.fail_json(msg="Provided zone name is not a valid zone name. "
+                                      "Please refer documentation for correct zone name specifications.")
 
     def configure(self):
         if not self.path:


### PR DESCRIPTION
##### SUMMARY

CVE-2019-14904 - solaris_zone module accepts zone name and performs actions related to that.
However, there is no user input validation done while performing actions.
A malicious user could provide a crafted zone name which allows executing commands
into the server manipulating the module behaviour.

Adding user input validation as per Solaris Zone documentation fixes this issue.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of https://github.com/ansible/ansible/pull/65686

(cherry picked from commit 7d2ae7e3226cdc8e37aea83c202aeb0e7e5a1aec)


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/solaris_zone_name_fix.yml
lib/ansible/modules/system/solaris_zone.py
