### PR TITLE
wording in examples changed ios to eos

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlans.py
+++ b/lib/ansible/modules/network/eos/eos_vlans.py
@@ -93,7 +93,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Delete attributes of the given VLANs.
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
     state: deleted
@@ -119,7 +119,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Merge given VLAN attributes with device configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend
@@ -150,7 +150,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Override device configuration of all VLANs with provided configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend
@@ -177,7 +177,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Replace all attributes of specified VLANs with provided configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend


### PR DESCRIPTION
##### SUMMARY
wrong module was used in examples
ios_vlans changed to eos_vlans

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
