### PR TITLE
AWS Guidelines: Make 'security_token' optional

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -649,7 +649,7 @@ for every call, it's preferable to use :ref:`module_defaults <module_defaults>`.
        group/aws:
          aws_access_key: "{{ aws_access_key }}"
          aws_secret_key: "{{ aws_secret_key }}"
-         security_token: "{{ security_token }}"
+         security_token: "{{ security_token | default(omit) }}"
          region: "{{ aws_region }}"
 
      block:


### PR DESCRIPTION
#### SUMMARY

When running AWS integration tests against your own AWS account you'll likely not have a security_token configured for a test user (It's used when you generate temporary tokens). As such we should make security_token optional.

Backport of #66107

>> When would someone need to specify this?
>
> This module_defaults stanza is common to most AWS integration tests.
> 
> If you run the tests within shippable / Ansible's CI you're passed all 4 values as temporary authentication tokens. However, if you run the integration tests using a 'normal' IAM User you'll generally just use standard secret/access tokens, at which point you'll have region, an 'access key' and a 'secret key', importantly you'll not have a 'security token'.
>
> Using the ``| default(omit)`` tweak means that these defaults will work both with and without this 'security token'.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

AWS Guidelines

##### ADDITIONAL INFORMATION
CC @gundalow - backporting to 2.9 as requested