### PR TITLE
[2.9] Multiple fixes to nios_* modules

### DIFF
--- a/changelogs/fragments/65369_nios_fixed_address.yml
+++ b/changelogs/fragments/65369_nios_fixed_address.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Multiple fixes in nios_* modules (https://github.com/ansible/ansible/issues/64034).

--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -463,9 +463,45 @@ class WapiModule(WapiBase):
                 # resolves issue where a_record with uppercase name was returning null and was failing
                 test_obj_filter = obj_filter
                 test_obj_filter['name'] = test_obj_filter['name'].lower()
+                # resolves issue where multiple a_records with same name and different IP address
+                try:
+                    ipaddr_obj = self.module._check_type_dict(obj_filter['ipv4addr'])
+                    ipaddr = ipaddr_obj['old_ipv4addr']
+                except TypeError:
+                    ipaddr = obj_filter['ipv4addr']
+                test_obj_filter['ipv4addr'] = ipaddr
+            elif (ib_obj_type == NIOS_TXT_RECORD):
+                # resolves issue where multiple txt_records with same name and different text
+                test_obj_filter = obj_filter
+                try:
+                    text_obj = self.module._check_type_dict(obj_filter['text'])
+                    txt = text_obj['old_text']
+                except TypeError:
+                    txt = obj_filter['text']
+                test_obj_filter['text'] = txt
             # check if test_obj_filter is empty copy passed obj_filter
             else:
                 test_obj_filter = obj_filter
+            ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())
+        elif (ib_obj_type == NIOS_A_RECORD):
+            # resolves issue where multiple a_records with same name and different IP address
+            test_obj_filter = obj_filter
+            try:
+                ipaddr_obj = self.module._check_type_dict(obj_filter['ipv4addr'])
+                ipaddr = ipaddr_obj['old_ipv4addr']
+            except TypeError:
+                ipaddr = obj_filter['ipv4addr']
+            test_obj_filter['ipv4addr'] = ipaddr
+            ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())
+        elif (ib_obj_type == NIOS_TXT_RECORD):
+            # resolves issue where multiple txt_records with same name and different text
+            test_obj_filter = obj_filter
+            try:
+                text_obj = self.module._check_type_dict(obj_filter['text'])
+                txt = text_obj['old_text']
+            except TypeError:
+                txt = obj_filter['text']
+            test_obj_filter['text'] = txt
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=ib_spec.keys())
         elif (ib_obj_type == NIOS_ZONE):
             # del key 'restart_if_needed' as nios_zone get_object fails with the key present

--- a/lib/ansible/modules/net_tools/nios/nios_fixed_address.py
+++ b/lib/ansible/modules/net_tools/nios/nios_fixed_address.py
@@ -41,7 +41,6 @@ options:
   network:
     description:
       - Specifies the network range in which ipaddr exists.
-    required: true
     aliases:
       - network
   network_view:
@@ -180,15 +179,23 @@ def options(module):
             vendor_class: <value>
         }
     It will remove any options that are set to None since WAPI will error on
-    that condition.  It will also verify that either `name` or `num` is
+    that condition.  The use_option field only applies
+    to special options that are displayed separately from other options and
+    have a use flag. This function removes the use_option flag from all
+    other options. It will also verify that either `name` or `num` is
     set in the structure but does not validate the values are equal.
     The remainder of the value validation is performed by WAPI
     '''
+    special_options = ['routers', 'router-templates', 'domain-name-servers',
+                       'domain-name', 'broadcast-address', 'broadcast-address-offset',
+                       'dhcp-lease-time', 'dhcp6.name-servers']
     options = list()
     for item in module.params['options']:
         opt = dict([(k, v) for k, v in iteritems(item) if v is not None])
         if 'name' not in opt and 'num' not in opt:
             module.fail_json(msg='one of `name` or `num` is required for option value')
+        if opt['name'] not in special_options:
+            del opt['use_option']
         options.append(opt)
     return options
 
@@ -226,7 +233,7 @@ def main():
         name=dict(required=True),
         ipaddr=dict(required=True, aliases=['ipaddr'], ib_req=True),
         mac=dict(required=True, aliases=['mac'], ib_req=True),
-        network=dict(required=True, aliases=['network'], ib_req=True),
+        network=dict(required=True, aliases=['network']),
         network_view=dict(default='default', aliases=['network_view']),
 
         options=dict(type='list', elements='dict', options=option_spec, transform=options),

--- a/lib/ansible/modules/net_tools/nios/nios_txt_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_txt_record.py
@@ -43,6 +43,7 @@ options:
         per substring, up to a total of 512 bytes. To enter leading,
         trailing, or embedded spaces in the text, add quotes around the
         text to preserve the spaces.
+    required: true
   ttl:
     description:
       - Configures the TTL to be associated with this tst record
@@ -106,7 +107,7 @@ def main():
     ib_spec = dict(
         name=dict(required=True, ib_req=True),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
-        text=dict(type='str'),
+        text=dict(ib_req=True),
         ttl=dict(type='int'),
         extattrs=dict(type='dict'),
         comment=dict(),


### PR DESCRIPTION
##### SUMMARY

Fixes: #56301
Fixes: #62377 nios_txt_record module cannot handle multiple TXT records
Fixes: #64045 nios_a_record is requested to modify IP of existing A record, but attempts to create new A record instead
Fixes: #64034 nios_fixed_address not able to add options that don't require use_options

(cherry picked from commit 0685691d073cd2a271e4fc60543e6a9f8142dd56)


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/65369_nios_fixed_address.yml
lib/ansible/module_utils/net_tools/nios/api.py
lib/ansible/modules/net_tools/nios/nios_fixed_address.py
lib/ansible/modules/net_tools/nios/nios_txt_record.py
