### PR TITLE
[stable-2.9] Disable failing azure_rm_storageaccount test.

### DIFF
--- a/test/integration/targets/azure_rm_storageaccount/aliases
+++ b/test/integration/targets/azure_rm_storageaccount/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/azure/group2
 destructive
+disabled


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Disable failing azure_rm_storageaccount test.

Backport of https://github.com/ansible/ansible/pull/66008

(cherry picked from commit 342b9953bcc47278de4a31e5c7c97d0037431093)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_storageaccount integration test