### PR TITLE
[stable-2.9] Add CentOS 8 to the test matrix (#63649)

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -72,6 +72,7 @@ matrix:
     - env: T=freebsd/12.0/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
+    - env: T=linux/centos8/1
     - env: T=linux/fedora30/1
     - env: T=linux/fedora31/1
     - env: T=linux/opensuse15py2/1
@@ -86,6 +87,7 @@ matrix:
     - env: T=freebsd/12.0/2
     - env: T=linux/centos6/2
     - env: T=linux/centos7/2
+    - env: T=linux/centos8/2
     - env: T=linux/fedora30/2
     - env: T=linux/fedora31/2
     - env: T=linux/opensuse15py2/2
@@ -100,6 +102,7 @@ matrix:
     - env: T=freebsd/12.0/3
     - env: T=linux/centos6/3
     - env: T=linux/centos7/3
+    - env: T=linux/centos8/3
     - env: T=linux/fedora30/3
     - env: T=linux/fedora31/3
     - env: T=linux/opensuse15py2/3
@@ -114,6 +117,7 @@ matrix:
     - env: T=freebsd/12.0/4
     - env: T=linux/centos6/4
     - env: T=linux/centos7/4
+    - env: T=linux/centos8/4
     - env: T=linux/fedora30/4
     - env: T=linux/fedora31/4
     - env: T=linux/opensuse15py2/4

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,7 @@
 default name=quay.io/ansible/default-test-container:1.10.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
 centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
+centos8 name=quay.io/ansible/centos8-test-container:1.10.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7
 fedora31 name=quay.io/ansible/fedora31-test-container:1.11.0 python=3.7
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.8.0 python=2.7


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #63649 for Ansible 2.9
Depends on #66594
Depends on #68020
(cherry picked from commit 2a7623dd5cd11ebc1651bce78f0af03fa5afcce5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`shippable.yml`
##### ADDITIONAL INFORMATION
We may need to backport some test fixes for MySQL and/or PostgreSQL. I believe most other test fixes have already been backported.
