### PR TITLE
elb_{network_lb,target_group}.py: allow UDP and TCP_UDP packets

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_network_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_network_lb.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
       - subnet-012345678
       - subnet-abcdef000
     listeners:
-      - Protocol: TCP # Required. The protocol for connections from clients to the load balancer (TCP or TLS) (case-sensitive).
+      - Protocol: TCP # Required. The protocol for connections from clients to the load balancer (TCP, TLS, UDP or TCP_UDP) (case-sensitive).
         Port: 80 # Required. The port on which the load balancer is listening.
         DefaultActions:
           - Type: forward # Required. Only 'forward' is accepted at this time
@@ -117,7 +117,7 @@ EXAMPLES = '''
       - SubnetId: subnet-012345678
         AllocationId: eipalloc-aabbccdd
     listeners:
-      - Protocol: TCP # Required. The protocol for connections from clients to the load balancer (TCP or TLS) (case-sensitive).
+      - Protocol: TCP # Required. The protocol for connections from clients to the load balancer (TCP, TLS, UDP or TCP_UDP) (case-sensitive).
         Port: 80 # Required. The port on which the load balancer is listening.
         DefaultActions:
           - Type: forward # Required. Only 'forward' is accepted at this time
@@ -402,8 +402,9 @@ def main():
     if listeners is not None:
         for listener in listeners:
             for key in listener.keys():
-                if key == 'Protocol' and listener[key] not in ['TCP', 'TLS']:
-                    module.fail_json(msg="'Protocol' must be either 'TCP' or 'TLS'")
+                protocols_list = ['TCP', 'TLS', 'UDP', 'TCP_UDP']
+                if key == 'Protocol' and listener[key] not in protocols_list:
+                    module.fail_json(msg="'Protocol' must be either " + ", ".join(protocols_list))
 
     connection = module.client('elbv2')
     connection_ec2 = module.client('ec2')


### PR DESCRIPTION
Allow UDP and TCP_UDP as protocol

- Fixing PEP8 errors from sanity check
- Fixing documentation
- Making it check response codes and paths only from HTTP/HTTPS

Fixes #65265