### PR TITLE
loop: simplify dict2items example in docs

### DIFF
--- a/changelogs/fragments/dict2items.yml
+++ b/changelogs/fragments/dict2items.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Simplify dict2items filter example in loop documentation (https://github.com/ansible/ansible/issues/65505).

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -121,18 +121,16 @@ To loop over a dict, use the  :ref:`dict2items <dict_filter>`:
 
 .. code-block:: yaml
 
-    - name: create a tag dictionary of non-empty tags
-      set_fact:
-        tags_dict: "{{ (tags_dict|default({}))|combine({item.key: item.value}) }}"
-      loop: "{{ tags|dict2items }}"
+    - name: Using dict2items
+      debug:
+        msg: "{{ item.key }} - {{ item.value }}"
+      loop: "{{ tag_data | dict2items }}"
       vars:
-        tags:
+        tag_data:
           Environment: dev
           Application: payment
-          Another: "{{ doesnotexist|default() }}"
-      when: item.value != ""
 
-Here, we don't want to set empty tags, so we create a dictionary containing only non-empty tags.
+Here, we are iterating over `tag_data` and printing the key and the value from it.
 
 Registering variables with a loop
 =================================


### PR DESCRIPTION
##### SUMMARY

* Added a simple example to explain "dict2items" filters for better understading.

Fixes: #65505

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/dict2items.yml
docs/docsite/rst/user_guide/playbooks_loops.rst
