### PR TITLE
nxos_interface: Always cleanup vlan interfaces in test

### DIFF
--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -109,7 +109,7 @@
 
   - assert: *false
 
-  rescue:
+  always:
   - name: "Set interface back to default"
     nxos_config: *intcleanup
     ignore_errors: yes
@@ -124,5 +124,4 @@
       state: disabled
     ignore_errors: yes
 
-  always:
   - debug: msg="END connection={{ ansible_connection }} nxos_interface sanity test"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Always cleanup vlan interfaces so that there are no left overs which may fail `before`/`after` assertions for RMs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
targets/nxos_interface
