### PR TITLE
Backport 2.9: nxos_interface: Always cleanup vlan interfaces in tests

### DIFF
--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -109,7 +109,7 @@
 
   - assert: *false
 
-  rescue:
+  always:
   - name: "Set interface back to default"
     nxos_config: *intcleanup
     ignore_errors: yes
@@ -124,5 +124,4 @@
       state: disabled
     ignore_errors: yes
 
-  always:
   - debug: msg="END connection={{ ansible_connection }} nxos_interface sanity test"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Backport of #65756

(cherry picked from commit 7af98f9724897a74d24ed2ca3f9996945c077a49)

##### SUMMARY
- Test fix, so no changelog added.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
targets/nxos_interface.py