### PR TITLE
Avoid inifinite loop during following symlinks when building ansible collection

### DIFF
--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -636,7 +636,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
         'format': MANIFEST_FORMAT,
     }
 
-    def _walk(b_path, b_top_level_dir):
+    def _walk(b_path, b_top_level_dir, resolved_dirs=set()):
         for b_item in os.listdir(b_path):
             b_abs_path = os.path.join(b_path, b_item)
             b_rel_base_dir = b'' if b_path == b_top_level_dir else b_path[len(b_top_level_dir) + 1:]
@@ -657,13 +657,18 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
                                         % to_text(b_abs_path))
                         continue
 
+                    if b_link_target in resolved_dirs:
+                        continue
+
+                    resolved_dirs.add(b_link_target)
+
                 manifest_entry = entry_template.copy()
                 manifest_entry['name'] = rel_path
                 manifest_entry['ftype'] = 'dir'
 
                 manifest['files'].append(manifest_entry)
 
-                _walk(b_abs_path, b_top_level_dir)
+                _walk(b_abs_path, b_top_level_dir, resolved_dirs=resolved_dirs)
             else:
                 if any(fnmatch.fnmatch(b_rel_path, b_pattern) for b_pattern in b_ignore_patterns):
                     display.vvv("Skipping '%s' for collection build" % to_text(b_abs_path))

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -636,7 +636,10 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
         'format': MANIFEST_FORMAT,
     }
 
-    def _walk(b_path, b_top_level_dir, resolved_dirs=set()):
+    def _walk(b_path, b_top_level_dir, resolved_dirs=None):
+        if resolved_dirs is None:
+            resolved_dirs = set()
+
         for b_item in os.listdir(b_path):
             b_abs_path = os.path.join(b_path, b_item)
             b_rel_base_dir = b'' if b_path == b_top_level_dir else b_path[len(b_top_level_dir) + 1:]


### PR DESCRIPTION
#### SUMMARY
There is case that Ansible Collection repo has

- Symbolic links may point dirs in the Ansible Collection repo dir
- Resolving the target of such symbolic links causes infinite loop to search targets

Here is an example of such case.

```
ssato@x1-carbon-gen6% cat galaxy.yml                                                                               /tmp/ansible-galaxy-pr-avoid-inifinite-loop
---
namespace: ssato
name: an_example
version: 0.1.0
description: A collection
readme: README.md
authors:
  - Satoru SATOH (https://github.com/ssato/)
dependencies: []
license:
  - MIT
ssato@x1-carbon-gen6% mkdir -p a/b/c/d/e/f/g                                                                       /tmp/ansible-galaxy-pr-avoid-inifinite-loop
ssato@x1-carbon-gen6% cd a/b/c/d/e/f/g                                                                             /tmp/ansible-galaxy-pr-avoid-inifinite-loop
ssato@x1-carbon-gen6% ln -s ../../../../../../../ ./h                                                /tmp/ansible-galaxy-pr-avoid-inifinite-loop/a/b/c/d/e/f/g
ssato@x1-carbon-gen6% ls -l                                                                          /tmp/ansible-galaxy-pr-avoid-inifinite-loop/a/b/c/d/e/f/g
合計 0
lrwxrwxrwx. 1 ssato ssato 21 12月 13 16:22 h -> ../../../../../../../
ssato@x1-carbon-gen6% cd -                                                                           /tmp/ansible-galaxy-pr-avoid-inifinite-loop/a/b/c/d/e/f/g
/tmp/ansible-galaxy-pr-avoid-inifinite-loop
ssato@x1-carbon-gen6% ansible-galaxy collection build -v --force --output-path /tmp                                /tmp/ansible-galaxy-pr-avoid-inifinite-loop
Using /etc/ansible/ansible.cfg as config file
Created collection for ssato.an_example at /tmp/ssato-an_example-0.1.0.tar.gz
ssato@x1-carbon-gen6% tar tvf /tmp/ssato-an_example-0.1.0.tar.gz                                                   /tmp/ansible-galaxy-pr-avoid-inifinite-loop
-rw-r--r-- 0/0             639 2019-12-13 16:22 MANIFEST.json
-rw-r--r-- 0/0          143153 2019-12-13 16:22 FILES.json
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/
drwxr-xr-x 0/0               0 2019-12-13 16:22 a/b/c/d/e/f/g/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/
drwxr-xr-x 0/0               0 2019-12-13 16:22 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/
        ... (snip) ...
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/
ssato@x1-carbon-gen6%
```

This PR resolves this problem and make ansible-galaxy list each files and dirs  only once
by caching the target of symbolic links internally.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
