### PR TITLE
Added functionality for the edgeos_config module to list and delete unmanaged config

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -25,11 +25,12 @@ description:
     configuration file and state of the active configuration. All
     configuration statements are based on `set` and `delete` commands
     in the device configuration.
-  - "This is a network module and requires the C(connection: network_cli) in order
-    to work properly."
-  - For more information please see the L(Network Guide,../network/getting_started/index.html).
+  - "This is a network module and requires the C(connection: network_cli) in
+    order to work properly."
+  - For more information please see the
+    L(Network Guide,../network/getting_started/index.html).
 notes:
-  - Tested against EdgeOS 1.9.7
+  - Tested against EdgeOS v2.0.8
   - Setting C(ANSIBLE_PERSISTENT_COMMAND_TIMEOUT) to 30 is recommended since
     the save command can take longer than the default of 10 seconds on
     some EdgeOS hardware.
@@ -87,23 +88,27 @@ options:
     default: 'no'
   backup_options:
     description:
-      - This is a dict object containing configurable options related to backup file path.
-        The value of this option is read only when C(backup) is set to I(yes), if C(backup) is set
-        to I(no) this option will be silently ignored.
+      - This is a dict object containing configurable options related to backup
+        file path. The value of this option is read only when C(backup) is set
+        to I(yes), if C(backup) is set to I(no) this option will be silently
+        ignored.
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the filename
-            is not given it will be generated based on the hostname, current time and date
-            in format defined by <hostname>_config.<current-date>@<current-time>
+          - The filename to be used to store the backup configuration. If the
+            filename is not given it will be generated based on the hostname,
+            current time and date in format defined by
+            <hostname>_config.<current-date>@<current-time>
       dir_path:
         description:
-          - This option provides the path ending with directory name in which the backup
-            configuration file will be stored. If the directory does not exist it will be first
-            created and the filename is either the value of C(filename) or default filename
-            as described in C(filename) options description. If the path value is not given
-            in that case a I(backup) directory will be created in the current working directory
-            and backup configuration will be copied in C(filename) within I(backup) directory.
+          - This option provides the path ending with directory name in which
+            the backup configuration file will be stored. If the directory does
+            not exist it will be first created and the filename is either the
+            value of C(filename) or default filename as described in
+            C(filename) options description. If the path value is not given in
+            that case a I(backup) directory will be created in the current
+            working directory and backup configuration will be copied in
+            C(filename) within I(backup) directory.
         type: path
     type: dict
     version_added: "2.8"
@@ -137,6 +142,16 @@ commands:
   returned: always
   type: list
   sample: ['...', '...']
+invalid:
+  description: The list of configuration commands removed for being invalid
+  returned: always
+  type: list
+  sample: ['...', '...']
+unmanaged:
+  description: The list of configuration commands on the remote device not matching the list provided
+  returned: always
+  type: list
+  sample: ['...', '...']
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
@@ -156,6 +171,18 @@ DEFAULT_COMMENT = 'configured by edgeos_config'
 
 
 def config_to_commands(config):
+    """Parse config depending on form and returns a list of commands
+
+    Only supports `set` and `delete` verbs
+
+    Supports a list of commands or a bracket based configuration file. When
+    passing a bracket based config it will parse into a list of set commands.
+
+    :param config: current config from the edgeos device
+    :type config: list
+    :return: filtered list of config starting with 'set' or 'delete'
+    :rtype: list
+    """
     set_format = config.startswith('set') or config.startswith('delete')
     candidate = NetworkConfig(indent=4, contents=config)
     if not set_format:
@@ -178,6 +205,13 @@ def config_to_commands(config):
 
 
 def get_candidate(module):
+    """Prepare passed ansible config for diff
+
+    :param module: ansible module for this type (edgeos)
+    :type module: ansible.module
+    :return contents: list of commands as potential updates
+    :rtype: list
+    """
     contents = module.params['src'] or module.params['lines']
 
     if module.params['lines']:
