### PR TITLE
[2.7] solaris_zone: Allow only valid characters in zone name

### DIFF
--- a/changelogs/fragments/solaris_zone_name_fix.yml
+++ b/changelogs/fragments/solaris_zone_name_fix.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- "**SECURITY** - CVE-2019-14904 - solaris_zone module accepts zone name and performs actions related to that.
+   However, there is no user input validation done while performing actions. A malicious user could provide a
+   crafted zone name which allows executing commands into the server manipulating the module behaviour. Adding
+   user input validation as per Solaris Zone documentation fixes this issue."

--- a/lib/ansible/modules/system/solaris_zone.py
+++ b/lib/ansible/modules/system/solaris_zone.py
@@ -41,6 +41,11 @@ options:
   name:
     description:
       - Zone name.
+      - A zone name must be unique name.
+      - A zone name must begin with an alpha-numeric character.
+      - The name can contain alpha-numeric characters, underbars I(_), hyphens I(-), and periods I(.).
+      - The name cannot be longer than 64 characters.
+    type: str
     required: true
   path:
     description:
@@ -137,6 +142,7 @@ EXAMPLES = '''
 
 import os
 import platform
+import re
 import tempfile
 import time
 
@@ -172,6 +178,11 @@ class Zone(object):
         (self.os_major, self.os_minor) = platform.release().split('.')
         if int(self.os_minor) < 10:
             self.module.fail_json(msg='This module requires Solaris 10 or later')
+
+        match = re.match('^[a-zA-Z0-9][-_.a-zA-Z0-9]{0,62}$', self.name)
+        if not match:
+            self.module.fail_json(msg="Provided zone name is not a valid zone name. "
+                                      "Please refer documentation for correct zone name specifications.")
 
     def configure(self):
         if not self.path:

--- a/test/sanity/code-smell/no-underscore-variable.py
+++ b/test/sanity/code-smell/no-underscore-variable.py
@@ -121,6 +121,8 @@ def main():
         'test/units/modules/cloud/amazon/test_ec2_vpc_nat_gateway.py',
         'test/units/modules/cloud/amazon/test_ec2_vpc_vpn.py',
         'test/units/modules/system/interfaces_file/test_interfaces_file.py',
+        # These files contain false positives.
+        'lib/ansible/modules/system/solaris_zone.py',
     ])
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():


### PR DESCRIPTION
##### SUMMARY

CVE-2019-14904 - solaris_zone module accepts zone name and performs actions related to that.
However, there is no user input validation done while performing actions.
A malicious user could provide a crafted zone name which allows executing commands
into the server manipulating the module behaviour.

Adding user input validation as per Solaris Zone documentation fixes this issue.

Backport of https://github.com/ansible/ansible/pull/65686

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/solaris_zone_name_fix.yml
lib/ansible/modules/system/solaris_zone.py
