### PR TITLE
add requirements keyword to meta/main.yml

### DIFF
--- a/changelogs/fragments/65809-add-requirements-to-role-meta.yaml
+++ b/changelogs/fragments/65809-add-requirements-to-role-meta.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- add requirements list to role meta

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -897,7 +897,7 @@ class GalaxyCLI(CLI):
                 if not role.metadata:
                     display.warning("Meta file %s is empty. Skipping dependencies." % role.path)
                 else:
-                    role_dependencies = role.metadata.get('dependencies') or []
+                    role_dependencies = (role.metadata.get('dependencies') or []) + (role.metadata.get('requirements') or [])
                     for dep in role_dependencies:
                         display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()

--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -53,3 +53,7 @@ dependencies: []
 {% for dependency in dependencies %}
   #- {{ dependency }}
 {%- endfor %}
+
+requirements: []
+  # List your role requirements here, one per line. Be sure to remove the '[]' above,
+  # if you add requirements to this list.

--- a/lib/ansible/playbook/role/metadata.py
+++ b/lib/ansible/playbook/role/metadata.py
@@ -41,6 +41,7 @@ class RoleMetadata(Base, CollectionSearch):
 
     _allow_duplicates = FieldAttribute(isa='bool', default=False)
     _dependencies = FieldAttribute(isa='list', default=list)
+    _requirements = FieldAttribute(isa='list', default=list)
     _galaxy_info = FieldAttribute(isa='GalaxyInfo')
 
     def __init__(self, owner=None):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add requirements list to meta/main.yml for a role.
Ansible Galaxy will download the roles in the list, but playbook run won't execute them automatically (like it does for the roles specified in the dependencies list).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #35905

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
meta/main.yml:
```paste below
dependencies: []

requirements:
  - role1
  - role2
```
