### PR TITLE
get_url: Add new parameter 'encode_url' #66002

### DIFF
--- a/changelogs/fragments/66002-get_url-add-encode_url-option.yaml
+++ b/changelogs/fragments/66002-get_url-add-encode_url-option.yaml
@@ -1,0 +1,2 @@
+bugfix:
+    Added URL encoding option for get_url module.

--- a/changelogs/fragments/66002-get_url-add-encode_url-option.yaml
+++ b/changelogs/fragments/66002-get_url-add-encode_url-option.yaml
@@ -1,2 +1,2 @@
-bugfix:
-    Added URL encoding option for get_url module.
+minor_changes:
+  - Added URL encoding option for get_url module.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1087,16 +1087,16 @@ class Request:
     def _url_encode(self, url):
         protocol, domain, path, params, query, fragment = urllib_parse.urlparse(url)
         try:
-            path = urllib_parse.quote_plus(path, safe='<>%-_.!*():?#/@&+,;=') if path != None else ''
-            params = urllib_parse.quote_plus(params, safe='<>%-_.!*():?#/@&+,;=') if params != None else ''
-            query = urllib_parse.quote_plus(query, safe='<>%-_.!*():?#/@&+,;=') if query != None else ''
-            fragment= urllib_parse.quote_plus(fragment, safe='<>%-_.!*():?#/@&+,;=') if fragment != None else ''
+            path = urllib_parse.quote_plus(path, safe='<>%-_.!*():?#/@&+,;=') if path is not None else ''
+            params = urllib_parse.quote_plus(params, safe='<>%-_.!*():?#/@&+,;=') if params is not None else ''
+            query = urllib_parse.quote_plus(query, safe='<>%-_.!*():?#/@&+,;=') if query is not None else ''
+            fragment = urllib_parse.quote_plus(fragment, safe='<>%-_.!*():?#/@&+,;=') if fragment is not None else ''
         except AttributeError:
             # Python2
-            path = urllib_quote.quote_plus(path, safe='<>%-_.!*():?#/@&+,;=') if path != None else ''
-            params = urllib_quote.quote_plus(params, safe='<>%-_.!*():?#/@&+,;=') if params != None else ''
-            query = urllib_quote.quote_plus(query, safe='<>%-_.!*():?#/@&+,;=') if query != None else ''
-            fragment= urllib_quote.quote_plus(fragment, safe='<>%-_.!*():?#/@&+,;=') if fragment != None else ''
+            path = urllib_quote.quote_plus(path, safe='<>%-_.!*():?#/@&+,;=') if path is not None else ''
+            params = urllib_quote.quote_plus(params, safe='<>%-_.!*():?#/@&+,;=') if params is not None else ''
+            query = urllib_quote.quote_plus(query, safe='<>%-_.!*():?#/@&+,;=') if query is not None else ''
+            fragment = urllib_quote.quote_plus(fragment, safe='<>%-_.!*():?#/@&+,;=') if fragment is not None else ''
         url = urllib_parse.urlunparse([protocol, domain, path, params, query, fragment])
         return url
 
@@ -1437,6 +1437,7 @@ def url_argument_spec():
         force_basic_auth=dict(type='bool', default=False),
         client_cert=dict(type='path'),
         client_key=dict(type='path'),
+        encode_url=dict(type='bool', default=False),
     )
 
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1144,7 +1144,7 @@ class Request:
             connection to the provided url
         :kwarg ca_path: (optional) String of file system path to CA cert bundle to use
         :kwarg unredirected_headers: (optional) A list of headers to not attach on a redirected request
-        :kwarg encode_url: (optional) Encode URL into IDNA format.
+        :kwarg encode_url: (optional) Encode URL into persent encoding
         :returns: HTTPResponse. Added in Ansible 2.9
         """
 
@@ -1183,7 +1183,7 @@ class Request:
         if HAS_GSSAPI and use_gssapi:
             handlers.append(urllib_gssapi.HTTPSPNEGOAuthHandler())
 
-        # Encode url into IDNA format
+        # Encode url into persent encoding
         if encode_url:
             url = self._url_encode(url)
 
@@ -1459,7 +1459,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg unix_socket: (optional) String of file system path to unix socket file to use when establishing
         connection to the provided url
     :kwarg ca_path: (optional) String of file system path to CA cert bundle to use
-    :kwarg encode_url: (optional) Encode URL into IDNA format.
+    :kwarg encode_url: (optional) Encode URL into persent encoding.
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status > 400)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1144,7 +1144,7 @@ class Request:
             connection to the provided url
         :kwarg ca_path: (optional) String of file system path to CA cert bundle to use
         :kwarg unredirected_headers: (optional) A list of headers to not attach on a redirected request
-        :kwarg encode_url: (optional) Encode URL into persent encoding
+        :kwarg encode_url: (optional) Encode URL into percent encoding
         :returns: HTTPResponse. Added in Ansible 2.9
         """
 
@@ -1183,7 +1183,7 @@ class Request:
         if HAS_GSSAPI and use_gssapi:
             handlers.append(urllib_gssapi.HTTPSPNEGOAuthHandler())
 
-        # Encode url into persent encoding
+        # Encode url into percent encoding
         if encode_url:
             url = self._url_encode(url)
 
@@ -1459,7 +1459,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg unix_socket: (optional) String of file system path to unix socket file to use when establishing
         connection to the provided url
     :kwarg ca_path: (optional) String of file system path to CA cert bundle to use
-    :kwarg encode_url: (optional) Encode URL into persent encoding.
+    :kwarg encode_url: (optional) Encode URL into percent encoding.
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status > 400)

