### PR TITLE
wrong usage of name tag in example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs_info.py
+++ b/lib/ansible/modules/cloud/amazon/efs_info.py
@@ -61,7 +61,7 @@ EXAMPLES = '''
 - name: Searching all EFS instances with tag Name = 'myTestNameTag', in subnet 'subnet-1a2b3c4d' and with security group 'sg-4d3c2b1a'
   efs_info:
     tags:
-        name: myTestNameTag
+        Name: myTestNameTag
     targets:
         - subnet-1a2b3c4d
         - sg-4d3c2b1a


### PR DESCRIPTION
##### SUMMARY
in name: section says that tag should be Name = ...
but in ansible code is name: ... which is wrong

in code should also be Name: 

That is: if you have in AWS tag with Name key you should use Name also in tags. and vice versa if you have key with name you should use name:


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
