### PR TITLE
service_mgr: detect systemd, even offline

### DIFF
--- a/changelogs/fragments/service-mgr-systemd-offline.yml
+++ b/changelogs/fragments/service-mgr-systemd-offline.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- setup - service_mgr - detect systemd even if it isn't running, such as during
+  a container build

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -52,6 +52,17 @@ class ServiceMgrFactCollector(BaseFactCollector):
                     return True
         return False
 
+    @staticmethod
+    def is_systemd_managed_offline(module):
+        # tools must be installed
+        if module.get_bin_path('systemctl'):
+            # check if /sbin/init is a symlink to systemd, or does not exist
+            if not os.path.exists('/sbin/init'):
+                return True
+            if os.path.islink('/sbin/init') and os.path.basename(os.readlink('/sbin/init')) == 'systemd':
+                return True
+        return False
+
     def collect(self, module=None, collected_facts=None):
         facts_dict = {}
 
@@ -129,6 +140,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
                 service_mgr_name = 'upstart'
             elif os.path.exists('/sbin/openrc'):
                 service_mgr_name = 'openrc'
+            elif self.is_systemd_managed_offline(module=module):
+                service_mgr_name = 'systemd'
             elif os.path.exists('/etc/init.d/'):
                 service_mgr_name = 'sysvinit'
 

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -56,9 +56,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
     def is_systemd_managed_offline(module):
         # tools must be installed
         if module.get_bin_path('systemctl'):
-            # check if /sbin/init is a symlink to systemd, or does not exist
-            if not os.path.exists('/sbin/init'):
-                return True
+            # check if /sbin/init is a symlink to systemd
+            # on SUSE, /sbin/init may be missing if systemd-sysvinit package is not installed.
             if os.path.islink('/sbin/init') and os.path.basename(os.readlink('/sbin/init')) == 'systemd':
                 return True
         return False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, systemd is only detected as the service manager if systemd is actually running.  This also adds a check that will detect systemd ever if it is not currently running, such as during a container bulid.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service_mgr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
