### PR TITLE
Add lun for azure_rm_manageddisk

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -115,6 +115,12 @@ options:
             - 3
             - ''
         version_added: "2.8"
+    lun:
+        description:
+            - The logical unit number for data disk.
+            - This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM.
+        type: int
+        version_added: '2.10'
 
 extends_documentation_fragment:
     - azure
@@ -263,6 +269,9 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             attach_caching=dict(
                 type='str',
                 choices=['', 'read_only', 'read_write']
+            ),
+            lun=dict(
+                type='int'
             )
         )
         required_if = [
@@ -286,6 +295,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         self.zone = None
         self.managed_by = None
         self.attach_caching = None
+        self.lun = None
         super(AzureRMManagedDisk, self).__init__(
             derived_arg_spec=self.module_arg_spec,
             required_if=required_if,
@@ -343,9 +353,12 @@ class AzureRMManagedDisk(AzureRMModuleBase):
     def attach(self, vm_name, disk):
         vm = self._get_vm(vm_name)
         # find the lun
-        luns = ([d.lun for d in vm.storage_profile.data_disks]
-                if vm.storage_profile.data_disks else [])
-        lun = max(luns) + 1 if luns else 0
+        if self.lun==0 or self.lun:
+            lun = self.lun
+        else:
+            luns = ([d.lun for d in vm.storage_profile.data_disks]
+                    if vm.storage_profile.data_disks else [])
+            lun = max(luns) + 1 if luns else 0
 
         # prepare the data disk
         params = self.compute_models.ManagedDiskParameters(id=disk.get('id'), storage_account_type=disk.get('storage_account_type'))

--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -353,7 +353,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
     def attach(self, vm_name, disk):
         vm = self._get_vm(vm_name)
         # find the lun
-        if self.lun == 0 or self.lun:
+        if self.lun:
             lun = self.lun
         else:
             luns = ([d.lun for d in vm.storage_profile.data_disks]

--- a/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_manageddisk.py
@@ -353,7 +353,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
     def attach(self, vm_name, disk):
         vm = self._get_vm(vm_name)
         # find the lun
-        if self.lun==0 or self.lun:
+        if self.lun == 0 or self.lun:
             lun = self.lun
         else:
             luns = ([d.lun for d in vm.storage_profile.data_disks]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add lun for azure_rm_manageddisk. Use a user-provided LUN number rather than the next-sequential LUN number when using azure_rm_manageddisk module to attach a data disk to a VM.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_manageddisk
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
