### PR TITLE
New module ip_link_device_attribute

### DIFF
--- a/lib/ansible/modules/net_tools/ip_link_device_attribute.py
+++ b/lib/ansible/modules/net_tools/ip_link_device_attribute.py
@@ -1,0 +1,536 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2019-2020, George Shuklin <george.shuklin@gmail.com>
+# this code is partially based on ip_netns.py code by
+# (c) 2017, Arie Bregman <abregman@redhat.com>
+
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: ip_link_device_attribute
+version_added: "2.10"
+author: "George Shuklin (@amarao)"
+short_description: Set link-level properties for network interfaces for Linux
+requirements: [iproute2]
+description: >
+    Supports the querying and modification of the link-level attributes of
+    interfaces such as administrative state (up/down), MTU, arp, multicast,
+    promisc, txqueuelen, address, broadcast, netns, alias.
+    Does not currently support some features of ip link set, such as
+    allmulticast, dynamic, protodown, trailers, link-netnsid, xdp, xdpgeneric,
+    xdpdrv, xdpoffload, master/nomaster, addrgenmode, macaddr, vrf.
+
+options:
+    name:
+        type: str
+        aliases: [device]
+        description:
+            - Name of the network device.
+            - Exactly on of I(name) or I(group_id) must be provided.
+
+    group_id:
+        type: str
+        description:
+            - Id of group of interfaces.
+            - Settings are applied for all interfaces in the group.
+            - Exactly on of I(name) or I(group_id) must be provided.
+
+    namespace:
+        type: str
+        description:
+            - Name of namespace where interface is present.
+            - To modify the namespace use I(netns) options.
+
+    state:
+        type: str
+        choices: [up, down]
+        description:
+            - controls the state of interface. Up or down.
+
+    arp:
+        type: bool
+        description:
+            - Enable or disable ARP on an interface.
+
+    multicast:
+        type: bool
+        description:
+            - Enable or disable mutliscast for the interface.
+
+    promisc:
+        type: bool
+        description:
+            - Enable or disable promiscuous mode for the interface.
+
+    txqueuelen:
+        type: int
+        description:
+            - Set transmit queue length of the interface.
+            - Default value for kernel is usually 1000.
+
+    mtu:
+        type: int
+        description:
+            - Set MTU value for interface.
+            - Default value is defined by the kernel and it is 1500.
+            - This is L3 mtu (limit on size of IP packets).
+
+    address:
+        type: str
+        description:
+            - The MAC address (L2 address) for the interface.
+            - Some interfaces can not have L2 address. Module will fail
+              if address is specified for interface without L2 address
+              support (for example 'type vcan').
+
+    broadcast:
+        type: str
+        description:
+            - The broadcast (L2) address for the interface.
+            - The usual value is 'ff:ff:ff:ff:ff:ff'.
+            - Some addresses have no broadcast support. Module will fail
+              if broadcast is specified for interface without broadcast
+              support (for example 'type vcan').
+
+    netns:
+        type: str
+        description:
+            - Set the namespace for an interface.
+            - If both I(namespace) and I(netns) are set, the module
+              will try to move interface from namespace I(namespace)
+              into namespace I(netns).
+            - Note, when the interface changes namespace it loses
+              most of properties (group, state, etc).
+            - This option should not be mixed up with I(namespace).
+
+    alias:
+        type: str
+        description:
+            - Set or change the alias for the interface.
+            - If no alias is specified, it does not change.
+            - Removing aliases from an interface is not currently supported.
+
+    group:
+        type: str
+        description:
+            - Set or change group id for ther interface.
+            - Interfaces in the same group can be addressed by
+              I(group_id) parameter.
+            - Group is a number or a name from /etc/iproute2/groups.
+            - You can not change group for a group
+              (I(group) and I(group_id) should not be used together).
+"""
+
+EXAMPLES = """
+- name: Bring up eth0
+  ip_link_device_attribute:
+    device: eth0
+    state: up
+
+- name: Disable arp for fab in namespace jos
+  ip_link_device_attribute:
+    name: fab0
+    namespace: jos
+    arp: off
+
+- name: Bring up and enable promisc mode and disable multicast
+  ip_link_device_attribute:
+    name: eth4
+    state: up
+    promisc: true
+    multicast: false
+
+- name: Reduce tx queue length
+  ip_link_device_attribute:
+     name: wlan0
+     txqueuelen: 1
+
+- name: Enable jumbo frames
+  ip_link_device_attribute:
+    name: bond0
+    mtu: 8972
+
+- name: Change mac and broadcast address for interface
+  ip_link_device_attribute:
+    name: wlan0
+    address: ba:d0:ba:d0:ba:d0
+    broadcast: ff:ff:ff:ff:ff:ff
+
+- name: Move interface veth1 into namespace steam
+  ip_link_device_attribute:
+    name: veth1
+    netns: steam
+
+- name: Move interface veth1 from namespace steam into namespace debug
+  ip_link_device_attribute:
+    name: veth1
+    namespace: steam
+    netns: debug
+
+- name: Enable promisc for interface
+  ip_link_device_attribute:
+    name: eno4
+    promisc: true
+
+- name: Assign group 42 to interfaces eth1 and eth0
+  ip_link_device_attribute:
+    name: '{{ item }}'
+    group: '42'
+  loop: ['eth0', 'eth1']
+
+- name: Turn down all interfaces in group 42
+  ip_link_device_attribute:
+    group_id: '42'
+    state: down
+
+- name: Gather information about interfaces in default group in namespace foo
+  ip_link_device_attribute:
+    group_id: default
+    namespace: foo
+  register: foo_if_info
+
+- name: Move interface into namespace foo and set it
+  ip_link_device_attribute:
+    name: eth3
+    netns: foo
+    state: up
+    mtu: 8172
+    arp: false
+    promisc: true
+    address: ba:ba:ba:ba:ba:ba
+    group: '12'
+"""
+
+RETURN = """
+interfaces:
+    description: List of all interfaces matching the I(group_id)
+                 (or a list with a single interface for I(name))
+    returned: success
+    type: complex
+    sample:
+    contains:
+      name:
+        description: Name of the interface.
+        type: str
+      group:
+        description: Group of the interface.
+        type: str
+      arp:
+        description: State of ARP protocol for the interface.
+        type: bool
+      mtu:
+        description: MTU value for the interface.
+        type: int
+      multicast:
+        description: State of mutlicast for the interface.
+        type: bool
+      promisc:
+        description: State of promisc mode for the interface.
+        type: bool
+      txqueuelen:
+        description: Length of TX queue.
+        type: int
+      state:
+        description: Adminitstrative state for interface, up or down.
+        type: str
+      address:
+        description: L2 address fof the interface
+                     (may be C(None), if interface can not have one).
+        type: str
+      broadcast:
+        description: Broadcast L2 address for the interface
+                     (may be C(None), if interface can not have one).
+        type: str
+      alias:
+        description: Alias for the interface (C(None) if not present).
+        type: str
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+
+
+__metaclass__ = type
+
+
+class Link(object):
+    """Interface to 'link' object."""
+
+    params_list = [  # module paramtes needed special treatment
+        'group_id', 'namespace', 'name', 'netns'
+    ]
+    knob_cmds = {  # attributes we may change by calling 'ip'
+        'address': lambda addr: ['address', str(addr)],
+        'alias': lambda alias: ['alias', str(alias)],
+        'arp': lambda is_arp: ['arp', ['off', 'on'][is_arp]],
+        'broadcast': lambda addr: ['broadcast', addr],
+        'group': lambda group: ['group', str(group)],
+        'mtu': lambda mtu: ['mtu', str(mtu)],
+        'multicast': lambda is_mc: ['multicast', ['off', 'on'][is_mc]],
+        'promisc': lambda is_prms: ['promisc', ['off', 'on'][is_prms]],
+        'txqueuelen': lambda qlen: ['txqueuelen', str(qlen)],
+        'state': lambda state: [state],
+    }
+
+    def __init__(self, module):
+        self.module = module
+        self.check_mode = module.check_mode
+        self.knobs = {}
+        for knob in self.knob_cmds.keys():
+            self.knobs[knob] = module.params[knob]
+        for param in self.params_list:
+            setattr(self, param, module.params[param])
+        if self.name and self.group_id:
+            self.module.fail_json(
+                msg=to_text('Can not use name and group_id together')
+            )
+        if self.knobs['group'] and self.group_id:
+            self.module.fail_json(
+                msg=to_text('Can not group and grop_id together')
+            )
+        if not (self.name or self.group_id):
+            self.module.fail_json(
+                msg=to_text('Either name or group_id should be present')
+            )
+        if self.namespace == self.netns and self.namespace:
+            self.module.fail_json(
+                msg=to_text('namespace and netns should not be the same')
+            )
+        if self.name:
+            self.id_postfix = ['dev', self.name]
+        if self.group_id:
+            self.id_postfix = ['group', self.group_id]
+        if self.knobs['address']:
+            self.knobs['address'] = self.knobs['address'].lower()
+        if self.knobs['broadcast']:
+            self.knobs['broadcast'] = self.knobs['broadcast'].lower()
+        if self.knobs['state']:
+            self.knobs['state'] = self.knobs['state'].lower()
+
+    def _exec(self, namespace, cmd, not_found_is_ok=False):
+        if namespace:
+            return self._exec(
+                None,
+                ['ip', 'netns', 'exec', namespace] + cmd,
+                not_found_is_ok
+            )
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            if not_found_is_ok:
+                # show for non-existing group  return empty output
+                # show for non-existing device yield a specific error
+                if self.name:
+                    not_found_msg = 'Device "%s" does not exist' % self.name
+                    if not_found_msg in err:
+                        return ''
+            self.module.fail_json(
+                msg=to_text(err),
+                failed_command=' '.join(cmd)
+            )
+        return out
+
+    def _split_ifline(self, ifstring):
+        _ifnum, ifname_raw, raw_data = ifstring.split(':', 2)
+        ifname = ifname_raw.split('@')[0].strip()
+        data = list(map(str.split, raw_data.split('\\')))
+
+        retval = {
+            'name': ifname,
+            'flags': data[0].pop(0).strip('<>').split(',')
+        }
+        for snip in data:
+            while snip:
+                key = snip.pop(0)
+                if not snip:
+                    break
+                value = snip.pop(0)
+                retval[key] = value
+
+        return retval
+
+    def _parse_interface(self, ifstring):
+        if not ifstring:
+            return {}
+        iface = self._split_ifline(ifstring)
+        flags = iface['flags']
+        multicast = 'MULTICAST' in flags
+        is_up = 'UP' in flags
+        arp = not ('NOARP' in flags)
+        promisc = 'PROMISC' in flags
+        return {
+            'address': iface.get('link/ether', None),
+            'alias': iface.get('alias', None),
+            'arp': arp,
+            'broadcast': iface.get('brd', None),
+            'group': iface['group'],
+            'mtu': int(iface['mtu']),
+            'multicast': multicast,
+            'name': iface['name'],
+            'promisc': promisc,
+            'txqueuelen': int(iface['qlen']),
+            'state': ['down', 'up'][int(is_up)],
+        }
+
+    def _get_interfaces_info(self, namespace, not_found_is_ok=False):
+        # we can't use json option of ip command
+        # because of Centos6.
+        # It's so young and so forever.
+        cmd = ['ip', '-o', 'link', 'show'] + self.id_postfix
+        output = self._exec(namespace, cmd, not_found_is_ok)
+        interfaces = filter(
+            lambda x: x,
+            map(self._parse_interface, output.strip().split('\n'))
+        )
+        return interfaces
+
+    def _is_changes_needed_for_interface(self, iface):
+        attr_list = [  # address and broadcast are handled separately
+            'alias', 'arp', 'group', 'mtu', 'multicast',
+            'promisc', 'txqueuelen', 'state'
+        ]
+        for attr in attr_list:
+            if self.knobs[attr] and self.knobs[attr] != iface[attr]:
+                return True
+        if self.knobs['broadcast'] and \
+                self.knobs['broadcast'] != iface['broadcast']:
+            if not iface['broadcast']:
+                self.module.fail_json(msg=to_text(
+                    'Interace %s can not have broadcast address'
+                ) % (iface['name']))
+            return True
+        if self.knobs['address'] and \
+                self.knobs['address'] != iface['address']:
+            if not iface['address']:
+                self.module.fail_json(msg=to_text(
+                    'Interace %s can not have MAC address'
+                ) % (iface['name']))
+            return True
+        return False
+
+    def _is_changes_needed(self, iflist):
+        return any(map(self._is_changes_needed_for_interface, iflist))
+
+    def _apply_change(self, knob, value):
+        cmd = ['ip', 'link', 'set'] + self.id_postfix
+        cmd += self.knob_cmds[knob](value)
+        self._exec(self.namespace, cmd)
+
+    def _apply_changes(self):
+        for knob, value in self.knobs.items():
+            if value is None:
+                continue
+            self._apply_change(knob, value)
+
+    def _get_iface_set(self, namespace):
+        iface_list = self._get_interfaces_info(namespace, not_found_is_ok=True)
+        return set(map(lambda x: x['name'], iface_list))
+
+    def _netns_need_to_move(self):
+        """
+            When we need to change netns for the interface(s),
+            there are few scenarios to consider:
+            1. There is target interface in source 'namespace'
+                and not target interface in destination 'netns'
+                    -> change netns for interface
+            2. There is a target interface in srouce 'namespace'
+                and there is a target interface in destination 'netns'
+                    -> Error
+            3. There is no target interface in source 'namespace'
+                and there is a target interface in destination 'netns'
+                    -> no change (in this part)
+            4. There is no target interface in source 'namespace'
+                and there is no target interface in destination 'netns'
+                    -> Error
+
+            Additionally, we need to support partial cases with
+            group_id (some of interfaces may be in one namespace
+            and some may be moved already).
+        """
+
+        src = self._get_iface_set(self.namespace)
+        dst = self._get_iface_set(self.netns)
+        if src.intersection(dst):
+            self.module.fail_json(
+                msg='Intefaces %s are in both namespaces' %
+                src.intersection(dst))
+        if not src and not dst:
+            self.module.fail_json(
+                msg='Unable to find interface %s to change namespace' %
+                ' '.join(self.id_postfix)
+            )
+        return bool(src)
+
+    def _move(self):
+        """If we moved the interface from
+        one namespace into another, we need to apply
+        the rest of parameters in the new namespace,
+        so we need to update self.namespace parameter.
+        """
+
+        cmd = ['ip', 'link', 'set'] + self.id_postfix + ['netns', self.netns]
+        self._exec(self.namespace, cmd)
+
+    def run(self):
+        changed = False
+        if self.netns:
+            if self._netns_need_to_move():
+                if self.check_mode:
+                    interfaces = self._get_interfaces_info(self.namespace)
+                    return self.module.exit_json(
+                        changed=True, interfaces=interfaces
+                    )
+                self._move()
+            self.namespace = self.netns
+            self.netns = None
+        interfaces_info = self._get_interfaces_info(self.namespace)
+        if self._is_changes_needed(interfaces_info):
+            changed = True
+            if not self.check_mode:
+                self._apply_changes()
+        interfaces = self._get_interfaces_info(self.namespace)
+        self.module.exit_json(changed=changed, interfaces=interfaces)
+
+
+def main():
+    """Entry point."""
+    module = AnsibleModule(
+        argument_spec={
+            'name': {'aliases': ['device']},
+            'group_id': {},
+            'namespace': {},
+            'state': {'choices': ['up', 'down']},
+            'arp': {'type': 'bool'},
+            'multicast': {'type': 'bool'},
+            'promisc': {'type': 'bool'},
+            'txqueuelen': {'type': 'int'},
+            'mtu': {'type': 'int'},
+            'address': {},
+            'broadcast': {},
+            'netns': {},
+            'alias': {},
+            'group': {}
+        },
+        supports_check_mode=True,
+        mutually_exclusive=[['group_id', 'group'], ['name', 'group_id']],
+        required_one_of=[['name', 'group_id']]
+    )
+
+    link = Link(module)
+    link.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/net_tools/ip_link_device_attribute.py
+++ b/lib/ansible/modules/net_tools/ip_link_device_attribute.py
@@ -85,7 +85,7 @@ options:
         description:
             - Set MTU value for interface.
             - Default value is defined by the kernel and it is 1500.
