### PR TITLE
Backport 2.9: nxos_l3_interfaces: allow dhcp to be rendered in facts

### DIFF
--- a/changelogs/fragments/66049_fix_nxos_l3_interfaces_dhcp.yaml
+++ b/changelogs/fragments/66049_fix_nxos_l3_interfaces_dhcp.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix issue where nxos_l3_interfaces was not rendering 'dhcp' in facts (https://github.com/ansible/ansible/pull/66049)

--- a/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/facts/l3_interfaces/l3_interfaces.py
@@ -17,7 +17,7 @@ from copy import deepcopy
 
 from ansible.module_utils.network.common import utils
 from ansible.module_utils.network.nxos.argspec.l3_interfaces.l3_interfaces import L3_interfacesArgs
-from ansible.module_utils.network.nxos.utils.utils import get_interface_type, validate_ipv4_addr, validate_ipv6_addr
+from ansible.module_utils.network.nxos.utils.utils import get_interface_type
 
 
 class L3_interfacesFacts(object):
@@ -83,18 +83,16 @@ class L3_interfacesFacts(object):
         if get_interface_type(intf) == 'unknown':
             return {}
         config['name'] = intf
-
         ipv4_match = re.compile(r'\n  ip address (.*)')
         matches = ipv4_match.findall(conf)
         if matches:
-            if validate_ipv4_addr(matches[0]):
+            if matches[0]:
                 config['ipv4'] = []
                 for m in matches:
                     ipv4_conf = m.split()
                     addr = ipv4_conf[0]
-                    ipv4_addr = addr if validate_ipv4_addr(addr) else None
-                    if ipv4_addr:
-                        config_dict = {'address': ipv4_addr}
+                    if addr:
+                        config_dict = {'address': addr}
                         if len(ipv4_conf) > 1:
                             d = ipv4_conf[1]
                             if d == 'secondary':
@@ -109,14 +107,13 @@ class L3_interfacesFacts(object):
         ipv6_match = re.compile(r'\n  ipv6 address (.*)')
         matches = ipv6_match.findall(conf)
         if matches:
-            if validate_ipv6_addr(matches[0]):
+            if matches[0]:
                 config['ipv6'] = []
                 for m in matches:
                     ipv6_conf = m.split()
                     addr = ipv6_conf[0]
-                    ipv6_addr = addr if validate_ipv6_addr(addr) else None
-                    if ipv6_addr:
-                        config_dict = {'address': ipv6_addr}
+                    if addr:
+                        config_dict = {'address': addr}
                         if len(ipv6_conf) > 1:
                             d = ipv6_conf[1]
                             if d == 'tag':


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit 94e054755febf17c6eaace58b7f56a2c498f993f)

Add changelog for nxos_l3_interfaces fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Backport of https://github.com/ansible/ansible/pull/66049

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_l3_interfaces.py