### PR TITLE
NX-OS: Fix bandwidth calculation for Py3.x

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -299,7 +299,7 @@ def state_present(module, existing, proposed, candidate):
                 if len(value) < 5:
                     command = '{0} {1} Mbps'.format(key, value)
                 else:
-                    value = str(int(value) / 1000)
+                    value = str(int(value) // 1000)
                     command = '{0} {1} Gbps'.format(key, value)
             elif key == 'bfd':
                 command = 'no bfd' if value == 'disable' else 'bfd'


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- This is related to [PEP 238](https://www.python.org/dev/peps/pep-0238/)
- The "true division" in Py3.x was resulting in a command string that the device doesn't accept.
- This patch changes it to floor division.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
nxos_ospf_vrf.py
