### PR TITLE
Backport 2.9: nxos_ospf_vrf: Fix bandwidth calculation for Py3.x

### DIFF
--- a/changelogs/fragments/66095_fix_nxos_ospf_vrf.yaml
+++ b/changelogs/fragments/66095_fix_nxos_ospf_vrf.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix bandwidth calculation in nxos_ospf_vrf for Python 3 (https://github.com/ansible/ansible/pull/66095)

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -299,7 +299,7 @@ def state_present(module, existing, proposed, candidate):
                 if len(value) < 5:
                     command = '{0} {1} Mbps'.format(key, value)
                 else:
-                    value = str(int(value) / 1000)
+                    value = str(int(value) // 1000)
                     command = '{0} {1} Gbps'.format(key, value)
             elif key == 'bfd':
                 command = 'no bfd' if value == 'disable' else 'bfd'


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Backport of https://github.com/ansible/ansible/pull/66095

(cherry picked from commit 06927eab1f80fd86c7f9ef86b5656fcba6fa3ee2)

Add changelog for nxos_ospf_vrf fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- This is related to PEP 238
- The "true division" in Py3.x was resulting in a command string that the device doesn't accept.
- This patch changes it to floor division.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
nxos_ospf_vrf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
