### PR TITLE
Add connection_local / connection_httpapi skip to eos

### DIFF
--- a/test/integration/targets/eos_banner/tasks/cli.yaml
+++ b/test/integration/targets/eos_banner/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_banner/tasks/eapi.yaml
+++ b/test/integration/targets/eos_banner/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_bgp/tasks/cli.yaml
+++ b/test/integration/targets/eos_bgp/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_command/tasks/cli.yaml
+++ b/test/integration/targets/eos_command/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_command/tasks/eapi.yaml
+++ b/test/integration/targets/eos_command/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_config/tasks/cli.yaml
+++ b/test/integration/targets/eos_config/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_config/tasks/cli_config.yaml
+++ b/test/integration/targets/eos_config/tasks/cli_config.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_config/tasks/eapi.yaml
+++ b/test/integration/targets/eos_config/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_eapi/tasks/cli.yaml
+++ b/test/integration/targets/eos_eapi/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_facts/tasks/cli.yaml
+++ b/test/integration/targets/eos_facts/tasks/cli.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/eos_facts/tasks/eapi.yaml
+++ b/test/integration/targets/eos_facts/tasks/eapi.yaml
@@ -14,9 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_local

--- a/test/integration/targets/eos_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_interface/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_interface/tasks/eapi.yaml
+++ b/test/integration/targets/eos_interface/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_interfaces/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_l2_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l2_interface/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_l2_interface/tasks/eapi.yaml
+++ b/test/integration/targets/eos_l2_interface/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_l2_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_l2_interfaces/tasks/main.yaml
@@ -15,6 +15,7 @@
     with_items: "{{ test_items }}"
     loop_control:
       loop_var: test_case_to_run
+  tags: connection_network_cli
 
   always:
   - name: Clean up test state

--- a/test/integration/targets/eos_l3_interface/tasks/cli.yaml
+++ b/test/integration/targets/eos_l3_interface/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_l3_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_l3_interfaces/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lacp/tasks/main.yaml
+++ b/test/integration/targets/eos_lacp/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lacp_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_lacp_interfaces/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lag_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_lag_interfaces/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_linkagg/tasks/cli.yaml
+++ b/test/integration/targets/eos_linkagg/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lldp/tasks/cli.yaml
+++ b/test/integration/targets/eos_lldp/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lldp/tasks/eapi.yaml
+++ b/test/integration/targets/eos_lldp/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lldp_global/tasks/main.yaml
+++ b/test/integration/targets/eos_lldp_global/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_lldp_interfaces/tasks/main.yaml
+++ b/test/integration/targets/eos_lldp_interfaces/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_logging/tasks/cli.yaml
+++ b/test/integration/targets/eos_logging/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_logging/tasks/eapi.yaml
+++ b/test/integration/targets/eos_logging/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/eos_smoke/tasks/cli.yaml
@@ -14,11 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-  tags: network_cli
+  tags: connection_network_cli
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-  tags: local
+  tags: connection_local

--- a/test/integration/targets/eos_smoke/tasks/eapi.yaml
+++ b/test/integration/targets/eos_smoke/tasks/eapi.yaml
@@ -14,11 +14,11 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-  tags: httpapi
+  tags: connection_httpapi
 
 - name: run test cases (connection=local)
   include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-  tags: local
+  tags: connection_local

--- a/test/integration/targets/eos_static_route/tasks/cli.yaml
+++ b/test/integration/targets/eos_static_route/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_system/tasks/cli.yaml
+++ b/test/integration/targets/eos_system/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_system/tasks/eapi.yaml
+++ b/test/integration/targets/eos_system/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_user/tasks/cli.yaml
+++ b/test/integration/targets/eos_user/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_user/tasks/eapi.yaml
+++ b/test/integration/targets/eos_user/tasks/eapi.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_httpapi

--- a/test/integration/targets/eos_vlan/tasks/cli.yaml
+++ b/test/integration/targets/eos_vlan/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_vlans/tasks/main.yaml
+++ b/test/integration/targets/eos_vlans/tasks/main.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli

--- a/test/integration/targets/eos_vrf/tasks/cli.yaml
+++ b/test/integration/targets/eos_vrf/tasks/cli.yaml
@@ -14,3 +14,4 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+  tags: connection_network_cli


### PR DESCRIPTION
This starts to allow us to break jobs out per connection testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>