### PR TITLE
NX-OS: Fix nxos_snmp_community command ordering

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -153,10 +153,13 @@ def config_snmp_community(delta, community):
         'no_acl': 'no snmp-server community {0} use-acl {no_acl}'
     }
     commands = []
-    for k, v in delta.items():
+    for k in delta.keys():
         cmd = CMDS.get(k).format(community, **delta)
         if cmd:
-            commands.append(cmd)
+            if 'group' in cmd:
+                commands.insert(0, cmd)
+            else:
+                commands.append(cmd)
             cmd = None
     return commands
 
@@ -219,6 +222,7 @@ def main():
             commands.append(command)
 
     cmds = flatten_list(commands)
+
     if cmds:
         results['changed'] = True
         if not module.check_mode:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- When trying to specify an acl for an SNMP community, we need to make sure that the SNMP community exists. Otherwise, the device throws an error.

- Hence, the ordering of the commands is important in this case. So for a task that tries to configure a snmp community with r/w access and a acl, the first command should be the one that creates the snmp community by specifying the group.

CI failure related to this [here](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_53/64853/41fdca86a7c53652db37fd38f70e7eda8bfd0bea/third-party-check/ansible-test-network-integration-nxos-cli-python36/c07a5cf/controller/ara-report/reports/d679bca0-e468-4ace-aeb1-df858fa135e6.html).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_community.py
