### PR TITLE
Stop using {{ }} in templates for conditionals.

### DIFF
--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -114,7 +114,7 @@
       - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
       - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
   # map was added to jinja2 in version 2.7
-  when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"')  is version('2.7', '>=') ) }}"
+  when: lookup('pipe', ansible_python.executable ~ ' -c "import jinja2; print(jinja2.__version__)"') is version('2.7', '>=')
 
 - name: Test extract filter with defaults
   vars:


### PR DESCRIPTION
##### SUMMARY

I noticed a warning about a conditional statement in jinja2 template in the output of a test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION
This was in the output of a test:

```
11:33 TASK [filters : Container lookups with extract] ********************************
11:33 [WARNING]: conditional statements should not include jinja2 templating
11:33 delimiters such as {{ }} or {% %}. Found: {{ ( lookup('pipe', '{{
11:33 ansible_python["executable"] }} -c "import jinja2; print(jinja2.__version__)"')
11:33 is version('2.7', '>=') ) }}
```