### PR TITLE
mysql_query: new module

### DIFF
--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -86,9 +86,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
             db_connection.autocommit(True)
 
     if cursor_class == 'DictCursor':
-        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
+        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor}), db_connection
     else:
-        return db_connection.cursor()
+        return db_connection.cursor(), db_connection
 
 
 def mysql_common_argument_spec():

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -44,7 +44,7 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
-                  connect_timeout=30):
+                  connect_timeout=30, autocommit=False):
     config = {}
 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
@@ -75,6 +75,8 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['db'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
+    if autocommit:
+        config['autocommit'] = autocommit
 
     db_connection = mysql_driver.connect(**config)
 

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -44,7 +44,7 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
-                  connect_timeout=30, autocommit=False):
+                  connect_timeout=30):
     config = {}
 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
@@ -79,9 +79,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     db_connection = mysql_driver.connect(**config)
 
     if cursor_class == 'DictCursor':
-        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor}), db_connection
+        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
     else:
-        return db_connection.cursor(), db_connection
+        return db_connection.cursor()
 
 
 def mysql_common_argument_spec():

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -44,7 +44,7 @@ mysql_driver_fail_msg = 'The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python
 
 
 def mysql_connect(module, login_user=None, login_password=None, config_file='', ssl_cert=None, ssl_key=None, ssl_ca=None, db=None, cursor_class=None,
-                  connect_timeout=30):
+                  connect_timeout=30, autocommit=False):
     config = {}
 
     if ssl_ca is not None or ssl_key is not None or ssl_cert is not None:
@@ -79,9 +79,9 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
     db_connection = mysql_driver.connect(**config)
 
     if cursor_class == 'DictCursor':
-        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})
+        return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor}), db_connection
     else:
-        return db_connection.cursor()
+        return db_connection.cursor(), db_connection
 
 
 def mysql_common_argument_spec():

--- a/lib/ansible/module_utils/mysql.py
+++ b/lib/ansible/module_utils/mysql.py
@@ -75,10 +75,15 @@ def mysql_connect(module, login_user=None, login_password=None, config_file='', 
         config['db'] = db
     if connect_timeout is not None:
         config['connect_timeout'] = connect_timeout
-    if autocommit:
-        config['autocommit'] = autocommit
 
-    db_connection = mysql_driver.connect(**config)
+    if _mysql_cursor_param == 'cursor':
+        # In case of PyMySQL driver:
+        db_connection = mysql_driver.connect(autocommit=autocommit, **config)
+    else:
+        # In case of MySQLdb driver
+        db_connection = mysql_driver.connect(**config)
+        if autocommit:
+            db_connection.autocommit(True)
 
     if cursor_class == 'DictCursor':
         return db_connection.cursor(**{_mysql_cursor_param: mysql_driver.cursors.DictCursor})

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -459,8 +459,8 @@ def main():
         if db == ['all']:
             module.fail_json(msg="name is not allowed to equal 'all' unless state equals import, or dump.")
     try:
-        cursor, _ = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
-                                  connect_timeout=connect_timeout)
+        cursor, db_conn = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
+                                        connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -459,8 +459,8 @@ def main():
         if db == ['all']:
             module.fail_json(msg="name is not allowed to equal 'all' unless state equals import, or dump.")
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
-                               connect_timeout=connect_timeout)
+        cursor, _ = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca,
+                                  connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "

--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -513,9 +513,9 @@ def main():
         module.fail_json(msg=mysql_driver_fail_msg)
 
     try:
-        cursor = mysql_connect(module, login_user, login_password,
-                               config_file, ssl_cert, ssl_key, ssl_ca, db,
-                               connect_timeout=connect_timeout, cursor_class='DictCursor')
+        cursor, _ = mysql_connect(module, login_user, login_password,
+                                  config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                  connect_timeout=connect_timeout, cursor_class='DictCursor')
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
                              "Exception message: %s" % (config_file, to_native(e)))

--- a/lib/ansible/modules/database/mysql/mysql_info.py
+++ b/lib/ansible/modules/database/mysql/mysql_info.py
@@ -513,9 +513,9 @@ def main():
         module.fail_json(msg=mysql_driver_fail_msg)
 
     try:
