### PR TITLE
Display item value in a output of include_tasks loop

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -350,8 +350,9 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_include(self, included_file):
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        if 'item' in included_file._args:
-            msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
+        label = self._get_item_label(included_file._vars)
+        if label:
+            msg += " => (item=%s)" % label
         self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):


### PR DESCRIPTION
##### SUMMARY
* Fixing item value in a output of include_tasks loop replacing `included_file._args` w/ `included_file._vars`

Fixes #65904 


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/callback/default.py

##### CURRENT OUTPUT
```
(venv_ansible) [ytale@localhost ansible]$ ansible-playbook examples/playbooks/playbook.yml -i invetory

PLAY [localhost] **************************************************************************************************

TASK [include_tasks] **********************************************************************************************
included: /home/ytale/opensource/ansible/examples/playbooks/included.yml for localhost => (item=1)
included: /home/ytale/opensource/ansible/examples/playbooks/included.yml for localhost => (item=2)

TASK [debug] ******************************************************************************************************
ok: [localhost] => {
    "item": 1
}

TASK [debug] ******************************************************************************************************
ok: [localhost] => {
    "item": 2
}

PLAY RECAP ********************************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

##### BONUS
![cute](https://user-images.githubusercontent.com/10824880/71308734-12251a00-2426-11ea-9698-bf3bed0200ce.jpg)
