### PR TITLE
Fix uptimerobot stacktrace on decode

### DIFF
--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -79,7 +79,7 @@ def checkID(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['status'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read()
+    result = req.read().decode("utf-8")
     jsonresult = json.loads(result)
     req.close()
     return jsonresult
@@ -91,7 +91,7 @@ def startMonitor(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read()
+    result = req.read().decode("utf-8")
     jsonresult = json.loads(result)
     req.close()
     return jsonresult['stat']
@@ -103,7 +103,7 @@ def pauseMonitor(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read()
+    result = req.read().decode("utf-8")
     jsonresult = json.loads(result)
     req.close()
     return jsonresult['stat']

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -59,6 +59,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 
 
 API_BASE = "https://api.uptimerobot.com/"
@@ -79,7 +80,7 @@ def checkID(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['status'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read().decode("utf-8")
+    result = to_text(req.read())
     jsonresult = json.loads(result)
     req.close()
     return jsonresult
@@ -91,7 +92,7 @@ def startMonitor(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read().decode("utf-8")
+    result = to_text(req.read())
     jsonresult = json.loads(result)
     req.close()
     return jsonresult['stat']
@@ -103,7 +104,7 @@ def pauseMonitor(module, params):
     data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
-    result = req.read().decode("utf-8")
+    result = to_text(req.read())
     jsonresult = json.loads(result)
     req.close()
     return jsonresult['stat']


### PR DESCRIPTION
`req.read()` always returns bytes whereas the json module expects
strings.

I don't know how this worked before.

##### SUMMARY

Fixes #66242 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
uptimerobot module.

##### ADDITIONAL INFORMATION

Currently the uptimerobot module fails with a stacktrace because it feeds bytes to the json module (that expects a string): `TypeError: the JSON object must be str, not 'bytes'`. This PR makes sure we (utf-8) decode the bytes to a string before (JSON) decoding the string to a dict.
