### PR TITLE
Zabbix: zabbix_host_info: Include host groups in host_name based search results

### DIFF
--- a/changelogs/fragments/66026-zabbix_host_info.yml
+++ b/changelogs/fragments/66026-zabbix_host_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_host_info - ``host_name`` based search results now include host groups.

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py
@@ -120,7 +120,7 @@ class Host(object):
         if exact_match:
             search_key = 'filter'
         host_list = self._zapi.host.get({'output': 'extend', 'selectParentTemplates': ['name'], search_key: {'host': [host_name]},
-                                         'selectInventory': host_inventory})
+                                         'selectInventory': host_inventory, 'selectGroups': 'extend'})
         if len(host_list) < 1:
             self._module.fail_json(msg="Host not found: %s" % host_name)
         else:


### PR DESCRIPTION
##### SUMMARY
`host_ip` based search results included host groups, but `host_name` based search results did not include host groups.
So fix it to include host groups in `host_name` based search results.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
zabbix_host_info

