### PR TITLE
ini_file module - do no set the option as changed if the diff is only about extra spaces

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -228,7 +228,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
                             newline = '%s\n' % option
                         else:
                             newline = assignment_format % (option, value)
-                        option_changed = ini_lines[index] != newline
+                        option_changed = ini_lines[index] != newline and not re.match('%s\s*=\s*%s' % (option, value), ini_lines[index])
                         changed = changed or option_changed
                         if option_changed:
                             msg = 'option changed'

--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -228,7 +228,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
                             newline = '%s\n' % option
                         else:
                             newline = assignment_format % (option, value)
-                        option_changed = ini_lines[index] != newline and not re.match('%s\s*=\s*%s' % (option, value), ini_lines[index])
+                        option_changed = ini_lines[index] != newline and not re.match(r'%s\s*=\s*%s' % (option, value), ini_lines[index])
                         changed = changed or option_changed
                         if option_changed:
                             msg = 'option changed'


### PR DESCRIPTION
##### SUMMARY

The ini_file module changes option/value lines even when the only changes to do are extra spaces.
I think nothing should be changed when there are no value or option to update. I fixed the module to achieve that but let me know if I should open a issue instead

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ini_file module

##### ADDITIONAL INFORMATION

I am using the ini_file module to enforce some configuration parameters in a mysql my.cnf file

These files have options and values indented this way:

```cnf
[mysql]
port                     	= 3366
socket                         	= /home/mysql/run/mysql.sock

[mysqld]
bind-address			= 0.0.0.0
user                      	= mysql
default_storage_engine     	= InnoDB
basedir                        	= /home/mysql
datadir                        	= /home/mysql/data
socket                         	= /home/mysql/run/mysql.sock
pid_file                       	= /home/mysql/run/mysql.pid
lc_messages_dir                 = /usr/share/mysql
```
I have the following task

```yml
- name: Ensure the /etc/my.cnf file is configured correctly
  ini_file:
    path: /etc/my.cnf
    section: '{{ item.section }}'
    option: '{{ item.option }}'
    value: '{{ item.value }}'
  with_items:
    - { section: 'mysql', option: 'port', value: '3306' }
    - { section: 'mysql', option: 'socket', value: '/home/mysql/run/mysql.sock' }
    - { section: 'mysqld', option: 'bind-address', value: '0.0.0.0' }
    - { section: 'mysqld', option: 'user', value: 'mysql' }
    - { section: 'mysqld', option: 'default_storage_engine', value: 'InnoDB' }
    - { section: 'mysqld', option: 'basedir', value: '/home/mysql' }
    - { section: 'mysqld', option: 'datadir', value: '/home/mysql/data' }
    - { section: 'mysqld', option: 'socket', value: '/home/mysql/run/mysql.sock' }
    - { section: 'mysqld', option: 'pid_file', value: '/home/mysql/run/mysql.pid' }
    - { section: 'mysqld', option: 'lc_messages_dir', value: '/usr/share/mysql' }
```

In this case, i would like the ini_file module to report changes only for the port option. Currently, every option is changed. For pretty long ini files indented like this, it becomes very complicated to track what really changes.