### PR TITLE
Clarify the advantage include* statement brought regarding looping

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse.rst
@@ -50,7 +50,7 @@ Tradeoffs and Pitfalls Between Includes and Imports
 
 Using ``include*`` vs. ``import*`` has some advantages as well as some tradeoffs which users should consider when choosing to use each:
 
-The primary advantage of using ``include*`` statements is looping. When a loop is used with an include, the included tasks or role will be executed once for each item in the loop.
+The primary advantage of using ``include*`` statements is the support of looping. When a loop is used with an include, the included tasks or role will be executed once for each item in the loop.
 
 Using ``include*`` does have some limitations when compared to ``import*`` statements:
 


### PR DESCRIPTION
##### SUMMARY
The current documentation:

> The primary advantage of using include* statements is looping.

isn't really clear about what scope of advantage the include* statements bring (is it a part of the usage of looping or is it supported at all?), this patch clarifies it without the readers do an experimentation to see the following error message:

> ERROR! You cannot use loops on 'import_tasks' statements. You should use 'include_tasks' instead.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
