### PR TITLE
Backport 2.9: Fix nxos_user roles bug (#65962)

### DIFF
--- a/changelogs/fragments/65962_nxos_user_roles_fix.yaml
+++ b/changelogs/fragments/65962_nxos_user_roles_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix issue where nxos_user unintentionally creates user with two different roles (https://github.com/ansible/ansible/pull/65962)

--- a/test/integration/targets/nxos_user/tests/common/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/common/basic.yaml
@@ -21,11 +21,13 @@
     state: present
   register: result
 
+- debug: msg="{{result}}"
+
 - assert:
     that:
       - 'result.changed == true'
       - '"username" in result.commands[0]'
-      - '"role network-operator" in result.commands[1]'
+      - '"role network-operator" in result.commands[0]'
 
 - name: Collection of users
   nxos_user:

--- a/test/integration/targets/nxos_user/tests/common/net_user.yaml
+++ b/test/integration/targets/nxos_user/tests/common/net_user.yaml
@@ -25,7 +25,7 @@
     that:
       - 'result.changed == true'
       - '"username" in result.commands[0]'
-      - '"role network-operator" in result.commands[1]'
+      - '"role network-operator" in result.commands[0]'
 
 - name: teardown
   net_user:


### PR DESCRIPTION
(cherry picked from commit c2fed8603c4d087fe4d5a1b752f7fa880520c911)

Backport of https://github.com/ansible/ansible/pull/65962

Add changelog for nxos_user roles fix

##### SUMMARY

Fixes #65954

This module has an order of operation bug. The module will build a list of commands based on checking each parameter individually. It's possible to end up with a list of commands that include the username first without a role (this case it will use the default role) and then later a command that specifies a role. This results in undesired behavior where the username has both the default and non-default role configured but the playbook explicitly requested a non-default role. This fix configures roles first if the playbook specifies a role to avoid this oder of operation issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_user.py

```