-            - This is L3 mtu (limit on size of IP packets).
+            - This is the L3 MTU (limit on size of IP packets).
 
     address:
         type: str
@@ -112,7 +112,7 @@ options:
               will try to move interface from namespace I(namespace)
               into namespace I(netns).
             - Note, when the interface changes namespace it loses
-              most of properties (group, state, etc).
+              many of its properties (group, state, etc).
             - This option should not be mixed up with I(namespace).
 
     alias:
@@ -129,8 +129,8 @@ options:
             - Interfaces in the same group can be addressed by
               I(group_id) parameter.
             - Group is a number or a name from /etc/iproute2/groups.
-            - You can not change group for a group
-              (I(group) and I(group_id) should not be used together).
+            - You can not change a group for a pre-existing group of interfaces
+              (the I(group) and I(group_id) options are mutually exclusive).
 """
 
 EXAMPLES = """
@@ -215,7 +215,7 @@ EXAMPLES = """
 
 RETURN = """
 interfaces:
-    description: List of all interfaces matching the I(group_id)
+    description: A list of all interfaces matching the I(group_id)
                  (or a list with a single interface for I(name))
     returned: success
     type: complex
@@ -240,18 +240,18 @@ interfaces:
         description: State of promisc mode for the interface.
         type: bool
       txqueuelen:
