### PR TITLE
homebrew: Add info about changed packages

### DIFF
--- a/changelogs/fragments/59376-homebrew-pkg.yml
+++ b/changelogs/fragments/59376-homebrew-pkg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Return list of unchanged and changed package list in module return (https://github.com/ansible/ansible/issues/59376).


### PR DESCRIPTION
##### SUMMARY

homebrew now returns details about changed and unchanged packages
after performing the operations.

Fixes: #59376

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/59376-homebrew-pkg.yml
lib/ansible/modules/packaging/os/homebrew.py
