### PR TITLE
Fix small typo in purefa_host documentation examples

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_host.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_host.py
@@ -87,7 +87,7 @@ EXAMPLES = r'''
 - name: Create new AIX host
   purefa_host:
     host: foo
-    personaility: aix
+    personality: aix
     fa_url: 10.10.10.2
     api_token: e31060a7-21fc-e277-6240-25983c6c4592
 


### PR DESCRIPTION
##### SUMMARY
Fix tiny typo in an example - incorrectly spelt parameter

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
purefa_host.py