### PR TITLE
ansible-galaxy - Avoid infinite loop by following symlinks when building collections

### DIFF
--- a/changelogs/fragments/65833-ansible-collection-avoid-infinite-loop-of-symlinks.yml
+++ b/changelogs/fragments/65833-ansible-collection-avoid-infinite-loop-of-symlinks.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >
+    ansible-galaxy - Avoid infinite loop by following symbolic link target dirs
+    when building collection (https://github.com/ansible/ansible/pull/65833)

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -636,7 +636,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
         'format': MANIFEST_FORMAT,
     }
 
-    def _walk(b_path, b_top_level_dir):
+    def _walk(b_path, b_top_level_dir, resolved_dirs):
         for b_item in os.listdir(b_path):
             b_abs_path = os.path.join(b_path, b_item)
             b_rel_base_dir = b'' if b_path == b_top_level_dir else b_path[len(b_top_level_dir) + 1:]
@@ -657,13 +657,18 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
                                         % to_text(b_abs_path))
                         continue
 
+                    if b_link_target in resolved_dirs:
+                        continue
+
+                    resolved_dirs.add(b_link_target)
+
                 manifest_entry = entry_template.copy()
                 manifest_entry['name'] = rel_path
                 manifest_entry['ftype'] = 'dir'
 
                 manifest['files'].append(manifest_entry)
 
-                _walk(b_abs_path, b_top_level_dir)
+                _walk(b_abs_path, b_top_level_dir, resolved_dirs)
             else:
                 if any(fnmatch.fnmatch(b_rel_path, b_pattern) for b_pattern in b_ignore_patterns):
                     display.vvv("Skipping '%s' for collection build" % to_text(b_abs_path))
@@ -677,7 +682,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
 
                 manifest['files'].append(manifest_entry)
 
-    _walk(b_collection_path, b_collection_path)
+    _walk(b_collection_path, b_collection_path, set())
 
     return manifest
 

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -658,6 +658,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
                         continue
 
                     if b_link_target in resolved_dirs:
+                        display.vvv("Skipping '%s' for collection build" % to_text(b_abs_path))
                         continue
 
                     resolved_dirs.add(b_link_target)

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -658,7 +658,8 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
                         continue
 
                     if b_link_target in resolved_dirs:
-                        display.vvv("Skipping '%s' for collection build" % to_text(b_abs_path))
+                        display.vvv("Skipping '%s' as it is a symbolic link to a directory already collected"
+                                    % to_text(b_abs_path))
                         continue
 
                     resolved_dirs.add(b_link_target)


### PR DESCRIPTION
##### SUMMARY

ansible-galaxy looks trying to follow symbolic links if targets of links are dirs or files
in the collection repository when building ansible collection, and it might search
them infinitely like the following example log.

This PR fixes this problem and make ansible-galaxy list each of them only once.

```
$ cat galaxy.yml
---
namespace: ssato
name: an_example
version: 0.1.0
description: A collection
readme: README.md
authors:
  - Satoru SATOH (https://github.com/ssato/)
dependencies: []
license:
  - MIT
$ mkdir -p a/b/c/d/e/f/g
$ cd a/b/c/d/e/f/g
$ ln -s ../../../../../../../ ./h
$ ls -l
合計 0
lrwxrwxrwx. 1 ssato ssato 21 12月 13 16:22 h -> ../../../../../../../
$ cd -
/tmp/ansible-galaxy-pr-avoid-inifinite-loop
$ ansible-galaxy collection build -v --force --output-path /tmp
Using /etc/ansible/ansible.cfg as config file
Created collection for ssato.an_example at /tmp/ssato-an_example-0.1.0.tar.gz
$ tar tvf /tmp/ssato-an_example-0.1.0.tar.gz
-rw-r--r-- 0/0             639 2019-12-13 16:22 MANIFEST.json
-rw-r--r-- 0/0          143153 2019-12-13 16:22 FILES.json
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/
drwxr-xr-x 0/0               0 2019-12-13 16:22 a/b/c/d/e/f/g/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/
drwxr-xr-x 0/0               0 2019-12-13 16:22 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/
        ... (snip) ...
drwxr-xr-x 0/0               0 2019-12-13 16:21 a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/a/b/c/d/e/f/g/h/
$
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION

- I confrmed it works with the ansible 2.9.2.

```
$ ansible --version
ansible 2.9.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ssato/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.5 (default, Oct 17 2019, 12:16:48) [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]
$
```