### PR TITLE
NX-OS: Temporarily disable vpc peer-link tests

### DIFF
--- a/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -57,20 +57,27 @@
       that:
         - "result.changed == false"
 
+# The vpc peer-link command seems to be invalid for the NXOSv we have in Zuul CI
+# Hence, we're temporarily skipping the tests that have `peer_link` key
+
   - name: Configure vpc port channel
     nxos_vpc_interface: &conf1
       portchannel: 11
       peer_link: True
       provider: "{{ connection }}"
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *true
+    when: image_version != "7.0(3)I5(1)"
 
   - name: "Conf Idempotence"
     nxos_vpc_interface: *conf1
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *false
+    when: image_version != "7.0(3)I5(1)"
 
   - name: Configure vpc port channel
     nxos_vpc_interface: &conf2
@@ -78,14 +85,18 @@
       peer_link: False
       provider: "{{ connection }}"
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *true
+    when: image_version != "7.0(3)I5(1)"
 
   - name: "Conf Idempotence"
     nxos_vpc_interface: *conf2
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *false
+    when: image_version != "7.0(3)I5(1)"
 
   - name: remove vpc port channel
     nxos_vpc_interface: &remove


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- It seems that the `vpc peer-link` command is invalid for the NXOSv we have in CI.
- This PR temporarily disable these tests.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
targets/nxos_vpc_interface

##### ADDITIONAL INFORMATION
As per persistent log, we are sending the expected set of commands:
```
2019-12-27 19:36:07,678 p=26592 u=zuul n=ansible | jsonrpc request: b'{"jsonrpc": "2.0", \
"method": "edit_config", "id": "a3fe71a8-e1c7-49fd-adbd-cc580e7d1a6f", \
"params": [[["interface port-channel11", "vpc peer-link"]], {"replace": null}]}'
```
Failure log [here](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_53/64853/41fdca86a7c53652db37fd38f70e7eda8bfd0bea/third-party-check/ansible-test-network-integration-nxos-cli-python36/1222a33/controller/ara-report/result/65e29180-c22b-4c74-bd92-3577ef648186/).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
