### PR TITLE
Update to fix #62377, #64045

### DIFF
--- a/lib/ansible/module_utils/net_tools/nios/api.py
+++ b/lib/ansible/module_utils/net_tools/nios/api.py
@@ -358,6 +358,24 @@ class WapiModule(WapiBase):
                     # popping 'view' key as update of 'view' is not supported with respect to a:record/aaaa:record/srv:record/ptr:record
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     del proposed_object['view']
+                    if (ib_obj_type == NIOS_A_RECORD):
+                        # resolves issue where multiple a_records with same name and different IP address
+                        try:
+                            ipaddr_obj = self.module._check_type_dict(proposed_object['ipv4addr'])
+                            ipaddr = ipaddr_obj['new_ipv4addr']
+                        except TypeError:
+                            ipaddr = proposed_object['ipv4addr']
+                        proposed_object['ipv4addr'] = ipaddr
+                    res = self.update_object(ref, proposed_object)
+                    result['changed'] = True
+                elif (ib_obj_type == NIOS_TXT_RECORD):
+                    # resolves issue where multiple txt_records with same name and different text
+                    try:
+                        text_obj = self.module._check_type_dict(proposed_object['text'])
+                        txt = text_obj['new_text']
+                    except TypeError:
+                        txt = proposed_object['text']
+                    proposed_object['text'] = txt
                     res = self.update_object(ref, proposed_object)
                     result['changed'] = True
                 elif 'network_view' in proposed_object:
@@ -584,7 +602,7 @@ class WapiModule(WapiBase):
         return ib_obj, update, new_name
 
     def on_update(self, proposed_object, ib_spec):
-        ''' Event called before the update is sent to the API endpoing
+        ''' Event called before the update is sent to the API endpoint
         This method will allow the final proposed object to be changed
         and/or keys filtered before it is sent to the API endpoint to
         be processed.

--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -28,7 +28,7 @@ options:
     description:
       - Specifies the fully qualified hostname to add or remove from
         the system. User can also update the hostname as it is possible
-        to pass a dict containing I(new_name), I(old_name). See examples.
+        to pass a dict containing I(new_ipv4addr), I(new_ipv4addr). See examples.
     required: true
   view:
     description:

--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -27,7 +27,8 @@ options:
   name:
     description:
       - Specifies the fully qualified hostname to add or remove from
-        the system
+        the system. User can also update the hostname as it is possible
+        to pass a dict containing I(new_name), I(old_name). See examples.
     required: true
   view:
     description:

--- a/lib/ansible/modules/net_tools/nios/nios_a_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_a_record.py
@@ -116,6 +116,17 @@ EXAMPLES = '''
       password: admin
   connection: local
 
+- name: update an A record IP address
+  nios_a_record:
+    name: a.ansible.com
+    ipv4: {new_ipv4addr: 10.10.10.1, old_ipv4addr: 192.168.10.1}
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
 - name: dynamically add a record to next available ip
   nios_a_record:
     name: a.ansible.com

--- a/lib/ansible/modules/net_tools/nios/nios_txt_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_txt_record.py
@@ -70,7 +70,7 @@ options:
 '''
 
 EXAMPLES = '''
-    - name: Ensure a text Record Exists
+    - name: Create a text record
       nios_txt_record:
         name: fqdn.txt.record.com
         text: mytext
@@ -81,7 +81,18 @@ EXAMPLES = '''
           username: admin
           password: admin
 
-    - name: Ensure a text Record does not exist
+    - name: update text of TXT record
+      nios_txt_record:
+        name: fqdn.txt.record.com
+        text: {new_text: newtext, old_text: mytext}
+        state: present
+        view: External
+        provider:
+          host: "{{ inventory_hostname_short }}"
+          username: admin
+          password: admin
+
+    - name: Delete a text record
       nios_txt_record:
         name: fqdn.txt.record.com
         text: mytext

--- a/lib/ansible/modules/net_tools/nios/nios_txt_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_txt_record.py
@@ -42,7 +42,8 @@ options:
       - Text associated with the record. It can contain up to 255 bytes
         per substring, up to a total of 512 bytes. To enter leading,
         trailing, or embedded spaces in the text, add quotes around the
-        text to preserve the spaces.
+        text to preserve the spaces.  User can also update the text as it is possible
+        to pass a dict containing I(new_text), I(old_text). See examples.
     required: true
   ttl:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #62377, #64045
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nios_a_record.py
nios_txt_record.py
api.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added new parameters to A record and TXT record to handle modification of content in the records.
In case of A record, adding this new parameter enables modifying the IP address of a specific record when there are multiple records with the same name.
Similarly for TXT record, adding the new parameters enable modifying the text content of a specific TXT record when there are multiple records with the same name.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
