### PR TITLE
Backport 2.9: nxos_vxlan_vtep_vni: fix rendering duplicate peer-ip commands

### DIFF
--- a/changelogs/fragments/66088_fix_nxos_vxlan_vtep_vni.yaml
+++ b/changelogs/fragments/66088_fix_nxos_vxlan_vtep_vni.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix nxos_vxlan_vtep_vni rendering duplicate peer-ip commands (https://github.com/ansible/ansible/pull/66088)

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -259,10 +259,10 @@ def state_present(module, existing, proposed, candidate):
                ingress_replicationnb_command, ingress_replicationns_command)):
             static_level_cmds = [cmd for cmd in commands if 'peer' in cmd]
             parents = [interface_command, vni_command]
+            commands = [cmd for cmd in commands if 'peer' not in cmd]
             for cmd in commands:
                 parents.append(cmd)
             candidate.add(static_level_cmds, parents=parents)
-            commands = [cmd for cmd in commands if 'peer' not in cmd]
 
         elif 'peer-ip' in commands[0]:
             static_level_cmds = [cmd for cmd in commands]
@@ -326,7 +326,7 @@ def main():
             if peer_list[0] == 'default':
                 module.params['peer_list'] = 'default'
             else:
-                stripped_peer_list = map(str.strip, peer_list)
+                stripped_peer_list = list(map(str.strip, peer_list))
                 module.params['peer_list'] = stripped_peer_list
 
     state = module.params['state']


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 0ebb0ac0fa57f9057ea685240ca2b0be5c112a5a)

Add changelog for nxos_vxlan_vtep_vni fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/66088

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni.py
