### PR TITLE
NX-OS: Use dict_diff instead of sets to take diff of lag members

### DIFF
--- a/lib/ansible/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/lag_interfaces/lag_interfaces.py
@@ -14,9 +14,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.network.common.cfg.base import ConfigBase
-from ansible.module_utils.network.common.utils import to_list, remove_empties
+from ansible.module_utils.network.common.utils import to_list, remove_empties, dict_diff, search_obj_in_list
 from ansible.module_utils.network.nxos.facts.facts import Facts
-from ansible.module_utils.network.nxos.utils.utils import normalize_interface, search_obj_in_list
+from ansible.module_utils.network.nxos.utils.utils import normalize_interface
 
 
 class Lag_interfaces(ConfigBase):
@@ -184,13 +184,22 @@ class Lag_interfaces(ConfigBase):
                 commands.extend(self.del_all_commands(h))
         return commands
 
-    def diff_list_of_dicts(self, w, h):
+    def diff_list_of_dicts(self, want, have):
+        if not want:
+            want = []
+
+        if not have:
+            have = []
+
         diff = []
-        set_w = set(tuple(d.items()) for d in w)
-        set_h = set(tuple(d.items()) for d in h)
-        difference = set_w.difference(set_h)
-        for element in difference:
-            diff.append(dict((x, y) for x, y in element))
+        for w_item in want:
+            h_item = search_obj_in_list(w_item['member'], have, key='member') or {}
+            delta = dict_diff(h_item, w_item)
+            if delta:
+                if 'member' not in delta.keys():
+                    delta['member'] = w_item['member']
+                diff.append(delta)
+
         return diff
 
     def intersect_list_of_dicts(self, w, h):


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- If the dictionary is read out of order from member the current logic in `diff_list_of_dicts` returns unwanted diff. Hence use `dict_diff` utils function instead of sets.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_lag_interfaces.py

##### ADDITIONAL INFORMATION
[CI Failure](https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_53/64853/41fdca86a7c53652db37fd38f70e7eda8bfd0bea/third-party-check/ansible-test-network-integration-nxos-cli-python36/1222a33/controller/ara-report/reports/0b1d5b8c-ed80-43bc-828b-5aa02abc2fe2.html) 
