### PR TITLE
use `query` instead of `q` in "if files exist" example

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -49,7 +49,7 @@ EXAMPLES = """
       files:
         - path/tasks.yaml
         - path/other_tasks.yaml
-  loop: "{{ q('first_found', params, errors='ignore') }}"
+  loop: "{{ query('first_found', params, errors='ignore') }}"
 
 - name: |
         copy first existing file found to /some/file,


### PR DESCRIPTION
##### SUMMARY
It's not obvious that `q` is the same as `query` (which is referred to in the name of the task) and using long-names is generally preferred in examples.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr