### PR TITLE
Restrict setuptools on Python 2 to make CI work again

### DIFF
--- a/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
@@ -1,4 +1,4 @@
 openshift
 
 # setuptools 45.0.0 no longer works with Python 2
-setuptools<=44.0.0 ; python_version < '3'
+setuptools<45.0.0 ; python_version < '3'

--- a/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
@@ -1,0 +1,2 @@
+openshift
+setuptools<=44.0.0 ; python_version < '3'

--- a/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
@@ -1,2 +1,4 @@
 openshift
+
+# setuptools 45.0.0 no longer works with Python 2
 setuptools<=44.0.0 ; python_version < '3'

--- a/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/requirements.txt
@@ -1,4 +1,4 @@
 openshift
 
 # setuptools 45.0.0 no longer works with Python 2
-setuptools<45.0.0 ; python_version < '3'
+setuptools<45 ; python_version < "3.0"

--- a/test/integration/targets/inventory_kubevirt_conformance/runme.sh
+++ b/test/integration/targets/inventory_kubevirt_conformance/runme.sh
@@ -9,12 +9,7 @@ fi
 set -eux
 
 source virtualenv.sh
-if [[ $(python --version 2>&1) =~ 2\.7 ]]
-  then
-    pip install "openshift,setuptools<=44.0.0"
-else
-    pip install openshift
-fi
+pip install -r requirements.txt
 
 ./server.py &
 

--- a/test/integration/targets/inventory_kubevirt_conformance/runme.sh
+++ b/test/integration/targets/inventory_kubevirt_conformance/runme.sh
@@ -11,7 +11,7 @@ set -eux
 source virtualenv.sh
 if [[ $(python --version 2>&1) =~ 2\.7 ]]
   then
-    pip install openshift,setuptools<=44.0.0
+    pip install "openshift,setuptools<=44.0.0"
 else
     pip install openshift
 fi

--- a/test/integration/targets/inventory_kubevirt_conformance/runme.sh
+++ b/test/integration/targets/inventory_kubevirt_conformance/runme.sh
@@ -9,7 +9,12 @@ fi
 set -eux
 
 source virtualenv.sh
-pip install openshift
+if [[ $(python --version 2>&1) =~ 2\.7 ]]
+  then
+    pip install openshift,setuptools<=44.0.0
+else
+    pip install openshift
+fi
 
 ./server.py &
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -496,7 +496,7 @@
 
   - name: install distribute in the virtualenv
     pip:
-      name: distribute
+      name: distribute,setuptools<=44.0.0
       virtualenv: "{{ output_dir }}/pipenv"
       state: present
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -499,7 +499,7 @@
       name:
         - distribute
         # setuptools 45.0.0 no longer works with Python 2
-        - setuptools<=44.0.0
+        - setuptools<45.0.0
       virtualenv: "{{ output_dir }}/pipenv"
       state: present
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -496,7 +496,10 @@
 
   - name: install distribute in the virtualenv
     pip:
-      name: distribute,setuptools<=44.0.0
+      name:
+        - distribute
+        # setuptools 45.0.0 no longer works with Python 2
+        - setuptools<=44.0.0
       virtualenv: "{{ output_dir }}/pipenv"
       state: present
 


### PR DESCRIPTION
##### SUMMARY
Fixes #66401.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/pip/tasks/pip.yml
test/integration/targets/inventory_kubevirt_conformance/runme.sh
