### PR TITLE
vmware_guest/test: create test vm in correct directory

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -114,7 +114,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: vm
+    folder: "{{ f0 }}"
     name: test_vm3
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/271

##### SUMMARY

Ensure we already create the `test_vm3` VM in the `{{ f0 }}` directory.
This to be sure the teardown playbook will be able to clean it up at the
end. This to avoid problem like this one:

```
Multiple virtual machines with same name [test_vm3] found, Folder value is a required parameter to find uniqueness of the virtual machine
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest
<!--- Write the short name of the module, plugin, task or feature below -->