### PR TITLE
[stable-2.7] Fix 'Assert CNAME failure' assertion (#65875)

### DIFF
--- a/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -67,7 +67,7 @@
    ignore_errors: yes
 
  - name: Assert CNAME failure
-   assert: { that: "'custom domain name could not be verified' in  change_account['msg']" }
+   assert: { that: "'Azure Error: StorageCustomDomainNameNotValid' in  change_account['msg']" }
 
  - name: Update account tags
    azure_rm_storageaccount:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #65875 for Ansible 2.7
(cherry picked from commit 14ebceec25)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/azure_rm_storageaccount/`