### PR TITLE
VMware: vmware_guest_network: Find network in before assigning it

### DIFF
--- a/changelogs/fragments/65835-fix_vmware_guest_network_fix_to_change_the_portgroup_of_the_interface.yml
+++ b/changelogs/fragments/65835-fix_vmware_guest_network_fix_to_change_the_portgroup_of_the_interface.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_network - Fixed an issue where portgroups would not change(https://github.com/ansible/ansible/issues/64456).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -469,7 +469,7 @@ class PyVmomiHelper(PyVmomi):
                                         nic_device.backing.deviceName = network['name']
                                         nic_device.backing.network = pg_obj
                                         self.change_detected = True
-                                    elif hasattr(pg_obj, vim.dvs.DistributedVirtualPortgroup):
+                                    elif isinstance(pg_obj, vim.dvs.DistributedVirtualPortgroup):
                                         nic_device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
                                         nic_device.device.backing.port = vim.dvs.PortConnection()
                                         nic_device.backing.port.switchUuid = pg_obj.config.distributedVirtualSwitch.uuid

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -235,3 +235,95 @@
       that:
         - not (no_nw_details is changed)
         - no_nw_details.failed
+
+  - name: Change portgroup to dvPortgroup
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: test_vm1
+      networks:
+        - name: "{{ dvpg1 }}"
+          label: "Network adapter 1"
+          connected: false
+          start_connected: true
+          state: present
+    register: change_netaddr_dvp
+
+  - debug: var=change_netaddr_dvp
+
+  - name: Check changed to dvPortgroup from PortGroup
+    assert:
+      that:
+        - change_netaddr_dvp.changed  is sameas true
+        - change_netaddr_dvp.network_data['0'].name == "DC0_DVPG0"
+
+  - name: Change portgroup to dvPortgroup
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: test_vm1
+      networks:
+        - name: "{{ dvpg1 }}"
+          label: "Network adapter 1"
+          connected: false
+          start_connected: true
+          state: present
+    register: change_netaddr_dvp
+
+  - debug: var=change_netaddr_dvp
+
+  - name: Check not changed of dvPortgroup
+    assert:
+      that:
+        - change_netaddr_dvp.changed  is sameas false
+        - change_netaddr_dvp.network_data['0'].name == "DC0_DVPG0"
+
+  - name: Change portgroup to PortGroup
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: test_vm1
+      networks:
+        - name: "VM Network"
+          label: "Network adapter 1"
+          connected: false
+          start_connected: true
+          state: present
+    register: change_netaddr_pg
+
+  - debug: var=change_netaddr_pg
+
+  - name: Check changed to dvPortgroup from PortGroup
+    assert:
+      that:
+        - change_netaddr_pg.changed  is sameas true
+        - change_netaddr_pg.network_data['0'].name == "VM Network"
+
+  - name: Change portgroup to PortGroup
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: test_vm1
+      networks:
+        - name: "VM Network"
+          label: "Network adapter 1"
+          connected: false
+          start_connected: true
+          state: present
+    register: change_netaddr_dvp
+
+  - debug: var=change_netaddr_pg
+
+  - name: Check not changed of PortGroup
+    assert:
+      that:
+        - change_netaddr_pg.changed  is sameas true
+        - change_netaddr_pg.network_data['0'].name == "VM Network"

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -256,7 +256,7 @@
   - name: Check changed to dvPortgroup from PortGroup
     assert:
       that:
-        - change_netaddr_dvp.changed  is sameas true
+        - change_netaddr_dvp.changed is sameas true
         - change_netaddr_dvp.network_data['0'].name == "DC0_DVPG0"
 
   - name: Change portgroup to dvPortgroup
@@ -279,10 +279,10 @@
   - name: Check not changed of dvPortgroup
     assert:
       that:
-        - change_netaddr_dvp.changed  is sameas false
+        - change_netaddr_dvp.changed is sameas false
         - change_netaddr_dvp.network_data['0'].name == "DC0_DVPG0"
 
-  - name: Change portgroup to PortGroup
+  - name: Change dvPortgroup to PortGroup
     vmware_guest_network:
       validate_certs: False
       hostname: "{{ vcenter_hostname }}"
@@ -302,10 +302,10 @@
   - name: Check changed to dvPortgroup from PortGroup
     assert:
       that:
-        - change_netaddr_pg.changed  is sameas true
+        - change_netaddr_pg.changed is sameas true
         - change_netaddr_pg.network_data['0'].name == "VM Network"
 
-  - name: Change portgroup to PortGroup
+  - name: Change dvPortgroup to PortGroup
     vmware_guest_network:
       validate_certs: False
       hostname: "{{ vcenter_hostname }}"
@@ -318,12 +318,12 @@
           connected: false
           start_connected: true
           state: present
-    register: change_netaddr_dvp
+    register: change_netaddr_pg
 
   - debug: var=change_netaddr_pg
 
   - name: Check not changed of PortGroup
     assert:
       that:
-        - change_netaddr_pg.changed  is sameas true
+        - change_netaddr_pg.changed is sameas false
         - change_netaddr_pg.network_data['0'].name == "VM Network"


### PR DESCRIPTION
…issues/64456

##### SUMMARY
Fix issue that does not change to the port group with the name given to networks.
Fixes https://github.com/ansible/ansible/issues/64456

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
Supports PortGroup and dvPortgroup.
Tested on vCenter 6.7.
