### PR TITLE
LastPass use `lpass status` to determine login state

### DIFF
--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -57,14 +57,17 @@ class LPass(object):
 
     @property
     def logged_in(self):
-        out, err = self._run(self._build_args("logout"), stdin="n\n", expected_rc=1)
-        return err.startswith("Are you sure you would like to log out?")
+        # logged in returns 0
+        # logged out returns 1
+        # both report on stdout
+        out, err = self._run(self._build_args("status"), expected_rc=[0,1])
+        return out.startswith("Logged in as")
 
-    def _run(self, args, stdin=None, expected_rc=0):
+    def _run(self, args, stdin=None, expected_rc=[0]):
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()
-        if rc != expected_rc:
+        if rc not in expected_rc:
             raise LPassException(err)
         return to_text(out, errors='surrogate_or_strict'), to_text(err, errors='surrogate_or_strict')
 

--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -60,7 +60,7 @@ class LPass(object):
         # logged in returns 0
         # logged out returns 1
         # both report on stdout
-        out, err = self._run(self._build_args("status"), expected_rc=[0,1])
+        out, err = self._run(self._build_args("status"), expected_rc=[0, 1])
         return out.startswith("Logged in as")
 
     def _run(self, args, stdin=None, expected_rc=[0]):

--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -10,7 +10,7 @@ DOCUMENTATION = """
       -  Andrew Zenk <azenk@umn.edu>
     version_added: "2.3"
     requirements:
-      - lpass (command line utility)
+      - lpass (command line utility) >= 1.0.0
       - must have already logged into lastpass
     short_description: fetch data from lastpass
     description:

--- a/lib/ansible/plugins/lookup/lastpass.py
+++ b/lib/ansible/plugins/lookup/lastpass.py
@@ -63,7 +63,10 @@ class LPass(object):
         out, err = self._run(self._build_args("status"), expected_rc=[0, 1])
         return out.startswith("Logged in as")
 
-    def _run(self, args, stdin=None, expected_rc=[0]):
+    def _run(self, args, stdin=None, expected_rc=None):
+        if expected_rc is None:
+            expected_rc = [0]
+
         p = Popen([self.cli_path] + args, stdout=PIPE, stderr=PIPE, stdin=PIPE)
         out, err = p.communicate(to_bytes(stdin))
         rc = p.wait()

--- a/test/units/plugins/lookup/test_lastpass.py
+++ b/test/units/plugins/lookup/test_lastpass.py
@@ -47,7 +47,10 @@ class MockLPass(LPass):
             if key == entry['id'] or key == entry['name']:
                 return entry
 
-    def _run(self, args, stdin=None, expected_rc=[0]):
+    def _run(self, args, stdin=None, expected_rc=None):
+        if expected_rc is None:
+            expected_rc = [0]
+
         # Mock behavior of lpass executable
         base_options = ArgumentParser(add_help=False)
         base_options.add_argument('--color', default="auto", choices=['auto', 'always', 'never'])

--- a/test/units/plugins/lookup/test_lastpass.py
+++ b/test/units/plugins/lookup/test_lastpass.py
@@ -55,7 +55,6 @@ class MockLPass(LPass):
         p = ArgumentParser()
         sp = p.add_subparsers(help='command', dest='subparser_name')
 
-        logout_p = sp.add_parser('logout', parents=[base_options], help='logout')
         show_p = sp.add_parser('show', parents=[base_options], help='show entry details')
         status_p = sp.add_parser('status', parents=[base_options], help='show logged in state')
 
@@ -74,18 +73,6 @@ class MockLPass(LPass):
 
         if args.color != 'never':
             return mock_exit(error='Error: Mock only supports --color=never', rc=1)
-
-        if args.subparser_name == 'logout':
-            if self._mock_logged_out:
-                return mock_exit(error='Error: Not currently logged in', rc=1)
-
-            logged_in_error = 'Are you sure you would like to log out? [Y/n]'
-            if stdin and stdin.lower() == 'n\n':
-                return mock_exit(output='Log out: aborted.', error=logged_in_error, rc=1)
-            elif stdin and stdin.lower() == 'y\n':
-                return mock_exit(output='Log out: complete.', error=logged_in_error, rc=0)
-            else:
-                return mock_exit(error='Error: aborted response', rc=1)
 
         if args.subparser_name == 'status':
             if self._mock_logged_out:
@@ -136,10 +123,6 @@ class TestLPass(unittest.TestCase):
     def test_lastpass_cli_path(self):
         lp = MockLPass(path='/dev/null')
         self.assertEqual('/dev/null', lp.cli_path)
-
-    def test_lastpass_build_args_logout(self):
-        lp = MockLPass()
-        self.assertEqual(['logout', '--color=never'], lp._build_args("logout"))
 
     def test_lastpass_build_args_status(self):
         lp = MockLPass()


### PR DESCRIPTION
##### SUMMARY
Replaces `lpass logout` with the newer dedicated `lpass status` command as the basis for determining lastpass-cli login state.

Previous versions of this plugin checked the stderr output from `lpass logout` and passed a cancellation `"n"` to cancel the command via stdin when determining whether a user had been logged into lastpass-cli. LastPass added `lpass status` for this purpose in [release 1.0.0 (July 26, 2016)](https://github.com/lastpass/lastpass-cli/releases/tag/v1.0.0)

This adds no new features

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
Lookup plugin: LastPass

##### ADDITIONAL INFORMATION
Changes to module private methods include the requirement that the comparator accept an array of valid return codes from `Popen()`. With the old `lpass logout`, the action was canceled and expected to return 1. Now with `lpass status`, the action will complete whether logged in or not, but will return 0 when logged in and 1 when not.

Here, `expected_rc` is now passed as an array rather than a scalar. https://github.com/mberkowski/ansible/blob/532d34259cac4c1804d3b743c0dc23d4aa2ef016/lib/ansible/plugins/lookup/lastpass.py#L63

Changes to unit tests include eliminating mock output for `lpass logout` commands and adding the appropriate messaging for `lpass status`.

**Backward compatibility**
Users with old versions of lastpass-cli < 1.0.0 (more than 3.5 years old) will not be able to use this, as their `lpass` command will lack a `status` option.  However, lastpass-cli 1.0.0 was released several months _before_ the lastpass lookup plugin was merged into Ansible.