### PR TITLE
[get_url] Return status_code on HTTP 304

### DIFF
--- a/changelogs/fragments/65307-get_url-return-status-code-on-http-304.yaml
+++ b/changelogs/fragments/65307-get_url-return-status-code-on-http-304.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "On HTTP status code 304, return status_code"

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -364,7 +364,7 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
     elapsed = (datetime.datetime.utcnow() - start).seconds
 
     if info['status'] == 304:
-        module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''), elapsed=elapsed)
+        module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''), status_code=info['status'], elapsed=elapsed)
 
     # Exceptions in fetch_url may result in a status -1, the ensures a proper error to the user in all cases
     if info['status'] == -1:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -221,7 +221,7 @@
       - result is changed
       - "stat_result.stat.mode == '0707'"
 
-- name: Test that setting file modes on an already downlaoded file work
+- name: Test that setting file modes on an already downloaded file work
   get_url:
     url: 'https://{{ httpbin_host }}/'
     dest: '{{ remote_tmp_dir }}/test'
@@ -237,6 +237,19 @@
     that:
       - result is changed
       - "stat_result.stat.mode == '0070'"
+
+# https://github.com/ansible/ansible/pull/65307/
+- name: Test that on http status 304, we get a status_code field.
+  get_url:
+    url: 'https://{{ httpbin_host }}/status/304'
+    dest: '{{ remote_tmp_dir }}/test'
+  register: result
+
+- name: Assert that we get the appropriate status_code
+  assert:
+    that:
+      - "'status_code' in result"
+      - "result.status_code == 304"
 
 # https://github.com/ansible/ansible/issues/29614
 - name: Change mode on an already downloaded file and specify checksum


### PR DESCRIPTION
Return field status_code on HTTP status 304 (implemented by @lkthomas on #65307)
Add an integration test for this case.

Fixes #65263

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module get_url
