### PR TITLE
Be more specific about the requirements per distro

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -141,7 +141,7 @@ options:
     type: str
     version_added: "2.1"
 requirements:
-  - cron
+  - cron (or cronie on CentOS) 
 author:
     - Dane Summers (@dsummersl)
     - Mike Grozak (@rhaido)

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -141,7 +141,7 @@ options:
     type: str
     version_added: "2.1"
 requirements:
-  - cron (or cronie on CentOS) 
+  - cron (or cronie on CentOS)
 author:
     - Dane Summers (@dsummersl)
     - Mike Grozak (@rhaido)


### PR DESCRIPTION
##### SUMMARY
The requirement `cron` is valid for Ubuntu and most likely for Debian. 

But at least on CentOS 7 and CentOS 6, we need `cronie` instead.

See https://stackoverflow.com/questions/21802223/how-to-install-crontab-on-centos#answer-21802522

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
cron

