### PR TITLE
Support changing fetch_url settings for Rundeck modules

### DIFF
--- a/changelogs/fragments/66357-support-changing-fetch_url-settings-for-rundeck-modules.yaml
+++ b/changelogs/fragments/66357-support-changing-fetch_url-settings-for-rundeck-modules.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- rundeck modules - added new options ``client_cert``, ``client_key``, ``force``, ``force_basic_auth``, ``http_agent``, ``url_password``, ``url_username``, ``use_proxy``, ``validate_certs`` to allow changing fetch_url parameters.

--- a/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
+++ b/lib/ansible/modules/web_infrastructure/rundeck_acl_policy.py
@@ -55,6 +55,25 @@ options:
             - Sets the ACL policy content.
             - ACL policy content is a YAML object as described in http://rundeck.org/docs/man5/aclpolicy.html.
             - It can be a YAML string or a pure Ansible inventory YAML object.
+    client_cert:
+        version_added: '2.10'
+    client_key:
+        version_added: '2.10'
+    force:
+        version_added: '2.10'
+    force_basic_auth:
+        version_added: '2.10'
+    http_agent:
+        version_added: '2.10'
+    url_password:
+        version_added: '2.10'
+    url_username:
+        version_added: '2.10'
+    use_proxy:
+        version_added: '2.10'
+    validate_certs:
+        version_added: '2.10'
+extends_documentation_fragment: url
 '''
 
 EXAMPLES = '''
@@ -101,7 +120,7 @@ after:
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_text
 import json
 
@@ -196,16 +215,20 @@ class RundeckACLManager:
 
 
 def main():
+    # Also allow the user to set values for fetch_url
+    argument_spec = url_argument_spec()
+    argument_spec.update(dict(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        name=dict(required=True, type='str'),
+        url=dict(required=True, type='str'),
+        api_version=dict(type='int', default=14),
+        token=dict(required=True, type='str', no_log=True),
+        policy=dict(type='str'),
+        project=dict(type='str'),
+    ))
+
     module = AnsibleModule(
-        argument_spec=dict(
-            state=dict(type='str', choices=['present', 'absent'], default='present'),
-            name=dict(required=True, type='str'),
-            url=dict(required=True, type='str'),
-            api_version=dict(type='int', default=14),
-            token=dict(required=True, type='str', no_log=True),
-            policy=dict(type='str'),
-            project=dict(type='str'),
-        ),
+        argument_spec=argument_spec,
         required_if=[
             ['state', 'present', ['policy']],
         ],

--- a/lib/ansible/modules/web_infrastructure/rundeck_project.py
+++ b/lib/ansible/modules/web_infrastructure/rundeck_project.py
@@ -48,6 +48,25 @@ options:
         description:
             - Sets the token to authenticate against Rundeck API.
         required: True
+    client_cert:
+        version_added: '2.10'
+    client_key:
+        version_added: '2.10'
+    force:
+        version_added: '2.10'
+    force_basic_auth:
+        version_added: '2.10'
+    http_agent:
+        version_added: '2.10'
+    url_password:
+        version_added: '2.10'
+    url_username:
+        version_added: '2.10'
+    use_proxy:
+        version_added: '2.10'
+    validate_certs:
+        version_added: '2.10'
+extends_documentation_fragment: url
 '''
 
 EXAMPLES = '''
@@ -85,7 +104,7 @@ after:
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, url_argument_spec
 import json
 
 
@@ -159,14 +178,18 @@ class RundeckProjectManager(object):
 
 
 def main():
+    # Also allow the user to set values for fetch_url
+    argument_spec = url_argument_spec()
+    argument_spec.update(dict(
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+        name=dict(required=True, type='str'),
+        url=dict(required=True, type='str'),
+        api_version=dict(type='int', default=14),
+        token=dict(required=True, type='str', no_log=True),
+    ))
+
     module = AnsibleModule(
-        argument_spec=dict(
-            state=dict(type='str', choices=['present', 'absent'], default='present'),
-            name=dict(required=True, type='str'),
-            url=dict(required=True, type='str'),
-            api_version=dict(type='int', default=14),
-            token=dict(required=True, type='str', no_log=True),
-        ),
+        argument_spec=argument_spec,
         supports_check_mode=True
     )
 


### PR DESCRIPTION
##### SUMMARY
Allows passing arguments for fetch_url into the Rundeck modules.

This allows settings values such as `validate_certs` and more to support more complex networking situations or Rundeck instances behind self-signed SSL certificates

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Rundeck

##### ADDITIONAL INFORMATION
Example use case:
```
- name: "Create rundeck projects"
  rundeck_project:
    name: "{{ item.key }}"
    state: present
    token: "{{ rundeck_api_token }}"
    url: "{{ rundeck_instance_url }}"
    validate_certs: False
  loop: "{{ rundeck_projects | dict2items }}"
  environment: "{{ proxy_env }}"
```

(Setting validate_certs was not possible before this patch)