### PR TITLE
PostgreSQL : Create unique index

### DIFF
--- a/changelogs/fragments/66157-postgresql-create-unique-indexes.yml
+++ b/changelogs/fragments/66157-postgresql-create-unique-indexes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - database - add support to unique indexes in postgresql_idx

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -528,7 +528,7 @@ def main():
     schema = module.params["schema"]
 
     if concurrent and cascade:
-        module.fail_json(msg="Cuncurrent mode and cascade parameters are mutually exclusive")
+         module.fail_json(msg="Concurrent mode and cascade parameters are mutually exclusive")
 
     if concurrent and unique:
         module.fail_json(msg="Cuncurrent mode and unique parameters are mutually exclusive")

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -94,6 +94,12 @@ options:
     - Mutually exclusive with I(cascade=yes).
     type: bool
     default: yes
+  unique:
+    description:
+    - Enable unique index.
+    - Mutually exclusive with I(state=absent).
+    type: bool
+    default: no 
   tablespace:
     description:
     - Set a tablespace for the index.
@@ -205,6 +211,13 @@ EXAMPLES = r'''
     db: mydb
     idxname: test_idx
     state: stat
+    
+- name: Create unique btree index if not exists test_unique_idx on column name of table products
+  postgresql_idx:
+    db: acme
+    table: products
+    columns: name
+    name: test_unique_idx
 '''
 
 RETURN = r'''
@@ -376,7 +389,7 @@ class Index(object):
             self.exists = False
             return False
 
-    def create(self, tblname, idxtype, columns, cond, tblspace, storage_params, concurrent=True):
+    def create(self, tblname, idxtype, columns, cond, tblspace, storage_params, concurrent=True, unique=False):
         """Create PostgreSQL index.
 
         Return True if success, otherwise, return False.
@@ -397,8 +410,13 @@ class Index(object):
         if idxtype is None:
             idxtype = "BTREE"
 
-        query = 'CREATE INDEX'
-
+        query = 'CREATE'
+        
+        if unique:
+            query += ' UNIQUE'
+        
+        query += ' INDEX
+        
         if concurrent:
             query += ' CONCURRENTLY'
 
@@ -476,6 +494,7 @@ def main():
         db=dict(type='str', aliases=['login_db']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'stat']),
         concurrent=dict(type='bool', default=True),
+        unique=dict(type='bool', default=False),
         table=dict(type='str'),
         idxtype=dict(type='str', aliases=['type']),
         columns=dict(type='list', aliases=['column']),
@@ -494,6 +513,7 @@ def main():
     idxname = module.params["idxname"]
     state = module.params["state"]
     concurrent = module.params["concurrent"]
+    unique = module.params["unique"]
     table = module.params["table"]
     idxtype = module.params["idxtype"]
     columns = module.params["columns"]
@@ -576,7 +596,7 @@ def main():
         if storage_params:
             storage_params = ','.join(storage_params)
 
-        changed = index.create(table, idxtype, columns, cond, tablespace, storage_params, concurrent)
+        changed = index.create(table, idxtype, columns, cond, tablespace, storage_params, concurrent, unique)
 
         if changed:
             kw = index.get_info()

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -99,7 +99,7 @@ options:
     - Enable unique index.
     - Mutually exclusive with I(state=absent).
     type: bool
-    default: no 
+    default: no
   tablespace:
     description:
     - Set a tablespace for the index.
@@ -211,7 +211,7 @@ EXAMPLES = r'''
     db: mydb
     idxname: test_idx
     state: stat
-    
+
 - name: Create unique btree index if not exists test_unique_idx on column name of table products
   postgresql_idx:
     db: acme
@@ -411,12 +411,12 @@ class Index(object):
             idxtype = "BTREE"
 
         query = 'CREATE'
-        
+
         if unique:
             query += ' UNIQUE'
