### PR TITLE
fix VALID_PRIVS forzenset for module mysql_user

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -252,16 +252,15 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'PROCESS', 'PROXY', 'RELOAD', 'REPLICATION CLIENT',
                          'REPLICATION SLAVE', 'SHOW DATABASES', 'SHUTDOWN',
                          'SUPER', 'ALL', 'ALL PRIVILEGES', 'USAGE', 'REQUIRESSL',
-                         'CREATE ROLE', 'DROP ROLE', 'APPLICATION PASSWORD ADMIN',
-                         'AUDIT ADMIN', 'BACKUP ADMIN', 'BINLOG ADMIN',
-                         'BINLOG ENCRYPTION ADMIN', 'CONNECTION ADMIN',
-                         'ENCRYPTION KEY ADMIN', 'FIREWALL ADMIN', 'FIREWALL USER',
-                         'GROUP REPLICATION ADMIN', 'PERSIST RO VARIABLES ADMIN',
-                         'REPLICATION SLAVE ADMIN', 'RESOURCE GROUP ADMIN',
-                         'RESOURCE GROUP USER', 'ROLE ADMIN', 'SET USER ID',
-                         'SESSION VARIABLES ADMIN', 'SYSTEM VARIABLES ADMIN',
-                         'VERSION TOKEN ADMIN', 'XA RECOVER ADMIN',
-                         'LOAD FROM S3', 'SELECT INTO S3'))
+                         'CREATE ROLE', 'DROP ROLE', 'APPLICATION_PASSWORD_ADMIN',
+                         'AUDIT_ADMIN', 'BACKUP_ADMIN', 'CLONE_ADMIN', 'BINLOG_ADMIN',
+                         'BINLOG_ENCRYPTION_ADMIN', 'CONNECTION_ADMIN',
+                         'ENCRYPTION_KEY_ADMIN', 'FIREWALL_ADMIN', 'FIREWALL_USER',
+                         'GROUP_REPLICATION_ADMIN', 'PERSIST_RO_VARIABLES_ADMIN',
+                         'REPLICATION_SLAVE_ADMIN', 'RESOURCE_GROUP_ADMIN',
+                         'RESOURCE_GROUP_USER', 'ROLE_ADMIN', 'SET_USER_ID',
+                         'SESSION_VARIABLES_ADMIN', 'SYSTEM_VARIABLES_ADMIN',
+                         'VERSION_TOKEN_ADMIN', 'XA_RECOVER_ADMIN'))
 
 
 class InvalidPrivsError(Exception):


### PR DESCRIPTION
- there were invalid dynamic privileges names

doc: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html

##### SUMMARY
Module mysql_user couldn't grant BACKUP_ADMIN, nor BACKUP ADMIN. First one was denied from module, second one was denied by mysql 8.0 sql syntax.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user