### PR TITLE
Do not install already installed packages via DNF, Fixes #64963

### DIFF
--- a/changelogs/fragments/64963-dnf_idempotence.yml
+++ b/changelogs/fragments/64963-dnf_idempotence.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf - Fix idempotence of `state: installed` (https://github.com/ansible/ansible/issues/64963)"

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -41,6 +41,24 @@
         that:
             - "'msg' in dnf_result"
     # ============================================================================
+    - name: Install dinginessentail again (noop, module is idempotent)
+      dnf:
+        name: dinginessentail
+        state: present
+      register: dnf_result
+
+    - name: Check dinginessentail with rpm
+      shell: rpm -q dinginessentail
+      register: rpm_result
+
+    - name: Verify installation
+      assert:
+        that:
+            # No upgrade happened to 1.1.1
+            - "not dnf_result.changed"
+            # Old version still installed
+            - "rpm_result.stdout.startswith('dinginessentail-1.0-1')"
+    # ============================================================================
     - name: Install dinginessentail-1:1.0-2
       dnf:
         name: "dinginessentail-1:1.0-2.{{ ansible_architecture }}"


### PR DESCRIPTION
##### SUMMARY
I restructured the dnf code that marks packages for installation to not mark already installed packages as this would result in an upgrade instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
dnf

##### ADDITIONAL INFORMATION
The original reproducer and output can be found in #64963, below is the fixed output
```
TASK [dnf] ***********************************************************************************************************************************************************************************************************************************
changed: [testing_dnf] => {"ansible_facts": {"discovered_interpreter_python": "/usr/libexec/platform-python"}, "changed": true, "msg": "", "rc": 0, "results": ["Removed: epel-release-8-5.el8.noarch"]}

TASK [dnf] ***********************************************************************************************************************************************************************************************************************************
changed: [testing_dnf] => {"changed": true, "msg": "", "rc": 0, "results": ["Installed: epel-release-8-5.el8.noarch"]}

TASK [dnf] ***********************************************************************************************************************************************************************************************************************************
ok: [testing_dnf] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}
```
