### PR TITLE
Backport 2.9: nxos_lag_interfaces Use dict_diff instead of sets to take diff of lag members

### DIFF
--- a/changelogs/fragments/66126_fix_nxos_lag_interfaces_idempotence.yaml
+++ b/changelogs/fragments/66126_fix_nxos_lag_interfaces_idempotence.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix idempotence issue in nxos_lag_interfaces with Python 3 (https://github.com/ansible/ansible/pull/66126)


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Backport of https://github.com/ansible/ansible/pull/66126

(cherry picked from commit cb46e5f06b1c0ffcd16a9a4013c451011f16421d)

Add nxos_lag_interfaces fix changelog

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- If the dictionary is read out of order from member the current logic in diff_list_of_dicts returns unwanted diff. Hence use dict_diff utils function instead of sets.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_lag_interfaces.py
