### PR TITLE
Backport 2.9: nxos_vpc_interface: Temporarily disable vpc peer-link tests

### DIFF
--- a/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tests/common/sanity.yaml
@@ -57,20 +57,27 @@
       that:
         - "result.changed == false"
 
+# The vpc peer-link command seems to be invalid for the NXOSv we have in Zuul CI
+# Hence, we're temporarily skipping the tests that have `peer_link` key
+
   - name: Configure vpc port channel
     nxos_vpc_interface: &conf1
       portchannel: 11
       peer_link: True
       provider: "{{ connection }}"
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *true
+    when: image_version != "7.0(3)I5(1)"
 
   - name: "Conf Idempotence"
     nxos_vpc_interface: *conf1
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *false
+    when: image_version != "7.0(3)I5(1)"
 
   - name: Configure vpc port channel
     nxos_vpc_interface: &conf2
@@ -78,14 +85,18 @@
       peer_link: False
       provider: "{{ connection }}"
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *true
+    when: image_version != "7.0(3)I5(1)"
 
   - name: "Conf Idempotence"
     nxos_vpc_interface: *conf2
     register: result
+    when: image_version != "7.0(3)I5(1)"
 
   - assert: *false
+    when: image_version != "7.0(3)I5(1)"
 
   - name: remove vpc port channel
     nxos_vpc_interface: &remove


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Backport of https://github.com/ansible/ansible/pull/66121

(cherry picked from commit 97aefb8e11ba1ac02ec6af5d30ab6f3759bd93ac)

##### SUMMARY
- Test change, hence no changelog added.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
targets/nxos_vpc_interface
