### PR TITLE
Persistent connections: These timeouts seem unused

### DIFF
--- a/changelogs/fragments/66267-httpapi-timeout.yaml
+++ b/changelogs/fragments/66267-httpapi-timeout.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+- Fix httpapi timeout value to read from persistent_command_timeout as intended.
+
+minor_changes:
+- Remove timeout option from httpapi, netconf, & network_cli connections, as they were unused.

--- a/lib/ansible/plugins/connection/httpapi.py
+++ b/lib/ansible/plugins/connection/httpapi.py
@@ -85,14 +85,6 @@ options:
     default: True
     vars:
       - name: ansible_httpapi_use_proxy
-  timeout:
-    type: int
-    description:
-      - Sets the connection time, in seconds, for communicating with the
-        remote device.  This timeout is used as the default timeout value for
-        commands when issuing a command to the network CLI.  If the command
-        does not return in timeout seconds, an error is generated.
-    default: 120
   become:
     type: boolean
     description:
@@ -265,7 +257,8 @@ class Connection(NetworkConnectionBase):
         Sends the command to the device over api
         '''
         url_kwargs = dict(
-            timeout=self.get_option('timeout'), validate_certs=self.get_option('validate_certs'),
+            timeout=self.get_option('persistent_command_timeout'),
+            validate_certs=self.get_option('validate_certs'),
             use_proxy=self.get_option("use_proxy"),
             headers={},
         )

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -82,14 +82,6 @@ options:
       - name: ANSIBLE_PRIVATE_KEY_FILE
     vars:
       - name: ansible_private_key_file
-  timeout:
-    type: int
-    description:
-      - Sets the connection time, in seconds, for communicating with the
-        remote device.  This timeout is used as the default timeout value when
-        awaiting a response after issuing a call to a RPC.  If the RPC
-        does not return in timeout seconds, an error is generated.
-    default: 120
   look_for_keys:
     default: True
     description:

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -75,14 +75,6 @@ options:
       - name: ANSIBLE_PRIVATE_KEY_FILE
     vars:
       - name: ansible_private_key_file
-  timeout:
-    type: int
-    description:
-      - Sets the connection time, in seconds, for communicating with the
-        remote device.  This timeout is used as the default timeout value for
-        commands when issuing a command to the network CLI.  If the command
-        does not return in timeout seconds, an error is generated.
-    default: 120
   become:
     type: boolean
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Persistent connection plugins have a non-modifiable timeout option that is generally unused. Migrate its use in httpapi to the usual persistent_command_timeout

Fixes #66179

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
httpapi
network_cli
netconf