### PR TITLE
Fix up deprecated_aliases spot for PS

### DIFF
--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -685,26 +685,26 @@ namespace Ansible.Basic
                     if (parameters.Contains(alias))
                         parameters[k] = parameters[alias];
                 }
-            }
 
-            List<Hashtable> deprecatedAliases = (List<Hashtable>)argumentSpec["deprecated_aliases"];
-            foreach (Hashtable depInfo in deprecatedAliases)
-            {
-                foreach (string keyName in new List<string> { "name", "version" })
+                List<Hashtable> deprecatedAliases = (List<Hashtable>)v["deprecated_aliases"];
+                foreach (Hashtable depInfo in deprecatedAliases)
                 {
-                    if (!depInfo.ContainsKey(keyName))
+                    foreach (string keyName in new List<string> { "name", "version" })
                     {
-                        string msg = String.Format("{0} is required in a deprecated_aliases entry", keyName);
-                        throw new ArgumentException(FormatOptionsContext(msg, " - "));
+                        if (!depInfo.ContainsKey(keyName))
+                        {
+                            string msg = String.Format("{0} is required in a deprecated_aliases entry", keyName);
+                            throw new ArgumentException(FormatOptionsContext(msg, " - "));
+                        }
                     }
-                }
-                string aliasName = (string)depInfo["name"];
-                string depVersion = (string)depInfo["version"];
+                    string aliasName = (string)depInfo["name"];
+                    string depVersion = (string)depInfo["version"];
 
-                if (parameters.Contains(aliasName))
-                {
-                    string msg = String.Format("Alias '{0}' is deprecated. See the module docs for more information", aliasName);
-                    Deprecate(FormatOptionsContext(msg, " - "), depVersion);
+                    if (parameters.Contains(aliasName))
+                    {
+                        string msg = String.Format("Alias '{0}' is deprecated. See the module docs for more information", aliasName);
+                        Deprecate(FormatOptionsContext(msg, " - "), depVersion);
+                    }
                 }
             }
 
@@ -1334,4 +1334,3 @@ namespace Ansible.Basic
         }
     }
 }
-

--- a/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/win_csharp_utils/library/ansible_basic_tests.ps1
@@ -796,24 +796,16 @@ test_no_log - Invoked with:
     "Deprecated aliases" = {
         $spec = @{
             options = @{
-                option1 = @{ type = "str"; aliases = "alias1" }
-                option2 = @{ type = "str"; aliases = "alias2" }
+                option1 = @{ type = "str"; aliases = "alias1"; deprecated_aliases = @(@{name = "alias1"; version = "2.10"}) }
+                option2 = @{ type = "str"; aliases = "alias2"; deprecated_aliases = @(@{name = "alias2"; version = "2.11"}) }
                 option3 = @{
                     type = "dict"
                     options = @{
-                        option1 = @{ type = "str"; aliases = "alias1" }
-                        option2 = @{ type = "str"; aliases = "alias2" }
+                        option1 = @{ type = "str"; aliases = "alias1"; deprecated_aliases = @(@{name = "alias1"; version = "2.10"}) }
+                        option2 = @{ type = "str"; aliases = "alias2"; deprecated_aliases = @(@{name = "alias2"; version = "2.11"}) }
                     }
-                    deprecated_aliases = @(
-                        @{ name = "alias1"; version = "2.10" }
-                        @{ name = "alias2"; version = "2.11" }
-                    )
                 }
             }
-            deprecated_aliases = @(
-                @{ name = "alias1"; version = "2.10" }
-                @{ name = "alias2"; version = "2.11" }
-            )
         }
 
         $complex_args = @{
@@ -1666,12 +1658,11 @@ test_no_log - Invoked with:
                 option_key = @{
                     type = "str"
                     aliases = ,"alias_name"
+                    deprecated_aliases = @(
+                        @{name = "alias_name"}
+                    )
                 }
             }
-
-            deprecated_aliases = @(
-                @{name = "alias_name"}
-            )
         }
 
         $failed = $false
@@ -1701,13 +1692,11 @@ test_no_log - Invoked with:
                         sub_option_key = @{
                             type = "str"
                             aliases = ,"alias_name"
-
+                            deprecated_aliases = @(
+                                @{version = "2.10"}
+                            )
                         }
                     }
-
-                    deprecated_aliases = @(
-                        @{version = "2.10"}
-                    )
                 }
             }
         }
@@ -2578,3 +2567,4 @@ try {
 }
 
 Exit-Module
+


### PR DESCRIPTION
##### SUMMARY
I mistakenly put the `deprecated_aliases` at the root (alongside options) of the module spec and not within each option as per the Python implementation. This fixes up this mistake.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs