### PR TITLE
adding proxy_address field for active proxies

### DIFF
--- a/changelogs/fragments/66247-zabbix_proxy-address-field.yaml
+++ b/changelogs/fragments/66247-zabbix_proxy-address-field.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_proxy - added option proxy_address for comma-delimited list of IP/CIDR addresses or DNS names to accept active proxy requests from


### PR DESCRIPTION
##### SUMMARY

Since 4.0.0 there is a field proxy_address for limiting proxy requests.

Official Docs: "Proxy address	If specified then active proxy requests are only accepted from this list of comma-delimited IP addresses, optionally in CIDR notation, or DNS names of active Zabbix proxy.
This field is only available if an active proxy is selected in the Proxy mode field. Macros are not supported.
This option is supported since Zabbix 4.0.0."

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_proxy

##### ADDITIONAL INFORMATION
```yaml
---

- hosts:
    - localhost
  tasks:
    - name: Create a new proxy or update an existing active proxy
      local_action:
        module: zabbix_proxy
        server_url: "{{ server_url }}"
        login_user: "{{ login_user }}"
        login_password: "{{ login_password }}"
        proxy_name: ExampleProxy
        description: ExampleProxy
        status: active
        state: present
        proxy_address: ExampleProxy
    - name: Create a new proxy or update an existing passive proxy
      local_action:
        module: zabbix_proxy
        server_url: "{{ server_url }}"
        login_user: "{{ login_user }}"
        login_password: "{{ login_password }}"
        proxy_name: ExampleProxy2
        description: ExampleProxy2
        status: passive
        state: present
        proxy_address: ExampleProxy2
        interface:
          type: 0
          main: 1
          useip: 1
          ip: 10.0.0.1
          dns: "example.local"
          port: 10050
```
ExampleProxy is active and will be created with proxy_address field. ExampleProxy2 is passive and will be created without proxy_address field but with interface.

Both fields are marked as not required. Depending on the status [active|passive] the corresponding field is kept or poped.
Zabbix Version lower than 4.0 can still be used if proxy_address is just not defined in config.