### PR TITLE
PluginLoader - recursively include dirs from extra and configured plugin paths

### DIFF
--- a/changelogs/fragments/65776-fix-PluginLoader-searching-subdirs.yaml
+++ b/changelogs/fragments/65776-fix-PluginLoader-searching-subdirs.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - PluginLoader - Allow recursively adding subdirs from extra and configured plugin paths
+    (https://github.com/ansible/ansible/issues/65565)

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -242,17 +242,20 @@ class PluginLoader:
 
         ret = self._extra_dirs[:]
 
-        # look in any configured plugin paths, allow one level deep for subcategories
+        # append configured plugin paths
         if self.config is not None:
             for path in self.config:
                 path = os.path.realpath(os.path.expanduser(path))
-                if subdirs:
-                    contents = glob.glob("%s/*" % path) + glob.glob("%s/*/*" % path)
-                    for c in contents:
-                        if os.path.isdir(c) and c not in ret:
-                            ret.append(c)
                 if path not in ret:
                     ret.append(path)
+
+        # look in extra and configured plugin paths to add nested directories
+        if subdirs:
+            for path in ret:
+                # iterate over directories in the path recursively
+                for directory in glob.glob("%s/**%s" % (path, os.sep), recursive=True):
+                    if directory not in ret:
+                        ret.append(directory)
 
         # look for any plugins installed in the package subtree
         # Note package path always gets added last so that every other type of

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -231,6 +231,11 @@ class PluginLoader:
             return self._all_directories(self.package_path)
         return [self.package_path]
 
+    def _find_sub_directories(self, path):
+        for root, subdirs, files in os.walk(path, followlinks=True):
+            for subdir in subdirs:
+                yield os.path.join(root, subdir)
+
     def _get_paths(self, subdirs=True):
         ''' Return a list of paths to search for plugins in '''
 
@@ -252,8 +257,7 @@ class PluginLoader:
         # look in extra and configured plugin paths to add nested directories
         if subdirs:
             for path in ret:
-                # iterate over directories in the path recursively
-                for directory in glob.glob("%s/**%s" % (path, os.sep), recursive=True):
+                for directory in self._find_sub_directories(path):
                     if directory not in ret:
                         ret.append(directory)
 

--- a/test/integration/targets/plugin_loader/override/filter_plugins/nested/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/nested/core.py
@@ -2,6 +2,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+# This file is nested in a directory under filter_plugins to test that extra directories
+# are added to the search path recursively. See https://github.com/ansible/ansible/issues/65565.
 
 def do_flag(myval):
     return 'flagged'

--- a/test/integration/targets/plugin_loader/override/filter_plugins/nested/core.py
+++ b/test/integration/targets/plugin_loader/override/filter_plugins/nested/core.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 # This file is nested in a directory under filter_plugins to test that extra directories
 # are added to the search path recursively. See https://github.com/ansible/ansible/issues/65565.
 
+
 def do_flag(myval):
     return 'flagged'
 


### PR DESCRIPTION
##### SUMMARY
Extra paths (such as `inventory_plugins` adjacent to a playbook) didn't check for nested directories at all. Configured plugin paths did to a depth of 2. Now they both behave the same way and are recursively searched.

Fixes #65565

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py
