### PR TITLE
AWS Guidelines: Make 'security_token' optional

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -649,7 +649,7 @@ for every call, it's preferable to use :ref:`module_defaults <module_defaults>`.
        group/aws:
          aws_access_key: "{{ aws_access_key }}"
          aws_secret_key: "{{ aws_secret_key }}"
-         security_token: "{{ security_token }}"
+         security_token: "{{ security_token | default(omit) }}"
          region: "{{ aws_region }}"
 
      block:


### PR DESCRIPTION
##### SUMMARY

When running AWS integration tests against your own AWS account you'll likely not have a security_token configured for a test user (It's used when you generate temporary tokens).  As such we should make security_token optional.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

AWS Guidelines

##### ADDITIONAL INFORMATION