### PR TITLE
Add support for extra options for terraform init

### DIFF
--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -109,7 +109,7 @@ options:
       - Allow extra options to be given to terraform init command.
     required: false
     type: list
-    version_added: 2.10
+    version_added: "2.10"
 notes:
    - To just run a `terraform plan`, use check mode.
 requirements: [ "terraform" ]


### PR DESCRIPTION
##### SUMMARY

ansible 2.10 :
When using terraform init, we might want to add extra args (https://www.terraform.io/docs/commands/init.html):

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
    - terraform:
        project_path: "/tfpath"
        variables: "{{ tfvars }}"
        backend_config: "{{ terraform_backend_config_vars }}"
        state: 'planned'
        workspace: "{{ env_name }}"
        force_init: true
        init_extra_args:
          - "-reconfigure"
        plan_file: "terraform.planfile"
```
