### PR TITLE
Add cacert param for self signed spacewalk usage

### DIFF
--- a/changelogs/fragments/66353-ca_cert-param-for-self-signed-spacewalk-usage.yaml
+++ b/changelogs/fragments/66353-ca_cert-param-for-self-signed-spacewalk-usage.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rhn_channel - add ca_cert param for use with self-signed spacewalk certificate

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -127,7 +127,7 @@ def main():
     password = module.params['password']
 
     # initialize connection
-    if module.params['ca_cert'] is not None and sys.version_info > (2, 7, 9):
+    if module.params['ca_cert'] is not None and sys.version_info >= (2, 7, 9):
         ctx = ssl.create_default_context()
         ctx.load_verify_locations(cafile=module.params['ca_cert'])
         client = xmlrpc_client.ServerProxy(saturl, context=ctx)

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -132,7 +132,7 @@ def main():
         ctx.load_verify_locations(cafile=module.params['ca_cert'])
         client = xmlrpc_client.ServerProxy(saturl, context=ctx)
     else:
-        if sys.version_info < (2, 7, 9):
+        if module.params['ca_cert'] and sys.version_info < (2, 7, 9):
             warnings.warn("ca_cert option require at least python 2.7.9")
         client = xmlrpc_client.ServerProxy(saturl)
 

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -16,7 +16,7 @@ module: rhn_channel
 short_description: Adds or removes Red Hat software channels
 description:
     - Adds or removes Red Hat software channels.
-version_added: "2.10"
+version_added: "1.1"
 author:
 - Vincent Van der Kussen (@vincentvdk)
 notes:
@@ -51,6 +51,7 @@ options:
         description:
             - ssl CA certificate for use with spacewalk self signed certificate
         required: False
+        version_added: "2.10"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -23,7 +23,7 @@ notes:
     - This module fetches the system id from RHN.
     - This module doesn't support I(check_mode).
 requirements:
-    - python >= 2.7.9 (only for cacert option usage due to use of xmlrpclib context arg added in 2.7.9)
+    - python >= 2.7.9 (only for ca_cert option usage due to use of xmlrpclib context arg added in 2.7.9)
 options:
     name:
         description:
@@ -63,7 +63,7 @@ EXAMPLES = '''
     url: https://rhn.redhat.com/rpc/api
     user: rhnuser
     password: guessme
-    cacert: '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
+    ca_cert: '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
   delegate_to: localhost
 '''
 
@@ -115,7 +115,7 @@ def main():
             url=dict(type='str', required=True),
             user=dict(type='str', required=True),
             password=dict(type='str', required=True, aliases=['pwd'], no_log=True),
-            cacert=dict(type='str', required=False),
+            ca_cert=dict(type='str', required=False),
         )
     )
 
@@ -127,13 +127,13 @@ def main():
     password = module.params['password']
 
     # initialize connection
-    if module.params['cacert'] is not None and sys.version_info > (2, 7, 9):
+    if module.params['ca_cert'] is not None and sys.version_info > (2, 7, 9):
         ctx = ssl.create_default_context()
-        ctx.load_verify_locations(cafile=module.params['cacert'])
+        ctx.load_verify_locations(cafile=module.params['ca_cert'])
         client = xmlrpc_client.ServerProxy(saturl, context=ctx)
     else:
         if sys.version_info < (2, 7, 9):
-            warnings.warn("cacert option require at least python 2.7.9")
+            warnings.warn("ca_cert option require at least python 2.7.9")
         client = xmlrpc_client.ServerProxy(saturl)
 
     try:

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -16,7 +16,7 @@ module: rhn_channel
 short_description: Adds or removes Red Hat software channels
 description:
     - Adds or removes Red Hat software channels.
-version_added: "1.1"
+version_added: "2.10"
 author:
 - Vincent Van der Kussen (@vincentvdk)
 notes:
@@ -124,8 +124,8 @@ def main():
     # initialize connection
     ctx = None
     if module.params['cacert'] is not None:
-            ctx = ssl.create_default_context()
-            ctx.load_verify_locations(cafile=module.params['cacert'])
+        ctx = ssl.create_default_context()
+        ctx.load_verify_locations(cafile=module.params['cacert'])
     client = xmlrpc_client.ServerProxy(saturl, context=ctx)
     try:
         session = client.auth.login(user, password)

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -49,7 +49,7 @@ options:
         description:
             - RHN/Satellite password.
         required: true
-    cacert:
+    ca_cert:
         description:
             - ssl CA certificate for use with spacewalk self signed certificate (require python >= 2.7.9)
         required: False


### PR DESCRIPTION
##### SUMMARY

rhn_channel raise a CERTIFICATE_VERIFY_FAILED error when use with self signed certificate

Fixes  #29649

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

rhn_channel

##### ADDITIONAL INFORMATION

Error raised before change:
```paste below
TASK [RHN_CHANNEL_configure : Configure Channel on Satellite] ******************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)
```
