### PR TITLE
homebrew: Add upgrade_options in upgrade_all

### DIFF
--- a/changelogs/fragments/54541-homebrew-upgrade_options.yml
+++ b/changelogs/fragments/54541-homebrew-upgrade_options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added upgrade_options in homebrew module to handle upgrade related options (https://github.com/ansible/ansible/issues/54541).


### PR DESCRIPTION
##### SUMMARY

Handle upgrade options in upgrade_all state in homebrew module.

Fixes: #54541

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/54541-homebrew-upgrade_options.yml
lib/ansible/modules/packaging/os/homebrew.py
