### PR TITLE
Allow SSH synchronization between Docker containers

### DIFF
--- a/changelogs/fragments/65698-synchronize-docker-controller-managed.yml
+++ b/changelogs/fragments/65698-synchronize-docker-controller-managed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - synchronize - allow data to be passed between two managed nodes when using the docker connection plugin (https://github.com/ansible/ansible/pull/65698)

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -391,7 +391,7 @@ class ActionModule(ActionBase):
 
         # If launching synchronize against docker container
         # use rsync_opts to support container to override rsh options
-        if self._remote_transport in ['docker', 'buildah']:
+        if self._remote_transport in ['docker', 'buildah'] and not use_delegate:
             # Replicate what we do in the module argumentspec handling for lists
             if not isinstance(_tmp_args.get('rsync_opts'), MutableSequence):
                 tmp_rsync_opts = _tmp_args.get('rsync_opts', [])


### PR DESCRIPTION
##### SUMMARY
When using [Molecule](https://github.com/ansible/molecule), use of `synchonize` module works as expected when syncing data from _controller_ to _inventory_hostname_ (driver: Docker).

But if fails to sync data over SSH between two controlled containers during a _play_ on one of them when the other is used as `delegate_to`

Note:
> The two controlled host are prepared during Molecule _prepare_ phase to communicate with each other (SSH keys shared and _authorized_key_ updated accordingly)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/action/synchronize.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<details><summary><i>molecule --debug converge</i> 
</summary><p>

```yaml
---
- name: Converge
  hosts: server
  tasks:
    - name: Send data from backup server to destination server
      become: true
      synchronize:
        src: "/backup/{{ src_server }}/hourly.0/home/{{ user }}/{{ item }}"
        dest: "/home/{{ user }}/volumes//{{ item }}/"
      with_items:
        - conf
        - data
      delegate_to: "{{ backup_server }}"
```

```bash
failed: [server -> backup-server] (item=conf) => {
    "ansible_loop_var": "item",
    "changed": false,
    "cmd": "/bin/rsync --delay-updates -F --compress --archive --blocking-io --rsh=/usr/bin/docker exec -u root -i --out-format=<<CHANGED>>%i %n%L /backup/org-server/hourly.0/home/user/ server:/home/user",
    "invocation": {
        "module_args": {
            "_local_rsync_password": null,
            "_local_rsync_path": "rsync",
            "_substitute_controller": false,
            "archive": true,
            "checksum": false,
            "compress": true,
            "copy_links": false,
            "delete": false,
            "dest": "server:/home/user/volumes/conf/",
            "dest_port": null,
            "dirs": false,
            "existing_only": false,
            "group": null,
            "link_dest": null,
            "links": null,
            "mode": "push",
            "owner": null,
            "partial": false,
            "perms": null,
            "private_key": null,
            "recursive": null,
            "rsync_opts": [
                "--blocking-io",
                "--rsh=/usr/bin/docker exec -u root -i"
            ],
            "rsync_path": null,
            "rsync_timeout": 0,
            "set_remote_user": true,
            "src": "/backup/org-server/hourly.0/home/user/conf",
            "ssh_args": null,
            "times": null,
            "verify_host": false
        }
    },
    "item": "conf",
    "msg": "rsync: Failed to exec /usr/bin/docker: No such file or directory (2)\nrsync error: error in IPC code (code 14) at pipe.c(85) [sender=3.1.2]\nrsync: connection unexpectedly closed (0 bytes received so far) [sender]\nrsync error: error in IPC c
ode (code 14) at io.c(226) [sender=3.1.2]\n",
    "rc": 14
}
```
</p></details>