### PR TITLE
Bugfix of 65761: postgresql_privs fail after it's updated to 2.9.2

### DIFF
--- a/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
+++ b/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix sorting lists with None elements for python3 (https://github.com/ansible/ansible/issues/65761).

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -780,8 +780,16 @@ class Connection(object):
         executed_queries.append(query)
         self.cursor.execute(query)
         status_after = get_status(objs)
-        status_before.sort()
-        status_after.sort()
+
+        def nonesorted(e):
+            # For python 3+ that can fail trying
+            # to compare NoneType elements by sort method.
+            if e is None:
+                return ''
+            return e
+
+        status_before.sort(key=nonesorted)
+        status_after.sort(key=nonesorted)
         return status_before != status_after
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/ansible/issues/65761

Python3 can't compare list elements of NoneType when sorting a list by sort() method.

I fixed it by adding nonesorted function that used as a ```key``` argument of ```sort``` method and converts elements to empty strings before comparing them
```
# python3
>>> def nonesorted(e):
...     if e is None:
...         return ''
...     return e
...
>>> STATUS_BEFORE = ['two', 'one', None, None]
>>> STATUS_BEFORE.sort()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'

>>> STATUS_BEFORE.sort(key=nonesorted)
>>> STATUS_BEFORE
[None, None, 'one', 'two']
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_privs.py```
