### PR TITLE
mysql_db: add master_data parameter

### DIFF
--- a/changelogs/fragments/66048-mysql_add_master_data_parameter.yml
+++ b/changelogs/fragments/66048-mysql_add_master_data_parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add ``master_data`` parameter (https://github.com/ansible/ansible/pull/66048).

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -90,6 +90,20 @@ options:
     type: bool
     default: no
     version_added: '2.10'
+  master_data:
+    description:
+      - Option to dump a master replication server to produce a dump file
+        that can be used to set up another server as a slave of the master.
+      - C(0) to not include master data.
+      - C(1) to generate a 'CHANGE MASTER TO' statement
+        required on the slave to start the replication process.
+      - C(2) to generate a commented 'CHANGE MASTER TO'.
+      - Can be used when I(state=dump).
+    required: no
+    type: int
+    choices: [0, 1, 2]
+    default: 0
+    version_added: '2.10'
 seealso:
 - module: mysql_info
 - module: mysql_variables
@@ -169,6 +183,13 @@ EXAMPLES = r'''
     state: dump
     name: all
     target: /tmp/dump.sql
+
+- name: Dump all databases to hostname.sql including master data
+  mysql_db:
+    state: dump
+    name: all
+    target: /tmp/dump.sql
+    master_data: 1
 
 # Import of sql script with encoding option
 - name: >
@@ -260,7 +281,7 @@ def db_delete(cursor, db):
 def db_dump(module, host, user, password, db_name, target, all_databases, port,
             config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
             single_transaction=None, quick=None, ignore_tables=None, hex_blob=None,
-            encoding=None, force=False):
+            encoding=None, force=False, master_data=0):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
@@ -296,6 +317,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port,
             cmd += " --ignore-table={0}".format(an_ignored_table)
     if hex_blob:
         cmd += " --hex-blob"
+    if master_data:
+        cmd += " --master-data=%s" % master_data
 
     path = None
     if os.path.splitext(target)[-1] == '.gz':
@@ -425,6 +448,7 @@ def main():
             ignore_tables=dict(type='list', default=[]),
             hex_blob=dict(default=False, type='bool'),
             force=dict(type='bool', default=False),
+            master_data=dict(type='int', default=0, choices=[0, 1, 2]),
         ),
         supports_check_mode=True,
     )
@@ -461,6 +485,7 @@ def main():
     quick = module.params["quick"]
     hex_blob = module.params["hex_blob"]
     force = module.params["force"]
+    master_data = module.params["master_data"]
 
     if len(db) > 1 and state == 'import':
         module.fail_json(msg="Multiple databases are not supported with state=import")
@@ -527,7 +552,7 @@ def main():
                                      login_password, db, target, all_databases,
                                      login_port, config_file, socket, ssl_cert, ssl_key,
                                      ssl_ca, single_transaction, quick, ignore_tables,
-                                     hex_blob, encoding, force)
+                                     hex_blob, encoding, force, master_data)
         if rc != 0:
             module.fail_json(msg="%s" % stderr)
         module.exit_json(changed=True, db=db_name, db_list=db, msg=stdout,

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -72,7 +72,7 @@
   assert:
     that:
     - result is changed
-    - result.executed_commands[0] is match('/usr/bin/mysqldump --force --socket={{ mysql_socket }} --databases {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1.*')
+    - result.executed_commands[0] is search("mysqldump --force --socket={{ mysql_socket }} --databases {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1")
 
 - name: state dump/import - file name should exist
   file: name={{ db_file_name }} state=file

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -65,12 +65,14 @@
         - "{{ db_name }}.department"
     login_unix_socket: '{{ mysql_socket }}'
     force: yes
+    master_data: 1
   register: result
 
 - name: assert successful completion of dump operation
   assert:
     that:
-       - "result.changed == true"
+    - result is changed
+    - result.executed_commands[0] is match('/usr/bin/mysqldump --force --socket={{ mysql_socket }} --databases {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1.*')
 
 - name: state dump/import - file name should exist
   file: name={{ db_file_name }} state=file


### PR DESCRIPTION
##### SUMMARY
mysql_db: add master_data parameter

Fixes: https://github.com/ansible/ansible/pull/19123

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_db.py```
