### PR TITLE
Fix network_cli become check to be compatible with collections

### DIFF
--- a/changelogs/fragments/network_cli_enable_fix.yml
+++ b/changelogs/fragments/network_cli_enable_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix for network_cli become method to be compatible with collections

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -460,7 +460,7 @@ class Connection(NetworkConnectionBase):
 
             self.receive(prompts=terminal_initial_prompt, answer=terminal_initial_answer, newline=newline, check_all=check_all)
 
-            if self._play_context.become and self._play_context.become_method == 'enable':
+            if self._play_context.become:
                 self.queue_message('vvvv', 'firing event: on_become')
                 auth_pass = self._play_context.become_pass
                 self._terminal.on_become(passwd=auth_pass)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  The become method name check is not required in network_cli
   as the become command is specific to platform and is implemented
   in the platform specific terminal plugins
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/network_cli.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
