### PR TITLE
Fix callback set_options issue with collections

### DIFF
--- a/changelogs/fragments/66128-fix-callback-set-options.yml
+++ b/changelogs/fragments/66128-fix-callback-set-options.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fix issue with callbacks ``set_options`` method that was not called with collections"

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -161,6 +161,7 @@ class TaskQueueManager:
         for callback_plugin_name in (c for c in C.DEFAULT_CALLBACK_WHITELIST if AnsibleCollectionRef.is_valid_fqcr(c)):
             # TODO: need to extend/duplicate the stdout callback check here (and possible move this ahead of the old way
             callback_obj = callback_loader.get(callback_plugin_name)
+            callback_obj.set_options()
             self._callback_plugins.append(callback_obj)
 
         self._callbacks_loaded = True


### PR DESCRIPTION
##### SUMMARY

Call the callback `set_options` method for collections callback.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #66127

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task_queue_manager.py

##### ADDITIONAL INFORMATION

Issue detected while moving the `grafana_annotations` callback to the [grafana collection](https://github.com/ansible-collections/grafana/issues/30).