@@ -187,6 +221,16 @@ def get_candidate(module):
 
 
 def diff_config(commands, config):
+    """Diff the candidate commands against current config returning lists for
+    updates
+
+    :param commands: candidate commands passed through ansible
+    :type commands: list
+    :param config: commands pulled from edgeos device or passed through ansible
+    :type config: list
+    :return: updates: changes to apply to remote device
+    :rtype: list
+    """
     config = [to_native(c).replace("'", '') for c in config.splitlines()]
 
     updates = list()
@@ -226,6 +270,19 @@ def diff_config(commands, config):
 
 
 def run(module, result):
+    """compares config against passed configuration to asnible to create an
+    update list and applies to the edgeos device.
+
+    .. warning:: docstring added long after code written, requires verification
+    of Arguments and Returns - please update if you see any errors
+
+    :param module: ansible module for self ref
+    :type module: ansible.module
+    :param result: result dict to be populated
+    process
+    :type result: dict
+    """
+
     # get the current active config from the node or passed in via
     # the config param
     config = module.params['config'] or get_config(module)
@@ -248,6 +305,9 @@ def run(module, result):
 
 
 def main():
+    """Sets up module before running changes, applies save of state if
+    changed.
+    """
 
     backup_spec = dict(
         filename=dict(),

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -336,8 +336,8 @@ def run(module, result):
         delete_unmanaged(updates, unmanaged_config)
 
     result['commands'] = updates
-    result['unmanaged'] = unmanaged_config
-    result['invalid'] = invalid_commands
+    result['unmanaged'] = sorted(unmanaged_config)
+    result['invalid'] = sorted(invalid_commands)
 
     commit = not module.check_mode
     comment = module.params['comment']

--- a/test/units/modules/network/edgeos/edgeos_module.py
+++ b/test/units/modules/network/edgeos/edgeos_module.py
@@ -48,7 +48,7 @@ def load_fixture(name):
 
 class TestEdgeosModule(ModuleTestCase):
 
-    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False):
+    def execute_module(self, failed=False, changed=False, commands=None, filtered=None, sort=True, defaults=False):
         self.load_fixtures(commands)
 
         if failed:
@@ -63,6 +63,9 @@ class TestEdgeosModule(ModuleTestCase):
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:
                 self.assertEqual(commands, result['commands'], result['commands'])
+
+        if filtered is not None:
+            self.assertEqual(sorted(filtered), sorted(result['filtered']), result['filtered'])
 
         return result
 

--- a/test/units/modules/network/edgeos/edgeos_module.py
+++ b/test/units/modules/network/edgeos/edgeos_module.py
@@ -48,7 +48,7 @@ def load_fixture(name):
 
 class TestEdgeosModule(ModuleTestCase):
 
-    def execute_module(self, failed=False, changed=False, commands=None, filtered=None, sort=True, defaults=False):
+    def execute_module(self, failed=False, changed=False, commands=None, filtered=None, unmanaged=None, invalid=None, sort=True, defaults=False):
         self.load_fixtures(commands)
 
         if failed:
@@ -66,6 +66,12 @@ class TestEdgeosModule(ModuleTestCase):
 
         if filtered is not None:
             self.assertEqual(sorted(filtered), sorted(result['filtered']), result['filtered'])
+
+        if unmanaged is not None:
+            self.assertEqual(sorted(unmanaged), sorted(result['unmanaged']), result['unmanaged'])
+
+        if invalid is not None:
+            self.assertEqual(sorted(invalid), sorted(result['invalid']), result['invalid'])
 
         return result
 

--- a/test/units/modules/network/edgeos/edgeos_module.py
+++ b/test/units/modules/network/edgeos/edgeos_module.py
@@ -64,9 +64,6 @@ class TestEdgeosModule(ModuleTestCase):
             else:
                 self.assertEqual(commands, result['commands'], result['commands'])
 
