### PR TITLE
Fix win_xml error: The property hostName cannot be found on this obje…

### DIFF
--- a/lib/ansible/modules/windows/win_xml.ps1
+++ b/lib/ansible/modules/windows/win_xml.ps1
@@ -227,10 +227,10 @@ if ($type -eq "element") {
                     $changed = $true
                 }
             } else { # assume NodeType is Element
+                if (!$node.HasAttribute($attribute)) { # add attribute to Element if missing
+                    $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
+                }
                 if ($node.$attribute -ne $fragment) {
-                    if (!$node.HasAttribute($attribute)) { # add attribute to Element if missing
-                        $node.SetAttributeNode($attribute, $xmlorig.get_DocumentElement().get_NamespaceURI())
-                    }
                     #set the attribute into the element
                     $node.SetAttribute($attribute, $fragment)
                     $changed = $true

--- a/test/integration/targets/win_xml/tasks/main.yml
+++ b/test/integration/targets/win_xml/tasks/main.yml
@@ -193,6 +193,51 @@
       - logger_level_value_attrs_again.changed == false
       - logger_level_value_attrs_again.msg == 'The supplied xpath did not match any nodes.  If this is unexpected, check your xpath is valid for the xml file at supplied path.'
 
+# features added ansible 2.10
+# attribute adding
+
+- name: add a name to log level
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: '/log4j:configuration/logger[@name="org.apache.commons.digester"]/level'
+    type: attribute
+    attribute: name1
+    fragment: information
+  register: attribute_add_name1
+
+- name: verify that the attribute was added
+  assert:
+    that:
+      - attribute_add_name1 is changed
+
+- name: add a 2nd name to log level
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: '/log4j:configuration/logger[@name="org.apache.commons.digester"]/level'
+    type: attribute
+    attribute: name2
+    fragment: "It's just an overview"
+  register: attribute_add_name2
+
+- name: verify that the attribute was added
+  assert:
+    that:
+      - attribute_add_name2 is changed
+
+- name: add a name to log level (idempotency test)
+  win_xml:
+    path: "{{ win_output_dir }}\\log4j.xml"
+    xpath: '/log4j:configuration/logger[@name="org.apache.commons.digester"]/level'
+    type: attribute
+    attribute: name1
+    fragment: information
+  register: attribute_add_name1
+
+- name: verify that the attribute isn't changed as it already exists
+  assert:
+    that:
+      - attribute_add_name1 is not changed
+
 # multiple text nodes
 - name: ensure test books.xml is present
   win_copy:


### PR DESCRIPTION
…ct. Verify that the property exists.

##### SUMMARY
Fix: Attribute is added in the if testing for its existence.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_xml

##### ADDITIONAL INFORMATION
Original Ansible error:
```
The property 'hostName' cannot be found on this object. Verify that the property exists.
At line:230 char:21
+                 if ($node.$attribute -ne $fragment) {
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : PropertyNotFoundStrict

ScriptStackTrace:
at <ScriptBlock>, <No file>: line 230

fatal: [HOSTNAME]: FAILED! => changed=false
  msg: 'Unhandled exception while executing module: The property ''hostName'' cannot be found on this object. Verify that the property exists.'
```
Module execution task
```
- name: "win_xml | add hostName key-value for initializationPage in web.config"
  win_xml:
    path: "{{ applications_path }}\\{{ site.name }}\\web.config"
    xpath: /configuration/system.webServer/applicationInitialization/add
    type: attribute
    attribute: hostName
    fragment: "{{ site.binding.fqdn }}"
```
After making this small change, the error disappeared and the expected attribute was added to the xml-file.

After a few tests, changing win_xml.attribute to another value, added the attibute inside of the xml file.
