### PR TITLE
ignore_errors: Use template variable values

### DIFF
--- a/changelogs/fragments/56345-ignore_errors.yml
+++ b/changelogs/fragments/56345-ignore_errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Use correct variable values for template var in ignore_errors (https://github.com/ansible/ansible/issues/56345).

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -487,6 +487,14 @@ class StrategyBase:
             if task_result.is_failed():
                 role_ran = True
                 ignore_errors = original_task.ignore_errors
+                if handler_templar.is_template(ignore_errors):
+                    handler_templar.available_variables = self._variable_manager.get_vars(
+                        play=iterator._play,
+                        task=original_task,
+                        _hosts=self._hosts_cache,
+                        _hosts_all=self._hosts_cache_all
+                    )
+                    ignore_errors = handler_templar.template(ignore_errors)
                 if not ignore_errors:
                     display.debug("marking %s as failed" % original_host.name)
                     if original_task.run_once:

--- a/test/integration/targets/ignore_errors/tasks/main.yml
+++ b/test/integration/targets/ignore_errors/tasks/main.yml
@@ -1,22 +1,14 @@
-# test code
-# (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# test code for ignore_errors
+# Copyright: (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: this will not stop the playbook
   shell: /bin/false
   register: failed
   ignore_errors: True
+
+- name: Use template var in ignore_errors
+  shell: /bin/false
+  ignore_errors: "{{ not ignore_test }}"
+  vars:
+    ignore_test: no


### PR DESCRIPTION

##### SUMMARY
Templatize the variable before using them in ignore_errors directive.

Fixes: #56345

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/56345-ignore_errors.yml
lib/ansible/plugins/strategy/__init__.py
test/integration/targets/ignore_errors/tasks/main.yml