### PR TITLE
Changing warnings to errors as described in #62055

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -36,7 +36,7 @@ options:
     description:
       - A package name, like C(foo), or multiple packages, like C(foo, bar).
     type: list
-    elements: str
+    elements: str_strict
   repository:
     description:
       - A package repository or multiple repositories.
@@ -300,7 +300,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'installed', 'absent', 'removed', 'latest']),
-            name=dict(type='list', elements='str'),
+            name=dict(type='list', elements='str_strict'),
             repository=dict(type='list'),
             update_cache=dict(default='no', type='bool'),
             upgrade=dict(default='no', type='bool'),

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -28,7 +28,7 @@ options:
         Name wildcards (fnmatch) like C(apt*) and version wildcards like C(foo=1.0*) are also supported.
     aliases: [ package, pkg ]
     type: list
-    elements: str
+    elements: str_strict
   state:
     description:
       - Indicates the desired package state. C(latest) ensures that the latest version is installed. C(build-dep) ensures the package build dependencies
@@ -1023,7 +1023,7 @@ def main():
             update_cache_retry_max_delay=dict(type='int', default=12),
             cache_valid_time=dict(type='int', default=0),
             purge=dict(type='bool', default=False),
-            package=dict(type='list', elements='str', aliases=['pkg', 'name']),
+            package=dict(type='list', elements='str_strict', aliases=['pkg', 'name']),
             deb=dict(type='path'),
             default_release=dict(type='str', aliases=['default-release']),
             install_recommends=dict(type='bool', aliases=['install-recommends']),

--- a/lib/ansible/modules/packaging/os/homebrew.py
+++ b/lib/ansible/modules/packaging/os/homebrew.py
@@ -38,7 +38,7 @@ options:
             - list of names of packages to install/remove
         aliases: ['pkg', 'package', 'formula']
         type: list
-        elements: str
+        elements: str_strict
     path:
         description:
             - "A ':' separated list of paths to search for 'brew' executable.
@@ -816,7 +816,7 @@ def main():
                 aliases=["pkg", "package", "formula"],
                 required=False,
                 type='list',
-                elements='str',
+                elements='str_strict',
             ),
             path=dict(
                 default="/usr/local/bin",

--- a/lib/ansible/modules/packaging/os/macports.py
+++ b/lib/ansible/modules/packaging/os/macports.py
@@ -30,7 +30,7 @@ options:
             - A list of port names.
         aliases: ['port']
         type: list
-        elements: str
+        elements: str_strict
     selfupdate:
         description:
             - Update Macports and the ports tree, either prior to installing ports or as a separate step.
@@ -269,7 +269,7 @@ def deactivate_ports(module, port_path, ports):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='list', elements='str', aliases=["port"]),
+            name=dict(type='list', elements='str_strict', aliases=["port"]),
             selfupdate=dict(aliases=["update_cache", "update_ports"], default=False, type='bool'),
             state=dict(default="present", choices=["present", "installed", "absent", "removed", "active", "inactive"]),
             upgrade=dict(default=False, type='bool'),

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -31,7 +31,7 @@ options:
               Can't be used in combination with C(upgrade).
         aliases: [ package, pkg ]
         type: list
-        elements: str
+        elements: str_strict
 
     state:
         description:
@@ -418,7 +418,7 @@ def expand_package_groups(module, pacman_path, pkgs):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(type='list', elements='str', aliases=['pkg', 'package']),
+            name=dict(type='list', elements='str_strict', aliases=['pkg', 'package']),
             state=dict(type='str', default='present', choices=['present', 'installed', 'latest', 'absent', 'removed']),
             force=dict(type='bool', default=False),
             extra_args=dict(type='str', default=''),

--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -31,7 +31,7 @@ options:
     description:
       - Package atom or set, e.g. C(sys-apps/foo) or C(>foo-2.13) or C(@world)
     type: list
-    elements: str
+    elements: str_strict
 
   state:
     description:
@@ -464,7 +464,7 @@ portage_absent_states = ['absent', 'unmerged', 'removed']
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            package=dict(type='list', elements='str', default=None, aliases=['name']),
+            package=dict(type='list', elements='str_strict', default=None, aliases=['name']),
             state=dict(
                 default=portage_present_states[0],
                 choices=portage_present_states + portage_absent_states,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[2108a2e](https://github.com/ansible/ansible/commit/2108a2e1c90ad97d69f82cd7e38390bc9f17839d) merged str elements, which left warnings.
This changes them to str_strict elements to produce an error rather than a warning.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

[apt module error when variable is provided #62055](https://github.com/ansible/ansible/issues/62055) 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt
pacman
homebrew
apk
portage
macports

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
