### PR TITLE
VMware: Handle NoneType in vmware_vmkernel_info

### DIFF
--- a/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
+++ b/changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Check for virtualNicManager in Esxi host system before accessing properties in vmware_vmkernel_info (https://github.com/ansible/ansible/issues/62772).

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel_info.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel_info.py
@@ -145,7 +145,7 @@ class VmkernelInfoManager(PyVmomi):
             self.module.fail_json(msg="Failed to get all VMKs for service type %s due to"
                                       "%s" % (service_type, to_native(e)))
 
-        if not query.selectedVnic:
+        if not query or not query.selectedVnic:
             return vmks_list
         selected_vnics = [vnic for vnic in query.selectedVnic]
         vnics_with_service_type = [vnic.device for vnic in query.candidateVnic if vnic.key in selected_vnics]


### PR DESCRIPTION
##### SUMMARY

Check for virtualNicManager in Esxi host system before accessing properties in vmware_vmkernel_info.

Fixes: #62772

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/62772-vmware_vmkernel_info-fix.yml
lib/ansible/modules/cloud/vmware/vmware_vmkernel_info.py
