### PR TITLE
Fix nxos_user roles bug

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -174,12 +174,30 @@ def map_obj_to_commands(updates, module):
         def remove(x):
             return commands.append('no username %s %s' % (want['name'], x))
 
+        def configure_roles():
+            if want['roles']:
+                if have:
+                    for item in set(have['roles']).difference(want['roles']):
+                        remove('role %s' % item)
+
+                    for item in set(want['roles']).difference(have['roles']):
+                        add('role %s' % item)
+                else:
+                    for item in want['roles']:
+                        add('role %s' % item)
+
+                return True
+            return False
+
         if want['state'] == 'absent':
             commands.append('no username %s' % want['name'])
             continue
 
+        roles_configured = False
         if want['state'] == 'present' and not have:
-            commands.append('username %s' % want['name'])
+            roles_configured = configure_roles()
+            if not roles_configured:
+                commands.append('username %s' % want['name'])
 
         if needs_update('configured_password'):
             if update_password == 'always' or not have:
@@ -188,16 +206,8 @@ def map_obj_to_commands(updates, module):
         if needs_update('sshkey'):
             add('sshkey %s' % want['sshkey'])
 
-        if want['roles']:
-            if have:
-                for item in set(have['roles']).difference(want['roles']):
-                    remove('role %s' % item)
-
-                for item in set(want['roles']).difference(have['roles']):
-                    add('role %s' % item)
-            else:
-                for item in want['roles']:
-                    add('role %s' % item)
+        if not roles_configured:
+            configure_roles()
 
     return commands
 

--- a/test/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/common/basic.yaml
@@ -21,11 +21,13 @@
     state: present
   register: result
 
+- debug: msg="{{result}}"
+
 - assert:
     that:
       - 'result.changed == true'
       - '"username" in result.commands[0]'
-      - '"role network-operator" in result.commands[1]'
+      - '"role network-operator" in result.commands[0]'
 
 - name: Collection of users
   nxos_user:

--- a/test/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/test/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -25,7 +25,7 @@
     that:
       - 'result.changed == true'
       - '"username" in result.commands[0]'
-      - '"role network-operator" in result.commands[1]'
+      - '"role network-operator" in result.commands[0]'
 
 - name: teardown
   net_user:


### PR DESCRIPTION
##### SUMMARY
Please cherry-pick this into `stable-2.9`

Fixes https://github.com/ansible/ansible/issues/65954

This module has an order of operation bug.  The module will build a list of commands based on checking each parameter individually.  It's possible to end up with a list of commands that include the username first without a role (this case it will use the default role) and then later a command that specifies a role.  This results in undesired behavior where the username has both the default and non-default role configured but the playbook explicitly requested a non-default role.  This fix configures roles first if the playbook specifies a role to avoid this oder of operation issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_user

##### TESTING

Tested against n3k, n6k, n7k, n9k (Multiple Versions)