### PR TITLE
ipa_dnsrecord: Add state append

### DIFF
--- a/changelogs/fragments/33193_ipa_dnsrecord_append.yml
+++ b/changelogs/fragments/33193_ipa_dnsrecord_append.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added 'append' state to append IPA dnsrecord entry (https://github.com/ansible/ansible/issues/33193).


### PR DESCRIPTION
##### SUMMARY

State 'append' allow user to append additional details into an
existing dnsrecord.

Fixes: #33193

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/33193_ipa_dnsrecord_append.yml
lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
