### PR TITLE
Update deprecation version and porting guide for resource_id option

### DIFF
--- a/changelogs/fragments/66060-redfish-new-resource-id-option.yaml
+++ b/changelogs/fragments/66060-redfish-new-resource-id-option.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- redfish_config, redfish_command - Add ``resource_id`` option to specify which System, Manager, or Chassis resource to modify.
+deprecated_features:
+- redfish_config, redfish_command - Behavior to modify the first System, Mananger, or Chassis resource when multiple are present is deprecated. Use the new ``resource_id`` option to specify target resource to modify.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -71,6 +71,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`iam_policy <iam_policy_module>`: the ``policy_document`` option will be removed. To maintain the existing behavior use the ``policy_json`` option and read the file with the ``lookup`` plugin.
 * :ref:`redfish_config <redfish_config_module>`: the ``bios_attribute_name`` and ``bios_attribute_value`` options will be removed. To maintain the existing behavior use the ``bios_attributes`` option instead.
 * :ref:`clc_aa_policy <clc_aa_policy_module>`: the ``wait`` parameter will be removed. It has always been ignored by the module.
+* :ref:`redfish_config <redfish_config_module>`, :ref:`redfish_command <redfish_command_module>`: the behavior to select the first System, Manager, or Chassis resource to modify when multiple are present will be removed. Use the new ``resource_id`` option to specify target resource to modify.
 
 
 

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -244,7 +244,7 @@ class RedfishUtils(object):
                         'msg': "System resource %s not found" % self.resource_id}
             elif len(self.systems_uris) > 1:
                 self.module.deprecate(DEPRECATE_MSG % {'resource': 'System'},
-                                      version='2.13')
+                                      version='2.14')
         return {'ret': True}
 
     def _find_updateservice_resource(self):
@@ -295,7 +295,7 @@ class RedfishUtils(object):
                         'msg': "Chassis resource %s not found" % self.resource_id}
             elif len(self.chassis_uris) > 1:
                 self.module.deprecate(DEPRECATE_MSG % {'resource': 'Chassis'},
-                                      version='2.13')
+                                      version='2.14')
         return {'ret': True}
 
     def _find_managers_resource(self):
@@ -325,7 +325,7 @@ class RedfishUtils(object):
                         'msg': "Manager resource %s not found" % self.resource_id}
             elif len(self.manager_uris) > 1:
                 self.module.deprecate(DEPRECATE_MSG % {'resource': 'Manager'},
-                                      version='2.13')
+                                      version='2.14')
         return {'ret': True}
 
     def get_logs(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a few small issues with feature PR #62921:

- The version number in the AnsibleModule.deprecate() call was set to '2.13'. But the feature did not make it into version '2.9' (it will be in '2.10'). So the deprecation removal version should be '2.14' ('2.10' + 4).
- Added a changelog fragment
- Added an entry to the porting guide

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #65983 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_config.py
redfish_command.py

##### ADDITIONAL INFORMATION
See #65983 for additional detail.
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

