### PR TITLE
vmware_category/test: ensure test can run on Zuul

### DIFF
--- a/test/integration/targets/vmware_category/aliases
+++ b/test/integration/targets/vmware_category/aliases
@@ -1,3 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/test/integration/targets/vmware_category/tasks/associable_obj_types.yml
+++ b/test/integration/targets/vmware_category/tasks/associable_obj_types.yml
@@ -2,91 +2,89 @@
 # Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- when: vcsim is not defined
-  block:
-    - name: Create different types of category with associable object types
-      vmware_category:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
-        validate_certs: False
-        category_name: '{{ item }} name'
-        category_description: '{{ item }} description'
-        associable_object_types:
-          - "{{ item }}"
-        state: present
-      with_items:
-        - All objects
-        - Folder
-        - Cluster
-        - Datacenter
-        - Datastore
-        - Datastore Cluster
-        - Distributed Port Group
-        - Distributed Switch
-        - Host
-        - Content Library
-        - Library item
-        - Network
-        - Resource Pool
-        - vApp
-        - Virtual Machine
-    
-    - name: Delete different types of category with associable object types
-      vmware_category:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
-        validate_certs: False
-        category_name: '{{ item }} name'
-        state: absent
-      with_items:
-        - All objects
-        - Folder
-        - Cluster
-        - Datacenter
-        - Datastore
-        - Datastore Cluster
-        - Distributed Port Group
-        - Distributed Switch
-        - Host
-        - Content Library
-        - Library item
-        - Network
-        - Resource Pool
-        - vApp
-        - Virtual Machine
+- name: Create different types of category with associable object types
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: '{{ item }} name'
+    category_description: '{{ item }} description'
+    associable_object_types:
+      - "{{ item }}"
+    state: present
+  with_items:
+    - All objects
+    - Folder
+    - Cluster
+    - Datacenter
+    - Datastore
+    - Datastore Cluster
+    - Distributed Port Group
+    - Distributed Switch
+    - Host
+    - Content Library
+    - Library item
+    - Network
+    - Resource Pool
+    - vApp
+    - Virtual Machine
 
-    - name: Create category with 2 associable object types
-      vmware_category:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
-        validate_certs: False
-        category_name: 'Sample_cate_0001'
-        category_description: 'sample description'
-        associable_object_types:
-        - Datastore
-        - Cluster
-        state: present
-      register: category_change
+- name: Delete different types of category with associable object types
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: '{{ item }} name'
+    state: absent
+  with_items:
+    - All objects
+    - Folder
+    - Cluster
+    - Datacenter
+    - Datastore
+    - Datastore Cluster
+    - Distributed Port Group
+    - Distributed Switch
+    - Host
+    - Content Library
+    - Library item
+    - Network
+    - Resource Pool
+    - vApp
+    - Virtual Machine
 
-    - name: Assert change is made
-      assert:
-        that:
-          - category_change.changed
+- name: Create category with 2 associable object types
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: 'Sample_cate_0001'
+    category_description: 'sample description'
+    associable_object_types:
+    - Datastore
+    - Cluster
+    state: present
+  register: category_change
 
-    - name: Delete category with 2 associable object types
-      vmware_category:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
-        validate_certs: False
-        category_name: 'Sample_cate_0001'
-        state: absent
-      register: category_change
+- name: Assert change is made
+  assert:
+    that:
+      - category_change.changed
 
-    - name: Assert change is made
-      assert:
-        that:
-          - category_change.changed
+- name: Delete category with 2 associable object types
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: False
+    category_name: 'Sample_cate_0001'
+    state: absent
+  register: category_change
+
+- name: Assert change is made
+  assert:
+    that:
+      - category_change.changed

--- a/test/integration/targets/vmware_category/tasks/main.yml
+++ b/test/integration/targets/vmware_category/tasks/main.yml
@@ -2,4 +2,8 @@
 # Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- include: associable_obj_types.yml
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+  - include: associable_obj_types.yml


### PR DESCRIPTION
##### SUMMARY

- set the zuul/vmware/vcenter_only alias
- import `prepare_vmware_tests` role
- little refactoring to avoid an extra level of indentation

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_category