### PR TITLE
Allow authorized_key module to use any URI that Ansible supports

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -541,13 +541,13 @@ def enforce_state(module, params):
     error_msg = "Error getting key from: %s"
 
     # if the key is a url, request it and use it as key source
-    if key.startswith("http"):
+    if re.search("^([A-Za-z0-9+.-]+:)?/", key):
         try:
             resp, info = fetch_url(module, key)
-            if info['status'] != 200:
-                module.fail_json(msg=error_msg % key)
-            else:
+            if resp:
                 key = resp.read()
+            else:
+                module.fail_json(msg=error_msg % key)
         except Exception:
             module.fail_json(msg=error_msg % key)
 

--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -227,7 +227,8 @@ from operator import itemgetter
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.six.moves.urllib.parse import urlparse
+from ansible.module_utils.urls import fetch_url, generic_urlparse
 
 
 class keydict(dict):
@@ -541,7 +542,7 @@ def enforce_state(module, params):
     error_msg = "Error getting key from: %s"
 
     # if the key is a url, request it and use it as key source
-    if re.search("^([A-Za-z0-9+.-]+:)?/", key):
+    if generic_urlparse(urlparse(key)).scheme:
         try:
             resp, info = fetch_url(module, key)
             if resp:


### PR DESCRIPTION
##### SUMMARY
At the present the authorized_key module supports fetching keys only from HTTP(S) despite of using fetch_url(), which supports e.g. ftp:// URIs.

Note: the flawed `if info['status'] == 200` check is used in other places, so similar treatment is likely needed there as well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
authorized_key

##### ADDITIONAL INFORMATION
Sample playbook:
```ansible
---
- name: pampampam
  hosts: localhost
  tasks:
    - name: lalala
      authorized_key:
        user: pers
        state: present
        key: ftp://127.0.0.1/pub/id_localtest.pub
```

Before:
```
PLAY [pampampam] ***********************************************************************************************************************************************************
                                                                                                                                                                            
TASK [Gathering Facts] *****************************************************************************************************************************************************
ok: [localhost]                                                                                                                                                             
                                                                                                                                                                            
TASK [lalala] **************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "invalid key specified: ftp://127.0.0.1/pub/id_localtest.pub"}                                                     
                                                                                                                                                                            
PLAY RECAP *****************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0                                                          
```

After:
```
PLAY [pampampam] *********************************************************************

TASK [Gathering Facts] ***************************************************************
ok: [localhost]

TASK [lalala] ************************************************************************
ok: [localhost]

PLAY RECAP ***************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```