### PR TITLE
vyos_config bug fix #66110

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -208,7 +208,13 @@ def get_candidate(module):
 
 
 def format_commands(commands):
-    return [line for line in commands if len(line.strip()) > 0]
+    """
+    This function format the input commands and removes the prepend white spaces
+    for command lines having 'set' or 'delete' and it skips empty lines.
+    :param commands:
+    :return: list of commands
+    """
+    return [line.strip() if line.split()[0] in ('set', 'delete') else line for line in commands if len(line.strip()) > 0]
 
 
 def diff_config(commands, config):

--- a/test/integration/targets/vyos_config/tests/cli/config.cfg
+++ b/test/integration/targets/vyos_config/tests/cli/config.cfg
@@ -1,0 +1,3 @@
+    set service lldp
+       set protocols static
+

--- a/test/integration/targets/vyos_config/tests/cli/simple.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/simple.yaml
@@ -25,6 +25,30 @@
     that:
       - "result.changed == false"
 
+- name: Configuring when commands starts with whitespaces
+  vyos_config:
+    src: "{{ role_path }}/tests/cli/config.cfg"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - '"set service lldp" in result.commands'
+      - '"set protocols static" in result.commands'
+
+- name: Delete description
+  vyos_config:
+    lines:
+      - delete service lldp
+      - delete protocols static
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - '"delete service lldp" in result.commands'
+      - '"delete protocols static" in result.commands'
+
 - name: teardown
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}

--- a/test/units/modules/network/vyos/fixtures/vyos_config_src.cfg
+++ b/test/units/modules/network/vyos/fixtures/vyos_config_src.cfg
@@ -2,5 +2,5 @@ set system host-name foo
 
 delete interfaces ethernet eth0 address
 set interfaces ethernet eth1 address '6.7.8.9/24'
-set interfaces ethernet eth1 description 'test string'
+     set interfaces ethernet eth1 description 'test string'
 set interfaces ethernet eth1 disable


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fixes #66110 
-  vyos_config module prepending  extra 'set' to config commands.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/network/vyos/vyos_config.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
