### PR TITLE
osx_defaults: diff support

### DIFF
--- a/changelogs/fragments/66397-osx_defaults-diff.yml
+++ b/changelogs/fragments/66397-osx_defaults-diff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "osx_defaults - the module now has diff support."

--- a/lib/ansible/modules/system/osx_defaults.py
+++ b/lib/ansible/modules/system/osx_defaults.py
@@ -382,7 +382,9 @@ def main():
 
     try:
         defaults = OSXDefaults(module=module)
-        module.exit_json(changed=defaults.run())
+        changed = defaults.run()
+        diff = dict(before=dict(value=defaults.current_value), after=dict(value=defaults.value))
+        module.exit_json(changed=changed, diff=diff)
     except OSXDefaultsException as e:
         module.fail_json(msg=e.message)
 


### PR DESCRIPTION
##### SUMMARY

Added diff support to osx_defaults module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

osx_defaults

##### ADDITIONAL INFORMATION

example output is below.

```diff
TASK [defaults : osx_defaults] **************************************************************************************************************
--- before
+++ after
@@ -1 +1 @@
-value: true
+value: false

changed: [127.0.0.1]
```
