### PR TITLE
[stable-2.7] Add ansible-test constraint to avoid coverage 5.0+.

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-constraint.yml
+++ b/changelogs/fragments/ansible-test-coverage-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test no longer tries to install ``coverage`` 5.0+ since those versions are unsupported

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,4 +1,4 @@
-coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
+coverage >= 4.2, < 5.0.0, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later


### PR DESCRIPTION
##### SUMMARY

[stable-2.7] Add ansible-test constraint to avoid coverage 5.0+

Backport of https://github.com/ansible/ansible/pull/65999

(cherry picked from commit 9ea5b539b60cb7035f08ac17688976a8e6dfb126)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