-        
-        query += ' INDEX
-        
+
+        query += ' INDEX'
+
         if concurrent:
             query += ' CONCURRENTLY'
 

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -91,14 +91,13 @@ options:
       For more information about the lock levels see U(https://www.postgresql.org/docs/current/explicit-locking.html).
     - If the building process was interrupted for any reason when I(cuncurrent=yes), the index becomes invalid.
       In this case it should be dropped and created again.
-    - Mutually exclusive with I(cascade=yes) and I(unique=yes).
+    - Mutually exclusive with I(cascade=yes).
     type: bool
     default: yes
   unique:
     description:
     - Enable unique index.
     - Only btree currently supports unique indexes.
-    - Mutually exclusive with I(concurrent=yes).
     type: bool
     default: no
     version_added: '2.10'
@@ -529,9 +528,6 @@ def main():
 
     if concurrent and cascade:
         module.fail_json(msg="Concurrent mode and cascade parameters are mutually exclusive")
-
-    if concurrent and unique:
-        module.fail_json(msg="Cuncurrent mode and unique parameters are mutually exclusive")
 
     if unique and (idxtype and idxtype != 'btree'):
         module.fail_json(msg="Only btree currently supports unique indexes.")

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -100,6 +100,7 @@ options:
     - Mutually exclusive with I(state=absent).
     type: bool
     default: no
+    version_added: '2.10'
   tablespace:
     description:
     - Set a tablespace for the index.

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -530,7 +530,7 @@ def main():
         module.fail_json(msg="Concurrent mode and cascade parameters are mutually exclusive")
 
     if unique and (idxtype and idxtype != 'btree'):
-        module.fail_json(msg="Only btree currently supports unique indexes.")
+        module.fail_json(msg="Only btree currently supports unique indexes")
 
     if state == 'present':
         if not table:

--- a/lib/ansible/modules/database/postgresql/postgresql_idx.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_idx.py
@@ -528,7 +528,7 @@ def main():
     schema = module.params["schema"]
 
     if concurrent and cascade:
-         module.fail_json(msg="Concurrent mode and cascade parameters are mutually exclusive")
+        module.fail_json(msg="Concurrent mode and cascade parameters are mutually exclusive")
 
     if concurrent and unique:
         module.fail_json(msg="Cuncurrent mode and unique parameters are mutually exclusive")

--- a/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
+++ b/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
@@ -296,7 +296,7 @@
 - assert:
     that:
     - result is not changed
-    - result.msg == 'Only btree currently supports unique indexes.'
+    - result.msg == 'Only btree currently supports unique indexes'
 
 # Get idx stat in check mode
 - name: postgresql_idx - test state stat in check_mode

--- a/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
+++ b/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
@@ -253,6 +253,70 @@
     - result.schema == 'public'
     - result.query == 'CREATE INDEX CONCURRENTLY test1_idx ON public.test_table USING BTREE (id) WHERE id > 1 AND id != 10'
 
+- name: postgresql_idx - create unique index
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_idx:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    table: test_table
+    columns: story
+    idxname: test_unique0_idx
+    unique: yes
+    concurrent: no
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is changed
+    - result.tblname == 'test_table'
+    - result.name == 'test_unique0_idx'
+    - result.state == 'present'
+    - result.valid != ''
+    - result.tblspace == ''
+    - result.storage_params == []
+    - result.schema == 'public'
+    - result.query == 'CREATE UNIQUE INDEX test_unique0_idx ON public.test_table USING BTREE (story)'
+
+- name: postgresql_idx - check the mutuality of concurrent and unique params
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_idx:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    table: test_table
+    columns: story
+    idxname: test_unique0_idx
+    unique: yes
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is not changed
+    - result.msg == 'Cuncurrent mode and unique parameters are mutually exclusive'
+
+- name: postgresql_idx - avoid unique index with type different of btree
+  become_user: "{{ pg_user }}"
+  become: yes
+  postgresql_idx:
+    db: postgres
+    login_user: "{{ pg_user }}"
+    table: test_table
+    columns: story
+    idxname: test_unique0_idx
+    unique: yes
+    concurrent: no
+    type: brin
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - result is not changed
+    - result.msg == 'Only btree currently supports unique indexes.'
+
 # Get idx stat in check mode
 - name: postgresql_idx - test state stat in check_mode
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
+++ b/test/integration/targets/postgresql_idx/tasks/postgresql_idx_initial.yml
@@ -263,7 +263,6 @@
     columns: story
     idxname: test_unique0_idx
     unique: yes
-    concurrent: no
   register: result
   ignore_errors: yes
 
@@ -277,25 +276,7 @@
     - result.tblspace == ''
     - result.storage_params == []
     - result.schema == 'public'
-    - result.query == 'CREATE UNIQUE INDEX test_unique0_idx ON public.test_table USING BTREE (story)'
-
-- name: postgresql_idx - check the mutuality of concurrent and unique params
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_idx:
-    db: postgres
-    login_user: "{{ pg_user }}"
-    table: test_table
-    columns: story
-    idxname: test_unique0_idx
-    unique: yes
-  register: result
-  ignore_errors: yes
-
-- assert:
-    that:
-    - result is not changed
-    - result.msg == 'Cuncurrent mode and unique parameters are mutually exclusive'
+    - result.query == 'CREATE UNIQUE INDEX CONCURRENTLY test_unique0_idx ON public.test_table USING BTREE (story)'
 
 - name: postgresql_idx - avoid unique index with type different of btree
   become_user: "{{ pg_user }}"


### PR DESCRIPTION
##### SUMMARY
Add the unique params to `postgresql_idx`, with that we can create unique indexes with something like that:

```yaml
- name: Create unique btree index if not exists test_unique_idx on column name of table products
  postgresql_idx:
    db: acme
    table: products
    columns: name
    unique: yes
    concurrent: no
    name: test_unique_idx
```


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
database/postgresql

