### PR TITLE
Explanation for "check_mode: no" is confusing

### DIFF
--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -47,7 +47,7 @@ existing system, using the `--check` flag to the `ansible` command will report i
 bring the system into a desired state.
 
 This can let you know up front if there is any need to deploy onto the given system.  Ordinarily scripts and commands don't run in check mode, so if you
-want certain steps to always execute in check mode, such as calls to the script module, disable check mode for those tasks::
+want certain steps to execute in normal mode even when the `--check` flag is used, such as calls to the script module, disable check mode for those tasks::
 
 
    roles:


### PR DESCRIPTION
##### SUMMARY
When an ansible module, e.g., command, does not support check mode. You can use "check_mode: no" in that task to execute the task in normal mode, even when "--check" flag is used. 
The current document basically says that, we should use "check_mode: no" to run in check mode, which is confusing and inaccurate.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When an ansible module, e.g., command, does not support check mode. You can use "check_mode: no" in that task to execute the task in normal mode, even when "--check" flag is used. 
The current document basically says that, we should use "check_mode: no" to run in check mode, which is confusing and inaccurate.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Documentation.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