-        description: Length of TX queue.
+        description: Length of the TX queue.
         type: int
       state:
-        description: Adminitstrative state for interface, up or down.
+        description: Administrative state for interface, C(up) or C(down).
         type: str
       address:
         description: L2 address fof the interface
-                     (may be C(None), if interface can not have one).
+                     (may be C(None), if the interface can not have one).
         type: str
       broadcast:
-        description: Broadcast L2 address for the interface
-                     (may be C(None), if interface can not have one).
+        description: L2 broadcast address for the interface
+                     (may be C(None), if the interface can not have one).
         type: str
       alias:
         description: Alias for the interface (C(None) if not present).

--- a/lib/ansible/modules/net_tools/ip_link_device_attribute.py
+++ b/lib/ansible/modules/net_tools/ip_link_device_attribute.py
@@ -475,7 +475,7 @@ class Link(object):
                 if self.check_mode:
                     interfaces = self._get_interfaces_info(self.namespace)
                     return self.module.exit_json(
-                        changed=True, interfaces=interfaces
+                        changed=True, interfaces=list(interfaces)
                     )
                 self._move()
             self.namespace = self.netns
@@ -486,7 +486,7 @@ class Link(object):
             if not self.check_mode:
                 self._apply_changes()
         interfaces = self._get_interfaces_info(self.namespace)
-        self.module.exit_json(changed=changed, interfaces=interfaces)
+        self.module.exit_json(changed=changed, interfaces=list(interfaces))
 
 
 def main():

--- a/test/integration/targets/ip_link_device_attribute/aliases
+++ b/test/integration/targets/ip_link_device_attribute/aliases
@@ -1,0 +1,6 @@
+needs/root
+shippable/posix/group2
+skip/docker
+skip/osx
+skip/freebsd
+skip/rhel

--- a/test/integration/targets/ip_link_device_attribute/defaults/main.yaml
+++ b/test/integration/targets/ip_link_device_attribute/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+  mock_mac: '00:23:54:84:d1:7a'
+  mock_broadcast: 'fe:fe:fe:fe:fe:fe'
+  mock_group: '9919'
+  mock_txqlen: 981
+  mock_mtu: 1337

--- a/test/integration/targets/ip_link_device_attribute/tasks/main.yaml
+++ b/test/integration/targets/ip_link_device_attribute/tasks/main.yaml
@@ -1,28 +1,32 @@
 - become: true
   block:
+    - name: Check if ip binary is present
+      command: ip -V
+      changed_when: false
+      failed_when: false
+      register: ip_ver
     - name: Ensure iproute2 is present
       become: true
       package: name=iproute2 state=present
-    - name: Integration tests for ip_link_device_attribute
+      when: ip_ver.rc != 0  # faster this way, as we skip python-apt and apt update
+
+
+    # TEST1: Check if we can set options for veth interface
+    # stages:
+    # - create veth
+    # - try check_mode and confirm there were no changes
+    # - run the module for real
+    # - confirm changes
+    # - run the module for the second time with the same parameters
+    # - confirm idempotency
+    # - delete veth
+    - name: TEST1 - set normal attributes
       become: true
       block:
-        - name: Create veth (normal interface)
+        - name: TEST1, preparation, create vethN interface
           command: ip link add dev vethN type veth peer name vethNP
