### PR TITLE
Adds organization cloudtrail parameter to the cloudtrail module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -226,6 +226,11 @@ trail:
             returned: success
             type: bool
             sample: true
+        is_organization_trail:
+            description: Whether the trail applies to all accounts in the organization
+            returned: success
+            type: bool
+            sample: true
         has_custom_event_selectors:
             description: Whether any custom event selectors are used for this trail.
             returned: success

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -71,6 +71,7 @@ options:
       - Specifies whether the trail is created for all accounts in an organization in AWS Organizations.
     default: false
     type: bool
+    version_added: "2.10"
   enable_log_file_validation:
     description:
       - Specifies whether log file integrity validation is enabled.

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -22,6 +22,7 @@ author:
     - Ansible Core Team
     - Ted Timmons (@tedder)
     - Daniel Shepherd (@shepdelacreme)
+    - Michael Barney (@mbarneyjr)
 requirements:
   - boto3
   - botocore
@@ -65,6 +66,11 @@ options:
     default: false
     type: bool
     version_added: "2.4"
+  is_organization_trail:
+    description:
+      - Specifies whether the trail is created for all accounts in an organization in AWS Organizations.
+    default: false
+    type: bool
   enable_log_file_validation:
     description:
       - Specifies whether log file integrity validation is enabled.
@@ -457,6 +463,7 @@ def main():
         s3_key_prefix=dict(),
         sns_topic_name=dict(),
         is_multi_region_trail=dict(default=False, type='bool'),
+        is_organization_trail=dict(default=False, type='bool'),
         enable_log_file_validation=dict(type='bool', aliases=['log_file_validation_enabled']),
         include_global_events=dict(default=True, type='bool', aliases=['include_global_service_events']),
         cloudwatch_logs_role_arn=dict(),
@@ -485,6 +492,7 @@ def main():
         S3BucketName=module.params['s3_bucket_name'],
         IncludeGlobalServiceEvents=module.params['include_global_events'],
         IsMultiRegionTrail=module.params['is_multi_region_trail'],
+        IsOrganizationTrail=module.params['is_organization_trail'],
     )
 
     if module.params['s3_key_prefix']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `is_organization_trail` parameter to the `cloudtrail` module, which if enabled will be passed directly into the `create_trail` and `update_trail` api calls as `IsOrganizationTrail`. More information on organizational cloudtrails can be found [here](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-ct.html)

```yaml
- name: Create organization cloudtrail
  cloudtrail:
    state: present
    name: default
    region: us-east-1
    is_organization_trail: true
    is_multi_region_trail: true
    s3_bucket_name: mybucket
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

cloudtrail

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```
$ ansible localhost -M roles/org-cloudtrail/library/ -m cloudtrail -a "state=present name=default region=us-east-1 is_organization_trail=true is_multi_region_trail=true s3_bucket_name=mybucket"
[WARNING]: No inventory was parsed, only implicit localhost is available

localhost | FAILED! => {
    "changed": false,
    "msg": "Unsupported parameters for (cloudtrail) module: is_organization_trail Supported parameters include: aws_access_key, aws_secret_key, cloudwatch_logs_log_group_arn, cloudwatch_logs_role_arn, debug_botocore_endpoint_logs, ec2_url, enable_log_file_validation, enable_logging, include_global_events, is_multi_region_trail, kms_key_id, name, profile, region, s3_bucket_name, s3_key_prefix, security_token, sns_topic_name, state, tags, validate_certs"
}
```

after
```
$ ansible localhost -M ./library/ -m cloudtrail -a "state=present name=default region=us-east-1 is_organization_trail=true is_multi_region_trail=true s3_bucket_name=mybucket"
[WARNING]: No inventory was parsed, only implicit localhost is available

localhost | SUCCESS => {
    "changed": false,
    "exists": true,
    "trail": {
        "cloud_watch_logs_log_group_arn": null,
        "cloud_watch_logs_role_arn": null,
        "has_custom_event_selectors": false,
        "home_region": "us-east-1",
        "include_global_service_events": true,
        "is_logging": true,
        "is_multi_region_trail": true,
        "is_organization_trail": true,
        "kms_key_id": null,
        "log_file_validation_enabled": false,
        "name": "default",
        "s3_bucket_name": "mybucket",
        "s3_key_prefix": null,
        "sns_topic_arn": null,
        "sns_topic_name": null,
        "tags": {},
        "trail_arn": "arn:aws:cloudtrail:us-east-1:111111111111:trail/default"
    }
}
```