### PR TITLE
Add ansible-test constraint to avoid coverage 5.0+

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-constraint.yml
+++ b/changelogs/fragments/ansible-test-coverage-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test no longer tries to install ``coverage`` 5.0+ since those versions are unsupported

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -1,5 +1,5 @@
-coverage >= 4.2, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
-coverage >= 4.5.4 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8
+coverage >= 4.2, < 5.0.0, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6, coverage 5.0+ incompatible
+coverage >= 4.5.4, < 5.0.0 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later


### PR DESCRIPTION
##### SUMMARY

Add ansible-test constraint to avoid coverage 5.0+

Resolves https://github.com/ansible/ansible/issues/65907

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

The new 5.0 release of [coverage](https://pypi.org/project/coverage/) on December 14th is incompatible with ansible-test. This PR updates the pip constraints used by ansible-test to avoid the incompatible versions.

See [Major changes in 5.0](https://coverage.readthedocs.io/en/coverage-5.0/whatsnew5x.html) for details on what has changed.