### PR TITLE
docker_swarm_service: Fix parsing of Healthcheck.StartPeriod

### DIFF
--- a/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
+++ b/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_swarm_service - fix task always reporting as changed when using healthcheck.start_period."

--- a/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
+++ b/changelogs/fragments/66151-docker_swarm_service-healthcheck-start-period.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "docker_swarm_service - fix task always reporting as changed when using healthcheck.start_period."
+- "docker_swarm_service - fix task always reporting as changed when using ``healthcheck.start_period``."

--- a/lib/ansible/modules/cloud/docker/docker_swarm_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_service.py
@@ -2270,10 +2270,16 @@ class DockerServiceManager(object):
 
         healthcheck_data = task_template_data['ContainerSpec'].get('Healthcheck')
         if healthcheck_data:
-            options = ['test', 'interval', 'timeout', 'start_period', 'retries']
+            options = {
+                'Test': 'test',
+                'Interval': 'interval',
+                'Timeout': 'timeout',
+                'StartPeriod': 'start_period',
+                'Retries': 'retries'
+            }
             healthcheck = dict(
-                (key.lower(), value) for key, value in healthcheck_data.items()
-                if value is not None and key.lower() in options
+                (options[key], value) for key, value in healthcheck_data.items()
+                if value is not None and key in options
             )
             ds.healthcheck = healthcheck
 
@@ -2882,8 +2888,8 @@ def main():
             usage_msg='set publish.mode'
         ),
         healthcheck_start_period=dict(
-            docker_py_version='2.4.0',
-            docker_api_version='1.25',
+            docker_py_version='2.6.0',
+            docker_api_version='1.29',
             detect_usage=_detect_healthcheck_start_period,
             usage_msg='set healthcheck.start_period'
         ),

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -909,6 +909,7 @@
       timeout: 2s
       interval: 0h0m2s3ms4us
       retries: 2
+      start_period: 20s
   register: healthcheck_1
   ignore_errors: yes
 
@@ -926,6 +927,7 @@
       timeout: 2s
       interval: 0h0m2s3ms4us
       retries: 2
+      start_period: 20s
   register: healthcheck_2
   ignore_errors: yes
 
@@ -1029,12 +1031,12 @@
     - healthcheck_7 is not changed
     - healthcheck_8 is changed
     - healthcheck_9 is not changed
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.6.0', '>=')
+  when: docker_api_version is version('1.29', '>=') and docker_py_version is version('2.6.0', '>=')
 - assert:
     that:
     - healthcheck_1 is failed
     - "'Minimum version required' in healthcheck_1.msg"
-  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.6.0', '<')
+  when: docker_api_version is version('1.29', '<') or docker_py_version is version('2.6.0', '<')
 
 ###################################################################
 ## hostname #######################################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
When using the `healthcheck`-parameter `start_period` the task will always be reported as changed. This was due to a bug where `StartPeriod` was not properly mapped against `start_period`. This PR fixes this issue.

I also found that the version check of `healthcheck.start_period` is wrong. `Healthcheck.StartPeriod` was introduced in in [1.29](https://docs.docker.com/engine/api/version-history/#v129-api-changes) and not 1.25.

Fixes #66146

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docker_swarm_service
