### PR TITLE
Fix nxos_file_copy argument error handling.

### DIFF
--- a/lib/ansible/plugins/action/nxos_file_copy.py
+++ b/lib/ansible/plugins/action/nxos_file_copy.py
@@ -85,7 +85,7 @@ class ActionModule(ActionBase):
                 elif option_type == 'path':
                     playvals[key] = validation.check_type_path(playvals[key])
                 else:
-                    raise AnsibleError('Unrecognized type <{0}> for playbook parameter <{1}>'.format(type, key))
+                    raise AnsibleError('Unrecognized type <{0}> for playbook parameter <{1}>'.format(option_type, key))
 
             except (TypeError, ValueError) as e:
                 raise AnsibleError("argument %s is of type %s and we were unable to convert to %s: %s"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Use `option_type` instead of `type` for error
   handling in task options
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_file_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
