### PR TITLE
[stable-2.9] Simplify docker_setup on Fedora.

### DIFF
--- a/test/integration/targets/setup_docker/tasks/Fedora.yml
+++ b/test/integration/targets/setup_docker/tasks/Fedora.yml
@@ -1,12 +1,12 @@
-- name: Install Docker pre-reqs
-  dnf:
-    name: "{{ docker_prereq_packages }}"
-    state: present
-
 - name: Add repository
-  command: dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-  args:
-    warn: no
+  yum_repository:
+    file: docker-ce
+    name: docker-ce-stable
+    description: Docker CE Stable - $basearch
+    baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: https://download.docker.com/linux/fedora/gpg
 
 - name: Update cache
   command: dnf makecache

--- a/test/integration/targets/setup_docker/vars/Fedora.yml
+++ b/test/integration/targets/setup_docker/vars/Fedora.yml
@@ -1,5 +1,4 @@
-docker_prereq_packages:
-  - dnf-plugins-core
+docker_prereq_packages: []
 
 docker_packages:
   - docker-ce


### PR DESCRIPTION
##### SUMMARY

This avoids installing dnf-plugins-core, which breaks the yum and dnf modules
when uninstalling packages using a wildcard after they have already been removed.

This should resolve issues with the yum integration tests failing after docker tests run.

Backport of https://github.com/ansible/ansible/pull/66286

(cherry picked from commit a5c36eedd87fb496ac7208763997f232c425b7fa)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_setup
