### PR TITLE
Update Documentation for win_scheduled_task.py

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -353,8 +353,7 @@ options:
   execution_time_limit:
     description:
     - The amount of time allowed to complete the task.
-    - When set to nothing, the time limit is infinite.
-      -  `PT0S` will also enable the task to run indefinitely.
+    - When set to `PT0S`, the time limit is infinite.
     - When omitted, the default time limit is 72 hours.
     - This is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
     type: str

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -353,7 +353,9 @@ options:
   execution_time_limit:
     description:
     - The amount of time allowed to complete the task.
-    - When not set, the time limit is infinite.
+    - When set to nothing, the time limit is infinite.
+      -  `PT0S` will also enable the task to run indefinitely.
+    - When omitted, the default time limit is 72 hours.
     - This is in the ISO 8601 Duration format C(P[n]Y[n]M[n]DT[n]H[n]M[n]S).
     type: str
     version_added: '2.5'


### PR DESCRIPTION
##### SUMMARY
Fix documentation for win_scheduled_task execution_time_limit.

A newly created task without a value for `TaskSettings.ExecutionTimeLimit` will default to 72 hours (https://docs.microsoft.com/en-us/windows/win32/taskschd/tasksettings-executiontimelimit).  Additionally, omitting the Ansible task parameter `execution_time_limit` does not cause the Windows Task definition value to become null, so tasks are still subject to a 72 hour maximum execution time.

This value must be set explicitly to an empty string to permit unbounded execution time.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
