### PR TITLE
VMware: Add support for specify tag and category as dict

### DIFF
--- a/changelogs/fragments/65765-vmware_tag_manager.yml
+++ b/changelogs/fragments/65765-vmware_tag_manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added support to vmware_tag_manager module for specifying tag and category as dict if any of the name contains colon (https://github.com/ansible/ansible/issues/65765).

--- a/test/integration/targets/vmware_tag_manager/aliases
+++ b/test/integration/targets/vmware_tag_manager/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+unsupported
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_tag_manager/tasks/main.yml
+++ b/test/integration/targets/vmware_tag_manager/tasks/main.yml
@@ -1,0 +1,5 @@
+# Test code for the vmware_tag_manger Operations.
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- include: tag_manager_dict.yml

--- a/test/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
+++ b/test/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
@@ -1,0 +1,113 @@
+# Test code for the vmware_tag_manager Operations.
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Testcase for https://github.com/ansible/ansible/issues/65765
+- when: vcsim is not defined
+  block:
+    - name: Create first category
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        category_name: "{{ cat_one }}"
+        category_cardinality: 'multiple'
+        state: present
+      register: category_one_create
+
+    - name: Set category one id
+      set_fact: cat_one_id={{ category_one_create['category_results']['category_id'] }}
+
+    - name: Create tag with colon in name
+      vmware_tag:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_name: "{{ tag_one }}"
+        category_id: "{{ cat_one_id }}"
+        state: present
+      register: tag_one_create
+
+    - name: Check tag is created
+      assert:
+        that:
+          - tag_one_create.changed
+
+    - name: Get VM Facts
+      vmware_vm_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: False
+      register: vm_info
+
+    - set_fact: vm_name="{{ vm_info['virtual_machines'][0]['guest_name'] }}"
+
+    - name: Assign tag to given virtual machine
+      vmware_tag_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_names:
+          - category: "{{ cat_one }}"
+            tag: "{{ tag_one }}"
+        object_name: "{{ vm_name }}"
+        object_type: VirtualMachine
+        state: add
+      delegate_to: localhost
+      register: vm_tag_info
+
+    - name: Check if we assigned correct tags
+      assert:
+        that:
+          - vm_tag_info.changed
+
+    - name: Remove tag to given virtual machine
+      vmware_tag_manager:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_names:
+          - category: "{{ cat_one }}"
+            tag: "{{ tag_one }}"
+        object_name: "{{ vm_name }}"
+        object_type: VirtualMachine
+        state: remove
+      delegate_to: localhost
+      register: vm_tag_info
+
+    - name: Check if we removed correct tag
+      assert:
+        that:
+          - vm_tag_info.changed
+
+    - name: Delete Tags
+      vmware_tag:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        tag_name: "{{ item }}"
+        state: absent
+      register: delete_tag
+      with_items:
+        - "{{ tag_one }}"
+
+    - name: Delete Categories
+      vmware_category:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        category_name: "{{ item }}"
+        state: absent
+      register: delete_categories
+      with_items:
+        - "{{ cat_one }}"
+  vars:
+    cat_one: category_1003
+    tag_one: tag:1003


### PR DESCRIPTION
##### SUMMARY

User can now specify tag and category using dict in vmware_tag_manager
module. This is useful when tag or category name contains colon.

Fixes: #65765

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/65765-vmware_tag_manager.yml
lib/ansible/modules/cloud/vmware/vmware_tag_manager.py
test/integration/targets/vmware_tag/tasks/main.yml
test/integration/targets/vmware_tag/tasks/tag_manager_dict.yml
