### PR TITLE
vmware: Add more integration tests to Zuul CI

### DIFF
--- a/test/integration/targets/vmware_content_deploy_template/aliases
+++ b/test/integration/targets/vmware_content_deploy_template/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 unsupported
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_content_library_info/aliases
+++ b/test/integration/targets/vmware_content_library_info/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_content_library_manager/aliases
+++ b/test/integration/targets/vmware_content_library_manager/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_guest_disk/aliases
+++ b/test/integration/targets/vmware_guest_disk/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_2esxi

--- a/test/integration/targets/vmware_host/tasks/main.yml
+++ b/test/integration/targets/vmware_host/tasks/main.yml
@@ -9,6 +9,7 @@
       vars:
         setup_attach_host: true
 
+    # NOTE: prepare_vmware_tests should have already done that
     - name: Add first ESXi Host to vCenter
       vmware_host:
         hostname: '{{ vcenter_hostname }}'

--- a/test/integration/targets/vmware_host_firewall_manager/aliases
+++ b/test/integration/targets/vmware_host_firewall_manager/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_2esxi

--- a/test/integration/targets/vmware_host_ipv6/aliases
+++ b/test/integration/targets/vmware_host_ipv6/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group2
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_host_powermgmt_policy/aliases
+++ b/test/integration/targets/vmware_host_powermgmt_policy/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group2
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_2esxi


### PR DESCRIPTION
##### SUMMARY

- vmware_content_library_info
- vmware_content_library_manager
- vmware_guest_disk
- vmware_host
- vmware_host
- vmware_host_firewall_manager
- vmware_host_ipv6
- vmware_host_powermgmt_policy
- vmware_vswitch


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_content_library_info
vmware_content_library_manager
vmware_guest_disk
vmware_host
vmware_host
vmware_host_dns
vmware_host_firewall_manager
vmware_host_ipv6
vmware_host_powermgmt_policy
vmware_vswitch