### PR TITLE
vmware_host_dns: consistent rslt when name changes

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
@@ -197,9 +197,10 @@ class VmwareHostDNS(PyVmomi):
         verbose = self.module.params.get('verbose', False)
         host_change_list = []
         for host in self.hosts:
+            initial_name = host.name
             changed = False
             changed_list = []
-            results['dns_config_result'][host.name] = dict(changed='', msg='')
+            host_result = {'changed': '', 'msg': '', 'host_name': host.name}
 
             host_netstack_config = host.config.network.netStackInstance
             for instance in host_netstack_config:
@@ -209,41 +210,50 @@ class VmwareHostDNS(PyVmomi):
                     netstack_spec.netStackInstance = vim.host.NetStackInstance()
                     netstack_spec.netStackInstance.key = 'defaultTcpipStack'
                     dns_config = vim.host.DnsConfig()
-                    results['dns_config_result'][host.name]['dns_config'] = self.network_type
+                    host_result['dns_config'] = self.network_type
+                    host_result['search_domains'] = self.search_domains
                     if self.network_type == 'static':
+                        if self.host_name:
+                            if instance.dnsConfig.hostName != self.host_name:
+                                host_result['host_name_previous'] = instance.dnsConfig.hostName
+                                changed = True
+                                changed_list.append("Host name")
+                            dns_config.hostName = self.host_name
+                        else:
+                            dns_config.hostName = instance.dnsConfig.hostName
+
+                        if self.search_domains:
+                            if instance.dnsConfig.searchDomain != self.search_domains:
+                                host_result['search_domains_previous'] = instance.dnsConfig.searchDomain
+                                host_result['search_domains_changed'] = (
+                                    self.get_differt_entries(instance.dnsConfig.searchDomain, self.search_domains)
+                                )
+                                changed = True
+                                changed_list.append("Search domains")
+                            dns_config.searchDomain = self.search_domains
+                        else:
+                            dns_config.searchDomain = instance.dnsConfig.searchDomain
+
                         if instance.dnsConfig.dhcp:
-                            results['dns_config_result'][host.name]['domain'] = self.domain
-                            results['dns_config_result'][host.name]['dns_servers'] = self.dns_servers
-                            results['dns_config_result'][host.name]['search_domains'] = self.search_domains
-                            results['dns_config_result'][host.name]['dns_config_previous'] = 'DHCP'
+                            host_result['domain'] = self.domain
+                            host_result['dns_servers'] = self.dns_servers
+                            host_result['search_domains'] = self.search_domains
+                            host_result['dns_config_previous'] = 'DHCP'
                             changed = True
                             changed_list.append("DNS configuration")
                             dns_config.dhcp = False
                             dns_config.virtualNicDevice = None
-                            if self.host_name:
-                                dns_config.hostName = self.host_name
-                            else:
-                                dns_config.hostName = instance.dnsConfig.hostName
                             dns_config.domainName = self.domain
                             dns_config.address = self.dns_servers
                             dns_config.searchDomain = self.search_domains
                         else:
-                            results['dns_config_result'][host.name]['host_name'] = self.host_name
                             # Check host name
-                            if self.host_name:
-                                if instance.dnsConfig.hostName != self.host_name:
-                                    results['dns_config_result'][host.name]['host_name_previous'] = instance.dnsConfig.hostName
-                                    changed = True
-                                    changed_list.append("Host name")
-                                dns_config.hostName = self.host_name
-                            else:
-                                dns_config.hostName = instance.dnsConfig.hostName
 
                             # Check domain
-                            results['dns_config_result'][host.name]['domain'] = self.domain
+                            host_result['domain'] = self.domain
                             if self.domain:
                                 if instance.dnsConfig.domainName != self.domain:
-                                    results['dns_config_result'][host.name]['domain_previous'] = instance.dnsConfig.domainName
+                                    host_result['domain_previous'] = instance.dnsConfig.domainName
                                     changed = True
                                     changed_list.append("Domain")
                                 dns_config.domainName = self.domain
@@ -251,11 +261,11 @@ class VmwareHostDNS(PyVmomi):
                                 dns_config.domainName = instance.dnsConfig.domainName
 
                             # Check DNS server(s)
-                            results['dns_config_result'][host.name]['dns_servers'] = self.dns_servers
+                            host_result['dns_servers'] = self.dns_servers
                             if self.dns_servers:
                                 if instance.dnsConfig.address != self.dns_servers:
