### PR TITLE
add support for config rewrite command in redis module

### DIFF
--- a/changelogs/fragments/66352-redis-add-config-rewrite-command.yml
+++ b/changelogs/fragments/66352-redis-add-config-rewrite-command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redis - add support for config rewrite command


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is possible to set config with the ansible redis module. But unfortunately it is not possible to persist these settings in the local redis config. Redis has a nice command CONFIG REWRITE to persist the running settings to disk.
This PR introduce the feature to persist the running redis settings to disk.
I add a new command for the module `command: config rewrite` which will do this via the py-redis python module. This python module is already needed by the ansible module itself.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #66352 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redis.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
An example of the usage of this feature:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Save local running redis config to disk
  redis:
    command: config rewrite
```
