### PR TITLE
Do not loop through chassis in IndicatorLed* commands

### DIFF
--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -702,22 +702,21 @@ class RedfishUtils(object):
         payloads = {'IndicatorLedOn': 'Lit', 'IndicatorLedOff': 'Off', "IndicatorLedBlink": 'Blinking'}
 
         result = {}
-        for chassis_uri in self.chassis_uris:
-            response = self.get_request(self.root_uri + chassis_uri)
+        response = self.get_request(self.root_uri + self.chassis_uri)
+        if response['ret'] is False:
+            return response
+        result['ret'] = True
+        data = response['data']
+        if key not in data:
+            return {'ret': False, 'msg': "Key %s not found" % key}
+
+        if command in payloads.keys():
+            payload = {'IndicatorLED': payloads[command]}
+            response = self.patch_request(self.root_uri + self.chassis_uri, payload)
             if response['ret'] is False:
                 return response
-            result['ret'] = True
-            data = response['data']
-            if key not in data:
-                return {'ret': False, 'msg': "Key %s not found" % key}
-
-            if command in payloads.keys():
-                payload = {'IndicatorLED': payloads[command]}
-                response = self.patch_request(self.root_uri + chassis_uri, payload)
-                if response['ret'] is False:
-                    return response
-            else:
-                return {'ret': False, 'msg': 'Invalid command'}
+        else:
+            return {'ret': False, 'msg': 'Invalid command'}
 
         return result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the `IndicatorLed*` commands from module `redfish_command`, this PR removes the looping through each chassis in a Redfish service. The pattern of looping through each system, manager, and chassis is only for the `refish_info` module commands which only perform read-only operations. For the data modification commands (`redfish_config` and `redfiah_command` modules), the commands are to act only on a single system, manager, or chassis. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65943 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```paste below
$ ansible-playbook -i myinventory.yml -v  playbooks/chassis/indicator_led_on.yml 
Using /Users/bdodd/.ansible.cfg as config file

PLAY [Set Indicator LED to On] *************************************************

TASK [Turn LED on] *************************************************************
[WARNING]: Platform darwin on host mockup-devel is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/devel/refer
ence_appendices/interpreter_discovery.html for more information.

[DEPRECATION WARNING]: Issuing a data modification command without specifying 
the ID of the target Chassis resource when there is more than one Chassis will 
use the first one in the collection. Use the `resource_id` option to specify 
the target Chassis ID. This feature will be removed in version 2.13. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
fatal: [mockup-devel]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "msg": "Key IndicatorLED not found"}

PLAY RECAP *********************************************************************
mockup-devel               : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

**After:**
```
$ ansible-playbook -i myinventory.yml -v  playbooks/chassis/indicator_led_on.yml 
Using /Users/bdodd/.ansible.cfg as config file

PLAY [Set Indicator LED to On] *************************************************

TASK [Turn LED on] *************************************************************
[WARNING]: Platform darwin on host mockup-devel is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/devel/refer
ence_appendices/interpreter_discovery.html for more information.

[DEPRECATION WARNING]: Issuing a data modification command without specifying 
the ID of the target Chassis resource when there is more than one Chassis will 
use the first one in the collection. Use the `resource_id` option to specify 
the target Chassis ID. This feature will be removed in version 2.13. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
changed: [mockup-devel] => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": true, "msg": "Action was successful"}

PLAY RECAP *********************************************************************
mockup-devel               : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```