### PR TITLE
Fix eos integration test for reset_config testcase

### DIFF
--- a/test/integration/targets/eos_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_interfaces/tests/cli/reset_config.yaml
@@ -32,4 +32,4 @@
 
 - assert:
     that:
-      - "expected_config|difference(ansible_facts.network_resources.interfaces) == []"
+      - "expected_config|difference(ansible_facts.ansible_network_resources.interfaces) == []"

--- a/test/integration/targets/eos_l2_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tests/cli/reset_config.yaml
@@ -28,4 +28,4 @@
 
 - assert:
     that:
-      - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(expected_config) == []"
+      - "ansible_facts.ansible_network_resources.l2_interfaces|symmetric_difference(expected_config) == []"

--- a/test/integration/targets/eos_l3_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tests/cli/reset_config.yaml
@@ -34,4 +34,4 @@
 
 - assert:
     that:
-      - "ansible_facts.network_resources.l3_interfaces|symmetric_difference(expected_config) == []"
+      - "ansible_facts.ansibe_network_resources.l3_interfaces|symmetric_difference(expected_config) == []"

--- a/test/integration/targets/eos_lacp_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tests/cli/reset_config.yaml
@@ -23,4 +23,4 @@
 
 - assert:
     that:
-      - "expected_config|symmetric_difference(ansible_facts.network_resources.lacp_interfaces) == []"
+      - "expected_config|symmetric_difference(ansible_facts.ansible_network_resources.lacp_interfaces) == []"

--- a/test/integration/targets/eos_lag_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tests/cli/reset_config.yaml
@@ -22,4 +22,4 @@
 
 - assert:
     that:
-      - "ansible_facts.network_resources.lag_interfaces|symmetric_difference(expected_config)|length == 0"
+      - "ansible_facts.ansible_network_resources.lag_interfaces|symmetric_difference(expected_config)|length == 0"

--- a/test/integration/targets/eos_lldp_interfaces/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tests/cli/reset_config.yaml
@@ -23,4 +23,4 @@
 
 - assert:
     that:
-      - "expected_config|symmetric_difference(ansible_facts.network_resources.lldp_interfaces) == []"
+      - "expected_config|symmetric_difference(ansible_facts.ansible_network_resources.lldp_interfaces) == []"

--- a/test/integration/targets/eos_vlans/tests/cli/reset_config.yaml
+++ b/test/integration/targets/eos_vlans/tests/cli/reset_config.yaml
@@ -13,6 +13,10 @@
     gather_network_resources: vlans
   become: yes
 
+- name: print facts - 1
+  debug:
+    msg: "{{ ansible_facts }}"
+
 - set_fact:
     expected_config:
       - vlan_id: 10
@@ -20,6 +24,10 @@
       - vlan_id: 20
         name: twenty
 
+- name: print facts - 2
+  debug:
+    msg: "{{ ansible_facts }}"
+
 - assert:
     that:
-      - "expected_config|symmetric_difference(ansible_facts.network_resources.vlans) == []"
+      - "expected_config|symmetric_difference(ansible_facts.ansible_network_resources.vlans) == []"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Rename the testcase file extension from yml to yaml
  as the testcases with yaml extension are run
* Fix the reset_config testcase to change the key in
  ansible_facts from `network_resources` to `ansible_network_resources`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/eos_interfaces/tests/cli/reset_config.yaml
test/integration/targets/eos_l2_interfaces/tests/cli/
test/integration/targets/eos_l3_interfaces/tests/cli/
test/integration/targets/eos_lacp_interfaces/tests/cli/
test/integration/targets/eos_lag_interfaces/tests/cli/
test/integration/targets/eos_lldp_interfaces/tests/cli/
integration/targets/eos_vlans/tests/cli/reset_config.yaml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
