### PR TITLE
[stable-2.9] Fix 'CyberarkPassword' object has no attribute 'delimiter' (#66268)

### DIFF
--- a/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
+++ b/changelogs/fragments/66268-cyberarkpassword-fix-invalid-attr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cyberarkpassword - fix invalid attribute access (https://github.com/ansible/ansible/issues/66268)

--- a/lib/ansible/plugins/lookup/cyberarkpassword.py
+++ b/lib/ansible/plugins/lookup/cyberarkpassword.py
@@ -121,7 +121,7 @@ class CyberarkPassword:
                 '-p', 'AppDescs.AppID=%s' % self.appid,
                 '-p', 'Query=%s' % self.query,
                 '-o', self.output,
-                '-d', self.delimiter]
+                '-d', self.b_delimiter]
             all_parms.extend(self.extra_parms)
 
             b_credential = b""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #66268 for Ansible 2.9
(cherry picked from commit 53e405dd42)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/lookup/cyberarkpassword.py`