### PR TITLE
use proxy settings for Redfish requests

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -45,7 +45,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False, timeout=self.timeout)
+                            use_proxy=True, timeout=self.timeout)
             data = json.loads(resp.read())
             headers = dict((k.lower(), v) for (k, v) in resp.info().items())
         except HTTPError as e:
@@ -71,7 +71,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False, timeout=self.timeout)
+                            use_proxy=True, timeout=self.timeout)
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,
@@ -106,7 +106,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False, timeout=self.timeout)
+                            use_proxy=True, timeout=self.timeout)
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,
@@ -131,7 +131,7 @@ class RedfishUtils(object):
                             url_password=self.creds['pswd'],
                             force_basic_auth=True, validate_certs=False,
                             follow_redirects='all',
-                            use_proxy=False, timeout=self.timeout)
+                            use_proxy=True, timeout=self.timeout)
         except HTTPError as e:
             msg = self._get_extended_message(e)
             return {'ret': False,


### PR DESCRIPTION
##### SUMMARY
Some environments require proxies to reach BMCs.  Previously, this setting was explicitly disabled, so that even if `http_proxy` or `https_proxy` env vars were set, `redfish_facts` wouldn't use them when making requests to BMCs.


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`redfish_utils`

##### ADDITIONAL INFORMATION
`use_proxy=True` is the [default for the underlying open_url function](https://github.com/ansible/ansible/blob/1915aa47db3984c16905c6b32acaeb8e80c8bf77/lib/ansible/module_utils/urls.py#L1364) used by redfish_utils
