### PR TITLE
Bugfix of 65761: postgresql_privs fail after it's updated to 2.9.2

### DIFF
--- a/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
+++ b/changelogs/fragments/65903-postgresql_privs_sort_lists_with_none_elements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_privs - fix sorting lists with None elements for python3 (https://github.com/ansible/ansible/issues/65761).

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -749,8 +749,16 @@ class Connection(object):
         executed_queries.append(query)
         self.cursor.execute(query)
         status_after = get_status(objs)
-        status_before.sort()
-        status_after.sort()
+
+        def nonesorted(e):
+            # For python 3+ that can fail trying
+            # to compare NoneType elements by sort method.
+            if e is None:
+                return ''
+            return e
+
+        status_before.sort(key=nonesorted)
+        status_after.sort(key=nonesorted)
         return status_before != status_after
 
 


### PR DESCRIPTION
(cherry picked from commit 9b85a51c64a687f8db4a9bfe3fea0f62f5f65af2)

##### SUMMARY
Bugfix of 65761: postgresql_privs fail after it's updated to 2.9.2

Backport of https://github.com/ansible/ansible/pull/65903

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
```lib/ansible/modules/database/postgresql/postgresql_privs.py```
