### PR TITLE
docker_swarm_service: Fix description of limits.memory

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -209,12 +209,12 @@ options:
         type: float
       memory:
         description:
-          - "Service memory reservation in format C(<number>[<unit>]). Number is a positive integer.
+          - "Service memory limit in format C(<number>[<unit>]). Number is a positive integer.
             Unit can be C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte),
             C(T) (tebibyte), or C(P) (pebibyte)."
-          - C(0) equals no reservation.
+          - C(0) equals no limit.
           - Omitting the unit defaults to bytes.
-          - Corresponds to the C(--reserve-memory) option of C(docker service create).
+          - Corresponds to the C(--limit-memory) option of C(docker service create).
         type: str
     type: dict
     version_added: "2.8"


### PR DESCRIPTION
This option corresponds to the '--limit-memory' option

##### SUMMARY

This commit fixes an error in the documentation of `docker_swarm_service`, in the parameter `limits.memory".

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

docker_swarm_service

##### ADDITIONAL INFORMATION

In the parameter `limit_memory` we can see:

```
Corresponds to the --limit-memory option of docker service create.
Deprecated in 2.8, will be removed in 2.12. Use parameter limits.memory instead.
```

But when you read `limits.memory` description you can see:

```
Corresponds to the --reserve-memory option of docker service create.
```


I believe it's clear the error, and that the solution proposed in this PR is correct. As additional information, in `reservations.memory` you can see:

```
Corresponds to the --reserve-memory option of docker service create.
```
