### PR TITLE
Backport 2.9: nxos_snmp_community: Fix command ordering

### DIFF
--- a/changelogs/fragments/66094_fix_nxos_snmp_community.yaml
+++ b/changelogs/fragments/66094_fix_nxos_snmp_community.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix ordering of the commands sent in nxos_snmp_community (https://github.com/ansible/ansible/pull/66094).

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -153,10 +153,13 @@ def config_snmp_community(delta, community):
         'no_acl': 'no snmp-server community {0} use-acl {no_acl}'
     }
     commands = []
-    for k, v in delta.items():
+    for k in delta.keys():
         cmd = CMDS.get(k).format(community, **delta)
         if cmd:
-            commands.append(cmd)
+            if 'group' in cmd:
+                commands.insert(0, cmd)
+            else:
+                commands.append(cmd)
             cmd = None
     return commands
 
@@ -220,6 +223,7 @@ def main():
             commands.append(command)
 
     cmds = flatten_list(commands)
+
     if cmds:
         results['changed'] = True
         if not module.check_mode:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 46744353678011d6e8556a0e936e1873fbecbe13)

Add changelog for nxos_snmp_community fix

Backport of https://github.com/ansible/ansible/pull/66094

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- When trying to specify an acl for an SNMP community, we need to make sure that the SNMP community exists. Otherwise, the device throws an error.

- Hence, the ordering of the commands is important in this case. So for a task that tries to configure a snmp community with r/w access and a acl, the first command should be the one that creates the snmp community by specifying the group.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_community.py