-                                    results['dns_config_result'][host.name]['dns_servers_previous'] = instance.dnsConfig.address
-                                    results['dns_config_result'][host.name]['dns_servers_changed'] = (
+                                    host_result['dns_servers_previous'] = instance.dnsConfig.address
+                                    host_result['dns_servers_changed'] = (
                                         self.get_differt_entries(instance.dnsConfig.address, self.dns_servers)
                                     )
                                     changed = True
@@ -271,22 +281,9 @@ class VmwareHostDNS(PyVmomi):
                             else:
                                 dns_config.address = instance.dnsConfig.address
 
-                            # Check search domain config
-                            results['dns_config_result'][host.name]['search_domains'] = self.search_domains
-                            if self.search_domains:
-                                if instance.dnsConfig.searchDomain != self.search_domains:
-                                    results['dns_config_result'][host.name]['search_domains_previous'] = instance.dnsConfig.searchDomain
-                                    results['dns_config_result'][host.name]['search_domains_changed'] = (
-                                        self.get_differt_entries(instance.dnsConfig.searchDomain, self.search_domains)
-                                    )
-                                    changed = True
-                                    changed_list.append("Search domains")
-                                dns_config.searchDomain = self.search_domains
-                            else:
-                                dns_config.searchDomain = instance.dnsConfig.searchDomain
                     elif self.network_type == 'dhcp' and not instance.dnsConfig.dhcp:
-                        results['dns_config_result'][host.name]['device'] = self.vmkernel_device
-                        results['dns_config_result'][host.name]['dns_config_previous'] = 'static'
+                        host_result['device'] = self.vmkernel_device
+                        host_result['dns_config_previous'] = 'static'
                         changed = True
                         changed_list.append("DNS configuration")
                         dns_config.dhcp = True
@@ -313,7 +310,7 @@ class VmwareHostDNS(PyVmomi):
                         message = dns_servers_verbose_message
                 else:
                     message += changed_suffix
-                results['dns_config_result'][host.name]['changed'] = True
+                host_result['changed'] = True
                 host_network_system = host.configManager.networkSystem
                 if not self.module.check_mode:
                     try:
@@ -344,9 +341,11 @@ class VmwareHostDNS(PyVmomi):
                             (host.name, to_native(config_fault.msg))
                         )
             else:
-                results['dns_config_result'][host.name]['changed'] = False
+                host_result['changed'] = False
                 message = 'All settings are already configured'
-            results['dns_config_result'][host.name]['msg'] = message
+
+            host_result['msg'] = message
+            results['dns_config_result'][initial_name] = host_result
 
             host_change_list.append(changed)
 

--- a/test/integration/targets/vmware_host_dns/tasks/static.yml
+++ b/test/integration/targets/vmware_host_dns/tasks/static.yml
@@ -101,7 +101,7 @@
         that:
           - vmware_host_dns_result_0005 is changed
 
-    # Revert to original DNS configuration
+    # Revert to original DNS configuration with a different search_domains
     - name: Revert to original DNS configuration
       vmware_host_dns:
         hostname: '{{ esxi1 }}'
@@ -115,7 +115,7 @@
         search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
 
     # Testcase 0006: Ensure DNS config on the cluster is idempotent for static
-    - name: Ensure static DNS config is idempotent when done on the cluster
+    - name: Apply configuration on a cluster
       vmware_host_dns:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
@@ -123,15 +123,25 @@
         cluster_name: "{{ ccr1 }}"
         validate_certs: False
         type: 'static'
+        search_domains: "different-search-domain"
+      register: vmware_host_dns_result_0006
+
+    - name: Ensure configuration has changed
+      assert:
+        that:
+          - vmware_host_dns_result_0006 is changed
+
+    - name: Revert to original DNS configuration
+      vmware_host_dns:
+        hostname: '{{ esxi1 }}'
+        username: '{{ esxi_user }}'
+        password: '{{ esxi_password }}'
+        validate_certs: False
+        type: 'static'
+        host_name: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['host_name'] }}"
         domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
         dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
         search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
-      register: vmware_host_dns_result_0006
-
-    - name: Ensure DNS config wasn't changed
-      assert:
-        that:
-          - vmware_host_dns_result_0006 is not changed
 
     # Testcase 0007: Ensure changing the domain on the cluster works
     - name: Ensure changing the domain on the cluster works


### PR DESCRIPTION
##### SUMMARY

This commit address a problem in static mode, if the hostname change,
`host.name` value with change too. And as a result:

    results['dns_config_result'][host.name]

will be initialized.
We now record the initial hostname first, and uses it as the key for the
results.

This commit also ensures a hostname change is detected if
`instance.dnsConfig.dhcp` is true.

Finally, if we target a cluster, the `changed` result will depend on the
number of nodes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_dns
<!--- Write the short name of the module, plugin, task or feature below -->