### PR TITLE
Backport 2.9: Fix nxos_hsrp keyerror (#65796)

### DIFF
--- a/changelogs/fragments/65796_fix_nxos_hsrp_keyerror.yaml
+++ b/changelogs/fragments/65796_fix_nxos_hsrp_keyerror.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix nxos_hsrp throwing a KeyError for `auth_enc` (https://github.com/ansible/ansible/pull/65796)

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -196,6 +196,8 @@ def get_hsrp_group(group, interface, module):
     try:
         body = run_commands(module, [command])[0]
         hsrp_table = body['TABLE_grp_detail']['ROW_grp_detail']
+        if 'sh_keystring_attr' not in hsrp_table:
+            del hsrp_key['sh_keystring_attr']
         if 'unknown enum:' in str(hsrp_table):
             hsrp_table = get_hsrp_group_unknown_enum(module, command, hsrp_table)
     except (AttributeError, IndexError, TypeError, KeyError):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>
(cherry picked from commit cb2a45d28686c1db6f78a8e93c402342c3ec8428)

Backport of https://github.com/ansible/ansible/pull/65796

Add changelog for nxos_hsrp fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY

- Fixes #65660

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_hsrp.py