### PR TITLE
NX-OS: Fix defaulting neighbor password

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -327,8 +327,11 @@ def state_present(module, existing, proposed, candidate):
             commands.append('no {0}'.format(key))
         elif value == 'default':
             if existing_commands.get(key):
-                existing_value = existing_commands.get(key)
-                commands.append('no {0} {1}'.format(key, existing_value))
+                if key == 'password':
+                    commands.append("no password")
+                else:
+                    existing_value = existing_commands.get(key)
+                    commands.append('no {0} {1}'.format(key, existing_value))
         else:
             if key == 'log-neighbor-changes':
                 if value == 'enable':

--- a/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -10,6 +10,9 @@
 - set_fact: log_neighbor_changesd="disable"
   when: (imagetag and (imagetag is version_compare('D1', 'ne')) and (imagetag is version_compare('N1', 'ne')))
 
+- debug:
+    var: titanium
+
 - set_fact: remove_private_asa="all"
   when: not titanium
 - set_fact: remove_private_asr="replace-as"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- It seems that, `nxos_bgp_neighbor` was sending `no password <pwd_type>` to the device when `pwd` and `pwd_type` was set to `default`. 
- This results in the following error for `7.0(3)I7(3)`:
`nxos-9k(config-router-neighbor)# no password 7
                                              ^
% Missing password at '^' marker.`
- Instead of appending the password type, only sending `no password` appears to work fine since at a time only one password can be added for a neighbor, so we don't need to be specific.

- [Failure in CI periodic run](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_14/63014/4fd9e871999fc13b776696b05eee0c2279fb4f85/third-party-check/ansible-test-network-integration-nxos-cli-python36/35942ee/controller/ara-report/result/e304c457-2280-4a1c-bc78-d6c38d3b9a85/)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
nxos_bgp_neighbor.py
