### PR TITLE
Improve deprecate sanity check; remove deprecated features which should have been removed for 2.9

### DIFF
--- a/changelogs/fragments/remove-2.9-deprecations.yml
+++ b/changelogs/fragments/remove-2.9-deprecations.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- "ansible-test - improve ``deprecate()`` call checker."
+removed_features:
+- "core - remove support for ``check_invalid_arguments`` in ``AnsibleModule``, ``AzureModule`` and ``UTMModule``."

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -339,7 +339,7 @@ AZURE_MIN_RELEASE = '2.0.0'
 
 class AzureRMModuleBase(object):
     def __init__(self, derived_arg_spec, bypass_checks=False, no_log=False,
-                 check_invalid_arguments=None, mutually_exclusive=None, required_together=None,
+                 mutually_exclusive=None, required_together=None,
                  required_one_of=None, add_file_common_args=False, supports_check_mode=False,
                  required_if=None, supports_tags=True, facts_module=False, skip_exec=False):
 
@@ -358,7 +358,6 @@ class AzureRMModuleBase(object):
         self.module = AnsibleModule(argument_spec=merged_arg_spec,
                                     bypass_checks=bypass_checks,
                                     no_log=no_log,
-                                    check_invalid_arguments=check_invalid_arguments,
                                     mutually_exclusive=mutually_exclusive,
                                     required_together=required_together,
                                     required_one_of=required_one_of,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -579,9 +579,9 @@ class AnsibleFallbackNotFound(Exception):
 
 class AnsibleModule(object):
     def __init__(self, argument_spec, bypass_checks=False, no_log=False,
-                 check_invalid_arguments=None, mutually_exclusive=None, required_together=None,
-                 required_one_of=None, add_file_common_args=False, supports_check_mode=False,
-                 required_if=None, required_by=None):
+                 mutually_exclusive=None, required_together=None,
+                 required_one_of=None, add_file_common_args=False,
+                 supports_check_mode=False, required_if=None, required_by=None):
 
         '''
         Common code for quickly building an ansible module in Python
@@ -597,14 +597,6 @@ class AnsibleModule(object):
         self.check_mode = False
         self.bypass_checks = bypass_checks
         self.no_log = no_log
-
-        # Check whether code set this explicitly for deprecation purposes
-        if check_invalid_arguments is None:
-            check_invalid_arguments = True
-            module_set_check_invalid_arguments = False
-        else:
-            module_set_check_invalid_arguments = True
-        self.check_invalid_arguments = check_invalid_arguments
 
         self.mutually_exclusive = mutually_exclusive
         self.required_together = required_together
@@ -654,7 +646,7 @@ class AnsibleModule(object):
         # a known valid (LANG=C) if it's an invalid/unavailable locale
         self._check_locale()
 
-        self._check_arguments(check_invalid_arguments)
+        self._check_arguments()
 
         # check exclusive early
         if not bypass_checks:
@@ -695,15 +687,6 @@ class AnsibleModule(object):
 
         # finally, make sure we're in a sane working dir
         self._set_cwd()
-
-        # Do this at the end so that logging parameters have been set up
-        # This is to warn third party module authors that the functionality is going away.
-        # We exclude uri and zfs as they have their own deprecation warnings for users and we'll
-        # make sure to update their code to stop using check_invalid_arguments when 2.9 rolls around
-        if module_set_check_invalid_arguments and self._name not in ('uri', 'zfs'):
-            self.deprecate('Setting check_invalid_arguments is deprecated and will be removed.'
-                           ' Update the code for this module  In the future, AnsibleModule will'
-                           ' always check for invalid arguments.', version='2.9')
 
     @property
     def tmpdir(self):
@@ -1454,7 +1437,7 @@ class AnsibleModule(object):
                                "%s" % to_native(te), invocation={'module_args': 'HIDDEN DUE TO FAILURE'})
         self._deprecations.extend(list_deprecations(spec, param))
 
-    def _check_arguments(self, check_invalid_arguments, spec=None, param=None, legal_inputs=None):
+    def _check_arguments(self, spec=None, param=None, legal_inputs=None):
         self._syslog_facility = 'LOG_USER'
         unsupported_parameters = set()
         if spec is None:
@@ -1466,7 +1449,7 @@ class AnsibleModule(object):
 
         for k in list(param.keys()):
 
-            if check_invalid_arguments and k not in legal_inputs:
+            if k not in legal_inputs:
                 unsupported_parameters.add(k)
 
         for k in PASS_VARS:
@@ -1728,7 +1711,7 @@ class AnsibleModule(object):
 
                     options_legal_inputs = list(spec.keys()) + list(options_aliases.keys())
 
-                    self._check_arguments(self.check_invalid_arguments, spec, param, options_legal_inputs)
+                    self._check_arguments(spec, param, options_legal_inputs)
 
                     # check exclusive early
                     if not self.bypass_checks:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2054,9 +2054,9 @@ class AnsibleModule(object):
                     elif isinstance(d, Mapping):
                         self.deprecate(d['msg'], version=d.get('version', None))
                     else:
-                        self.deprecate(d)
+                        self.deprecate(d)  # pylint: disable=ansible-deprecated-no-version
             else:
-                self.deprecate(kwargs['deprecations'])
+                self.deprecate(kwargs['deprecations'])  # pylint: disable=ansible-deprecated-no-version
 
         if self._deprecations:
             kwargs['deprecations'] = self._deprecations

--- a/lib/ansible/module_utils/utm_utils.py
+++ b/lib/ansible/module_utils/utm_utils.py
@@ -55,7 +55,7 @@ class UTMModule(AnsibleModule):
     See the other modules like utm_aaa_group for example.
     """
 
-    def __init__(self, argument_spec, bypass_checks=False, no_log=False, check_invalid_arguments=None,
+    def __init__(self, argument_spec, bypass_checks=False, no_log=False,
                  mutually_exclusive=None, required_together=None, required_one_of=None, add_file_common_args=False,
                  supports_check_mode=False, required_if=None):
         default_specs = dict(
@@ -68,7 +68,7 @@ class UTMModule(AnsibleModule):
             state=dict(default='present', choices=['present', 'absent'])
         )
         super(UTMModule, self).__init__(self._merge_specs(default_specs, argument_spec), bypass_checks, no_log,
-                                        check_invalid_arguments, mutually_exclusive, required_together, required_one_of,
+                                        mutually_exclusive, required_together, required_one_of,
                                         add_file_common_args, supports_check_mode, required_if)
 
     def _merge_specs(self, default_specs, custom_specs):

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
@@ -64,7 +64,7 @@ class AnsibleDeprecatedChecker(BaseChecker):
         version = None
         try:
             if (node.func.attrname == 'deprecated' and 'display' in _get_expr_name(node) or
-                    node.func.attrname == 'deprecate' and 'module' in _get_expr_name(node)):
+                    node.func.attrname == 'deprecate' and _get_expr_name(node)):
                 if node.keywords:
                     for keyword in node.keywords:
                         if len(node.keywords) == 1 and keyword.arg is None:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6274,6 +6274,7 @@ test/units/module_utils/aws/test_aws_module.py metaclass-boilerplate
 test/units/module_utils/basic/test__symbolic_mode_to_octal.py future-import-boilerplate
 test/units/module_utils/basic/test_deprecate_warn.py future-import-boilerplate
 test/units/module_utils/basic/test_deprecate_warn.py metaclass-boilerplate
+test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-no-version
 test/units/module_utils/basic/test_exit_json.py future-import-boilerplate
 test/units/module_utils/basic/test_get_file_attributes.py future-import-boilerplate
 test/units/module_utils/basic/test_heuristic_log_sanitize.py future-import-boilerplate


### PR DESCRIPTION
##### SUMMARY
This PR improves the sanity check for the deprecation sanity check, and removes features which should have been removed for Ansible 2.9 but weren't. These are:
```
ERROR: lib/ansible/module_utils/basic.py:704:12: ansible-deprecated-version: Deprecated version ('2.9') found in call to Display.deprecated or AnsibleModule.deprecate
ERROR: lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py:743:16: ansible-deprecated-version: Deprecated version ('2.9') found in call to Display.deprecated or AnsibleModule.deprecate
ERROR: lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py:640:12: ansible-deprecated-version: Deprecated version ('2.9') found in call to Display.deprecated or AnsibleModule.deprecate
```

Fixes #65471.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
lib/ansible/module_utils/basic.py
lib/ansible/module_utils/azure_rm_common.py
lib/ansible/module_utils/utm_utils.py
