### PR TITLE
Fix 'CyberarkPassword' object has no attribute 'delimiter'

### DIFF
--- a/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
+++ b/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cyberarkpassword - fix invalid attribute access (https://github.com/ansible/ansible/issues/66268)

--- a/lib/ansible/plugins/lookup/cyberarkpassword.py
+++ b/lib/ansible/plugins/lookup/cyberarkpassword.py
@@ -121,7 +121,7 @@ class CyberarkPassword:
                 '-p', 'AppDescs.AppID=%s' % self.appid,
                 '-p', 'Query=%s' % self.query,
                 '-o', self.output,
-                '-d', self.delimiter]
+                '-d', self.b_delimiter]
             all_parms.extend(self.extra_parms)
 
             b_credential = b""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
@Akasurde @samdoran @webknjaz

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This is a very small follow up to PR #59500 to fix the following exception:
```
ERROR! Unexpected Exception, this is probably a bug: 'CyberarkPassword' object has no attribute 'delimiter'
the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-playbook", line 123, in <module>
    exit_code = cli.run()
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/cli/playbook.py", line 127, in run
    results = pbex.run()
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/executor/playbook_executor.py", line 169, in run
    result = self._tqm.run(play=play)
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/executor/task_queue_manager.py", line 240, in run
    play_return = strategy.run(iterator, play_context)
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/plugins/strategy/linear.py", line 282, in run
    _hosts=self._hosts_cache, _hosts_all=self._hosts_cache_all)
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/vars/manager.py", line 425, in get_vars
    all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/vars/manager.py", line 523, in _get_delegated_vars
    items = wrap_var(lookup_loader.get(task.loop_with, loader=self._loader, templar=templar).run(terms=loop_terms, variables=vars_copy))
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/plugins/lookup/cyberarkpassword.py", line 179, in run
    result = cyberark_conn.get()
  File "/opt/ansible-virtualenv/lib/python3.5/site-packages/ansible/plugins/lookup/cyberarkpassword.py", line 124, in get
    '-d', self.delimiter]
AttributeError: 'CyberarkPassword' object has no attribute 'delimiter'
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cyberarkpassword lookup plugin