-        cursor, _ = mysql_connect(module, login_user, login_password,
-                                  config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                  connect_timeout=connect_timeout, cursor_class='DictCursor')
+        cursor, db_conn = mysql_connect(module, login_user, login_password,
+                                        config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                        connect_timeout=connect_timeout, cursor_class='DictCursor')
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
                              "Exception message: %s" % (config_file, to_native(e)))

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -116,7 +116,8 @@ from ansible.module_utils.mysql import (
 from ansible.module_utils._text import to_native
 
 DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE')
-DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER')
+# TRUNCATE is not DDL query but it also returns 0 rows affected:
+DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER', 'TRUNCATE')
 
 
 # ===========================================

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -205,13 +205,13 @@ def main():
             module.fail_json(msg="Cannot fetch rows from cursor: %s" % to_native(e))
 
         # Check DML or DDL keywords in query and set changed accordingly:
-        q = q.lstrip()[0:max_keyword_len]
+        q = q.lstrip()[0:max_keyword_len].upper()
         for keyword in DML_QUERY_KEYWORDS:
-            if keyword in q.upper() and cursor.rowcount > 0:
+            if keyword in q and cursor.rowcount > 0:
                 changed = True
 
         for keyword in DDL_QUERY_KEYWORDS:
-            if keyword in q.upper():
+            if keyword in q:
                 changed = True
 
         executed_queries.append(cursor._last_executed)

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = r'''
+---
+module: mysql_query
+short_description: Run MySQL queries
+description:
+- Runs arbitrary MySQL queries.
+- Pay attention, the module does not support check mode!
+  All queries will be executed in autocommit mode.
+- Can run queries from SQL script files.
+version_added: '2.10'
+options:
+  query:
+    description:
+    - SQL query to run.
+    - Mutually exclusive with I(path_to_script).
+    type: str
+  positional_args:
+    description:
+    - List of values to be passed as positional arguments to the query.
+    - Mutually exclusive with I(named_args).
+    type: list
+  named_args:
+    description:
+    - Dictionary of key-value arguments to pass to the query.
+    - Mutually exclusive with I(positional_args).
+    type: dict
+  path_to_script:
+    description:
+    - Path to SQL script on the remote host.
+    - Returns result of the last query in the script.
+    - Mutually exclusive with I(query).
+    type: path
+  login_db:
+    description:
+    - Name of database to connect to and run queries against.
+    type: str
+author:
+- Andrew Klychkov (@Andersson007)
+extends_documentation_fragment: mysql
+'''
+
+EXAMPLES = r'''
+- name: Simple select query to acme db
+  mysql_query:
+    login_db: acme
+    query: SELECT * FROM orders
+
+- name: Select query to db acme with positional arguments
+  mysql_query:
+    login_db: acme
+    query: SELECT * FROM acme WHERE id = %s AND story = %s
+    positional_args:
+    - 1
+    - test
+
+- name: Select query to test_db with named_args
+  mysql_query:
+    login_db: test_db
+    query: SELECT * FROM test WHERE id = %(id_val)s AND story = %(story_val)s
+    named_args:
+      id_val: 1
+      story_val: test
+
+- name: Insert query to test_table in db test_db
+  mysql_query:
+    login_db: test_db
+    query: INSERT INTO test_table (id, story) VALUES (2, 'my_long_story')
+
+- name: Run queries from SQL script
+  mysql_query:
+    login_db: test_db
+    path_to_script: /tmp/test.sql
+'''
+
+RETURN = r'''
+query:
+    description: Executed query.
+    returned: always
+    type: str
+    sample: 'SELECT * FROM bar'
+query_result:
+    description:
+    - List of dictionaries in column:value form representing returned rows.
+    returned: changed
+    type: list
+    sample: [{"Column": "Value1"},{"Column": "Value2"}]
+rowcount:
+    description: Number of affected rows.
+    returned: changed
+    type: int
+    sample: 5
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.mysql import (
+    mysql_connect,
+    mysql_common_argument_spec,
+    mysql_driver,
+    mysql_driver_fail_msg,
+)
+from ansible.module_utils._text import to_native
+
+DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE')
+DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER')
+
+
+# ===========================================
+# Module execution.
+#
+
+def main():
+    argument_spec = mysql_common_argument_spec()
+    argument_spec.update(
+        query=dict(type='str'),
+        login_db=dict(type='str'),
+        positional_args=dict(type='list'),
+        named_args=dict(type='dict'),
+        path_to_script=dict(type='path'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=(
+            ('positional_args', 'named_args'),
+            ('query', 'path_to_script'),
+        ),
+    )
+
+    db = module.params['login_db']
+    connect_timeout = module.params['connect_timeout']
+    login_user = module.params['login_user']
+    login_password = module.params['login_password']
+    ssl_cert = module.params['client_cert']
+    ssl_key = module.params['client_key']
+    ssl_ca = module.params['ca_cert']
+    config_file = module.params['config_file']
+    query = module.params["query"]
+    positional_args = module.params["positional_args"]
+    named_args = module.params["named_args"]
+    path_to_script = module.params["path_to_script"]
+
+    if positional_args and named_args:
+        module.fail_json(msg="positional_args and named_args params are mutually exclusive")
+
+    if path_to_script and query:
+        module.fail_json(msg="path_to_script is mutually exclusive with query")
+
+    if path_to_script:
+        try:
+            query = open(path_to_script, 'r').read()
+        except Exception as e:
+            module.fail_json(msg="Cannot read file '%s' : %s" % (path_to_script, to_native(e)))
+
+    if mysql_driver is None:
+        module.fail_json(msg=mysql_driver_fail_msg)
+
+    # Connect to DB:
+    try:
+        cursor, db_connection = mysql_connect(module, login_user, login_password,
+                                              config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                              connect_timeout=connect_timeout,
+                                              cursor_class='DictCursor', autocommit=True)
+    except Exception as e:
+        module.fail_json(msg="unable to connect to database, check login_user and "
+                             "login_password are correct or %s has the credentials. "
+                             "Exception message: %s" % (config_file, to_native(e)))
+    # Prepare args:
+    if module.params.get("positional_args"):
+        arguments = module.params["positional_args"]
+    elif module.params.get("named_args"):
+        arguments = module.params["named_args"]
+    else:
+        arguments = None
+
+    # Set defaults:
+    changed = False
+
+    # Execute query:
+    try:
+        cursor.execute(query, arguments)
+    except Exception as e:
+        cursor.close()
+        module.fail_json(msg="Cannot execute SQL '%s' args [%s]: %s" % (query, arguments, to_native(e)))
+
+    try:
+        query_result = [dict(row) for row in cursor.fetchall()]
+
+    except Exception as e:
+        module.fail_json(msg="Cannot fetch rows from cursor: %s" % to_native(e))
+
+    # Check DML or DDL keywords in query and set changed accordingly:
+    for keyword in DML_QUERY_KEYWORDS:
+        if keyword in query.upper() and cursor.rowcount > 0:
+            changed = True
+
+    for keyword in DDL_QUERY_KEYWORDS:
+        if keyword in query.upper():
+            changed = True
+
+    # Create dict with returned values:
+    kw = {
+        'changed': changed,
+        'query': cursor._last_executed,
+        'query_result': query_result,
+        'rowcount': cursor.rowcount,
+    }
+
+    # Clean up:
+    db_connection.close()
+
+    # Exit:
+    module.exit_json(**kw)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -171,10 +171,10 @@ def main():
 
     # Connect to DB:
     try:
-        cursor, db_connection = mysql_connect(module, login_user, login_password,
-                                              config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                              connect_timeout=connect_timeout,
-                                              cursor_class='DictCursor', autocommit=True)
+        cursor = mysql_connect(module, login_user, login_password,
+                               config_file, ssl_cert, ssl_key, ssl_ca, db,
+                               connect_timeout=connect_timeout,
+                               cursor_class='DictCursor')
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and "
                              "login_password are correct or %s has the credentials. "
@@ -219,9 +219,6 @@ def main():
         'query_result': query_result,
         'rowcount': cursor.rowcount,
     }
-
-    # Clean up:
-    db_connection.close()
 
     # Exit:
     module.exit_json(**kw)

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -178,6 +178,8 @@ def main():
     # Set defaults:
     changed = False
 
+    max_keyword_len = len(max(DML_QUERY_KEYWORDS + DDL_QUERY_KEYWORDS, key=len))
+
     # Execute query:
     query_result = []
     executed_queries = []
@@ -203,6 +205,7 @@ def main():
             module.fail_json(msg="Cannot fetch rows from cursor: %s" % to_native(e))
 
         # Check DML or DDL keywords in query and set changed accordingly:
+        q = q.lstrip()[0:max_keyword_len]
         for keyword in DML_QUERY_KEYWORDS:
             if keyword in q.upper() and cursor.rowcount > 0:
                 changed = True

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -117,7 +117,7 @@ from ansible.module_utils._text import to_native
 
 DML_QUERY_KEYWORDS = ('INSERT', 'UPDATE', 'DELETE')
 # TRUNCATE is not DDL query but it also returns 0 rows affected:
-DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER', 'TRUNCATE')
+DDL_QUERY_KEYWORDS = ('CREATE', 'DROP', 'ALTER', 'RENAME', 'TRUNCATE')
 
 
 # ===========================================

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -174,7 +174,7 @@ def main():
         cursor = mysql_connect(module, login_user, login_password,
                                config_file, ssl_cert, ssl_key, ssl_ca, db,
                                connect_timeout=connect_timeout,
-                               cursor_class='DictCursor')
+                               cursor_class='DictCursor', autocommit=True)
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and "
                              "login_password are correct or %s has the credentials. "

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -46,6 +46,8 @@ options:
     - Where run passed queries in a single transaction or commit them one-by-one.
     type: bool
     default: no
+notes:
+- To pass a query containing commas, use YAML list notation with hyphen (see EXAMPLES block).
 author:
 - Andrew Klychkov (@Andersson007)
 extends_documentation_fragment: mysql

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -21,7 +21,6 @@ description:
 - Runs arbitrary MySQL queries.
 - Pay attention, the module does not support check mode!
   All queries will be executed in autocommit mode.
-- Can run queries from SQL script files.
 version_added: '2.10'
 options:
   query:

--- a/lib/ansible/modules/database/mysql/mysql_query.py
+++ b/lib/ansible/modules/database/mysql/mysql_query.py
@@ -163,7 +163,8 @@ def main():
 
     if path_to_script:
         try:
-            query = open(path_to_script, 'r').read()
+            query = to_native(open(path_to_script, 'rb').read())
+            query = query.replace('\n', ' ')
         except Exception as e:
             module.fail_json(msg="Cannot read file '%s' : %s" % (path_to_script, to_native(e)))
 
@@ -194,6 +195,7 @@ def main():
     # Execute query:
     try:
         cursor.execute(query, arguments)
+
     except Exception as e:
         cursor.close()
         module.fail_json(msg="Cannot execute SQL '%s' args [%s]: %s" % (query, arguments, to_native(e)))

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -428,9 +428,9 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file,
-                               ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
-                               connect_timeout=connect_timeout)
+        cursor, _ = mysql_connect(module, login_user, login_password, config_file,
+                                  ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
+                                  connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -428,9 +428,9 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor, _ = mysql_connect(module, login_user, login_password, config_file,
-                                  ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
-                                  connect_timeout=connect_timeout)
+        cursor, db_conn = mysql_connect(module, login_user, login_password, config_file,
+                                        ssl_cert, ssl_key, ssl_ca, None, cursor_class='DictCursor',
+                                        connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -714,14 +714,14 @@ def main():
     try:
         if check_implicit_admin:
             try:
-                cursor, _ = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                          connect_timeout=connect_timeout)
+                cursor, db_conn = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                                connect_timeout=connect_timeout)
             except Exception:
                 pass
 
         if not cursor:
-            cursor, _ = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                      connect_timeout=connect_timeout)
+            cursor, db_conn = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                            connect_timeout=connect_timeout)
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
                              "Exception message: %s" % (config_file, to_native(e)))

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -714,14 +714,14 @@ def main():
     try:
         if check_implicit_admin:
             try:
-                cursor = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                       connect_timeout=connect_timeout)
+                cursor, _ = mysql_connect(module, 'root', '', config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                          connect_timeout=connect_timeout)
             except Exception:
                 pass
 
         if not cursor:
-            cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                   connect_timeout=connect_timeout)
+            cursor, _ = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                      connect_timeout=connect_timeout)
     except Exception as e:
         module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. "
                              "Exception message: %s" % (config_file, to_native(e)))

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -212,8 +212,8 @@ def main():
         warnings.filterwarnings('error', category=mysql_driver.Warning)
 
     try:
-        cursor, _ = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,
-                                  connect_timeout=connect_timeout)
+        cursor, db_conn = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                        connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg=("unable to connect to database, check login_user and "

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -212,8 +212,8 @@ def main():
         warnings.filterwarnings('error', category=mysql_driver.Warning)
 
     try:
-        cursor = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,
-                               connect_timeout=connect_timeout)
+        cursor, _ = mysql_connect(module, user, password, config_file, ssl_cert, ssl_key, ssl_ca, db,
+                                  connect_timeout=connect_timeout)
     except Exception as e:
         if os.path.exists(config_file):
             module.fail_json(msg=("unable to connect to database, check login_user and "

--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -444,11 +444,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -444,11 +444,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -197,11 +197,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -197,11 +197,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -188,10 +188,10 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -188,10 +188,10 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -416,11 +416,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -416,11 +416,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -543,11 +543,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -543,11 +543,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -314,11 +314,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -314,11 +314,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -354,11 +354,11 @@ def main():
 
     cursor = None
     try:
-        cursor, _ = mysql_connect(module,
-                                  login_user,
-                                  login_password,
-                                  config_file,
-                                  cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, db_conn = mysql_connect(module,
+                                        login_user,
+                                        login_password,
+                                        config_file,
+                                        cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -354,11 +354,11 @@ def main():
 
     cursor = None
     try:
-        cursor = mysql_connect(module,
-                               login_user,
-                               login_password,
-                               config_file,
-                               cursor_class=mysql_driver.cursors.DictCursor)
+        cursor, _ = mysql_connect(module,
+                                  login_user,
+                                  login_password,
+                                  config_file,
+                                  cursor_class=mysql_driver.cursors.DictCursor)
     except mysql_driver.Error as e:
         module.fail_json(
             msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)

--- a/test/integration/targets/mysql_query/aliases
+++ b/test/integration/targets/mysql_query/aliases
@@ -1,0 +1,6 @@
+destructive
+shippable/posix/group1
+skip/osx
+skip/freebsd
+skip/rhel
+skip/opensuse

--- a/test/integration/targets/mysql_query/aliases
+++ b/test/integration/targets/mysql_query/aliases
@@ -1,6 +1,8 @@
 destructive
-shippable/posix/group1
+shippable/posix/group3
 skip/osx
 skip/freebsd
-skip/rhel
+skip/ubuntu
+skip/fedora
 skip/opensuse
+skip/rhel

--- a/test/integration/targets/mysql_query/defaults/main.yml
+++ b/test/integration/targets/mysql_query/defaults/main.yml
@@ -1,0 +1,5 @@
+db_name: data
+user_name: alice
+user_pass: alice
+test_db: testdb
+test_table1: test1

--- a/test/integration/targets/mysql_query/defaults/main.yml
+++ b/test/integration/targets/mysql_query/defaults/main.yml
@@ -3,3 +3,4 @@ user_name: alice
 user_pass: alice
 test_db: testdb
 test_table1: test1
+test_script_path: /tmp/test.sql

--- a/test/integration/targets/mysql_query/defaults/main.yml
+++ b/test/integration/targets/mysql_query/defaults/main.yml
@@ -2,4 +2,5 @@ root_user: root
 db_name: data
 test_db: testdb
 test_table1: test1
+test_table2: test2
 test_script_path: /tmp/test.sql

--- a/test/integration/targets/mysql_query/defaults/main.yml
+++ b/test/integration/targets/mysql_query/defaults/main.yml
@@ -1,6 +1,5 @@
+root_user: root
 db_name: data
-user_name: alice
-user_pass: alice
 test_db: testdb
 test_table1: test1
 test_script_path: /tmp/test.sql

--- a/test/integration/targets/mysql_query/meta/main.yml
+++ b/test/integration/targets/mysql_query/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_mysql_db
+  - setup_remote_tmp_dir

--- a/test/integration/targets/mysql_query/meta/main.yml
+++ b/test/integration/targets/mysql_query/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
-  - setup_mysql_db
-  - setup_remote_tmp_dir
+- setup_mysql8

--- a/test/integration/targets/mysql_query/tasks/main.yml
+++ b/test/integration/targets/mysql_query/tasks/main.yml
@@ -1,0 +1,2 @@
+# mysql_query module initial CI tests
+- import_tasks: mysql_query_initial.yml

--- a/test/integration/targets/mysql_query/tasks/main.yml
+++ b/test/integration/targets/mysql_query/tasks/main.yml
@@ -1,2 +1,5 @@
 # mysql_query module initial CI tests
 - import_tasks: mysql_query_initial.yml
+  when:
+  - ansible_distribution == 'CentOS'
+  - ansible_distribution_major_version >= '7'

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -1,0 +1,52 @@
+# Test code for mysql_query module
+# Copyright: (c) 2020, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+###################
+# Prepare for tests
+#
+
+# Create role for tests
+- name: Create mysql user {{ user_name }}
+  mysql_user:
+    name: '{{ user_name }}'
+    password: '{{ user_pass }}'
+    state: present
+    priv: '*.*:ALL'
+    login_unix_socket: '{{ mysql_socket }}'
+
+# Create default MySQL config file with credentials
+- name: Create default config file
+  template:
+    src: my.cnf.j2
+    dest: '/root/.my.cnf'
+    mode: 0400
+
+# Create non-default MySQL config file with credentials
+- name: Create non-default config file
+  template:
+    src: my.cnf.j2
+    dest: '/root/non-default_my.cnf'
+    mode: 0400
+
+###############
+# Do tests
+
+- name: Create db {{ test_db }}
+  mysql_query:
+    login_user: '{{ user_name }}'
+    query: 'CREATE DATABASE {{ test_db }}'
+  register: result
+
+- assert:
+    that: result is changed
+
+- name: Create table {{ test_table1 }}
+  mysql_query:
+    login_db: '{{ test_db }}'
+    login_user: '{{ user_name }}'
+    query: 'CREATE TABLE {{ test_table1 }} (id int)'
+  register: result
+
+- assert:
+    that: result is changed

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -39,6 +39,7 @@
       query:
       - 'INSERT INTO {{ test_table1 }} VALUES (1), (2)'
       - 'INSERT INTO {{ test_table1 }} VALUES (3)'
+      single_transaction: yes
     register: result
 
   - assert:

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -13,9 +13,9 @@
 - assert:
     that:
     - result is changed
-    - result.query == "CREATE DATABASE {{ test_db }}"
+    - result.executed_queries == ['CREATE DATABASE {{ test_db }}']
 
-- name: Create table {{ test_table1 }}
+- name: Create db {{ test_db }} and {{ test_table1 }}
   mysql_query:
     login_unix_socket: '{{ mysql_socket }}'
     login_user: '{{ root_user }}'
@@ -27,7 +27,7 @@
 - assert:
     that:
     - result is changed
-    - result.query == "CREATE TABLE {{ test_table1 }} (id int)"
+    - result.executed_queries == ['CREATE TABLE {{ test_table1 }} (id int)']
 
 - name: Insert test data
   mysql_query:
@@ -35,11 +35,16 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: 'INSERT INTO {{ test_table }} VALUES (1), (2), (3)'
+    query:
+    - 'INSERT INTO {{ test_table1 }} VALUES (1), (2)'
+    - 'INSERT INTO {{ test_table1 }} VALUES (3)'
   register: result
 
 - assert:
-    that: result is changed
+    that:
+    - result is changed
+    - result.rowcount == [2, 1]
+    - result.executed_queries == ['INSERT INTO {{ test_table1 }} VALUES (1), (2)', 'INSERT INTO {{ test_table1 }} VALUES (3)']
 
 - name: Check data in {{ test_table1 }}
   mysql_query:
@@ -53,11 +58,11 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }}"
-    - result.rowcount == 3
-    - result.query_result[0].id == 1
-    - result.query_result[1].id == 2
-    - result.query_result[2].id == 3
+    - result.executed_queries == ['SELECT * FROM {{ test_table1 }}']
+    - result.rowcount == [3]
+    - result.query_result[0][0].id == 1
+    - result.query_result[0][1].id == 2
+    - result.query_result[0][2].id == 3
 
 - name: Check data in {{ test_table1 }} using positional args
   mysql_query:
@@ -73,9 +78,9 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
-    - result.rowcount == 1
-    - result.query_result[0].id == 1
+    - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
+    - result.rowcount == [1]
+    - result.query_result[0][0].id == 1
 
 - name: Check data in {{ test_table1 }} using named args
   mysql_query:
@@ -91,9 +96,9 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
-    - result.rowcount == 1
-    - result.query_result[0].id == 1
+    - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
+    - result.rowcount == [1]
+    - result.query_result[0][0].id == 1
 
 - name: Update data in {{ test_table1 }}
   mysql_query:
@@ -101,7 +106,7 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s"
+    query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
     named_args:
       current_id: 1
       new_id: 0
@@ -110,8 +115,8 @@
 - assert:
     that:
     - result is changed
-    - result.query == "UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1"
-    - result.rowcount == 1
+    - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
+    - result.rowcount == [1]
 
 - name: Check the prev update - row with value 1 does not exist anymore
   mysql_query:
@@ -127,8 +132,8 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
-    - result.rowcount == 0
+    - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 1']
+    - result.rowcount == [0]
 
 - name: Check the prev update - row with value - exist
   mysql_query:
@@ -144,8 +149,8 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 0"
-    - result.rowcount == 1
+    - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 0']
+    - result.rowcount == [1]
 
 - name: Update data in {{ test_table1 }} again
   mysql_query:
@@ -153,7 +158,7 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s"
+    query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
     named_args:
       current_id: 1
       new_id: 0
@@ -162,8 +167,8 @@
 - assert:
     that:
     - result is not changed
-    - result.query == "UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1"
-    - result.rowcount == 0
+    - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
+    - result.rowcount == [0]
 
 - name: Delete data from {{ test_table1 }}
   mysql_query:
@@ -171,29 +176,16 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "DELETE FROM {{ test_table1 }} WHERE id = 0"
+    query:
+    - 'DELETE FROM {{ test_table1 }} WHERE id = 0'
+    - 'SELECT * FROM {{ test_table1 }} WHERE id = 0'
   register: result
 
 - assert:
     that:
     - result is changed
-    - result.query == "DELETE FROM {{ test_table1 }} WHERE id = 0"
-    - result.rowcount == 1
-
-- name: Check the prev delete - row with value 0 does not exist anymore
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: "SELECT * FROM {{ test_table1 }} WHERE id = 0"
-  register: result
-
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 0"
-    - result.rowcount == 0
+    - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0', 'SELECT * FROM {{ test_table1 }} WHERE id = 0']
+    - result.rowcount == [1, 0]
 
 - name: Delete data from {{ test_table1 }} again
   mysql_query:
@@ -201,14 +193,14 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "DELETE FROM {{ test_table1 }} WHERE id = 0"
+    query: 'DELETE FROM {{ test_table1 }} WHERE id = 0'
   register: result
 
 - assert:
     that:
     - result is not changed
-    - result.query == "DELETE FROM {{ test_table1 }} WHERE id = 0"
-    - result.rowcount == 0
+    - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0']
+    - result.rowcount == [0]
 
 - name: Truncate {{ test_table1 }}
   mysql_query:
@@ -216,44 +208,31 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "TRUNCATE {{ test_table1 }}"
+    query:
+    - 'TRUNCATE {{ test_table1 }}'
+    - 'SELECT * FROM {{ test_table1 }}'
   register: result
 
 - assert:
     that:
     - result is changed
-    - result.query == "TRUNCATE {{ test_table1 }}"
-    - result.rowcount == 0
+    - result.executed_queries == ['TRUNCATE {{ test_table1 }}', 'SELECT * FROM {{ test_table1 }}']
+    - result.rowcount == [0, 0]
 
-- name: Check the prev truncate
+- name: Rename {{ test_table1 }}
   mysql_query:
     login_unix_socket: '{{ mysql_socket }}'
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "SELECT * FROM {{ test_table1 }}"
-  register: result
-
-- assert:
-    that:
-    - result is not changed
-    - result.query == "SELECT * FROM {{ test_table1 }}"
-    - result.rowcount == 0
-
-- name: Truncate {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: "RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}"
+    query: 'RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}'
   register: result
 
 - assert:
     that:
     - result is changed
-    - result.query == "RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}"
-    - result.rowcount == 0
+    - result.executed_queries == ['RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}']
+    - result.rowcount == [0]
 
 - name: Check the prev rename
   mysql_query:
@@ -261,7 +240,7 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "SELECT * FROM {{ test_table1 }}"
+    query: 'SELECT * FROM {{ test_table1 }}'
   register: result
   ignore_errors: yes
 
@@ -275,12 +254,12 @@
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    query: "SELECT * FROM {{ test_table2 }}"
+    query: 'SELECT * FROM {{ test_table2 }}'
   register: result
 
 - assert:
     that:
-    - result.rowcount == 0
+    - result.rowcount == [0]
 
 - name: Drop db {{ test_db }}
   mysql_query:
@@ -293,4 +272,4 @@
 - assert:
     that:
     - result is changed
-    - result.query == "DROP DATABASE {{ test_db }}"
+    - result.executed_queries == ['DROP DATABASE {{ test_db }}']

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -2,35 +2,6 @@
 # Copyright: (c) 2020, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-###################
-# Prepare for tests
-#
-
-# Prepare SQL script:
-- name: Remove SQL script if exists
-  become: yes
-  file:
-    path: '{{ test_script_path }}'
-    state: absent
-  ignore_errors: yes
-
-- name: Create test sql script
-  become: yes
-  file:
-    path: '{{ test_script_path }}'
-    state: touch
-    mode: 0644
-
-- name: Prepare SQL script
-  become: yes
-  shell: 'echo "{{ item }}" >> {{ test_script_path }}'
-  ignore_errors: yes
-  loop:
-  - 'INSERT INTO {{ test_table1 }} (id) VALUES (1), (2), (3);'
-
-###############
-# Do tests
-
 - name: Create db {{ test_db }}
   mysql_query:
     login_unix_socket: '{{ mysql_socket }}'
@@ -58,13 +29,13 @@
     - result is changed
     - result.query == "CREATE TABLE {{ test_table1 }} (id int)"
 
-- name: Run queries from sql script file
+- name: Insert test data
   mysql_query:
     login_unix_socket: '{{ mysql_socket }}'
     login_user: '{{ root_user }}'
     login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    path_to_script: '{{ test_script_path }}'
+    query: 'INSERT INTO {{ test_table }} VALUES (1), (2), (3)'
   register: result
 
 - assert:
@@ -323,10 +294,3 @@
     that:
     - result is changed
     - result.query == "DROP DATABASE {{ test_db }}"
-
-# Clean up:
-- name: Remove test sql script
-  become: yes
-  file:
-    path: '{{ test_script_path }}'
-    state: absent

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -325,7 +325,7 @@
     - result.query == "DROP DATABASE {{ test_db }}"
 
 # Clean up:
-- name: Create test sql script
+- name: Remove test sql script
   become: yes
   file:
     path: '{{ test_script_path }}'

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -238,3 +238,95 @@
     - result is not changed
     - result.query == "DELETE FROM {{ test_table1 }} WHERE id = 0"
     - result.rowcount == 0
+
+- name: Truncate {{ test_table1 }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "TRUNCATE {{ test_table1 }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.query == "TRUNCATE {{ test_table1 }}"
+    - result.rowcount == 0
+
+- name: Check the prev truncate
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "SELECT * FROM {{ test_table1 }}"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }}"
+    - result.rowcount == 0
+
+- name: Truncate {{ test_table1 }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.query == "RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}"
+    - result.rowcount == 0
+
+- name: Check the prev rename
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "SELECT * FROM {{ test_table1 }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result.failed == true
+
+- name: Check the prev rename
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "SELECT * FROM {{ test_table2 }}"
+  register: result
+
+- assert:
+    that:
+    - result.rowcount == 0
+
+- name: Drop db {{ test_db }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    query: 'DROP DATABASE {{ test_db }}'
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.query == "DROP DATABASE {{ test_db }}"
+
+# Clean up:
+- name: Create test sql script
+  become: yes
+  file:
+    path: '{{ test_script_path }}'
+    state: absent

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -1,275 +1,248 @@
 # Test code for mysql_query module
 # Copyright: (c) 2020, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- vars:
+    mysql_parameters: &mysql_params
+      login_unix_socket: '{{ mysql_socket }}'
+      login_user: '{{ root_user }}'
+      login_password: '{{ root_pass }}'
 
-- name: Create db {{ test_db }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    query: 'CREATE DATABASE {{ test_db }}'
-  register: result
+  block:
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['CREATE DATABASE {{ test_db }}']
+  - name: Create db {{ test_db }}
+    mysql_query:
+      <<: *mysql_params
+      query: 'CREATE DATABASE {{ test_db }}'
+    register: result
 
-- name: Create db {{ test_db }} and {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'CREATE TABLE {{ test_table1 }} (id int)'
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['CREATE DATABASE {{ test_db }}']
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['CREATE TABLE {{ test_table1 }} (id int)']
+  - name: Create {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'CREATE TABLE {{ test_table1 }} (id int)'
+    register: result
 
-- name: Insert test data
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query:
-    - 'INSERT INTO {{ test_table1 }} VALUES (1), (2)'
-    - 'INSERT INTO {{ test_table1 }} VALUES (3)'
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['CREATE TABLE {{ test_table1 }} (id int)']
 
-- assert:
-    that:
-    - result is changed
-    - result.rowcount == [2, 1]
-    - result.executed_queries == ['INSERT INTO {{ test_table1 }} VALUES (1), (2)', 'INSERT INTO {{ test_table1 }} VALUES (3)']
+  - name: Insert test data
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query:
+      - 'INSERT INTO {{ test_table1 }} VALUES (1), (2)'
+      - 'INSERT INTO {{ test_table1 }} VALUES (3)'
+    register: result
 
-- name: Check data in {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }}'
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.rowcount == [2, 1]
+      - result.executed_queries == ['INSERT INTO {{ test_table1 }} VALUES (1), (2)', 'INSERT INTO {{ test_table1 }} VALUES (3)']
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ['SELECT * FROM {{ test_table1 }}']
-    - result.rowcount == [3]
-    - result.query_result[0][0].id == 1
-    - result.query_result[0][1].id == 2
-    - result.query_result[0][2].id == 3
+  - name: Check data in {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }}'
+    register: result
 
-- name: Check data in {{ test_table1 }} using positional args
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %s'
-    positional_args:
-    - 1
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ['SELECT * FROM {{ test_table1 }}']
+      - result.rowcount == [3]
+      - result.query_result[0][0].id == 1
+      - result.query_result[0][1].id == 2
+      - result.query_result[0][2].id == 3
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
-    - result.rowcount == [1]
-    - result.query_result[0][0].id == 1
+  - name: Check data in {{ test_table1 }} using positional args
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }} WHERE id = %s'
+      positional_args:
+      - 1
+    register: result
 
-- name: Check data in {{ test_table1 }} using named args
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
-    named_args:
-      some_id: 1
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
+      - result.rowcount == [1]
+      - result.query_result[0][0].id == 1
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
-    - result.rowcount == [1]
-    - result.query_result[0][0].id == 1
+  - name: Check data in {{ test_table1 }} using named args
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+      named_args:
+        some_id: 1
+    register: result
 
-- name: Update data in {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
-    named_args:
-      current_id: 1
-      new_id: 0
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ["SELECT * FROM {{ test_table1 }} WHERE id = 1"]
+      - result.rowcount == [1]
+      - result.query_result[0][0].id == 1
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
-    - result.rowcount == [1]
+  - name: Update data in {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
+      named_args:
+        current_id: 1
+        new_id: 0
+    register: result
 
-- name: Check the prev update - row with value 1 does not exist anymore
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
-    named_args:
-      some_id: 1
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
+      - result.rowcount == [1]
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 1']
-    - result.rowcount == [0]
+  - name: Check the prev update - row with value 1 does not exist anymore
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+      named_args:
+        some_id: 1
+    register: result
 
-- name: Check the prev update - row with value - exist
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
-    named_args:
-      some_id: 0
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 1']
+      - result.rowcount == [0]
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 0']
-    - result.rowcount == [1]
+  - name: Check the prev update - row with value - exist
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+      named_args:
+        some_id: 0
+    register: result
 
-- name: Update data in {{ test_table1 }} again
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
-    named_args:
-      current_id: 1
-      new_id: 0
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ['SELECT * FROM {{ test_table1 }} WHERE id = 0']
+      - result.rowcount == [1]
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
-    - result.rowcount == [0]
+  - name: Update data in {{ test_table1 }} again
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s'
+      named_args:
+        current_id: 1
+        new_id: 0
+    register: result
 
-- name: Delete data from {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query:
-    - 'DELETE FROM {{ test_table1 }} WHERE id = 0'
-    - 'SELECT * FROM {{ test_table1 }} WHERE id = 0'
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ['UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1']
+      - result.rowcount == [0]
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0', 'SELECT * FROM {{ test_table1 }} WHERE id = 0']
-    - result.rowcount == [1, 0]
+  - name: Delete data from {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query:
+      - 'DELETE FROM {{ test_table1 }} WHERE id = 0'
+      - 'SELECT * FROM {{ test_table1 }} WHERE id = 0'
+    register: result
 
-- name: Delete data from {{ test_table1 }} again
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'DELETE FROM {{ test_table1 }} WHERE id = 0'
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0', 'SELECT * FROM {{ test_table1 }} WHERE id = 0']
+      - result.rowcount == [1, 0]
 
-- assert:
-    that:
-    - result is not changed
-    - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0']
-    - result.rowcount == [0]
+  - name: Delete data from {{ test_table1 }} again
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'DELETE FROM {{ test_table1 }} WHERE id = 0'
+    register: result
 
-- name: Truncate {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query:
-    - 'TRUNCATE {{ test_table1 }}'
-    - 'SELECT * FROM {{ test_table1 }}'
-  register: result
+  - assert:
+      that:
+      - result is not changed
+      - result.executed_queries == ['DELETE FROM {{ test_table1 }} WHERE id = 0']
+      - result.rowcount == [0]
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['TRUNCATE {{ test_table1 }}', 'SELECT * FROM {{ test_table1 }}']
-    - result.rowcount == [0, 0]
+  - name: Truncate {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query:
+      - 'TRUNCATE {{ test_table1 }}'
+      - 'SELECT * FROM {{ test_table1 }}'
+    register: result
 
-- name: Rename {{ test_table1 }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}'
-  register: result
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['TRUNCATE {{ test_table1 }}', 'SELECT * FROM {{ test_table1 }}']
+      - result.rowcount == [0, 0]
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}']
-    - result.rowcount == [0]
+  - name: Rename {{ test_table1 }}
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}'
+    register: result
 
-- name: Check the prev rename
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table1 }}'
-  register: result
-  ignore_errors: yes
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['RENAME TABLE {{ test_table1 }} TO {{ test_table2 }}']
+      - result.rowcount == [0]
 
-- assert:
-    that:
-    - result.failed == true
+  - name: Check the prev rename
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table1 }}'
+    register: result
+    ignore_errors: yes
 
-- name: Check the prev rename
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    login_db: '{{ test_db }}'
-    query: 'SELECT * FROM {{ test_table2 }}'
-  register: result
+  - assert:
+      that:
+      - result.failed == true
 
-- assert:
-    that:
-    - result.rowcount == [0]
+  - name: Check the prev rename
+    mysql_query:
+      <<: *mysql_params
+      login_db: '{{ test_db }}'
+      query: 'SELECT * FROM {{ test_table2 }}'
+    register: result
 
-- name: Drop db {{ test_db }}
-  mysql_query:
-    login_unix_socket: '{{ mysql_socket }}'
-    login_user: '{{ root_user }}'
-    login_password: '{{ root_pass }}'
-    query: 'DROP DATABASE {{ test_db }}'
-  register: result
+  - assert:
+      that:
+      - result.rowcount == [0]
 
-- assert:
-    that:
-    - result is changed
-    - result.executed_queries == ['DROP DATABASE {{ test_db }}']
+  - name: Drop db {{ test_db }}
+    mysql_query:
+      <<: *mysql_params
+      query: 'DROP DATABASE {{ test_db }}'
+    register: result
+
+  - assert:
+      that:
+      - result is changed
+      - result.executed_queries == ['DROP DATABASE {{ test_db }}']

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -6,29 +6,6 @@
 # Prepare for tests
 #
 
-# Create role for tests
-- name: Create mysql user {{ user_name }}
-  mysql_user:
-    name: '{{ user_name }}'
-    password: '{{ user_pass }}'
-    state: present
-    priv: '*.*:ALL'
-    login_unix_socket: '{{ mysql_socket }}'
-
-# Create default MySQL config file with credentials
-- name: Create default config file
-  template:
-    src: my.cnf.j2
-    dest: '/root/.my.cnf'
-    mode: 0400
-
-# Create non-default MySQL config file with credentials
-- name: Create non-default config file
-  template:
-    src: my.cnf.j2
-    dest: '/root/non-default_my.cnf'
-    mode: 0400
-
 # Prepare SQL script:
 - name: Remove SQL script if exists
   become: yes
@@ -45,34 +22,219 @@
     mode: 0644
 
 - name: Prepare SQL script
-  become_user: "{{ pg_user }}"
   become: yes
-  shell: 'echo "{{ item }}" >> ~{{ pg_user}}/test.sql'
+  shell: 'echo "{{ item }}" >> {{ test_script_path }}'
   ignore_errors: yes
-  with_items:
-  - 'INSERT INTO {{ test_table1 }} VALUES (1, 2, 3);'
-  - 'INSERT INTO {{ test_table1 }} VALUES (4, 5, 6);'
-  when: sql_file_created
-
+  loop:
+  - 'INSERT INTO {{ test_table1 }} (id) VALUES (1), (2), (3);'
 
 ###############
 # Do tests
 
 - name: Create db {{ test_db }}
   mysql_query:
-    login_user: '{{ user_name }}'
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
     query: 'CREATE DATABASE {{ test_db }}'
   register: result
 
 - assert:
-    that: result is changed
+    that:
+    - result is changed
+    - result.query == "CREATE DATABASE {{ test_db }}"
 
 - name: Create table {{ test_table1 }}
   mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
     login_db: '{{ test_db }}'
-    login_user: '{{ user_name }}'
     query: 'CREATE TABLE {{ test_table1 }} (id int)'
   register: result
 
 - assert:
+    that:
+    - result is changed
+    - result.query == "CREATE TABLE {{ test_table1 }} (id int)"
+
+- name: Run queries from sql script file
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    path_to_script: '{{ test_script_path }}'
+  register: result
+
+- assert:
     that: result is changed
+
+- name: Check data in {{ test_table1 }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: 'SELECT * FROM {{ test_table1 }}'
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }}"
+    - result.rowcount == 3
+    - result.query_result[0].id == 1
+    - result.query_result[1].id == 2
+    - result.query_result[2].id == 3
+
+- name: Check data in {{ test_table1 }} using positional args
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %s'
+    positional_args:
+    - 1
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
+    - result.rowcount == 1
+    - result.query_result[0].id == 1
+
+- name: Check data in {{ test_table1 }} using named args
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+    named_args:
+      some_id: 1
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
+    - result.rowcount == 1
+    - result.query_result[0].id == 1
+
+- name: Update data in {{ test_table1 }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s"
+    named_args:
+      current_id: 1
+      new_id: 0
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.query == "UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1"
+    - result.rowcount == 1
+
+- name: Check the prev update - row with value 1 does not exist anymore
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+    named_args:
+      some_id: 1
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 1"
+    - result.rowcount == 0
+
+- name: Check the prev update - row with value - exist
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: 'SELECT * FROM {{ test_table1 }} WHERE id = %(some_id)s'
+    named_args:
+      some_id: 0
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 0"
+    - result.rowcount == 1
+
+- name: Update data in {{ test_table1 }} again
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "UPDATE {{ test_table1 }} SET id = %(new_id)s WHERE id = %(current_id)s"
+    named_args:
+      current_id: 1
+      new_id: 0
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "UPDATE {{ test_table1 }} SET id = 0 WHERE id = 1"
+    - result.rowcount == 0
+
+- name: Delete data from {{ test_table1 }}
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "DELETE FROM {{ test_table1 }} WHERE id = 0"
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.query == "DELETE FROM {{ test_table1 }} WHERE id = 0"
+    - result.rowcount == 1
+
+- name: Check the prev delete - row with value 0 does not exist anymore
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "SELECT * FROM {{ test_table1 }} WHERE id = 0"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "SELECT * FROM {{ test_table1 }} WHERE id = 0"
+    - result.rowcount == 0
+
+- name: Delete data from {{ test_table1 }} again
+  mysql_query:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: '{{ root_user }}'
+    login_password: '{{ root_pass }}'
+    login_db: '{{ test_db }}'
+    query: "DELETE FROM {{ test_table1 }} WHERE id = 0"
+  register: result
+
+- assert:
+    that:
+    - result is not changed
+    - result.query == "DELETE FROM {{ test_table1 }} WHERE id = 0"
+    - result.rowcount == 0

--- a/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
+++ b/test/integration/targets/mysql_query/tasks/mysql_query_initial.yml
@@ -29,6 +29,32 @@
     dest: '/root/non-default_my.cnf'
     mode: 0400
 
+# Prepare SQL script:
+- name: Remove SQL script if exists
+  become: yes
+  file:
+    path: '{{ test_script_path }}'
+    state: absent
+  ignore_errors: yes
+
+- name: Create test sql script
+  become: yes
+  file:
+    path: '{{ test_script_path }}'
+    state: touch
+    mode: 0644
+
+- name: Prepare SQL script
+  become_user: "{{ pg_user }}"
+  become: yes
+  shell: 'echo "{{ item }}" >> ~{{ pg_user}}/test.sql'
+  ignore_errors: yes
+  with_items:
+  - 'INSERT INTO {{ test_table1 }} VALUES (1, 2, 3);'
+  - 'INSERT INTO {{ test_table1 }} VALUES (4, 5, 6);'
+  when: sql_file_created
+
+
 ###############
 # Do tests
 

--- a/test/integration/targets/mysql_query/templates/my.cnf.j2
+++ b/test/integration/targets/mysql_query/templates/my.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user={{ user_name }}
+password={{ user_pass }}

--- a/test/integration/targets/mysql_query/templates/my.cnf.j2
+++ b/test/integration/targets/mysql_query/templates/my.cnf.j2
@@ -1,3 +1,0 @@
-[client]
-user={{ user_name }}
-password={{ user_pass }}


### PR DESCRIPTION
##### SUMMARY
mysql_query: new module

Fixes: https://github.com/ansible/ansible/issues/65925

analog of ```postgresql_query``` module which is very popular since it was released in 2.9

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
mysql_query

##### ADDITIONAL INFORMATION
Examples:
```
- name: Simple select query to acme db
  mysql_query:
    login_db: acme
    query: SELECT * FROM orders
- name: Select query to db acme with positional arguments
  mysql_query:
    login_db: acme
    query: SELECT * FROM acme WHERE id = %s AND story = %s
    positional_args:
    - 1
    - test
- name: Select query to test_db with named_args
  mysql_query:
    login_db: test_db
    query: SELECT * FROM test WHERE id = %(id_val)s AND story = %(story_val)s
    named_args:
      id_val: 1
      story_val: test
- name: Run several insert queries against db test_db in single transaction
  mysql_query:
    login_db: test_db
    query:
    - INSERT INTO articles (id, story) VALUES (2, 'my_long_story')
    - INSERT INTO prices (id, price) VALUES (123, '100.00')
    single_transaction: yes
```
Returns
```
executed_queries:
    description: List of executed queries.
    returned: always
    type: list
    sample: ['SELECT * FROM bar', 'UPDATE bar SET id = 1 WHERE id = 2']
query_result:
    description:
    - List of lists (sublist for each query) containing dictionaries
      in column:value form representing returned rows.
    returned: changed
    type: list
    sample: [[{"Column": "Value1"},{"Column": "Value2"}], [{"ID": 1}, {"ID": 2}]]
rowcount:
    description: Number of affected rows for each subquery.
    returned: changed
    type: list
    sample: [5, 1]
```
