### PR TITLE
callback: Use variable in show_per_host_start

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -254,7 +254,7 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_start(self, host, task):
         if self.get_option('show_per_host_start'):
-            self._display.display(" [started %s on %s]" % (task, host), color=C.COLOR_OK)
+            self._display.display(" [started %s on %s]" % (self._last_task_name, host), color=C.COLOR_OK)
 
     def v2_playbook_on_play_start(self, play):
         name = play.get_name().strip()

--- a/test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stderr
@@ -1,0 +1,5 @@
++ ansible-playbook -i inventory test.yml
+++ set +x
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}

--- a/test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stdout
@@ -2,27 +2,33 @@
 PLAY [testhost] ****************************************************************
 
 TASK [Changed task] ************************************************************
+ [started Changed task on testhost]
 changed: [testhost]
 
 TASK [Ok task] *****************************************************************
+ [started Ok task on testhost]
 ok: [testhost]
 
 TASK [Failed task] *************************************************************
-fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+ [started Failed task on testhost]
 ...ignoring
 
 TASK [Skipped task] ************************************************************
+ [started Skipped task on testhost]
 skipping: [testhost]
 
 TASK [Task with var in name (foo bar)] *****************************************
+ [started Task with var in name (foo bar) on testhost]
 changed: [testhost]
 
 TASK [Loop task] ***************************************************************
+ [started Loop task on testhost]
 changed: [testhost] => (item=foo-1)
 changed: [testhost] => (item=foo-2)
 changed: [testhost] => (item=foo-3)
 
 TASK [debug loop] **************************************************************
+ [started debug loop on testhost]
 changed: [testhost] => (item=debug-1) => {
     "msg": "debug-1"
 }
@@ -33,33 +39,39 @@ ok: [testhost] => (item=debug-3) => {
     "msg": "debug-3"
 }
 skipping: [testhost] => (item=debug-4) 
-fatal: [testhost]: FAILED! => {"msg": "All items completed"}
 ...ignoring
 
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
-fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
+ [started EXPECTED FAILURE Failed task to be rescued on testhost]
 
 TASK [Rescue task] *************************************************************
+ [started Rescue task on testhost]
 changed: [testhost]
 
 TASK [Using show_per_host_start variable - hello world] ************************
+ [started Using show_per_host_start variable - hello world on testhost]
 ok: [testhost] => {
     "msg": "hello world"
 }
 
 RUNNING HANDLER [Test handler 1] ***********************************************
+ [started Test handler 1 on testhost]
 changed: [testhost]
 
 RUNNING HANDLER [Test handler 2] ***********************************************
+ [started Test handler 2 on testhost]
 ok: [testhost]
 
 RUNNING HANDLER [Test handler 3] ***********************************************
+ [started Test handler 3 on testhost]
 changed: [testhost]
 
 PLAY [testhost] ****************************************************************
+ [started None on testhost]
 
 TASK [First free task] *********************************************************
 changed: [testhost]
+ [started None on testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -39,6 +39,11 @@ TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 TASK [Rescue task] *************************************************************
 changed: [testhost]
 
+TASK [Using show_per_host_start variable - hello world] ************************
+ok: [testhost] => {
+    "msg": "hello world"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -57,5 +62,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=13   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -51,5 +51,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=13   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -38,6 +38,11 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 TASK [Rescue task] *************************************************************
 changed: [testhost]
 
+TASK [Using show_per_host_start variable - hello world] ************************
+ok: [testhost] => {
+    "msg": "hello world"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -56,5 +61,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=13   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -47,5 +47,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=13   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -176,3 +176,10 @@ run_test_dryrun check_nomarkers_wet
 
 # Test the dry run without check markers
 run_test_dryrun check_nomarkers_dry --check
+
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
+export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_FAILED_STDERR=1
+export ANSIBLE_SHOW_PER_HOST_START=1
+
+run_test default_show_per_host_start

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -57,6 +57,12 @@
         - name: Rescue task
           command: echo rescued
 
+    - name: Using show_per_host_start variable - {{ sample_var }}
+      debug:
+        msg: "{{ sample_var }}"
+      vars:
+        sample_var: "hello world"
+
   handlers:
     - name: Test handler 1
       command: echo foo


### PR DESCRIPTION
##### SUMMARY

Fixes: #65836

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
lib/ansible/plugins/callback/default.py
test/integration/targets/callback_default/callback_default.out.default.stdout
test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stderr
test/integration/targets/callback_default/callback_default.out.default_show_per_host_start.stdout
test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
test/integration/targets/callback_default/runme.sh
test/integration/targets/callback_default/test.yml
