### PR TITLE
Fix version param in deprecate() call and update porting guide

### DIFF
--- a/changelogs/fragments/65894-redfish-bios-attributes.yaml
+++ b/changelogs/fragments/65894-redfish-bios-attributes.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- redfish_config - New ``bios_attributes`` option to allow setting multiple BIOS attributes in one command.
+deprecated_features:
+- redfish_config - Deprecate ``bios_attribute_name`` and ``bios_attribute_value`` in favor of new `bios_attributes`` option.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -69,6 +69,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`ec2_key <ec2_key_module>`: the ``wait_timeout`` option will be removed. It has had no effect since Ansible 2.5.
 * :ref:`ec2_lc <ec2_lc_module>`: the ``associate_public_ip_address`` option will be removed. It has always been ignored by the module.
 * :ref:`iam_policy <iam_policy_module>`: the ``policy_document`` option will be removed. To maintain the existing behavior use the ``policy_json`` option and read the file with the ``lookup`` plugin.
+* :ref:`redfish_config <redfish_config_module>`: the ``bios_attribute_name`` and ``bios_attribute_value`` options will be removed. To maintain the existing behavior use the ``bios_attributes`` option instead.
 
 
 

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -276,7 +276,7 @@ def main():
             'bios_attribute_value']
         module.deprecate(msg='The bios_attribute_name/bios_attribute_value '
                          'options are deprecated. Use bios_attributes instead',
-                         version='2.10')
+                         version='2.14')
 
     # boot order
     boot_order = module.params['boot_order']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In feature PR #62764 I incorrectly specified the `version=` param in the `AnsibleModule.deprecate()` call. It should have been `version='2.14'` but I used `version='2.10'`.

With this PR, I correct that. I am also adding a changelog fragment with `minor_changes` and `deprecated_features` sections. And also updating the porting guide to provide guidance on updating existing playbooks. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65746 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_config.py

##### ADDITIONAL INFORMATION
See conversation in issue #65746 starting at https://github.com/ansible/ansible/issues/65746#issuecomment-564753528

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

