### PR TITLE
Use libc wcwidth to calculate print width in display

### DIFF
--- a/changelogs/fragments/63105-wcswidth.yml
+++ b/changelogs/fragments/63105-wcswidth.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Display - Use wcswidth to calculate printable width of a text string
+  (https://github.com/ansible/ansible/issues/63105)

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -60,10 +60,12 @@ if __name__ == '__main__':
 
     try:  # bad ANSIBLE_CONFIG or config options can force ugly stacktrace
         import ansible.constants as C
-        from ansible.utils.display import Display
+        from ansible.utils.display import Display, initialize_locale
     except AnsibleOptionsError as e:
         display.error(to_text(e), wrap_text=False)
         sys.exit(5)
+
+    initialize_locale()
 
     cli = None
     me = os.path.basename(sys.argv[0])

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -26,6 +26,7 @@ __requires__ = ['ansible_base']
 
 
 import errno
+import locale
 import os
 import shutil
 import sys
@@ -35,6 +36,8 @@ from ansible import context
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_text
 
+# Set the locale to the users default setting
+locale.setlocale(locale.LC_ALL, '')
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -35,6 +35,7 @@ from ansible import context
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_text
 
+
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
 _PY3_MIN = sys.version_info[:2] >= (3, 5)

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -26,7 +26,6 @@ __requires__ = ['ansible_base']
 
 
 import errno
-import locale
 import os
 import shutil
 import sys
@@ -35,9 +34,6 @@ import traceback
 from ansible import context
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_text
-
-# Set the locale to the users default setting
-locale.setlocale(locale.LC_ALL, '')
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -49,6 +49,8 @@ except NameError:
     # Python 3, we already have raw_input
     pass
 
+# Set the locale to the users default setting
+locale.setlocale(locale.LC_ALL, '')
 
 _LIBC = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
 # Set argtypes, to avoid segfault if the wrong type is provided,

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -151,8 +151,6 @@ b_COW_PATHS = (
 )
 
 
-
-
 class Display(with_metaclass(Singleton, object)):
 
     def __init__(self, verbosity=0):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -56,7 +56,7 @@ _LIBC = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
 _LIBC.wcwidth.argtypes = (ctypes.c_wchar,)
 _LIBC.wcswidth.argtypes = (ctypes.c_wchar_p, ctypes.c_int)
 # Max for c_int
-_MAX_INT =  2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
+_MAX_INT = 2 ** (ctypes.sizeof(ctypes.c_int) * 8 - 1) - 1
 
 
 def get_text_width(text):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -405,6 +405,8 @@ class Display(with_metaclass(Singleton, object)):
         '''
         Prints a header-looking line with cowsay or stars with length depending on terminal width (3 minimum)
         '''
+        msg = to_text(msg)
+
         if self.b_cowsay and cows:
             try:
                 self.banner_cowsay(msg)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -115,13 +115,13 @@ def get_text_width(text):
     for c in text:
         counter += 1
         if c in (u'\x08', u'\x7f', u'\x94', u'\x1b'):
-            counter -= 1
             # A few characters result in a subtraction of length:
             # BS, DEL, CCH, ESC
             # ESC is slightly different in that it's part of an escape sequence, and
             # while ESC is non printable, it's part of an escape sequence, which results
             # in a single non printable length
             width -= 1
+            counter -= 1
             continue
 
         try:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -37,7 +37,7 @@ from termios import TIOCGWINSZ
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils._text import to_bytes, to_text, to_native
-from ansible.module_utils.six import with_metaclass, string_types, text_type
+from ansible.module_utils.six import with_metaclass, text_type
 from ansible.utils.color import stringc
 from ansible.utils.singleton import Singleton
 from ansible.utils.unsafe_proxy import wrap_var

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -81,6 +81,15 @@ def get_text_width(text):
 
     width = 0
     for c in text:
+        if c in ('\x08', '\x7f', '\x94', '\x1b'):
+            # A few characters result in a subtraction of length:
+            # BS, DEL, CCH, ESC
+            # ESC is slightly different in that it's part of an escape sequence, and
+            # while ESC is non printable, it's part of an escape sequence, which results
+            # in a single non printable length
+            width -= 1
+            continue
+
         try:
             w = _LIBC.wcwidth(c)
         except ctypes.ArgumentError:
@@ -90,7 +99,8 @@ def get_text_width(text):
             # use 0 here as a best effort
             w = 0
         width += w
-    return width
+    # It doesn't make sense to have a negative printable width
+    return width if width >= 0 else 0
 
 
 class FilterBlackList(logging.Filter):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -72,7 +72,6 @@ def get_text_width(text):
     On Py2, this depends on ``locale.setlocale(locale.LC_ALL, '')``,
     that in the case of Ansible is done in ``bin/ansible``
     """
-    text = to_text(text)
     try:
         width = _LIBC.wcswidth(text, _MAX_INT)
     except ctypes.ArgumentError:

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -21,3 +21,9 @@ def test_get_text_width():
     assert get_text_width(u'ab\u0000') == 2
     assert get_text_width(u'abコ\u0000') == 4
     assert get_text_width(u'🚀🐮') == 4
+    assert get_text_width('\x08') == 0
+    assert get_text_width('\x08\x08') == 0
+    assert get_text_width('ab\x08cd') == 3
+    assert get_text_width('ab\x1bcd') == 3
+    assert get_text_width('ab\x7fcd') == 3
+    assert get_text_width('ab\x94cd') == 3

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -20,3 +20,4 @@ def test_get_text_width():
     assert get_text_width(u'\u001B') == 0
     assert get_text_width(u'ab\u0000') == 2
     assert get_text_width(u'abコ\u0000') == 4
+    assert get_text_width(u'🚀🐮') == 4

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,9 +5,14 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import locale
+
 import pytest
 
 from ansible.utils.display import get_text_width
+
+# Set the locale to the users default setting
+locale.setlocale(locale.LC_ALL, '')
 
 
 def test_get_text_width():

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,14 +5,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import locale
-
 import pytest
 
 from ansible.utils.display import get_text_width
-
-# Set the locale to the users default setting
-locale.setlocale(locale.LC_ALL, '')
 
 
 def test_get_text_width():
@@ -23,5 +18,5 @@ def test_get_text_width():
     assert get_text_width(1) == 1
     assert get_text_width(b'four') == 4
     assert get_text_width(u'\u001B') == 0
-    assert get_text_width(u'a\u0000b') == 2
-    assert get_text_width(u'a\u0000bコ') == 4
+    assert get_text_width(u'ab\u0000') == 2
+    assert get_text_width(u'abコ\u0000') == 4

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.utils.display import get_text_width
+
+
+def test_get_text_width():
+    assert get_text_width(u'コンニチハ') == 10
+    assert get_text_width(u'abコcd') == 6
+    assert get_text_width(u'café') == 4
+    assert get_text_width(u'four') == 4
+    assert get_text_width(1) == 1
+    assert get_text_width(b'four') == 4
+    assert get_text_width(u'\u001B') == 0
+    assert get_text_width(u'a\u0000b') == 2
+    assert get_text_width(u'a\u0000bコ') == 4

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,25 +5,61 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from units.compat.mock import MagicMock
+
 import pytest
 
-from ansible.utils.display import get_text_width
+from ansible.module_utils.six import PY3
+from ansible.utils.display import Display, get_text_width, initialize_locale
 
 
 def test_get_text_width():
+    initialize_locale()
     assert get_text_width(u'コンニチハ') == 10
     assert get_text_width(u'abコcd') == 6
     assert get_text_width(u'café') == 4
     assert get_text_width(u'four') == 4
-    assert get_text_width(1) == 1
-    assert get_text_width(b'four') == 4
     assert get_text_width(u'\u001B') == 0
     assert get_text_width(u'ab\u0000') == 2
     assert get_text_width(u'abコ\u0000') == 4
     assert get_text_width(u'🚀🐮') == 4
-    assert get_text_width('\x08') == 0
-    assert get_text_width('\x08\x08') == 0
-    assert get_text_width('ab\x08cd') == 3
-    assert get_text_width('ab\x1bcd') == 3
-    assert get_text_width('ab\x7fcd') == 3
-    assert get_text_width('ab\x94cd') == 3
+    assert get_text_width(u'\x08') == 0
+    assert get_text_width(u'\x08\x08') == 0
+    assert get_text_width(u'ab\x08cd') == 3
+    assert get_text_width(u'ab\x1bcd') == 3
+    assert get_text_width(u'ab\x7fcd') == 3
+    assert get_text_width(u'ab\x94cd') == 3
+
+    pytest.raises(TypeError, get_text_width, 1)
+    pytest.raises(TypeError, get_text_width, b'four')
+
+
+@pytest.mark.skipif(PY3, reason='Fallback only happens reliably on py2')
+def test_get_text_width_no_locale():
+    pytest.raises(EnvironmentError, get_text_width, u'🚀🐮')
+
+
+def test_Display_banner_get_text_width(monkeypatch):
+    initialize_locale()
+    display = Display()
+    display_mock = MagicMock()
+    monkeypatch.setattr(display, 'display', display_mock)
+
+    display.banner(u'🚀🐮', color=False, cows=False)
+    args, kwargs = display_mock.call_args
+    msg = args[0]
+    stars = u' %s' % (75 * u'*')
+    assert msg.endswith(stars)
+
+
+@pytest.mark.skipif(PY3, reason='Fallback only happens reliably on py2')
+def test_Display_banner_get_text_width_fallback(monkeypatch):
+    display = Display()
+    display_mock = MagicMock()
+    monkeypatch.setattr(display, 'display', display_mock)
+
+    display.banner(u'🚀🐮', color=False, cows=False)
+    args, kwargs = display_mock.call_args
+    msg = args[0]
+    stars = u' %s' % (77 * u'*')
+    assert msg.endswith(stars)


### PR DESCRIPTION
##### SUMMARY
Use libc wcwidth to calculate print width in display. Fixes #63105

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
