### PR TITLE
luks_device: make key add/removal idempotent

### DIFF
--- a/changelogs/fragments/52409-make_key_idempotent.yaml
+++ b/changelogs/fragments/52409-make_key_idempotent.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - luks_device - make key add/removel idempotent

--- a/test/integration/targets/luks_device/tasks/tests/passphrase.yml
+++ b/test/integration/targets/luks_device/tasks/tests/passphrase.yml
@@ -52,7 +52,6 @@
 - name: Give access to passphrase2
   luks_device:
     device: "{{ cryptfile_device }}"
-    state: closed
     passphrase: "{{ cryptfile_passphrase1 }}"
     new_passphrase: "{{ cryptfile_passphrase2 }}"
   become: yes
@@ -68,6 +67,7 @@
 - assert:
     that:
     - open_try is not failed
+
 - name: Close
   luks_device:
     device: "{{ cryptfile_device }}"


### PR DESCRIPTION
- fix documentation
- if new_keyfile is used AND the key already exists, dont fail and sets
  variable result['change'] to False
- if remove_keyfile is used AND the key dont exists, dont fail and sets
  variable result['change'] to False

Fixes: #52409
Signed-off-by: Alexandre Mulatinho <alex@mulatinho.net>