### PR TITLE
Add support for OSCM-distribution in hostname module

### DIFF
--- a/changelogs/fragments/66189-hostname-osmc.yml
+++ b/changelogs/fragments/66189-hostname-osmc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Added support for OSMC distro in hostname module (https://github.com/ansible/ansible/issues/66189).

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -796,6 +796,12 @@ class NeonHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class OsmcHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Osmc'
+    strategy_class = SystemdStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
Added subclass to detect the new distribution OSMC

##### SUMMARY
Fixes #66189
Just added a new subclass to respect the Linux distribution Osmc.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module hostname

##### ADDITIONAL INFORMATION
see reported issue