### PR TITLE
Clean up flake8 errors for eos unit tests

### DIFF
--- a/test/units/modules/network/eos/test_eos_config.py
+++ b/test/units/modules/network/eos/test_eos_config.py
@@ -70,7 +70,7 @@ class TestEosConfigModule(TestEosModule):
         args = dict(lines=lines)
         set_module_args(args)
         self.conn.get_diff = MagicMock(return_value=self.cliconf_obj.get_diff(config, config))
-        result = self.execute_module()
+        self.execute_module()
 
     def test_eos_config_src(self):
         src = load_fixture('eos_config_candidate.cfg')
@@ -134,27 +134,27 @@ class TestEosConfigModule(TestEosModule):
     def test_eos_config_src_and_lines_fails(self):
         args = dict(src='foo', lines='foo')
         set_module_args(args)
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)
 
     def test_eos_config_match_exact_requires_lines(self):
         args = dict(match='exact')
         set_module_args(args)
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)
 
     def test_eos_config_match_strict_requires_lines(self):
         args = dict(match='strict')
         set_module_args(args)
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)
 
     def test_eos_config_replace_block_requires_lines(self):
         args = dict(replace='block')
         set_module_args(args)
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)
 
     def test_eos_config_replace_config_requires_src(self):
         args = dict(replace='config')
         set_module_args(args)
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)
 
     def test_eos_config_backup_returns__backup__(self):
         args = dict(backup=True)
@@ -171,14 +171,14 @@ class TestEosConfigModule(TestEosModule):
 
         args = dict(save_when='modified')
         set_module_args(args)
-        result = self.execute_module()
+        self.execute_module()
 
         run_commands.return_value = [load_fixture('eos_config_config.cfg'),
                                      load_fixture('eos_config_config_updated.cfg')]
 
         args = dict(save_when='modified')
         set_module_args(args)
-        result = self.execute_module(changed=True)
+        self.execute_module(changed=True)
 
         mock_run_commands.stop()
 

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -160,9 +160,3 @@ class TestEosEapiModule(TestEosModule):
         set_module_args(dict(state='stopped', timeout=1))
         result = self.start_configured(failed=True)
         'timeout expired before eapi running state changed' in result['msg']
-
-    def test_eos_eapi_state_failed(self):
-        self.mock_verify_state.stop()
-        set_module_args(dict(state='stopped', timeout=1))
-        result = self.start_configured(failed=True)
-        'timeout expired before eapi running state changed' in result['msg']

--- a/test/units/modules/network/eos/test_eos_logging.py
+++ b/test/units/modules/network/eos/test_eos_logging.py
@@ -19,9 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from units.compat.mock import patch, MagicMock
+from units.compat.mock import patch
 from ansible.modules.network.eos import eos_logging
-from ansible.plugins.cliconf.eos import Cliconf
 from units.modules.utils import set_module_args
 from .eos_module import TestEosModule, load_fixture
 
@@ -72,31 +71,29 @@ class TestEosLoggingModule(TestEosModule):
     def test_eos_buffer_size(self):
         set_module_args(dict(dest='buffered', size=5000))
         commands = ['logging buffered 5000']
-        result = self.execute_module(changed=True, commands=commands)
+        self.execute_module(changed=True, commands=commands)
 
     def test_eos_buffer_size_idempotent(self):
         set_module_args(dict(dest='buffered', size=50000, level='informational'))
-        result = self.execute_module(changed=False, commands=[])
+        self.execute_module(changed=False, commands=[])
 
     def test_eos_facilty(self):
         set_module_args(dict(facility='local2'))
         commands = ['logging facility local2']
-        result = self.execute_module(changed=True, commands=commands)
-        # when dest is not passed, 'None' is set to dest
-        # self.assertEqual(sorted(result['commands'])[1], commands[0])
+        self.execute_module(changed=True, commands=commands)
 
     def test_eos_facility_idempotent(self):
         set_module_args(dict(facility='local7'))
-        result = self.execute_module(changed=False, commands=[])
+        self.execute_module(changed=False, commands=[])
 
     def test_eos_level(self):
         set_module_args(dict(dest='console', level='critical'))
         commands = ['logging console critical']
-        result = self.execute_module(changed=True, commands=commands)
+        self.execute_module(changed=True, commands=commands)
 
     def test_eos_level_idempotent(self):
         set_module_args(dict(dest='console', level='warnings'))
-        result = self.execute_module(changed=False, commands=[])
+        self.execute_module(changed=False, commands=[])
 
     def test_eos_logging_state_absent(self):
         set_module_args(dict(dest='host', name='175.16.0.10', state='absent'))

--- a/test/units/modules/network/eos/test_eos_system.py
+++ b/test/units/modules/network/eos/test_eos_system.py
@@ -107,4 +107,4 @@ class TestEosSystemModule(TestEosModule):
     def test_eos_system_missing_vrf(self):
         name_servers = dict(server='8.8.8.8', vrf='missing')
         set_module_args(dict(name_servers=name_servers))
-        result = self.execute_module(failed=True)
+        self.execute_module(failed=True)


### PR DESCRIPTION
These were found while migrating our content to eos collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>