### PR TITLE
VMware: Fix cluster argument of module vmware_content_deploy_template

### DIFF
--- a/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
+++ b/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "`vmware_content_deploy_template`'s `cluster` argument no longer fails with an error message about resource pools."

--- a/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
@@ -190,7 +190,7 @@ class VmwareContentDeployTemplate(VmwareRestClient):
         # Find the Cluster by the given Cluster name
         self.cluster_id = None
         if self.cluster:
-            self.cluster_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool)
+            self.cluster_id = self.get_cluster_by_name(self.datacenter, self.cluster)
             if not self.cluster_id:
                 self.module.fail_json(msg="Failed to find the Cluster %s" % self.cluster)
         # Create VM placement specs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix copy-paste typo which breaks cluster argument of vmware_content_deploy_template

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_content_deploy_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If you try using the cluster argument of vmware_content_deploy_template you will get an error about how it cannot be found because it's looking for a resource pool with that name instead of a cluster.

This fixes that problem.