### PR TITLE
add possibility to dump only tables

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -72,7 +72,9 @@ options:
     version_added: "2.10"
   only_tables:
     description:
-      - dump only tabels of exactly one database, without use database inside the dump
+      - Dump only tabels of exactly one database, without use database inside the dump.
+      - Can be used only when I(state=dump).
+      - Mutually exclusive with ....
     required: false
     default: false
     type: bool

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -275,7 +275,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
         cmd += " --host=%s --port=%i" % (shlex_quote(host), port)
     if all_databases:
         cmd += " --all-databases"
-    elif only_tables and len(db_name) == 1:
+    elif only_tables:
         cmd += " %s" % db_name[0]
     else:
         cmd += " --databases {0} --skip-lock-tables".format(' '.join(db_name))

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -76,7 +76,7 @@ options:
     required: false
     default: false
     type: bool
-    version_added: "?? devel"
+    version_added: "2.10"
   force:
     description:
       - Continue dump or import even if we get an SQL error.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `only_tables` option for dumps. This don't add `CREATE DATABASE <name>` and `USE <database>` in the dump. This is needed, if you import a dump from database **A** in Database **B**

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65351

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
