### PR TITLE
VMware: Add advanced settings to vmware_cluster_drs

### DIFF
--- a/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
+++ b/changelogs/fragments/66217-vmware_cluster_drs-advanced-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_cluster_drs - Implemented DRS advanced settings (https://github.com/ansible/ansible/issues/66217)

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster_drs.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster_drs.py
@@ -73,7 +73,7 @@ options:
     advanced_settings:
       version_added: "2.10"
       description:
-      - A dictionary of advanced HA settings.
+      - A dictionary of advanced DRS settings.
       default: {}
       type: dict
 extends_documentation_fragment: vmware.documentation
@@ -88,6 +88,18 @@ EXAMPLES = r"""
     datacenter_name: datacenter
     cluster_name: cluster
     enable_drs: yes
+  delegate_to: localhost
+
+- name: Enable DRS and distribute a more even number of virtual machines across hosts for availability
+  vmware_cluster_drs:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: datacenter
+    cluster_name: cluster
+    enable_drs: yes
+    advanced_settings:
+      'TryBalanceVmsPerHost': '1'
   delegate_to: localhost
 
 - name: Enable DRS and set default VM behavior to partially automated

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster_drs.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster_drs.py
@@ -70,6 +70,12 @@ options:
       type: int
       default: 3
       choices: [ 1, 2, 3, 4, 5 ]
+    advanced_settings:
+      version_added: "2.10"
+      description:
+      - A dictionary of advanced HA settings.
+      default: {}
+      type: dict
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -107,7 +113,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import (PyVmomi, TaskError, find_datacenter_by_name,
-                                         vmware_argument_spec, wait_for_task)
+                                         vmware_argument_spec, wait_for_task, option_diff)
 from ansible.module_utils._text import to_native
 
 
@@ -128,6 +134,12 @@ class VMwareCluster(PyVmomi):
         if self.cluster is None:
             self.module.fail_json(msg="Cluster %s does not exist." % self.cluster_name)
 
+        self.advanced_settings = self.params.get('advanced_settings')
+        if self.advanced_settings:
+            self.changed_advanced_settings = option_diff(self.advanced_settings, self.cluster.configurationEx.drsConfig.option)
+        else:
+            self.changed_advanced_settings = None
+
     def check_drs_config_diff(self):
         """
         Check DRS configuration diff
@@ -141,6 +153,10 @@ class VMwareCluster(PyVmomi):
                 drs_config.defaultVmBehavior != self.params.get('drs_default_vm_behavior') or \
                 drs_config.vmotionRate != self.params.get('drs_vmotion_rate'):
             return True
+
+        if self.changed_advanced_settings:
+            return True
+
         return False
 
     def configure_drs(self):
@@ -158,6 +174,10 @@ class VMwareCluster(PyVmomi):
                 cluster_config_spec.drsConfig.enableVmBehaviorOverrides = self.params.get('drs_enable_vm_behavior_overrides')
                 cluster_config_spec.drsConfig.defaultVmBehavior = self.params.get('drs_default_vm_behavior')
                 cluster_config_spec.drsConfig.vmotionRate = self.params.get('drs_vmotion_rate')
+
+                if self.changed_advanced_settings:
+                    cluster_config_spec.drsConfig.option = self.changed_advanced_settings
+
                 try:
                     task = self.cluster.ReconfigureComputeResource_Task(cluster_config_spec, True)
                     changed, result = wait_for_task(task)
@@ -190,6 +210,7 @@ def main():
         drs_vmotion_rate=dict(type='int',
                               choices=range(1, 6),
                               default=3),
+        advanced_settings=dict(type='dict', default=dict(), required=False),
     ))
 
     module = AnsibleModule(

--- a/test/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -50,14 +50,48 @@
     that:
         - "{{ cluster_drs_result_0002.changed == true }}"
 
-# Delete test cluster
-- name: Delete test cluster
-  vmware_cluster:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter_name: "{{ dc1 }}"
-    cluster_name: test_cluster_drs
-    state: absent
-  when: vcsim is not defined
+- when: vcsim is not defined
+  block:
+  - name: Change advanced setting "TryBalanceVmsPerHost" (check-mode)
+    vmware_cluster_drs: &change_balance_vms
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_drs
+      advanced_settings:
+          'TryBalanceVmsPerHost': '1'
+    check_mode: yes
+    register: change_balance_vms_check
+
+  - assert:
+      that:
+        - change_balance_vms_check.changed
+
+  - name: Change advanced setting "TryBalanceVmsPerHost"
+    vmware_cluster_drs: *change_balance_vms
+    register: change_balance_vms
+
+  - assert:
+      that:
+        - change_balance_vms.changed
+
+  - name: Change advanced setting "TryBalanceVmsPerHost" again
+    vmware_cluster_drs: *change_balance_vms
+    register: change_balance_vms_again
+
+  - assert:
+      that:
+        - not change_balance_vms_again.changed
+
+  # Delete test cluster
+  - name: Delete test cluster
+    vmware_cluster:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_drs
+      state: absent


### PR DESCRIPTION
##### SUMMARY
Add advanced DRS settings to vmware_cluster_drs.

Implements #66217

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs

##### ADDITIONAL INFORMATION
This PR is more or less the same as #65675, only for DRS instead of HA. If you compare the changes you'll see the similarities.

```
name: Enable DRS and distribute a more even number of virtual machines across hosts for availability
  vmware_cluster_drs:
    hostname: '{{ vcenter_hostname }}'
    username: '{{ vcenter_username }}'
    password: '{{ vcenter_password }}'
    datacenter_name: datacenter
    cluster_name: cluster
    enable_drs: yes
    advanced_settings:
      'TryBalanceVmsPerHost': '1'
```
