### PR TITLE
Backport 2.9: nxos_bgp_neighbor: Fix defaulting neighbor password

### DIFF
--- a/changelogs/fragments/65909_fix_nxos_bgp_neighbor.yaml
+++ b/changelogs/fragments/65909_fix_nxos_bgp_neighbor.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix how the neighbour password was being defaulted (https://github.com/ansible/ansible/pull/65909)

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -327,8 +327,11 @@ def state_present(module, existing, proposed, candidate):
             commands.append('no {0}'.format(key))
         elif value == 'default':
             if existing_commands.get(key):
-                existing_value = existing_commands.get(key)
-                commands.append('no {0} {1}'.format(key, existing_value))
+                if key == 'password':
+                    commands.append("no password")
+                else:
+                    existing_value = existing_commands.get(key)
+                    commands.append('no {0} {1}'.format(key, existing_value))
         else:
             if key == 'log-neighbor-changes':
                 if value == 'enable':

--- a/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tests/common/sanity.yaml
@@ -10,6 +10,9 @@
 - set_fact: log_neighbor_changesd="disable"
   when: (imagetag and (imagetag is version_compare('D1', 'ne')) and (imagetag is version_compare('N1', 'ne')))
 
+- debug:
+    var: titanium
+
 - set_fact: remove_private_asa="all"
   when: not titanium
 - set_fact: remove_private_asr="replace-as"


### PR DESCRIPTION
Add debug (#65909)

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>
(cherry picked from commit ae0df675397bf7cd10d3c01eabd3553d4ddd1982)

Add changelog for nxos_bgp_neighbor fix

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/65909

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_bgp_neighbor.py