### PR TITLE
nxos_gir timeout fixes

### DIFF
--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -621,7 +621,6 @@ class HttpApi:
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = list()
 
-        self.set_module_specific_options()
         self.check_edit_config_capability(candidate, commit, replace, comment)
 
         if replace:
@@ -635,18 +634,6 @@ class HttpApi:
             resp = ['']
 
         return resp
-
-    def set_module_specific_options(self):
-        """Set module-specific options; e.g. minimum timeout requirements.
-        """
-        if self._module._name == 'nxos_gir':
-            gir_timeout = 200
-            conn = self._connection
-            persistent_command_timeout = conn.get_option('persistent_command_timeout')
-            if persistent_command_timeout < gir_timeout:
-                conn.set_option('persistent_command_timeout', gir_timeout)
-                msg = "timeout value extended to %ss for nxos_gir." % gir_timeout
-                self._module.warn(msg)
 
     def get_capabilities(self):
         """Returns platform info of the remove device

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -621,6 +621,7 @@ class HttpApi:
     def edit_config(self, candidate=None, commit=True, replace=None, comment=None):
         resp = list()
 
+        self.set_module_specific_options()
         self.check_edit_config_capability(candidate, commit, replace, comment)
 
         if replace:
@@ -634,6 +635,18 @@ class HttpApi:
             resp = ['']
 
         return resp
+
+    def set_module_specific_options(self):
+        """Set module-specific options; e.g. minimum timeout requirements.
+        """
+        if self._module._name == 'nxos_gir':
+            gir_timeout = 200
+            conn = self._connection
+            persistent_command_timeout = conn.get_option('persistent_command_timeout')
+            if persistent_command_timeout < gir_timeout:
+                conn.set_option('persistent_command_timeout', gir_timeout)
+                msg = "timeout value extended to %ss for nxos_gir." % gir_timeout
+                self._module.warn(msg)
 
     def get_capabilities(self):
         """Returns platform info of the remove device

--- a/lib/ansible/modules/network/nxos/nxos_gir.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir.py
@@ -29,6 +29,7 @@ version_added: "2.2"
 short_description: Trigger a graceful removal or insertion (GIR) of the switch.
 description:
     - Trigger a graceful removal or insertion (GIR) of the switch.
+    - GIR processing may take more than 2 minutes to complete. Timeout settings for this module will be automatically extended to 200 seconds when user timeout settings are insufficient.
 author:
     - Gabriele Gerbino (@GGabriele)
 notes:

--- a/lib/ansible/modules/network/nxos/nxos_gir.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir.py
@@ -29,7 +29,7 @@ version_added: "2.2"
 short_description: Trigger a graceful removal or insertion (GIR) of the switch.
 description:
     - Trigger a graceful removal or insertion (GIR) of the switch.
-    - GIR processing may take more than 2 minutes to complete. Timeout settings for this module will be automatically extended to 200 seconds when user timeout settings are insufficient.
+    - GIR processing may take more than 2 minutes. Timeout settings are automatically extended to 200s when user timeout settings are insufficient.
 author:
     - Gabriele Gerbino (@GGabriele)
 notes:

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -80,6 +80,9 @@ class ActionModule(ActionNetworkModule):
                 display.warning('transport is unnecessary when using %s and will be ignored' % self._play_context.connection)
                 del self._task.args['transport']
 
