### PR TITLE
vmware_local_role_info/test: avoid json_query

### DIFF
--- a/test/integration/targets/vmware_local_role_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_local_role_facts/tasks/main.yml
@@ -9,8 +9,8 @@
   set_fact:
     role_list:
       - Admin
-      - NoCryptoAdmin
-      - NoAccess
+# With govcsim, NoCryptoAdmin has no privilege.
+#      - NoCryptoAdmin
       - Anonymous
       - ReadOnly
 
@@ -23,12 +23,19 @@
     validate_certs: no
   register: role_details
 
+- &list_to_dict
+  name: List to dict
+  set_fact:
+    role_dict: "{{ dict(role_details.local_role_facts|map(attribute='role_name')|zip(role_details.local_role_facts)) }}"
+
+- name: Test if NoAccess has no privilege
+  assert:
+    that: "{{ role_dict['NoAccess']['privileges'] | list | length == 0 }}"
+
 - &role_test
   name: Test if role id is present for role
   assert:
-    that: "{{ role_details.local_role_facts | json_query(s_query) != [] }}"
-  vars:
-    s_query: "[?role_name == '{{ item }}'].role_id"
+    that: "{{ role_dict[item]['privileges'] | list | length > 0 }}"
   with_items: "{{ role_list }}"
 
 - <<: *role_data

--- a/test/integration/targets/vmware_local_role_info/tasks/main.yml
+++ b/test/integration/targets/vmware_local_role_info/tasks/main.yml
@@ -9,8 +9,8 @@
   set_fact:
     role_list:
       - Admin
-      - NoCryptoAdmin
-      - NoAccess
+      # NoCryptoAdmin has no privilege with govcsim
+      # - NoCryptoAdmin
       - Anonymous
       - ReadOnly
 
@@ -23,17 +23,24 @@
     validate_certs: no
   register: role_details
 
+- &list_to_dict
+  name: List to dict
+  set_fact:
+    role_dict: "{{ dict(role_details.local_role_info|map(attribute='role_name')|zip(role_details.local_role_info)) }}"
+
+- name: Test if NoAccess has no privilege
+  assert:
+    that: "{{ role_dict['NoAccess']['privileges'] | list | length == 0 }}"
+
 - &role_test
   name: Test if role id is present for role
   assert:
-    that: "{{ role_details.local_role_info | json_query(s_query) != [] }}"
-  vars:
-    s_query: "[?role_name == '{{ item }}'].role_id"
+    that: "{{ role_dict[item]['privileges'] | list | length > 0 }}"
   with_items: "{{ role_list }}"
 
 - <<: *role_data
   name: Gather Role info in check mode
   check_mode: yes
-
+- <<: *list_to_dict
 - <<: *role_test
   name: Test if role id is present for role in check mode


### PR DESCRIPTION
##### SUMMARY

Refactoring to avoid the use of `json_query`. As a bonus point, we now
also ensure `NoAccess` role has no provilege.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_local_role_info
vmware_local_role_facts