### PR TITLE
Deprecate Windows 2008, and 2008 R2

### DIFF
--- a/changelogs/fragments/server2008-dep.yaml
+++ b/changelogs/fragments/server2008-dep.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Windows - add deprecation notice in the Windows setup module when running on Server 2008, 2008 R2, and Windows 7

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -31,7 +31,7 @@ No notable changes
 Deprecated
 ==========
 
-No notable changes
+* Windows Server 2008 and 2008 R2 will no longer be supported or tested in the next Ansible release, see :ref:`windows_faq_server2008`.
 
 
 Modules

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -14,18 +14,31 @@ Does Ansible work with Windows XP or Server 2003?
 ``````````````````````````````````````````````````
 Ansible does not work with Windows XP or Server 2003 hosts. Ansible does work with these Windows operating system versions:
 
-* Windows Server 2008
-* Windows Server 2008 R2
+* Windows Server 2008 :sup:`1`
+* Windows Server 2008 R2 :sup:`1`
 * Windows Server 2012
 * Windows Server 2012 R2
 * Windows Server 2016
 * Windows Server 2019
-* Windows 7
+* Windows 7 :sup:`1`
 * Windows 8.1
 * Windows 10
 
+1 - See the :ref:`Server 2008 FAQ <windows_faq_server2008>` entry for more details.
+
 Ansible also has minimum PowerShell version requirements - please see
 :ref:`windows_setup` for the latest information.
+
+.. _windows_faq_server2008:
+
+What is the support for Server 2008, 2008 R2 and Windows 7
+``````````````````````````````````````````````````````````
+The end of life for these versions of Windows is January 14th 2020 which means Ansible is planning on dropping support
+in the 2.11 release. A part of this deprecation process is to stop testing changes for Server 2008 and 2008 R2 in CI
+and any new features will be targeted towards newer Windows versions. While existing features should continue to work
+on these older versions some things may break between now and the 2.11 release. We will still continue to accept PRs
+that are simple fixes for bugs that come up until the 2.11 release.
+
 
 Can I manage Windows Nano Server with Ansible?
 ``````````````````````````````````````````````

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -31,14 +31,9 @@ Ansible also has minimum PowerShell version requirements - please see
 
 .. _windows_faq_server2008:
 
-What is the support for Server 2008, 2008 R2 and Windows 7
-``````````````````````````````````````````````````````````
-The end of life for these versions of Windows is January 14th 2020 which means Ansible is planning on dropping support
-in the 2.11 release. A part of this deprecation process is to stop testing changes for Server 2008 and 2008 R2 in CI
-and any new features will be targeted towards newer Windows versions. While existing features should continue to work
-on these older versions some things may break between now and the 2.11 release. We will still continue to accept PRs
-that are simple fixes for bugs that come up until the 2.11 release.
-
+Are Server 2008, 2008 R2 and Windows 7 supported?
+`````````````````````````````````````````````````
+Microsoft ended Extended Support for these versions of Windows on January 14th, 2020, and Ansible deprecated official support in the 2.10 release. No new feature development will occur targeting these operating systems, and automated testing has ceased. However, existing modules and features will likely continue to work, and simple pull requests to resolve issues with these Windows versions may be accepted.
 
 Can I manage Windows Nano Server with Ansible?
 ``````````````````````````````````````````````

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -140,6 +140,14 @@ $ansible_facts = @{
 
 $osversion = [Environment]::OSVersion
 
+if ($osversion.Version -lt [version]"6.2") {
+    # Server 2008, 2008 R2, and Windows 7 are not tested in CI and we want to let customers know about it before
+    # removing support altogether.
+    $version_string = "{0}.{1}" -f ($osversion.Version.Major, $osversion.Version.Minor)
+    $msg = "This version of Windows '$version_string' will no longer be supported or tested in the next Ansible release"
+    Add-DeprecationWarning -obj $result -message $msg -version "2.11"
+}
+
 if($gather_subset.Contains('all_ipv4_addresses') -or $gather_subset.Contains('all_ipv6_addresses')) {
     $netcfg = Get-LazyCimInstance Win32_NetworkAdapterConfiguration
 

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -144,7 +144,7 @@ if ($osversion.Version -lt [version]"6.2") {
     # Server 2008, 2008 R2, and Windows 7 are not tested in CI and we want to let customers know about it before
     # removing support altogether.
     $version_string = "{0}.{1}" -f ($osversion.Version.Major, $osversion.Version.Minor)
-    $msg = "This version of Windows '$version_string' will no longer be supported or tested in the next Ansible release"
+    $msg = "Windows version '$version_string' will no longer be supported or tested in the next Ansible release"
     Add-DeprecationWarning -obj $result -message $msg -version "2.11"
 }
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -28,50 +28,36 @@ matrix:
     - env: T=units/3.7/2
     - env: T=units/3.8/2
 
-    - env: T=windows/2008/1
-    - env: T=windows/2008-R2/1
     - env: T=windows/2012/1
     - env: T=windows/2012-R2/1
     - env: T=windows/2016/1
     - env: T=windows/2019/1
 
-    - env: T=windows/2008/2
-    - env: T=windows/2008-R2/2
     - env: T=windows/2012/2
     - env: T=windows/2012-R2/2
     - env: T=windows/2016/2
     - env: T=windows/2019/2
 
-    - env: T=windows/2008/3
-    - env: T=windows/2008-R2/3
     - env: T=windows/2012/3
     - env: T=windows/2012-R2/3
     - env: T=windows/2016/3
     - env: T=windows/2019/3
 
-    - env: T=windows/2008/4
-    - env: T=windows/2008-R2/4
     - env: T=windows/2012/4
     - env: T=windows/2012-R2/4
     - env: T=windows/2016/4
     - env: T=windows/2019/4
 
-    - env: T=windows/2008/5
-    - env: T=windows/2008-R2/5
     - env: T=windows/2012/5
     - env: T=windows/2012-R2/5
     - env: T=windows/2016/5
     - env: T=windows/2019/5
 
-    - env: T=windows/2008/6
-    - env: T=windows/2008-R2/6
     - env: T=windows/2012/6
     - env: T=windows/2012-R2/6
     - env: T=windows/2016/6
     - env: T=windows/2019/6
 
-    - env: T=windows/2008/7
-    - env: T=windows/2008-R2/7
     - env: T=windows/2012/7
     - env: T=windows/2012-R2/7
     - env: T=windows/2016/7


### PR DESCRIPTION
##### SUMMARY
Due to the impending EOL and expected difficulty of running Server 2008 (R2) in CI we are removing these hosts from our Shippable groups and adding a deprecated warning for 2.10. We are expecting to fully drop support in the 2.11 release.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
Windows