### PR TITLE
Fix unarchive integration test on CentOS 6

### DIFF
--- a/test/integration/targets/unarchive/handlers/main.yml
+++ b/test/integration/targets/unarchive/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: remove python TLS packages
+  yum:
+    name:
+      - python-urllib3
+      - python2-ndg_httpsclient
+      - pyOpenSSL
+      - 'python-backports*'
+      - python-six
+    state: absent

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -230,7 +230,7 @@
     src: "{{ remote_tmp_dir }}/unarchive-00.{{item}}"
     dest: "{{ remote_tmp_dir }}/exclude-{{item}}"
     remote_src: yes
-    exclude: 
+    exclude:
       - "exclude/exclude-*.txt"
       - "other/exclude-1.ext"
   with_items:
@@ -632,6 +632,16 @@
 # Test downloading a file before unarchiving it
 - name: create our unarchive destination
   file: path={{remote_tmp_dir}}/test-unarchive-tar-gz state=directory
+
+- name: Install packages to make TLS connections work on CentOS 6
+  yum:
+    name:
+      - python-urllib3
+      - python2-ndg_httpsclient
+    state: present
+  when:
+    - ansible_facts.distribution == 'CentOS'
+    - ansible_facts.distribution_major_version is version('6', '==')
 
 - name: unarchive a tar from an URL
   unarchive:

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -641,7 +641,8 @@
     state: present
   when:
     - ansible_facts.distribution == 'CentOS'
-    - ansible_facts.distribution_major_version is version('6', '==')
+    - not ansible_facts.python.has_sslcontext
+  notify: remove python TLS packages
 
 - name: unarchive a tar from an URL
   unarchive:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Python 2.6 on CentOS 6 needs to have additional libraries installed in order to work with SNI and use TLS rather than SSLv3 connections.

Add a task that installs these libraries on CentOS 6. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/unarchive/`