### PR TITLE
[2.9] vmware_deploy_ovf: Use correct datastore in multi-datacenter environment

### DIFF
--- a/changelogs/fragments/63920-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/63920-vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Use correct datastore in multi-datacenter environment while using vmware_deploy_ovf (https://github.com/ansible/ansible/issues/63920).

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -168,8 +168,8 @@ def get_parent_datacenter(obj):
     return datacenter
 
 
-def find_datastore_by_name(content, datastore_name):
-    return find_object_by_name(content, datastore_name, [vim.Datastore])
+def find_datastore_by_name(content, datastore_name, datacenter_name=None):
+    return find_object_by_name(content, datastore_name, [vim.Datastore], datacenter_name)
 
 
 def find_dvs_by_name(content, switch_name, folder=None):
@@ -1272,16 +1272,18 @@ class PyVmomi(object):
             return False
         return True
 
-    def find_datastore_by_name(self, datastore_name):
+    def find_datastore_by_name(self, datastore_name, datacenter_name=None):
         """
         Get datastore managed object by name
         Args:
             datastore_name: Name of datastore
+            datacenter_name: Name of datacenter where the datastore resides.  This is needed because Datastores can be
+            shared across Datacenters, so we need to specify the datacenter to assure we get the correct Managed Object Reference
 
         Returns: datastore managed object if found else None
 
         """
-        return find_datastore_by_name(self.content, datastore_name=datastore_name)
+        return find_datastore_by_name(self.content, datastore_name=datastore_name, datacenter_name=datacenter_name)
 
     # Datastore cluster
     def find_datastore_cluster_by_name(self, datastore_cluster_name):

--- a/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
@@ -338,7 +338,7 @@ class VMwareDeployOvf(PyVmomi):
             if datastore:
                 self.datastore = datastore
         else:
-            self.datastore = self.find_datastore_by_name(self.params['datastore'])
+            self.datastore = self.find_datastore_by_name(self.params['datastore'], self.datacenter)
 
         if not self.datastore:
             self.module.fail_json(msg='%(datastore)s could not be located' % self.params)


### PR DESCRIPTION
##### SUMMARY

Fixes: #63920

Need to pass the datacenter to assure we get the correct datastore managed object Id.

(cherry picked from commit dc59880c31ee894f6545bdef25acbc792b9c1a9c)

Backport of https://github.com/ansible/ansible/pull/65152

##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/63920-vmware_deploy_ovf.yml
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_deploy_ovf.py
