### PR TITLE
Fix to eos_vlans is using ios_vlans examples

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlans.py
+++ b/lib/ansible/modules/network/eos/eos_vlans.py
@@ -215,6 +215,7 @@ commands:
   returned: always
   type: list
   sample: ['vlan 10', 'no name', 'vlan 11', 'name Eleven']
+
 """
 
 


### PR DESCRIPTION
##### SUMMARY
Fix  to #65989

Documentation error corrected.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/network/eos/eos_vlans.py