### PR TITLE
Mount: don't check src existence at all, because there are non-device-based filesystems

### DIFF
--- a/changelogs/fragments/65869-fstab_after_failed_mount.yaml
+++ b/changelogs/fragments/65869-fstab_after_failed_mount.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "mount - if the mount fails, don't leave the non-working fstab entry and the mount point behind"

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -719,9 +719,6 @@ def main():
 
             changed = True
     elif state == 'mounted':
-        if not os.path.exists(args['src']):
-            module.fail_json(msg="Unable to mount %s as it does not exist" % args['src'])
-
         if not os.path.exists(name) and not module.check_mode:
             try:
                 os.makedirs(name)

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -33,7 +33,7 @@ options:
     aliases: [ name ]
   src:
     description:
-      - Device to be mounted on I(path).
+      - Device (or NFS volume, or something else) to be mounted on I(path).
       - Required when I(state) set to C(present) or C(mounted).
     type: path
   fstype:


### PR DESCRIPTION
##### SUMMARY
Fixes #59183 without breaking non-device-based filesystems like NFS and tmpfs.

See more discussion in #65544.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
In #59183, it was requested that it should be impossible to get into a situation where a line is added into /etc/fstab, but mount fails. Commit 72023d7 attempted to fix the bug, but broke NFS, tmpfs and other filesystems that mount something else than a valid path.

Test cases (assuming that /dev/sdb1 contains an XFS filesystem, and 192.168.0.1:/mnt/bigdisk is a valid NFS share):

```
# Should succeed
ansible -i hosts myserver --become -m mount -a 'src=/dev/sdb1 path=/mnt/local state=mounted fstype=xfs'

# Should also work, was broken before the change
# "Unable to mount 192.168.0.1:/mnt/bigdisk as it does not exist"
ansible -i hosts myserver --become -m mount -a 'src=192.168.0.1:/mnt/bigdisk path=/mnt/big state=mounted fstype=nfs'

# Should fail without changing /etc/fstab and without leaving /mnt/bad
ansible -i hosts myserver --become -m mount -a 'src=/dev/sdb1 path=/mnt/bad state=mounted fstype=ext4'
```

##### RELEVANT PEOPLE
@Akasurde @MartinVerges