### PR TITLE
Ensure that data within a tuple is marked as unsafe

### DIFF
--- a/changelogs/fragments/65722-unsafe-tuples.yml
+++ b/changelogs/fragments/65722-unsafe-tuples.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- unsafe_proxy - Ensure that data within a tuple is marked as unsafe
+  (https://github.com/ansible/ansible/issues/65722)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -662,7 +662,7 @@ class TaskExecutor:
                 if not isidentifier(self._task.register):
                     raise AnsibleError("Invalid variable name in 'register' specified: '%s'" % self._task.register)
 
-                vars_copy[self._task.register] = wrap_var(result)
+                vars_copy[self._task.register] = result = wrap_var(result)
 
             if self._task.async_val > 0:
                 if self._task.poll > 0 and not result.get('skipped') and not result.get('failed'):
@@ -720,7 +720,7 @@ class TaskExecutor:
             # This gives changed/failed_when access to additional recently modified
             # attributes of result
             if self._task.register:
-                vars_copy[self._task.register] = wrap_var(result)
+                vars_copy[self._task.register] = result = wrap_var(result)
 
             # if we didn't skip this task, use the helpers to evaluate the changed/
             # failed_when properties
@@ -751,7 +751,7 @@ class TaskExecutor:
         # do the final update of the local variables here, for both registered
         # values and any facts which may have been created
         if self._task.register:
-            variables[self._task.register] = wrap_var(result)
+            variables[self._task.register] = result = wrap_var(result)
 
         if 'ansible_facts' in result:
             if self._task.action in ('set_fact', 'include_vars'):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -270,11 +270,11 @@ class AnsibleContext(Context):
         a key or value which contains jinja2 syntax and would otherwise
         lose the AnsibleUnsafe value.
         '''
-        if isinstance(val, Mapping):
+        if isinstance(val, dict):
             for key in val.keys():
                 if self._is_unsafe(val[key]):
                     return True
-        elif is_sequence(val):
+        elif isinstance(val, list):
             for item in val:
                 if self._is_unsafe(item):
                     return True
@@ -670,11 +670,11 @@ class Templar:
         '''lets us know if data has a template'''
         if isinstance(data, string_types):
             return is_template(data, self.environment)
-        elif is_sequence(data):
+        elif isinstance(data, (list, tuple)):
             for v in data:
                 if self.is_template(v):
                     return True
-        elif isinstance(data, Mapping):
+        elif isinstance(data, dict):
             for k in data:
                 if self.is_template(k) or self.is_template(data[k]):
                     return True

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -44,6 +44,7 @@ from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleUndefinedVar
 from ansible.module_utils.six import iteritems, string_types, text_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.module_utils.common._collections_compat import Sequence, Mapping, MutableMapping
+from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
 from ansible.template.template import AnsibleJ2Template
@@ -269,11 +270,11 @@ class AnsibleContext(Context):
         a key or value which contains jinja2 syntax and would otherwise
         lose the AnsibleUnsafe value.
         '''
-        if isinstance(val, dict):
+        if isinstance(val, Mapping):
             for key in val.keys():
                 if self._is_unsafe(val[key]):
                     return True
-        elif isinstance(val, list):
+        elif is_sequence(val):
             for item in val:
                 if self._is_unsafe(item):
                     return True
@@ -632,7 +633,7 @@ class Templar:
 
                 return result
 
-            elif isinstance(variable, (list, tuple)):
+            elif is_sequence(variable):
                 return [self.template(
                     v,
                     preserve_trailing_newlines=preserve_trailing_newlines,
@@ -640,7 +641,7 @@ class Templar:
                     overrides=overrides,
                     disable_lookups=disable_lookups,
                 ) for v in variable]
-            elif isinstance(variable, (dict, Mapping)):
+            elif isinstance(variable, Mapping):
                 d = {}
                 # we don't use iteritems() here to avoid problems if the underlying dict
                 # changes sizes due to the templating, which can happen with hostvars
@@ -669,11 +670,11 @@ class Templar:
         '''lets us know if data has a template'''
         if isinstance(data, string_types):
             return is_template(data, self.environment)
-        elif isinstance(data, (list, tuple)):
+        elif is_sequence(data):
             for v in data:
                 if self.is_template(v):
                     return True
-        elif isinstance(data, dict):
+        elif isinstance(data, Mapping):
             for k in data:
                 if self.is_template(k) or self.is_template(data[k]):
                     return True

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -53,8 +53,11 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import functools
+
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common._collections_compat import Mapping, MutableSequence, Set
+from ansible.module_utils.common._collections_compat import Mapping, Set
+from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types, binary_type, text_type
 
 
@@ -97,21 +100,19 @@ class UnsafeProxy(object):
 
 
 def _wrap_dict(v):
-    for k in v.keys():
-        if v[k] is not None:
-            v[wrap_var(k)] = wrap_var(v[k])
-    return v
+    return dict((k, wrap_var(item)) for k, item in v.items())
 
 
-def _wrap_list(v):
-    for idx, item in enumerate(v):
-        if item is not None:
-            v[idx] = wrap_var(item)
-    return v
+def _wrap_sequence(v):
+    v_type = type(v)
+    return v_type(wrap_var(item) for item in v)
+
+def _wrap_tuple(v):
+    return tuple(wrap_var(item) for item in v)
 
 
 def _wrap_set(v):
-    return set(item if item is None else wrap_var(item) for item in v)
+    return set(wrap_var(item) for item in v)
 
 
 def wrap_var(v):
@@ -120,10 +121,10 @@ def wrap_var(v):
 
     if isinstance(v, Mapping):
         v = _wrap_dict(v)
-    elif isinstance(v, MutableSequence):
-        v = _wrap_list(v)
     elif isinstance(v, Set):
         v = _wrap_set(v)
+    elif is_sequence(v):
+        v = _wrap_sequence(v)
     elif isinstance(v, binary_type):
         v = AnsibleUnsafeBytes(v)
     elif isinstance(v, text_type):

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -53,8 +53,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import functools
-
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common._collections_compat import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -102,6 +102,9 @@ def _wrap_dict(v):
 
 
 def _wrap_sequence(v):
+    """Wraps a sequence with unsafe, not meant for strings, primarily
+    ``tuple`` and ``list``
+    """
     v_type = type(v)
     return v_type(wrap_var(item) for item in v)
 

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -54,7 +54,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common._collections_compat import Mapping, Set, MutableSequence
+from ansible.module_utils.common._collections_compat import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types, binary_type, text_type
 

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -54,7 +54,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from ansible.module_utils.common._collections_compat import Mapping, Set, MutableSequence
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types, binary_type, text_type
 
@@ -98,7 +98,7 @@ class UnsafeProxy(object):
 
 
 def _wrap_dict(v):
-    return dict((k, wrap_var(item)) for k, item in v.items())
+    return dict((wrap_var(k), wrap_var(item)) for k, item in v.items())
 
 
 def _wrap_sequence(v):
@@ -107,10 +107,6 @@ def _wrap_sequence(v):
     """
     v_type = type(v)
     return v_type(wrap_var(item) for item in v)
-
-
-def _wrap_tuple(v):
-    return tuple(wrap_var(item) for item in v)
 
 
 def _wrap_set(v):

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -108,6 +108,7 @@ def _wrap_sequence(v):
     v_type = type(v)
     return v_type(wrap_var(item) for item in v)
 
+
 def _wrap_tuple(v):
     return tuple(wrap_var(item) for item in v)
 

--- a/test/units/utils/test_unsafe_proxy.py
+++ b/test/units/utils/test_unsafe_proxy.py
@@ -83,6 +83,25 @@ def test_wrap_var_unsafe_bytes():
     assert isinstance(wrap_var(AnsibleUnsafeBytes(b'foo')), AnsibleUnsafeBytes)
 
 
+def test_wrap_var_no_ref():
+    thing = {
+        'foo': {
+            'bar': 'baz'
+        },
+        'bar': ['baz', 'qux'],
+        'baz': ('qux',),
+        'none': None,
+        'text': 'text',
+    }
+    wrapped_thing = wrap_var(thing)
+    thing is not wrapped_thing
+    thing['foo'] is not wrapped_thing['foo']
+    thing['bar'][0] is not wrapped_thing['bar'][0]
+    thing['baz'][0] is not wrapped_thing['baz'][0]
+    thing['none'] is not wrapped_thing['none']
+    thing['text'] is not wrapped_thing['text']
+
+
 def test_AnsibleUnsafeText():
     assert isinstance(AnsibleUnsafeText(u'foo'), AnsibleUnsafe)
 

--- a/test/units/utils/test_unsafe_proxy.py
+++ b/test/units/utils/test_unsafe_proxy.py
@@ -62,8 +62,12 @@ def test_wrap_var_set_None():
 def test_wrap_var_tuple():
     assert isinstance(wrap_var(('foo',)), tuple)
     assert not isinstance(wrap_var(('foo',)), AnsibleUnsafe)
-    assert isinstance(wrap_var(('foo',))[0], type(''))
-    assert not isinstance(wrap_var(('foo',))[0], AnsibleUnsafe)
+    assert isinstance(wrap_var(('foo',))[0], AnsibleUnsafe)
+
+
+def test_wrap_var_tuple_None():
+    assert wrap_var((None,))[0] is None
+    assert not isinstance(wrap_var((None,))[0], AnsibleUnsafe)
 
 
 def test_wrap_var_None():


### PR DESCRIPTION
##### SUMMARY
Ensure that data within a tuple is marked as unsafe

Fixes #65722 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/unsafe_proxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
