### PR TITLE
Fix aws_ssm connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/aws_ssm.py
+++ b/lib/ansible/plugins/connection/aws_ssm.py
@@ -146,7 +146,6 @@ EXAMPLES = r'''
 '''
 
 import os
-import boto3
 import getpass
 import json
 import os
@@ -158,9 +157,17 @@ import string
 import subprocess
 import time
 
+try:
+    import boto3
+    HAS_BOTO_3 = True
+except ImportError as e:
+    HAS_BOTO_3_ERROR = str(e)
+    HAS_BOTO_3 = False
+
 from functools import wraps
 from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleFileNotFound
+from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -240,6 +247,8 @@ class Connection(ConnectionBase):
     MARK_LENGTH = 26
 
     def __init__(self, *args, **kwargs):
+        if not HAS_BOTO_3:
+            raise AnsibleError('{0}: {1}'.format(missing_required_lib("ncclient"), HAS_BOTO_3_ERROR))
 
         super(Connection, self).__init__(*args, **kwargs)
         self.host = self._play_context.remote_addr

--- a/test/integration/targets/connection_aws_ssm/aliases
+++ b/test/integration/targets/connection_aws_ssm/aliases
@@ -4,4 +4,3 @@ shippable/aws/group1
 non_local
 needs/root
 needs/target/connection
-disabled


### PR DESCRIPTION
##### SUMMARY
The aws_ssm connection plugin directly imports `boto3` without watching for `ImportError`s. This causes a warning to be emitted when `boto3` is not around (`[WARNING]: Skipping plugin (.../aws_ssm.py) as it seems to be invalid: No module named boto3`).

This PR makes sure this error is handled better.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connections/aws_ssm.py