-        if filtered is not None:
-            self.assertEqual(sorted(filtered), sorted(result['filtered']), result['filtered'])
-
         if unmanaged is not None:
             self.assertEqual(sorted(unmanaged), sorted(result['unmanaged']), result['unmanaged'])
 

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_filtered_src_brackets.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_filtered_src_brackets.cfg
@@ -1,0 +1,9 @@
+system {
+    login {
+        user test {
+            authentication {
+                encrypted-password test1
+            }
+        }
+    }
+}

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_unmanaged_src_brackets.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_unmanaged_src_brackets.cfg
@@ -1,0 +1,3 @@
+system {
+    host-name router
+}

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -145,18 +145,6 @@ class TestEdgeosConfigModule(TestEdgeosModule):
         ]
         self.execute_module(changed=True, commands=result_commands)
 
-    def test_edgeos_config_filtered(self):
-        candidate_config = ['set system login user test authentication encrypted-password test1']
-        set_module_args(dict(lines=candidate_config))
-        result_filtered = ['set system login user test authentication encrypted-password test1']
-        self.execute_module(changed=False, filtered=result_filtered)
-
-    def test_edgeos_config_filtered_src_brackets(self):
-        candidate_config = load_fixture('edgeos_config_filtered_src_brackets.cfg')
-        set_module_args(dict(src=candidate_config))
-        result_filtered = ['set system login user test authentication encrypted-password test1']
-        self.execute_module(changed=False, filtered=result_filtered)
-
     def test_edgeos_config_delete_unmanaged(self):
         candidate_config = ['set system host-name router']
         set_module_args(dict(lines=candidate_config, delete_unmanaged=True))

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -157,3 +157,103 @@ class TestEdgeosConfigModule(TestEdgeosModule):
         result_filtered = ['set system login user test authentication encrypted-password test1']
         self.execute_module(changed=False, filtered=result_filtered)
 
