### PR TITLE
Update terraform.py

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -74,6 +74,7 @@ options:
       - When 'state' has the 'absent' value mention the path in state_file instead
         to destroy this state's deployment.
     required: false
+    version_added: 2.10
   variables_file:
     description:
       - The path to a variables file for Terraform to fill into the TF
@@ -331,11 +332,10 @@ def main():
     if state == 'present':
         command.extend(APPLY_ARGS)
         if state_out_file:
-          command.extend(['-state-out', state_out_file])
+            command.extend(['-state-out', state_out_file])
     elif state == 'absent':
         command.extend(DESTROY_ARGS)
 
-        
     variables_args = []
     for k, v in variables.items():
         variables_args.extend([
@@ -386,7 +386,8 @@ def main():
                 command=' '.join(command)
             )
 
-    outputs_command = [command[0], 'output', '-no-color', '-json'] + (['-state', state_out_file] if state == 'present' and state_out_file else _state_args(state_file))
+    outputs_command = [command[0], 'output', '-no-color', '-json'] + \
+    (['-state', state_out_file] if state == 'present' and state_out_file else _state_args(state_file))
     rc, outputs_text, outputs_err = module.run_command(outputs_command, cwd=project_path)
     if rc == 1:
         module.warn("Could not get Terraform outputs. This usually means none have been defined.\nstdout: {0}\nstderr: {1}".format(outputs_text, outputs_err))

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -386,7 +386,7 @@ def main():
                 command=' '.join(command)
             )
 
-    outputs_command = [command[0], 'output', '-no-color', '-json'] + (['-state', state_out_file] 
+    outputs_command = [command[0], 'output', '-no-color', '-json'] + (['-state', state_out_file]
                                                                       if state == 'present' and state_out_file else _state_args(state_file))
     rc, outputs_text, outputs_err = module.run_command(outputs_command, cwd=project_path)
     if rc == 1:

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -74,7 +74,7 @@ options:
       - When 'state' has the 'absent' value mention the path in state_file instead
         to destroy this state's deployment.
     required: false
-    version_added: 2.10
+    version_added: '2.10'
   variables_file:
     description:
       - The path to a variables file for Terraform to fill into the TF
@@ -386,8 +386,8 @@ def main():
                 command=' '.join(command)
             )
 
-    outputs_command = [command[0], 'output', '-no-color', '-json'] + \
-    (['-state', state_out_file] if state == 'present' and state_out_file else _state_args(state_file))
+    outputs_command = [command[0], 'output', '-no-color', '-json'] + (['-state', state_out_file] 
+                                                                      if state == 'present' and state_out_file else _state_args(state_file))
     rc, outputs_text, outputs_err = module.run_command(outputs_command, cwd=project_path)
     if rc == 1:
         module.warn("Could not get Terraform outputs. This usually means none have been defined.\nstdout: {0}\nstderr: {1}".format(outputs_text, outputs_err))


### PR DESCRIPTION
##### SUMMARY
Added state_out_file option in terraform module to create tf.state files  with names other than the default terraform.tfstate at any given location. This makes the Terraform Project directory reuseable by effectively maintaining state files at different location than project directory.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fix adds the ability to run Terraform apply command with [state-out=path](https://www.terraform.io/docs/commands/apply.html#state-out-path), so that user can create state_files in directories other than project directory thus making the Terraform Project reuseable. Addition of state_out_file gives an additional option to either create terraform.tfstate with a different name and at any given  location or simply at the default location with default 'Terraform.tfstate' name.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Terraform ansible module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
