### PR TITLE
mysql_db does not support --no-create-db flag

### DIFF
--- a/changelogs/fragments/65773-add-no-create-db-flag.yml
+++ b/changelogs/fragments/65773-add-no-create-db-flag.yml
@@ -1,0 +1,3 @@
+minor_changes:
+    - mysql_db creates a db unless its passed the --no-create-db flag (https://github.com/ansible/ansible/pull/65773).
+    

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -249,7 +249,7 @@ def db_delete(cursor, db):
 def db_dump(module, host, user, password, db_name, target, all_databases, port,
             config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None, hex_blob=None,
-            encoding=None, force=False, create_new=None):
+            encoding=None, force=False, no_create_db=False):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -62,7 +62,7 @@ options:
       - Option used to exclude CREATE DATABASE and USE commands
     type: bool
     default: 'no'
-    version_added: "2.X"
+    version_added: '2.10'
   ignore_tables:
     description:
       - A list of table names that will be ignored in the dump of the form database_name.table_name

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -413,6 +413,7 @@ def main():
             config_file=dict(type='path', default='~/.my.cnf'),
             single_transaction=dict(type='bool', default=False),
             quick=dict(type='bool', default=True),
+            no_create_db=dict(type='bool', Default=False),
             ignore_tables=dict(type='list', default=[]),
             hex_blob=dict(default=False, type='bool'),
             force=dict(type='bool', default=False),
@@ -450,6 +451,7 @@ def main():
             module.fail_json(msg="Name of ignored table cannot be empty")
     single_transaction = module.params["single_transaction"]
     quick = module.params["quick"]
+    no_create_db = module.params["no_create_db"]
     hex_blob = module.params["hex_blob"]
     force = module.params["force"]
 

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -57,6 +57,12 @@ options:
     type: bool
     default: 'yes'
     version_added: "2.1"
+  create_new:
+    description:
+      - Option used to exclude CREATE DATABASE and USE commands
+    type: bool
+    default: 'no'
+    version_added: "2.X"
   ignore_tables:
     description:
       - A list of table names that will be ignored in the dump of the form database_name.table_name
@@ -243,7 +249,7 @@ def db_delete(cursor, db):
 def db_dump(module, host, user, password, db_name, target, all_databases, port,
             config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None, hex_blob=None,
-            encoding=None, force=False):
+            encoding=None, force=False, create_new=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
@@ -274,6 +280,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
         cmd += " --single-transaction=true"
     if quick:
         cmd += " --quick"
+    if create_new:
+        cmd += " --no-create-db"
     if ignore_tables:
         for an_ignored_table in ignore_tables:
             cmd += " --ignore-table={0}".format(an_ignored_table)

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -59,7 +59,7 @@ options:
     version_added: "2.1"
   no_create_db:
     description:
-      - Option used to exclude CREATE DATABASE and USE commands
+      - Option used to exclude CREATE DATABASE and USE commands. Used only with I(state=export).
     type: bool
     default: 'no'
     version_added: '2.10'

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -280,7 +280,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
         cmd += " --single-transaction=true"
     if quick:
         cmd += " --quick"
-    if create_new:
+    if no_create_db:
         cmd += " --no-create-db"
     if ignore_tables:
         for an_ignored_table in ignore_tables:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -57,7 +57,7 @@ options:
     type: bool
     default: 'yes'
     version_added: "2.1"
-  create_new:
+  no_create_db:
     description:
       - Option used to exclude CREATE DATABASE and USE commands
     type: bool


### PR DESCRIPTION
…o-create-db flag

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The mysql_db module does not provide the ability to include the --no-create-db flag when performing a dump. This PR includes this functionality. We have tested this within the scope of our project.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mysql_db

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue can be seen in detail here. I am not the author of the stackoverflow.
https://stackoverflow.com/questions/59216939/database-specificity-in-sql-dump-file-generated-using-ansible-mysql-db-module 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
--no-create-db
```
