### PR TITLE
NX-OS: Fix rendering duplicate peer-ip commands in nxos_vxlan_vtep_vni module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -259,10 +259,10 @@ def state_present(module, existing, proposed, candidate):
                ingress_replicationnb_command, ingress_replicationns_command)):
             static_level_cmds = [cmd for cmd in commands if 'peer' in cmd]
             parents = [interface_command, vni_command]
+            commands = [cmd for cmd in commands if 'peer' not in cmd]
             for cmd in commands:
                 parents.append(cmd)
             candidate.add(static_level_cmds, parents=parents)
-            commands = [cmd for cmd in commands if 'peer' not in cmd]
 
         elif 'peer-ip' in commands[0]:
             static_level_cmds = [cmd for cmd in commands]
@@ -325,7 +325,7 @@ def main():
             if peer_list[0] == 'default':
                 module.params['peer_list'] = 'default'
             else:
-                stripped_peer_list = map(str.strip, peer_list)
+                stripped_peer_list = list(map(str.strip, peer_list))
                 module.params['peer_list'] = stripped_peer_list
 
     state = module.params['state']


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- There seems to be an inherent issue with `peer-ip` commands in nxos_vxlan_vtep_vni module.
- The problem is somewhat different for Py2.x and Py3.x:

`Py2.x`:
- The command list was containing duplicate `peer-ip` commands. We didn't catch it so far because we were not asserting the commands sent and the device doesn't throw a warning/error when the same command is repeated.

- With Py2.x, the command list was actually:
```
 "interface nve1",
 "member vni 8000",
 "ingress-replication protocol static",
 "peer-ip 192.0.2.1",
 "peer-ip 192.0.2.2",
 "peer-ip 192.0.2.3",
 "peer-ip 192.0.2.4",
 "peer-ip 192.0.2.1",
 "peer-ip 192.0.2.2",
 "peer-ip 192.0.2.3",
 "peer-ip 192.0.2.4"
```

`Py3.x`:
- Once we enabled NX-OS in Zuul with Py3.6, we started seeing `invalid command` failure. [Here](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_53/64853/41fdca86a7c53652db37fd38f70e7eda8bfd0bea/third-party-check/ansible-test-network-integration-nxos-cli-python36/c07a5cf/controller/ara-report/result/c1e20cf4-9439-4727-bdca-c00f7d44b67a/) is the link to a failure.
- With Py3.6, the command list was actually:
```
 "interface nve1",
 "member vni 8000",
 "peer-ip 192.0.2.1",
 "peer-ip 192.0.2.2",
 "peer-ip 192.0.2.3",
 "peer-ip 192.0.2.4",
 "ingress-replication protocol static",
 "peer-ip 192.0.2.1",
 "peer-ip 192.0.2.2",
 "peer-ip 192.0.2.3",
 "peer-ip 192.0.2.4"
```
Since, `peer-ip` is not a valid command under nve membership context, we started seeing this failure.

- Also, in Py3.x, map() returns an object of class map and not list, unlike Py2.x. This was causing a traceback in Py3.6 runs.

`Solution`
- Move `commands = [cmd for cmd in commands if 'peer' not in cmd]` to the correct place.
- Typecast the `map` object to a list.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni.py