+    def test_edgeos_config_delete_unmanaged(self):
+        candidate_config = ['set system host-name router']
+        set_module_args(dict(lines=candidate_config, delete_unmanaged=True))
+        result_updated = [
+            "delete system domain-name acme.com",
+            "delete system domain-search domain acme.com",
+            "delete system name-server 208.67.220.220",
+            "delete system name-server 208.67.222.222",
+            "delete interfaces ethernet eth0 address 1.2.3.4/24",
+            "delete interfaces ethernet eth0 description Outside",
+            "delete interfaces ethernet eth1 address 10.77.88.1/24",
+            "delete interfaces ethernet eth1 description Inside",
+            "delete interfaces ethernet eth1 disable"
+        ]
+        result_unmanaged = [
+            "set system domain-name acme.com",
+            "set system domain-search domain acme.com",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description Outside",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description Inside",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=True, commands=result_updated, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_delete_unmanaged_src_brackets(self):
+        candidate_config = load_fixture('edgeos_config_unmanaged_src_brackets.cfg')
+        set_module_args(dict(src=candidate_config, delete_unmanaged=True))
+        result_updated = [
+            "delete system domain-name acme.com",
+            "delete system domain-search domain acme.com",
+            "delete system name-server 208.67.220.220",
+            "delete system name-server 208.67.222.222",
+            "delete interfaces ethernet eth0 address 1.2.3.4/24",
+            "delete interfaces ethernet eth0 description Outside",
+            "delete interfaces ethernet eth1 address 10.77.88.1/24",
+            "delete interfaces ethernet eth1 description Inside",
+            "delete interfaces ethernet eth1 disable"
+        ]
+        result_unmanaged = [
+            "set system domain-name acme.com",
+            "set system domain-search domain acme.com",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description Outside",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description Inside",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=True, commands=result_updated, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_unmanaged_lines(self):
+        candidate_config = ['set system host-name router']
+        set_module_args(dict(lines=candidate_config))
+        result_unmanaged = [
+            "set system domain-name acme.com",
+            "set system domain-search domain acme.com",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description Outside",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description Inside",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=False, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_unmanaged_src(self):
+        candidate_config = load_fixture('edgeos_config_unmanaged_src_brackets.cfg')
+        set_module_args(dict(src=candidate_config))
+        result_unmanaged = [
+            "set system domain-name acme.com",
+            "set system domain-search domain acme.com",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description Outside",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description Inside",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=False, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_invalid(self):
+        candidate_config = [
+            'set system host-name router',
+            'setsystem host-name router',
+            'deletesystem host-name router',
+            'invalid'
+        ]
+        set_module_args(dict(lines=candidate_config))
+        result_invalid = [
+            'invalid',
+            'setsystem host-name router',
+            'deletesystem host-name router',
+        ]
+        self.execute_module(changed=False, invalid=result_invalid)

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -54,41 +54,106 @@ class TestEdgeosConfigModule(TestEdgeosModule):
         self.get_config.return_value = load_fixture(config_file)
         self.load_config.return_value = None
 
-    def test_edgeos_config_unchanged(self):
-        src = load_fixture('edgeos_config_config.cfg')
-        set_module_args(dict(src=src))
-        self.execute_module()
-
-    def test_edgeos_config_src(self):
-        src = load_fixture('edgeos_config_src.cfg')
-        set_module_args(dict(src=src))
-        commands = ['set system host-name er01', 'delete interfaces ethernet eth0 address']
-        self.execute_module(changed=True, commands=commands)
-
-    def test_edgeos_config_src_brackets(self):
-        src = load_fixture('edgeos_config_src_brackets.cfg')
-        set_module_args(dict(src=src))
-        commands = ['set interfaces ethernet eth0 address 10.10.10.10/24', 'set system host-name er01']
-        self.execute_module(changed=True, commands=commands)
-
     def test_edgeos_config_backup(self):
         set_module_args(dict(backup=True))
         result = self.execute_module()
         self.assertIn('__backup__', result)
 
-    def test_edgeos_config_lines(self):
-        commands = ['set system host-name er01']
-        set_module_args(dict(lines=commands))
-        self.execute_module(changed=True, commands=commands)
+    def test_edgeos_config_unchanged_src(self):
+        candidate_config = load_fixture('edgeos_config_config.cfg')
+        set_module_args(dict(src=candidate_config))
+        self.execute_module()
+
+    def test_edgeos_config_unchanged_lines(self):
+        candidate_config = [
+            "set system host-name 'router'",
+            "set system domain-name 'acme.com'",
+            "set system domain-search domain 'acme.com'",
+            "set system name-server '208.67.220.220'",
+            "set system name-server '208.67.222.222'",
+            "set interfaces ethernet eth0 address '1.2.3.4/24'",
+            "set interfaces ethernet eth0 description 'Outside'",
+            "set interfaces ethernet eth1 address '10.77.88.1/24'",
+            "set interfaces ethernet eth1 description 'Inside'",
+            "set interfaces ethernet eth1 disable"
+        ]
+        set_module_args(dict(lines=candidate_config))
+        self.execute_module()
+
+    def test_edgeos_config_changed_src(self):
+        candidate_config = load_fixture('edgeos_config_src.cfg')
+        set_module_args(dict(src=candidate_config))
+        result_commands = [
+            'delete interfaces ethernet eth0 address',
+            'set system host-name er01',
+        ]
+        self.execute_module(changed=True, commands=result_commands)
+
+    def test_edgeos_config_changed_src_brackets(self):
+        candidate_config = load_fixture('edgeos_config_src_brackets.cfg')
+        set_module_args(dict(src=candidate_config))
+        result_commands = [
+            'set interfaces ethernet eth0 address 10.10.10.10/24',
+            'set system host-name er01'
+        ]
+        self.execute_module(changed=True, commands=result_commands)
+
+    def test_edgeos_config_changed_lines(self):
+        candidate_config = ['set system host-name test1']
+        set_module_args(dict(lines=candidate_config))
+        result_updated = ['set system host-name test1']
+        self.execute_module(changed=True, commands=result_updated)
+
+    def test_edgeos_config_changed_with_delete(self):
+        candidate_config = [
+            'delete interfaces ethernet eth0',
+            'set interfaces ethernet eth0 address 1.2.3.4/24',
+            'set interfaces ethernet eth0 description Outside'
+        ]
+        set_module_args(dict(lines=candidate_config))
+        result_updated = [
+            'delete interfaces ethernet eth0',
+            'set interfaces ethernet eth0 address 1.2.3.4/24',
+            'set interfaces ethernet eth0 description Outside'
+        ]
+        self.execute_module(changed=True, commands=result_updated)
+
+    def test_edgeos_config_changed_delete_only(self):
+        candidate_config = ['delete interfaces ethernet eth0']
+        set_module_args(dict(lines=candidate_config))
+        result_updated = [
+            'delete interfaces ethernet eth0'
+        ]
+        self.execute_module(changed=True, commands=result_updated)
 
     def test_edgeos_config_config(self):
-        config = 'set system host-name localhost'
-        new_config = ['set system host-name er01']
-        set_module_args(dict(lines=new_config, config=config))
-        self.execute_module(changed=True, commands=new_config)
+        config = ['set system host-name localhost']
+        candidate_config = ['set system host-name er01']
+        set_module_args(dict(lines=candidate_config, config=config))
+        result_commands = ['set system host-name er01']
+        self.execute_module(changed=True, commands=result_commands)
 
     def test_edgeos_config_match_none(self):
-        lines = ['set system interfaces ethernet eth0 address 1.2.3.4/24',
-                 'set system interfaces ethernet eth0 description Outside']
-        set_module_args(dict(lines=lines, match='none'))
-        self.execute_module(changed=True, commands=lines, sort=False)
+        candidate_config = [
+            'set system interfaces ethernet eth0 address 1.2.3.4/24',
+            'set system interfaces ethernet eth0 description Outside'
+        ]
+        set_module_args(dict(lines=candidate_config, match='none'))
+        result_commands = [
+            'set system interfaces ethernet eth0 address 1.2.3.4/24',
+            'set system interfaces ethernet eth0 description Outside'
+        ]
+        self.execute_module(changed=True, commands=result_commands, sort=False)
+
+    def test_edgeos_config_filtered(self):
+        candidate_config = ['set system login user test authentication encrypted-password test1']
+        set_module_args(dict(lines=candidate_config))
+        result_filtered = ['set system login user test authentication encrypted-password test1']
+        self.execute_module(changed=False, filtered=result_filtered)
+
+    def test_edgeos_config_filtered_src_brackets(self):
+        candidate_config = load_fixture('edgeos_config_filtered_src_brackets.cfg')
+        set_module_args(dict(src=candidate_config))
+        result_filtered = ['set system login user test authentication encrypted-password test1']
+        self.execute_module(changed=False, filtered=result_filtered)
+

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -143,7 +143,7 @@ class TestEdgeosConfigModule(TestEdgeosModule):
             'set system interfaces ethernet eth0 address 1.2.3.4/24',
             'set system interfaces ethernet eth0 description Outside'
         ]
-        self.execute_module(changed=True, commands=result_commands, sort=False)
+        self.execute_module(changed=True, commands=result_commands)
 
     def test_edgeos_config_filtered(self):
         candidate_config = ['set system login user test authentication encrypted-password test1']


### PR DESCRIPTION
##### SUMMARY
Added the ability for the edgeos_config module to return a list of unmanaged config. A flag can also be passed to allow this unmanaged config to be changed into delete statements. 

By adding this functionality it provides a method of moving towards a one to one relation between code and active config. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
- Have also included some general updates to variable names and test formatting to improve readability 
- Included a warning and list for invalid candidate commands
