### PR TITLE
[stable-2.9] user - honor update_password parameter on BusyBox hosts (#65977)

### DIFF
--- a/changelogs/fragments/user-alpine-on-changed-fix.yaml
+++ b/changelogs/fragments/user-alpine-on-changed-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - on systems using busybox, honor the ``on_changed`` parameter to prevent unnecessary password changing (https://github.com/ansible/ansible/issues/65711)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2794,15 +2794,14 @@ class BusyBox(User):
                             self.module.fail_json(name=self.name, msg=err, rc=rc)
 
         # Manage password
-        if self.password is not None:
-            if info[1] != self.password:
-                cmd = [self.module.get_bin_path('chpasswd', True)]
-                cmd.append('--encrypted')
-                data = '{name}:{password}'.format(name=self.name, password=self.password)
-                rc, out, err = self.execute_command(cmd, data=data)
+        if self.update_password == 'always' and self.password is not None and info[1] != self.password:
+            cmd = [self.module.get_bin_path('chpasswd', True)]
+            cmd.append('--encrypted')
+            data = '{name}:{password}'.format(name=self.name, password=self.password)
+            rc, out, err = self.execute_command(cmd, data=data)
 
-                if rc is not None and rc != 0:
-                    self.module.fail_json(name=self.name, msg=err, rc=rc)
+            if rc is not None and rc != 0:
+                self.module.fail_json(name=self.name, msg=err, rc=rc)
 
         return rc, out, err
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -68,6 +68,32 @@
   assert:
     that: "'warnings' not in test_user_encrypt0"
 
+# https://github.com/ansible/ansible/issues/65711
+- name: Test updating password only on creation
+  user:
+    name: ansibulluser
+    password: '*'
+    update_password: on_create
+  register: test_user_update_password
+
+- name: Ensure password was not changed
+  assert:
+    that:
+      - test_user_update_password is not changed
+
+- name: Verify password hash for Linux
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: LINUX | Get shadow entry for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: LINUX | Ensure password hash was not removed
+      assert:
+        that:
+          - getent_shadow['ansibulluser'][1] != '*'
+
 - block:
     - name: add an plaintext password for user
       user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #65977 for Ansible 2.9
(cherry picked from commit 18130e1419)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/system/user.py`