### PR TITLE
Delete linter ignore lines for keycloak modules

### DIFF
--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -44,7 +44,6 @@ options:
             - State of the group.
             - On C(present), the group will be created if it does not yet exist, or updated with the parameters you provide.
             - On C(absent), the group will be removed if it exists.
-        required: true
         default: 'present'
         type: str
         choices:

--- a/lib/ansible/plugins/doc_fragments/keycloak.py
+++ b/lib/ansible/plugins/doc_fragments/keycloak.py
@@ -22,7 +22,6 @@ options:
             - OpenID Connect I(client_id) to authenticate to the API with.
         type: str
         default: admin-cli
-        required: true
 
     auth_realm:
         description:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1815,13 +1815,10 @@ lib/ansible/modules/files/xml.py validate-modules:doc-required-mismatch
 lib/ansible/modules/identity/cyberark/cyberark_authentication.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/identity/keycloak/keycloak_client.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/identity/keycloak/keycloak_client.py validate-modules:doc-missing-type
-lib/ansible/modules/identity/keycloak/keycloak_client.py validate-modules:doc-required-mismatch
 lib/ansible/modules/identity/keycloak/keycloak_client.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-missing-type
-lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:doc-required-mismatch
 lib/ansible/modules/identity/keycloak/keycloak_clienttemplate.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/identity/keycloak/keycloak_group.py validate-modules:doc-required-mismatch
 lib/ansible/modules/identity/opendj/opendj_backendprop.py validate-modules:doc-missing-type
 lib/ansible/modules/identity/opendj/opendj_backendprop.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/messaging/rabbitmq/rabbitmq_binding.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Delete the `required: True` for the `auth_client_id` argument of all keycloak module which has a default value. This argument is described in a doc_fragment. This allows to delete some extra lines in ` test/sanity/ignore.txt`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- keycloak_client
- keycloak_clienttemplate
- keycloak_group

##### ADDITIONAL INFORMATION
