### PR TITLE
don't use `with_file` in exclusive=True examples

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -139,11 +139,9 @@ EXAMPLES = r'''
 - name: Set authorized key, removing all the authorized keys already set
   authorized_key:
     user: root
-    key: '{{ item }}'
+    key: "{{ lookup('file', 'public_keys/doe-jane') }}"
     state: present
     exclusive: True
-  with_file:
-    - public_keys/doe-jane
 
 - name: Set authorized key for user ubuntu copying it from current user
   authorized_key:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->

See docs for `exclusive`: This option is not loop aware, so if you use C(with_) , it will be exclusive per iteration of the loop.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
