### PR TITLE
Fix purefa_host preferred array connection logic

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_host.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_host.py
@@ -452,12 +452,13 @@ def main():
                 if not all_connected_arrays:
                     module.fail_json(msg='No target arrays connected to source array. Setting preferred arrays not possible.')
                 else:
-                    current_arrays = []
+                    current_arrays = [array.get()['array_name']]
                     for current_array in range(0, len(all_connected_arrays)):
-                        current_arrays.append(all_connected_arrays[current_array]['array_name'])
+                        if all_connected_arrays[current_array]['type'] == "sync-replication":
+                            current_arrays.append(all_connected_arrays[current_array]['array_name'])
                 for array_to_connect in range(0, len(module.params['preferred_array'])):
                     if module.params['preferred_array'][array_to_connect] not in current_arrays:
-                        module.fail_json(msg='Array {0} not in existing array connections.'.format(module.params['preferred_array'][array_to_connect]))
+                        module.fail_json(msg='Array {0} is not a synchronously connected array.'.format(module.params['preferred_array'][array_to_connect]))
         except Exception:
             module.fail_json(msg='Failed to get existing array connections.')
 


### PR DESCRIPTION
##### SUMMARY
Ensure that the current array is an approved selection for `preferred_array` and also ensure that approved remote arrays are all syn-replication as async-replication is not supported for this option

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
purefa_host.py