### PR TITLE
vmware_vmotion/test: ensure we can run tests

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -338,7 +338,8 @@ class VmotionManager(PyVmomi):
             self.module.fail_json(msg="Multiple virtual machines with same name %s found."
                                       " Please specify vm_uuid instead of vm_name." % self.vm_name)
 
-        self.vm = vms[0]
+        if vms:
+            self.vm = vms[0]
 
 
 def main():

--- a/test/integration/targets/prepare_vmware_tests/vars/vcenter_2esxi.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcenter_2esxi.yml
@@ -5,6 +5,7 @@ esxi_hosts:
 rw_datastore: rw_datastore
 ro_datastore: ro_datastore
 esxi_password: '{{ esxi1_password }}'
+esxi_user: '{{ esxi1_username }}'
 infra:
   datastores:
     rw_datastore:

--- a/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
+++ b/test/integration/targets/prepare_vmware_tests/vars/vcsim.yml
@@ -3,6 +3,8 @@ esxi_hosts:
   - DC0_C0_H0
   - DC0_C0_H1
   - DC0_C0_H2
+esxi_password: 'pass'
+esxi_user: 'user'
 rw_datastore: LocalDS_0
 ro_datastore: LocalDS_1
 virtual_machines:

--- a/test/integration/targets/vmware_vmotion/aliases
+++ b/test/integration/targets/vmware_vmotion/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_2esxi

--- a/test/integration/targets/vmware_vmotion/tasks/main.yml
+++ b/test/integration/targets/vmware_vmotion/tasks/main.yml
@@ -7,8 +7,27 @@
   vars:
     setup_attach_host: true
     setup_datastore: true
+    setup_resource_pool: true
 
-- name: Create VMs
+- when: vcsim is not defined
+  block:
+    - name: Add ESXi Hosts to vCenter
+      vmware_host:
+        datacenter_name: '{{ dc1 }}'
+        esxi_hostname: '{{ item }}'
+        esxi_username: '{{ esxi_user }}'
+        esxi_password: '{{ esxi_password }}'
+        folder: '/DC0/host'
+        state: present
+      with_items: "{{ esxi_hosts }}"
+
+    - name: Disable the Maintenance Mode
+      vmware_maintenancemode:
+        esxi_hostname: '{{ item }}'
+        state: absent
+      with_items: "{{ esxi_hosts }}"
+
+- name: Create VM
   vmware_guest:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -31,6 +50,23 @@
       scsi: paravirtual
   register: vm_create
 
+- name: Perform vMotion of non-existing VM
+  vmware_vmotion:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: no
+    vm_name: not_a_thing
+    destination_host: '{{ esxi2 }}'
+    destination_datastore: '{{ rw_datastore }}'
+  register: vm_vmotion
+  ignore_errors: true
+
+- assert:
+    that:
+        - vm_vmotion.msg == "Failed to find the virtual machine with not_a_thing"
+
+
 - name: Perform vMotion of virtual machine
   vmware_vmotion:
     hostname: '{{ vcenter_hostname }}'
@@ -39,6 +75,7 @@
     validate_certs: no
     vm_name: test_vm1
     destination_host: '{{ esxi2 }}'
+    destination_datastore: '{{ rw_datastore }}'
   register: vm_vmotion
 
 - name: assert that changes were made
@@ -46,15 +83,32 @@
     that:
         - vm_vmotion is changed
 
+
+- name: Add ESXi Hosts to a cluster
+  vmware_host:
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    esxi_hostname: '{{ item }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    state: present
+  with_items: "{{ esxi_hosts }}"
+
+- name: Disable the Maintenance Mode
+  vmware_maintenancemode:
+    esxi_hostname: '{{ item }}'
+    state: absent
+  with_items: "{{ esxi_hosts }}"
+
 - name: Perform vMotion of virtual machine to resource_pool
   vmware_vmotion:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: no
-    vm_name: DC0_C0_RP0_VM0
+    vm_name: test_vm1
     destination_host: '{{ esxi1 }}'
-    destination_resourcepool: Resources
+    destination_resourcepool: DC0_C0_RP1
   register: vm_vmotion_to_rp
 
 - name: assert that changes were made
@@ -62,15 +116,15 @@
     that:
         - vm_vmotion_to_rp is changed
 
-- name: Perform storage vMotion of of virtual machine
+- name: Perform storage vMotion of virtual machine
   vmware_vmotion:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: no
-    vm_name: DC0_C0_RP0_VM1
-    destination_host: '{{ esxi3 }}'
-    destination_datastore: '{{ ro_datastore }}'
+    vm_name: test_vm1
+    destination_host: '{{ esxi2 }}'
+    destination_datastore: '{{ rw_datastore }}'
   register: vm_vmotion_to_datastore
 
 - name: assert that changes were made


### PR DESCRIPTION
##### SUMMARY

Some adjustments to be able to run the test-suite properly:

- Starts with the ESXi out of the cluster to be able to deploy the
  VM on a proper host consistently
- Ensure the resource pool exists
- The resource pool is called `DC0_C0_RP1`, not `Resources`
- Avoid an exception if we try to move a non existing VM.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_vmotion