### PR TITLE
get_vm should not return a vm from another folder than specified

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -986,7 +986,7 @@ class PyVmomi(object):
                                       details="Please see documentation of the vmware_guest module "
                                       "for folder parameter.")
 
-            elif len(vms) > 0 and self.params['folder'] is not None
+            elif len(vms) > 0 and self.params['folder'] is not None:
                 # User provided folder where virtual machine may be found
                 user_folder = self.params['folder']
                 # User defined datacenter


### PR DESCRIPTION
This change is to prevent `get_vm` returning a vm not matching the `folder` parameter.

##### SUMMARY
When I use the vmware_guest module to provision a new vm having the same name as an existing vm in another folder nothing happens because `get_vm` returns the vm from another folder ignoring the specified folder parameter.

This PR allows me to provision a new vm using the vmware_guest module when there is an existing vm with the same name in another folder.

`get_vm()` should respect the `folder` parameter even if there is just one vm found having the specified name. When the found vm is in another folder `get_vm()` should return nothing.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
The vmware_guest module calls get_vm() from vmware.py.
