### PR TITLE
postgresql modules: use query parameters with cursor objects

### DIFF
--- a/changelogs/fragments/65791-postgresql_modules_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65791-postgresql_modules_use_query_params_with_cursor.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- postgresql_set - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).
+- postgresql_slot - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).
+- postgresql_subscription - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65791).

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -185,9 +185,9 @@ POSSIBLE_SIZE_UNITS = ("mb", "gb", "tb")
 
 def param_get(cursor, module, name):
     query = ("SELECT name, setting, unit, context, boot_val "
-             "FROM pg_settings WHERE name = '%s'" % name)
+             "FROM pg_settings WHERE name = %(name)s")
     try:
-        cursor.execute(query)
+        cursor.execute(query, {'name': name})
         info = cursor.fetchall()
         cursor.execute("SHOW %s" % name)
         val = cursor.fetchone()

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -184,26 +184,28 @@ class PgSlot(object):
         if kind == 'physical':
             # Check server version (needs for immedately_reserverd needs 9.6+):
             if self.cursor.connection.server_version < 96000:
-                query = "SELECT pg_create_physical_replication_slot('%s')" % self.name
+                query = "SELECT pg_create_physical_replication_slot(%(name)s)"
 
             else:
-                query = "SELECT pg_create_physical_replication_slot('%s', %s)" % (self.name, immediately_reserve)
+                query = "SELECT pg_create_physical_replication_slot(%(name)s, %s)" % immediately_reserve)
+
+            self.changed = exec_sql(self, query, query_params={'name': self.name}, ddl=True)
 
         elif kind == 'logical':
-            query = "SELECT pg_create_logical_replication_slot('%s', '%s')" % (self.name, output_plugin)
-
-        self.changed = exec_sql(self, query, ddl=True)
+            query = "SELECT pg_create_logical_replication_slot(%(name)s, %(o_plugin)s)"
+            self.changed = exec_sql(self, query,
+                                    query_params={'name': self.name, 'o_plugin': output_plugin}, ddl=True)
 
     def drop(self):
         if not self.exists:
             return False
 
-        query = "SELECT pg_drop_replication_slot('%s')" % self.name
-        self.changed = exec_sql(self, query, ddl=True)
+        query = "SELECT pg_drop_replication_slot(%(name)s)"
+        self.changed = exec_sql(self, query, query_params={'name': self.name}, ddl=True)
 
     def __slot_exists(self):
-        query = "SELECT slot_type FROM pg_replication_slots WHERE slot_name = '%s'" % self.name
-        res = exec_sql(self, query, add_to_executed=False)
+        query = "SELECT slot_type FROM pg_replication_slots WHERE slot_name = %(name)s"
+        res = exec_sql(self, query, query_params={'name': self.name}, add_to_executed=False)
         if res:
             self.exists = True
             self.kind = res[0][0]

--- a/lib/ansible/modules/database/postgresql/postgresql_slot.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_slot.py
@@ -187,9 +187,11 @@ class PgSlot(object):
                 query = "SELECT pg_create_physical_replication_slot(%(name)s)"
 
             else:
-                query = "SELECT pg_create_physical_replication_slot(%(name)s, %s)" % immediately_reserve)
+                query = "SELECT pg_create_physical_replication_slot(%(name)s, %(i_reserve)s)"
 
-            self.changed = exec_sql(self, query, query_params={'name': self.name}, ddl=True)
+            self.changed = exec_sql(self, query,
+                                    query_params={'name': self.name, 'i_reserve': immediately_reserve},
+                                    ddl=True)
 
         elif kind == 'logical':
             query = "SELECT pg_create_logical_replication_slot(%(name)s, %(o_plugin)s)"

--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -555,9 +555,9 @@ class PgSubscription():
                  "ON s.subdbid = d.oid "
                  "JOIN pg_catalog.pg_roles AS r "
                  "ON s.subowner = r.oid "
-                 "WHERE s.subname = '%s' AND d.datname = '%s'" % (self.name, self.db))
+                 "WHERE s.subname = %(name)s AND d.datname = %(db)s")
 
-        result = exec_sql(self, query, add_to_executed=False)
+        result = exec_sql(self, query, query_params={'name': self.name, 'db': self.db}, add_to_executed=False)
         if result:
             return result[0]
         else:
@@ -573,9 +573,9 @@ class PgSubscription():
                  "FROM pg_catalog.pg_subscription_rel r "
                  "JOIN pg_catalog.pg_subscription s ON s.oid = r.srsubid "
                  "JOIN pg_catalog.pg_class c ON c.oid = r.srrelid "
-                 "WHERE s.subname = '%s'" % self.name)
+                 "WHERE s.subname = %(name)s")
 
-        result = exec_sql(self, query, add_to_executed=False)
+        result = exec_sql(self, query, query_params={'name', self.name}, add_to_executed=False)
         if result:
             return [dict(row) for row in result]
         else:

--- a/lib/ansible/modules/database/postgresql/postgresql_subscription.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_subscription.py
@@ -575,7 +575,7 @@ class PgSubscription():
                  "JOIN pg_catalog.pg_class c ON c.oid = r.srrelid "
                  "WHERE s.subname = %(name)s")
 
-        result = exec_sql(self, query, query_params={'name', self.name}, add_to_executed=False)
+        result = exec_sql(self, query, query_params={'name': self.name}, add_to_executed=False)
         if result:
             return [dict(row) for row in result]
         else:

--- a/test/integration/targets/postgresql_slot/tasks/postgresql_slot_initial.yml
+++ b/test/integration/targets/postgresql_slot/tasks/postgresql_slot_initial.yml
@@ -73,7 +73,7 @@
 - assert:
     that:
     - result is changed
-    - result.queries == ["SELECT pg_create_physical_replication_slot('slot0', False)"]
+    - result.queries == ["SELECT pg_create_physical_replication_slot('slot0', false)"]
   when: postgres_version_resp.stdout is version('9.6', '>=')
 
 - assert:
@@ -177,7 +177,7 @@
 - assert:
     that:
     - result is changed
-    - result.queries == ["SELECT pg_create_physical_replication_slot('slot1', True)"]
+    - result.queries == ["SELECT pg_create_physical_replication_slot('slot1', true)"]
   when: postgres_version_resp.stdout is version('9.6', '>=')
 
 # Check, rowcount must be 1


### PR DESCRIPTION
##### SUMMARY
postgresql modules: use query parameters with cursor objects

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_set.py```
```lib/ansible/modules/database/postgresql/postgresql_slot.py```
```lib/ansible/modules/database/postgresql/postgresql_subscription.py```
