### PR TITLE
ec2_vol module filtering bug

### DIFF
--- a/changelogs/fragments/65960-ec2_vol-filtering-bugfix.yml
+++ b/changelogs/fragments/65960-ec2_vol-filtering-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ec2_vol - fix filtering bug"

--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -267,7 +267,7 @@ def get_volume(module, ec2):
     if zone:
         filters['availability_zone'] = zone
     if name:
-        filters = {'tag:Name': name}
+        filters['tag:Name'] = name
     if id:
         volume_ids = [id]
     try:


### PR DESCRIPTION
When `name` is specified, it ignores `zone` filter. That is you could not have same tag:Name in different zones.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vol module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
