### PR TITLE
[2.8] Fix nxos_file_copy option value path validation

### DIFF
--- a/changelogs/fragments/nxos_file_copy_path_issue.yml
+++ b/changelogs/fragments/nxos_file_copy_path_issue.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- "CVE-2019-14905 - nxos_file_copy module accepts remote_file parameter which is used for destination name
+   and performs actions related to that on the device using the value of remote_file which is of string type
+   However, there is no user input validation done while performing actions. A malicious code could crafts
+   the filename parameter to take advantage by performing an OS command injection. This fix validates the
+   option value if it is legitimate file path or not."

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -65,7 +65,7 @@ options:
         The remote directory must exist.
       - When (file_pull is True) this is the full path to the file on the remote SCP
         server to be copied to the NXOS device.
-    type: path    
+    type: path
   file_system:
     description:
       - The remote file system of the device. If omitted,
@@ -93,7 +93,7 @@ options:
         and written to this directory on the NXOS device. If the directory does not exist, it
         will be created under the file_system. This is an optional parameter.
       - When (file_pull is False), this not used.
-    type: path  
+    type: path
     version_added: "2.7"
   file_pull_timeout:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -57,6 +57,7 @@ options:
       - When (file_pull is False) this is the path to the local file on the Ansible controller.
         The local directory must exist.
       - When (file_pull is True) this is the file name used on the NXOS device.
+    type: path
   remote_file:
     description:
       - When (file_pull is False) this is the remote file path on the NXOS device.
@@ -64,6 +65,7 @@ options:
         The remote directory must exist.
       - When (file_pull is True) this is the full path to the file on the remote SCP
         server to be copied to the NXOS device.
+    type: path    
   file_system:
     description:
       - The remote file system of the device. If omitted,
@@ -91,6 +93,7 @@ options:
         and written to this directory on the NXOS device. If the directory does not exist, it
         will be created under the file_system. This is an optional parameter.
       - When (file_pull is False), this not used.
+    type: path  
     version_added: "2.7"
   file_pull_timeout:
     description:
@@ -125,7 +128,6 @@ EXAMPLES = '''
 # Initiate file copy from the nxos device to transfer file from an SCP server back to the nxos device
   - name: "initiate file copy from device"
     nxos_file_copy:
-      nxos_file_copy:
       file_pull: True
       local_file: "xyz"
       local_filr_directory: "dir1/dir2/dir3"
@@ -352,13 +354,13 @@ def copy_file_from_remote(module, local, local_file_directory, file_system='boot
 
 def main():
     argument_spec = dict(
-        local_file=dict(type='str'),
-        remote_file=dict(type='str'),
+        local_file=dict(type='path'),
+        remote_file=dict(type='path'),
         file_system=dict(required=False, default='bootflash:'),
         connect_ssh_port=dict(required=False, type='int', default=22),
         file_pull=dict(type='bool', default=False),
         file_pull_timeout=dict(type='int', default=300),
-        local_file_directory=dict(required=False, type='str'),
+        local_file_directory=dict(required=False, type='path'),
         remote_scp_server=dict(type='str'),
         remote_scp_server_user=dict(type='str'),
         remote_scp_server_password=dict(no_log=True),


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix nxos_file_copy option value path validation

*  Modify `local_file`, `local_file_directory` and
   `remote_file` option type from `str` to `path`
   so that the option value is validated in Ansible
   for a legitimate path value

* Fix review comments

(cherry picked from commit 88008badb1b0186e060d6796449ddb28f4a8457b)
Backport of https://github.com/ansible/ansible/pull/65423
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