-        - name: Create vcan (interface without mac)
-          command: ip link add dev vcan_example type vcan
-        - name: assign vcan alias
-          command: ip link set dev vcan_example alias foo
-        - name: Create veths (group)
-          command: ip link add dev {{ item }} type veth peer name {{ item }}_peer
-          loop:
-           - gr1
-           - gr2
-        - name: Create namespaces
-          ip_netns: name={{ item }}
-          loop:
-           - ip_net_set_src
-           - ip_net_set_dst
-        - name: Test1 - set paramters for veth
+        - name: TEST1, check_mode support for normal attributes
+          check_mode: true
           ip_link_device_attribute:
               name: vethN
               state: up
@@ -34,22 +38,62 @@
               txqueuelen: '{{ mock_txqlen }}'
               arp: off
               group: '{{ mock_group }}'
-          register: ip_link_device_attribute_res
-        - name: Test1 - check module output
+          register: res
+        - name: TEST1, validate module output after check_mode
           assert:
               that:
-                  - ip_link_device_attribute_res.interfaces|length == 1
-                  - ip_link_device_attribute_res.interfaces[0].name == 'vethN'
-                  - ip_link_device_attribute_res.interfaces[0].alias == 'vethalias'
-                  - ip_link_device_attribute_res.interfaces[0].txqueuelen == mock_txqlen
-                  - ip_link_device_attribute_res.interfaces[0].promisc == true
-                  - ip_link_device_attribute_res.interfaces[0].broadcast == mock_broadcast
-                  - ip_link_device_attribute_res.interfaces[0].state == 'up'
-                  - ip_link_device_attribute_res.interfaces[0].group == mock_group
-        - name: Test1 - gather results
+                  - res.interfaces|length == 1
+                  - res.interfaces[0].name == 'vethN'
+                  - res.interfaces[0].mtu == 1500
+                  - res.interfaces[0].promisc == false
+                  - res.interfaces[0].broadcast == 'ff:ff:ff:ff:ff:ff'
+                  - res.interfaces[0].state == 'down'
+                  - res.interfaces[0].group == 'default'
+                  - res.changed == true
+        - name: TEST1, get actual values from OS for interface
           command: ip link show dev vethN
           register: test1_res
-        - name: Test1 - check results
+          changed_when: false
+        - name: TEST1 - validate OS result
+          assert:
+              that:
+                 - ('UP' not in test1_res.stdout)
+                 - ('mtu 1500' in test1_res.stdout)
+                 - ('alias vethalias' not in test1_res.stdout)
+                 - ('PROMISC' not in test1_res.stdout)
+                 - ('NOARP' not in test1_res.stdout)
+                 - ('brd ff:ff:ff:ff:ff:ff' in test1_res.stdout)
+                 - ('group default' in test1_res.stdout)
+        - name: TEST1, change attributes
+          ip_link_device_attribute:
+              name: vethN
+              state: up
+              mtu: '{{ mock_mtu }}'
+              address: '{{ mock_mac }}'
+              broadcast: '{{ mock_broadcast }}'
+              alias: vethalias
+              promisc: on
+              txqueuelen: '{{ mock_txqlen }}'
+              arp: off
+              group: '{{ mock_group }}'
+          register: res
+        - name: TEST1 - validate module output after change
+          assert:
+              that:
+                  - res.changed == true
+                  - res.interfaces|length == 1
+                  - res.interfaces[0].name == 'vethN'
+                  - res.interfaces[0].alias == 'vethalias'
+                  - res.interfaces[0].txqueuelen == mock_txqlen
+                  - res.interfaces[0].promisc == true
+                  - res.interfaces[0].broadcast == mock_broadcast
+                  - res.interfaces[0].state == 'up'
+                  - res.interfaces[0].group == mock_group
+        - name: TEST1, get actual values from OS for interface
+          command: ip link show dev vethN
+          register: test1_res
+          changed_when: false
+        - name: TEST1, validate OS result
           assert:
               that:
                  - ('UP' in test1_res.stdout)
@@ -61,125 +105,199 @@
                  - ('ether ' +  mock_mac in test1_res.stdout)
                  - ('brd ' + mock_broadcast in test1_res.stdout)
                  - ('group ' + mock_group in test1_res.stdout)
-        - name: Test2 - move veth into namespace
+        - name: TEST1, set attrubutes  second time
           ip_link_device_attribute:
-            name: vethN
-            netns: ip_net_set_src
-            alias: vethalias2
-            state: down
-          register: ip_link_device_attribute_res
-        - name: Test2 - check module output
-          assert:
-              that:
-                - ip_link_device_attribute_res.interfaces|length == 1
-                - ip_link_device_attribute_res.interfaces[0].name == 'vethN'
-                - ip_link_device_attribute_res.interfaces[0].alias == 'vethalias2'
-                - ip_link_device_attribute_res.interfaces[0].txqueuelen == mock_txqlen
-                - ip_link_device_attribute_res.interfaces[0].promisc == true
-                - ip_link_device_attribute_res.interfaces[0].address == mock_mac
-                - ip_link_device_attribute_res.interfaces[0].broadcast == mock_broadcast
-                - ip_link_device_attribute_res.interfaces[0].state == 'down'
-                - ip_link_device_attribute_res.interfaces[0].group == mock_group
-        - name: Test2 - check results
-          # we just check if interface is in namespace
-          command: ip net exec ip_net_set_src ip link show dev vethN
-        - name: Test3 - setup, Move gr1 into src namespace
-          command: ip link set dev gr1 netns ip_net_set_src
-        - name: Test3 - setup, Move gr2 into dst namespace
-          command: ip link set dev gr2 netns ip_net_set_dst
-        - name: Test3 - setup, Restore group membership for gr1
-          command: ip net exec ip_net_set_src ip link set dev gr1 group 42
-        - name: Test3 - setup, Restore group membership for gr2
-          command: ip net exec ip_net_set_dst ip link set dev gr2 group 42
-        - name: Test3 - move group 42 into dst namespace, partial move
-          ip_link_device_attribute:
-            group_id: '42'
-            namespace: ip_net_set_src
-            netns: ip_net_set_dst
-            state: up
-            promisc: true
-          register: ip_link_device_attribute_res
-        - name: Test 3 check module output
-          assert:
-             that:
-               - ip_link_device_attribute_res.interfaces|length == 2
-               - ip_link_device_attribute_res.interfaces[0].state == 'up'
-               - ip_link_device_attribute_res.interfaces[1].state == 'up'
-               - ip_link_device_attribute_res.interfaces[0].promisc == True
-               - ip_link_device_attribute_res.interfaces[1].promisc == True
-        - name: Test3 - check result
-          command: ip net exec ip_net_set_dst ip link show {{ item }}
-          loop: ['gr1', 'gr2']
-        - name: Test4 - non-ethernet interface
-          ip_link_device_attribute:
-              device: vcan_example  # test alias use as well
+              name: vethN
               state: up
