### PR TITLE
Make sure warnings are printed during fact gathering

### DIFF
--- a/changelogs/fragments/gather_facts-warnings.yaml
+++ b/changelogs/fragments/gather_facts-warnings.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- fact gathering - Display warnings and deprecation messages that are created during the fact gathering phase

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -45,6 +45,15 @@ class ActionModule(ActionBase):
 
         return mod_args
 
+    def _combine_task_result(self, result, task_result):
+        filtered_res = {
+            'ansible_facts': task_result.get('ansible_facts', {}),
+            'warnings': task_result.get('warnings', []),
+            'deprecations': task_result.get('deprecations', []),
+        }
+
+        return combine_vars(result, filtered_res)
+
     def run(self, tmp=None, task_vars=None):
 
         self._supports_check_mode = True
@@ -73,7 +82,7 @@ class ActionModule(ActionBase):
                 elif res.get('skipped', False):
                     skipped[fact_module] = res
                 else:
-                    result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})})
+                    result = self._combine_task_result(result, res)
 
             self._remove_tmp_path(self._connection._shell.tmpdir)
         else:
@@ -95,7 +104,7 @@ class ActionModule(ActionBase):
                         elif res.get('skipped', False):
                             skipped[module] = res
                         else:
-                            result = combine_vars(result, {'ansible_facts': res.get('ansible_facts', {})})
+                            result = self._combine_task_result(result, res)
                         del jobs[module]
                         break
                     else:


### PR DESCRIPTION
##### SUMMARY
Due to extra filtering that occurs during the `gather_facts` action plugin, any warning or deprecation message that is added by the fact module is stripped out. This PR makes sure we also include the warnings and facts into the combined result that is eventually sent to the callback so warnings are displayed to the end user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gather_facts