### PR TITLE
Fix network action plugin load in collection (#65849)

### DIFF
--- a/changelogs/fragments/network_action_plugin_load.yml
+++ b/changelogs/fragments/network_action_plugin_load.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes in network action plugins load from collections using module prefix (https://github.com/ansible/ansible/issues/65071)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1022,7 +1022,7 @@ class TaskExecutor:
         if self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
             handler_name = self._task.action
         # FIXME: is this code path even live anymore? check w/ networking folks; it trips sometimes when it shouldn't
-        elif all((module_prefix in C.NETWORK_GROUP_MODULES, module_prefix in self._shared_loader_obj.action_loader)):
+        elif all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(module_prefix, collection_list=collections))):
             handler_name = module_prefix
         else:
             # FUTURE: once we're comfortable with collections impl, preface this action with ansible.builtin so it can't be hijacked

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -428,20 +428,21 @@ class TestTaskExecutor(unittest.TestCase):
         )
 
         action_loader = te._shared_loader_obj.action_loader
-        action_loader.has_plugin.return_value = False
+        action_loader.has_plugin.side_effect = [False, True]
         action_loader.get.return_value = mock.sentinel.handler
         action_loader.__contains__.return_value = True
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
         action = 'namespace.netconf_sufix'
+        module_prefix = action.split('.')[-1].split('_')[0]
         te._task.action = action
 
         handler = te._get_action_handler(mock_connection, mock_templar)
 
         self.assertIs(mock.sentinel.handler, handler)
-        action_loader.has_plugin.assert_called_once_with(
-            action, collection_list=te._task.collections)
+        action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections),
+                                                   mock.call(module_prefix, collection_list=te._task.collections)])
 
         action_loader.get.assert_called_once_with(
             'netconf', task=te._task, connection=mock_connection,
@@ -469,13 +470,14 @@ class TestTaskExecutor(unittest.TestCase):
         mock_connection = MagicMock()
         mock_templar = MagicMock()
         action = 'namespace.prefix_sufix'
+        module_prefix = action.split('.')[-1].split('_')[0]
         te._task.action = action
-
         handler = te._get_action_handler(mock_connection, mock_templar)
 
         self.assertIs(mock.sentinel.handler, handler)
-        action_loader.has_plugin.assert_called_once_with(
-            action, collection_list=te._task.collections)
+
+        action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections),
+                                                   mock.call(module_prefix, collection_list=te._task.collections)])
 
         action_loader.get.assert_called_once_with(
             'normal', task=te._task, connection=mock_connection,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Fix network action plugin load in collection

Fixes https://github.com/ansible/ansible/issues/65071

*  Load network action plugin that matches the module
   prefix name from list of collections.

* Update changelog

* Fix unit test

(cherry picked from commit 74e9b1e2190b4fa7f6fa59294d03ea154d44cfd8)
Backport of https://github.com/ansible/ansible/pull/65849
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
