### PR TITLE
Add parsing of templates in dynamic inventory

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -242,7 +242,8 @@ class BaseInventoryPlugin(AnsiblePlugin):
 
         for k in self._options:
             if k in data:
-                self._options[k] = data.pop(k)
+                # Parse templates in options
+                self._options[k] = self.templar.template(data.pop(k))
 
     def _expand_hostpattern(self, hostpattern):
         '''


### PR DESCRIPTION
##### SUMMARY
Enable the use of **lookups** in parameters of dynamic inventories, to avoid repeating our selves.

Examples
* `password: "{{ lookup('passwordstore', ...) }}"`
* `password: "{{ lookup('hashi_vault', ...) }}"`
* `hostname: "{{ lookup('file', ...) }}"`

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
Dynamic inventories

##### ADDITIONAL INFORMATION
Use **templar.template** in **_consume_options**, which is used only in:
 * vmware_vm_inventory.py
 * virtualbox.py

I'm actually using **vmware_vm_inventory**, it enables me to use **passwordstore** lookup to get the same password in my dynamic inventory and in my group_vars.

I didn't checked if the other dynamic inventory plugins not using **_consume_options** are able to parse templated parameters, but if they are not, it could be a good idea to implement.