### PR TITLE
Check vars against Mapping in DEBUG

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -506,8 +506,8 @@ class Templar:
         are being changed.
         '''
 
-        if not isinstance(variables, dict):
-            raise AnsibleAssertionError("the type of 'variables' should be a dict but was a %s" % (type(variables)))
+        if not isinstance(variables, Mapping):
+            raise AnsibleAssertionError("the type of 'variables' should be a Mapping but was a %s" % (type(variables)))
         self._available_variables = variables
         self._cached_result = {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When ANSIBLE_DEBUG=1, vars are VarsWithSources now which is a Mapping.
Check vars against Mapping instead of dict.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Reproducer:
```yaml
- hosts: localhost
  gather_facts: no
  tasks:
    - debug:
        msg: "{{ lookup('vars', 'foo') }}"
      vars:
        foo: bar
```

Run the above playbook with `ANSIBLE_DEBUG=1`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Templar