### PR TITLE
Remove account type StandardSSD_LRS

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -50,7 +50,6 @@ options:
             - Premium_LRS
             - Standard_GRS
             - Standard_LRS
-            - StandardSSD_LRS
             - Standard_RAGRS
             - Standard_ZRS
             - Premium_ZRS
@@ -339,7 +338,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             account_type=dict(type='str',
-                              choices=['Premium_LRS', 'Standard_GRS', 'Standard_LRS', 'StandardSSD_LRS', 'Standard_RAGRS', 'Standard_ZRS', 'Premium_ZRS'],
+                              choices=['Premium_LRS', 'Standard_GRS', 'Standard_LRS', 'Standard_RAGRS', 'Standard_ZRS', 'Premium_ZRS'],
                               aliases=['type']),
             custom_domain=dict(type='dict', aliases=['custom_dns_domain_suffix']),
             location=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
StandardSSD_LRS is not a valid account type. When creating an account of type StandardSSD_LRS, error : "nValueError: StandardSSD_LRS is not a valid SkuName\n"
Creating the PR is removing the option--Fixes #65563 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_storageaccount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
