### PR TITLE
make: use -f instead of --file to aid in portability

### DIFF
--- a/lib/ansible/modules/system/make.py
+++ b/lib/ansible/modules/system/make.py
@@ -127,7 +127,7 @@ def main():
         make_parameters = []
 
     if module.params['file'] is not None:
-        base_command = [make_path, "--file", module.params['file'], make_target]
+        base_command = [make_path, "-f", module.params['file'], make_target]
     else:
         base_command = [make_path, make_target]
     base_command.extend(make_parameters)


### PR DESCRIPTION
##### SUMMARY
FreeBSD's [make](https://www.freebsd.org/cgi/man.cgi?query=make&apropos=0&sektion=1&manpath=FreeBSD+12.1-RELEASE+and+Ports&arch=default&format=html), OpenBSD's [make](https://man.openbsd.org/make) have support for an option `-f` to specify a `Makefile`, whereas GNU make uses `--file` or `-f`. In the interest of portability use `-f` which covers both.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
make

##### ADDITIONAL INFORMATION

This should not be a breaking change for any existing platform.