### PR TITLE
more reliably detect container environment

### DIFF
--- a/changelogs/fragments/detect-generic-container.yml
+++ b/changelogs/fragments/detect-generic-container.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- virtual facts - detect generic container environment based on non-empty
+  "container" env var

--- a/lib/ansible/module_utils/facts/utils.py
+++ b/lib/ansible/module_utils/facts/utils.py
@@ -36,11 +36,17 @@ def get_file_content(path, default=None, strip=True):
     return data
 
 
-def get_file_lines(path, strip=True):
+def get_file_lines(path, strip=True, line_sep=None):
     '''get list of lines from file'''
     data = get_file_content(path, strip=strip)
     if data:
-        ret = data.splitlines()
+        if line_sep is None:
+            ret = data.splitlines()
+        else:
+            if len(line_sep) == 1:
+                ret = data.rstrip(line_sep).split(line_sep)
+            else:
+                ret = data.split(line_sep)
     else:
         ret = []
     return ret

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -58,6 +58,10 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_type'] = 'podman'
                     virtual_facts['virtualization_role'] = 'guest'
                     return virtual_facts
+                if re.search('^container=.', line):
+                    virtual_facts['virtualization_type'] = 'container'
+                    virtual_facts['virtualization_role'] = 'guest'
+                    return virtual_facts
 
         if os.path.exists('/proc/vz') and not os.path.exists('/proc/lve'):
             virtual_facts['virtualization_type'] = 'openvz'

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -49,7 +49,7 @@ class LinuxVirtual(Virtual):
 
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):
-            for line in get_file_content('/proc/1/environ').split('\x00'):
+            for line in get_file_lines('/proc/1/environ', line_sep='\x00'):
                 if re.search('container=lxc', line):
                     virtual_facts['virtualization_type'] = 'lxc'
                     virtual_facts['virtualization_role'] = 'guest'

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -49,7 +49,7 @@ class LinuxVirtual(Virtual):
 
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):
-            for line in get_file_lines('/proc/1/environ'):
+            for line in get_file_content('/proc/1/environ').split('\x00'):
                 if re.search('container=lxc', line):
                     virtual_facts['virtualization_type'] = 'lxc'
                     virtual_facts['virtualization_role'] = 'guest'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes two bugs:

1. The `/proc/<pid>/environ` is null-delimited, not newline-delimited
2. Other container environments can be detected by looking for a non-empty `container=` environment variable, the same way that systemd looks for it.  A real-world example of where the current example fails is the Red Hat UBI containers which define `container=oci`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virtual

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```paste below
[root@317e6f4743a0 /]# ansible localhost -m setup -a gather_subset='virtual,!min'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "host", 
        "ansible_virtualization_type": "kvm", 
        "gather_subset": [
            "virtual", 
            "!min"
        ], 
        "module_setup": true
    }, 
    "changed": false
}
```
After
```
[root@317e6f4743a0 ansible]# ansible localhost -m setup -a gather_subset='virtual,!min'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "container", 
        "gather_subset": [
            "virtual", 
            "!min"
        ], 
        "module_setup": true
    }, 
    "changed": false
}
```

Also:
```
[root@317e6f4743a0 ansible]# systemd-detect-virt --container ; echo $?
other
0
```