### PR TITLE
Fix hcloud_server and hcloud_server_info module when the image is None

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_server.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server.py
@@ -272,12 +272,13 @@ class AnsibleHcloudServer(Hcloud):
         self.hcloud_server = None
 
     def _prepare_result(self):
+        image = None if self.hcloud_server.image is None else to_native(self.hcloud_server.image.name)
         return {
             "id": to_native(self.hcloud_server.id),
             "name": to_native(self.hcloud_server.name),
             "ipv4_address": to_native(self.hcloud_server.public_net.ipv4.ip),
             "ipv6": to_native(self.hcloud_server.public_net.ipv6.ip),
-            "image": to_native(self.hcloud_server.image.name),
+            "image": image,
             "server_type": to_native(self.hcloud_server.server_type.name),
             "datacenter": to_native(self.hcloud_server.datacenter.name),
             "location": to_native(self.hcloud_server.datacenter.location.name),

--- a/lib/ansible/modules/cloud/hcloud/hcloud_server_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_server_info.py
@@ -150,12 +150,13 @@ class AnsibleHcloudServerInfo(Hcloud):
 
         for server in self.hcloud_server_info:
             if server is not None:
+                image = None if server.image is None else to_native(server.image.name)
                 tmp.append({
                     "id": to_native(server.id),
                     "name": to_native(server.name),
                     "ipv4_address": to_native(server.public_net.ipv4.ip),
                     "ipv6": to_native(server.public_net.ipv6.ip),
-                    "image": to_native(server.image.name),
+                    "image": image,
                     "server_type": to_native(server.server_type.name),
                     "datacenter": to_native(server.datacenter.name),
                     "location": to_native(server.datacenter.location.name),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes an exception when the image of a server is None.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #64500
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_server
hcloud_server_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
