### PR TITLE
mysql_info: add return_empty_dbs parameter

### DIFF
--- a/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
+++ b/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
@@ -1,2 +1,2 @@
-bugfixes:
-- mysql_info - doesn't list empty databases (https://github.com/ansible/ansible/issues/65727).
+minor_changes:
+- mysql_info - add ``return_empty_dbs`` parameter to list empty databases (https://github.com/ansible/ansible/issues/65727).

--- a/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
+++ b/changelogs/fragments/65755-mysql_info_doesnt_list_empty_dbs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_info - doesn't list empty databases (https://github.com/ansible/ansible/issues/65727).

--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -251,14 +251,14 @@ class MySQL_Info(object):
             'slave_status': {},
         }
 
-    def get_info(self, filter_, exclude_fields):
+    def get_info(self, filter_, exclude_fields, return_empty_dbs):
         """Get MySQL instance information based on filter_.
 
         Arguments:
             filter_ (list): List of collected subsets (e.g., databases, users, etc.),
                 when it is empty, return all available information.
         """
-        self.__collect(exclude_fields)
+        self.__collect(exclude_fields, return_empty_dbs)
 
         inc_list = []
         exc_list = []
@@ -294,7 +294,7 @@ class MySQL_Info(object):
 
     def __collect(self, exclude_fields, return_empty_dbs):
         """Collect all possible subsets."""
-        self.__get_databases(exclude_fields)
+        self.__get_databases(exclude_fields, return_empty_dbs)
         self.__get_global_variables()
         self.__get_global_status()
         self.__get_engines()

--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -428,6 +428,16 @@ class MySQL_Info(object):
                 if not exclude_fields or 'db_size' not in exclude_fields:
                     self.info['databases'][db['name']]['size'] = int(db['size'])
 
+        # Add info about empty databases (issue #65727):
+        res = self.__exec_sql('SHOW DATABASES')
+        if res:
+            for db in res:
+                if db['Database'] not in self.info['databases']:
+                    self.info['databases'][db['Database']] = {}
+
+                    if not exclude_fields or 'db_size' not in exclude_fields:
+                        self.info['databases'][db['Database']]['size'] = 0
+
     def __exec_sql(self, query, ddl=False):
         """Execute SQL.
 

--- a/test/integration/targets/mysql_info/tasks/main.yml
+++ b/test/integration/targets/mysql_info/tasks/main.yml
@@ -154,6 +154,7 @@
     login_password: '{{ user_pass }}'
     filter:
     - databases
+    return_empty_dbs: yes
   register: result
 
 # Check acme is in returned dict
@@ -171,6 +172,7 @@
     - databases
     exclude_fields:
     - db_size
+    return_empty_dbs: yes
   register: result
 
 # Check acme is in returned dict

--- a/test/integration/targets/mysql_info/tasks/main.yml
+++ b/test/integration/targets/mysql_info/tasks/main.yml
@@ -138,3 +138,51 @@
     - result.changed == false
     - result.databases != {}
     - result.databases.mysql == {}
+
+########################################################
+# Issue #65727, empty databases must be in returned dict
+#
+- name: Create empty database acme
+  mysql_db:
+    login_user: '{{ user_name }}'
+    login_password: '{{ user_pass }}'
+    name: acme
+
+- name: Collect info about databases
+  mysql_info:
+    login_user: '{{ user_name }}'
+    login_password: '{{ user_pass }}'
+    filter:
+    - databases
+  register: result
+
+# Check acme is in returned dict
+- assert:
+    that:
+    - result.changed == false
+    - result.databases.acme.size == 0
+    - result.databases.mysql != {}
+
+- name: Collect info about databases excluding their sizes
+  mysql_info:
+    login_user: '{{ user_name }}'
+    login_password: '{{ user_pass }}'
+    filter:
+    - databases
+    exclude_fields:
+    - db_size
+  register: result
+
+# Check acme is in returned dict
+- assert:
+    that:
+    - result.changed == false
+    - result.databases.acme == {}
+    - result.databases.mysql == {}
+
+- name: Remove acme database
+  mysql_db:
+    login_user: '{{ user_name }}'
+    login_password: '{{ user_pass }}'
+    name: acme
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/ansible/issues/65727

1. mysql_info: add return_empty_dbs parameter
2. Bugfix: mysql_info doesn't list empty DBs

Now, when db is empty, it returns:
```
    "databases": {
        "empty": {
            "size": 0
        },
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_info.py```
