### PR TITLE
Added additional error handling inside the hcloud.py inventory plugin…

### DIFF
--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -168,16 +168,33 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.inventory.set_variable(server.name, "ansible_host", to_native(server.public_net.ipv4.dns_ptr))
 
         # Server Type
-        self.inventory.set_variable(server.name, "server_type", to_native(server.image.name))
+        if server.image is not None and server.image.name is not None:
+            self.inventory.set_variable(server.name, "server_type", to_native(server.image.name))
+        else:
+            self.inventory.set_variable(server.name, "server_type", to_native("No Image name found."))
 
         # Datacenter
         self.inventory.set_variable(server.name, "datacenter", to_native(server.datacenter.name))
         self.inventory.set_variable(server.name, "location", to_native(server.datacenter.location.name))
 
         # Image
-        self.inventory.set_variable(server.name, "image_id", to_native(server.image.id))
-        self.inventory.set_variable(server.name, "image_name", to_native(server.image.name))
-        self.inventory.set_variable(server.name, "image_os_flavor", to_native(server.image.os_flavor))
+        if server.image is not None:
+            if server.image.id is not None:
+                self.inventory.set_variable(server.name, "image_id", to_native(server.image.id))
+            else:
+                self.inventory.set_variable(server.name, "image_id", to_native("No Image ID found"))
+            if server.image.name is not None:
+                self.inventory.set_variable(server.name, "image_name", to_native(server.image.name))
+            else:
+                self.inventory.set_variable(server.name, "image_name", to_native("No Image Name found"))
+            if server.image.os_flavor is not None:
+                self.inventory.set_variable(server.name, "image_os_flavor", to_native(server.image.os_flavor))
+            else:
+                self.inventory.set_variable(server.name, "image_os_flavor", to_native("No Image OS Flavor found"))
+        else:
+            self.inventory.set_variable(server.name, "image_id", to_native("No Image ID found"))
+            self.inventory.set_variable(server.name, "image_name", to_native("No Image Name found"))
+            self.inventory.set_variable(server.name, "image_os_flavor", to_native("No Image OS Flavor found"))
 
         # Labels
         self.inventory.set_variable(server.name, "labels", dict(server.labels))

--- a/lib/ansible/plugins/inventory/hcloud.py
+++ b/lib/ansible/plugins/inventory/hcloud.py
@@ -179,18 +179,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         # Image
         if server.image is not None:
-            if server.image.id is not None:
-                self.inventory.set_variable(server.name, "image_id", to_native(server.image.id))
-            else:
-                self.inventory.set_variable(server.name, "image_id", to_native("No Image ID found"))
+            self.inventory.set_variable(server.name, "image_id", to_native(server.image.id))
+            self.inventory.set_variable(server.name, "image_os_flavor", to_native(server.image.os_flavor))
             if server.image.name is not None:
                 self.inventory.set_variable(server.name, "image_name", to_native(server.image.name))
             else:
-                self.inventory.set_variable(server.name, "image_name", to_native("No Image Name found"))
-            if server.image.os_flavor is not None:
-                self.inventory.set_variable(server.name, "image_os_flavor", to_native(server.image.os_flavor))
-            else:
-                self.inventory.set_variable(server.name, "image_os_flavor", to_native("No Image OS Flavor found"))
+                self.inventory.set_variable(server.name, "image_name", to_native(server.image.description))
         else:
             self.inventory.set_variable(server.name, "image_id", to_native("No Image ID found"))
             self.inventory.set_variable(server.name, "image_name", to_native("No Image Name found"))