--- a/lib/ansible/modules/monitoring/grafana/grafana_dashboard.py
+++ b/lib/ansible/modules/monitoring/grafana/grafana_dashboard.py
@@ -487,6 +487,7 @@ def main():
     del argument_spec['force']
     del argument_spec['force_basic_auth']
     del argument_spec['http_agent']
+    del argument_spec['encode_url']
     argument_spec.update(
         state=dict(choices=['present', 'absent', 'export'], default='present'),
         url=dict(aliases=['grafana_url'], required=True),

--- a/lib/ansible/modules/monitoring/grafana/grafana_datasource.py
+++ b/lib/ansible/modules/monitoring/grafana/grafana_datasource.py
@@ -589,6 +589,7 @@ def main():
     del argument_spec['force']
     del argument_spec['force_basic_auth']
     del argument_spec['http_agent']
+    del argument_spec['encode_url']
 
     argument_spec.update(
         name=dict(required=True, type='str'),

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -343,7 +343,6 @@ from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
-
 # ==============================================================
 # url handling
 
@@ -509,7 +508,6 @@ def main():
 
         if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
             checksum_url = checksum
-
             # download checksum file to checksum_tmpsrc
             checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, encode_url)
             with open(checksum_tmpsrc) as f:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -174,6 +174,7 @@ options:
       - If checksum URL is specified with C(checksum), it will also be encoded.
     type: bool
     default: no
+    version_added: '2.10'
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files
@@ -367,7 +368,8 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
         method = 'GET'
 
     start = datetime.datetime.utcnow()
-    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method, encode_url=encode_url)
+    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method,
+                          encode_url=encode_url)
     elapsed = (datetime.datetime.utcnow() - start).seconds
 
     if info['status'] == 304:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -170,7 +170,7 @@ options:
     default: ansible-httpget
   encode_url:
     description:
-      - Encode URL into IDNA format.
+      - Encode URL into persent encoding.
     type: bool
     default: no
 # informational: requirements for nodes

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -170,7 +170,8 @@ options:
     default: ansible-httpget
   encode_url:
     description:
-      - If C(yes), URL specified with I(url) will be encoded into persent encoding.
+      - If C(yes), URL specified with C(url) will be encoded into percent encoding.
+      - If checksum URL is specified with C(checksum), it will also be encoded.
     type: bool
     default: no
 # informational: requirements for nodes

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -170,7 +170,7 @@ options:
     default: ansible-httpget
   encode_url:
     description:
-      - Encode URL into persent encoding.
+      - If C(yes), URL specified with I(url) will be encoded into persent encoding.
     type: bool
     default: no
 # informational: requirements for nodes

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -551,6 +551,10 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
 
 def main():
     argument_spec = url_argument_spec()
+
+    # remove unnecessary arguments
+    del argument_spec['encode_url']
+
     argument_spec.update(
         dest=dict(type='path'),
         url_username=dict(type='str', aliases=['user']),

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -63,6 +63,6 @@ options:
     type: path
   encode_url:
     description:
-      - If C(yes), URL specified with I(url) will be encoded into persent encoding.
+      - If C(yes), URL specified with C(url) will be encoded into percent encoding.
     type: bool
 '''

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -61,4 +61,8 @@ options:
       - PEM formatted file that contains your private key to be used for SSL client authentication.
       - If C(client_cert) contains both the certificate and key, this option is not required.
     type: path
+  encode_url:
+    description:
+      - If C(yes), URL specified with I(url) will be encoded into persent encoding.
+    type: bool
 '''

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -48,6 +48,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         cookies=cookies,
         unix_socket='/foo/bar/baz.sock',
         ca_path='/foo/bar/baz.pem',
+        encode_url=False,
     )
     fallback_mock = mocker.spy(request, '_fallback')
 
@@ -68,10 +69,11 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, cookies),  # cookies
         call(None, '/foo/bar/baz.sock'),  # unix_socket
         call(None, '/foo/bar/baz.pem'),  # ca_path
+        call(None, False),  # encode_url
     ]
     fallback_mock.assert_has_calls(calls)
 
-    assert fallback_mock.call_count == 14  # All but headers use fallback
+    assert fallback_mock.call_count == 15  # All but headers use fallback
 
     args = urlopen_mock.call_args[0]
     assert args[1] is None  # data, this is handled in the Request not urlopen
@@ -453,4 +455,4 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      url_username=None, url_password=None, http_agent=None,
                                      force_basic_auth=False, follow_redirects='urllib2',
                                      client_cert=None, client_key=None, cookies=None, use_gssapi=False,
-                                     unix_socket=None, ca_path=None, unredirected_headers=None)
+                                     unix_socket=None, ca_path=None, unredirected_headers=None, encode_url=False)

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -67,7 +67,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert=None, client_key=None, cookies=kwargs['cookies'], data=None,
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
-                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None)
+                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None, encode_url=False)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -89,7 +89,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert='client.pem', client_key='client.key', cookies=kwargs['cookies'], data=None,
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
-                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None)
+                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None, encode_url=False)
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added URL encoding option for get_url module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #66002

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/urls.py
lib/ansible/modules/net_tools/basics/get_url.py
lib/ansible/plugins/doc_fragments/url.py
changelogs/fragments/66002-get_url-add-encode_url-option.yaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added `encode_url` option for `get_url` module.

 - If `encode_url` is set to `yes`, it encodes URL string into percent encoding format.
 - This module uses `urllib.parse.quote_plus` in python3, and uses `urllib.quote_plus` in python2.
 - It encodes only path, params, query and fragment in URL string. 
 - If checksum URL is specified, it will also be encoded.

I'm new to this project. Please let me know if there is anything wrong.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```