### PR TITLE
wrong usage of name tag in example (repeating #66129)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -121,7 +121,7 @@ EXAMPLES = '''
     state: present
     name: myTestEFS
     tags:
-        name: myTestNameTag
+        Name: myTestNameTag
         purpose: file-storage
     targets:
         - subnet_id: subnet-748c5d03


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Repeating the previous change https://github.com/ansible/ansible/pull/66129/commits/1b2f1f913eff1b8cf8dba4397fe500ea346d669c

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Related with #66129

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- lib/ansible/modules/cloud/amazon/efs.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This PR is just repeating previous change that is made by @orescek and @acozine