### PR TITLE
Split ios tests into network_cli and local connections

### DIFF
--- a/test/integration/targets/ios_banner/tasks/cli.yaml
+++ b/test/integration/targets/ios_banner/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_bgp/tasks/cli.yaml
+++ b/test/integration/targets/ios_bgp/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_command/tasks/cli.yaml
+++ b/test/integration/targets/ios_command/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_config/tasks/cli.yaml
+++ b/test/integration/targets/ios_config/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_config/tasks/cli_config.yaml
+++ b/test/integration/targets/ios_config/tasks/cli_config.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_facts/tasks/cli.yaml
+++ b/test/integration/targets/ios_facts/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_file/tasks/cli.yaml
+++ b/test/integration/targets/ios_file/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_interface/tasks/cli.yaml
+++ b/test/integration/targets/ios_interface/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_interfaces/tasks/cli.yaml
@@ -18,3 +18,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_l2_interface/tasks/cli.yaml
+++ b/test/integration/targets/ios_l2_interface/tasks/cli.yaml
@@ -14,6 +14,7 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
@@ -22,3 +23,4 @@
       skip: true
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_l2_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_l2_interfaces/tasks/cli.yaml
@@ -22,3 +22,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_l3_interface/tasks/cli.yaml
+++ b/test/integration/targets/ios_l3_interface/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_l3_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tasks/cli.yaml
@@ -18,3 +18,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_lacp/tasks/cli.yaml
+++ b/test/integration/targets/ios_lacp/tasks/cli.yaml
@@ -22,3 +22,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_lacp_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_lacp_interfaces/tasks/cli.yaml
@@ -22,3 +22,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_lag_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_lag_interfaces/tasks/cli.yaml
@@ -22,3 +22,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_linkagg/tasks/cli.yaml
+++ b/test/integration/targets/ios_linkagg/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_lldp/tasks/cli.yaml
+++ b/test/integration/targets/ios_lldp/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_lldp_global/tasks/cli.yaml
+++ b/test/integration/targets/ios_lldp_global/tasks/cli.yaml
@@ -18,3 +18,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_lldp_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/ios_lldp_interfaces/tasks/cli.yaml
@@ -18,3 +18,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/ios_logging/tasks/cli.yaml
+++ b/test/integration/targets/ios_logging/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_ntp/tasks/cli.yaml
+++ b/test/integration/targets/ios_ntp/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_ping/tasks/cli.yaml
+++ b/test/integration/targets/ios_ping/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_smoke/tasks/cli.yaml
+++ b/test/integration/targets/ios_smoke/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_static_route/tasks/cli.yaml
+++ b/test/integration/targets/ios_static_route/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_system/tasks/cli.yaml
+++ b/test/integration/targets/ios_system/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_user/tasks/cli.yaml
+++ b/test/integration/targets/ios_user/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_vlan/tasks/cli.yaml
+++ b/test/integration/targets/ios_vlan/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test case (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/ios_vlans/tasks/cli.yaml
+++ b/test/integration/targets/ios_vlans/tasks/cli.yaml
@@ -22,3 +22,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli


### PR DESCRIPTION
This allows to group tests by connections, which allow us to disable
local connection testing in collections for the moment.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>