-          register: ip_link_device_attribute_res
-        - name: Test4 - check output results
+              mtu: '{{ mock_mtu }}'
+              address: '{{ mock_mac }}'
+              broadcast: '{{ mock_broadcast }}'
+              alias: vethalias
+              promisc: on
+              txqueuelen: '{{ mock_txqlen }}'
+              arp: off
+              group: '{{ mock_group }}'
+          register: res
+        - name: TEST1, assert idempotency
+          assert:
+            that:
+              - res.changed == false
+      always:
+        - name: TEST1, cleanup
+          command: ip link delete vethN
+
+
+    # TEST2: Check if we can change namespace for the interface
+    # and to change it paramters after move
+    # stages:
+    # - create veth
+    # - try check_mode and confirm there were no changes
+    # - run the module for real
+    # - confirm changes
+    # - run the module for the second time with the same parameters
+    # - confirm idempotency
+    # - check for scenario with netns==namespace
+    # - delete veth
+    - name: TEST2 - check if we can move interface into namespace
+      become: true
+      block:
+        - name: TEST2, preparation, create vethM interface
+          command: ip link add dev vethM type veth peer name vethMP
+        - name: TEST2, preparation, create namespace target_namespace
+          ip_netns: name=target_namespace state=present
+        - name: TEST2 - check_mode support for changing namespace
+          check_mode: true
+          ip_link_device_attribute:
+            name: vethM
+            netns: target_namespace
+            alias: vethalias2
+            state: up
+          register: res
+        - name: TEST2, validate module output after check_mode
           assert:
               that:
-                  - ip_link_device_attribute_res.interfaces[0].state == 'up'
-                  - ip_link_device_attribute_res.interfaces[0].alias == 'foo'
-                  - ip_link_device_attribute_res.interfaces[0].name == 'vcan_example'
-        - name: Test5 - check idempotency
+                  - res.interfaces|length == 1
+                  - res.interfaces[0].name == 'vethM'
+                  - res.interfaces[0].state == 'down'
+                  - res.changed == true
+        - name: TEST2, get actual values from OS for interface
+          command: ip link show dev vethM
+          # no need to assert. If ip failed, interface was moved
+        - name: TEST2 - try to move interface into namespace
+          ip_link_device_attribute:
+            name: vethM
+            netns: target_namespace
+            alias: vethalias2
+            state: up
+          register: res
+        - name: TEST2, validate module output
+          assert:
+              that:
+                  - res.interfaces|length == 1
+                  - res.interfaces[0].name == 'vethM'
+                  - res.interfaces[0].state == 'up'
+                  - res.interfaces[0].alias == 'vethalias2'
+                  - res.changed == true
+        - name: TEST2, get actual values from OS for interface
+          command: ip net exec target_namespace ip link show dev vethM
+          # no need to assert. If ip failed, interface was moved
+        - name: TEST2 - try to move interface second time
+          ip_link_device_attribute:
+            name: vethM
+            netns: target_namespace
+            alias: vethalias2
+            state: up
+          register: res
+        - name: TEST2, validate module idempotency
+          assert:
+              that:
+                  - res.changed == false
+                  - res.interfaces|length == 1
+                  - res.interfaces[0].name == 'vethM'
+                  - res.interfaces[0].state == 'up'
+        - name: TEST2, try with netns==namespace
+          ip_link_device_attribute:
+            name: vethM
+            namespace: target_namespace
+            netns: target_namespace
+          register: res
+        - name: TEST2, validate module idempotency when netns==namespace
+          assert:
+              that:
+                  - res.changed == false
+
+      always:
+        - name: TEST2, cleanup interface
+          command: ip link delete vethM
+          failed_when: false # may fail if test successful
+        - name: TEST2, cleanup namespace
+          ip_netns: name=target_namespace state=absent
+
+    # TEST3: Check if module can work with interfaces without mac addresses
+    # stages:
+    # - create vcan
+    # - run the module
+    # - confirm changes  and module output
+    # - delete vcan
+    - name: TEST3 - work with interfaces without MAC addresses
+      become: true
+      block:
+        - name: TEST3, preparation, create vcan_example interface
+          command: ip link add dev vcan_example type vcan
+        - name: TEST3 - non-ethernet interface
           ip_link_device_attribute:
               device: vcan_example
               state: up
-          register: ip_link_device_attribute_res
-        - name: Test5 - run asserts for test
+          register: res
+        - name: TEST3, validate results
           assert:
             that:
-              - ip_link_device_attribute_res is not changed
-        - name: Test6 - check check_mode, prepare
-          command: ip net exec ip_net_set_dst ip link show gr1
-          register: test6_pre
-        - name: Test6  check preparation
-          assert:
-              that:
-                '"UP" in test6_pre.stdout'
-        - name: Test6 - check check_mode, run1
-          check_mode: true
-          ip_link_device_attribute:
-              name: gr1
-              namespace: ip_net_set_dst
-              state: down
-          register: ip_link_device_attribute_res
-        - name: Tes6 - check assertion for run1
-          assert:
-            that:
-              ip_link_device_attribute_res is changed
-        - name: Test6 - check check_mode, run2
-          check_mode: true
-          ip_link_device_attribute:
-              name: gr1
-              namespace: ip_net_set_dst
-              state: down
-          register: ip_link_device_attribute_res
-        - name: Tes6 - check assertions for run2
-          assert:
-            that:
-              ip_link_device_attribute_res is changed
-        - name: Tes6 - get results
-          command: ip net exec ip_net_set_dst ip link show gr1
-          register: test6_res
-        - name: Test6 - check results
-          assert:
-            that:
-              '"UP" in test6_res.stdout'
+              - res.changed == true
+              - res.interfaces|length == 1
+              - res.interfaces[0].name == 'vcan_example'
+              - res.interfaces[0].state == 'up'
+              - res.interfaces[0].address == None
+              - res.interfaces[0].broadcast == None
+              - res.interfaces[0].arp == false
       always:
-          - name: Delete namespaces
-            ip_netns: name={{item}} state=absent
-            with_items:
-              - ip_net_set_src
-              - ip_net_set_dst
-          - name: Delete interfaces
-            command: ip link delete '{{ item }}'
-            # if tests failed we want to cleanup, but if tests passed
-            # those interfaces are removed together with namespaces
-            failed_when: false
-            with_items:
-              - vcan_example
-              - vethN
-              - gr1
-              - gr2
+        - name: TEST3, cleanup interface
+          command: ip link delete vcan_example
+
+    # TEST4: Support for group operations
+    # stages:
+    # - create two interfaces and set their group to the same value
+    # - run the module in check_mode
+    # - validate output
+    # - run the module for real
+    # - validate output
+    # - run module second time
+    # - check of idempotency
+    # - delete interfaces
+    - name: TEST4 - work with groups
+      become: true
+      block:
+        - name: TEST4, preparation, create 2 veths in group 42
+          command: ip link add group 42 dev {{ item }} type veth peer name {{ item }}_peer
+          loop:
+           - gr1
+           - gr2
+        - name: TEST4, run module with check_mode
+          check_mode: true
+          ip_link_device_attribute:
+              group_id: '42'
+              state: up
+          register: res
+        - name: TEST4, assert results for check_mode
+          assert:
+            that:
+              - res.changed == true
+              - res.interfaces|length == 2
+              - res.interfaces[0].state == 'down'
+              - res.interfaces[1].state == 'down'
+        - name: TEST4, run module
+          ip_link_device_attribute:
+              group_id: '42'
+              state: up
+          register: res
+        - name: TEST4, assert results
+          assert:
+            that:
+              - res.changed == true
+              - res.interfaces|length == 2
+              - res.interfaces[0].state == 'up'
+              - res.interfaces[1].state == 'up'
+        - name: TEST4, run module for the second time
+          ip_link_device_attribute:
+              group_id: '42'
+              state: up
+          register: res
+        - name: TEST4, assert idempotency
+          assert:
+            that:
+              - res.changed == false
+              - res.interfaces|length == 2
+      always:
+        - name: TEST4, cleanup interface
+          command: ip link delete group 42
+
   when: ansible_virtualization_type | default('') != 'docker'

