### PR TITLE
Do not install/remove requests[security] for MongoDB tests

### DIFF
--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -41,5 +41,4 @@ redhat_packages_py3:
 
 pip_packages:
   - psutil
-  - requests[security]
   - pymongo

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -39,6 +39,8 @@ redhat_packages_py3:
   - python3-setuptools
   - python3-pip
 
+# Do not install requests[security] via pip. It will cause test failures.
+# See https://github.com/ansible/ansible/pull/66319
 pip_packages:
   - psutil
   - pymongo


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was previously fixed in PR #60083 but was added again in PR #61257. This will cause a lot of things to fail if it is uninstalled during cleanup after the test role, which is why it was originally removed from the test.

See #59918 for the original detailed investigation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_mongodb/defaults/main.yml`