### PR TITLE
[WIP] Docker connection plugin: allow to use Docker SDK for Python

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -536,7 +536,7 @@ class DockerSocketHandler:
         if data is None:
             # no data available
             return
-        display.vvv('read {0} bytes'.format(len(data)), host=self._container)
+        display.vvvv('read {0} bytes'.format(len(data)), host=self._container)
         if len(data) == 0:
             # Stream EOF
             self._eof = True
@@ -567,7 +567,7 @@ class DockerSocketHandler:
             else:
                 written = os.write(self._sock.fileno(), self._write_buffer)
             self._write_buffer = self._write_buffer[written:]
-            display.vvv('wrote {0} bytes, {1} are left'.format(written, len(self._write_buffer)), host=self._container)
+            display.vvvv('wrote {0} bytes, {1} are left'.format(written, len(self._write_buffer)), host=self._container)
             if len(self._write_buffer) > 0:
                 self._selector.modify(self._sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
             else:

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -3,6 +3,7 @@
 # (c) 2014, Lorin Hochstein
 # (c) 2015, Leendert Brouwer (https://github.com/objectified)
 # (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+# (c) 2019, Felix Fontein <felix@fontein.de>
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -13,6 +14,7 @@ DOCUMENTATION = """
     author:
         - Lorin Hochestein
         - Leendert Brouwer
+        - Felix Fontein (@felixfontein)
     connection: docker
     short_description: Run tasks in docker containers
     description:

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -807,6 +807,7 @@ class DockerPyDriver:
             data,  # can also be file object for streaming; this is only clear from the
                    # implementation of put_archive(), which uses requests's put().
                    # See https://2.python-requests.org/en/master/user/advanced/#streaming-uploads
+                   # WARNING: might not work with all transports!
         ), not_found_can_be_resource=True)
         if not ok:
             raise AnsibleConnectionFailure(

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -74,7 +74,6 @@ import re
 import socket as pysocket
 import subprocess
 import tarfile
-import traceback
 
 from distutils.version import LooseVersion
 
@@ -627,19 +626,16 @@ class DockerPyDriver:
             if e.response and e.response.status_code == 409:
                 raise AnsibleConnectionFailure('The container "{1}" has been paused ({0})'.format(e, play_context.remote_addr))
             self.client.fail(
-                'An unexpected docker error occurred for container "{1}": {0}'.format(e, play_context.remote_addr),
-                exception=traceback.format_exc()
+                'An unexpected docker error occurred for container "{1}": {0}'.format(e, play_context.remote_addr)
             )
         except DockerException as e:
             self.client.fail(
-                'An unexpected docker error occurred for container "{1}": {0}'.format(e, play_context.remote_addr),
-                exception=traceback.format_exc()
+                'An unexpected docker error occurred for container "{1}": {0}'.format(e, play_context.remote_addr)
             )
         except RequestException as e:
             self.client.fail(
                 'An unexpected requests error occurred for container "{1}" when docker-py tried to talk to the docker daemon: {0}'
-                .format(e, play_context.remote_addr),
-                exception=traceback.format_exc()
+                .format(e, play_context.remote_addr)
             )
 
     def __init__(self, connection_display, play_context, connection_plugin):

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -831,8 +831,8 @@ class DockerPyDriver:
         # TODO: stream tar file, instead of creating it in-memory into a BytesIO
 
         bio = io.BytesIO()
-        with tarfile.open(fileobj=bio, mode='w|') as tar:
-            tarinfo = tar.gettarinfo(in_path if PY3 else b_in_path)
+        with tarfile.open(fileobj=bio, mode='w|', dereference=True) as tar:
+            tarinfo = tar.gettarinfo(to_text(in_path) if PY3 else b_in_path)
             tarinfo.name = out_file
             user_id, group_id = self.ids[self.actual_user]
             tarinfo.uid = user_id

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -108,6 +108,7 @@ MIN_DOCKER_API = None
 def _sanitize_version(version):
     return re.sub(u'[^0-9a-zA-Z.]', u'', version)
 
+
 def _old_docker_cli_version(docker_cmd, play_context):
     cmd_args = []
     if play_context.docker_extra_args:
@@ -121,6 +122,7 @@ def _old_docker_cli_version(docker_cmd, play_context):
 
     return old_docker_cmd, to_native(cmd_output), err, p.returncode
 
+
 def _new_docker_cli_version(docker_cmd, play_context):
     # no result yet, must be newer Docker version
     cmd_args = []
@@ -133,6 +135,7 @@ def _new_docker_cli_version(docker_cmd, play_context):
     p = subprocess.Popen(new_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     cmd_output, err = p.communicate()
     return new_docker_cmd, to_native(cmd_output), err, p.returncode
+
 
 def get_docker_cli_version(docker_cmd, play_context):
 
@@ -631,7 +634,8 @@ class DockerPyDriver:
             )
         except RequestException as e:
             self.client.fail(
-                'An unexpected requests error occurred for container "{1}" when docker-py tried to talk to the docker daemon: {0}'.format(e, play_context.remote_addr),
+                'An unexpected requests error occurred for container "{1}" when docker-py tried to talk to the docker daemon: {0}'
+                .format(e, play_context.remote_addr),
                 exception=traceback.format_exc()
             )
 

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -28,11 +28,11 @@ DOCUMENTATION = """
         vars:
             - name: ansible_user
             - name: ansible_docker_user
-      docker_command:
-        type: str
-        description:
-            - Docker CLI command to use instead of trying to find C(docker) in the path.
-            - Note that this is ignored by the Docker SDK for Python driver.
+      #docker_command:
+      #  type: str
+      #  description:
+      #      - Docker CLI command to use instead of trying to find C(docker) in the path.
+      #      - Note that this is ignored by the Docker SDK for Python driver.
       docker_extra_args:
         type: str
         description:
@@ -53,8 +53,8 @@ DOCUMENTATION = """
             - Which internal driver to use to talk to the docker daemon.
             - Allowed values are C(auto) for autodetection, C(cli) for using the C(docker) CLI program,
               and C(docker-py) for using the Docker SDK for Python.
-            - C(auto) tries to decide which driver to use. If I(docker_command) or I(docker_extra_args)
-              are specified, the CLI driver will be used. Otherwise, it will check whether the Docker
+            - C(auto) tries to decide which driver to use. If I(docker_extra_args)
+              is specified, the CLI driver will be used. Otherwise, it will check whether the Docker
               SDK for Python is installed; if a new enough version (1.7.0 or higher) is there, it will
               be used. Otherwise, it will check whether C(docker) can be found in the path. If it is
               found with a new enough version (1.3 or higher), it will be used.
@@ -175,7 +175,7 @@ class Connection(ConnectionBase):
                 if driver == 'auto':
                     driver = 'cli'
                 elif driver == 'docker-py':
-                    raise AnsibleError('docker_command or docker_extra_args must not be specified for docker-py driver')
+                    raise AnsibleError('docker_extra_args must not be specified for docker-py driver')
 
             docker_cli_version = None
             if driver == 'auto':

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -47,7 +47,6 @@ import re
 
 from distutils.version import LooseVersion
 
-import ansible.constants as C
 from ansible.compat import selectors
 from ansible.errors import AnsibleError, AnsibleFileNotFound
 from ansible.module_utils.six.moves import shlex_quote
@@ -67,137 +66,14 @@ class Connection(ConnectionBase):
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
-        # Note: docker supports running as non-root in some configurations.
-        # (For instance, setting the UNIX socket file to be readable and
-        # writable by a specific UNIX group and then putting users into that
-        # group).  Therefore we don't check that the user is root when using
-        # this connection.  But if the user is getting a permission denied
-        # error it probably means that docker on their system is only
-        # configured to be connected to by root and they are not running as
-        # root.
-
-        if 'docker_command' in kwargs:
-            self.docker_cmd = kwargs['docker_command']
-        else:
-            self.docker_cmd = distutils.spawn.find_executable('docker')
-            if not self.docker_cmd:
-                raise AnsibleError("docker command not found in PATH")
-
-        docker_version = self._get_docker_version()
-        if docker_version == u'dev':
-            display.warning(u'Docker version number is "dev". Will assume latest version.')
-        if docker_version != u'dev' and LooseVersion(docker_version) < LooseVersion(u'1.3'):
-            raise AnsibleError('docker connection type requires docker 1.3 or higher')
-
-        # The remote user we will request from docker (if supported)
-        self.remote_user = None
-        # The actual user which will execute commands in docker (if known)
-        self.actual_user = None
-
-        if self._play_context.remote_user is not None:
-            if docker_version == u'dev' or LooseVersion(docker_version) >= LooseVersion(u'1.7'):
-                # Support for specifying the exec user was added in docker 1.7
-                self.remote_user = self._play_context.remote_user
-                self.actual_user = self.remote_user
-            else:
-                self.actual_user = self._get_docker_remote_user()
-
-                if self.actual_user != self._play_context.remote_user:
-                    display.warning(u'docker {0} does not support remote_user, using container default: {1}'
-                                    .format(docker_version, self.actual_user or u'?'))
-        elif self._display.verbosity > 2:
-            # Since we're not setting the actual_user, look it up so we have it for logging later
-            # Only do this if display verbosity is high enough that we'll need the value
-            # This saves overhead from calling into docker when we don't need to
-            self.actual_user = self._get_docker_remote_user()
-
-    @staticmethod
-    def _sanitize_version(version):
-        return re.sub(u'[^0-9a-zA-Z.]', u'', version)
-
-    def _old_docker_version(self):
-        cmd_args = []
-        if self._play_context.docker_extra_args:
-            cmd_args += self._play_context.docker_extra_args.split(' ')
-
-        old_version_subcommand = ['version']
-
-        old_docker_cmd = [self.docker_cmd] + cmd_args + old_version_subcommand
-        p = subprocess.Popen(old_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        cmd_output, err = p.communicate()
-
-        return old_docker_cmd, to_native(cmd_output), err, p.returncode
-
-    def _new_docker_version(self):
-        # no result yet, must be newer Docker version
-        cmd_args = []
-        if self._play_context.docker_extra_args:
-            cmd_args += self._play_context.docker_extra_args.split(' ')
-
-        new_version_subcommand = ['version', '--format', "'{{.Server.Version}}'"]
-
-        new_docker_cmd = [self.docker_cmd] + cmd_args + new_version_subcommand
-        p = subprocess.Popen(new_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        cmd_output, err = p.communicate()
-        return new_docker_cmd, to_native(cmd_output), err, p.returncode
-
-    def _get_docker_version(self):
-
-        cmd, cmd_output, err, returncode = self._old_docker_version()
-        if returncode == 0:
-            for line in to_text(cmd_output, errors='surrogate_or_strict').split(u'\n'):
-                if line.startswith(u'Server version:'):  # old docker versions
-                    return self._sanitize_version(line.split()[2])
-
-        cmd, cmd_output, err, returncode = self._new_docker_version()
-        if returncode:
-            raise AnsibleError('Docker version check (%s) failed: %s' % (to_native(cmd), to_native(err)))
-
-        return self._sanitize_version(to_text(cmd_output, errors='surrogate_or_strict'))
-
-    def _get_docker_remote_user(self):
-        """ Get the default user configured in the docker container """
-        p = subprocess.Popen([self.docker_cmd, 'inspect', '--format', '{{.Config.User}}', self._play_context.remote_addr],
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-        out, err = p.communicate()
-        out = to_text(out, errors='surrogate_or_strict')
-
-        if p.returncode != 0:
-            display.warning(u'unable to retrieve default user from docker container: %s %s' % (out, to_text(err)))
-            return None
-
-        # The default exec user is root, unless it was changed in the Dockerfile with USER
-        return out.strip() or u'root'
-
-    def _build_exec_cmd(self, cmd):
-        """ Build the local docker exec command to run cmd on remote_host
-
-            If remote_user is available and is supported by the docker
-            version we are using, it will be provided to docker exec.
-        """
-
-        local_cmd = [self.docker_cmd]
-
-        if self._play_context.docker_extra_args:
-            local_cmd += self._play_context.docker_extra_args.split(' ')
-
-        local_cmd += [b'exec']
-
-        if self.remote_user is not None:
-            local_cmd += [b'-u', self.remote_user]
-
-        # -i is needed to keep stdin open which allows pipelining to work
-        local_cmd += [b'-i', self._play_context.remote_addr] + cmd
-
-        return local_cmd
+        self.driver = CLIDriver(self._display, play_context, kwargs)
 
     def _connect(self, port=None):
         """ Connect to the container. Nothing to do """
         super(Connection, self)._connect()
         if not self._connected:
             display.vvv(u"ESTABLISH DOCKER CONNECTION FOR USER: {0}".format(
-                self.actual_user or u'?'), host=self._play_context.remote_addr
+                self.driver.actual_user or u'?'), host=self._play_context.remote_addr
             )
             self._connected = True
 
@@ -205,61 +81,7 @@ class Connection(ConnectionBase):
         """ Run a command on the docker host """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        local_cmd = self._build_exec_cmd([self._play_context.executable, '-c', cmd])
-
-        display.vvv(u"EXEC {0}".format(to_text(local_cmd)), host=self._play_context.remote_addr)
-        display.debug("opening command with Popen()")
-
-        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
-
-        p = subprocess.Popen(
-            local_cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        display.debug("done running command with Popen()")
-
-        if self.become and self.become.expect_prompt() and sudoable:
-            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
-            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) | os.O_NONBLOCK)
-            selector = selectors.DefaultSelector()
-            selector.register(p.stdout, selectors.EVENT_READ)
-            selector.register(p.stderr, selectors.EVENT_READ)
-
-            become_output = b''
-            try:
-                while not self.become.check_success(become_output) and not self.become.check_password_prompt(become_output):
-                    events = selector.select(self._play_context.timeout)
-                    if not events:
-                        stdout, stderr = p.communicate()
-                        raise AnsibleError('timeout waiting for privilege escalation password prompt:\n' + to_native(become_output))
-
-                    for key, event in events:
-                        if key.fileobj == p.stdout:
-                            chunk = p.stdout.read()
-                        elif key.fileobj == p.stderr:
-                            chunk = p.stderr.read()
-
-                    if not chunk:
-                        stdout, stderr = p.communicate()
-                        raise AnsibleError('privilege output closed while waiting for password prompt:\n' + to_native(become_output))
-                    become_output += chunk
-            finally:
-                selector.close()
-
-            if not self.become.check_success(become_output):
-                become_pass = self.become.get_option('become_pass', playcontext=self._play_context)
-                p.stdin.write(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
-            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-
-        display.debug("getting output with communicate()")
-        stdout, stderr = p.communicate(in_data)
-        display.debug("done communicating")
-
-        display.debug("done with docker.exec_command()")
-        return (p.returncode, stdout, stderr)
+        return self.driver.exec_command(self._play_context, self.become, cmd, in_data, sudoable)
 
     def _prefix_login_path(self, remote_path):
         ''' Make sure that we put files into a standard path
@@ -285,6 +107,210 @@ class Connection(ConnectionBase):
             raise AnsibleFileNotFound(
                 "file or module does not exist: %s" % to_native(in_path))
 
+        return self.driver.put_file(self._play_context, in_path, out_path)
+
+    def fetch_file(self, in_path, out_path):
+        """ Fetch a file from container to local. """
+        super(Connection, self).fetch_file(in_path, out_path)
+        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
+
+        in_path = self._prefix_login_path(in_path)
+
+        return self.driver.fetch_file(self._play_context, in_path, out_path)
+
+    def close(self):
+        """ Terminate the connection. Nothing to do for Docker"""
+        super(Connection, self).close()
+        self._connected = False
+
+
+class CLIDriver:
+    def __init__(self, connection_display, play_context, kwargs):
+        # Note: docker supports running as non-root in some configurations.
+        # (For instance, setting the UNIX socket file to be readable and
+        # writable by a specific UNIX group and then putting users into that
+        # group).  Therefore we don't check that the user is root when using
+        # this connection.  But if the user is getting a permission denied
+        # error it probably means that docker on their system is only
+        # configured to be connected to by root and they are not running as
+        # root.
+
+        if 'docker_command' in kwargs:
+            self.docker_cmd = kwargs['docker_command']
+        else:
+            self.docker_cmd = distutils.spawn.find_executable('docker')
+            if not self.docker_cmd:
+                raise AnsibleError("docker command not found in PATH")
+
+        docker_version = self._get_docker_version(play_context)
+        if docker_version == u'dev':
+            display.warning(u'Docker version number is "dev". Will assume latest version.')
+        if docker_version != u'dev' and LooseVersion(docker_version) < LooseVersion(u'1.3'):
+            raise AnsibleError('docker connection type requires docker 1.3 or higher')
+
+        # The remote user we will request from docker (if supported)
+        self.remote_user = None
+        # The actual user which will execute commands in docker (if known)
+        self.actual_user = None
+
+        if play_context.remote_user is not None:
+            if docker_version == u'dev' or LooseVersion(docker_version) >= LooseVersion(u'1.7'):
+                # Support for specifying the exec user was added in docker 1.7
+                self.remote_user = play_context.remote_user
+                self.actual_user = self.remote_user
+            else:
+                self.actual_user = self._get_docker_remote_user()
+
+                if self.actual_user != play_context.remote_user:
+                    display.warning(u'docker {0} does not support remote_user, using container default: {1}'
+                                    .format(docker_version, self.actual_user or u'?'))
+        elif connection_display.verbosity > 2:
+            # Since we're not setting the actual_user, look it up so we have it for logging later
+            # Only do this if display verbosity is high enough that we'll need the value
+            # This saves overhead from calling into docker when we don't need to
+            self.actual_user = self._get_docker_remote_user(play_context)
+
+    @staticmethod
+    def _sanitize_version(version):
+        return re.sub(u'[^0-9a-zA-Z.]', u'', version)
+
+    def _old_docker_version(self, play_context):
+        cmd_args = []
+        if play_context.docker_extra_args:
+            cmd_args += play_context.docker_extra_args.split(' ')
+
+        old_version_subcommand = ['version']
+
+        old_docker_cmd = [self.docker_cmd] + cmd_args + old_version_subcommand
+        p = subprocess.Popen(old_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd_output, err = p.communicate()
+
+        return old_docker_cmd, to_native(cmd_output), err, p.returncode
+
+    def _new_docker_version(self, play_context):
+        # no result yet, must be newer Docker version
+        cmd_args = []
+        if play_context.docker_extra_args:
+            cmd_args += play_context.docker_extra_args.split(' ')
+
+        new_version_subcommand = ['version', '--format', "'{{.Server.Version}}'"]
+
+        new_docker_cmd = [self.docker_cmd] + cmd_args + new_version_subcommand
+        p = subprocess.Popen(new_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd_output, err = p.communicate()
+        return new_docker_cmd, to_native(cmd_output), err, p.returncode
+
+    def _get_docker_version(self, play_context):
+
+        cmd, cmd_output, err, returncode = self._old_docker_version(play_context)
+        if returncode == 0:
+            for line in to_text(cmd_output, errors='surrogate_or_strict').split(u'\n'):
+                if line.startswith(u'Server version:'):  # old docker versions
+                    return self._sanitize_version(line.split()[2])
+
+        cmd, cmd_output, err, returncode = self._new_docker_version(play_context)
+        if returncode:
+            raise AnsibleError('Docker version check (%s) failed: %s' % (to_native(cmd), to_native(err)))
+
+        return self._sanitize_version(to_text(cmd_output, errors='surrogate_or_strict'))
+
+    def _get_docker_remote_user(self, play_context):
+        """ Get the default user configured in the docker container """
+        p = subprocess.Popen([self.docker_cmd, 'inspect', '--format', '{{.Config.User}}', play_context.remote_addr],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        out, err = p.communicate()
+        out = to_text(out, errors='surrogate_or_strict')
+
+        if p.returncode != 0:
+            display.warning(u'unable to retrieve default user from docker container: %s %s' % (out, to_text(err)))
+            return None
+
+        # The default exec user is root, unless it was changed in the Dockerfile with USER
+        return out.strip() or u'root'
+
+    def _build_exec_cmd(self, play_context, cmd):
+        """ Build the local docker exec command to run cmd on remote_host
+
+            If remote_user is available and is supported by the docker
+            version we are using, it will be provided to docker exec.
+        """
+
+        local_cmd = [self.docker_cmd]
+
+        if play_context.docker_extra_args:
+            local_cmd += play_context.docker_extra_args.split(' ')
+
+        local_cmd += [b'exec']
+
+        if self.remote_user is not None:
+            local_cmd += [b'-u', self.remote_user]
+
+        # -i is needed to keep stdin open which allows pipelining to work
+        local_cmd += [b'-i', play_context.remote_addr] + cmd
+
+        return local_cmd
+
+    def exec_command(self, play_context, become, cmd, in_data=None, sudoable=False):
+        """ Run a command on the docker host """
+        local_cmd = self._build_exec_cmd(play_context, [play_context.executable, '-c', cmd])
+
+        display.vvv(u"EXEC {0}".format(to_text(local_cmd)), host=play_context.remote_addr)
+        display.debug("opening command with Popen()")
+
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
+
+        p = subprocess.Popen(
+            local_cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        display.debug("done running command with Popen()")
+
+        if become and become.expect_prompt() and sudoable:
+            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) | os.O_NONBLOCK)
+            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) | os.O_NONBLOCK)
+            selector = selectors.DefaultSelector()
+            selector.register(p.stdout, selectors.EVENT_READ)
+            selector.register(p.stderr, selectors.EVENT_READ)
+
+            become_output = b''
+            try:
+                while not become.check_success(become_output) and not become.check_password_prompt(become_output):
+                    events = selector.select(play_context.timeout)
+                    if not events:
+                        stdout, stderr = p.communicate()
+                        raise AnsibleError('timeout waiting for privilege escalation password prompt:\n' + to_native(become_output))
+
+                    for key, event in events:
+                        if key.fileobj == p.stdout:
+                            chunk = p.stdout.read()
+                        elif key.fileobj == p.stderr:
+                            chunk = p.stderr.read()
+
+                    if not chunk:
+                        stdout, stderr = p.communicate()
+                        raise AnsibleError('privilege output closed while waiting for password prompt:\n' + to_native(become_output))
+                    become_output += chunk
+            finally:
+                selector.close()
+
+            if not become.check_success(become_output):
+                become_pass = become.get_option('become_pass', playcontext=play_context)
+                p.stdin.write(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+            fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+            fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
+
+        display.debug("getting output with communicate()")
+        stdout, stderr = p.communicate(in_data)
+        display.debug("done communicating")
+
+        display.debug("done with docker.exec_command()")
+        return (p.returncode, stdout, stderr)
+
+    def put_file(self, play_context, in_path, out_path):
+        """ Transfer a file from local to docker container """
         out_path = shlex_quote(out_path)
         # Older docker doesn't have native support for copying files into
         # running containers, so we use docker exec to implement this
@@ -295,7 +321,7 @@ class Connection(ConnectionBase):
                 count = ' count=0'
             else:
                 count = ''
-            args = self._build_exec_cmd([self._play_context.executable, "-c", "dd of=%s bs=%s%s" % (out_path, BUFSIZE, count)])
+            args = self._build_exec_cmd(play_context, [play_context.executable, "-c", "dd of=%s bs=%s%s" % (out_path, BUFSIZE, count)])
             args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
             try:
                 p = subprocess.Popen(args, stdin=in_file,
@@ -308,17 +334,13 @@ class Connection(ConnectionBase):
                 raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" %
                                    (to_native(in_path), to_native(out_path), to_native(stdout), to_native(stderr)))
 
-    def fetch_file(self, in_path, out_path):
+    def fetch_file(self, play_context, in_path, out_path):
         """ Fetch a file from container to local. """
-        super(Connection, self).fetch_file(in_path, out_path)
-        display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
-
-        in_path = self._prefix_login_path(in_path)
         # out_path is the final file path, but docker takes a directory, not a
         # file path
         out_dir = os.path.dirname(out_path)
 
-        args = [self.docker_cmd, "cp", "%s:%s" % (self._play_context.remote_addr, in_path), out_dir]
+        args = [self.docker_cmd, "cp", "%s:%s" % (play_context.remote_addr, in_path), out_dir]
         args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
 
         p = subprocess.Popen(args, stdin=subprocess.PIPE,
@@ -330,7 +352,7 @@ class Connection(ConnectionBase):
         if p.returncode != 0:
             # Older docker doesn't have native support for fetching files command `cp`
             # If `cp` fails, try to use `dd` instead
-            args = self._build_exec_cmd([self._play_context.executable, "-c", "dd if=%s bs=%s" % (in_path, BUFSIZE)])
+            args = self._build_exec_cmd(play_context, [play_context.executable, "-c", "dd if=%s bs=%s" % (in_path, BUFSIZE)])
             args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
             with open(to_bytes(actual_out_path, errors='surrogate_or_strict'), 'wb') as out_file:
                 try:
@@ -346,8 +368,3 @@ class Connection(ConnectionBase):
         # Rename if needed
         if actual_out_path != out_path:
             os.rename(to_bytes(actual_out_path, errors='strict'), to_bytes(out_path, errors='strict'))
-
-    def close(self):
-        """ Terminate the connection. Nothing to do for Docker"""
-        super(Connection, self).close()
-        self._connected = False

--- a/test/integration/targets/connection_docker/aliases
+++ b/test/integration/targets/connection_docker/aliases
@@ -1,2 +1,5 @@
-non_local
-unsupported
+shippable/posix/group4
+skip/osx
+skip/freebsd
+needs/root
+destructive

--- a/test/integration/targets/connection_docker/meta/main.yml
+++ b/test/integration/targets/connection_docker/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_docker

--- a/test/integration/targets/connection_docker/runme-connection.sh
+++ b/test/integration/targets/connection_docker/runme-connection.sh
@@ -1,0 +1,1 @@
+../connection_posix/test.sh

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 
+# Setup phase
+
+echo "Setup"
+ANSIBLE_ROLES_PATH=.. ansible-playbook setup.yml
+
+# If docker wasn't installed, don't run the tests
+if [ "$(command -v docker)" == "" ]; then
+    exit
+fi
+
+
+# Test phase
+
+
 DOCKER_CONTAINERS="docker-connection-test-container"
 
 [[ -n "$DEBUG" || -n "$ANSIBLE_DEBUG" ]] && set -x
 
 set -euo pipefail
-
-echo "Setup"
-ANSIBLE_ROLES_PATH=.. ansible-playbook setup.yml
 
 cleanup() {
     echo "Cleanup"
@@ -27,7 +38,7 @@ for CONTAINER in ${DOCKER_CONTAINERS}; do
 done
 
 echo "Run autodetection test"
-ansible-playbook -vvv -i test_connection.inventory test-auto.yml
+ansible-playbook -vvvv -i test_connection.inventory test-auto.yml
 
 echo "Run tests"
 ./runme-connection.sh

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -1,1 +1,28 @@
-../connection_posix/test.sh
+#!/usr/bin/env bash
+
+DOCKER_CONTAINERS="docker-connection-test-container"
+
+[[ -n "$DEBUG" || -n "$ANSIBLE_DEBUG" ]] && set -x
+
+set -euo pipefail
+
+echo "Setup"
+ANSIBLE_ROLES_PATH=.. ansible-playbook setup.yml
+
+cleanup() {
+    echo "Cleanup"
+    docker rm -f ${DOCKER_CONTAINERS}
+    echo "Done"
+    exit 0
+}
+
+trap cleanup INT TERM EXIT
+
+echo "Start containers"
+for CONTAINER in ${DOCKER_CONTAINERS}; do
+    docker run --rm --name ${CONTAINER} --detach python:3 /bin/sh -c 'sleep 10m'
+    echo ${CONTAINER}
+done
+
+echo "Run tests"
+./runme-connection.sh

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -34,6 +34,7 @@ trap cleanup INT TERM EXIT
 echo "Start containers"
 for CONTAINER in ${DOCKER_CONTAINERS}; do
     docker run --rm --name ${CONTAINER} --detach python:3-alpine /bin/sh -c 'sleep 10m'
+    docker exec ${CONTAINER} pip3 install coverage
     echo ${CONTAINER}
 done
 

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -12,6 +12,8 @@ ANSIBLE_ROLES_PATH=.. ansible-playbook setup.yml
 cleanup() {
     echo "Cleanup"
     docker rm -f ${DOCKER_CONTAINERS}
+    echo "Shutdown"
+    ANSIBLE_ROLES_PATH=.. ansible-playbook shutdown.yml
     echo "Done"
     exit 0
 }

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -24,5 +24,8 @@ for CONTAINER in ${DOCKER_CONTAINERS}; do
     echo ${CONTAINER}
 done
 
+echo "Run autodetection test"
+ansible-playbook -vvv -i test_connection.inventory test-auto.yml
+
 echo "Run tests"
 ./runme-connection.sh

--- a/test/integration/targets/connection_docker/runme.sh
+++ b/test/integration/targets/connection_docker/runme.sh
@@ -33,7 +33,7 @@ trap cleanup INT TERM EXIT
 
 echo "Start containers"
 for CONTAINER in ${DOCKER_CONTAINERS}; do
-    docker run --rm --name ${CONTAINER} --detach python:3 /bin/sh -c 'sleep 10m'
+    docker run --rm --name ${CONTAINER} --detach python:3-alpine /bin/sh -c 'sleep 10m'
     echo ${CONTAINER}
 done
 

--- a/test/integration/targets/connection_docker/setup.yml
+++ b/test/integration/targets/connection_docker/setup.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: localhost
   connection: local
+  vars:
+    docker_skip_cleanup: yes
 
   tasks:
     - name: Setup docker

--- a/test/integration/targets/connection_docker/setup.yml
+++ b/test/integration/targets/connection_docker/setup.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Setup docker
+      import_role:
+        name: setup_docker

--- a/test/integration/targets/connection_docker/shutdown.yml
+++ b/test/integration/targets/connection_docker/shutdown.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  connection: local
+  vars:
+    docker_skip_cleanup: yes
+
+  tasks:
+    - name: Remove docker packages
+      action: "{{ ansible_facts.pkg_mgr }}"
+      args:
+        name:
+          - docker
+          - docker-ce
+          - docker-ce-cli
+        state: absent

--- a/test/integration/targets/connection_docker/test-auto.yml
+++ b/test/integration/targets/connection_docker/test-auto.yml
@@ -1,0 +1,5 @@
+---
+- hosts: docker_auto
+  gather_facts: no
+  tasks:
+    - command: ls

--- a/test/integration/targets/connection_docker/test_connection.inventory
+++ b/test/integration/targets/connection_docker/test_connection.inventory
@@ -1,10 +1,10 @@
 [docker_cli]
-docker-cli-pipelining         ansible_pipelining=true
 docker-cli-no-pipelining      ansible_pipelining=false
+docker-cli-pipelining         ansible_pipelining=true
 
 [docker_dockerpy]
-docker-dockerpy-pipelining    ansible_pipelining=true
 docker-dockerpy-no-pipelining ansible_pipelining=false
+docker-dockerpy-pipelining    ansible_pipelining=true
 
 [docker_auto]
 docker-auto

--- a/test/integration/targets/connection_docker/test_connection.inventory
+++ b/test/integration/targets/connection_docker/test_connection.inventory
@@ -29,3 +29,4 @@ docker_driver=auto
 [docker_all:vars]
 ansible_host=docker-connection-test-container
 ansible_connection=docker
+ansible_python_interpreter=/usr/bin/python3

--- a/test/integration/targets/connection_docker/test_connection.inventory
+++ b/test/integration/targets/connection_docker/test_connection.inventory
@@ -1,6 +1,10 @@
 [docker]
-docker-pipelining    ansible_ssh_pipelining=true
-docker-no-pipelining ansible_ssh_pipelining=false
+docker-cli-pipelining         ansible_pipelining=true  docker_driver=cli
+docker-cli-no-pipelining      ansible_pipelining=false docker_driver=cli
+docker-dockerpy-pipelining    ansible_pipelining=true  docker_driver=docker-py
+docker-dockerpy-no-pipelining ansible_pipelining=false docker_driver=docker-py
+docker-auto                   docker_driver=auto
+
 [docker:vars]
-ansible_host=ubuntu-latest
+ansible_host=docker-connection-test-container
 ansible_connection=docker

--- a/test/integration/targets/connection_docker/test_connection.inventory
+++ b/test/integration/targets/connection_docker/test_connection.inventory
@@ -29,4 +29,4 @@ docker_driver=auto
 [docker_all:vars]
 ansible_host=docker-connection-test-container
 ansible_connection=docker
-ansible_python_interpreter=/usr/bin/python3
+ansible_python_interpreter=/usr/local/bin/python3

--- a/test/integration/targets/connection_docker/test_connection.inventory
+++ b/test/integration/targets/connection_docker/test_connection.inventory
@@ -1,10 +1,31 @@
-[docker]
-docker-cli-pipelining         ansible_pipelining=true  docker_driver=cli
-docker-cli-no-pipelining      ansible_pipelining=false docker_driver=cli
-docker-dockerpy-pipelining    ansible_pipelining=true  docker_driver=docker-py
-docker-dockerpy-no-pipelining ansible_pipelining=false docker_driver=docker-py
-docker-auto                   docker_driver=auto
+[docker_cli]
+docker-cli-pipelining         ansible_pipelining=true
+docker-cli-no-pipelining      ansible_pipelining=false
 
-[docker:vars]
+[docker_dockerpy]
+docker-dockerpy-pipelining    ansible_pipelining=true
+docker-dockerpy-no-pipelining ansible_pipelining=false
+
+[docker_auto]
+docker-auto
+
+[docker:children]
+docker_cli
+docker_dockerpy
+
+[docker_all:children]
+docker
+docker_auto
+
+[docker_cli:vars]
+docker_driver=cli
+
+[docker_dockerpy:vars]
+docker_driver=docker-py
+
+[docker_auto:vars]
+docker_driver=auto
+
+[docker_all:vars]
 ansible_host=docker-connection-test-container
 ansible_connection=docker

--- a/test/units/plugins/connection/test_connection.py
+++ b/test/units/plugins/connection/test_connection.py
@@ -143,21 +143,21 @@ class TestConnectionBaseClass(unittest.TestCase):
     def test_ssh_connection_module(self):
         self.assertIsInstance(SSHConnection(self.play_context, self.in_stream), SSHConnection)
 
-    @mock.patch('ansible.plugins.connection.docker.Connection._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker.Connection._new_docker_version', return_value=('docker version', '1.2.3', '', 0))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('docker version', '1.2.3', '', 0))
     def test_docker_connection_module_too_old(self, mock_new_docker_verison, mock_old_docker_version):
         self.assertRaisesRegexp(AnsibleError, '^docker connection type requires docker 1.3 or higher$',
                                 DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')
 
-    @mock.patch('ansible.plugins.connection.docker.Connection._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker.Connection._new_docker_version', return_value=('docker version', '1.3.4', '', 0))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('docker version', '1.3.4', '', 0))
     def test_docker_connection_module(self, mock_new_docker_verison, mock_old_docker_version):
         self.assertIsInstance(DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker'),
                               DockerConnection)
 
     # old version and new version fail
-    @mock.patch('ansible.plugins.connection.docker.Connection._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker.Connection._new_docker_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('false', 'garbage', '', 1))
     def test_docker_connection_module_wrong_cmd(self, mock_new_docker_version, mock_old_docker_version):
         self.assertRaisesRegexp(AnsibleError, '^Docker version check (.*?) failed: ',
                                 DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')

--- a/test/units/plugins/connection/test_connection.py
+++ b/test/units/plugins/connection/test_connection.py
@@ -146,21 +146,22 @@ class TestConnectionBaseClass(unittest.TestCase):
     @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
     @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('docker version', '1.2.3', '', 0))
     def test_docker_connection_module_too_old(self, mock_new_docker_verison, mock_old_docker_version):
-        self.assertRaisesRegexp(AnsibleError, '^docker connection type requires docker 1.3 or higher$',
-                                DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')
+        instance = DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker')
+        self.assertRaisesRegexp(AnsibleError, '^docker connection type requires docker 1.3 or higher$', instance._connect)
 
     @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
     @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('docker version', '1.3.4', '', 0))
     def test_docker_connection_module(self, mock_new_docker_verison, mock_old_docker_version):
-        self.assertIsInstance(DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker'),
-                              DockerConnection)
+        instance = DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker')
+        self.assertIsInstance(instance, DockerConnection)
+        instance._connect()
 
     # old version and new version fail
     @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
     @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('false', 'garbage', '', 1))
     def test_docker_connection_module_wrong_cmd(self, mock_new_docker_version, mock_old_docker_version):
-        self.assertRaisesRegexp(AnsibleError, '^Docker version check (.*?) failed: ',
-                                DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')
+        instance = DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker')
+        self.assertRaisesRegexp(AnsibleError, '^Docker version check (.*?) failed: ', instance._connect)
 
 #    def test_winrm_connection_module(self):
 #        self.assertIsInstance(WinRmConnection(), WinRmConnection)

--- a/test/units/plugins/connection/test_connection.py
+++ b/test/units/plugins/connection/test_connection.py
@@ -143,21 +143,21 @@ class TestConnectionBaseClass(unittest.TestCase):
     def test_ssh_connection_module(self):
         self.assertIsInstance(SSHConnection(self.play_context, self.in_stream), SSHConnection)
 
-    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('docker version', '1.2.3', '', 0))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('docker version', '1.2.3', '', 0))
     def test_docker_connection_module_too_old(self, mock_new_docker_verison, mock_old_docker_version):
         self.assertRaisesRegexp(AnsibleError, '^docker connection type requires docker 1.3 or higher$',
                                 DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')
 
-    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('docker version', '1.3.4', '', 0))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('docker version', '1.3.4', '', 0))
     def test_docker_connection_module(self, mock_new_docker_verison, mock_old_docker_version):
         self.assertIsInstance(DockerConnection(self.play_context, self.in_stream, docker_command='/fake/docker'),
                               DockerConnection)
 
     # old version and new version fail
-    @mock.patch('ansible.plugins.connection.docker._old_docker_version', return_value=('false', 'garbage', '', 1))
-    @mock.patch('ansible.plugins.connection.docker._new_docker_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._old_docker_cli_version', return_value=('false', 'garbage', '', 1))
+    @mock.patch('ansible.plugins.connection.docker._new_docker_cli_version', return_value=('false', 'garbage', '', 1))
     def test_docker_connection_module_wrong_cmd(self, mock_new_docker_version, mock_old_docker_version):
         self.assertRaisesRegexp(AnsibleError, '^Docker version check (.*?) failed: ',
                                 DockerConnection, self.play_context, self.in_stream, docker_command='/fake/docker')


### PR DESCRIPTION
##### SUMMARY
Allows the docker connection plugin to use Docker SDK for Python (aka docker-py) to communicate with the docker daemon, as opposed to using the `docker` CLI program. By default, it auto-detects whether to use the `cli` driver (i.e. use the `docker` CLI program) or the `docker-py` driver (i.e. the Docker SDK for Python), but the user can force the decision.

Fixes #17692.

There are currently some problems / things not implemented / working:

 1) Up- and downloading files requires the files to fit into memory. It would be nice to stream them, to reduce memory usage. That will definitely require some more work.

 2) `sudo` seems to work (haven't tested other become plugins), but pipelining right now isn't: it looks like passing larger amounts of data via stdin is not working, and it hangs after sending the data.

 3) There's no way to configure how to talk to the docker daemon yet. That's the easiest to add :)

I also had to touch the `synchronize` module; it won't work with the new Docker SDK for Python driver, as opposed to the `docker` CLI driver, since there's no `docker` executable we can just use.

CC @ssbarnea

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/docker.py
