### PR TITLE
azure_rm_loadbalancer, azure_rm_networkinterface: remove functionality which should have been removed for Ansible 2.9

### DIFF
--- a/changelogs/fragments/remove-2.9-deprecations-azure.yml
+++ b/changelogs/fragments/remove-2.9-deprecations-azure.yml
@@ -1,0 +1,6 @@
+removed_features:
+- "azure_rm_networkinterface - the deprecated options ``private_ip_address``, ``private_ip_allocation_method``, ``public_ip``, ``public_ip_address_name``, ``public_ip_allocation_method`` were removed. Use ``ip_configurations`` instead."
+- "azure_rm_loadbalancer - the deprecated option ``public_ip_address_name`` was removed. Use ``frontend_ip_configurations`` instead."
+- "azure_rm_loadbalancer - the deprecated options ``probe_port``, ``probe_protocol``, ``probe_interval``, ``probe_fail_count``, ``probe_request_path`` were removed. Use ``probes`` instead."
+- "azure_rm_loadbalancer - the deprecated options ``protocol``, ``load_distribution``, ``frontend_port``, ``backend_port``, ``idle_timeout`` were removed. Use ``load_balancing_rules`` instead."
+- "azure_rm_loadbalancer - the deprecated options ``natpool_frontend_port_start``, ``natpool_frontend_port_end``, ``natpool_backend_port``, ``natpool_protocol`` were removed. Use ``inbound_nat_pools`` instead."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -103,6 +103,12 @@ Noteworthy module changes
     * When the directory specified by ``paths`` does not exist or is a file, it will no longer fail and will just warn the user
     * Junction points are no longer reported as ``islnk``, use ``isjunction`` to properly report these files. This behaviour matches the :ref:`win_stat <win_stat_module>`
     * Directories no longer return a ``size``, this matches the ``stat`` and ``find`` behaviour and has been removed due to the difficulties in correctly reporting the size of a directory
+* The deprecated options ``private_ip_address``, ``private_ip_allocation_method``, ``public_ip``, ``public_ip_address_name``, ``public_ip_allocation_method`` of :ref:`azure_rm_networkinterface <azure_rm_networkinterface_module>` were removed. Use the ``ip_configurations`` option instead.
+* The deprecated option ``public_ip_address_name`` of :ref:`azure_rm_loadbalancer <azure_rm_loadbalancer_module>` was removed. Use ``frontend_ip_configurations`` instead."
+* The deprecated options ``probe_port``, ``probe_protocol``, ``probe_interval``, ``probe_fail_count``, ``probe_request_path`` of :ref:`azure_rm_loadbalancer <azure_rm_loadbalancer_module>` were removed. Use ``probes`` instead."
+* The deprecated options ``protocol``, ``load_distribution``, ``frontend_port``, ``backend_port``, ``idle_timeout`` of :ref:`azure_rm_loadbalancer <azure_rm_loadbalancer_module>` were removed. Use ``load_balancing_rules`` instead."
+* The deprecated options ``natpool_frontend_port_start``, ``natpool_frontend_port_end``, ``natpool_backend_port``, ``natpool_protocol`` of :ref:`azure_rm_loadbalancer <azure_rm_loadbalancer_module>` were removed. Use ``inbound_nat_pools`` instead."
+
 
 Plugins
 =======


### PR DESCRIPTION
##### SUMMARY
As found in #65745, these two modules contain options which were supposed to be removed in Ansible 2.9. Since the sanity check didn't find the corresponding `module.deprecate()` calls, no issue was created and these deprecations were apparently forgotten.

I've started to remove the code in #65745, but noticed that this also requires exensive updating of the tests, since many integration tests seem to use the deprecated options a lot.

I'm not using any of the azure modules, and I don't have access to azure, so I'd be really happy if someone else would complete this work :-) Feel free to update this PR (if you have the appropriate rights), to clone the PR, or to start a new PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer
azure_rm_networkinterface
