### PR TITLE
Backport of 65787 - postgresql_sequence: use query parameters with cu…

### DIFF
--- a/changelogs/fragments/65787-postgresql_sequence_use_query_params_with_cursor.yml
+++ b/changelogs/fragments/65787-postgresql_sequence_use_query_params_with_cursor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_sequence - use query parameters with cursor object (https://github.com/ansible/ansible/pull/65787).

--- a/lib/ansible/modules/database/postgresql/postgresql_sequence.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_sequence.py
@@ -369,11 +369,12 @@ class Sequence(object):
                  "LEFT JOIN pg_namespace n ON n.oid = c.relnamespace "
                  "WHERE NOT pg_is_other_temp_schema(n.oid) "
                  "AND c.relkind = 'S'::\"char\" "
-                 "AND sequence_name = '%s' "
-                 "AND sequence_schema = '%s'" % (self.name,
-                                                 self.schema))
+                 "AND sequence_name = %(name)s "
+                 "AND sequence_schema = %(schema)s")
 
-        res = exec_sql(self, query, add_to_executed=False)
+        res = exec_sql(self, query,
+                       query_params={'name': self.name, 'schema': self.schema},
+                       add_to_executed=False)
 
         if not res:
             self.exists = False


### PR DESCRIPTION
##### SUMMARY
Backport of #65787 - postgresql_sequence: use query parameters with cursor object

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_sequence.py```
