### PR TITLE
Add 'bin' option to use an alternative pacman binary

### DIFF
--- a/changelogs/fragments/66245-add-bin-option-to-use-an-alternative-pacman-binary.yaml
+++ b/changelogs/fragments/66245-add-bin-option-to-use-an-alternative-pacman-binary.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pacman - add 'bin' option to use an AUR helper instead that shares the same interface as Pacman

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -59,6 +59,7 @@ options:
         description:
             - Name of pacman binary or AUR helper that shares the same interface as pacman.
         default: pacman
+        version_added: "2.10"
 
     update_cache:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are some nice [AUR helpers](https://wiki.archlinux.org/index.php/AUR_helpers) that extend the pacman interface and can be used interchangeably with pacman. This PR adds the option to specify the binary to be used, when executing package queries on ArchLinux.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pacman

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
With this PR an AUR package can be easily installed using [YAY](https://github.com/Jguer/yay) for example. In this example the user needs to provide a non-root user with the privileges to install packages, otherwise yay will refuse to work.
```yaml
tasks:
  - pacman:
      state: present
      name: foo
      bin: yay
      extra_args: --noconfirm --builddir /tmp/yay-build
    become_user: yay
```
