### PR TITLE
[uri] testing https_proxy env variable and no_proxy

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -526,7 +526,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
 
     resp, info = fetch_url(module, url, data=data, headers=headers,
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
-                           **kwargs)
+                           use_proxy=module.params['use_proxy'], **kwargs)
 
     try:
         content = resp.read()

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -203,6 +203,34 @@
     that:
       - 'result.allow.split(", ")|sort == ["GET", "HEAD", "OPTIONS"]'
 
+- name: Testing support of https_proxy (with failure expected)
+  environment:
+    LANG: C
+    https_proxy: 'https://localhost:3456'
+  uri:
+    url: 'https://{{ httpbin_host }}/get/'
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+    - result is failed
+    - result.status == -1
+
+- name: Testing use_proxy=no is honored
+  environment:
+    LANG: C
+    https_proxy: 'https://localhost:3456'
+  uri:
+    url: 'https://{{ httpbin_host }}/get/'
+    use_proxy: no
+  register: result
+
+- assert:
+    that:
+      - result.status == 200
+      - "'X-Forwarded-For' not in result.json.headers"
+
 # Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations
 # We'll use this to just skip 12.04 on those tests.  We should be sufficiently covered with other OSes and versions
 - name: Set fact if running on Ubuntu 12.04


### PR DESCRIPTION
##### SUMMARY
Adding a couple of tests about ` https_proxy` environment variable and `use_proxy`
parameter to complete PR #65706  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module uri

##### ADDITIONAL INFORMATION
none