--- a/test/integration/targets/ip_link_device_attribute/tasks/main.yaml
+++ b/test/integration/targets/ip_link_device_attribute/tasks/main.yaml
@@ -1,0 +1,185 @@
+- become: true
+  block:
+    - name: Ensure iproute2 is present
+      become: true
+      package: name=iproute2 state=present
+    - name: Integration tests for ip_link_device_attribute
+      become: true
+      block:
+        - name: Create veth (normal interface)
+          command: ip link add dev vethN type veth peer name vethNP
+        - name: Create vcan (interface without mac)
+          command: ip link add dev vcan_example type vcan
+        - name: assign vcan alias
+          command: ip link set dev vcan_example alias foo
+        - name: Create veths (group)
+          command: ip link add dev {{ item }} type veth peer name {{ item }}_peer
+          loop:
+           - gr1
+           - gr2
+        - name: Create namespaces
+          ip_netns: name={{ item }}
+          loop:
+           - ip_net_set_src
+           - ip_net_set_dst
+        - name: Test1 - set paramters for veth
+          ip_link_device_attribute:
+              name: vethN
+              state: up
+              mtu: '{{ mock_mtu }}'
+              address: '{{ mock_mac }}'
+              broadcast: '{{ mock_broadcast }}'
+              alias: vethalias
+              promisc: on
+              txqueuelen: '{{ mock_txqlen }}'
+              arp: off
+              group: '{{ mock_group }}'
+          register: ip_link_device_attribute_res
+        - name: Test1 - check module output
+          assert:
+              that:
+                  - ip_link_device_attribute_res.interfaces|length == 1
+                  - ip_link_device_attribute_res.interfaces[0].name == 'vethN'
+                  - ip_link_device_attribute_res.interfaces[0].alias == 'vethalias'
+                  - ip_link_device_attribute_res.interfaces[0].txqueuelen == mock_txqlen
+                  - ip_link_device_attribute_res.interfaces[0].promisc == true
+                  - ip_link_device_attribute_res.interfaces[0].broadcast == mock_broadcast
+                  - ip_link_device_attribute_res.interfaces[0].state == 'up'
+                  - ip_link_device_attribute_res.interfaces[0].group == mock_group
+        - name: Test1 - gather results
+          command: ip link show dev vethN
+          register: test1_res
+        - name: Test1 - check results
+          assert:
+              that:
+                 - ('UP' in test1_res.stdout)
+                 - ('mtu '+ mock_mtu|string in test1_res.stdout)
+                 - ('alias vethalias' in test1_res.stdout)
+                 - ('PROMISC' in test1_res.stdout)
+                 - ('NOARP' in test1_res.stdout)
+                 - ('qlen ' + mock_txqlen|string in test1_res.stdout)
+                 - ('ether ' +  mock_mac in test1_res.stdout)
+                 - ('brd ' + mock_broadcast in test1_res.stdout)
+                 - ('group ' + mock_group in test1_res.stdout)
+        - name: Test2 - move veth into namespace
+          ip_link_device_attribute:
+            name: vethN
+            netns: ip_net_set_src
+            alias: vethalias2
+            state: down
+          register: ip_link_device_attribute_res
+        - name: Test2 - check module output
+          assert:
+              that:
+                - ip_link_device_attribute_res.interfaces|length == 1
+                - ip_link_device_attribute_res.interfaces[0].name == 'vethN'
+                - ip_link_device_attribute_res.interfaces[0].alias == 'vethalias2'
+                - ip_link_device_attribute_res.interfaces[0].txqueuelen == mock_txqlen
+                - ip_link_device_attribute_res.interfaces[0].promisc == true
+                - ip_link_device_attribute_res.interfaces[0].address == mock_mac
+                - ip_link_device_attribute_res.interfaces[0].broadcast == mock_broadcast
+                - ip_link_device_attribute_res.interfaces[0].state == 'down'
+                - ip_link_device_attribute_res.interfaces[0].group == mock_group
+        - name: Test2 - check results
+          # we just check if interface is in namespace
+          command: ip net exec ip_net_set_src ip link show dev vethN
+        - name: Test3 - setup, Move gr1 into src namespace
+          command: ip link set dev gr1 netns ip_net_set_src
+        - name: Test3 - setup, Move gr2 into dst namespace
+          command: ip link set dev gr2 netns ip_net_set_dst
+        - name: Test3 - setup, Restore group membership for gr1
+          command: ip net exec ip_net_set_src ip link set dev gr1 group 42
+        - name: Test3 - setup, Restore group membership for gr2
+          command: ip net exec ip_net_set_dst ip link set dev gr2 group 42
+        - name: Test3 - move group 42 into dst namespace, partial move
+          ip_link_device_attribute:
+            group_id: '42'
+            namespace: ip_net_set_src
+            netns: ip_net_set_dst
+            state: up
+            promisc: true
+          register: ip_link_device_attribute_res
+        - name: Test 3 check module output
+          assert:
+             that:
+               - ip_link_device_attribute_res.interfaces|length == 2
+               - ip_link_device_attribute_res.interfaces[0].state == 'up'
+               - ip_link_device_attribute_res.interfaces[1].state == 'up'
+               - ip_link_device_attribute_res.interfaces[0].promisc == True
+               - ip_link_device_attribute_res.interfaces[1].promisc == True
+        - name: Test3 - check result
+          command: ip net exec ip_net_set_dst ip link show {{ item }}
+          loop: ['gr1', 'gr2']
+        - name: Test4 - non-ethernet interface
+          ip_link_device_attribute:
+              device: vcan_example  # test alias use as well
+              state: up
+          register: ip_link_device_attribute_res
+        - name: Test4 - check output results
+          assert:
+              that:
+                  - ip_link_device_attribute_res.interfaces[0].state == 'up'
+                  - ip_link_device_attribute_res.interfaces[0].alias == 'foo'
+                  - ip_link_device_attribute_res.interfaces[0].name == 'vcan_example'
+        - name: Test5 - check idempotency
+          ip_link_device_attribute:
+              device: vcan_example
+              state: up
+          register: ip_link_device_attribute_res
+        - name: Test5 - run asserts for test
+          assert:
+            that:
+              - ip_link_device_attribute_res is not changed
+        - name: Test6 - check check_mode, prepare
+          command: ip net exec ip_net_set_dst ip link show gr1
+          register: test6_pre
+        - name: Test6  check preparation
+          assert:
+              that:
+                '"UP" in test6_pre.stdout'
+        - name: Test6 - check check_mode, run1
+          check_mode: true
+          ip_link_device_attribute:
+              name: gr1
+              namespace: ip_net_set_dst
+              state: down
+          register: ip_link_device_attribute_res
+        - name: Tes6 - check assertion for run1
+          assert:
+            that:
+              ip_link_device_attribute_res is changed
+        - name: Test6 - check check_mode, run2
+          check_mode: true
+          ip_link_device_attribute:
+              name: gr1
+              namespace: ip_net_set_dst
+              state: down
+          register: ip_link_device_attribute_res
+        - name: Tes6 - check assertions for run2
+          assert:
+            that:
+              ip_link_device_attribute_res is changed
+        - name: Tes6 - get results
+          command: ip net exec ip_net_set_dst ip link show gr1
+          register: test6_res
+        - name: Test6 - check results
+          assert:
+            that:
+              '"UP" in test6_res.stdout'
+      always:
+          - name: Delete namespaces
+            ip_netns: name={{item}} state=absent
+            with_items:
+              - ip_net_set_src
+              - ip_net_set_dst
+          - name: Delete interfaces
+            command: ip link delete '{{ item }}'
+            # if tests failed we want to cleanup, but if tests passed
+            # those interfaces are removed together with namespaces
+            failed_when: false
+            with_items:
+              - vcan_example
+              - vethN
+              - gr1
+              - gr2
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/test/units/modules/net_tools/test_ip_link_device_attribute.py
+++ b/test/units/modules/net_tools/test_ip_link_device_attribute.py
@@ -260,9 +260,10 @@ def test_get_iface_set_good(Zlink, module, input, output):
 ])
 def test_netns_need_to_move_good(Zlink, module, src, dst, status):
     module.params['name'] = 'eth0'
