### PR TITLE
add judgment

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
@@ -273,8 +273,10 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
     def record_to_dict(self, record):
         record_type = record.type[len('Microsoft.Network/dnszones/'):]
         records = getattr(record, RECORDSET_VALUE_MAP.get(record_type))
-        if not isinstance(records, list):
+        if not isinstance(records, list) and records:
             records = [records]
+        else:
+            records = []
         return dict(
             id=record.id,
             relative_name=record.name,

--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset_info.py
@@ -273,8 +273,9 @@ class AzureRMRecordSetInfo(AzureRMModuleBase):
     def record_to_dict(self, record):
         record_type = record.type[len('Microsoft.Network/dnszones/'):]
         records = getattr(record, RECORDSET_VALUE_MAP.get(record_type))
-        if not isinstance(records, list) and records:
-            records = [records]
+        if records:
+            if not isinstance(records, list):
+                records = [records]
         else:
             records = []
         return dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
azure_rm_dnsrecordset_info: When searching for A records, if there is an A record that is an "alias record set" the module fails. Add judgment before type conversion!
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Try to fixes #60244 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure_rm_dnsrecordset_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
