### PR TITLE
Add changed condition when update azure_rm_virtualnetworkpeering

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetworkpeering.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetworkpeering.py
@@ -251,7 +251,10 @@ class AzureRMVirtualNetworkPeering(AzureRMModuleBase):
                     self.fail("Cannot update remote_virtual_network of Virtual Network Peering!")
 
                 # check if update
-                to_be_updated = self.check_update(response)
+                if response['peering_state'] == 'Disconnected':
+                    to_be_updated = True
+                else:
+                    to_be_updated = self.check_update(response)
 
             else:
                 # not exists, create new vnet peering


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The enhancement would be to enforce peerings where if either the remote or local vnet is disconnected to delete and recreate. Try to fixes #66031 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_virtualnetworkpeering
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
