### PR TITLE
Netbox prefix fix prefix creation and idempotency on update

### DIFF
--- a/lib/ansible/modules/net_tools/netbox/netbox_prefix.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_prefix.py
@@ -404,13 +404,14 @@ def get_or_create_prefix(nb_endpoint, data):
             module.fail_json(
                 msg="Request failed, couldn't update prefix: %s" % (data["prefix"])
             )
-        if diff:
+
+        if not diff or (len(diff['after']) == 0 and len(diff['before']) == 0):
+            msg = "Prefix %s already exists" % (data["prefix"])
+            changed = False
+        else:
             msg = "Prefix %s updated" % (data["prefix"])
             changed = True
             result["diff"] = diff
-        else:
-            msg = "Prefix %s already exists" % (data["prefix"])
-            changed = False
 
     result.update({"prefix": prefix, "msg": msg, "changed": changed})
     return result

--- a/lib/ansible/modules/net_tools/netbox/netbox_prefix.py
+++ b/lib/ansible/modules/net_tools/netbox/netbox_prefix.py
@@ -355,9 +355,9 @@ def _check_and_adapt_data(nb, data):
 
 def _search_prefix(nb_endpoint, data):
     if data.get("prefix"):
-        prefix = ipaddress.ip_network(data["prefix"])
+        prefix = ipaddress.ip_network(unicode(data["prefix"]))
     elif data.get("parent"):
-        prefix = ipaddress.ip_network(data["parent"])
+        prefix = ipaddress.ip_network(unicode(data["parent"]))
 
     network = to_text(prefix.network_address)
     mask = prefix.prefixlen


### PR DESCRIPTION
##### SUMMARY

Fixing #66204 66204
Note: There is still work to do because the netbox_prefix module is still not idempotent

The main issue is that the module netbox_prefix was sending a string instead of a unicode
to ipaddress.ip_nework.
The ValueError exception was then silently catched.

I enforced the unicode type in the argument and created a new exception to this module
to be sure we silently cacth only what we are raising in this module.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
netbox_prefix

##### ADDITIONAL INFORMATION
Everything is in the issue’s description.
