### PR TITLE
Print task banner when running ad-hoc command

### DIFF
--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -30,6 +30,13 @@ class CallbackModule(CallbackBase):
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'minimal'
 
+    def __init__(self):
+        self._last_task_banner = None
+        self._last_task_name = None
+        self._task_type_cache = {}
+
+        super(CallbackModule, self).__init__()
+
     def _command_generic_msg(self, host, result, caption):
         ''' output the result of a command run '''
 
@@ -40,9 +47,53 @@ class CallbackModule(CallbackBase):
 
         return buf + "\n"
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def _print_task_banner(self, task):
+        # args can be specified as no_log in several places: in the task or in
+        # the argument spec.  We can check whether the task is no_log but the
+        # argument spec can't be because that is only run on the target
+        # machine and we haven't run it thereyet at this time.
+        #
+        # So we give people a config option to affect display of the args so
+        # that they can secure this if they feel that their stdout is insecure
+        # (shoulder surfing, logging stdout straight to a file, etc).
+        args = ''
+        if not task.no_log and C.DISPLAY_ARGS_TO_STDOUT:
+            args = u', '.join(u'%s=%s' % a for a in task.args.items())
+            args = u' %s' % args
 
+        prefix = self._task_type_cache.get(task._uuid, 'TASK')
+
+        # Use cached task name
+        task_name = self._last_task_name
+        if task_name is None:
+            task_name = task.get_name().strip()
+
+        if task.check_mode and self.check_mode_markers:
+            checkmsg = " [CHECK MODE]"
+        else:
+            checkmsg = ""
+        self._display.banner(u"%s [%s%s]%s" % (prefix, task_name, args, checkmsg))
+        if self._display.verbosity >= 2:
+            path = task.get_path()
+            if path:
+                self._display.display(u"task path: %s" % path, color=C.COLOR_DEBUG)
+
+        self._last_task_banner = task._uuid
+
+    def _task_start(self, task, prefix=None):
+        # Cache output prefix for task if provided
+        # This is needed to properly display 'RUNNING HANDLER' and similar
+        # when hiding skipped/ok task results
+        if prefix is not None:
+            self._task_type_cache[task._uuid] = prefix
+
+        # Preserve task name, as all vars may not be available for templating
+        # when we need it later
+        self._last_task_name = task.get_name().strip()
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
         self._handle_exception(result._result)
+        self._print_task_banner(result._task)
         self._handle_warnings(result._result)
 
         if result._task.action in C.MODULE_NO_JSON and 'module_stderr' not in result._result:
@@ -52,7 +103,7 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
         self._clean_results(result._result, result._task.action)
-
+        self._print_task_banner(result._task)
         self._handle_warnings(result._result)
 
         if result._result.get('changed', False):
@@ -68,11 +119,16 @@ class CallbackModule(CallbackBase):
             self._display.display("%s | %s => %s" % (result._host.get_name(), state, self._dump_results(result._result, indent=4)), color=color)
 
     def v2_runner_on_skipped(self, result):
+        self._print_task_banner(result._task)
         self._display.display("%s | SKIPPED" % (result._host.get_name()), color=C.COLOR_SKIP)
 
     def v2_runner_on_unreachable(self, result):
+        self._print_task_banner(result._task)
         self._display.display("%s | UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_UNREACHABLE)
 
     def v2_on_file_diff(self, result):
         if 'diff' in result._result and result._result['diff']:
             self._display.display(self._get_diff(result._result['diff']))
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self._task_start(task, prefix='TASK')


### PR DESCRIPTION
##### SUMMARY
This PR allows to show task name when running ad-hoc `ansible` command. This is useful mainly when using `include_role` directly from the command line. Without this PR, the output is pretty much useless as we don't see which task has failed/succeeded. This PR fixes #65803.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
callback plugin

##### ADDITIONAL INFORMATION
The added logic is based on the code in the `default` callback plugin. The logic of the `_task_start` function was slightly modified as we don't deal with Plays here.