### PR TITLE
Added extra logic to match security group rules existing rules

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -250,6 +250,16 @@ def _find_matching_rule(module, secgroup, remotegroup):
     ethertype = module.params['ethertype']
     direction = module.params['direction']
     remote_group_id = remotegroup['id']
+    port_range_min = module.params['port_range_min']
+    port_range_max = module.params['port_range_max']
+
+    # Because 'any' protocol does not match ports, we need to make sure we
+    # correct the parameters the sdk return when matching.
+    # And also re-set the protocol type (which is translated to None earlier)
+    if protocol == None:
+        protocol = 'any'
+        port_range_min = 0
+        port_range_max = 65535
 
     for rule in secgroup['security_group_rules']:
         if (protocol == rule['protocol'] and
@@ -258,8 +268,8 @@ def _find_matching_rule(module, secgroup, remotegroup):
                 direction == rule['direction'] and
                 remote_group_id == rule['remote_group_id'] and
                 _ports_match(protocol,
-                             module.params['port_range_min'],
-                             module.params['port_range_max'],
+                             port_range_min,
+                             port_range_max,
                              rule['port_range_min'],
                              rule['port_range_max'])):
             return rule

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -256,7 +256,7 @@ def _find_matching_rule(module, secgroup, remotegroup):
     # Because 'any' protocol does not match ports, we need to make sure we
     # correct the parameters the sdk return when matching.
     # And also re-set the protocol type (which is translated to None earlier)
-    if protocol == None:
+    if protocol is None:
         protocol = 'any'
         port_range_min = 0
         port_range_max = 65535


### PR DESCRIPTION
Added extra logic to correct module input parameters when matching rules with protocol 'any'

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #66350 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_security_group_rule
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See the linked issue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
