### PR TITLE
podman_image: Use provided credentials when pulling image

### DIFF
--- a/changelogs/fragments/66372-podman-image-pull-credentials.yml
+++ b/changelogs/fragments/66372-podman-image-pull-credentials.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - podman_image - honor username and password options when pulling image from a remote registry

--- a/lib/ansible/modules/cloud/podman/podman_image.py
+++ b/lib/ansible/modules/cloud/podman/podman_image.py
@@ -489,6 +489,10 @@ class PodmanImageManager(object):
         if self.auth_file:
             args.extend(['--authfile', self.auth_file])
 
+        if self.username and self.password:
+            cred_string = '{user}:{password}'.format(user=self.username, password=self.password)
+            args.extend(['--creds', cred_string])
+
         if self.validate_certs:
             args.append('--tls-verify')
 


### PR DESCRIPTION
##### SUMMARY
The `podman_image` module has `username` and `password` options to allow authenticating to a remote registry, but only uses them for build and push operations. Pulling images from an authenticated registry is a common operation, so credentials should be honored for pull operations too.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
podman_image

##### ADDITIONAL INFORMATION
This can be tested by trying to pull an image from any authenticated registry.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# does not work in ansible 2.9.2
$ ansible -b -m podman_image -a "name=registry.redhat.io/rhel8/dotnet-30-runtime username=peasters password=**** force=yes" localhost
localhost | FAILED! => {
    "changed": false,
    "msg": "Failed to pull image registry.********.io/rhel8/dotnet-30-runtime:latest"
}

# works after changes in PR
$ ansible -b -M ./lib/ansible/modules/cloud/podman -m podman_image -a "name=registry.redhat.io/rhel8/dotnet-30-runtime username=peasters password=**** force=yes" localhost
localhost | CHANGED => {
    "actions": [
        "Pulled image registry.********.io/rhel8/dotnet-30-runtime:latest"
    ],
    "changed": true,
<SNIP>
```
