### PR TITLE
[stable-2.9] Fix pacman stdout parsing in the Ansible module (#65238)

### DIFF
--- a/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
+++ b/changelogs/fragments/65238-fix_pacman_stdout_parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pacman - Fix pacman output parsing on localized environment. (https://github.com/ansible/ansible/issues/65237)

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -443,6 +443,7 @@ def main():
     )
 
     pacman_path = module.get_bin_path('pacman', True)
+    module.run_command_environ_update = dict(LC_ALL='C')
 
     p = module.params
 


### PR DESCRIPTION
##### SUMMARY

`pacman` output is localized and the Ansible module is parsing its output.
So, we need to force the locale.

Fixes #65237

Backport of https://github.com/ansible/ansible/pull/65238

(cherry picked from commit 10b6038e21b6d78dda736db644643520d5398b77)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

module `pacman`

##### ADDITIONAL INFORMATION