### PR TITLE
mysql_user: support for MySQL plugin authentication

### DIFF
--- a/changelogs/fragments/65789-mysql_user_add_plugin_authentication_parameters.yml
+++ b/changelogs/fragments/65789-mysql_user_add_plugin_authentication_parameters.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- mysql_user - add ``plugin`` parameter (https://github.com/ansible/ansible/pull/44267).
+- mysql_user - add ``plugin_hash_string`` parameter (https://github.com/ansible/ansible/pull/44267).
+- mysql_user - add ``plugin_auth_string`` parameter (https://github.com/ansible/ansible/pull/44267).


### PR DESCRIPTION
##### SUMMARY
Rewrites https://github.com/ansible/ansible/pull/44267

mysql_user: support for MySQL plugin authentication

Regarding the discussion https://github.com/ansible/ansible/pull/44267 , tested manually

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
```lib/ansible/modules/database/mysql/mysql_user.py```
