### PR TITLE
Correct fetch_url error code documentation

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1435,7 +1435,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg ca_path: (optional) String of file system path to CA cert bundle to use
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
-        The **info** contains the 'status' and other meta data. When a HttpError (status > 400)
+        The **info** contains the 'status' and other meta data. When a HttpError (status >= 400)
         occurred then ``info['body']`` contains the error response data::
 
     Example::


### PR DESCRIPTION
##### SUMMARY
HttpError is passed for 400 and above, not only greater than 400. This PR changes it to `>=` instead of `>`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
urls.py
