### PR TITLE
Fix variable name in an example in documentation of variables

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -1186,7 +1186,7 @@ This can often be used for things that might apply to some hosts multiple times.
            myname: John
 
 In this example, the same role was invoked multiple times.  It's quite likely there was
-no default for ``name`` supplied at all.  Ansible can warn you when variables aren't defined -- it's the default behavior in fact.
+no default for ``myname`` supplied at all.  Ansible can warn you when variables aren't defined -- it's the default behavior in fact.
 
 There are a few other things that go on with roles.
 


### PR DESCRIPTION
##### SUMMARY
The variable name does not seem to be consistent between the example code (`myname`) and the text below (mentioning a variable called `name`).
I think it should be fixed with `myname` on both sides

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr