### PR TITLE
vmware_guest: exclude dvswitch_name from guest os customization

### DIFF
--- a/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
+++ b/changelogs/fragments/65997-vmware_guest-exclude-dvswitch-name-from-os-customization.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - Exclude dvswitch_name from triggering guest os customization.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -2414,7 +2414,7 @@ class PyVmomiHelper(PyVmomi):
                 if key == 'type' and nw['type'] == 'dhcp':
                     network_changes = True
                     break
-                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected'):
+                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected', 'dvswitch_name'):
                     network_changes = True
                     break
 
@@ -2683,7 +2683,7 @@ class PyVmomiHelper(PyVmomi):
         for nw in self.params['networks']:
             for key in nw:
                 # We don't need customizations for these keys
-                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected'):
+                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected', 'dvswitch_name'):
                     network_changes = True
                     break
         if len(self.params['customization']) > 1 or network_changes or self.params.get('customization_spec'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Exclude dvswitch_name from triggering guest os customization, as it is external to the guest and vmware-tools.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
```
ansible 2.9.2
  config file = None
  configured module search path = [u'/home/testuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Mar 26 2019, 22:13:06) [GCC 4.8.5 20150623 (Red Hat 4.8.5-36)]
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Cloning off of a OVA (or template) that has never been booted before will fail if dvswitch_name is specified. This is due to a combination of vmware trying to customize the guest os, and vcenter not knowing that the guest has vmware-tools (since the original OVA has never been booted, it never told vCenter that vmware-tools is installed).
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```paste below
TASK [vmware-guest : Create Red Hat CoreOS nodes] ****************************************************************************************************************************************************************************************************
fatal: [compute-node-1 -> localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "msg": "Failed to create a virtual machine : Customization of the guest operating system 'rhel7_64Guest' is not supported in this configuration. Microsoft Vista (TM) and Linux guests with Logical Volume Manager are supported only for recent ESX host and VMware Tools versions. Refer to vCenter documentation for supported configurations."}

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
compute-node-1            : ok=0    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0
```
After:
```
TASK [vmware-guest : Create Red Hat CoreOS nodes] ****************************************************************************************************************************************************************************************************
changed: [compute-node-1 -> localhost]

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
compute-node-1            : ok=0    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```
