### PR TITLE
pamd: Fix AttributeError when removing the first or last rule (#60497)(#66504)

### DIFF
--- a/changelogs/fragments/60497-pamd_fix-attributeerror-when-removing-first-line.yml
+++ b/changelogs/fragments/60497-pamd_fix-attributeerror-when-removing-first-line.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- "pamd - Bugfix for attribute error when removing the first line. In this fix, the prev/next attribute of pamd_line is explicitly set to None."

--- a/changelogs/fragments/60497-pamd_fix-attributeerror-when-removing-first-line.yml
+++ b/changelogs/fragments/60497-pamd_fix-attributeerror-when-removing-first-line.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pamd - Bugfix for attribute error when removing the first line. In this fix, the prev/next attribute of pamd_line is explicitly set to None."

--- a/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
+++ b/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pamd - Bugfix for attribute error when removing the first or last line"

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -480,7 +480,8 @@ class PamdService(object):
             if current_line.matches(rule_type, rule_control, rule_path):
                 if current_line.prev is not None:
                     current_line.prev.next = current_line.next
-                    current_line.next.prev = current_line.prev
+                    if current_line.next is not None:
+                        current_line.next.prev = current_line.prev
                 else:
                     self._head = current_line.next
                     current_line.next.prev = None

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -351,6 +351,8 @@ class PamdRule(PamdLine):
     valid_control_actions = ['ignore', 'bad', 'die', 'ok', 'done', 'reset']
 
     def __init__(self, rule_type, rule_control, rule_path, rule_args=None):
+        self.prev = None
+        self.next = None
         self._control = None
         self._args = None
         self.rule_type = rule_type
@@ -463,8 +465,6 @@ class PamdService(object):
 
     def append(self, pamd_line):
         if self._head is None:
-            pamd_line.prev = None
-            pamd_line.next = None
             self._head = self._tail = pamd_line
         else:
             pamd_line.prev = self._tail

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -463,6 +463,8 @@ class PamdService(object):
 
     def append(self, pamd_line):
         if self._head is None:
+            pamd_line.prev = None
+            pamd_line.next = None
             self._head = self._tail = pamd_line
         else:
             pamd_line.prev = self._tail

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -134,6 +134,12 @@ session    required pam_unix.so"""
         auth       required pam_env.so
 """
 
+        self.no_header_system_auth_string = """auth       required pam_env.so
+auth       sufficient pam_unix.so nullok try_first_pass
+auth       requisite pam_succeed_if.so uid
+auth       required pam_deny.so
+"""
+
         self.pamd = PamdService(self.system_auth_string)
 
     def test_properly_parsed(self):
@@ -352,4 +358,15 @@ session    required pam_unix.so"""
         # Second run should not change anything
         self.assertFalse(self.pamd.remove('account', 'required', 'pam_unix.so'))
         test_rule = PamdRule('account', 'required', 'pam_unix.so')
+        self.assertNotIn(str(test_rule), str(self.pamd))
+
+    def test_remove_first_rule(self):
+        no_header_service = PamdService(self.no_header_system_auth_string)
+        self.assertTrue(no_header_service.remove('auth', 'required', 'pam_env.so'))
+        test_rule = PamdRule('auth', 'required', 'pam_env.so')
+        self.assertNotIn(str(test_rule), str(no_header_service))
+
+    def test_remove_last_rule(self):
+        self.assertTrue(self.pamd.remove('session', 'required', 'pam_unix.so'))
+        test_rule = PamdRule('session', 'required', 'pam_unix.so')
         self.assertNotIn(str(test_rule), str(self.pamd))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added inintialization of two properties in PamdRule class in `pamd.py`.

```python
self.prev = None
self.next = None
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #60497

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

 - lib/ansible/modules/system/pamd.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue #60497 is caused by reference to unset property (`PamdRule.prev`) at line 481 of `pamd.py`.
In this fix, `PamdRule.prev` and `PamdRule.next` is explicitly set to None in the constructor.<br>
I'm new to this project. Please let me know if there is anything wrong.