### PR DESCRIPTION
…. Otherwise, errors may happen, if the HCloud API is not able to correctly identify the server image.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
During a test run of the plugin with my HCloud, I recognized errors inside the inventory code. By adding additional checks for "None" Objects, those errors could be fixed and I was able to get the information from the Inventory Plugin.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
HCloud Inventory Plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Error before the change:
```paste below
daniel@ubuntu:~/ansible_test$ HCLOUD_TOKEN=<TOKEN> ansible-inventory -i hcloud.yml --list -vvvv
ansible-inventory 2.9.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/daniel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/daniel/.local/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-inventory
  python version = 3.6.8 (default, Oct  7 2019, 12:59:55) [GCC 8.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /home/daniel/ansible_test/hcloud.yml as it did not pass its verify_file() method
script declined parsing /home/daniel/ansible_test/hcloud.yml as it did not pass its verify_file() method
toml declined parsing /home/daniel/ansible_test/hcloud.yml as it did not pass its verify_file() method
[WARNING]:  * Failed to parse /home/daniel/ansible_test/hcloud.yml with auto plugin: 'NoneType' object has no attribute 'id'

  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/plugins/inventory/hcloud.py", line 208, in parse
    self._set_server_attributes(server)
  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/plugins/inventory/hcloud.py", line 181, in _set_server_attributes
    self.inventory.set_variable(server.name, "image_id", to_native(server.image.id))

[WARNING]:  * Failed to parse /home/daniel/ansible_test/hcloud.yml with yaml plugin: Plugin configuration YAML file, not YAML inventory

  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/plugins/inventory/yaml.py", line 112, in parse
    raise AnsibleParserError('Plugin configuration YAML file, not YAML inventory')

[WARNING]:  * Failed to parse /home/daniel/ansible_test/hcloud.yml with ini plugin: Invalid host pattern 'plugin:' supplied, ending in ':' is not allowed, this character is reserved to provide a port.

  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/daniel/.local/lib/python3.6/site-packages/ansible/plugins/inventory/ini.py", line 138, in parse
    raise AnsibleParserError(e)

[WARNING]: Unable to parse /home/daniel/ansible_test/hcloud.yml as an inventory source

[WARNING]: No inventory was parsed, only implicit localhost is available

{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    }
}

```

Corrected after the change (I removed server names/IPs/IDs):
```paste below
daniel@ubuntu:~/ansible_test$ HCLOUD_TOKEN=<TOKEN> ansible-inventory -i hcloud.yml --list -vvvv
ansible-inventory 2.9.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/daniel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/daniel/.local/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-inventory
  python version = 3.6.8 (default, Oct  7 2019, 12:59:55) [GCC 8.3.0]
Using /etc/ansible/ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /home/daniel/ansible_test/hcloud.yml as it did not pass its verify_file() method
script declined parsing /home/daniel/ansible_test/hcloud.yml as it did not pass its verify_file() method
Parsed /home/daniel/ansible_test/hcloud.yml inventory source with auto plugin
{
    "_meta": {
        "hostvars": {
            "Server1": {
                "ansible_host": "<Correct-IP>",
                "datacenter": "nbg1-dc3",
                "id": "1233",
                "image_id": "2",
                "image_name": "debian-9",
                "image_os_flavor": "debian",
                "ipv4": "<Correct-IP>",
                "ipv6_network": "<Correct-IP>",
                "ipv6_network_mask": "64",
                "labels": {},
                "location": "nbg1",
                "name": "Server1",
                "server_type": "debian-9",
                "status": "running",
                "type": "cx31"
            },
            "Server2": {
                "ansible_host": "<Correct-IP>",
                "datacenter": "fsn1-dc14",
                "id": "1234",
                "image_id": "11331244",
                "image_name": "No Image Name found",
                "image_os_flavor": "debian",
                "ipv4": "<Correct-IP>",
                "ipv6_network": "<Correct-IP>",
                "ipv6_network_mask": "64",
                "labels": {},
                "location": "fsn1",
                "name": "Server2",
                "server_type": "No Image name found.",
                "status": "running",
                "type": "cx21"
            },
            ...
        }
    },
    "all": {
        "children": [
            "hcloud",
            "ungrouped"
        ]
    },
    "hcloud": {
        "hosts": [
            "Server1",
            "Server2"
        ]
    }
}

```