### PR TITLE
[2.8] k8s was crashing when yaml ended with 3 dashes

### DIFF
--- a/changelogs/fragments/61182-k8s_rd-ending-with-dashes.yaml
+++ b/changelogs/fragments/61182-k8s_rd-ending-with-dashes.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- k8s module - fix for case when resource definition yaml ended with 3 dashes

--- a/lib/ansible/module_utils/k8s/raw.py
+++ b/lib/ansible/module_utils/k8s/raw.py
@@ -128,6 +128,10 @@ class KubernetesRawModule(KubernetesAnsibleModule):
         src = self.params.get('src')
         if src:
             self.resource_definitions = self.load_resource_definitions(src)
+        try:
+            self.resource_definitions = [item for item in self.resource_definitions if item]
+        except AttributeError:
+            pass
 
         if not resource_definition and not src:
             self.resource_definitions = [{

--- a/test/integration/targets/k8s/tasks/full_test.yml
+++ b/test/integration/targets/k8s/tasks/full_test.yml
@@ -291,11 +291,28 @@
         - testing5
       register: k8s_facts
 
-
     - name: Resources are terminating if still in results
       assert:
         that: not item.resources or item.resources[0].status.phase == "Terminating"
       loop: "{{ k8s_facts.results }}"
+
+    - name: Create resources from a yaml string ending with ---
+      k8s:
+        definition: |+
+          ---
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: testing6
+          ---
+
+    - name: Namespace should exist
+      k8s_info:
+        kind: Namespace
+        api_version: v1
+        name: testing6
+      register: k8s_info_testing6
+      failed_when: not k8s_info_testing6.resources or k8s_info_testing6.resources[0].status.phase != "Active"
 
     - include_tasks: crd.yml
     - include_tasks: lists.yml
@@ -330,4 +347,8 @@
             apiVersion: v1
             metadata:
               name: testing5
+          - kind: Namespace
+            apiVersion: v1
+            metadata:
+              name: testing6
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

* fix bug - k8s was crashing when yaml ended with 3 dashes

Fixes: #64129

(cherry picked from commit 8ed3a0b360e304051aa79821f6a5df64e3e7e54c)

Backport of https://github.com/ansible/ansible/pull/61182

##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/61182-k8s_rd-ending-with-dashes.yaml
lib/ansible/module_utils/k8s/raw.py
test/integration/targets/k8s/tasks/full_test.yml
