### PR TITLE
doc: Update regex_replace documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1216,23 +1216,23 @@ To replace text in a string with regex, use the "regex_replace" filter::
    For example ``^(.*)$`` will always match only one result, while ``(.*)`` on some Python versions will match the whole string and an empty string at the
    end, which means it will make two replacements::
 
-    # add "https://" prefix to each item in a list
-    GOOD:
-    {{ hosts | map('regex_replace', '^(.*)$', 'https://\\1') | list }}
-    {{ hosts | map('regex_replace', '(.+)', 'https://\\1') | list }}
-    {{ hosts | map('regex_replace', '^', 'https://') | list }}
+      # add "https://" prefix to each item in a list
+      GOOD:
+      {{ hosts | map('regex_replace', '^(.*)$', 'https://\\1') | list }}
+      {{ hosts | map('regex_replace', '(.+)', 'https://\\1') | list }}
+      {{ hosts | map('regex_replace', '^', 'https://') | list }}
 
-    BAD:
-    {{ hosts | map('regex_replace', '(.*)', 'https://\\1') | list }}
+      BAD:
+      {{ hosts | map('regex_replace', '(.*)', 'https://\\1') | list }}
 
-    # append ':80' to each item in a list
-    GOOD:
-    {{ hosts | map('regex_replace', '^(.*)$', '\\1:80') | list }}
-    {{ hosts | map('regex_replace', '(.+)', '\\1:80') | list }}
-    {{ hosts | map('regex_replace', '$', ':80') | list }}
+      # append ':80' to each item in a list
+      GOOD:
+      {{ hosts | map('regex_replace', '^(.*)$', '\\1:80') | list }}
+      {{ hosts | map('regex_replace', '(.+)', '\\1:80') | list }}
+      {{ hosts | map('regex_replace', '$', ':80') | list }}
 
-    BAD:
-    {{ hosts | map('regex_replace', '(.*)', '\\1:80') | list }}
+      BAD:
+      {{ hosts | map('regex_replace', '(.*)', '\\1:80') | list }}
 
 .. note:: Prior to ansible 2.0, if "regex_replace" filter was used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments),
    then you needed to escape backreferences (e.g. ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).


### PR DESCRIPTION
The `regex_replace` documentation included an example that was meant
to be preformatted text but due to an indentation error was rendering
incorrectly.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbooks_filters.rst