### PR TITLE
[stable-2.9] Add test for reboot & wait_for_connection on EOS & IOS (#63014)

### DIFF
--- a/changelogs/fragments/63014-delayed-persistent-prompt.yaml
+++ b/changelogs/fragments/63014-delayed-persistent-prompt.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "network_cli: Only check cli prompt when the connection is actually used"

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -302,8 +302,9 @@ def main():
                 pc_data = to_text(init_data)
                 try:
                     conn.update_play_context(pc_data)
+                    conn.set_check_prompt(task_uuid)
                 except Exception as exc:
-                    # Only network_cli has update_play context, so missing this is
+                    # Only network_cli has update_play context and set_check_prompt, so missing this is
                     # not fatal e.g. netconf
                     if isinstance(exc, ConnectionError) and getattr(exc, 'code', None) == -32601:
                         pass

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -273,6 +273,7 @@ options:
         - name: ansible_network_cli_retries
 """
 
+from functools import wraps
 import getpass
 import json
 import logging
@@ -290,8 +291,18 @@ from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.connection import NetworkConnectionBase, ensure_connect
+from ansible.plugins.connection import NetworkConnectionBase
 from ansible.plugins.loader import cliconf_loader, terminal_loader, connection_loader
+
+
+def ensure_connect(func):
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        if not self._connected:
+            self._connect()
+        self.update_cli_prompt_context()
+        return func(self, *args, **kwargs)
+    return wrapped
 
 
 class AnsibleCmdRespRecv(Exception):
@@ -318,7 +329,11 @@ class Connection(NetworkConnectionBase):
 
         self._terminal = None
         self.cliconf = None
-        self.paramiko_conn = None
+        self._paramiko_conn = None
+
+        # Managing prompt context
+        self._check_prompt = False
+        self._task_uuid = to_text(kwargs.get('task_uuid', ''))
 
         if self._play_context.verbosity > 3:
             logging.getLogger('paramiko').setLevel(logging.DEBUG)
@@ -400,6 +415,15 @@ class Connection(NetworkConnectionBase):
             self.reset_history()
         if hasattr(self, 'disable_response_logging'):
             self.disable_response_logging()
+
+    def set_check_prompt(self, task_uuid):
+        self._check_prompt = task_uuid
+
+    def update_cli_prompt_context(self):
+        # set cli prompt context at the start of new task run only
+        if self._check_prompt and self._task_uuid != self._check_prompt:
+            self._task_uuid, self._check_prompt = self._check_prompt, False
+            self.set_cli_prompt_context()
 
     def _connect(self):
         '''

--- a/test/integration/targets/eos_smoke/tests/cli/reboot.yaml
+++ b/test/integration/targets/eos_smoke/tests/cli/reboot.yaml
@@ -1,0 +1,20 @@
+---
+- block:
+  - cli_command:
+      command: reload power
+      prompt:
+        - "yes/no/cancel/diff]"
+        - "confirm]"
+      answer:
+        - "no"
+        - ""
+      check_all: yes
+    become: yes
+
+  - wait_for_connection:
+      delay: 20
+      sleep: 10
+
+  - cli_command:
+      command: show version
+  when: ansible_connection.endswith("network_cli")

--- a/test/integration/targets/ios_smoke/tests/cli/reboot.yaml
+++ b/test/integration/targets/ios_smoke/tests/cli/reboot.yaml
@@ -1,0 +1,19 @@
+---
+- block:
+  - cli_command:
+      command: reload
+      prompt:
+        - "yes/no"
+        - "confirm"
+      answer:
+        - "no"
+        - "y"
+      check_all: yes
+
+  - wait_for_connection:
+      delay: 20
+      sleep: 10
+
+  - cli_command:
+      command: show version
+  when: ansible_connection.endswith("network_cli")

--- a/test/integration/targets/junos_smoke/tasks/cli.yaml
+++ b/test/integration/targets/junos_smoke/tasks/cli.yaml
@@ -1,0 +1,15 @@
+- name: collect cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=network_cli)
+  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/junos_smoke/tasks/main.yaml
+++ b/test/integration/targets/junos_smoke/tasks/main.yaml
@@ -1,2 +1,3 @@
 ---
+- { include: cli.yaml, tags: ['cli'] }
 - { include: netconf.yaml, tags: ['netconf'] }

--- a/test/integration/targets/junos_smoke/tests/cli/reboot.yaml
+++ b/test/integration/targets/junos_smoke/tests/cli/reboot.yaml
@@ -1,0 +1,14 @@
+---
+- cli_command:
+    command: request system reboot
+    prompt:
+      - Reboot the system?
+    answer:
+     - y
+
+- wait_for_connection:
+    delay: 20
+    sleep: 10
+
+- cli_command:
+    command: show version


### PR DESCRIPTION
(cherry picked from commit e19b94f43b62c011a07ba65db276ed54fb3f1082)

Backport of https://github.com/ansible/ansible/pull/63014

Co-authored-by: Nathaniel Case <ncase@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This fixes some issues with how delayed persistent connection works & adds tests to match new functionality.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli