### PR TITLE
dnf - remove numerical version in NEVRA check

### DIFF
--- a/changelogs/fragments/64294-yum-handle-invalid-nevra.yaml
+++ b/changelogs/fragments/64294-yum-handle-invalid-nevra.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - dnf - fixed an issue where invalid NEVRA values in package specs would fail to remove/uninstall
+  - dnf - fixed an issue where invalid NEVRA values in package specs would fail to remove/uninstall (https://github.com/ansible/ansible/issues/64294)

--- a/changelogs/fragments/64294-yum-handle-invalid-nevra.yaml
+++ b/changelogs/fragments/64294-yum-handle-invalid-nevra.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - fixed an issue where invalid NEVRA values in package specs would fail to remove/uninstall

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -430,7 +430,7 @@ class DnfModule(YumDnf):
             rpm_nevr_match = rpm_nevr_re.match(packagename)
             if rpm_nevr_match:
                 name, epoch, version, release = rpm_nevr_re.match(packagename).groups()
-                if not version or not version.split('.')[0].isdigit():
+                if not version:
                     return None
             else:
                 return None

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -294,11 +294,36 @@
       assert:
         that:
           - rpm_result.stdout == '0'
+
+    # ============================================================================
+    # https://github.com/ansible/ansible/issues/64294
+    - name: Install dinginessentail-invalida-nevra
+      dnf:
+        name: dinginessentail-invalid-nevra
+        state: present
+      register: dnf_invalid_nevra_result
+
+    - name: Check dinginessentail-invalid-nevra with rpm
+      shell: rpm -q dinginessentail-invalid-nevra
+      register: rpm_invalid_nevra_result
+
+    - name: Verify installation
+      assert:
+        that:
+            - "dnf_invalid_nevra_result.changed"
+            - "rpm_invalid_nevra_result.stdout.startswith('dinginessentail-invalid-nevra-ABC')"
+
+    - name: Verify dnf module outputs
+      assert:
+        that:
+            - "'results' in dnf_invalid_nevra_result"
+    # ============================================================================
   always:
     - name: Clean up
       dnf:
         name:
         - dinginessentail
+        - dinginessentail-invalid-nevra
         - dinginessentail-with-weak-dep
         - dinginessentail-weak-dep
         state: absent

--- a/test/integration/targets/setup_rpm_repo/files/create-repo.py
+++ b/test/integration/targets/setup_rpm_repo/files/create-repo.py
@@ -34,6 +34,7 @@ SPECS = [
     RPM('landsidescalping', '1.1', '1', None, None),
     RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep']),
     RPM('dinginessentail-weak-dep', '1.0', '1', None, None),
+    RPM('dinginessentail-invalid-nevra', 'ABC', '1', None, None),
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #64294

Previously we were validating RPM Package NEVRA values as per Fedora
Packaging Guidelines which appears to have been an incorrect course
of action because many packages "in the wild" aren't compliant.
Now we won't do additional checks that aren't necessary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf
