### PR TITLE
New magic var: `ansible_config_file`

### DIFF
--- a/changelogs/fragments/66085-ansible_config_file.yml
+++ b/changelogs/fragments/66085-ansible_config_file.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "new magic variable - ``ansible_config_file`` - full path of used Ansible config file"

--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -10,6 +10,9 @@ These variables cannot be set directly by the user; Ansible will always override
 ansible_check_mode
     Boolean that indicates if we are in check mode or not
 
+ansible_config_file
+    The full path of used Ansible configuration file
+
 ansible_dependent_role_names
     The names of the roles currently imported into the current play as dependencies of other plays
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -23,6 +23,7 @@ from ansible.vars.plugins import get_vars_from_inventory_sources, get_vars_from_
 display = Display()
 
 INTERNAL_VARS = frozenset(['ansible_diff_mode',
+                           'ansible_config_file',
                            'ansible_facts',
                            'ansible_forks',
                            'ansible_inventory_sources',

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -431,6 +431,7 @@ class VariableManager:
         variables = {}
         variables['playbook_dir'] = os.path.abspath(self._loader.get_basedir())
         variables['ansible_playbook_python'] = sys.executable
+        variables['ansible_config_file'] = C.CONFIG_FILE
 
         if play:
             # This is a list of all role names of all dependencies for all roles for this play


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are many magic variables ie. ansible_diff_mode, ansible_forks, playbook_dir or ansible_playbook_python.
In some cases it is good to know real path of Ansible config file, check if right one was applied, to read it again manually or just to know its presence.
Therefore I suggest to add new magic variable `ansible_config_file` which keeps path to config or null if none is found.
Overall system impact is unnoticeable, just another var lying around - don't need? don't touch :)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
