### PR TITLE
add one note to help ansible user to understand the requirements

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -27,6 +27,7 @@ description:
     Please use M(iosxr_config) to configure iosxr devices.
 extends_documentation_fragment: iosxr
 notes:
+  - Make sure the user has been authorized to execute commands terminal length 0, terminal width 512 and terminal exec prompt no-timestamp.
   - This module works with C(network_cli). See L(the IOS-XR Platform Options,../network/user_guide/platform_iosxr.html).
   - This module does not support C(netconf) connection.
   - Tested against IOS XR 6.1.3


### PR DESCRIPTION
execute iosxr_command module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

add one note to help ansible users understand the requirements for this module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

iosxr_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
```
It took us a long time to figure out why this error happened, even we know the user has been authorized to execute `terminal length` and `terminal width` command.

```
FAILED! => {"msg": "unable to set terminal parameters"}
```
the user need to be authorized to execute command `terminal exec prompt no-timestamp` as well.