### PR TITLE
[2.9] Fix net_put module text file issue

### DIFF
--- a/changelogs/fragments/net_put_fix.yml
+++ b/changelogs/fragments/net_put_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix net_put module to handle text based files (https://github.com/ansible/ansible/issues/66059)

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -25,15 +25,15 @@ import hashlib
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_bytes
-from ansible.module_utils.connection import Connection
-from ansible.plugins.action import ActionBase
+from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class ActionModule(ActionBase):
+class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         socket_path = None

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -27,15 +27,15 @@ import re
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text, to_bytes
-from ansible.module_utils.connection import Connection
-from ansible.plugins.action import ActionBase
+from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.plugins.action.network import ActionModule as ActionNetworkModule
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class ActionModule(ActionBase):
+class ActionModule(ActionNetworkModule):
 
     def run(self, tmp=None, task_vars=None):
         changed = True
@@ -73,7 +73,7 @@ class ActionModule(ActionBase):
 
         if mode == 'text':
             try:
-                self._handle_template(convert_data=False)
+                self._handle_src_option(convert_data=False)
             except ValueError as exc:
                 return dict(failed=True, msg=to_text(exc))
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Modify the parent class for net_put and net_get
   module to refer from `ActionModule` class in
   network.py action plugin which contains the
   common code for network plugins.
*  Replace `_handle_template` with `_handle_src_option`
   function name which is defined in common class.

(cherry picked from commit fa66813696b372bc4b8e0d836968e226a56928c7)
Merged to devel https://github.com/ansible/ansible/pull/66065
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