+    module.params['netns'] = 'foo'
     link = Zlink(module)
-    with mock.patch.object(link, '_get_iface_set') as mock_info:
-        mock_info.side_effect = [src, dst]
+    with mock.patch.object(link, '_get_iface_set') as mock_iface_set:
+        mock_iface_set.side_effect = [src, dst]
         assert link._netns_need_to_move() is status
 
 
@@ -272,8 +273,9 @@ def test_netns_need_to_move_good(Zlink, module, src, dst, status):
 ])
 def test_netns_need_to_move_bad(Zlink, module, src, dst):
     module.params['name'] = 'eth0'
+    module.params['netns'] = 'foo'
     link = Zlink(module)
-    with mock.patch.object(link, '_get_iface_set') as mock_info:
-        mock_info.side_effect = [src, dst]
+    with mock.patch.object(link, '_get_iface_set') as mock_iface_set:
+        mock_iface_set.side_effect = [src, dst]
         with pytest.raises(FailJsonException):
-            link._netns_need_to_move()
+            raise Exception(link._netns_need_to_move())

--- a/test/units/modules/net_tools/test_ip_link_device_attribute.py
+++ b/test/units/modules/net_tools/test_ip_link_device_attribute.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2019 George Shuklin
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import pytest
+from units.compat import mock
+from ansible.modules.net_tools import ip_link_device_attribute
+
+
+IF1 = '2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000\\    link/ether 00:23:54:84:d1:7a brd ff:ff:ff:ff:ff:ff link-netnsid 0'  # noqa
+IF1_data = {
+    "address": '00:23:54:84:d1:7a',
+    "alias": None,
+    "arp": True,
+    "broadcast": 'ff:ff:ff:ff:ff:ff',
+    "group": 'default',
+    "mtu": 1500,
+    "multicast": True,
+    "name": 'eth0',
+    "promisc": False,
+    "txqueuelen": 1000,
+    "state": 'up'
+}
+
+
+IF2 = '6: veth3@veth2: <BROADCAST,NOARP,PROMISC,M-DOWN> mtu 8000 qdisc noop master ovs-system state DOWN mode DEFAULT group 42 qlen 1\\    link/ether 3e:bf:a6:f0:6c:fb brd 0a:0a:0a:0a:0a:0a\\    alias for_test'  # noqa
+IF2_data = {
+    "address": '3e:bf:a6:f0:6c:fb',
+    "alias": 'for_test',
+    "arp": False,
+    "broadcast": '0a:0a:0a:0a:0a:0a',
+    "group": '42',
+    "mtu": 8000,
+    "multicast": False,
+    "name": 'veth3',
+    "promisc": True,
+    "txqueuelen": 1,
+    "state": 'down'
+}
+IF3 = '118: vcan9: <NOARP> mtu 72 qdisc noop state DOWN mode DEFAULT group default qlen 1000\\    link/can \\    alias foo'  # noqa
+IF3_data = {
+    "address": None,
+    "alias": 'foo',
+    "arp": False,
+    "broadcast": None,
+    "group": 'default',
+    "mtu": 72,
+    "multicast": False,
+    "name": 'vcan9',
+    "promisc": False,
+    "txqueuelen": 1000,
+    "state": 'down'
+}
+
+
+@pytest.fixture(scope='function')
+def eth0():
+    '''Example of parsed interface'''
+    return IF1_data
+
+
+class FailJsonException(Exception):
+    pass
+
+
+@pytest.fixture(scope='function')
+def module():
+    module = mock.MagicMock()
+    module.params = {}
+    for knob in ip_link_device_attribute.Link.knob_cmds.keys():
+        module.params[knob] = None
+    for param in ip_link_device_attribute.Link.params_list:
+        module.params[param] = None
+    module.check_mode = False
+    module.fail_json.side_effect = FailJsonException("fail_json was called")
+    return module
+
+
+@pytest.fixture(scope='function')
+def Zlink():
+    ''' Link class with mocked _exec'''
+    with mock.patch.object(ip_link_device_attribute.Link, '_exec'):
+        yield ip_link_device_attribute.Link
+
+
+@pytest.fixture(scope='function')
+def elink(module):
+    ''' Link object with trivial initialization'''
+    module.params["name"] = True
+    link = ip_link_device_attribute.Link(module)
+    return link
+
+
+@pytest.mark.parametrize('input,output', [
+    (
+        IF1,
+        {
+            'name': 'eth0',
+            'mtu': 1500,
+            'group': 'default',
+            'txqueuelen': 1000,
+            'multicast': True,
+            'state': 'up',
+            'arp': True,
+            'promisc': False,
+            'address': '00:23:54:84:d1:7a',
+            'broadcast': 'ff:ff:ff:ff:ff:ff',
+            'alias': None
+        }
+    ),
+    (
+        IF2,
+        IF2_data,
+    ),
+    (
+        IF3,
+        IF3_data,
+    )
+])
+def test_parse_interface_good_cases(elink, input, output):
+    assert elink._parse_interface(input) == output
+
+
+@pytest.mark.parametrize("input,output", [
+    ('\n', []),
+    ('', []),
+    (
+        '\n'.join([IF1, IF2]),
+        [
+            IF1_data,
+            IF2_data
+        ]
+    )
+])
+def test_get_interfaces_info_good_parsing(Zlink, module, input, output):
+    Zlink._exec.return_value = input
+    module.params['name'] = 'eth0'
+    assert list(Zlink(module)._get_interfaces_info(None)) == output
+
+
+def test_get_interfaces_info_check_calling_args_group(Zlink, module):
+    module.params['group_id'] = 'test_group'
+    link = Zlink(module)
+    list(link._get_interfaces_info(None))
+    link._exec.assert_called_once_with(
+        None, ['ip', '-o', 'link', 'show', 'group', 'test_group'], False
+    )
+
+
+def test_get_interfaces_info_check_calling_args_name(Zlink, module):
+    module.params['name'] = 'eth0'
+    link = Zlink(module)
+    list(link._get_interfaces_info(None))
+    link._exec.assert_called_once_with(
+        None, ['ip', '-o', 'link', 'show', 'dev', 'eth0'], False
+    )
+
+
+def test_is_changes_needed_for_interface_no_changes(eth0, module):
+    module.params['name'] = 'eth0'
+    link = ip_link_device_attribute.Link(module)
+    assert link._is_changes_needed_for_interface(eth0) is False
+
+
+@pytest.mark.parametrize("change_attr", [
+    'address',
+    'alias',
+    'arp',
+    'broadcast',
+    'group',
+    'mtu',
+    'multicast',
+    'promisc',
+    'txqueuelen',
+    'state'
+])
+def test_is_changes_needed_for_interface_one_param(eth0, module, change_attr):
+    module.params['name'] = 'eth0'
+    module.params[change_attr] = 'need_change'
+    link = ip_link_device_attribute.Link(module)
+    assert link._is_changes_needed_for_interface(eth0) is True
+
+
+@pytest.mark.parametrize("change_attr", ['address', 'broadcast'])
+def test_is_changes_needed_for_interface_no_l2(eth0, module, change_attr):
+    module.params['name'] = 'eth0'
+    eth0["address"] = None
+    eth0["broadcast"] = None
+    module.params[change_attr] = 'need_change'
+    link = ip_link_device_attribute.Link(module)
+    with pytest.raises(FailJsonException):
+        link._is_changes_needed_for_interface(eth0)
+
+
+@pytest.mark.parametrize('knob, knob_value, command', [
+    ('state', 'up', 'ip link set dev eth0 up'),
+    ('state', 'down', 'ip link set dev eth0 down'),
+    ('mtu', 1500, 'ip link set dev eth0 mtu 1500'),
+    ('arp', True, 'ip link set dev eth0 arp on'),
+    ('arp', False, 'ip link set dev eth0 arp off'),
+    ('multicast', False, 'ip link set dev eth0 multicast off'),
+    ('multicast', True, 'ip link set dev eth0 multicast on'),
+    ('promisc', True, 'ip link set dev eth0 promisc on'),
+    ('promisc', False, 'ip link set dev eth0 promisc off'),
+    ('broadcast', 'FA:FA:FA:FA:FA:FA', 'ip link set dev eth0 broadcast fa:fa:fa:fa:fa:fa'),  # noqa
+    ('address', 'BB:BB:BB:BB:BB:BB', 'ip link set dev eth0 address bb:bb:bb:bb:bb:bb'),  # noqa
+    ('group', 3, 'ip link set dev eth0 group 3'),
+    ('group', 'bar', 'ip link set dev eth0 group bar'),
+    ('alias', 'foobar', 'ip link set dev eth0 alias foobar'),
+    ('txqueuelen', 2, 'ip link set dev eth0 txqueuelen 2'),
+])
+def test_apply_change_good(Zlink, module, knob, knob_value, command):
+    module.params['name'] = 'eth0'
+    module.params[knob] = knob_value
+    link = Zlink(module)
+    link._apply_changes()
+    Zlink._exec.assert_called_once_with(None, command.split())
+
+
+def test_apply_change_uses_group_id(Zlink, module):
+    module.params['group_id'] = '42'
+    module.params['mtu'] = 1500
+    link = Zlink(module)
+    link._apply_changes()
+    command = 'ip link set group 42 mtu 1500'
+    Zlink._exec.assert_called_once_with(None, command.split())
+
+
+def test_apply_change_uses_namespace(Zlink, module):
+    module.params['name'] = 'eth0'
+    module.params['mtu'] = 1500
+    module.params['namespace'] = 'test'
+    link = Zlink(module)
+    link._apply_changes()
+    command = 'ip link set dev eth0 mtu 1500'
+    Zlink._exec.assert_called_with('test', command.split())
+
+
+@pytest.mark.parametrize('input, output', [
+    ([], set()),
+    ([IF1_data], set(['eth0'])),
+    ([IF1_data, IF2_data], set(['eth0', 'veth3']))
+])
+def test_get_iface_set_good(Zlink, module, input, output):
+    module.params['name'] = 'eth0'
+    link = Zlink(module)
+    with mock.patch.object(link, '_get_interfaces_info') as mock_info:
+        mock_info.return_value = input
+        assert link._get_iface_set('dosntmatter') == output
+
+
+@pytest.mark.parametrize('src, dst, status', [
+    (set([]), set(['eth0']), False),
+    (set(['eth0']), set([]), True),
+    (set(['eth0']), set(['eth1']), True),
+])
+def test_netns_need_to_move_good(Zlink, module, src, dst, status):
+    module.params['name'] = 'eth0'
+    link = Zlink(module)
+    with mock.patch.object(link, '_get_iface_set') as mock_info:
+        mock_info.side_effect = [src, dst]
+        assert link._netns_need_to_move() is status
+
+
+@pytest.mark.parametrize('src, dst', [
+    (set([]), set([])),
+    (set(['eth0']), set(['eth0'])),
+])
+def test_netns_need_to_move_bad(Zlink, module, src, dst):
+    module.params['name'] = 'eth0'
+    link = Zlink(module)
+    with mock.patch.object(link, '_get_iface_set') as mock_info:
+        mock_info.side_effect = [src, dst]
+        with pytest.raises(FailJsonException):
+            link._netns_need_to_move()


### PR DESCRIPTION
##### SUMMARY
This module implements subset of features of `ip link set` command in Linux. It allows to set and query link-level attributes for interfaces: MTU, administrative state, flags (ARP/PROMISC/MULTICAST),  aliases and  interface groups. It also supports move of interfaces between namespaces (netns attribute). It does so in idempotent way and supports the check mode.

As a side effect it allows to query interface attributes when run without list of attributes to change. It provides more information than a normal `setup`, moreover, it can gather them in a network namespace.

I plan to write more of those modules for other ip subcommands: `ip link create`, `ip address`, `ip route`.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ip_link_device_attribute

##### ADDITIONAL INFORMATION
I found that in laboratory environment I have trouble to create 'integration mocks' - fake namespaces with routing and complicated topology (veth from one namespace into bridge to join it into another namespace). While this is possible with careful 'command'/when sequence, it's really hard to debug and become verbose very quickly. This module removes part of that verbosity.

ip utility (iproute2 package) is extremely widespread on Linux and it's obvious that it should have a module in Ansible. Currently Ansible have only `ip_netns` module, but I hope to fill this gap.