### PR TITLE
Fix list formatting in Getting Started docs page

### DIFF
--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -47,10 +47,10 @@ Confirm that you can connect using SSH to all the nodes in your inventory using 
 Beyond the basics
 -----------------
 You can override the default remote user name in several ways, including:
-* passing the ``-u`` parameter at the command line
-* setting user information in your inventory file
-* setting user information in your configuration file
-* setting environment variables
+  * passing the ``-u`` parameter at the command line
+  * setting user information in your inventory file
+  * setting user information in your configuration file
+  * setting environment variables
 
 See :ref:`general_precedence_rules` for details on the (sometimes unintuitive) precedence of each method of passing user information. You can read more about connections in :ref:`connections`.
 


### PR DESCRIPTION
##### SUMMARY

A bullet list in the docs does not render as a list on the website, this indents the list so that it renders correctly in HTML.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Docs "Getting Started" page

##### ADDITIONAL INFORMATION

Screenshot of the issue taken from https://docs.ansible.com/ansible/latest/user_guide/intro_getting_started.html#id1

<img width="633" alt="Screen Shot 2019-12-11 at 8 17 48 AM" src="https://user-images.githubusercontent.com/1879136/70580673-950cd000-1bef-11ea-95e5-cd9bfb0002c8.png">

