### PR TITLE
Check for index before calling drop on it in mongodb cache plugin

### DIFF
--- a/lib/ansible/plugins/cache/mongodb.py
+++ b/lib/ansible/plugins/cache/mongodb.py
@@ -97,10 +97,12 @@ class CacheModule(BaseCacheModule):
                 )
             except pymongo.errors.OperationFailure:
                 # We make it here when the fact_caching_timeout was set to a different value between runs
-                collection.drop_index('ttl')
+                if 'ttl' in collection.index_information():
+                    collection.drop_index('ttl')
                 return self._manage_indexes(collection)
         else:
-            collection.drop_index('ttl')
+            if 'ttl' in collection.index_information():
+                collection.drop_index('ttl')
 
     @contextmanager
     def _collection(self):


### PR DESCRIPTION
##### SUMMARY
Added a condition to validate whether the collection has the index defined or not, before calling drop operation on it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb cache plugin.
https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/cache/mongodb.py

##### ADDITIONAL INFORMATION
If the plugin runs with default timeout or no timeout defined, then the plugin runs as it will never call the drop index operation. But if the timeout is defined as 0 or less than 0 (which is allowed as per code), then it would call the drop index operation. 

Here, the plugin is calling the drop index operation without first checking whether the index exists or not in first place. So, when the code calls drop the index operation without the index being defined in first place, we are getting error "index not found with name 'ttl'".


