### PR TITLE
WebRequest - remove generically named aliases from util

### DIFF
--- a/changelogs/fragments/ps_web_request-aliases.yaml
+++ b/changelogs/fragments/ps_web_request-aliases.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Ansible.ModuleUtils.WebRequest - Move username and password aliases out of util to avoid option name collision

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -18,14 +18,24 @@ $spec = @{
         checksum = @{ type='str' }
         checksum_algorithm = @{ type='str'; default='sha1'; choices = @("md5", "sha1", "sha256", "sha384", "sha512") }
         checksum_url = @{ type='str' }
+
+       # Defined for the alias backwards compatibility, remove once aliases are removed
+       url_username = @{
+           aliases = @("user", "username")
+           deprecated_aliases = @(
+               @{ name = "user"; version = "2.14" },
+               @{ name = "username"; version = "2.14" }
+           )
+       }
+       url_password = @{
+           aliases = @("password")
+           deprecated_aliases = @(
+               @{ name = "password"; version = "2.14" }
+           )
+       }
     }
     mutually_exclusive = @(
         ,@('checksum', 'checksum_url')
-    )
-    deprecated_aliases = @(
-        @{ name = "user"; version = "2.14" },
-        @{ name = "username"; version = "2.14" },
-        @{ name = "password"; version = "2.14" }
     )
     supports_check_mode = $true
 }

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -22,9 +22,14 @@ $spec = @{
     mutually_exclusive = @(
         ,@('checksum', 'checksum_url')
     )
+    deprecated_aliases = @(
+        @{ name = "user"; version = "2.14" },
+        @{ name = "username"; version = "2.14" },
+        @{ name = "password"; version = "2.14" }
+    )
     supports_check_mode = $true
 }
-$spec.options += $ansible_web_request_options
+$spec = Merge-WebRequestSpec -ModuleSpec $spec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -73,6 +73,20 @@ options:
       - This option cannot be set with I(checksum).
     type: str
     version_added: "2.8"
+  url_username:
+    description:
+    - The username to use for authentication.
+    - The aliases I(user) and I(username) are deprecated and will be removed in
+      Ansible 2.14.
+    aliases:
+    - user
+    - username
+  url_password:
+    description:
+    - The password for I(url_username).
+    - The alias I(password) is deprecated and will be removed in Ansible 2.14.
+    aliases:
+    - password
   proxy_url:
     version_added: "2.0"
   proxy_username:

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -21,15 +21,21 @@ $spec = @{
        return_content = @{ type = "bool"; default = $false }
        status_code = @{ type = "list"; elements = "int"; default = @(200) }
 
-       # Defined for the alias backwards compatibilityi, remove once aliases are removed
-       url_username = @{ aliases = @("user", "username") }
-       url_password = @{ aliases = @("password") }
+       # Defined for the alias backwards compatibility, remove once aliases are removed
+       url_username = @{
+           aliases = @("user", "username")
+           deprecated_aliases = @(
+               @{ name = "user"; version = "2.14" },
+               @{ name = "username"; version = "2.14" }
+           )
+       }
+       url_password = @{
+           aliases = @("password")
+           deprecated_aliases = @(
+               @{ name = "password"; version = "2.14" }
+           )
+       }
     }
-    deprecated_aliases = @(
-        @{ name = "user"; version = "2.14" },
-        @{ name = "username"; version = "2.14" },
-        @{ name = "password"; version = "2.14" }
-    )
     supports_check_mode = $true
 }
 $spec = Merge-WebRequestSpec -ModuleSpec $spec

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -16,14 +16,23 @@ $spec = @{
        body = @{ type = "raw" }
        dest = @{ type = "path" }
        creates = @{ type = "path" }
+       method = @{ default = "GET" }
        removes = @{ type = "path" }
        return_content = @{ type = "bool"; default = $false }
        status_code = @{ type = "list"; elements = "int"; default = @(200) }
+
+       # Defined for the alias backwards compatibilityi, remove once aliases are removed
+       url_username = @{ aliases = @("user", "username") }
+       url_password = @{ aliases = @("password") }
     }
+    deprecated_aliases = @(
+        @{ name = "user"; version = "2.14" },
+        @{ name = "username"; version = "2.14" },
+        @{ name = "password"; version = "2.14" }
+    )
     supports_check_mode = $true
 }
-$spec.options += $ansible_web_request_options
-$spec.options.method.default = "GET"
+$spec = Merge-WebRequestSpec -ModuleSpec $spec
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 

--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -73,12 +73,20 @@ options:
     - The username to use for authentication.
     - Was originally called I(user) but was changed to I(url_username) in
       Ansible 2.9.
+    - The aliases I(user) and I(username) are deprecated and will be removed in
+      Ansible 2.14.
+    aliases:
+    - user
+    - username
     version_added: "2.4"
   url_password:
     description:
     - The password for I(url_username).
     - Was originally called I(password) but was changed to I(url_password) in
       Ansible 2.9.
+    - The alias I(password) is deprecated and will be removed in Ansible 2.14.
+    aliases:
+    - password
     version_added: "2.4"
   follow_redirects:
     version_added: "2.4"

--- a/lib/ansible/plugins/doc_fragments/url_windows.py
+++ b/lib/ansible/plugins/doc_fragments/url_windows.py
@@ -101,15 +101,10 @@ options:
     description:
     - The username to use for authentication.
     type: str
-    aliases:
-    - user
-    - username
   url_password:
     description:
     - The password for I(url_username).
     type: str
-    aliases:
-    - password
   use_default_credential:
     description:
     - Uses the current user's credentials when authenticating with a server


### PR DESCRIPTION
##### SUMMARY
The aliases for `url_username` and `url_password` were just too generic and would could potentially cause collisions with other modules when used. This PR moves those aliases out of the util to `win_get_url` and `win_uri` where they were previously defined and deprecate those aliases there. It also standardises the way of merging a module's spec with the module utils options.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.WebRequest.psm1
win_get_url
win_uri