+            if persistent_connection == 'httpapi':
+                self._connection.set_options(direct={'persistent_command_timeout': C.PERSISTENT_COMMAND_TIMEOUT})
+
         elif self._play_context.connection == 'local':
             provider = load_provider(nxos_provider_spec, self._task.args)
             transport = provider['transport'] or 'cli'

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -265,7 +265,8 @@ class Connection(NetworkConnectionBase):
         Sends the command to the device over api
         '''
         url_kwargs = dict(
-            timeout=self.get_option('timeout'), validate_certs=self.get_option('validate_certs'),
+            timeout=self.get_option('persistent_command_timeout'),
+            validate_certs=self.get_option('validate_certs'),
             use_proxy=self.get_option("use_proxy"),
             headers={},
         )

--- a/test/integration/targets/nxos_gir/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_gir/tests/common/sanity.yaml
@@ -1,13 +1,11 @@
 ---
 - debug: msg="START connection={{ ansible_connection }} nxos_gir sanity test"
+- set_fact: gir_run='{{ true if (platform is not search("N35")) else false }}'
 
-- set_fact: gir_run="true"
-- set_fact: gir_run="false"
-  when: platform is search("N35")
-#- name: "Setup"
-#  nxos_gir: &setup
-#    system_mode_maintenance: false
-#  ignore_errors: yes
+- name: "Setup"
+  nxos_gir: &setup
+    system_mode_maintenance: false
+  ignore_errors: yes
 
 - block:
   - name: "Put system in maintenance mode with reload reset reason"
@@ -68,12 +66,12 @@
 
   - assert: *false
 
-#  - name: "Put system in maintenance mode"
-#    nxos_gir: &configure_system_mode_maintenance
-#      system_mode_maintenance: true
-#    register: result
-#
-#  - assert: *true
+  - name: "Put system in maintenance mode"
+    nxos_gir: &configure_system_mode_maintenance
+      system_mode_maintenance: true
+    register: result
+
+  - assert: *true
 
   when: gir_run
 
@@ -100,9 +98,14 @@
       match: none
     ignore_errors: yes
 
-#  - name: "Put system back in normal mode"
-#    nxos_gir: *setup
-#    register: result
-#    ignore_errors: yes
+  - name: "Put system back in normal mode"
+    nxos_gir:
+      system_mode_maintenance: false
+    # Try again if cli is blocking while changing modes
+    retries: 3
+    delay: 30
+    register: result
+    until: result is not failed
+    ignore_errors: yes
 
 - debug: msg="END connection={{ ansible_connection }} nxos_gir sanity test"

--- a/test/integration/targets/nxos_gir/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_gir/tests/common/sanity.yaml
@@ -2,8 +2,17 @@
 - debug: msg="START connection={{ ansible_connection }} nxos_gir sanity test"
 - set_fact: gir_run='{{ true if (platform is not search("N35")) else false }}'
 
-- name: "Setup"
-  nxos_gir: &setup
+- name: Setup0
+  nxos_config: &cleanup0
+    lines:
+      - no system mode maintenance timeout 30
+      - no configure maintenance profile normal-mode
+      - no configure maintenance profile maintenance-mode
+    match: none
+  ignore_errors: yes
+
+- name: Setup1
+  nxos_gir:
     system_mode_maintenance: false
   ignore_errors: yes
 
@@ -86,16 +95,8 @@
       action: delete_all
     ignore_errors: yes
 
-  - name: "Remove other config1"
-    nxos_config:
-      lines: no configure maintenance profile normal-mode
-      match: none
-    ignore_errors: yes
-
-  - name: "Remove other config2"
-    nxos_config:
-      lines: no configure maintenance profile maintenance-mode
-      match: none
+  - name: Teardown0
+    nxos_config: *cleanup0
     ignore_errors: yes
 
   - name: "Put system back in normal mode"


### PR DESCRIPTION
##### SUMMARY
`nxos_gir` is getting a timeout-related failure when using `httpapi` transport.

This PR supercedes #64907 

Analysis: The CLI command `system mode maintenence` often requires at least 120 seconds to complete. The standard timeout is 30 seconds but users can override this timeout by setting environment variable `ANSIBLE_PERSISTENT_COMMAND_TIMEOUT`; however, this env var was ignored when the `httpapi` codepath was used. 

Further, since this extended minimum timeout is specific to `nxos_gir`, we felt it would be beneficial to automatically set the timeout for this module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`nxos_gir`

##### ADDITIONAL INFORMATION
Tested on `N9K, N9Kv, N6K, N7K, N3K` (internal testbeds: `dt-n9k5-1, greensboro-nx-1, hamilton-nx-1, n6k-77, n7k-99, n3k-105`