### PR TITLE
Make banner detection non-greedy in ios_banner (#63092)

### DIFF
--- a/changelogs/fragments/66274-ios_banner_nongreedy.yml
+++ b/changelogs/fragments/66274-ios_banner_nongreedy.yml
@@ -1,3 +1,2 @@
 bugfixes:
-- Modified the regular expression check to be non greedy when multiple banners are present.
-  Modification in ios_banner.py.
+- ios_banner - Modified the regular expression check to be non greedy when multiple banners are present.

--- a/changelogs/fragments/66274-ios_banner_nongreedy.yml
+++ b/changelogs/fragments/66274-ios_banner_nongreedy.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Modified the regular expression check to be non greedy when multiple banners are present.
+  Modification in ios_banner.py.

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -123,7 +123,7 @@ def map_config_to_obj(module):
                                     'show running-config | begin banner %s'
                                     % module.params['banner'])
         if out:
-            output = re.search(r'\^C(.*)\^C', out, re.S).group(1).strip()
+            output = re.search(r'\^C(.*?)\^C', out, re.S).group(1).strip()
         else:
             output = None
     obj = {'banner': module.params['banner'], 'state': 'absent'}

--- a/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/multiple-login-exec.yaml
@@ -1,0 +1,55 @@
+---
+
+- name: Setup - set login and exec
+  ios_banner:
+    banner: "{{ item }}"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+  loop:
+    - login
+    - exec
+
+
+- name: Set login
+  ios_banner:
+    banner: "login"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.commands | length == 0"
+
+- name: Set exec
+  ios_banner:
+    banner: "exec"
+    text: |
+      this is my login banner
+      that as a multiline
+      string
+    state: present
+    provider: "{{ cli }}"
+
+  register: result
+
+- debug:
+    msg: "{{ result }}"
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.commands | length == 0"

--- a/test/units/modules/network/ios/fixtures/ios_banner_show_running_config_ios12.txt
+++ b/test/units/modules/network/ios/fixtures/ios_banner_show_running_config_ios12.txt
@@ -1,0 +1,15 @@
+banner exec ^C
+this is a sample
+mulitline banner
+used for testing
+^C
+banner login ^C
+this is a sample
+mulitline banner
+used for testing
+^C
+!
+dummy
+end
+of
+config

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -60,3 +60,18 @@ class TestIosBannerModule(TestIosModule):
         banner_text = load_fixture('ios_banner_show_banner.txt').strip()
         set_module_args(dict(banner='login', text=banner_text))
         self.execute_module()
+
+
+class TestIosBannerIos12Module(TestIosBannerModule):
+
+    def load_fixtures(self, commands):
+        show_banner_return_value = (1, '', None)
+        show_running_config_return_value = \
+            (0, load_fixture('ios_banner_show_running_config_ios12.txt').strip(), None)
+        self.exec_command.side_effect = [show_banner_return_value,
+                                         show_running_config_return_value]
+
+    def test_ios_banner_nochange(self):
+        banner_text = load_fixture('ios_banner_show_banner.txt').strip()
+        set_module_args(dict(banner='exec', text=banner_text))
+        self.execute_module()


### PR DESCRIPTION


*


Backport of #63092

(cherry picked from commit 01a92f0191de904ca8351cbfd1516e1aee874372)

##### SUMMARY
 Make banner detection non-greedy in ios_banner


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/ios/ios_banner.py 

