### PR TITLE
Backport 2.9: Fix nxos_vrf purge breaking with empty aggregate

### DIFF
--- a/changelogs/fragments/66004_fix_nxos_vrf.yaml
+++ b/changelogs/fragments/66004_fix_nxos_vrf.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix issue where purge breaks with empty aggregate (https://github.com/ansible/ansible/pull/66004).

--- a/lib/ansible/modules/network/nxos/nxos_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf.py
@@ -237,11 +237,13 @@ def map_obj_to_commands(updates, module):
         admin_state = w['admin_state']
         vni = w['vni']
         interfaces = w.get('interfaces') or []
-        state = w['state']
+        if purge:
+            state = "absent"
+        else:
+            state = w['state']
         del w['state']
 
         obj_in_have = search_obj_in_list(name, have)
-
         if state == 'absent' and obj_in_have:
             commands.append('no vrf context {0}'.format(name))
 
@@ -344,12 +346,14 @@ def map_obj_to_commands(updates, module):
 
 
 def validate_vrf(name, module):
-    if name == 'default':
-        module.fail_json(msg='cannot use default as name of a VRF')
-    elif len(name) > 32:
-        module.fail_json(msg='VRF name exceeded max length of 32', name=name)
-    else:
-        return name
+    if name:
+        name = name.strip()
+        if name == 'default':
+            module.fail_json(msg='cannot use default as name of a VRF')
+        elif len(name) > 32:
+            module.fail_json(msg='VRF name exceeded max length of 32', name=name)
+        else:
+            return name
 
 
 def map_params_to_obj(module):


### PR DESCRIPTION
Fix to nxos_vrf purge breaks with empty aggregate (#66004)

* resolving conflicts

* fixed issue with purge and state var. fixed space issue with vrf name

* lint issues

(cherry picked from commit a3d67edfcaa6d04adf9da4119f2443ca35176a03)

Add changelog for nxos_vrf fix

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/66004

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos_vrf.py
