### PR TITLE
Sanitize debug var= tasks of the loop variable

### DIFF
--- a/changelogs/fragments/66269-hide-debug-loop-vars.yml
+++ b/changelogs/fragments/66269-hide-debug-loop-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fixed it so that debug tasks using var option will no longer show loop control variables."

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -269,6 +269,11 @@ class CallbackBase(AnsiblePlugin):
                 # 'var' value as field, so eliminate others and what is left should be varname
                 for hidme in self._hide_in_debug:
                     result.pop(hidme, None)
+                # when using loop control, remove these vars in addition to the var they reference
+                for control_var in ('ansible_loop_var', 'ansible_index_var'):
+                    if control_var in result:
+                        loop_var = result.pop(control_var)
+                        result.pop(loop_var, None)
 
     def _print_task_path(self, task, color=C.COLOR_DEBUG):
         path = task.get_path()


### PR DESCRIPTION
##### SUMMARY
Proposed fix for https://github.com/ansible/ansible/issues/65856

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
debug

##### ADDITIONAL INFORMATION
I have a test case for this, modeled after

https://github.com/ansible/ansible/blob/495c197770191e697e64026c5670da357a423898/test/integration/targets/loop_control/runme.sh#L10

```
./runme.sh
```

(you have to manually inspect the exit code in that case)

inside runme.sh

```bash
[ "$(ansible-playbook -i localhost, loop_test.yml | grep 'value2')" == "" ]
```

inside loop_test.yml

```yaml
- name: loop_control/debug
  hosts: localhost
  gather_facts: false
  connection: local
  vars:
    my_var: foo
    loop_me:
      - attr1: value1
        attr2: value2
  tasks:

    - name: Echo a var inside of a loop, should only print the label value1
      debug: var=my_var
      loop: "{{ loop_me }}"
      loop_control:
        label: "{{ foo_bar.attr1 }}"
        loop_var: "foo_bar"

    - name: Echo text inside of a loop, should not print anything in loop_me
      debug: msg='hello'
      loop: "{{ loop_me }}"
      loop_control:
        label: "{{ foo_bar.attr1 }}"
        loop_var: "foo_bar"
```

I am less confident about integrating this into the tests, although there really shouldn't be a problem with it.

and I confirm exit code 1 with devel and exit code 0 with this patch.