### PR TITLE
Warn if user has set "append" but not set "groups"

### DIFF
--- a/changelogs/fragments/65795-warn-if-user-has-set-append-but-not-set-groups.yaml
+++ b/changelogs/fragments/65795-warn-if-user-has-set-append-but-not-set-groups.yaml
@@ -1,0 +1,2 @@
+deprecated_features:
+ - user - usage of append=True without setting a list of groups. This is currently a no-op, and will throw a warning in 2.14.

--- a/changelogs/fragments/65795-warn-if-user-has-set-append-but-not-set-groups.yaml
+++ b/changelogs/fragments/65795-warn-if-user-has-set-append-but-not-set-groups.yaml
@@ -1,2 +1,2 @@
-deprecated_features:
- - user - usage of append=True without setting a list of groups. This is currently a no-op, and will throw a warning in 2.14.
+minor_changes:
+  - 'user - usage of ``append: True`` without setting a list of groups. This is currently a no-op with a warning, and will change to an error in 2.14. (https://github.com/ansible/ansible/pull/65795)'

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -513,7 +513,7 @@ class User(object):
 
         if self.groups is None and self.append:
             module.warn("Append is set, but no groups are specified. Use 'groups' for appending new groups.")
-            
+
     def check_password_encrypted(self):
         # Darwin needs cleartext password, so skip validation
         if self.module.params['password'] and self.platform != 'Darwin':

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -511,6 +511,9 @@ class User(object):
         else:
             self.ssh_file = os.path.join('.ssh', 'id_%s' % self.ssh_type)
 
+        if self.groups is None and self.append:
+            module.warn("Append is set, but no groups are specified. Use 'groups' for appending new groups.")
+            
     def check_password_encrypted(self):
         # Darwin needs cleartext password, so skip validation
         if self.module.params['password'] and self.platform != 'Darwin':

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -512,7 +512,10 @@ class User(object):
             self.ssh_file = os.path.join('.ssh', 'id_%s' % self.ssh_type)
 
         if self.groups is None and self.append:
-            module.warn("Append is set, but no groups are specified. Use 'groups' for appending new groups.")
+            # Change the argument_spec in 2.14 and remove this warning
+            # required_by={'append': ['groups']}
+            module.warn("'append' is set, but no 'groups' are specified. Use 'groups' for appending new groups."
+                        "This will change to an error in Ansible 2.14.")
 
     def check_password_encrypted(self):
         # Darwin needs cleartext password, so skip validation

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -996,6 +996,16 @@
   tags:
     - user_test_local_mode
 
+- name: Test append without groups for local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: present
+    append: yes
+  register: local_user_test_5
+  ignore_errors: yes
+  tags:
+    - user_test_local_mode
+
 - name: Ensure local user accounts were created and removed properly
   assert:
     that:
@@ -1005,6 +1015,7 @@
       - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
       - local_user_test_4 is failed
       - "local_user_test_4['msg'] is search('parameters are mutually exclusive: groups|append')"
+      - "local_user_test_5['msg'] is search('\'append\' is set, but no \'groups\' are specified')"
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1015,7 +1015,7 @@
       - 'local_user_test_3["msg"] is search("parameters are mutually exclusive: groups|local")'
       - local_user_test_4 is failed
       - 'local_user_test_4["msg"] is search("parameters are mutually exclusive: groups|append")'
-      - 'local_user_test_5["msg"] is search("'append' is set, but no 'groups' are specified. Use 'groups'")'
+      - local_user_test_5["msg"] is search("'append' is set, but no 'groups' are specified. Use 'groups'")
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1015,7 +1015,6 @@
       - 'local_user_test_3["msg"] is search("parameters are mutually exclusive: groups|local")'
       - local_user_test_4 is failed
       - 'local_user_test_4["msg"] is search("parameters are mutually exclusive: groups|append")'
-      - local_user_test_5["msg"] is search("'append' is set, but no 'groups' are specified. Use 'groups'")
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:
@@ -1026,6 +1025,7 @@
     that:
       - local_user_test_1['warnings'] | length > 0
       - local_user_test_1['warnings'] | first is search('The local user account may already exist')
+      - local_user_test_5['warnings'] is search("'append' is set, but no 'groups' are specified. Use 'groups'")
       - local_existing['warnings'] is not defined
   when: ansible_facts.system in ['Linux']
   tags:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1015,7 +1015,7 @@
       - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
       - local_user_test_4 is failed
       - "local_user_test_4['msg'] is search('parameters are mutually exclusive: groups|append')"
-      - "local_user_test_5['msg'] is search('\'append\' is set, but no \'groups\' are specified')"
+      - "local_user_test_5['msg'] is search('is set, but no [^\s]+ are specified')"
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1015,7 +1015,7 @@
       - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
       - local_user_test_4 is failed
       - "local_user_test_4['msg'] is search('parameters are mutually exclusive: groups|append')"
-      - "local_user_test_5['msg'] is search('is set, but no [^\s]+ are specified')"
+      - 'local_user_test_5['msg'] is search("'append' is set, but no 'groups' are specified. Use 'groups'")'
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1012,10 +1012,10 @@
       - local_user_test_1 is changed
       - local_user_test_2 is not changed
       - local_user_test_3 is failed
-      - "local_user_test_3['msg'] is search('parameters are mutually exclusive: groups|local')"
+      - 'local_user_test_3["msg"] is search("parameters are mutually exclusive: groups|local")'
       - local_user_test_4 is failed
-      - "local_user_test_4['msg'] is search('parameters are mutually exclusive: groups|append')"
-      - 'local_user_test_5['msg'] is search("'append' is set, but no 'groups' are specified. Use 'groups'")'
+      - 'local_user_test_4["msg"] is search("parameters are mutually exclusive: groups|append")'
+      - 'local_user_test_5["msg"] is search("'append' is set, but no 'groups' are specified. Use 'groups'")'
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:


### PR DESCRIPTION
This fixes people unknowingly changing the primary group rather than adding a secondary group.
Might need to either fail, or make it more clear in the api and deprecating group(s).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Set group + append in user task
2. Watch how your primary group gets changed and no warning gets emitted (shouldve used groups instead of group)
<!--- Paste verbatim command output below, e.g. before and after your change -->
