### PR TITLE
Remove unstable from yum tests since they are working on Fedora 31 now

### DIFF
--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group4
 skip/freebsd
 skip/osx
-unstable


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #65674 

It looks like the task that was failing is now working. Removing the `unstable` mark for `yum` tests.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/yum/aliases`