### PR TITLE
ansible-galaxy ignore empty server_list

### DIFF
--- a/changelogs/fragments/galaxy-server-list.yaml
+++ b/changelogs/fragments/galaxy-server-list.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Treat the ``GALAXY_SERVER_LIST`` config entry that is defined but with no values as an empty list

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -320,7 +320,10 @@ class GalaxyCLI(CLI):
                       ('auth_url', False)]
 
         config_servers = []
-        for server_key in (C.GALAXY_SERVER_LIST or []):
+
+        # Need to filter out empty strings or non truthy values as an empty server list env var is equal to [''].
+        server_list = [s for s in C.GALAXY_SERVER_LIST or [] if s]
+        for server_key in server_list:
             # Config definitions are looked up dynamically based on the C.GALAXY_SERVER_LIST entry. We look up the
             # section [galaxy_server.<server>] for the values url, username, password, and token.
             config_dict = dict((k, server_config_def(server_key, k, req)) for k, req in server_def)

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -171,7 +171,7 @@ pushd "${galaxy_testdir}"
 f_ansible_galaxy_status \
     "collection install from local tarball test"
 
-    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install | tee out.txt
+    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install "$@" | tee out.txt
 
     [[ -f "${galaxy_testdir}/install/ansible_collections/ansible_test/my_collection/MANIFEST.json" ]]
     grep "Installing 'ansible_test.my_collection:1.0.0' to .*" out.txt
@@ -180,7 +180,7 @@ f_ansible_galaxy_status \
 f_ansible_galaxy_status \
     "collection install with existing collection and without --force"
 
-    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install | tee out.txt
+    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install "$@" | tee out.txt
 
     [[ -f "${galaxy_testdir}/install/ansible_collections/ansible_test/my_collection/MANIFEST.json" ]]
     grep "Skipping 'ansible_test.my_collection' as it is already installed" out.txt
@@ -188,7 +188,22 @@ f_ansible_galaxy_status \
 f_ansible_galaxy_status \
     "collection install with existing collection and with --force"
 
-    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force | tee out.txt
+    ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force "$@" | tee out.txt
+
+    [[ -f "${galaxy_testdir}/install/ansible_collections/ansible_test/my_collection/MANIFEST.json" ]]
+    grep "Installing 'ansible_test.my_collection:1.0.0' to .*" out.txt
+
+f_ansible_galaxy_status \
+    "ansible-galaxy with a sever list with an undefined URL"
+
+    ANSIBLE_GALAXY_SERVER_LIST=undefined  ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force "$@" 2>&1 | tee out.txt || echo "expected failure"
+
+    grep "No setting was provided for required configuration plugin_type: galaxy_server plugin: undefined setting: url" out.txt
+
+f_ansible_galaxy_status \
+    "ansible-galaxy with an empty server list"
+
+    ANSIBLE_GALAXY_SERVER_LIST= ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force "$@" | tee out.txt
 
     [[ -f "${galaxy_testdir}/install/ansible_collections/ansible_test/my_collection/MANIFEST.json" ]]
     grep "Installing 'ansible_test.my_collection:1.0.0' to .*" out.txt

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -203,7 +203,7 @@ f_ansible_galaxy_status \
 f_ansible_galaxy_status \
     "ansible-galaxy with an empty server list"
 
-    ANSIBLE_GALAXY_SERVER_LIST= ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force "$@" | tee out.txt
+    ANSIBLE_GALAXY_SERVER_LIST='' ansible-galaxy collection install "ansible_test-my_collection-1.0.0.tar.gz" -p ./install --force "$@" | tee out.txt
 
     [[ -f "${galaxy_testdir}/install/ansible_collections/ansible_test/my_collection/MANIFEST.json" ]]
     grep "Installing 'ansible_test.my_collection:1.0.0' to .*" out.txt


### PR DESCRIPTION
##### SUMMARY
If the `GALAXY_SERVER_LIST` config entry is empty or is an empty string `ANSIBLE_GALAXY_SERVER_LIST=''` then currently the code will fail with

```
ERROR! No setting was provided for required configuration plugin_type: galaxy_server setting: url
```

This doesn't really tell the user what is happening as it makes them believe the URL needs to be set for a server list entry when in fact it's trying to find a URL for an unnamed server.  What this PR does is to ignore non-truthy values in the server list so it doesn't fail and just falls back to the scenario when no server list is defined.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy