### PR TITLE
Account for argument spec of None in validate modules sanity test

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1177,6 +1177,8 @@ class ModuleValidator(Validator):
         args_from_argspec = set()
         deprecated_args_from_argspec = set()
         doc_options = docs.get('options', {})
+        if doc_options is None:
+            doc_options = {}
         for arg, data in spec.items():
             if not isinstance(data, dict):
                 msg = "Argument '%s' in argument_spec" % arg


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the `argument_spec=None`, we would get a stack trace:

```
Traceback (most recent call last):
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules", line 8, in <module>
    main()
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1964, in main
    run()
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1862, in run
    mv1.validate()
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1699, in validate
    self._validate_ansible_module_call(docs)
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1154, in _validate_ansible_module_call
    self._validate_argument_spec(docs, spec, kwargs)
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1467, in _validate_argument_spec
    self._validate_argument_spec({'options': doc_suboptions}, spec_suboptions, kwargs, context=context + [arg])
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1467, in _validate_argument_spec
    self._validate_argument_spec({'options': doc_suboptions}, spec_suboptions, kwargs, context=context + [arg])
  File "/Users/sdoran/Source/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1291, in _validate_argument_spec
    if alias in doc_options:
TypeError: argument of type 'NoneType' is not iterable
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This was found in PR #66276
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py`