### PR TITLE
Cloudformation info checkmode

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation_info.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_info.py
@@ -297,7 +297,7 @@ def main():
         stack_template=dict(required=False, default=False, type='bool'),
         stack_change_sets=dict(required=False, default=False, type='bool'),
     )
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     is_old_facts = module._name == 'cloudformation_facts'
     if is_old_facts:

--- a/test/integration/targets/cloudformation/tasks/main.yml
+++ b/test/integration/targets/cloudformation/tasks/main.yml
@@ -153,11 +153,45 @@
           - "'stack_tags' in stack_info.cloudformation[stack_name]"
           - "stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name"
 
+    - name: get stack details (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+      register: stack_info
+      check_mode: yes
+
+    - name: assert stack info
+      assert:
+        that:
+          - "'cloudformation' in stack_info"
+          - "stack_info.cloudformation | length == 1"
+          - "stack_name in stack_info.cloudformation"
+          - "'stack_description' in stack_info.cloudformation[stack_name]"
+          - "'stack_outputs' in stack_info.cloudformation[stack_name]"
+          - "'stack_parameters' in stack_info.cloudformation[stack_name]"
+          - "'stack_tags' in stack_info.cloudformation[stack_name]"
+          - "stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name"
+
     - name: get stack details (all_facts)
       cloudformation_info:
         stack_name: "{{ stack_name }}"
         all_facts: yes
       register: stack_info
+
+    - name: assert stack info
+      assert:
+        that:
+          - "'stack_events' in stack_info.cloudformation[stack_name]"
+          - "'stack_policy' in stack_info.cloudformation[stack_name]"
+          - "'stack_resource_list' in stack_info.cloudformation[stack_name]"
+          - "'stack_resources' in stack_info.cloudformation[stack_name]"
+          - "'stack_template' in stack_info.cloudformation[stack_name]"
+
+    - name: get stack details (all_facts) (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+        all_facts: yes
+      register: stack_info
+      check_mode: yes
 
     - name: assert stack info
       assert:
@@ -203,6 +237,19 @@
       assert:
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
+
+    - name: get stack details with changesets (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+        stack_change_sets: True
+      register: stack_info
+      check_mode: yes
+
+    - name: assert changesets in info
+      assert:
+        that:
+          - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
+
 
     # try to create an empty changeset by passing in unchanged template
     - name: create a changeset
@@ -257,6 +304,17 @@
         that:
           - "stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
 
+    - name: get stack details (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+      register: stack_info
+      check_mode: yes
+
+    - name: assert stack info
+      assert:
+        that:
+          - "stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+
     - name: set termination protection to false
       cloudformation:
         stack_name: "{{ stack_name }}"
@@ -281,6 +339,17 @@
       cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
+
+    - name: assert stack info
+      assert:
+        that:
+          - "not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+
+    - name: get stack details (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+      register: stack_info
+      check_mode: yes
 
     - name: assert stack info
       assert:
@@ -345,6 +414,17 @@
       cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
+
+    - name: assert stack info
+      assert:
+        that:
+          - "not stack_info.cloudformation"
+
+    - name: get stack details (checkmode)
+      cloudformation_info:
+        stack_name: "{{ stack_name }}"
+      register: stack_info
+      check_mode: yes
 
     - name: assert stack info
       assert:

--- a/test/integration/targets/cloudformation/tasks/main.yml
+++ b/test/integration/targets/cloudformation/tasks/main.yml
@@ -250,7 +250,6 @@
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
 
-
     # try to create an empty changeset by passing in unchanged template
     - name: create a changeset
       cloudformation:


### PR DESCRIPTION
##### SUMMARY
Enabling checkmode for this module.  The below API calls are made, none of which modify configurations.  I don't see any reason checkmode cannot be suppported and I have been running it without problems.

All using boto3.client('cloudformation')
describe_change_set
describe_stacks
describe_stack_events
get_paginator
get_stack_policy
get_template
list_change_sets
list_stack_resources

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cloudformation_info

##### ADDITIONAL INFORMATION
Also duplicated all existing cloudformation_info tests to test again with check_mode: true
