### PR TITLE
Fix url handling in lxd_container and lxd_profile module

### DIFF
--- a/changelogs/fragments/lxd_container_url.yaml
+++ b/changelogs/fragments/lxd_container_url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes the url handling in lxd_container module that url cannot be specified in lxd environment created by snap.

--- a/changelogs/fragments/lxd_profile_url.yaml
+++ b/changelogs/fragments/lxd_profile_url.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes the url handling in lxd_profile module that url cannot be specified in lxd environment created by snap.

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -300,6 +300,9 @@ ANSIBLE_LXD_STATES = {
     'Frozen': 'frozen',
 }
 
+# ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
+ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
+
 # CONFIG_PARAMS is a list of config attribute names.
 CONFIG_PARAMS = [
     'architecture', 'config', 'devices', 'ephemeral', 'profiles', 'source'
@@ -329,7 +332,9 @@ class LXDContainerManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            if os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
+            if self.module.params['url'] != ANSIBLE_LXD_DEFAULT_URL:
+                self.url = self.module.params['url']
+            elif os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']
@@ -623,7 +628,7 @@ def main():
             ),
             url=dict(
                 type='str',
-                default='unix:/var/lib/lxd/unix.socket'
+                default=ANSIBLE_LXD_DEFAULT_URL
             ),
             snap_url=dict(
                 type='str',

--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -182,6 +182,8 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.lxd import LXDClient, LXDClientException
 
+# ANSIBLE_LXD_DEFAULT_URL is a default value of the lxd endpoint
+ANSIBLE_LXD_DEFAULT_URL = 'unix:/var/lib/lxd/unix.socket'
 
 # PROFILE_STATES is a list for states supported
 PROFILES_STATES = [
@@ -212,7 +214,9 @@ class LXDProfileManagement(object):
         self.debug = self.module._verbosity >= 4
 
         try:
-            if os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
+            if self.module.params['url'] != ANSIBLE_LXD_DEFAULT_URL:
+                self.url = self.module.params['url']
+            elif os.path.exists(self.module.params['snap_url'].replace('unix:', '')):
                 self.url = self.module.params['snap_url']
             else:
                 self.url = self.module.params['url']
@@ -366,7 +370,7 @@ def main():
             ),
             url=dict(
                 type='str',
-                default='unix:/var/lib/lxd/unix.socket'
+                default=ANSIBLE_LXD_DEFAULT_URL
             ),
             snap_url=dict(
                 type='str',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

When there is a lxd environment created by snap, the url specified by user is ignored and the default snap_url will be used, because of the url handling bug. This pull request fixes this bug.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `lib/ansible/modules/cloud/lxd/lxd_container.py`
- `lib/ansible/modules/cloud/lxd/lxd_profile.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```